### PR TITLE
Resolve init params with $config() config ref function

### DIFF
--- a/gateway/gateway-builder/internal/discovery/manifest.go
+++ b/gateway/gateway-builder/internal/discovery/manifest.go
@@ -239,7 +239,7 @@ func DiscoverPoliciesFromManifest(manifestPath string, baseDir string) ([]*types
 			YAMLPath:       policyYAMLPath,
 			GoModPath:      filepath.Join(policyPath, "go.mod"),
 			SourceFiles:    sourceFiles,
-			InitParameters: definition.InitParameters,
+			InitParameters: ExtractDefaultValues(definition.InitParameters),
 			Definition:     definition,
 		}
 

--- a/gateway/gateway-builder/internal/discovery/schema.go
+++ b/gateway/gateway-builder/internal/discovery/schema.go
@@ -1,0 +1,82 @@
+package discovery
+
+import "log/slog"
+
+// ExtractDefaultValues extracts default values from a JSON schema structure.
+// It processes the "properties" object and extracts either "default" or "wso2/defaultValue"
+// with precedence given to "wso2/defaultValue" when both exist.
+//
+// Input schema format (from initParameters in policy-definition.yaml):
+//
+//	{
+//	  "type": "object",
+//	  "properties": {
+//	    "propName": {
+//	      "type": "string",
+//	      "default": "value1",
+//	      "wso2/defaultValue": "$config(Path.To.Config)"
+//	    }
+//	  }
+//	}
+//
+// Returns: map[string]interface{} with only the default values
+//
+//	{"propName": "$config(Path.To.Config)"}
+//
+// TODO: (renuka) handle nested objects
+func ExtractDefaultValues(schema map[string]interface{}) map[string]interface{} {
+	result := make(map[string]interface{})
+
+	// Handle nil or empty schema
+	if schema == nil {
+		slog.Debug("Schema is nil, returning empty map", "phase", "discovery")
+		return result
+	}
+
+	// Extract properties object
+	properties, ok := schema["properties"].(map[string]interface{})
+	if !ok {
+		slog.Debug("No properties found in schema", "phase", "discovery")
+		return result
+	}
+
+	slog.Debug("Extracting defaults from schema",
+		"propertyCount", len(properties),
+		"phase", "discovery")
+
+	// Iterate through each property
+	for propName, propDef := range properties {
+		propDefMap, ok := propDef.(map[string]interface{})
+		if !ok {
+			slog.Debug("Property definition is not a map, skipping",
+				"property", propName,
+				"phase", "discovery")
+			continue
+		}
+
+		// Check for wso2/defaultValue first (higher precedence)
+		if wso2Default, exists := propDefMap["wso2/defaultValue"]; exists {
+			result[propName] = wso2Default
+			slog.Debug("Extracted wso2/defaultValue",
+				"property", propName,
+				"value", wso2Default,
+				"phase", "discovery")
+			continue
+		}
+
+		// Fallback to standard default
+		if defaultValue, exists := propDefMap["default"]; exists {
+			result[propName] = defaultValue
+			slog.Debug("Extracted default",
+				"property", propName,
+				"value", defaultValue,
+				"phase", "discovery")
+		}
+	}
+
+	slog.Debug("Extraction complete",
+		"extractedCount", len(result),
+		"phase", "discovery")
+
+	return result
+}

