### PR TITLE
Fix upstream path issue and use a specific oapi-codegen version

### DIFF
--- a/gateway/gateway-controller/Makefile
+++ b/gateway/gateway-controller/Makefile
@@ -28,7 +28,7 @@ help: ## Show this help message
 
 generate: ## Generate API server code from OpenAPI spec
 	@echo "Generating API server code from OpenAPI spec..."
-	@go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@latest
+	@go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.5.1
 	@oapi-codegen --config=oapi-codegen.yaml api/openapi.yaml
 
 build: ## Build the Gateway-Controller binary


### PR DESCRIPTION
## Purpose
Fix upstream path issue and use a specific oapi-codegen version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned oapi-codegen dependency to a specific version for consistent builds.

* **Refactor**
  * Improved internal route creation logic for enhanced path handling and request routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->