### PR TITLE
Set admin as default provider in DP to CP flow

### DIFF
--- a/platform-api/src/internal/service/gateway_internal.go
+++ b/platform-api/src/internal/service/gateway_internal.go
@@ -172,6 +172,7 @@ func (s *GatewayInternalAPIService) CreateGatewayAPIDeployment(apiID, orgID, gat
 			Version:          notification.Configuration.Data.Version,
 			ProjectID:        projectID,
 			OrganizationID:   orgID,
+			Provider:         "admin", // Default provider
 			LifeCycleStatus:  "CREATED",
 			Type:             "HTTP",
 			Transport:        []string{"http", "https"},


### PR DESCRIPTION
## Purpose
The provider of an API is an required parameter when publishing to dev portal.

## Approach
Set admin as default provider of an API in DP to CP flow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Gateway deployments now initialize with a default provider during creation, ensuring consistent configuration for new API instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->