### PR TITLE
Use initParameters in policy-definition.yaml

### DIFF
--- a/gateway/policies/basic-auth/v1.0.0/policy-definition.yaml
+++ b/gateway/policies/basic-auth/v1.0.0/policy-definition.yaml
@@ -45,3 +45,5 @@ parameters:
     validation:
       minLength: 1
       maxLength: 256
+
+initParameters: []

--- a/gateway/policies/modify-headers/v1.0.0/policy-definition.yaml
+++ b/gateway/policies/modify-headers/v1.0.0/policy-definition.yaml
@@ -75,3 +75,5 @@ parameters:
           description: Header value (required for SET and APPEND, ignored for DELETE)
           validation:
             maxLength: 8192
+
+initParameters: []

--- a/gateway/policies/respond/v1.0.0/policy-definition.yaml
+++ b/gateway/policies/respond/v1.0.0/policy-definition.yaml
@@ -50,3 +50,5 @@ parameters:
           description: Header value
           validation:
             maxLength: 8192
+
+initParameters: []

--- a/gateway/sample-policies/count-letters/v1.0.0/policy-definition.yaml
+++ b/gateway/sample-policies/count-letters/v1.0.0/policy-definition.yaml
@@ -37,3 +37,4 @@ parameters:
         - json
         - text
 
+initParameters: []

--- a/gateway/sample-policies/uppercase-body/v1.0.0/policy-definition.yaml
+++ b/gateway/sample-policies/uppercase-body/v1.0.0/policy-definition.yaml
@@ -7,3 +7,4 @@ description: |
 
 parameters: []  # No configuration parameters
 
+initParameters: []

--- a/sdk/gateway/policy/v1alpha/definition.go
+++ b/sdk/gateway/policy/v1alpha/definition.go
@@ -50,8 +50,8 @@ type PolicyDefinition struct {
 	// Each schema defines name, type, validation rules
 	Parameters []ParameterSchema `yaml:"parameters" json:"parameters"`
 
-	// Configuration for THIS version
-	Configuration []ParameterSchema `yaml:"configuration" json:"configuration"`
+	// InitParameters for THIS version
+	InitParameters []ParameterSchema `yaml:"initParameters" json:"initParameters"`
 }
 
 // PolicySpec is a configuration instance specifying how to use a policy


### PR DESCRIPTION
## Purpose
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `initParameters` configuration field to policy definitions across multiple gateway and sample policies, enabling a new initialization parameters structure.

* **SDK Updates**
  * Updated policy definition structure to support the new `initParameters` field for policy initialization configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->