### PR TITLE
[CLI] Add the initial implementation of the CLI tool

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,30 @@
+# API Platform Command Line Interface Tool
+
+## Development
+
+### Prerequisites
+
+- Go 1.25.x
+- Make
+
+### Building from source
+
+```bash
+# Generate the ctl executable for your OS
+make build
+```
+
+```bash
+# Generate executables for Linux, MacOS, and Windows in both amd64 and arm64
+make build-all
+```
+
+```bash
+# Run tests
+make test
+```
+
+```bash
+# Clean the build directory
+make clean
+```

--- a/cli/src/Makefile
+++ b/cli/src/Makefile
@@ -1,0 +1,116 @@
+# --------------------------------------------------------------------
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# --------------------------------------------------------------------
+
+# Makefile for fusionctl CLI
+
+# Binary name
+BINARY_NAME=fusionctl
+
+# Go parameters
+GOCMD=go
+GOBUILD=$(GOCMD) build
+GOCLEAN=$(GOCMD) clean
+GOTEST=$(GOCMD) test
+GOGET=$(GOCMD) get
+GOMOD=$(GOCMD) mod
+
+# Build directory
+BUILD_DIR=build
+
+# Version information
+VERSION?=0.0.1
+BUILD_TIME=$(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
+
+# Linker flags
+LDFLAGS=-ldflags "-X github.com/wso2/api-platform/cli/cmd.Version=$(VERSION) -X github.com/wso2/api-platform/cli/cmd.BuildTime=$(BUILD_TIME)"
+
+.PHONY: all build clean test deps help install build-all build-macos build-linux build-windows
+
+all: clean build
+
+## build: Build the binary for current platform
+build:
+	@echo "Building $(BINARY_NAME)..."
+	@mkdir -p $(BUILD_DIR)
+	$(GOBUILD) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME) main.go
+	@echo "Build complete: $(BUILD_DIR)/$(BINARY_NAME)"
+
+## build-all: Build binaries for all platforms (macOS, Linux, Windows)
+build-all: build-macos build-linux build-windows
+	@echo "All platform builds complete"
+
+## build-macos: Build for macOS (Intel and Apple Silicon)
+build-macos:
+	@echo "Building for macOS..."
+	@mkdir -p $(BUILD_DIR)
+	GOOS=darwin GOARCH=amd64 $(GOBUILD) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-darwin-amd64 main.go
+	GOOS=darwin GOARCH=arm64 $(GOBUILD) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-darwin-arm64 main.go
+	@echo "macOS builds complete"
+
+## build-linux: Build for Linux (amd64 and arm64)
+build-linux:
+	@echo "Building for Linux..."
+	@mkdir -p $(BUILD_DIR)
+	GOOS=linux GOARCH=amd64 $(GOBUILD) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-linux-amd64 main.go
+	GOOS=linux GOARCH=arm64 $(GOBUILD) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-linux-arm64 main.go
+	@echo "Linux builds complete"
+
+## build-windows: Build for Windows (amd64 and arm64)
+build-windows:
+	@echo "Building for Windows..."
+	@mkdir -p $(BUILD_DIR)
+	GOOS=windows GOARCH=amd64 $(GOBUILD) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-windows-amd64.exe main.go
+	GOOS=windows GOARCH=arm64 $(GOBUILD) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-windows-arm64.exe main.go
+	@echo "Windows builds complete"
+
+## clean: Clean build files
+clean:
+	@echo "Cleaning..."
+	$(GOCLEAN)
+	@rm -rf $(BUILD_DIR)
+	@echo "Clean complete"
+
+## test: Run tests
+test:
+	@echo "Running tests..."
+	$(GOTEST) -v ./...
+
+## deps: Download dependencies
+deps:
+	@echo "Downloading dependencies..."
+	$(GOGET) -v ./...
+	$(GOMOD) tidy
+	@echo "Dependencies downloaded"
+
+## install: Install the binary to $GOPATH/bin
+install: build
+	@echo "Installing $(BINARY_NAME)..."
+	@cp $(BUILD_DIR)/$(BINARY_NAME) $(GOPATH)/bin/$(BINARY_NAME)
+	@echo "Installed to $(GOPATH)/bin/$(BINARY_NAME)"
+
+## run: Build and run the binary
+run: build
+	@echo "Running $(BINARY_NAME)..."
+	@$(BUILD_DIR)/$(BINARY_NAME)
+
+## help: Display this help message
+help:
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Targets:"
+	@grep -E '^## ' $(MAKEFILE_LIST) | sed 's/## /  /'

