### PR TITLE
Fix OpenAPI definiton to remove redundancy

### DIFF
--- a/platform-api/src/resources/openapi.yaml
+++ b/platform-api/src/resources/openapi.yaml
@@ -612,7 +612,7 @@ components:
     Organization:
       type: object
       required:
-        - uuid
+        - id
         - handle
       properties:
         id:
@@ -634,11 +634,13 @@ components:
           type: string
           format: date-time
           description: Timestamp when the organization was created
+          readOnly: true
           example: "2023-10-12T10:30:00Z"
         updatedAt:
           type: string
           format: date-time
           description: Timestamp when the organization was last updated
+          readOnly: true
           example: "2023-10-12T10:30:00Z"
 
     CreateProjectRequest:
@@ -672,7 +674,9 @@ components:
       properties:
         id:
           type: string
+          format: uuid
           description: Unique identifier for the project
+          readOnly: true
           example: "yr434567-de34-76uj6-w376-234324532"
         name:
           type: string
@@ -689,11 +693,13 @@ components:
           type: string
           format: date-time
           description: Timestamp when the project was created
+          readOnly: true
           example: "2023-10-12T10:30:00Z"
         updatedAt:
           type: string
           format: date-time
           description: Timestamp when the project was last updated
+          readOnly: true
           example: "2023-10-12T10:30:00Z"
 
     API:


### PR DESCRIPTION
## Purpose
This pull request makes several improvements and corrections to the OpenAPI schema definitions in `platform-api/src/resources/openapi.yaml`. The changes focus on increasing schema consistency, improving documentation accuracy, and simplifying API request definitions by leveraging schema references.

Fixes: [wso2/api-platform/issues#23](https://github.com/wso2/api-platform/issues/23)

## Approach
Key changes include:

**Schema consistency and documentation improvements:**

* Changed required field in the `Organization` schema from `uuid` to `id` for consistency with property naming.
* Added `readOnly: true` to `createdAt` and `updatedAt` fields in the `Organization`, `Project`, and `API` schemas to clarify that these timestamps are set by the system and not user-editable. [[1]](diffhunk://#diff-373427645329a5cac7b576478de6776e6fa704a1415aad22cb834a2839d9495eR637-R643) [[2]](diffhunk://#diff-373427645329a5cac7b576478de6776e6fa704a1415aad22cb834a2839d9495eR696-R702) [[3]](diffhunk://#diff-373427645329a5cac7b576478de6776e6fa704a1415aad22cb834a2839d9495eL747-R770)
* Specified `format: uuid` and `readOnly: true` for the `id` field in the `Project` schema to improve type safety and documentation.

**API schema and request definition simplification:**

* Updated the `projectId` and `organizationId` descriptions in the `API` schema for clarity and removed unnecessary `readOnly: true` from `projectId`.
* Refactored `CreateAPIRequest` and `UpdateAPIRequest` schemas to use `allOf` with a reference to the main `API` schema, reducing duplication and ensuring alignment with the core API definition.