### PR TITLE
Add UI for Github API Creation flow

### DIFF
--- a/portals/management-portal/src/context/CreateComponentBuildpackContext.tsx
+++ b/portals/management-portal/src/context/CreateComponentBuildpackContext.tsx
@@ -1,0 +1,94 @@
+import * as React from "react";
+
+/* ---------- Types ---------- */
+export type ProxyMetadata = {
+  name: string;
+  target?: string;
+  context: string;
+  version: string;
+  description?: string;
+  /** flips true once the user edits Context manually */
+  contextEdited?: boolean;
+};
+
+type Setter<T> =
+  | React.Dispatch<React.SetStateAction<T>>
+  | ((next: T | ((prev: T) => T)) => void);
+
+type Ctx = {
+  /** API Contract (OAS upload) flow slice */
+  contractMeta: ProxyMetadata;
+  setContractMeta: Setter<ProxyMetadata>;
+  resetContractMeta: () => void;
+
+  /** Endpoint flow slice */
+  endpointMeta: ProxyMetadata;
+  setEndpointMeta: Setter<ProxyMetadata>;
+  resetEndpointMeta: () => void;
+};
+
+const defaultMeta: ProxyMetadata = {
+  name: "",
+  target: "",
+  context: "",
+  version: "1.0.0",
+  description: "",
+  contextEdited: false,
+};
+
+/* ---------- Context ---------- */
+const CreateComponentBuildpackContext = React.createContext<Ctx | null>(null);
+
+export const CreateComponentBuildpackProvider: React.FC<
+  React.PropsWithChildren<{
+    initialContract?: Partial<ProxyMetadata>;
+    initialEndpoint?: Partial<ProxyMetadata>;
+  }>
+> = ({ children, initialContract, initialEndpoint }) => {
+  const [contractMeta, setContractMeta] = React.useState<ProxyMetadata>({
+    ...defaultMeta,
+    ...(initialContract ?? {}),
+  });
+
+  const [endpointMeta, setEndpointMeta] = React.useState<ProxyMetadata>({
+    ...defaultMeta,
+    ...(initialEndpoint ?? {}),
+  });
+
+  const resetContractMeta = React.useCallback(
+    () => setContractMeta({ ...defaultMeta }),
+    []
+  );
+  const resetEndpointMeta = React.useCallback(
+    () => setEndpointMeta({ ...defaultMeta }),
+    []
+  );
+
+  const value = React.useMemo<Ctx>(
+    () => ({
+      contractMeta,
+      setContractMeta,
+      resetContractMeta,
+      endpointMeta,
+      setEndpointMeta,
+      resetEndpointMeta,
+    }),
+    [contractMeta, endpointMeta]
+  );
+
+  return (
+    <CreateComponentBuildpackContext.Provider value={value}>
+      {children}
+    </CreateComponentBuildpackContext.Provider>
+  );
+};
+
+export const useCreateComponentBuildpackContext = () => {
+  const ctx = React.useContext(CreateComponentBuildpackContext);
+  if (!ctx) {
+    throw new Error(
+      "useCreateComponentBuildpackContext must be used within CreateComponentBuildpackProvider"
+    );
+  }
+  return ctx;
+};

--- a/portals/management-portal/src/main.tsx
+++ b/portals/management-portal/src/main.tsx
@@ -11,6 +11,7 @@ import "@fontsource/poppins/700.css";
 import { OrganizationProvider } from "./context/OrganizationContext";
 import { ProjectProvider } from "./context/ProjectContext";
 import { ApiProvider } from "./context/ApiContext";
+import { CreateComponentBuildpackProvider } from "./context/CreateComponentBuildpackContext";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
@@ -19,7 +20,9 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
         <OrganizationProvider>
           <ProjectProvider>
             <ApiProvider>
-              <App />
+              <CreateComponentBuildpackProvider>
+                <App />
+              </CreateComponentBuildpackProvider>
             </ApiProvider>
           </ProjectProvider>
         </OrganizationProvider>

--- a/portals/management-portal/src/pages/apis/CreationFlows/APIContractCreationFlow.tsx
+++ b/portals/management-portal/src/pages/apis/CreationFlows/APIContractCreationFlow.tsx
@@ -1,21 +1,10 @@
 import * as React from "react";
-import {
-  Alert,
-  Box,
-  Grid,
-  Paper,
-  Snackbar,
-  Stack,
-  Typography,
-} from "@mui/material";
-import UploadRoundedIcon from "@mui/icons-material/UploadRounded";
-import { Button } from "../../../components/src/components/Button";
-import { TextInput } from "../../../components/src/components/TextInput";
-import yaml from "js-yaml";
-import { Chip } from "../../../components/src/components/Chip";
-import { IconButton } from "../../../components/src/components/IconButton";
-import Delete from "../../../components/src/Icons/generated/Delete";
+import { Box, Stack, Typography, Tabs, Tab } from "@mui/material";
 import ArrowLeftLong from "../../../components/src/Icons/generated/ArrowLeftLong";
