### PR TITLE
Implement organization registration

### DIFF
--- a/platform-api/spec/impls/organization-management.md
+++ b/platform-api/spec/impls/organization-management.md
@@ -10,12 +10,12 @@
 
 ## Behaviour
 
-1. POST requests bind to `dto.Organization`, ensuring handle presence before calling the service.
-2. Service enforces lowercase URL-friendly handles and uniqueness checks via repository lookups.
-3. Upon creation, service inserts the organization and immediately creates a default project.
+1. POST requests bind to `dto.Organization`, ensuring both UUID and handle presence before calling the service.
+2. Service enforces lowercase URL-friendly handles and uniqueness checks via repository lookups for both ID and handle.
+3. Upon registration, service inserts the organization and immediately creates a default project.
 4. GET requests fetch by UUID, returning `404` when the organization is absent.
 
 ## Verification
 
-- Create: `curl -k -X POST https://localhost:8443/api/v1/organizations -d '{"handle":"alpha","name":"Alpha"}' -H 'Content-Type: application/json'`.
+- Register: `curl -k -X POST https://localhost:8443/api/v1/organizations -d '{"uuid":"123e4567-e89b-12d3-a456-426614174000","handle":"alpha","name":"Alpha"}' -H 'Content-Type: application/json'`.
 - Fetch: `curl -k https://localhost:8443/api/v1/organizations/<uuid>`; expect JSON payload with organization metadata (handle, name, timestamps).

--- a/platform-api/src/internal/constants/error.go
+++ b/platform-api/src/internal/constants/error.go
@@ -21,6 +21,7 @@ import "errors"
 
 var (
 	ErrHandleExists          = errors.New("handle already exists")
+	ErrOrganizationExists    = errors.New("organization already exists with the given UUID")
 	ErrInvalidHandle         = errors.New("invalid handle format")
 	ErrOrganizationNotFound  = errors.New("organization not found")
 	ErrMultipleOrganizations = errors.New("multiple organizations found")

--- a/platform-api/src/internal/handler/organization.go
+++ b/platform-api/src/internal/handler/organization.go
@@ -38,7 +38,7 @@ func NewOrganizationHandler(orgService *service.OrganizationService) *Organizati
 	}
 }
 
-func (h *OrganizationHandler) CreateOrganization(c *gin.Context) {
+func (h *OrganizationHandler) RegisterOrganization(c *gin.Context) {
 	var req dto.Organization
 
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -52,12 +52,22 @@ func (h *OrganizationHandler) CreateOrganization(c *gin.Context) {
 			"Handle is required"))
 		return
 	}
+	if req.UUID == "" {
+		c.JSON(http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request",
+			"Organization UUID is required"))
+		return
+	}
 
