### PR TITLE
Generate backend name if empty

### DIFF
--- a/platform-api/src/internal/repository/api.go
+++ b/platform-api/src/internal/repository/api.go
@@ -21,6 +21,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"github.com/google/uuid"
 	"time"
 
 	"platform-api/src/internal/database"
@@ -624,6 +625,9 @@ func (r *APIRepo) loadCORSConfig(apiId string) (*model.CORSConfig, error) {
 
 // Helper methods for Backend Services
 func (r *APIRepo) insertBackendService(tx *sql.Tx, apiId string, service *model.BackendService) error {
+	if service.Name == "" {
+		service.Name = uuid.New().String()
+	}
 	// Build timeout and load balance values
 	var timeoutConnect, timeoutRead, timeoutWrite *int
 	if service.Timeout != nil {


### PR DESCRIPTION
$Subject

Generates a unique backend name if it is not provided. This ensures that the database constraint of backend name being unique.