--- a/cli/src/cmd/constants.go
+++ b/cli/src/cmd/constants.go
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cmd
+
+const CliName = "fusionctl"

--- a/cli/src/cmd/gateway.go
+++ b/cli/src/cmd/gateway.go
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cmd
+
+import "github.com/spf13/cobra"
+
+const (
+	GatewayCmdLiteral = "gateway"
+	GatewayCmdExample = `# Add new API in the gateway` + "\n" + CliName + ` ` + GatewayCmdLiteral + ` add api [flags]` + "\n\n" +
+		`# Generate MCP configuration` + "\n" + CliName + ` ` + GatewayCmdLiteral + ` ` + GenCmdLiteral + ` mcp [flags]`
+)
+
+var gatewayCmd = &cobra.Command{
+	Use:     GatewayCmdLiteral,
+	Short:   "Execute API Platform Gateway operations",
+	Long:    "This command allows you to execute various operations related to the WSO2 API Platform Gateway.",
+	Example: GatewayCmdExample,
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(gatewayCmd)
+}

--- a/cli/src/cmd/generate.go
+++ b/cli/src/cmd/generate.go
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+const GenCmdLiteral = "generate"
+const GenCmdExample = `# Generate MCP configuration` + "\n" +
+	CliName + ` ` + GatewayCmdLiteral + ` ` + GenCmdLiteral + ` mcp`
+
+var genCmd = &cobra.Command{
+	Use:     GenCmdLiteral,
+	Aliases: []string{"gen"},
+	Short:   "Generate configuration",
+	Long:    "Generate a configuration which can be deployed in the WSO2 API Platform Gateway",
+	Example: GenCmdExample,
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+}
+
+func init() {
+	gatewayCmd.AddCommand(genCmd)
+}

