### PR TITLE
Refactor list APIs endpoint

### DIFF
--- a/platform-api/src/internal/repository/interfaces.go
+++ b/platform-api/src/internal/repository/interfaces.go
@@ -47,7 +47,7 @@ type APIRepository interface {
 	CreateAPI(api *model.API) error
 	GetAPIByUUID(apiId string) (*model.API, error)
 	GetAPIsByProjectID(projectID string) ([]*model.API, error)
-	GetAPIsByOrganizationID(orgID string) ([]*model.API, error)
+	GetAPIsByOrganizationID(orgID string, projectID *string) ([]*model.API, error)
 	UpdateAPI(api *model.API) error
 	DeleteAPI(apiId string) error
 	CreateDeployment(deployment *model.APIDeployment) error

--- a/platform-api/src/internal/service/gateway_internal.go
+++ b/platform-api/src/internal/service/gateway_internal.go
@@ -46,7 +46,7 @@ func NewGatewayInternalAPIService(apiRepo repository.APIRepository, gatewayRepo 
 // GetAPIsByOrganization retrieves all APIs for a specific organization (used by gateways)
 func (s *GatewayInternalAPIService) GetAPIsByOrganization(orgID string) (map[string]string, error) {
 	// Get all APIs for the organization
-	apis, err := s.apiRepo.GetAPIsByOrganizationID(orgID)
+	apis, err := s.apiRepo.GetAPIsByOrganizationID(orgID, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve APIs: %w", err)
 	}

--- a/platform-api/src/resources/openapi.yaml
+++ b/platform-api/src/resources/openapi.yaml
@@ -231,6 +231,31 @@ paths:
           $ref: '#/components/responses/InternalServerError'
 
   /apis:
+    get:
+      summary: Get all APIs for an organization
+      description: |
+        Retrieves all APIs belonging to an organization. Optionally filter by project using 
+        the projectId query parameter. Access is validated against the organization in the JWT token.
+      operationId: ListAPIs
+      tags:
+        - APIs
+      parameters:
+        - $ref: '#/components/parameters/projectId-Q'
+      responses:
+        '200':
+          description: APIs retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIListResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     post:
       summary: Create a new API
       description: |
@@ -261,33 +286,6 @@ paths:
           $ref: '#/components/responses/NotFound'
         '409':
           $ref: '#/components/responses/Conflict'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-
-  /projects/{projectId}/apis:
-    get:
-      summary: Get all APIs for a project
-      description: |
-        Retrieves all APIs belonging to a specific project. Access is validated against 
-        the organization in the JWT token.
-      operationId: ListAPIs
-      tags:
-        - APIs
-      parameters:
-        - $ref: '#/components/parameters/ProjectID'
-      responses:
-        '200':
-          description: APIs retrieved successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/APIListResponse'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '404':
-          $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
 
@@ -1713,6 +1711,17 @@ components:
         type: string
         format: uuid
         example: crer4354-jui52345-245vd-93fvk-137063
+
+    projectId-Q:
+      name: projectId
+      in: query
+      required: false
+      description: |
+        **Project ID** consisting of the **UUID** of the Project to filter APIs by.
+      schema:
+        type: string
+        format: uuid
+        example: "yr434567-de34-76uj6-w376-234324532"
 
     GatewayID:
       name: gatewayId


### PR DESCRIPTION
## Purpose
List all the APIs of a organization. Filter the APIs by project optionally.

Fixes: [wso2/api-platform/issues#60](https://github.com/wso2/api-platform/issues/60)

## Goals
APIs are listed for an organization and projects and support filtering by project via a query parameter instead of a separate route.

## Approach
**API Endpoint Refactor:**

* The `ListAPIs` endpoint now lists APIs for an organization and optionally filters by project using the `projectId` query parameter, replacing the previous project-specific route (`/projects/{projectId}/apis`). [[1]](diffhunk://#diff-217d35ad76103e4562305d2e0d7cd413ed1e660840dad62158ef3523344cdd5dL161-R161) [[2]](diffhunk://#diff-373427645329a5cac7b576478de6776e6fa704a1415aad22cb834a2839d9495eL267-L293) [[3]](diffhunk://#diff-373427645329a5cac7b576478de6776e6fa704a1415aad22cb834a2839d9495eR234-R258)

**Handler, Service, and Repository Updates:**

* Updated the handler, service, and repository methods to support organization-level API listing with an optional project filter, including validation that the project belongs to the organization. [[1]](diffhunk://#diff-217d35ad76103e4562305d2e0d7cd413ed1e660840dad62158ef3523344cdd5dL171-R178) [[2]](diffhunk://#diff-b708f9ffa32632b7541587a33ef9eeecbbc1ddb4825c7b94db8d884923e9e357L168-R172) [[3]](diffhunk://#diff-b708f9ffa32632b7541587a33ef9eeecbbc1ddb4825c7b94db8d884923e9e357R182-R184) [[4]](diffhunk://#diff-da9eb2b4f1269a5af62b287b6148643fa3f1036b3b0a99283a6b1cf56e6bcaf2L203-R232) [[5]](diffhunk://#diff-074f5f4f6c3225342030a3ff77c407762c95334a899b29a7caf7483445a63801L50-R50) [[6]](diffhunk://#diff-aab2ea5e962b20d8fe0c4af97ec28a1190a9197aa4a2c6515707b240dc0ce044L49-R49)

**OpenAPI Documentation Changes:**

* The OpenAPI spec now documents the new `/apis` GET endpoint and removes the old project-specific listing endpoint, with a new query parameter definition for `projectId`. [[1]](diffhunk://#diff-373427645329a5cac7b576478de6776e6fa704a1415aad22cb834a2839d9495eR234-R258) [[2]](diffhunk://#diff-373427645329a5cac7b576478de6776e6fa704a1415aad22cb834a2839d9495eL267-L293) [[3]](diffhunk://#diff-373427645329a5cac7b576478de6776e6fa704a1415aad22cb834a2839d9495eR1715-R1725)

**Route Registration Simplification:**

* Removed the project-specific API route registration from the handler, consolidating all API listing under `/api/v1/apis`.