--- a/gateway/gateway-builder/internal/discovery/schema_test.go
+++ b/gateway/gateway-builder/internal/discovery/schema_test.go
@@ -1,0 +1,270 @@
+package discovery
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExtractDefaultValues_Empty(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema map[string]interface{}
+		want   map[string]interface{}
+	}{
+		{
+			name:   "nil schema",
+			schema: nil,
+			want:   map[string]interface{}{},
+		},
+		{
+			name:   "empty schema",
+			schema: map[string]interface{}{},
+			want:   map[string]interface{}{},
+		},
+		{
+			name: "no properties",
+			schema: map[string]interface{}{
+				"type": "object",
+			},
+			want: map[string]interface{}{},
+		},
+		{
+			name: "empty properties",
+			schema: map[string]interface{}{
+				"type":       "object",
+				"properties": map[string]interface{}{},
+			},
+			want: map[string]interface{}{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractDefaultValues(tt.schema)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ExtractDefaultValues() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractDefaultValues_Precedence(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema map[string]interface{}
+		want   map[string]interface{}
+	}{
+		{
+			name: "wso2/defaultValue takes precedence over default",
+			schema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"prop1": map[string]interface{}{
+						"type":              "string",
+						"default":           "default-value",
+						"wso2/defaultValue": "$config(Prop1)",
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"prop1": "$config(Prop1)",
+			},
+		},
+		{
+			name: "only default value",
+			schema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"prop1": map[string]interface{}{
+						"type":    "string",
+						"default": "default-value",
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"prop1": "default-value",
+			},
+		},
+		{
+			name: "only wso2/defaultValue",
+			schema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"prop1": map[string]interface{}{
+						"type":              "string",
+						"wso2/defaultValue": "$config(Prop1)",
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"prop1": "$config(Prop1)",
+			},
+		},
+		{
+			name: "property without any default",
+			schema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"prop1": map[string]interface{}{
+						"type": "string",
+					},
+				},
+			},
+			want: map[string]interface{}{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractDefaultValues(tt.schema)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ExtractDefaultValues() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractDefaultValues_Types(t *testing.T) {
+	schema := map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"stringProp": map[string]interface{}{
+				"type":    "string",
+				"default": "hello",
+			},
+			"intProp": map[string]interface{}{
+				"type":    "integer",
+				"default": 401,
+			},
+			"boolProp": map[string]interface{}{
+				"type":    "boolean",
+				"default": false,
+			},
+			"arrayProp": map[string]interface{}{
+				"type":    "array",
+				"default": []interface{}{"a", "b"},
+			},
+		},
+	}
+
+	got := ExtractDefaultValues(schema)
+	want := map[string]interface{}{
+		"stringProp": "hello",
+		"intProp":    401,
+		"boolProp":   false,
+		"arrayProp":  []interface{}{"a", "b"},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ExtractDefaultValues() = %v, want %v", got, want)
+	}
+}
+
+func TestExtractDefaultValues_JWTAuthRealWorld(t *testing.T) {
+	// Real-world schema from jwt-auth policy
+	schema := map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"authHeaderScheme": map[string]interface{}{
+				"type":              "string",
+				"default":           "Bearer",
+				"wso2/defaultValue": "$config(JWTAuth.AuthHeaderScheme)",
+			},
+			"headerName": map[string]interface{}{
+				"type":              "string",
+				"default":           "Authorization",
+				"wso2/defaultValue": "$config(JWTAuth.HeaderName)",
+			},
+			"onFailureStatusCode": map[string]interface{}{
+				"type":              "integer",
+				"default":           401,
+				"wso2/defaultValue": "$config(JWTAuth.OnFailureStatusCode)",
+			},
+			"jwksCacheTtl": map[string]interface{}{
+				"type":              "string",
+				"wso2/defaultValue": "$config(JWTAuth.JwksCacheTtl)",
+			},
+			"keyManagers": map[string]interface{}{
+				"type":              "array",
+				"wso2/defaultValue": "$config(JWTAuth.KeyManagers)",
+			},
+		},
+	}
+
+	got := ExtractDefaultValues(schema)
+	want := map[string]interface{}{
+		"authHeaderScheme":    "$config(JWTAuth.AuthHeaderScheme)",
+		"headerName":          "$config(JWTAuth.HeaderName)",
+		"onFailureStatusCode": "$config(JWTAuth.OnFailureStatusCode)",
+		"jwksCacheTtl":        "$config(JWTAuth.JwksCacheTtl)",
+		"keyManagers":         "$config(JWTAuth.KeyManagers)",
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ExtractDefaultValues() =\n%v\nwant\n%v", got, want)
+	}
+}
+
+func TestExtractDefaultValues_MixedProperties(t *testing.T) {
+	// Test with some properties having defaults and some not
+	schema := map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"withDefault": map[string]interface{}{
+				"type":    "string",
+				"default": "value1",
+			},
+			"withWso2Default": map[string]interface{}{
+				"type":              "string",
+				"wso2/defaultValue": "$config(Value2)",
+			},
+			"noDefault": map[string]interface{}{
+				"type": "string",
+			},
+			"withBothDefaults": map[string]interface{}{
+				"type":              "integer",
+				"default":           100,
+				"wso2/defaultValue": "$config(Value3)",
+			},
+		},
+	}
+
+	got := ExtractDefaultValues(schema)
+	want := map[string]interface{}{
+		"withDefault":      "value1",
+		"withWso2Default":  "$config(Value2)",
+		"withBothDefaults": "$config(Value3)", // wso2/defaultValue takes precedence
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ExtractDefaultValues() = %v, want %v", got, want)
+	}
+}
+
+func TestExtractDefaultValues_InvalidPropertyDef(t *testing.T) {
+	// Test with invalid property definition (not a map)
+	schema := map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"validProp": map[string]interface{}{
+				"type":    "string",
+				"default": "value1",
+			},
+			"invalidProp": "not-a-map", // Invalid: should be skipped
+			"anotherValidProp": map[string]interface{}{
+				"type":    "string",
+				"default": "value2",
+			},
+		},
+	}
+
+	got := ExtractDefaultValues(schema)
+	want := map[string]interface{}{
+		"validProp":        "value1",
+		"anotherValidProp": "value2",
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ExtractDefaultValues() = %v, want %v", got, want)
+	}
+}