--- a/cli/src/cmd/mcp.go
+++ b/cli/src/cmd/mcp.go
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/wso2/api-platform/cli/utils"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	GenMcpCmdLiteral = "mcp"
+	GenMcpCmdExample = `# Generate MCP configuration` + "\n" + CliName + ` ` + GenCmdLiteral +
+		` ` + GenMcpCmdLiteral + ` -s http://localhost:3031/mcp`
+
+	MethodInitialized   = "notifications/initialized"
+	MethodToolsList     = "tools/list"
+	MethodPromptsList   = "prompts/list"
+	MethodResourcesList = "resources/list"
+)
+
+var mcpServerURL string
+var outputDirectory string
+
+var genMcpCmd = &cobra.Command{
+	Use:     GenMcpCmdLiteral,
+	Short:   "Generate MCP configuration",
+	Long:    "Generate an MCP configuration which can be deployed in the WSO2 API Platform Gateway.",
+	Example: GenMcpCmdExample,
+	Run: func(cmd *cobra.Command, args []string) {
+		generateMCPConfiguration(mcpServerURL, outputDirectory)
+	},
+}
+
+func init() {
+	genCmd.AddCommand(genMcpCmd)
+	cwd, err := os.Getwd()
+	if err != nil {
+		cwd = "."
+	}
+	genMcpCmd.Flags().StringVarP(&mcpServerURL, "server", "s", "http://localhost:3001/mcp", "MCP server URL")
+	genMcpCmd.Flags().StringVarP(&outputDirectory, "output", "o", cwd, "Output directory for generated configuration")
+}
+
+// generateMCPConfiguration handles the MCP configuration generation process
+func generateMCPConfiguration(url string, outputDir string) {
+	fmt.Printf("Generating MCP configuration for server: %s\n", url)
+
+	// Step 1: initialize
+	fmt.Println("→ Sending initialize...")
+	sessionID, err := utils.InitializeMCPServer(url)
+	if err != nil {
+		fmt.Println("ERROR: Failed to initialize MCP server:", err)
+		return
+	}
+	fmt.Println("---------------------------------------------------")
+
+	// Step 2: notifications/initialized
+	fmt.Println("→ Sending notifications/initialized...")
+	notifyReq := utils.JsonRPCRequest{
+		JSONRPC: utils.JsonRpcVersion,
+		Method:  MethodInitialized,
+	}
+	_, err = utils.PostJSONRPCWithSession(url, notifyReq, sessionID)
+	if err != nil {
+		fmt.Println("ERROR: Failed to send notification:", err)
+		return
+	}
+	fmt.Println("---------------------------------------------------")
+
+	// Step 3: tools/list
+	fmt.Println("→ Sending tools/list...")
+	toolsReq := utils.JsonRPCRequest{
+		JSONRPC: utils.JsonRpcVersion,
+		ID:      2,
+		Method:  MethodToolsList,
+	}
+	toolsResp, err := utils.PostJSONRPCWithSession(url, toolsReq, sessionID)
+	if err != nil {
+		fmt.Println("ERROR: Failed to get tools:", err)
+		return
+	}
+	var toolsResult utils.ToolsResult
+	if err := json.Unmarshal(toolsResp, &toolsResult); err != nil {
+		fmt.Println("ERROR: Failed to parse tools response:", err)
+		return
+	}
+	if toolsResult.Error != nil {
+		fmt.Println("ERROR: tools/list request returned an error:")
+		fmt.Println(toolsResult.Error.Message)
+		return
+	}
+	fmt.Printf("→ Available Tools: %d\n", len(toolsResult.Result.Tools))
+	fmt.Println("---------------------------------------------------")
+
+	// Step 4: prompts/list
+	fmt.Println("→ Sending prompts/list...")
+	promptsReq := utils.JsonRPCRequest{
+		JSONRPC: utils.JsonRpcVersion,
+		ID:      3,
+		Method:  MethodPromptsList,
+	}
+	promptsResp, err := utils.PostJSONRPCWithSession(url, promptsReq, sessionID)
+	if err != nil {
+		fmt.Println("ERROR: Failed to get prompts:", err)
+		return
+	}
+	var promptsResult utils.PromptsResult
+	if err := json.Unmarshal(promptsResp, &promptsResult); err != nil {
+		fmt.Println("ERROR: Failed to parse prompts response:", err)
+		return
+	}
+	if promptsResult.Error != nil {
+		fmt.Println("ERROR: prompts/list request returned an error:")
+		fmt.Println(promptsResult.Error.Message)
+		return
+	}
+	fmt.Printf("→ Available Prompts: %d\n", len(promptsResult.Result.Prompts))
+	fmt.Println("---------------------------------------------------")
+
+	// Step 5: resources/list
+	fmt.Println("→ Sending resources/list...")
+	resourcesReq := utils.JsonRPCRequest{
+		JSONRPC: utils.JsonRpcVersion,
+		ID:      4,
+		Method:  MethodResourcesList,
+	}
+	resourcesResp, err := utils.PostJSONRPCWithSession(url, resourcesReq, sessionID)
+	if err != nil {
+		fmt.Println("ERROR: Failed to get resources:", err)
+		return
+	}
+	var resourcesResult utils.ResourcesResult
+	if err := json.Unmarshal(resourcesResp, &resourcesResult); err != nil {
+		fmt.Println("ERROR: Failed to parse resources response:", err)
+		return
+	}
+	if resourcesResult.Error != nil {
+		fmt.Println("ERROR: resources/list request returned an error:")
+		fmt.Println(resourcesResult.Error.Message)
+		return
+	}
+	fmt.Printf("→ Available Resources: %d\n", len(resourcesResult.Result.Resources))
+	fmt.Println("---------------------------------------------------")
+
+	// Generate MCP configuration file
+	err = utils.GenerateMCPConfigFile(url, toolsResult, resourcesResult, promptsResult, outputDir)
+	if err != nil {
+		fmt.Println("ERROR: Failed to generate MCP configuration file:", err)
+		return
+	}
+	fmt.Println("→ Generated MCP configuration YAML file: generated-mcp.yaml")
+}