-	org, err := h.orgService.CreateOrganization(req.Handle, req.Name)
+	org, err := h.orgService.RegisterOrganization(req.UUID, req.Handle, req.Name)
 	if err != nil {
 		if errors.Is(err, constants.ErrHandleExists) {
 			c.JSON(http.StatusConflict, utils.NewErrorResponse(409, "Conflict",
 				"Organization already exists"))
+			return
+		}
+		if errors.Is(err, constants.ErrOrganizationExists) {
+			c.JSON(http.StatusConflict, utils.NewErrorResponse(409, "Conflict",
+				"Organization with the given ID already exists"))
 			return
 		}
 		if errors.Is(err, constants.ErrInvalidHandle) {
@@ -104,7 +114,7 @@ func (h *OrganizationHandler) GetOrganization(c *gin.Context) {
 func (h *OrganizationHandler) RegisterRoutes(r *gin.Engine) {
 	orgGroup := r.Group("/api/v1/organizations")
 	{
-		orgGroup.POST("", h.CreateOrganization)
+		orgGroup.POST("", h.RegisterOrganization)
 		orgGroup.GET("/:org_uuid", h.GetOrganization)
 	}
 }

--- a/platform-api/src/internal/repository/interfaces.go
+++ b/platform-api/src/internal/repository/interfaces.go
@@ -24,6 +24,7 @@ import (
 // OrganizationRepository defines the interface for organization data access
 type OrganizationRepository interface {
 	CreateOrganization(org *model.Organization) error
+	GetOrganizationByIdOrHandle(id, handle string) (*model.Organization, error)
 	GetOrganizationByUUID(uuid string) (*model.Organization, error)
 	GetOrganizationByHandle(handle string) (*model.Organization, error)
 	UpdateOrganization(org *model.Organization) error

--- a/platform-api/src/internal/repository/organization.go
+++ b/platform-api/src/internal/repository/organization.go
@@ -49,6 +49,26 @@ func (r *OrganizationRepo) CreateOrganization(org *model.Organization) error {
 	return err
 }
 
+// GetOrganizationByIdOrHandle retrieves an organization by id or handle
+func (r *OrganizationRepo) GetOrganizationByIdOrHandle(id, handle string) (*model.Organization, error) {
+	org := &model.Organization{}
+	query := `
+		SELECT uuid, handle, name, created_at, updated_at
+		FROM organizations
+		WHERE uuid = ? OR handle = ?
+	`
+	err := r.db.QueryRow(query, id, handle).Scan(
+		&org.UUID, &org.Handle, &org.Name, &org.CreatedAt, &org.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return org, nil
+}
+
 // GetOrganizationByUUID retrieves an organization by UUID
 func (r *OrganizationRepo) GetOrganizationByUUID(uuid string) (*model.Organization, error) {
 	org := &model.Organization{}

--- a/platform-api/src/resources/openapi.yaml
+++ b/platform-api/src/resources/openapi.yaml
@@ -18,9 +18,11 @@ servers:
 paths:
   /organizations:
     post:
-      summary: Create a new organization
-      description: Creates a new organization with a unique handle
-      operationId: createOrganization
+      summary: Register a new organization
+      description: |
+        Registers a new organization with a unique UUID and handle. 
+        This endpoint is used during the organization onboarding process.
+      operationId: registerOrganization
       tags:
         - Organizations
       requestBody:
@@ -32,7 +34,7 @@ paths:
               $ref: '#/components/schemas/Organization'
       responses:
         '201':
-          description: Organization created successfully
+          description: Organization registered successfully
           content:
             application/json:
               schema:
@@ -580,6 +582,7 @@ components:
     Organization:
       type: object
       required:
+        - uuid
         - handle
       properties:
         uuid:
@@ -592,11 +595,11 @@ components:
           description: URL-friendly unique handle for the organization
           pattern: '^[a-z0-9-]+$'
           minLength: 1
-          example: "wso2"
+          example: "acme"
         name:
           type: string
           description: Display name of the organization
-          example: "WSO2"
+          example: "Acme Corporation"
         created_at:
           type: string
           format: date-time
@@ -606,7 +609,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the organization was last updated
-          example: "2023-10-12T10:30:00Z"
+          example: "Acme Corporation"
 
     Project:
       type: object


### PR DESCRIPTION
## Purpose
This pull request refactors the organization creation flow to register an organization with a given ID.

Fixes: [wso2/api-platform/issues#18](https://github.com/wso2/api-platform/issues/18)

## Approach
**API and Handler Refactor:**
* Renamed the endpoint and handler from `CreateOrganization` to `RegisterOrganization`, now requiring both a UUID and handle in the request, and updated route registration and OpenAPI documentation to match (`organization.go`, `openapi.yaml`). [[1]](diffhunk://#diff-52e63211c382431590f9c6a4712d41315d8b9ef4cb66dd7ccf3f4f7d38dd4c12L41-R41) [[2]](diffhunk://#diff-52e63211c382431590f9c6a4712d41315d8b9ef4cb66dd7ccf3f4f7d38dd4c12L107-R117) [[3]](diffhunk://#diff-373427645329a5cac7b576478de6776e6fa704a1415aad22cb834a2839d9495eL21-R25) [[4]](diffhunk://#diff-373427645329a5cac7b576478de6776e6fa704a1415aad22cb834a2839d9495eL35-R37)

**Validation and Error Handling:**
* Added validation to ensure the UUID is present in requests and introduced a new error (`ErrOrganizationExists`) for duplicate UUIDs, with corresponding error responses in the handler and service layers (`error.go`, `organization.go`, `service/organization.go`). [[1]](diffhunk://#diff-c419d36ed4a009ec119bf132fc0e36ceb5c1c9f0169ac31b6d7d54e8e2d5cc69R24) [[2]](diffhunk://#diff-52e63211c382431590f9c6a4712d41315d8b9ef4cb66dd7ccf3f4f7d38dd4c12R55-R72) [[3]](diffhunk://#diff-345cca26d57f3126c1a754b0c011d8ac1173266b9b7b005c8a9ae0b751533db6L43-R56)

**Repository and Service Logic:**
* Added `GetOrganizationByIdOrHandle` to the repository to check for existing organizations by either UUID or handle, and updated service logic to enforce uniqueness for both fields before registration (`interfaces.go`, `organization.go`, `service/organization.go`). [[1]](diffhunk://#diff-074f5f4f6c3225342030a3ff77c407762c95334a899b29a7caf7483445a63801R27) [[2]](diffhunk://#diff-63edb0b970aa5b7ed1de825ce4c82d51493eb9d1b2c5656c67347cb6e70fed73R52-R71) [[3]](diffhunk://#diff-345cca26d57f3126c1a754b0c011d8ac1173266b9b7b005c8a9ae0b751533db6L43-R56)

**DTO and Model Changes:**
* Changed organization registration to use the provided UUID instead of generating one, and set the default project UUID to `"default"` instead of a random value (`service/organization.go`). [[1]](diffhunk://#diff-345cca26d57f3126c1a754b0c011d8ac1173266b9b7b005c8a9ae0b751533db6L64-R66) [[2]](diffhunk://#diff-345cca26d57f3126c1a754b0c011d8ac1173266b9b7b005c8a9ae0b751533db6L79-R81)

**Documentation and Example Updates:**
* Updated markdown documentation, OpenAPI schema, and examples to reflect the new registration flow, required fields, and improved example values for clarity (`organization-management.md`, `openapi.yaml`). [[1]](diffhunk://#diff-892bf9d9592d5bf05e044ebb342afa2d6ed9c7f2333b07af1f1dca3064f82c4aL13-R20) [[2]](diffhunk://#diff-373427645329a5cac7b576478de6776e6fa704a1415aad22cb834a2839d9495eR585) [[3]](diffhunk://#diff-373427645329a5cac7b576478de6776e6fa704a1415aad22cb834a2839d9495eL595-R602) [[4]](diffhunk://#diff-373427645329a5cac7b576478de6776e6fa704a1415aad22cb834a2839d9495eL609-R612)