--- a/gateway/gateway-builder/templates/plugin_registry.go.tmpl
+++ b/gateway/gateway-builder/templates/plugin_registry.go.tmpl
@@ -25,7 +25,11 @@ func init() {
 	policyDef_{{ .ImportAlias }} := &policy.PolicyDefinition{
 		Name:           "{{ .Name }}",
 		Version:        "{{ .Version }}",
-		InitParameters: nil,
+		InitParameters: {{ if .InitParameters }}map[string]interface{}{
+			{{- range $key, $value := .InitParameters }}
+			"{{ $key }}": {{ printf "%#v" $value }},
+			{{- end }}
+		}{{ else }}nil{{ end }},
 	}
 	if err := registry.GetRegistry().Register(policyDef_{{ .ImportAlias }}, {{ .ImportAlias }}.NewPolicy); err != nil {
 		slog.ErrorContext(ctx, "Failed to register policy", "policy", "{{ .Name }}", "version", "{{ .Version }}", "error", err)

--- a/gateway/policy-engine/cmd/policy-engine/main.go
+++ b/gateway/policy-engine/cmd/policy-engine/main.go
@@ -67,6 +67,10 @@ func main() {
 	k := kernel.NewKernel()
 	reg := registry.GetRegistry()
 
+	// Set config in registry for $config() resolution
+	reg.SetConfig(cfg.RawConfig)
+	slog.InfoContext(ctx, "Config set in registry for $config() resolution")
+
 	// Initialize CEL evaluator
 	celEvaluator, err := cel.NewCELEvaluator()
 	if err != nil {

--- a/gateway/policy-engine/internal/config/config.go
+++ b/gateway/policy-engine/internal/config/config.go
@@ -16,6 +16,10 @@ type Config struct {
 	XDS        XDSConfig        `mapstructure:"xds"`
 	FileConfig FileConfigConfig `mapstructure:"file_config"`
 	Logging    LoggingConfig    `mapstructure:"logging"`
+
+	// RawConfig holds the complete raw configuration map including custom fields
+	// This is used for resolving $config() CEL expressions in policy initParameters
+	RawConfig map[string]interface{} `mapstructure:",remain"`
 }
 
 // ServerConfig holds ext_proc server configuration
@@ -129,6 +133,9 @@ func Load(configPath string) (*Config, error) {
 	if err := v.Unmarshal(&cfg); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 	}
+
+	// Capture complete raw config map for $config() resolution
+	cfg.RawConfig = v.AllSettings()
 
 	// Validate config
 	if err := cfg.Validate(); err != nil {


### PR DESCRIPTION
## Purpose
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Policies now support `$config()` expressions to access configuration values in initialization parameters.
  * Improved default value extraction with support for vendor-specific defaults in policy initialization.

* **Tests**
  * Added comprehensive unit tests for default value extraction functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->