--- a/cli/src/cmd/root.go
+++ b/cli/src/cmd/root.go
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "fusionctl",
+	Short: "fusionctl is a cli tool to interact with the WSO2 API Platform",
+	Long:  "fusionctl is a cli tool to interact with the WSO2 API Platform",
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+}
+
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "Oops. An error occurred while executing %s: %v\n", CliName, err)
+		os.Exit(1)
+	}
+}

--- a/cli/src/cmd/version.go
+++ b/cli/src/cmd/version.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	Version   = "dev"
+	BuildTime = "unknown"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version of fusionctl",
+	Long:  "Print the version and build information of fusionctl",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("fusionctl version v%s (built at %s)\n", Version, BuildTime)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/cli/src/go.mod
+++ b/cli/src/go.mod
@@ -1,0 +1,13 @@
+module github.com/wso2/api-platform/cli
+
+go 1.25.4
+
+require (
+	github.com/spf13/cobra v1.10.1
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.10 // indirect
+)

--- a/cli/src/go.sum
+++ b/cli/src/go.sum
@@ -1,0 +1,13 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.1 h1:lJeBwCfmrnXthfAupyUTzJ/J4Nc1RsHC/mSRU2dll/s=
+github.com/spf13/cobra v1.10.1/go.mod h1:7SmJGaTHFVBY0jW4NXGluQoLvhqFQM+6XSKD+P4XaB0=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
+github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/cli/src/main.go
+++ b/cli/src/main.go
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package main
+
+import "github.com/wso2/api-platform/cli/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/cli/src/utils/mcp.go
+++ b/cli/src/utils/mcp.go
@@ -1,0 +1,301 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package utils
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	JsonRpcVersion   = "2.0"
+	ProtocolVersion  = "2025-06-18"
+	ClientName       = "platform-gateway-client"
+	ClientVersion    = "1.0.0"
+	MethodInitialize = "initialize"
+)
+
+type JsonRPCRequest struct {
+	JSONRPC string      `json:"jsonrpc"`
+	ID      int         `json:"id,omitempty"`
+	Method  string      `json:"method"`
+	Params  interface{} `json:"params,omitempty"`
+}
+
+type Tool struct {
+	Name         string          `json:"name"`
+	Title        string          `json:"title"`
+	Description  string          `json:"description"`
+	InputSchema  json.RawMessage `json:"inputSchema"`
+	OutputSchema json.RawMessage `json:"outputSchema"`
+	Policies     []string        `json:"policies"`
+}
+
+// MarshalYAML customizes YAML marshaling to keep schemas as JSON strings
+func (t Tool) MarshalYAML() (interface{}, error) {
+	type ToolAlias struct {
+		Name         string   `yaml:"name"`
+		Title        string   `yaml:"title"`
+		Description  string   `yaml:"description"`
+		InputSchema  string   `yaml:"inputSchema"`
+		OutputSchema string   `yaml:"outputSchema"`
+		Policies     []string `yaml:"policies"`
+	}
+
+	return ToolAlias{
+		Name:         t.Name,
+		Title:        t.Title,
+		Description:  t.Description,
+		InputSchema:  string(t.InputSchema),
+		OutputSchema: string(t.OutputSchema),
+		Policies:     t.Policies,
+	}, nil
+}
+
+type Resource struct {
+	Name        string   `json:"name" yaml:"name"`
+	URI         string   `json:"uri" yaml:"uri"`
+	Description string   `json:"description" yaml:"description"`
+	MimeType    string   `json:"mimeType" yaml:"mimeType"`
+	Policies    []string `json:"policies" yaml:"policies"`
+}
+
+type Prompt struct {
+	Name        string   `json:"name" yaml:"name"`
+	Description string   `json:"description" yaml:"description"`
+	Policies    []string `json:"policies" yaml:"policies"`
+}
+
+type McpYAML struct {
+	Version string `yaml:"version"`
+	Kind    string `yaml:"kind"`
+	Spec    struct {
+		Name        string `yaml:"name"`
+		Version     string `yaml:"version"`
+		Context     string `yaml:"context"`
+		SpecVersion string `yaml:"specVersion"`
+		Upstreams   []struct {
+			URL string `yaml:"url"`
+		} `yaml:"upstreams"`
+		Policies  []string   `yaml:"policies"`
+		Tools     []Tool     `yaml:"tools"`
+		Resources []Resource `yaml:"resources"`
+		Prompts   []Prompt   `yaml:"prompts"`
+	} `yaml:"spec"`
+}
+
+type ToolsResult struct {
+	Error *struct {
+		Message string `json:"message"`
+	} `json:"error"`
+	Result struct {
+		Tools []Tool `json:"tools"`
+	} `json:"result"`
+}
+
+type PromptsResult struct {
+	Error *struct {
+		Message string `json:"message"`
+	} `json:"error"`
+	Result struct {
+		Prompts []Prompt `json:"prompts"`
+	} `json:"result"`
+}
+
+type ResourcesResult struct {
+	Error *struct {
+		Message string `json:"message"`
+	} `json:"error"`
+	Result struct {
+		Resources []Resource `json:"resources"`
+	} `json:"result"`
+}
+
+// PostJSONRPCWithSession sends a JSON-RPC request with mcp-session-id header if provided
+func PostJSONRPCWithSession(url string, req interface{}, sessionID string) ([]byte, error) {
+	data, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	httpReq, err := http.NewRequest("POST", url, bytes.NewBuffer(data))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json, text/event-stream")
+	if sessionID != "" {
+		httpReq.Header.Set("mcp-session-id", sessionID)
+	}
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if response is event stream
+	if isEventStream(resp) {
+		// Extract JSON data from event stream
+		data, err := parseEventStream(body)
+		if err != nil {
+			return body, nil // Return original body if parsing fails
+		}
+		return data, nil
+	}
+
+	return body, nil
+}
+
+// InitializeMCPServer initializes the MCP server and returns the session ID
+func InitializeMCPServer(url string) (string, error) {
+	initReq := JsonRPCRequest{
+		JSONRPC: JsonRpcVersion,
+		ID:      1,
+		Method:  MethodInitialize,
+		Params: map[string]interface{}{
+			"protocolVersion": ProtocolVersion,
+			"capabilities":    map[string]interface{}{"roots": map[string]bool{"listChanged": true}},
+			"clientInfo":      map[string]string{"name": ClientName, "version": ClientVersion},
+		},
+	}
+	data, err := json.Marshal(initReq)
+	if err != nil {
+		return "", err
+	}
+	httpReq, err := http.NewRequest("POST", url, bytes.NewBuffer(data))
+	if err != nil {
+		fmt.Println("ERROR: Failed to create init request:", err)
+		return "", err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json, text/event-stream")
+	client := &http.Client{}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		fmt.Println("ERROR: Failed to reach MCP server for initialize.")
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	// Check if response is event stream and parse it
+	if isEventStream(resp) {
+		data, err := parseEventStream(body)
+		if err == nil {
+			body = data
+		}
+	}
+
+	// Check for JSON-RPC error in response
+	var initResponse map[string]interface{}
+	if err := json.Unmarshal(body, &initResponse); err == nil {
+		if errObj, hasError := initResponse["error"]; hasError {
+			fmt.Println("ERROR: initialize request returned an error:")
+			if errMap, ok := errObj.(map[string]interface{}); ok {
+				if msg, ok := errMap["message"].(string); ok {
+					fmt.Println(msg)
+				}
+			}
+			return "", fmt.Errorf("initialize request returned an error: %v", errObj)
+		}
+	}
+
+	sessionID := getSessionIDFromResponse(resp)
+	if sessionID == "" {
+		fmt.Println("WARNING: No mcp-session-id received. Server might not support HTTP transport state.")
+	} else {
+		fmt.Printf("→ Captured Session ID: %s\n", sessionID)
+	}
+	return sessionID, nil
+
+}
+
+func getSessionIDFromResponse(resp *http.Response) string {
+	return resp.Header.Get("mcp-session-id")
+}
+
+// parseEventStream extracts JSON data from event stream response
+func parseEventStream(body []byte) ([]byte, error) {
+	lines := bytes.Split(body, []byte("\n"))
+	for _, line := range lines {
+		if bytes.HasPrefix(line, []byte("data: ")) {
+			data := bytes.TrimPrefix(line, []byte("data: "))
+			data = bytes.TrimSpace(data)
+			if len(data) > 0 && !bytes.Equal(data, []byte("{}")) {
+				return data, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("no data found in event stream")
+}
+
+// isEventStream checks if the response is an event stream
+func isEventStream(resp *http.Response) bool {
+	contentType := resp.Header.Get("Content-Type")
+	return bytes.Contains([]byte(contentType), []byte("text/event-stream"))
+}
+
+// generateMCPConfigFile generates the MCP configuration YAML file
+func GenerateMCPConfigFile(url string, toolsResult ToolsResult,
+	resourcesResult ResourcesResult, promptsResult PromptsResult, outputDir string) error {
+	// Build YAML
+	mcp := McpYAML{
+		Version: "ai.api-platform.wso2.com/v1",
+		Kind:    "mcp",
+	}
+	mcp.Spec.Name = "Generated-MCP"
+	mcp.Spec.Version = "v1.0"
+	mcp.Spec.Context = "/generated"
+	mcp.Spec.SpecVersion = ProtocolVersion
+	mcp.Spec.Upstreams = []struct {
+		URL string `yaml:"url"`
+	}{{URL: strings.TrimSuffix(url, "/mcp")}}
+	mcp.Spec.Policies = []string{}
+	mcp.Spec.Tools = toolsResult.Result.Tools
+	mcp.Spec.Resources = resourcesResult.Result.Resources
+	mcp.Spec.Prompts = promptsResult.Result.Prompts
+
+	out, err := yaml.Marshal(&mcp)
+	if err != nil {
+		return err
+	}
+	err = os.WriteFile(filepath.Join(outputDir, "generated-mcp.yaml"), out, 0644)
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
## Purpose

This pull request introduces a new CLI tool called `fusionctl` for interacting with the WSO2 API Platform. The changes include a complete initial implementation of the CLI, covering the project structure, build system, command hierarchy, and core functionality for generating MCP configurations. The CLI is built using Cobra, includes versioning support, and provides commands for gateway operations and configuration generation.

Project setup and build system:

* Added a comprehensive `Makefile` to manage building, testing, dependency management, multi-platform builds, and installation for the CLI tool.
* Created a new Go module with `go.mod`, specifying dependencies on Cobra and YAML libraries.

CLI structure and commands:

* Implemented the main entrypoint (`main.go`) and root command (`root.go`) for the CLI, establishing the command hierarchy and error handling. [[1]](diffhunk://#diff-4e8beb33fce816f1b67428f3486e9b6387ad5688afd023c5eebfdfe12075ab2fR1-R25) [[2]](diffhunk://#diff-c9e00cb061c2fc60d6186176a43f4da48fa6b1df7b00aadd61b1e58292b3dc04R1-R42)
* Added subcommands for gateway operations (`gateway.go`) and configuration generation (`generate.go`), including help texts, usage examples, and command registration. [[1]](diffhunk://#diff-fd201e9be6e4373f1139b4666623fd06bbc1da137b2eb3cb5141a86452b6ae33R1-R41) [[2]](diffhunk://#diff-23805b84e783412c459e5a5d703aa2eb872267f983c05ccec167dfdc97d2deb9R1-R44)
* Added a version command to display CLI version and build information, with support for build-time variables.

MCP configuration generation functionality:

* Implemented the `mcp.go` command to interact with an MCP server, send JSON-RPC requests for initialization, tools, prompts, and resources, and generate a YAML configuration file based on the responses.

Related issue: https://github.com/wso2/api-platform/issues/328


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced fusionctl CLI with gateway, generate (gen alias), and mcp subcommands.
  * Added version command showing build version and build time.
  * MCP command can query an MCP server and generate YAML configuration.
  * Multi-platform builds: produce binaries for macOS, Linux, and Windows on amd64/arm64.

* **Chores**
  * Added build orchestration (Makefile), module setup, and CLI entrypoint.

* **Documentation**
  * Added README with build and usage instructions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->