+import GithubCreationFlow from "./ContractCreationFlows/GithubCreationFlow";
+import UploadCreationFlow from "./ContractCreationFlows/UploadCreationFlow";
+import URLCreationFlow from "./ContractCreationFlows/URLCreationFlow";
+import { Button } from "../../../components/src/components/Button";
 
 type Props = {
   open: boolean;
@@ -46,496 +35,92 @@ type Props = {
   onClose: () => void;
 };
 
-type Step = "upload" | "details";
+type TabKey = "upload" | "github" | "url";
 
-type WizardState = {
-  name: string;
-  context: string;
-  version: string;
-  description?: string;
-  target?: string;
-};
+const APIContractCreationFlow: React.FC<Props> = ({
+  open,
+  selectedProjectId,
+  createApi,
+  onClose,
+}) => {
+  const [tab, setTab] = React.useState<TabKey>("upload");
 
-type OpenAPI = {
-  openapi?: string;
-  swagger?: string;
-  info?: { title?: string; version?: string; description?: string };
-  servers?: { url?: string }[];
-  paths?: Record<
-    string,
-    Record<
-      string,
-      {
-        summary?: string;
-        description?: string;
-        operationId?: string;
-      }
-    >
-  >;
-};
-
-const METHOD_COLORS: Record<
-  string,
-  "primary" | "success" | "warning" | "error" | "info" | "secondary"
-> = {
-  get: "info",
-  post: "success",
-  put: "warning",
-  delete: "error",
-  patch: "secondary",
-  head: "primary",
-  options: "primary",
-};
-
-const methodOrder = ["get", "post", "put", "delete", "patch", "head", "options"];
-
-function slugify(val: string) {
-  return val.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
-}
-function defaultServiceName(apiName: string) {
-  const base = apiName?.trim() || "service";
-  return `${slugify(base)}-service`;
-}
-function firstServerUrl(doc?: OpenAPI) {
-  const u = doc?.servers?.find((s) => !!s?.url)?.url?.trim();
-  return u || "";
-}
-function deriveContext(doc: OpenAPI, fallbackTitle?: string) {
-  const urlStr = doc?.servers?.[0]?.url;
-  if (urlStr) {
-    try {
-      const u = new URL(urlStr, "https://placeholder.local");
-      const p = u.pathname || "/";
-      const segs = p.split("/").filter(Boolean);
-      if (segs.length > 0) return `/${segs[0]}`;
-      return "/";
-    } catch {
-      if (urlStr.startsWith("/")) return urlStr;
-    }
-  }
-  const t = fallbackTitle ? slugify(fallbackTitle) : "api";
-  return `/${t}`;
-}
-
-const SwaggerPathList: React.FC<{ doc?: OpenAPI }> = ({ doc }) => {
-  if (!doc) return null;
-  const paths = doc.paths ?? {};
-  const ordered = Object.entries(paths).sort(([a], [b]) => a.localeCompare(b));
-  if (!ordered.length) return null;
-
-  return (
-    <Box sx={{ border: "1px solid", borderColor: "divider", borderRadius: 2, overflow: "hidden", bgcolor: "background.paper" }}>
-      <Box sx={{ px: 2, py: 1.25, borderBottom: "1px solid", borderColor: "divider", fontWeight: 700 }}>
-        Fetched OAS Definition
-      </Box>
-      <Box sx={{ maxHeight: 500, overflow: "auto" }}>
-        {ordered.map(([path, ops], i) => {
-          const opsOrdered = methodOrder
-            .filter((m) => (ops as any)[m])
-            .map((m) => [m, (ops as any)[m]!] as const);
-
-          return opsOrdered.map(([method, op], j) => (
-            <Box
-              key={`${path}-${method}`}
-              sx={{
-                px: 2,
-                py: 1.5,
-                display: "grid",
-                gridTemplateColumns: "120px 1fr",
-                alignItems: "center",
-                borderBottom: i === ordered.length - 1 && j === opsOrdered.length - 1 ? "none" : "1px solid",
-                borderColor: "divider",
-              }}
-            >
-              <Chip size="large" color={METHOD_COLORS[method] ?? "primary"} label={method.toUpperCase()} sx={{ fontWeight: 700, width: 72, justifySelf: "start" }} />
-              <Stack direction="row" spacing={1.5} alignItems="center">
-                <Typography variant="body2" sx={{ fontFamily: "monospace" }}>
-                  {path}
-                </Typography>
-                <Typography variant="body2" color="#7c7c7cff" noWrap>
-                  {op?.summary || op?.description || ""}
-                </Typography>
-              </Stack>
-            </Box>
-          ));
-        })}
-      </Box>
-    </Box>
-  );
-};
-
-const APIContractCreationFlow: React.FC<Props> = ({ open, selectedProjectId, createApi, onClose }) => {
-  const [step, setStep] = React.useState<Step>("upload");
-  const [rawSpec, setRawSpec] = React.useState<string>("");
-  const [doc, setDoc] = React.useState<OpenAPI | undefined>(undefined);
-  const [fileName, setFileName] = React.useState<string>("");
-  const [error, setError] = React.useState<string | null>(null);
-  const [creating, setCreating] = React.useState(false);
-
-  const [wizardState, setWizardState] = React.useState<WizardState>({
-    name: "",
-    context: "",
-    version: "1.0.0",
-    description: "",
-    target: "",
-  });
-
-  const [snack, setSnack] = React.useState<{ open: boolean; msg: string }>({ open: false, msg: "" });
-
-  // Always-mounted input + stable id/label wiring
-  const fileInputRef = React.useRef<HTMLInputElement>(null);
-  const inputId = React.useId();
-  const [fileKey, setFileKey] = React.useState(0);
+  const tabSx = {
+    textTransform: "capitalize",
+    color: "#2d2d2dff",
+    letterSpacing: 0.25,
+    "&.Mui-selected": {
+      color: "#2d2d2dff",
+      fontWeight: 600,
+    },
+  };
 
   React.useEffect(() => {
-    if (!open) {
-      setStep("upload");
-      setRawSpec("");
-      setDoc(undefined);
-      setFileName("");
-      setError(null);
-      setWizardState({ name: "", context: "", version: "1.0.0", description: "", target: "" });
-      if (fileInputRef.current) fileInputRef.current.value = "";
-      setFileKey((k) => k + 1);
-    }
+    if (open) setTab("upload");
   }, [open]);
-
-  const parseSpec = React.useCallback((text: string) => {
-    try {
-      const trimmed = text.trim();
-      if (!trimmed) throw new Error("Empty definition");
-      let parsed: any;
-      if (trimmed.startsWith("{")) parsed = JSON.parse(trimmed);
-      else parsed = yaml.load(text);
-      if (!parsed || typeof parsed !== "object") throw new Error("Invalid OpenAPI definition");
-      return parsed as OpenAPI;
-    } catch (e: any) {
-      throw new Error(e?.message || "Invalid OpenAPI definition");
-    }
-  }, []);
-
-  const autoFill = React.useCallback((d: OpenAPI) => {
-    const title = d?.info?.title?.trim() || "";
-    const version = d?.info?.version?.trim() || "1.0.0";
-    const description = d?.info?.description || "";
-    const targetUrl = firstServerUrl(d);
-
-    setWizardState((prev) => ({
-      ...prev,
-      name: title || prev.name || "Sample API",
-      version,
-      description,
-      context: deriveContext(d, title),
-      target: prev.target || targetUrl || "",
-    }));
-  }, []);
-
-  const handleFiles = React.useCallback(
-    async (files: FileList | null) => {
-      if (!files || !files[0]) return;
-      const f = files[0];
-      try {
-        setError(null);
-        const text = await f.text();
-        const parsed = parseSpec(text);
-        setRawSpec(text);
-        setDoc(parsed);
-        setFileName(f.name);
-        autoFill(parsed);
-      } catch (e: any) {
-        setError(e?.message || "OpenAPI Definition validation failed");
-      } finally {
-        // reset so choosing the same file again will fire onChange
-        if (fileInputRef.current) fileInputRef.current.value = "";
-        setFileKey((k) => k + 1);
-      }
-    },
-    [autoFill, parseSpec]
-  );
-
-  const onDrop = (e: React.DragEvent<HTMLDivElement>) => {
-    e.preventDefault();
-    handleFiles(e.dataTransfer.files);
-    if (fileInputRef.current) fileInputRef.current.value = "";
-    setFileKey((k) => k + 1);
-  };
-
-  const buildOperationsFromDoc = React.useCallback((d?: OpenAPI, serviceName?: string) => {
-    if (!d?.paths)
-      return [] as Array<{
-        name: string;
-        description?: string;
-        request: { method: string; path: string; ["backend-services"]: Array<{ name: string }> };
-      }>;
-
-    const ops: Array<{
-      name: string;
-      description?: string;
-      request: { method: string; path: string; ["backend-services"]: Array<{ name: string }> };
-    }> = [];
-
-    const serviceRef = serviceName ? [{ name: serviceName }] : [];
-
-    const sortedPaths = Object.keys(d.paths).sort((a, b) => a.localeCompare(b));
-    for (const path of sortedPaths) {
-      const methods = d.paths[path] || {};
-      for (const m of methodOrder) {
-        const op = (methods as any)[m];
-        if (!op) continue;
-        const opId = (op.operationId as string | undefined)?.trim();
-        const pretty =
-          opId ||
-          `${m.toUpperCase()} ${path}`
-            .replace(/[{}]/g, "")
-            .replace(/\s+/g, "_");
-        ops.push({
-          name: pretty,
-          description: op.summary || op.description || undefined,
-          request: { method: m.toUpperCase(), path, "backend-services": serviceRef },
-        });
-      }
-    }
-    return ops;
-  }, []);
-
-  const onCreate = async () => {
-    const { name, context, version, description, target } = wizardState;
-    if (!name.trim() || !context.trim() || !version.trim()) {
-      setError("Please complete all required fields.");
-      return;
-    }
-    const targetUrl = target?.trim();
-    let validTarget = true;
-    if (targetUrl) {
-      try {
-        if (/^https?:\/\//i.test(targetUrl)) new URL(targetUrl);
-      } catch {
-        validTarget = false;
-      }
-    }
-    if (targetUrl && !validTarget) {
-      setError("Target must be a valid URL (or leave it empty).");
-      return;
-    }
-
-    try {
-      setCreating(true);
-      setError(null);
-
-      const serviceName = defaultServiceName(name.trim());
-      const backendServices =
-        targetUrl
-          ? [
-              {
-                name: serviceName,
-                isDefault: true,
-                retries: 2,
-                endpoints: [{ url: targetUrl, description: "Primary backend" }],
-              },
-            ]
-          : [];
-
-      const operations = buildOperationsFromDoc(doc, serviceName);
-
-      await createApi({
-        name: name.trim(),
-        context: context.startsWith("/") ? context.trim() : `/${context.trim()}`,
-        version: version.trim(),
-        description: description?.trim() || undefined,
-        projectId: selectedProjectId,
-        contract: rawSpec,
-        backendServices,
-        operations,
-      });
-
-      setSnack({ open: true, msg: `API “${name.trim()}” created successfully.` });
-      setTimeout(() => onClose(), 1200);
-    } catch (e: any) {
-      setError(e?.message || "Failed to create API");
-    } finally {
-      setCreating(false);
-    }
-  };
-
-  const handleChange = (patch: Partial<WizardState>) => setWizardState((prev) => ({ ...prev, ...patch }));
 
   if (!open) return null;
 
   return (
     <Box>
-      {/* Hidden, always-mounted input controlled by labels */}
-      <input
-        id={inputId}
-        ref={fileInputRef}
-        key={fileKey}
-        type="file"
-        accept=".yaml,.yml,.json,.yamal"
-        style={{ display: "none" }}
-        onChange={(e) => {
-          handleFiles(e.target.files);
-          e.currentTarget.value = "";
-        }}
-      />
-
-      {/* Header */}
       <Box mb={1}>
-        <Button onClick={onClose} variant="link" startIcon={<ArrowLeftLong fontSize="small" />}>
-          Back to List
+        <Button
+          onClick={onClose}
+          variant="link"
+          startIcon={<ArrowLeftLong fontSize="small" />}
+        >
+          Back to Home
         </Button>
       </Box>
-      <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 2 }}>
+
+      <Stack
+        direction="row"
+        alignItems="center"
+        justifyContent="space-between"
+        sx={{ mb: 1 }}
+      >
         <Typography variant="h3" fontWeight={600}>
           Import API Contract
         </Typography>
       </Stack>
 
-      {step === "upload" && (
-        <Grid container spacing={2}>
-          <Grid  size={{ xs: 12, md: 6 }}>
-            <Paper
-              component="label"
-              htmlFor={inputId}
-              variant="outlined"
-              sx={{
-                p: 4,
-                borderStyle: "dashed",
-                textAlign: "center",
-                minHeight: 280,
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                position: "relative",
-                backgroundColor: "#f5f5f5ff",
-                cursor: "pointer",
-              }}
-              onDragOver={(e) => e.preventDefault()}
-              onDrop={onDrop}
-              // No programmatic click — native label→input behavior is more reliable
-            >
-              {!rawSpec ? (
-                <Stack spacing={1} alignItems="center">
-                  <Typography variant="h5" fontWeight={600}>
-                    Upload API Contract
-                  </Typography>
-                  <Typography color="#aeacacff">Drag &amp; Drop your files, click, or paste raw spec</Typography>
-                  <Button component="label" startIcon={<UploadRoundedIcon />} htmlFor={inputId}>
-                    Upload
-                  </Button>
-                </Stack>
-              ) : (
-                <Stack spacing={2} alignItems="center">
-                  <Typography variant="h6" fontWeight={700}>
-                    Uploaded file
-                  </Typography>
-                  <Stack direction="row" spacing={1} alignItems="center">
-                    <Typography color="primary">{fileName}</Typography>
-                    <IconButton
-                      size="small"
-                      color="error"
-                      onClick={() => {
-                        setRawSpec("");
-                        setDoc(undefined);
-                        setFileName("");
-                        setError(null);
-                        if (fileInputRef.current) fileInputRef.current.value = "";
-                        setFileKey((k) => k + 1);
-                      }}
-                    >
-                      <Delete fontSize="small" />
-                    </IconButton>
-                  </Stack>
-                </Stack>
-              )}
-            </Paper>
+      {/* Tabs with bottom border */}
+      <Box sx={{ borderBottom: "1px solid", borderColor: "divider", mb: 3 }}>
+        <Tabs
+          value={tab}
+          onChange={(_e, v) => setTab(v as TabKey)}
+        >
+          <Tab label="Upload" value="upload" sx={tabSx} />
+          <Tab label="GitHub" value="github" sx={tabSx} />
+          <Tab label="URL" value="url" sx={tabSx} />
+        </Tabs>
+      </Box>
 
-            <Stack direction="row" spacing={1} sx={{ mt: 2 }}>
-              <Button variant="outlined" onClick={onClose} sx={{ textTransform: "none" }}>
-                Cancel
-              </Button>
-              <Button variant="contained" disabled={!rawSpec} onClick={() => setStep("details")} sx={{ textTransform: "none" }}>
-                Next
-              </Button>
-            </Stack>
-
-            {error && (
-              <Alert severity="error" sx={{ mt: 2 }}>
-                {error}
-              </Alert>
-            )}
-          </Grid>
-
-          <Grid  size={{ xs: 12, md: 6 }}>
-            <SwaggerPathList doc={doc} />
-          </Grid>
-        </Grid>
+      {/* Child flows */}
+      {tab === "upload" && (
+        <UploadCreationFlow
+          open={open}
+          selectedProjectId={selectedProjectId}
+          createApi={createApi}
+          onClose={onClose}
+        />
       )}
-
-      {step === "details" && (
-        <Box>
-          <Grid container spacing={2}>
-            <Grid size={{ xs: 12, md: 6 }}>
-              <Paper variant="outlined" sx={{ p: 3, borderRadius: 2 }}>
-                <Stack spacing={2}>
-                  <TextInput label="Name" placeholder="Sample API" value={wizardState.name} onChange={(v: string) => handleChange({ name: v })} testId="" size="medium" />
-                  <TextInput
-                    label="Target"
-                    placeholder="https://api.example.com/v1"
-                    value={wizardState.target ?? ""}
-                    onChange={(v: string) => handleChange({ target: v })}
-                    testId=""
-                    size="medium"
-                    helperText="Base URL for your backend (used to create a default backend-service)."
-                  />
-                  <TextInput label="Context" placeholder="/sample" value={wizardState.context} onChange={(v: string) => handleChange({ context: v })} testId="" size="medium" />
-                  <TextInput label="Version" placeholder="1.0.0" value={wizardState.version} onChange={(v: string) => handleChange({ version: v })} testId="" size="medium" />
-                  <TextInput
-                    label="Description"
-                    placeholder="Optional description"
-                    value={wizardState.description ?? ""}
-                    onChange={(v: string) => handleChange({ description: v })}
-                    multiline
-                    testId=""
-                  />
-                </Stack>
-
-                <Stack direction="row" spacing={1} justifyContent="flex-end" sx={{ mt: 3 }}>
-                  <Button variant="outlined" onClick={() => setStep("upload")} sx={{ textTransform: "none" }}>
-                    Back
-                  </Button>
-                  <Button
-                    variant="contained"
-                    disabled={!wizardState.name.trim() || !wizardState.context.trim() || !wizardState.version.trim() || creating}
-                    onClick={onCreate}
-                    sx={{ textTransform: "none" }}
-                  >
-                    {creating ? "Creating..." : "Create"}
-                  </Button>
-                </Stack>
-
-                {error && (
-                  <Alert severity="error" sx={{ mt: 2 }}>
-                    {error}
-                  </Alert>
-                )}
-              </Paper>
-            </Grid>
-
-            <Grid size={{ xs: 12, md: 6 }}>
-              <SwaggerPathList doc={doc} />
-            </Grid>
-          </Grid>
-        </Box>
+      {tab === "github" && (
+        <GithubCreationFlow
+          open={open}
+          selectedProjectId={selectedProjectId}
+          // createApi={createApi}
+          onClose={onClose}
+        />
       )}
-      <Snackbar
-        open={snack.open}
-        autoHideDuration={3000}
-        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
-        onClose={() => setSnack((s) => ({ ...s, open: false }))}
-      >
-        <Alert severity="success" onClose={() => setSnack((s) => ({ ...s, open: false }))}>
-          {snack.msg}
-        </Alert>
-      </Snackbar>
+      {tab === "url" && (
+        <URLCreationFlow
+          open={open}
+          selectedProjectId={selectedProjectId}
+          createApi={createApi}
+          onClose={onClose}
+        />
+      )}
     </Box>
   );
 };

--- a/portals/management-portal/src/pages/apis/CreationFlows/ContractCreationFlows/ApiDirectoryModal.tsx
+++ b/portals/management-portal/src/pages/apis/CreationFlows/ContractCreationFlows/ApiDirectoryModal.tsx
@@ -1,0 +1,155 @@
+import * as React from "react";
+import {
+  Box,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Typography,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Divider,
+} from "@mui/material";
+import FolderOutlinedIcon from "@mui/icons-material/FolderOutlined";
+import ChevronRightRoundedIcon from "@mui/icons-material/ChevronRightRounded";
+import { TextInput } from "../../../../components/src/components/TextInput";
+import { Button } from "../../../../components/src/components/Button";
+
+type Props = {
+  open: boolean;
+  currentPath: string;
+  rootLabel: string; // e.g., "bijira-samples"
+  onCancel: () => void;
+  onContinue: (path: string) => void;
+};
+
+const ApiDirectoryModal: React.FC<Props> = ({
+  open,
+  currentPath,
+  rootLabel,
+  onCancel,
+  onContinue,
+}) => {
+  // UI only; static list
+  const [path, setPath] = React.useState(currentPath || "/");
+  const [query, setQuery] = React.useState("");
+
+  React.useEffect(() => {
+    if (open) {
+      setPath(currentPath || "/");
+      setQuery("");
+    }
+  }, [open, currentPath]);
+
+  const items = [
+    ".samples",
+    "chat-service-api",
+    "cloudmersive-currency-api",
+    "external-lib",
+    "mcp-card-promotion-server",
+    "mcp-chat-agent",
+  ];
+
+  const filtered = items.filter((n) =>
+    n.toLowerCase().includes(query.toLowerCase())
+  );
+
+  return (
+    <Dialog open={open} onClose={onCancel} maxWidth="md" fullWidth>
+      <DialogTitle sx={{ textAlign: "center", fontWeight: 700, fontSize: 28, mt: 1 }}>
+        API directory
+      </DialogTitle>
+
+      <DialogContent sx={{ pt: 1 }}>
+        {/* Current path */}
+        <TextInput
+          label=""
+          placeholder="/"
+          value={path}
+          onChange={(v: string) => setPath(v)}
+          size="medium"
+          testId=""
+          disabled
+        />
+
+        {/* Search */}
+        <Box sx={{ mt: 2 }}>
+          <TextInput
+            label=""
+            placeholder="Search Directories"
+            value={query}
+            onChange={(v: string) => setQuery(v)}
+            size="medium"
+            testId=""
+          />
+        </Box>
+
+        {/* Directory list */}
+        <Box
+          sx={{
+            mt: 2,
+            border: "1px solid",
+            borderColor: "divider",
+            borderRadius: 2,
+          }}
+        >
+          <Box
+            sx={{
+              px: 2,
+              py: 1.25,
+              borderBottom: "1px solid",
+              borderColor: "divider",
+              display: "flex",
+              alignItems: "center",
+              gap: 1,
+            }}
+          >
+            <FolderOutlinedIcon fontSize="small" />
+            <Typography variant="subtitle2" fontWeight={700}>
+              {rootLabel}
+            </Typography>
+          </Box>
+
+          <Box sx={{ maxHeight: 360, overflow: "auto" }}>
+            <List disablePadding>
+              {filtered.map((name) => (
+                <React.Fragment key={name}>
+                  <ListItem disablePadding>
+                    <ListItemButton onClick={() => setPath(`/${name}`)} sx={{ px: 2 }}>
+                      <ListItemIcon sx={{ minWidth: 32 }}>
+                        <FolderOutlinedIcon fontSize="small" />
+                      </ListItemIcon>
+                      <ListItemText
+                        primary={
+                          <Typography variant="body2" sx={{ fontSize: 14 }}>
+                            {name}
+                          </Typography>
+                        }
+                      />
+                      <ChevronRightRoundedIcon fontSize="small" />
+                    </ListItemButton>
+                  </ListItem>
+                  <Divider />
+                </React.Fragment>
+              ))}
+            </List>
+          </Box>
+        </Box>
+      </DialogContent>
+
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button variant="outlined" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button variant="contained" onClick={() => onContinue(path)}>
+          Continue
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ApiDirectoryModal;

--- a/portals/management-portal/src/pages/apis/CreationFlows/ContractCreationFlows/GithubCreationFlow.tsx
+++ b/portals/management-portal/src/pages/apis/CreationFlows/ContractCreationFlows/GithubCreationFlow.tsx
@@ -1,0 +1,271 @@
+import * as React from "react";
+import { Box, Stack, Typography, InputAdornment, Grid } from "@mui/material";
+import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
+import { Button } from "../../../../components/src/components/Button";
+import { TextInput } from "../../../../components/src/components/TextInput";
+import { Card, CardContent } from "../../../../components/src/components/Card";
+import { Select as AppSelect } from "../../../../components/src/components/Select";
+import ArrowRightLong from "../../../../components/src/Icons/generated/ArrowRightLong";
+import ApiDirectoryModal from "./ApiDirectoryModal";
+import Refresh from "../../../../components/src/Icons/generated/Refresh";
+import { IconButton } from "../../../../components/src/components/IconButton";
+import Edit from "../../../../components/src/Icons/generated/Edit";
+import CreationMetaData from "../CreationMetaData";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  selectedProjectId?: string;
+};
+
+type BranchOption = { label: string; value: string };
+type Step = "form" | "details";
+
+const GithubCreationFlow: React.FC<Props> = ({ open, onClose }) => {
+  const [repoUrl, setRepoUrl] = React.useState("");
+  const [branch, setBranch] = React.useState("main");
+  const [apiDir, setApiDir] = React.useState("/");
+  const [dirModalOpen, setDirModalOpen] = React.useState(false);
+  const [step, setStep] = React.useState<Step>("form");
+
+  React.useEffect(() => {
+    if (!open) {
+      // reset when parent closes
+      setRepoUrl("");
+      setBranch("main");
+      setApiDir("/");
+      setDirModalOpen(false);
+      setStep("form");
+    }
+  }, [open]);
+
+  if (!open) return null;
+
+  const showInitial = repoUrl.trim().length === 0;
+
+  const branchOptions: BranchOption[] = React.useMemo(
+    () => [
+      { label: "main", value: "main" },
+      { label: "develop", value: "develop" },
+      { label: "release", value: "release" },
+    ],
+    []
+  );
+
+  const selectedBranchOption = React.useMemo<BranchOption | null>(
+    () => branchOptions.find((o) => o.value === branch) ?? null,
+    [branch, branchOptions]
+  );
+
+  const handleBranchChange = (opt: BranchOption | null) => {
+    if (opt) setBranch(opt.value);
+  };
+
+  const cancelForm = () => {
+    // behave like your example "finishAndClose" from other flows:
+    setRepoUrl("");
+    setBranch("main");
+    setApiDir("/");
+    setDirModalOpen(false);
+    onClose(); // if you prefer to only reset and not close, remove this line
+  };
+
+  return (
+    <Box>
+      {/* ------------ view A: initial card ------------ */}
+      {showInitial && step === "form" && (
+        <Grid container spacing={2}>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <Card testId="github-creation-card">
+              <CardContent sx={{ p: 3 }}>
+                <TextInput
+                  label="Public Repository URL"
+                  placeholder="https://github.com/org/repo"
+                  value={repoUrl}
+                  onChange={(v: string) => setRepoUrl(v)}
+                  testId=""
+                  size="medium"
+                />
+
+                <Stack
+                  direction="row"
+                  justifyContent="space-between"
+                  alignItems="center"
+                  sx={{ mt: 2 }}
+                >
+                  <Button
+                    variant="text"
+                    onClick={() =>
+                      setRepoUrl("https://github.com/wso2/bijira-samples")
+                    }
+                    endIcon={<ArrowRightLong fontSize="small" />}
+                  >
+                    Try with Sample URL
+                  </Button>
+
+                  <Button
+                    variant="outlined"
+                    onClick={() => setRepoUrl(repoUrl.trim())}
+                    disabled={!repoUrl.trim()}
+                  >
+                    Continue
+                  </Button>
+                </Stack>
+              </CardContent>
+            </Card>
+          </Grid>
+        </Grid>
+      )}
+
+      {/* ------------ view B: form (URL/Branch/Dir) ------------ */}
+      {!showInitial && step === "form" && (
+        <Grid container spacing={2}>
+          {/* Row 1: URL | Branch */}
+          <Grid size={{ xs: 12, md: 4 }} sx={{ mt: 1 }}>
+            <TextInput
+              label="Public Repository URL"
+              placeholder="https://github.com/org/repo"
+              value={repoUrl}
+              onChange={(v: string) => setRepoUrl(v)}
+              size="medium"
+              testId=""
+              InputProps={
+                {
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      {repoUrl && (
+                        <IconButton
+                          size="small"
+                          onClick={() => setRepoUrl("")}
+                          edge="end"
+                        >
+                          <CloseRoundedIcon fontSize="small" />
+                        </IconButton>
+                      )}
+                    </InputAdornment>
+                  ),
+                } as any
+              }
+            />
+          </Grid>
+
+          <Grid size={{ xs: 12, md: 2 }}>
+            <AppSelect<BranchOption>
+              label="Branch"
+              labelId="repo-branch"
+              name="repo-branch"
+              options={branchOptions}
+              value={selectedBranchOption}
+              onChange={handleBranchChange}
+              getOptionLabel={(o) => (typeof o === "string" ? o : o.label)}
+              getOptionValue={(o) => (typeof o === "string" ? o : o.value)}
+              placeholder="Select branch"
+              testId="repo-branch-select"
+              size="medium"
+              isClearable={false}
+              actions={
+                <IconButton
+                  aria-label="refresh branches"
+                  title="Refresh branches"
+                  onClick={() => {
+                    // add refresh logic here
+                  }}
+                  size="small"
+                >
+                  <Refresh fontSize="small" />
+                </IconButton>
+              }
+            />
+          </Grid>
+
+          {/* Row 2: API directory | Edit */}
+          <Grid size={{ xs: 12 }}>
+            <Grid container spacing={2} alignItems="flex-end">
+              <Grid size={{ xs: 12, md: 6 }}>
+                <TextInput
+                  label="API directory"
+                  placeholder="/"
+                  value={apiDir}
+                  onChange={(v: string) => setApiDir(v)}
+                  size="medium"
+                  testId=""
+                  disabled
+                />
+              </Grid>
+
+              <Grid size={{ xs: 12, md: 6 }} sx={{ display: "flex" }}>
+                <Button
+                  variant="link"
+                  onClick={() => setDirModalOpen(true)}
+                  testId="edit"
+                  startIcon={<Edit fontSize="inherit" />}
+                >
+                  Edit
+                </Button>
+              </Grid>
+            </Grid>
+          </Grid>
+
+          {/* Actions row */}
+          <Grid size={{ xs: 12 }}>
+            <Stack direction="row" spacing={1} sx={{ mt: 2 }}>
+              <Button variant="outlined" onClick={cancelForm}>
+                Cancel
+              </Button>
+              <Button
+                variant="contained"
+                onClick={() => setStep("details")}
+                disabled={!repoUrl.trim()}
+              >
+                Next
+              </Button>
+            </Stack>
+          </Grid>
+        </Grid>
+      )}
+
+      {/* ------------ view C: details (CreationMetaData) ------------ */}
+      {step === "details" && (
+        <Grid container spacing={2}>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <Card testId={""}>
+              <CardContent sx={{ p: 3 }}>
+                <CreationMetaData scope="contract" title="API Details" />
+
+                <Stack
+                  direction="row"
+                  spacing={1}
+                  justifyContent="flex-end"
+                  sx={{ mt: 3 }}
+                >
+                  <Button variant="outlined" onClick={() => setStep("form")}>
+                    Back
+                  </Button>
+                  <Button variant="contained" onClick={onClose}>
+                    Create
+                  </Button>
+                </Stack>
+              </CardContent>
+            </Card>
+          </Grid>
+        </Grid>
+      )}
+
+      {/* Directory picker modal */}
+      <ApiDirectoryModal
+        open={dirModalOpen}
+        currentPath={apiDir}
+        rootLabel={
+          repoUrl ? repoUrl.split("/").filter(Boolean).pop() || "repo" : "repo"
+        }
+        onCancel={() => setDirModalOpen(false)}
+        onContinue={(newPath) => {
+          setApiDir(newPath);
+          setDirModalOpen(false);
+        }}
+      />
+    </Box>
+  );
+};
+
+export default GithubCreationFlow;

--- a/portals/management-portal/src/pages/apis/CreationFlows/ContractCreationFlows/URLCreationFlow.tsx
+++ b/portals/management-portal/src/pages/apis/CreationFlows/ContractCreationFlows/URLCreationFlow.tsx
@@ -1,0 +1,231 @@
+import * as React from "react";
+import { Box, Paper, Stack, Typography, Alert, Grid } from "@mui/material";
+import { Button } from "../../../../components/src/components/Button";
+import { Chip } from "../../../../components/src/components/Chip";
+import { TextInput } from "../../../../components/src/components/TextInput";
+import CreationMetaData from "../CreationMetaData";
+
+/* ---------- Types (UI-only) ---------- */
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  // kept for compatibility with parent, unused in UI-only version
+  selectedProjectId?: string;
+  createApi?: (..._args: any[]) => Promise<any>;
+};
+
+type Step = "url" | "details";
+
+type OpenAPI = {
+  paths?: Record<
+    string,
+    Record<
+      string,
+      { summary?: string; description?: string; operationId?: string }
+    >
+  >;
+};
+
+/* ---------- helpers for the preview list (UI-only) ---------- */
+
+const METHOD_COLORS: Record<
+  string,
+  "primary" | "success" | "warning" | "error" | "info" | "secondary"
+> = {
+  get: "info",
+  post: "success",
+  put: "warning",
+  delete: "error",
+  patch: "secondary",
+  head: "primary",
+  options: "primary",
+};
+
+const methodOrder = ["get", "post", "put", "delete", "patch", "head", "options"];
+
+const SwaggerPathList: React.FC<{ doc?: OpenAPI }> = ({ doc }) => {
+  if (!doc?.paths) return null;
+  const ordered = Object.entries(doc.paths).sort(([a], [b]) => a.localeCompare(b));
+  if (!ordered.length) return null;
+
+  return (
+    <Box
+      sx={{
+        border: "1px solid",
+        borderColor: "divider",
+        borderRadius: 2,
+        overflow: "hidden",
+        bgcolor: "background.paper",
+      }}
+    >
+      <Box
+        sx={{
+          px: 2,
+          py: 1.25,
+          borderBottom: "1px solid",
+          borderColor: "divider",
+          fontWeight: 700,
+        }}
+      >
+        Fetched OAS Definition
+      </Box>
+      <Box sx={{ maxHeight: 500, overflow: "auto" }}>
+        {ordered.flatMap(([path, ops], i) => {
+          const opsOrdered = methodOrder
+            .filter((m) => (ops as any)[m])
+            .map((m) => [m, (ops as any)[m]!] as const);
+
+          return opsOrdered.map(([method, op], j) => (
+            <Box
+              key={`${path}-${method}`}
+              sx={{
+                px: 2,
+                py: 1.5,
+                display: "grid",
+                gridTemplateColumns: "120px 1fr",
+                alignItems: "center",
+                borderBottom:
+                  i === ordered.length - 1 && j === opsOrdered.length - 1
+                    ? "none"
+                    : "1px solid",
+                borderColor: "divider",
+              }}
+            >
+              <Chip
+                size="large"
+                color={METHOD_COLORS[method] ?? "primary"}
+                label={method.toUpperCase()}
+                sx={{ fontWeight: 700, width: 72, justifySelf: "start" }}
+              />
+              <Stack direction="row" spacing={1.5} alignItems="center">
+                <Typography variant="body2" sx={{ fontFamily: "monospace" }}>
+                  {path}
+                </Typography>
+                <Typography variant="body2" color="#7c7c7cff" noWrap>
+                  {op?.summary || op?.description || ""}
+                </Typography>
+              </Stack>
+            </Box>
+          ));
+        })}
+      </Box>
+    </Box>
+  );
+};
+
+/* ---------- component (UI-only) ---------- */
+
+const URLCreationFlow: React.FC<Props> = ({ open, onClose }) => {
+  const [step, setStep] = React.useState<Step>("url");
+  const [specUrl, setSpecUrl] = React.useState<string>("");
+
+  // purely for preview demo; in UI-only we can show nothing or a stub
+  const [doc] = React.useState<OpenAPI | undefined>(undefined);
+  const [error] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (open) {
+      setStep("url");
+      setSpecUrl("");
+    }
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <Box>
+      {step === "url" && (
+        <Grid container spacing={2}>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <Paper variant="outlined" sx={{ p: 3, borderRadius: 2 }}>
+              <Typography variant="subtitle2" sx={{ mb: 1 }}>
+                Public Specification URL
+              </Typography>
+              <TextInput
+                label=""
+                placeholder="https://example.com/openapi.yaml"
+                value={specUrl}
+                onChange={(v: string) => setSpecUrl(v)}
+                testId=""
+                size="medium"
+              />
+
+              <Stack direction="row" spacing={1} sx={{ mt: 2 }}>
+                <Button
+                  variant="text"
+                  onClick={() =>
+                    setSpecUrl(
+                      "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.0/petstore.yaml"
+                    )
+                  }
+                >
+                  Try with Sample URL
+                </Button>
+                <Box flex={1} />
+                <Button
+                  variant="outlined"
+                  onClick={() => setStep("details")} // UI-only: just go to next step
+                  disabled={!specUrl.trim()}
+                >
+                  Fetch &amp; Preview
+                </Button>
+              </Stack>
+
+              {error && (
+                <Alert severity="error" sx={{ mt: 2 }}>
+                  {error}
+                </Alert>
+              )}
+            </Paper>
+          </Grid>
+
+          <Grid size={{ xs: 12, md: 6 }}>
+            <Paper
+              variant="outlined"
+              sx={{ p: 3, borderRadius: 2, color: "text.secondary" }}
+            >
+              <Typography variant="body2">
+                Enter a direct URL to an OpenAPI/Swagger document (YAML or JSON).
+                We’ll fetch and preview it here.
+              </Typography>
+            </Paper>
+          </Grid>
+        </Grid>
+      )}
+
+      {step === "details" && (
+        <Grid container spacing={2}>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <Paper variant="outlined" sx={{ p: 3, borderRadius: 2 }}>
+              <CreationMetaData scope="contract" title="API Details" />
+
+              <Stack
+                direction="row"
+                spacing={1}
+                justifyContent="flex-end"
+                sx={{ mt: 3 }}
+              >
+                <Button variant="outlined" onClick={() => setStep("url")}>
+                  Back
+                </Button>
+                <Button
+                  variant="contained"
+                  onClick={onClose} // UI-only: close or do nothing
+                >
+                  Create
+                </Button>
+              </Stack>
+            </Paper>
+          </Grid>
+
+          <Grid size={{ xs: 12, md: 6 }}>
+            {/* In UI-only mode we have no parsed doc; leave empty or pass a stub */}
+            <SwaggerPathList doc={doc} />
+          </Grid>
+        </Grid>
+      )}
+    </Box>
+  );
+};
+
+export default URLCreationFlow;

--- a/portals/management-portal/src/pages/apis/CreationFlows/ContractCreationFlows/UploadCreationFlow.tsx
+++ b/portals/management-portal/src/pages/apis/CreationFlows/ContractCreationFlows/UploadCreationFlow.tsx
@@ -1,0 +1,497 @@
+import * as React from "react";
+import { Alert, Box, Grid, Paper, Stack, Typography } from "@mui/material";
+import UploadRoundedIcon from "@mui/icons-material/UploadRounded";
+import { Button } from "../../../../components/src/components/Button";
+import yaml from "js-yaml";
+import { Chip } from "../../../../components/src/components/Chip";
+import { IconButton } from "../../../../components/src/components/IconButton";
+import Delete from "../../../../components/src/Icons/generated/Delete";
+import CreationMetaData from "../CreationMetaData";
+import {
+  useCreateComponentBuildpackContext,
+} from "../../../../context/CreateComponentBuildpackContext";
+
+/* ---------- Types ---------- */
+type Props = {
+  open: boolean;
+  selectedProjectId: string;
+  createApi: (payload: {
+    name: string;
+    context: string;
+    version: string;
+    description?: string;
+    projectId: string;
+    contract?: string;
+    backendServices?: Array<{
+      name: string;
+      isDefault?: boolean;
+      endpoints: Array<{ url: string; description?: string }>;
+      retries?: number;
+    }>;
+    operations?: Array<{
+      name: string;
+      description?: string;
+      request: {
+        method: string;
+        path: string;
+        ["backend-services"]?: Array<{ name: string }>;
+      };
+    }>;
+  }) => Promise<any>;
+  onClose: () => void;
+};
+
+type Step = "upload" | "details";
+
+type OpenAPI = {
+  openapi?: string;
+  swagger?: string;
+  info?: { title?: string; version?: string; description?: string };
+  servers?: { url?: string }[];
+  paths?: Record<
+    string,
+    Record<
+      string,
+      { summary?: string; description?: string; operationId?: string }
+    >
+  >;
+};
+
+/* ---------- helpers ---------- */
+
+const METHOD_COLORS: Record<
+  string,
+  "primary" | "success" | "warning" | "error" | "info" | "secondary"
+> = {
+  get: "info",
+  post: "success",
+  put: "warning",
+  delete: "error",
+  patch: "secondary",
+  head: "primary",
+  options: "primary",
+};
+
+const methodOrder = ["get", "post", "put", "delete", "patch", "head", "options"];
+
+function slugify(val: string) {
+  return val.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+function defaultServiceName(apiName: string) {
+  const base = apiName?.trim() || "service";
+  return `${slugify(base)}-service`;
+}
+function firstServerUrl(doc?: OpenAPI) {
+  const u = doc?.servers?.find((s) => !!s?.url)?.url?.trim();
+  return u || "";
+}
+function deriveContext(doc: OpenAPI, fallbackTitle?: string) {
+  const urlStr = doc?.servers?.[0]?.url;
+  if (urlStr) {
+    try {
+      const u = new URL(urlStr, "https://placeholder.local");
+      const p = u.pathname || "/";
+      const segs = p.split("/").filter(Boolean);
+      if (segs.length > 0) return `/${segs[0]}`;
+      return "/";
+    } catch {
+      if (urlStr.startsWith("/")) return urlStr;
+    }
+  }
+  const t = fallbackTitle ? slugify(fallbackTitle) : "api";
+  return `/${t}`;
+}
+
+const SwaggerPathList: React.FC<{ doc?: OpenAPI }> = ({ doc }) => {
+  if (!doc) return null;
+  const paths = doc.paths ?? {};
+  const ordered = Object.entries(paths).sort(([a], [b]) => a.localeCompare(b));
+  if (!ordered.length) return null;
+
+  return (
+    <Box sx={{ border: "1px solid", borderColor: "divider", borderRadius: 2, overflow: "hidden", bgcolor: "background.paper" }}>
+      <Box sx={{ px: 2, py: 1.25, borderBottom: "1px solid", borderColor: "divider", fontWeight: 700 }}>
+        Fetched OAS Definition
+      </Box>
+      <Box sx={{ maxHeight: 500, overflow: "auto" }}>
+        {ordered.flatMap(([path, ops], i) => {
+          const opsOrdered = methodOrder
+            .filter((m) => (ops as any)[m])
+            .map((m) => [m, (ops as any)[m]!] as const);
+
+          return opsOrdered.map(([method, op], j) => (
+            <Box
+              key={`${path}-${method}`}
+              sx={{
+                px: 2,
+                py: 1.5,
+                display: "grid",
+                gridTemplateColumns: "120px 1fr",
+                alignItems: "center",
+                borderBottom: i === ordered.length - 1 && j === opsOrdered.length - 1 ? "none" : "1px solid",
+                borderColor: "divider",
+              }}
+            >
+              <Chip size="large" color={METHOD_COLORS[method] ?? "primary"} label={method.toUpperCase()} sx={{ fontWeight: 700, width: 72, justifySelf: "start" }} />
+              <Stack direction="row" spacing={1.5} alignItems="center">
+                <Typography variant="body2" sx={{ fontFamily: "monospace" }}>
+                  {path}
+                </Typography>
+                <Typography variant="body2" color="#7c7c7cff" noWrap>
+                  {op?.summary || op?.description || ""}
+                </Typography>
+              </Stack>
+            </Box>
+          ));
+        })}
+      </Box>
+    </Box>
+  );
+};
+
+/* ---------- component ---------- */
+
+const UploadCreationFlow: React.FC<Props> = ({ open, selectedProjectId, createApi, onClose }) => {
+  const [step, setStep] = React.useState<Step>("upload");
+  const [rawSpec, setRawSpec] = React.useState<string>("");
+  const [doc, setDoc] = React.useState<OpenAPI | undefined>(undefined);
+  const [fileName, setFileName] = React.useState<string>("");
+  const [error, setError] = React.useState<string | null>(null);
+  const [creating, setCreating] = React.useState(false);
+
+  const { contractMeta, setContractMeta, resetContractMeta } = useCreateComponentBuildpackContext();
+
+  // Always-mounted input + stable id/label wiring
+  const fileInputRef = React.useRef<HTMLInputElement>(null);
+  const inputId = React.useId();
+  const [fileKey, setFileKey] = React.useState(0);
+
+  React.useEffect(() => {
+    if (open) {
+      resetContractMeta();
+      setStep("upload");
+      setRawSpec("");
+      setDoc(undefined);
+      setFileName("");
+      setError(null);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      setFileKey((k) => k + 1);
+    }
+  }, [open, resetContractMeta]);
+
+  const parseSpec = React.useCallback((text: string) => {
+    try {
+      const trimmed = text.trim();
+      if (!trimmed) throw new Error("Empty definition");
+      let parsed: any;
+      if (trimmed.startsWith("{")) parsed = JSON.parse(trimmed);
+      else parsed = yaml.load(text);
+      if (!parsed || typeof parsed !== "object") throw new Error("Invalid OpenAPI definition");
+      return parsed as OpenAPI;
+    } catch (e: any) {
+      throw new Error(e?.message || "Invalid OpenAPI definition");
+    }
+  }, []);
+
+  const autoFill = React.useCallback((d: OpenAPI) => {
+    const title = d?.info?.title?.trim() || "";
+    const version = d?.info?.version?.trim() || "1.0.0";
+    const description = d?.info?.description || "";
+    const targetUrl = firstServerUrl(d);
+
+    setContractMeta((prev: any) => ({
+      ...prev,
+      name: title || prev?.name || "Sample API",
+      version,
+      description,
+      context: deriveContext(d, title),
+      target: prev?.target || targetUrl || "",
+    }));
+  }, [setContractMeta]);
+
+  const handleFiles = React.useCallback(
+    async (files: FileList | null) => {
+      if (!files || !files[0]) return;
+      const f = files[0];
+      try {
+        setError(null);
+        const text = await f.text();
+        const parsed = parseSpec(text);
+        setRawSpec(text);
+        setDoc(parsed);
+        setFileName(f.name);
+        autoFill(parsed);
+      } catch (e: any) {
+        setError(e?.message || "OpenAPI Definition validation failed");
+      } finally {
+        if (fileInputRef.current) fileInputRef.current.value = "";
+        setFileKey((k) => k + 1);
+      }
+    },
+    [autoFill, parseSpec]
+  );
+
+  const onDrop = (e: React.DragEvent<HTMLLabelElement>) => {
+    e.preventDefault();
+    handleFiles(e.dataTransfer.files);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+    setFileKey((k) => k + 1);
+  };
+
+  const buildOperationsFromDoc = React.useCallback((d?: OpenAPI, serviceName?: string) => {
+    if (!d?.paths)
+      return [] as Array<{
+        name: string;
+        description?: string;
+        request: { method: string; path: string; ["backend-services"]: Array<{ name: string }> };
+      }>;
+
+    const ops: Array<{
+      name: string;
+      description?: string;
+      request: { method: string; path: string; ["backend-services"]: Array<{ name: string }> };
+    }> = [];
+
+    const serviceRef = serviceName ? [{ name: serviceName }] : [];
+
+    const sortedPaths = Object.keys(d.paths).sort((a, b) => a.localeCompare(b));
+    for (const path of sortedPaths) {
+      const methods = d.paths[path] || {};
+      for (const m of methodOrder) {
+        const op = (methods as any)[m];
+        if (!op) continue;
+        const opId = (op.operationId as string | undefined)?.trim();
+        const pretty =
+          opId ||
+          `${m.toUpperCase()} ${path}`.replace(/[{}]/g, "").replace(/\s+/g, "_");
+        ops.push({
+          name: pretty,
+          description: op.summary || op.description || undefined,
+          request: { method: m.toUpperCase(), path, "backend-services": serviceRef },
+        });
+      }
+    }
+    return ops;
+  }, []);
+
+  const finishAndClose = React.useCallback(() => {
+    // clean up this flow slice so next open starts fresh
+    resetContractMeta();
+    setStep("upload");
+    setRawSpec("");
+    setDoc(undefined);
+    setFileName("");
+    setError(null);
+    onClose(); // hand back to list view
+  }, [onClose, resetContractMeta]);
+
+  const onCreate = async () => {
+    const name = (contractMeta?.name || "").trim();
+    const context = (contractMeta?.context || "").trim();
+    const version = (contractMeta?.version || "").trim();
+    const description = (contractMeta?.description || "").trim() || undefined;
+    const target = (contractMeta?.target || "").trim();
+
+    if (!name || !context || !version) {
+      setError("Please complete all required fields.");
+      return;
+    }
+    if (target) {
+      try {
+        if (/^https?:\/\//i.test(target)) new URL(target);
+      } catch {
+        setError("Target must be a valid URL (or leave it empty).");
+        return;
+      }
+    }
+
+    try {
+      setCreating(true);
+      setError(null);
+
+      const serviceName = defaultServiceName(name);
+      const backendServices =
+        target
+          ? [
+              {
+                name: serviceName,
+                isDefault: true,
+                retries: 2,
+                endpoints: [{ url: target, description: "Primary backend" }],
+              },
+            ]
+          : [];
+
+      const operations = buildOperationsFromDoc(doc, serviceName);
+
+      await createApi({
+        name,
+        context: context.startsWith("/") ? context : `/${context}`,
+        version,
+        description,
+        projectId: selectedProjectId,
+        contract: rawSpec,
+        backendServices,
+        operations,
+      });
+
+      // success → close to list immediately
+      finishAndClose();
+    } catch (e: any) {
+      setError(e?.message || "Failed to create API");
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <Box>
+      {/* Hidden, always-mounted input controlled by labels */}
+      <input
+        id={inputId}
+        ref={fileInputRef}
+        key={fileKey}
+        type="file"
+        accept=".yaml,.yml,.json,.yamal"
+        style={{ display: "none" }}
+        onChange={(e) => {
+          handleFiles(e.target.files);
+          e.currentTarget.value = "";
+        }}
+      />
+
+      {step === "upload" && (
+        <Grid container spacing={2}>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <Box
+              component="label"
+              htmlFor={inputId}
+              onDragOver={(e) => e.preventDefault()}
+              onDrop={onDrop}
+              sx={{ display: "block", cursor: "pointer" }}
+            >
+              <Paper
+                variant="outlined"
+                sx={{
+                  p: 4,
+                  borderStyle: "dashed",
+                  textAlign: "center",
+                  minHeight: 280,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  position: "relative",
+                  backgroundColor: "#f5f5f5ff",
+                }}
+              >
+                {!rawSpec ? (
+                  <Stack spacing={1} alignItems="center">
+                    <Typography variant="h5" fontWeight={600}>
+                      Upload API Contract
+                    </Typography>
+                    <Typography color="#aeacacff">
+                      Drag &amp; Drop your files, click, or paste raw spec
+                    </Typography>
+                    <Button component="label" startIcon={<UploadRoundedIcon />} htmlFor={inputId}>
+                      Upload
+                    </Button>
+                  </Stack>
+                ) : (
+                  <Stack spacing={2} alignItems="center">
+                    <Typography variant="h6" fontWeight={700}>
+                      Uploaded file
+                    </Typography>
+                    <Stack direction="row" spacing={1} alignItems="center">
+                      <Typography color="primary">{fileName}</Typography>
+                      <IconButton
+                        size="small"
+                        color="error"
+                        onClick={() => {
+                          setRawSpec("");
+                          setDoc(undefined);
+                          setFileName("");
+                          setError(null);
+                          if (fileInputRef.current) fileInputRef.current.value = "";
+                          setFileKey((k) => k + 1);
+                        }}
+                      >
+                        <Delete fontSize="small" />
+                      </IconButton>
+                    </Stack>
+                  </Stack>
+                )}
+              </Paper>
+            </Box>
+
+            <Stack direction="row" spacing={1} sx={{ mt: 2 }}>
+              <Button variant="outlined" onClick={finishAndClose} sx={{ textTransform: "none" }}>
+                Cancel
+              </Button>
+              <Button
+                variant="contained"
+                disabled={!rawSpec}
+                onClick={() => setStep("details")}
+                sx={{ textTransform: "none" }}
+              >
+                Next
+              </Button>
+            </Stack>
+
+            {error && (
+              <Alert severity="error" sx={{ mt: 2 }}>
+                {error}
+              </Alert>
+            )}
+          </Grid>
+
+          <Grid size={{ xs: 12, md: 6 }}>
+            <SwaggerPathList doc={doc} />
+          </Grid>
+        </Grid>
+      )}
+
+      {step === "details" && (
+        <Box>
+          <Grid container spacing={2}>
+            <Grid size={{ xs: 12, md: 6 }}>
+              <Paper variant="outlined" sx={{ p: 3, borderRadius: 2 }}>
+                <CreationMetaData scope="contract" title="API Details" />
+                <Stack direction="row" spacing={1} justifyContent="flex-end" sx={{ mt: 3 }}>
+                  <Button variant="outlined" onClick={() => setStep("upload")} sx={{ textTransform: "none" }}>
+                    Back
+                  </Button>
+                  <Button
+                    variant="contained"
+                    disabled={
+                      creating ||
+                      !(contractMeta?.name || "").trim() ||
+                      !(contractMeta?.context || "").trim() ||
+                      !(contractMeta?.version || "").trim()
+                    }
+                    onClick={onCreate}
+                    sx={{ textTransform: "none" }}
+                  >
+                    {creating ? "Creating..." : "Create"}
+                  </Button>
+                </Stack>
+
+                {error && (
+                  <Alert severity="error" sx={{ mt: 2 }}>
+                    {error}
+                  </Alert>
+                )}
+              </Paper>
+            </Grid>
+
+            <Grid size={{ xs: 12, md: 6 }}>
+              <SwaggerPathList doc={doc} />
+            </Grid>
+          </Grid>
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default UploadCreationFlow;
+

--- a/portals/management-portal/src/pages/apis/CreationFlows/CreationMetaData.tsx
+++ b/portals/management-portal/src/pages/apis/CreationFlows/CreationMetaData.tsx
@@ -1,0 +1,133 @@
+import * as React from "react";
+import { Stack, Typography } from "@mui/material";
+
+import {
+  useCreateComponentBuildpackContext,
+  type ProxyMetadata,
+} from "../../../context/CreateComponentBuildpackContext";
+import { TextInput } from "../../../components/src/components/TextInput";
+
+const slugify = (val: string) =>
+  val.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+
+type Scope = "contract" | "endpoint";
+
+type Props = {
+  /**
+   * Which slice of context to use.
+   * Ignored if you pass value/onChange and use it as a controlled form.
+   */
+  scope: Scope;
+
+  /** Optional controlled usage (overrides context). */
+  value?: ProxyMetadata;
+  onChange?: (next: ProxyMetadata) => void;
+
+  readOnlyFields?: Partial<Record<keyof ProxyMetadata, boolean>>;
+  title?: string;
+};
+
+const CreationMetaData: React.FC<Props> = ({
+  scope,
+  value,
+  onChange,
+  readOnlyFields,
+  title,
+}) => {
+  const usingContext = !value && !onChange;
+  const ctx = useCreateComponentBuildpackContext();
+
+  const meta =
+    value ??
+    (scope === "contract" ? ctx.contractMeta : ctx.endpointMeta) ?? {
+      name: "",
+      target: "",
+      context: "",
+      version: "1.0.0",
+      description: "",
+      contextEdited: false,
+    };
+
+  const setMeta =
+    onChange ??
+    (scope === "contract" ? ctx.setContractMeta : ctx.setEndpointMeta);
+
+  const change = (patch: Partial<ProxyMetadata>) =>
+    setMeta({ ...meta, ...patch });
+
+  const handleNameChange = (v: string) => {
+    if (!meta.contextEdited) {
+      const slug = slugify(v);
+      change({ name: v, context: slug ? `/${slug}` : "" });
+    } else {
+      change({ name: v });
+    }
+  };
+
+  const handleContextChange = (v: string) => {
+    change({ context: v, contextEdited: true });
+  };
+
+  return (
+    <Stack spacing={2}>
+      {title ? (
+        <Typography variant="subtitle2" sx={{ mb: 0.25 }}>
+          {title}
+        </Typography>
+      ) : null}
+
+      <TextInput
+        label="Name"
+        placeholder="Sample API"
+        value={meta.name || ""}
+        onChange={(v: string) => handleNameChange(v)}
+        testId=""
+        size="medium"
+        disabled={!!readOnlyFields?.name}
+      />
+
+      <TextInput
+        label="Target"
+        placeholder="https://api.example.com/v1"
+        value={meta.target ?? ""}
+        onChange={(v: string) => change({ target: v })}
+        testId=""
+        size="medium"
+        helperText="Base URL for your backend (used to create a default backend-service)."
+        disabled={!!readOnlyFields?.target}
+      />
+
+      <TextInput
+        label="Context"
+        placeholder="/sample"
+        value={meta.context || ""}
+        onChange={(v: string) => handleContextChange(v)}
+        testId=""
+        size="medium"
+        disabled={!!readOnlyFields?.context}
+      />
+
+      <TextInput
+        label="Version"
+        placeholder="1.0.0"
+        value={meta.version || ""}
+        onChange={(v: string) => change({ version: v })}
+        testId=""
+        size="medium"
+        disabled={!!readOnlyFields?.version}
+      />
+
+      <TextInput
+        label="Description"
+        placeholder="Optional description"
+        value={meta.description ?? ""}
+        onChange={(v: string) => change({ description: v })}
+        multiline
+        testId=""
+        disabled={!!readOnlyFields?.description}
+      />
+    </Stack>
+  );
+};
+
+export default CreationMetaData;


### PR DESCRIPTION
This pull request introduces a new context provider for managing API creation flows in the management portal, and adds two new UI-only creation flow components for importing APIs via GitHub or a public URL. It also includes a reusable modal component for selecting API directories within a repository. The changes are primarily focused on improving the modularity and user experience of the API onboarding process.

Issue: https://github.com/wso2/api-platform/issues/133


https://github.com/user-attachments/assets/14361e7a-4df8-4f6c-b3ae-09f357fd3656



**API Creation Context and Integration:**

* Added `CreateComponentBuildpackContext.tsx`, which defines a React context and provider for managing API contract and endpoint metadata throughout the creation flows. This context is now integrated into the main application provider tree to enable state sharing across creation flow components. [[1]](diffhunk://#diff-342a0a7e286ce80d51ff7b9a5024d43a40d57bb17e6f38f95a7a0ccd1ef8c887R1-R94) [[2]](diffhunk://#diff-57a862a6c5e050accf569f551d397e5d4eb0c5f59716a3f92f6f87215de0c747R14) [[3]](diffhunk://#diff-57a862a6c5e050accf569f551d397e5d4eb0c5f59716a3f92f6f87215de0c747R23-R25)

**New Creation Flow Components (UI-only):**

* Added `GithubCreationFlow.tsx`, a UI-only component for onboarding APIs from a GitHub repository. It includes steps for entering repo details, selecting a branch, picking an API directory (with modal), and entering API metadata.
* Added `URLCreationFlow.tsx`, a UI-only component for onboarding APIs by providing a public OpenAPI/Swagger specification URL. It features a two-step process: entering the spec URL and previewing the (stubbed) API definition, then entering API metadata.

**Reusable Directory Selection Modal:**

* Added `ApiDirectoryModal.tsx`, a reusable modal for selecting directories within a repository, used by the GitHub creation flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced tab-based API creation with three methods: file upload, GitHub repository, and direct URL input.
  * Added directory picker for selecting API specification locations in GitHub flow.
  * Enhanced metadata form with intelligent context slug generation from API names.

* **Refactor**
  * Reorganized API creation flow from monolithic design to modular, tab-based architecture.
  * Centralized metadata management using a new context system for streamlined state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->