### PR TITLE
Change http/rest to RestApi kind

### DIFF
--- a/gateway/README.md
+++ b/gateway/README.md
@@ -66,7 +66,7 @@ curl -X POST http://localhost:9090/apis \
   -H "Content-Type: application/yaml" \
   --data-binary @- <<'EOF'
 version: api-platform.wso2.com/v1
-kind: http/rest
+kind: RestApi
 spec:
   name: Weather-API
   version: v1.0
@@ -145,7 +145,7 @@ User → Gateway-Controller (REST API)
 
 ```yaml
 version: api-platform.wso2.com/v1
-kind: http/rest
+kind: RestApi
 data:
   name: Weather API
   version: v1.0

--- a/gateway/examples/petstore-api.yaml
+++ b/gateway/examples/petstore-api.yaml
@@ -16,8 +16,8 @@
 # under the License.
 # --------------------------------------------------------------------
 
-version: api-platform.wso2.com/v1
-kind: http/rest
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
 metadata:
   name: petstore-api-v1.0
 spec:

--- a/gateway/examples/self-signed-secure-api.yaml
+++ b/gateway/examples/self-signed-secure-api.yaml
@@ -15,10 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 # --------------------------------------------------------------------
-version: api-platform.wso2.com/v1
-kind: http/rest
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: self-signed-secure-api-v1.0
 spec:
-  name: self-signed-api
+  displayName: self-signed-api
   version: v1.0
   context: /ssa
   upstream:
@@ -29,13 +31,8 @@ spec:
     - name: JwtAuthentication
       version: v0.1.0
       params:
-        keyManagers:
-          - name: WSO2KeyManager
-            issuer: https://localhost:9443/oauth2/token
-            jwks:
-              remote:
-                uri: https://api.asgardeo.io/t/testorgforsecurity/oauth2/jwks
-                skipTlsVerify: false
+        issuers:
+          - WSO2KeyManager1
   operations:
     - method: GET
       path: /info

--- a/gateway/examples/weather-api.yaml
+++ b/gateway/examples/weather-api.yaml
@@ -16,8 +16,8 @@
 # under the License.
 # --------------------------------------------------------------------
 
-version: api-platform.wso2.com/v1
-kind: http/rest
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
 metadata:
   name: weather-api-v1.0
 spec:

--- a/gateway/examples/websubhub.yaml
+++ b/gateway/examples/websubhub.yaml
@@ -16,7 +16,7 @@
 # under the License.
 # --------------------------------------------------------------------
 
-version: api-platform.wso2.com/v1
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
 kind: async/websub
 metadata:
   name: websub-api-v1.0

--- a/gateway/gateway-controller/README.md
+++ b/gateway/gateway-controller/README.md
@@ -241,7 +241,7 @@ POST /apis
 Content-Type: application/yaml
 
 version: api-platform.wso2.com/v1
-kind: http/rest
+kind: RestApi
 data:
   name: Weather API
   version: v1.0
@@ -295,7 +295,7 @@ PUT /apis/Weather%20API/v1.0
 Content-Type: application/yaml
 
 version: api-platform.wso2.com/v1
-kind: http/rest
+kind: RestApi
 data:
   name: Weather API
   version: v1.0
@@ -336,7 +336,7 @@ The SQLite database contains the following table:
 | `name` | TEXT | API name (indexed for fast lookups) |
 | `version` | TEXT | API version (indexed for fast lookups) |
 | `context` | TEXT | Base path (e.g., "/weather") |
-| `kind` | TEXT | API type ("http/rest", "graphql", etc.) |
+| `kind` | TEXT | API type ("RestApi", "graphql", etc.) |
 | `configuration` | TEXT | Full JSON-serialized API configuration |
 | `status` | TEXT | Deployment status ("pending", "deployed", "failed") |
 | `created_at` | TIMESTAMP | Record creation timestamp |

--- a/gateway/gateway-controller/api/openapi.yaml
+++ b/gateway/gateway-controller/api/openapi.yaml
@@ -69,8 +69,8 @@ paths:
             schema:
               $ref: "#/components/schemas/APIConfiguration"
             example:
-              version: api-platform.wso2.com/v1
-              kind: http/rest
+              version: gateway.api-platform.wso2.com/v1alpha1
+              kind: RestApi
               spec:
                 name: PetStore API
                 version: v1.0
@@ -115,8 +115,8 @@ paths:
             schema:
               $ref: "#/components/schemas/APIConfiguration"
             example:
-              version: api-platform.wso2.com/v1
-              kind: http/rest
+              version: gateway.api-platform.wso2.com/v1alpha1
+              kind: RestApi
               spec:
                 name: PetStore API
                 version: v1.0
@@ -1228,22 +1228,23 @@ components:
     APIConfiguration:
       type: object
       required:
-        - version
+        - apiVersion
+        - metadata
         - kind
         - spec
       properties:
-        version:
+        apiVersion:
           type: string
           description: API specification version
-          example: api-platform.wso2.com/v1
+          example: gateway.api-platform.wso2.com/v1alpha1
           enum:
-            - api-platform.wso2.com/v1
+            - gateway.api-platform.wso2.com/v1alpha1
         kind:
           type: string
           description: API type
-          example: http/rest
+          example: RestApi
           enum:
-            - http/rest
+            - RestApi
             - async/websub
             - async/websocket
             - async/sse
@@ -1268,14 +1269,14 @@ components:
     APIConfigData:
       type: object
       required:
-        - name
+        - displayName
         - version
         - context
         - upstream
         - operations
         # - kind
       properties:
-        name:
+        displayName:
           type: string
           description: Human-readable API name (must be URL-friendly - only letters, numbers, spaces, hyphens, underscores, and dots allowed)
           minLength: 1
@@ -1285,9 +1286,9 @@ components:
         # kind:
         #   type: string
         #   description: API type
-        #   example: http/rest
+        #   example: RestApi
         #   enum:
-        #     - http/rest
+        #     - RestApi
         version:
           type: string
           description: Semantic version of the API

--- a/gateway/gateway-controller/cmd/controller/main.go
+++ b/gateway/gateway-controller/cmd/controller/main.go
@@ -170,7 +170,7 @@ func main() {
 			derivedCount := 0
 			for _, apiConfig := range loadedAPIs {
 				// Derive policy configuration from API
-				if apiConfig.Configuration.Kind == api.Httprest {
+				if apiConfig.Configuration.Kind == api.RestApi {
 					storedPolicy := derivePolicyFromAPIConfig(apiConfig, &cfg.GatewayController.Router)
 					if storedPolicy != nil {
 						if err := policyStore.Set(storedPolicy); err != nil {
@@ -405,7 +405,7 @@ func derivePolicyFromAPIConfig(cfg *models.StoredConfig, routerConfig *config.Ro
 				CreatedAt:       now,
 				UpdatedAt:       now,
 				ResourceVersion: 0,
-				APIName:         apiData.Name,
+				APIName:         apiData.DisplayName,
 				Version:         apiData.Version,
 				Context:         apiData.Context,
 			},

--- a/gateway/gateway-controller/pkg/api/generated/generated.go
+++ b/gateway/gateway-controller/pkg/api/generated/generated.go
@@ -21,17 +21,17 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 )
 
+// Defines values for APIConfigurationApiVersion.
+const (
+	GatewayApiPlatformWso2Comv1alpha1 APIConfigurationApiVersion = "gateway.api-platform.wso2.com/v1alpha1"
+)
+
 // Defines values for APIConfigurationKind.
 const (
 	Asyncsse       APIConfigurationKind = "async/sse"
 	Asyncwebsocket APIConfigurationKind = "async/websocket"
 	Asyncwebsub    APIConfigurationKind = "async/websub"
-	Httprest       APIConfigurationKind = "http/rest"
-)
-
-// Defines values for APIConfigurationVersion.
-const (
-	ApiPlatformWso2Comv1 APIConfigurationVersion = "api-platform.wso2.com/v1"
+	RestApi        APIConfigurationKind = "RestApi"
 )
 
 // Defines values for APIDetailResponseApiMetadataStatus.
@@ -188,8 +188,8 @@ type APIConfigData struct {
 	// Context Base path for all API routes (must start with /, no trailing slash)
 	Context string `json:"context" yaml:"context"`
 
-	// Name Human-readable API name (must be URL-friendly - only letters, numbers, spaces, hyphens, underscores, and dots allowed)
-	Name string `json:"name" yaml:"name"`
+	// DisplayName Human-readable API name (must be URL-friendly - only letters, numbers, spaces, hyphens, underscores, and dots allowed)
+	DisplayName string `json:"displayName" yaml:"displayName"`
 
 	// Operations List of HTTP operations/routes
 	Operations []Operation `json:"operations" yaml:"operations"`
@@ -221,16 +221,19 @@ type APIConfigData struct {
 
 // APIConfiguration defines model for APIConfiguration.
 type APIConfiguration struct {
+	// ApiVersion API specification version
+	ApiVersion APIConfigurationApiVersion `json:"apiVersion" yaml:"apiVersion"`
+
 	// Kind API type
 	Kind     APIConfigurationKind `json:"kind" yaml:"kind"`
-	Metadata *Metadata            `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	Metadata Metadata             `json:"metadata" yaml:"metadata"`
 
 	// Spec API configuration payload (REST or Async API variants)
 	Spec APIConfiguration_Spec `json:"spec" yaml:"spec"`
-
-	// Version API specification version
-	Version APIConfigurationVersion `json:"version" yaml:"version"`
 }
+
+// APIConfigurationApiVersion API specification version
+type APIConfigurationApiVersion string
 
 // APIConfigurationKind API type
 type APIConfigurationKind string
@@ -239,9 +242,6 @@ type APIConfigurationKind string
 type APIConfiguration_Spec struct {
 	union json.RawMessage
 }
-
-// APIConfigurationVersion API specification version
-type APIConfigurationVersion string
 
 // APICreateResponse defines model for APICreateResponse.
 type APICreateResponse struct {
@@ -257,8 +257,10 @@ type APICreateResponse struct {
 type APIDetailResponse struct {
 	Api *struct {
 		Configuration *APIConfiguration `json:"configuration,omitempty" yaml:"configuration,omitempty"`
-		Id            *string           `json:"id,omitempty" yaml:"id,omitempty"`
-		Metadata      *struct {
+
+		// Id Unique handle (metadata.name) for the API configuration
+		Id       *string `json:"id,omitempty" yaml:"id,omitempty"`
+		Metadata *struct {
 			CreatedAt  *time.Time                          `json:"created_at,omitempty" yaml:"created_at,omitempty"`
 			DeployedAt *time.Time                          `json:"deployed_at,omitempty" yaml:"deployed_at,omitempty"`
 			Status     *APIDetailResponseApiMetadataStatus `json:"status,omitempty" yaml:"status,omitempty"`
@@ -399,7 +401,7 @@ type ConfigDumpResponse struct {
 	// Apis All deployed API configurations
 	Apis *[]struct {
 		Configuration *APIConfiguration   `json:"configuration,omitempty" yaml:"configuration,omitempty"`
-		Id            *string              `json:"id,omitempty" yaml:"id,omitempty"`
+		Id            *openapi_types.UUID `json:"id,omitempty" yaml:"id,omitempty"`
 		Metadata      *struct {
 			CreatedAt  *time.Time                            `json:"created_at,omitempty" yaml:"created_at,omitempty"`
 			DeployedAt *time.Time                            `json:"deployed_at,omitempty" yaml:"deployed_at,omitempty"`
@@ -671,8 +673,10 @@ type LLMProviderUpdateResponse struct {
 type MCPDetailResponse struct {
 	Mcp *struct {
 		Configuration *MCPProxyConfiguration `json:"configuration,omitempty" yaml:"configuration,omitempty"`
-		Id            *string                `json:"id,omitempty" yaml:"id,omitempty"`
-		Metadata      *struct {
+
+		// Id Unique handle (metadata.name) for the MCP configuration
+		Id       *string `json:"id,omitempty" yaml:"id,omitempty"`
+		Metadata *struct {
 			CreatedAt  *time.Time                          `json:"created_at,omitempty" yaml:"created_at,omitempty"`
 			DeployedAt *time.Time                          `json:"deployed_at,omitempty" yaml:"deployed_at,omitempty"`
 			Status     *MCPDetailResponseMcpMetadataStatus `json:"status,omitempty" yaml:"status,omitempty"`
@@ -1974,146 +1978,147 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+x9+XfbONLgv4Ll9nufndZld5xv4n3z5jm2O/F0nGh8dM83kTcNkZCEMQmwAdC2Ouv/",
-	"fR8uniBFyfKV8fwwHYsgWChUFepC1TfPp1FMCSKCe7vfPO7PUATVP/eGR/uUTPD0AAoof4gZjRETGKnH",
-	"PiUC3Qj5zwBxn+FYYEq8Xe8d5AjEUMzAhDIAwxDsDY8Ao4lAHGxECReAC8gEuMZiBvodQCgQDOIQkyng",
-	"IeSzTa/joRsYxSHydr3+NYJihpjX8SJ48xGRqZh5u9uDQceLMLF/b3W8GAqBmATh/45G/S+w++de91+D",
-	"7tuvo1F3NOpfvPoif7/4wet4Yh7LqblgmEy9245HYISqS/mQRJB0GYIBHIdIrUMONKsYI3B+8rE7YRiR",
-	"IJyDLqAknIMQSTB4B5AkGqt/8Bj6iHfAbB7PEOEdkJAAMe5TJn+FJAABFVyiil6joLh6s/gujHERAVuN",
-	"CMhWPxp1v45GPXDxo3PhckuhXC6vLv8j5gLQCfhwdjYE2cC+3kuv42GBIvXeDwxNvF3vf/czauobUup/",
-	"ti/Kz0WYHOmXtlJgIGNwLh/GNMS+IS83JHvDo26IrlAI7FgA4zjEKACCKlrLwAQJCRHngF4hxnAQINIW",
-	"4qGcW0FUhjCJuWAIRlUIM8jsGOAr7knM4jsl/okgJosAObefu+14HJJgTG/av3Lb8Rj6I8EMBd7uF/29",
-	"i3RJdPxv5As58RViXK2hvKRTFEEisA/MCLkBYqbYoECiV1u9gVegvqvRKPhxNOrJ/zip7mpGuXDs837C",
-	"BY3AFWYigSFQo/oBlbBzJU6y77uxuXA6M5uaLGY0SHw5VgqgyQT7hXXBGPfMXz2fRl4tg/VGo24Ne+V2",
-	"bSnQzHtOuMyz7t3ha0cipVFKVGZk00lPghx7FOSKi+jSw8WyR+V8ucQkcLIZUJN1PESSSMIzEyLuM8Ql",
-	"AJDPid+/RmOejAt/Uv8SZQM4RxKqDKX5OSp7GCEBA3MGNrHesR0n9z1GvhwPyfzzxNv90vxm8ai97TSP",
-	"/g2NZ5Re7g2P9PCLjgNJBeEDYjgPKQzAxsnh6RmgDOxJPKgD7QoyDIngm42yQI6Ua8IT7Osps/23GwFj",
-	"3I1DKCaURb1rTrclVfavtoqorh21iDqzDyrSMDiuIy6GoEAniMeUcOTQXtTz4CtUCkwG3fZge6e7Nehu",
-	"bZ1tDXZ/GuwOBv/yOp4EVg71AihQV2DFARVCwQ6CPSf4jwQBHCAi8AQjlooxAwKo7FaB2Xd2BugvrweD",
-	"Ltp+O+6+3gped+F/b73pvn795s3OzuvXg8FgkAcwSXDgJmLO4RQVV1slFAsUT3wfcT5JwnDulGsCioQX",
-	"ZzPvODfStUcHSEAc1u+RVHlcamdRarTiqyTTQPQm3QeCMynxALQWoDik81az7rSfNbethqljRAL5MPui",
-	"nAziEAVFvs49rkybxMG6MXDrOqYqVLYOMpW6p9RZG00gp7lSwcM9Sh2nxdA1qlmtuVNnZzxjwigcYhUl",
-	"td2Wnyuw6iXT/cmQVkLaYG29QrrdZmztvt65E5d2vH2JR6VGIMlaDWd0NlBjvY3tlps9ndlhyC2JGkEF",
-	"DN/Nhcs2PZPPwFg+lBaSNEJzkIMJDpWtnH5ne3tr5+3b9COYCDRFLP3KPk2IqPuKdinIzzR+4qfq7At2",
-	"omEX3PB8ckHCASZKt5EQ5QHaci23nbq0cX5+dLCZaU3Z11bRk6rSk/MEMYd9lsOvHgMOPoENCcYEMy4U",
-	"IABPwDghQYiKTpv9T389noP9vc5n+d/PbAoJ/lPxbmf/r+enC1i/ZIVrqpRKOyaa5zAlMAT2jcKHc1An",
-	"sVT5UaAcTKcHp63FhtsX9glGyHoA6jYhmnd9Zdd2feicmYq9iViEbnQTYyPpJMBtkb492H7T3drqbr8B",
-	"gze7g//e3X5zB70nEwaIMcqKR1qDpOCJZq/GFZpB90lRC/j9XBHHCfojkUZvk+itrmR4eNxFxKeStv7Z",
-	"2xm8zdPDBt/sgX1I5JElICYgSkKB47BANLxXWFxX/u/d4fujT2D/8OTs6Oej/b2zQ/XriBwfHR3882x/",
-	"f+/yt+ne9dG7venR3/d++Tg4f/9jdPKL+Pfx3uD9/ukf70+Pxj8d/OPw3f71+d7x4fnN/p97f383/fTr",
-	"iPR6vRFRsx1+OnB8oT0PGOmkfMAOgdQDx8YvnOiB0GeU8/KRUFp9iWlWcPH2vrZy7xS5Vq3QZT3vzyAh",
-	"KHRQsH4ANgSNsd9HV4gIoB0+myBAE0ywYlrl9rf+BbXYInGNsdIctY0XBFjLs2FujGAJKjs1howK6tOw",
-	"a90QwDfw2PnABmRjLBhkc3CJ5v0rGCZIApj4ImFos+c5Vlv4yAL/f+5hKgk1DMUdfY/Fh2Ssjw2g0MTz",
-	"AyvEFkMGIyQQa0BJmUNLcFflkNKHlkPx308/fwKn6kUwYXAayQ22dJ4CCRReHci8XYRebwjFrG+3LVs1",
-	"2LhEcxSA8Tz3FUmf7i2LoWSGOupUkScJsyTSvCLBUAgFvkJAUOtzkdZbcev6atOckn1xdKISk1DxIEGB",
-	"mGGeRSbAhglJIHWqwyDgBqZSbGPz7gGLOBmHmDvQNVS+b6lfcUSCzRx0GSdXWTenpTQq4Xovjs1odSxG",
-	"EWTzosI91MAVGKXX7ijjyViuZuwQ0vuU8CSSK2PIR/gKPc7iTvTHl19cSWoram+Q08d1iuOh/GTfLCov",
-	"nwWDhMeUSV1QUiKAeenkcHEQ8VV/3YFq+VR55K1ENK7mXimUEofGcdz/N6dLHLkf6RT7mbarxEJx7iOJ",
-	"YLVYt2xV4KwuCBmKGeKICJiX+xacMQ3mBXAqTky/VkQrysg9aZKjDgZIaa5kL8woE66jyoBcRJ7CG0AR",
-	"FpIarmeIAEgMzWJu3cG9hbqFCQpZbDvpVUc4kihudPk65OteGALrRaq6ywuB6Bdn8YuzeFVncfnsLPuf",
-	"qkTJ0BRzgRgKCvp922O7pa+qXvGQMBgjXw2a58Q8X055OEhfrHOXYS6wz10OCiWJQDYGwDFNhNaPE8ak",
-	"hGnOhVCOrz0n75f9Xk72T4lkp96tluF6JT/eUi68RsJp8OQVP1I7/7CWIMpzO6liWTfhsr5SHCEuYBQ7",
-	"wLOP9EmjCETtJQgS+SPkYIqI1NWUaCjz/lZ3+80aeL/jHTJGWf0ppDw+DuzqgCUKpAWEA60PmLEtee3X",
-	"9EUFgovVah2BH/B0ZgwE9dH8GV/0FRWCBTlYjSRuGSnQfq9FB795M4PbdfQf3gimFaGj1B5zRVXyz6oa",
-	"mbQeAbqR6phOR2JghmBgbEVpQpkZ5oqyBL1ERBurBfT80EuUHoRJnIgzOchJxiH1odsr8NsMMfW5CSZB",
-	"7lM592wuK8KqRB1PA1s8CLOnzWhOoenk0eTC9cePx3uKN6VyzmjoIO8bH8U1KX8Gx3aANl4RgNoH7esp",
-	"QUQD1JbkT2gi0KGd0Unxcrbq2eb8ZJprEob0+isMQ6VrkLn6Z0nFML8uzHqSM9dg0hjWFRRW46fjJJgi",
-	"YXHuNETErH0YK/223BAX0mqDnDVhzsYMLg1bIw6GxulSNpnFjAbFZdkten945nW84edT9Z9z+f8Hhx8P",
-	"zw7ln3tn+x+8jvd5eHb0+dOp1/E+HO4d5CDIHSdlbQgyGPHV7Tn9ZIzJtOjW4orIY6H9UMpjo0/PHjiT",
-	"f2DBUTiRRhEEhfmon0SIiEZXVc7B5M+gUDseInsgN++WmqOTojrFQN12MXqFA8SacrdhWUAsIMWiQLnt",
-	"FJO/JzAJ5SHc9zr3nQpOY0QgXjITfKM2FXzzb6sng3/8eAwsrh8+K5zT7a5GRjc2QNxLevgTdnpm4tkh",
-	"JQSK4tAZvTozT1KlIeE2mIN5YVcLGE8pz2GvZjnhMAxbpHvm0rrbDdxL5CFwsUqydu2CVs3arn7611wO",
-	"s8ZqwlGgcCpZHZNpD5wmcUyZ4JLfSQCZJG6V7CzHS2ZIxibNuyPJ4xqHgZ+N4iayNqGSGcDJz/tdJUEx",
-	"JEJ9Vn2VJSHiPfCbeZcDyJCmRsNDNjshRBPRjSS0IRyjEGyg3rTXAa/y2dSbvRGpZIM7xc/OTw2MtjEa",
-	"vRqNev8vY7iLjb/tFtjv4tug82brNjdi82+jUW/zR/PLxbftzu0Pyx/qKQsU8rKLor/VGbJkinYqFE2a",
-	"rtUHwjDqp7KqoKoVnrisE5NMvUgaVE++Jo5J4VyY14x7LVObGwauL7s5v9I7ZTlvdbd31pBveK/Jb1J8",
-	"WdJ4uOTkHIoXJSmndHs353Mt06XeW6ljfr0nl+tTc3OvSJkL3NzprDtLzdrsj14J1AdKXs4RVUMS83OS",
-	"EY68Zbcm/FDBirye2U5ZDNaP7TsmPOfI5Cy3nDZnfapMN5z13RRHtYd+N6er3PX0tyAtPP9T2J/v+W+X",
-	"8Ii3nR5DD7DU8igKQYG+HIe+dewYz/ICwnV6xpfKP6xgpaXZGjMaxeJuUDKdP3pMAxSuOoeKaN0FDJcd",
-	"1JJvFil3y0a+aqXnqrpgKo+/n1yERwrvt+TqVfWkJyZDq3rSqirJmjbEiewndc3KfcI876tWOZw/XVw/",
-	"Coq1pr0GFB/vDxedIpEf3/FEON4fDhm9mT/5/LSt7vbrezHcXz+X/LSVMPBA/gBNRlHsuPAD2VRFMR2B",
-	"ns+xuXAWmohPOlbpoPruirmMVJ+K2XjP4qCarWo/stoFtaa3M2XRkdghZogVZgCYg/SNdLYxpSGCOpsB",
-	"ixA1YG1WDBuq4YvBbKvUluNejWiug6mYSLTcXShHYQttWbhTw5bCFcntqJ5UfSPAPA7hHMQJiylHfHXs",
-	"FeXqknXOjveHQL1tb5IAE6nPxasjP+7GcszKYebsKybAk7s4Zifvbt1P7FehvH3OSiZeHITJEKcJ89FS",
-	"052Yl5wpqTHyf63z7Uis1bp1ihJ78Ka79ZezgRTXRmI7bn/TcCm4z6hOk6grH9YQTh9D/xKRAHDErrCv",
-	"cglaZxce7w/zFcMaa61dNaFOE5wLZbVexSUrRPEW/Lhk3DEDvFQgSupfFyXGWXedp/ba20K/ZLaOZ+aY",
-	"tOtctmBKo5C8F32zrDbnJOkSJVOK8tfpt/7V5ZlvK3aej/565xBEXtYvpzqmusMCJSbCETpzXmJLZzg+",
-	"Oj60sqPlYX02K2op9pRzbif+s+nr8jHARF9A8Jy5/6trTxaulvpTx0sYXkblq193SZrIeTuNCpk6O5ej",
-	"geZr2pOE+BpDWDhFjEoEP03vSzeljk4wwWQK0E2MfIGCXPboOhRnqWc4a7QmogHCdP+bQdWTZNfh16yf",
-	"S9id1NX67mCRgfObUkMp57nEuyK1JCx01SWuaFZgI4JzgIkfJoFJVI0ZmuAbEOJLBPowxv2r7WLq5UyI",
-	"mO/25bOeKZqljlI9tuBcYbgFP7iTsI5rHTCNRDWDJAiRiy2XqQ/W1nzKKvvWJIY7WPXsbAjMw85SqeIq",
-	"QTzLGC8cd/p9Z8p9FQR1IUFvtko7ppa6vyluvgVxCH00o2Gg2TqnqXxTxZDY/KtPA3Tb/+ZjMb/1yvnG",
-	"vVc/fCf1A8o3Jey+1d5Jr7svgW6Qn0jY9ynRSfuO++rZzR5z6UOlgfv2DRiCdJrUK6C/l98kE5PsWW3+",
-	"C0zETIpaX2o9F+B//RUIlqDV/EqO78EY/4Lm2cWu2gIfS95Z2EtrmeSuKKQuFn2vb2PCEOpKgeMseOKt",
-	"o9qzY8npNZOa5OH6HOJmQ7GeonK3U1dQDUBTBRe9vv/i9sCqXC4YLHuym82p+Gv2hkdlSmm+xrBSoZgn",
-	"df+Fz7lA0XC9YEMiz2wsMAyN27nKImuBfkVeyV23fRC26XiTkF7zBvZZUGfRVvhrvnqcP7/WerH8TjGN",
-	"0vXCphtqtZpIwcHWXidpd1vNpYKoW5aWCjrrvB3mooFTxK5cd2r17+7KXZSB39D4NBnfcw0vrmF4vBJe",
-	"mBsYSkVliNwbGFosqHpehAtIfNSrcZarpTl8BLbcDrBj9P2Ysb6mnPu6oby0fH2+cD3XJ9MfQv5xCSeX",
-	"sKgCpy/VQlbrLP+1KMQ4Co1xa8HdwBNgKviMQ70J2Ydr3GUc+QmTBreD7PQTG1bLQom53QAbCPozILkS",
-	"RDDmQAmV7NJWqrRzn8ZSY5YMpyBLGbmujlo6YCHzLoy21diZXBuXlEnllSDdYUJ/JtXg7DJV+f1xiDiQ",
-	"puhYUiih5hD+Jld7W8K3tT/1hndnybiHDbHuvh28/ctCC7Tjpd9cptycueVZDd2qB/qefbo6+4WeO9q/",
-	"XCi4cTLNNI7CKOrCl4KKF8hiwa6XxKtd98XC2nY2qSkA2ZaaGpjZzTOz6+cnH93188qugZxccUFwXtuO",
-	"xj5J40nFCtIbHJNpiICAbIqEpFSGJogh4iurgRJkrjFWfBW3neKP8vy/uL0onw9KLahY3vYbqlkPiBlS",
-	"Zw8K0p45B3nNyeGUdLDbAWbIF+k6JeMJqu8Y2+4pQNAKC+32+zGjQde8t7szGAyW8OHUboW6qllNr3D+",
-	"agpC1BPlt0JvjUskzbAxgqxQ+iHP12GhoFiNyqCeXrRKOSnXK6ksYYJR6HDz/Cx/BmIGhSk6kitDUuxl",
-	"EyO/l4UH25dFLp3ruiKKsySyCc5XbpurK9Y+JIQKIClH/9put0stWKoqta6n1+DryfWp6pYbbCkxqjq1",
-	"SOVLcqcqH9jXJS1L47JKq63LTpkCr4tCxC8d3r6LDm9Pv6uaPhWXTIrQlbNTLtlM2QTMknFuRMYfrd2h",
-	"xmBaOYXi3hqntc+zsCjtZKLIIfFV8GtCbWge6rrlmlO8304/byuGGJq0AXBmEktKp7rZAiUMIkjgVLJ5",
-	"tU6b1YGq876HAl3DeW9ERuRshuzfwNxSDxEzvileM+3/7B0rdVt5dvTZrZluTmCEfRiG8xGxryGuwFCO",
-	"AwY2DskVneuEi01whSG4OThNTZ9c4YJJEoZg/+T8AIR4gvy5H6IRkUt2gKTkHkMwVPFyk+GcFlPSX1ar",
-	"ffXqFzQHPyMorVu+++rViHTBaTKOsGixVDn4JP1KrtCXXLs+ERmS0GMylWP/hRjtBvSaqPGuniJcDhtK",
-	"euJCV/emDE6RXtDpPz5igeSIfySIzZtKcuqi6jqa6Dm2U3NCykCe9ozpdpRE9X3yfuoNej95ubpJfVsc",
-	"dIqES7cUDKMrBGCWp9pcNlQvyoYJeiNygkTCCAdjyLGfr+Zl6hkqi1TOsyE5pGO5u2Pz/zogu6kNJIpN",
-	"DYlUeB4FRqaZ05oZl5xa1fZgkCu4q4uhlormpv1Z6wuntpJv+aZGrrqXFX+gs6ziHV13txVBkjuOyiUe",
-	"bzvezpL4abxIVqj/5wAldf8Yg03XwrvN193V4Frlp1KSUsAplzJaPjyWQlH5OaT95MXOKiqG6yEg6Lo6",
-	"pZUdVV7qgbNZiZlHBHMrDlDQAbFh6ECrIqr+szZVBQVa/kmhl6Zo6im1mBqRMZpiwm0pl9SmynXjVJyE",
-	"CdgBHPmUBNzItsx6ACdJmMq3VMn6MT0gfRqNMdFDo0IPBflCnQr/e/93taCCBv97/3f1EQFCBCVBEZS1",
-	"ZJWj5Q9ZLNWep/Kdn1XjzShTA1PWToHyKbGy0TR3MEvgDlbX13K1rDNhyXc0mLcg41w5aZ3sWOhQaZMO",
-	"UwXd68dISFmdNnbY9YZInMpfjKzN9/n9ksXnjZtbu6nVNP1vMRJHgQprp5rjF3cId4lgq4HKES3NgqPW",
-	"Hvb+2ZUq6S/K3o0gCaCgkuXkVHm9y0ZUbpVXIl2S8dnn1uQVn583Pk69/C6kFEYWcafw38dE6qAS3CaY",
-	"9FjK5HKV8+S5YLqTqocciQ9qFl6Y2cBpH8n1/LNr+sx0T02GX6ZbatGokWCPw/K7+tfGl91UUUi4/mLS",
-	"glLvj+GYHr+G0yliPUz7V9vqreJUBVW/vn1poefGcnXGbzsFITCHUfgiBF6EwIsQ+I8SAgXj3uC+ZCFs",
-	"rU0DrrZIdmjBLdsD33a81w+rnCvdthzSqBS63tSQvX04yOSWhtgXoJuqxVqhVOquVD6twgtDhmAwB+gG",
-	"c/E07RtNH3UGSZOJc9vRxnr/m85HvdXWTohc9ThPUESl2U4cRs+E0ajR7DFOHC5ozEdEO4mqRgrmbisF",
-	"HJHuJMTTmQBGYnFgci/QiORp/P8oJKSDTGMh8HrwGnyiAvxMExK4jP0DtWh9+OaTt76UsZAVNMk5C6V5",
-	"ptEGNlI/hS7+IhHzP3vHHzcXpfZioqqMqyQRI7T1pnhlcZMXXWXr/WKtzooVb62v2i5Xo/DeqwS1kZ9O",
-	"UJSUev1wzF8FSxrQE0nDT1IQaSZySohmR0uzo1B3n9DcXpY7lAGYXr9Tnx3PARbcJthvKAYs8ORmhfnf",
-	"I7E3PHo3/2D5bQUJ8Mz5foEKUqqcUWcIrT5fK5aU7/AXLlzAhe+RIyQh2SIlqyaXZyJcOSqqvS8kWgty",
-	"Ro30Ma+DEyDv1VTalI1SQkFNmKenI0hGLzDntA742DozxQW0UQpGJJUTSqWTs9GwNFNJRUg4qv+q8Y8e",
-	"RTFlAhKx++oVOJqUW7XwjpohRU4RcIZUZWwAfYGvkEv50Pi9i/Jh8P4UhNAy3tM1+2Hu06Jbqzgt1Xhq",
-	"JXSc1ZeeuEX3IqVrpXQbmbrIdCv3vVsQbw1DUwMInH08LXQzs93fwrntUmdSAPx8L3Tlf1FimxebhKv6",
-	"/WkrgSvE8GQuF/Th7Gx4msV0shxbXhdv3S+2WLs3Hsx9p3DloiHYWUD2kw5zmk0utauzlJRvb98q3qk7",
-	"0Bv3gpuAbNCzSi465pn9PCI2QIcJGB4emySQHtibCFViTn6r455MXQpKBI2gsKkiDBl6lUrG6cEp2DhF",
-	"PkMCHGDu0yvE5uBUpyJtyretDBUUxAnX+gFB1yNSWosOtcaM3mBkY6QHOkUFaMaVisD+DJKp1FngJQJo",
-	"MkG+ADiKUIChQOFcqSA0kdqJCoXai1zTNInGoQjI5ewX2r+vHI/Md5F/Cq37jV5R6KLf2g2bw4lGknFS",
-	"P7Q71tkJ1OFfzNGTpuknc3LnIDPJ00/zeMwLnQJDLBRk5aOxr6WEcm85JdwxJImUJ0AwPJ2qPtv6FVd7",
-	"0czXOcEh0vcmlfjRwmVETg9O7V1GZV1MkhDgCZjT5L+uEIjst2AQoNJ2yPmMKC2IJA4ClTtP2dwIo09U",
-	"iyD1GUSCmGJdAU/MYy0blfpDEFLCkRsi5DrZDpk7ayNSEKfp8vXinYf0CSpJqDWnRzk9hfnPgYrIv6ey",
-	"pKrc9ddx6xa0BqplO9G2cU+6118WJ0+Oh1O2Msy0rEJS4eNvOGiMUFj/o0MDAuM5ODqwaoblgBpFQ6Vl",
-	"FVmjQnVFbYLp2Eh5NikqRuSxtAmNjqI20exeOLBuhZI+ZBDeWT4U4HAsqEK232VEI0/JNoBwr1JqSeHx",
-	"NKIaeYCeRzxjJQVEGfJfg0S3114mwmE6sUtKSOuZOFKzdTUkTKa7Ko2yOYfaDqltQm8H1HTKV+nuWtfR",
-	"FKoI27ob9X2AkipiVB9VagqNk+kUk2kHRJRgQZn6t5xiDP3LJM6KUDnk2HvVrneCpwcSmffpFUi/0pw7",
-	"4AxFqZ1+klScRLG7vb8msRxF6x02FDxDMNSXIeuIVyXhS+rUQy1l1JJsZWc/qPf2Z8i/XK8a6ZKiGsj5",
-	"wk74K9YBr+yNi2U5sFAU90gjAvgSEykT1W1MGEbdSkOmpS9cONso1DrmHE0h1qz5Vy8z/HTnywxZp5fl",
-	"GnrX9RpxXUJvfVvCjfCn7UqsgTkjzEJz5eWvT9R0i6oGFtNn+iI6HxHdyl8w6F/qWkOBaj0fApQ2H5Ja",
-	"u1K6cneHGq47FBsOV283qN5HuXKQXI9JuLnSpa56mb78tkJa/W0DV/Og+4mfOdsU3SmE5p7xQR1xi5ur",
-	"uVixfXOyl1xJR65kyiHlhMlnliTppINWUq3+/O3rIjDtMijdhNiURVlr37vlSKOdny+UmH7cbean3agc",
-	"hry51fxdmvLuDXq0BMUlwHloc94N2nNJVFxdEqwva7EOhooV7GD1d/NPmgtbM3zd154ozy/bTHadiYpt",
-	"5m/Nqo+TvPgcufM9EjUH5Dgt1trK/miZy9jGCKnN2lvj8atdxPfMit+1eXGvomVx0t4SnSlfEvees4Rq",
-	"K0RWMinu5Mnji7x39+61c5ckzq9tWTdcUwmUe6ttUkTqs3HS3c03d6ACSC4j2eGSS58ZlxyY0Wt5jKki",
-	"p9AXI6K8BEbJNhXBOlnYKksMtQ5v3gG5e9IqPg/VVto+A50RgSRIi5/12jjX7t+pts7k9IZpmyVnUbC7",
-	"S215j+SgW9IxZ/1xOlfJhDRfnHOLnHMpq39Ht5nzdLHaYWrccv1vBgWrOOga/HKLnXKr2ubFKzucbne1",
-	"MdDNDViHVdBZUGW8Fqb6q0NZncPv3zf4NFyCT88T+BwdgI/o91vg7tNuvl9TvnqRKE/G83hfHsclPY1P",
-	"wsH4zPyKxp2Y15DW4FoU5SqPyk6vcRUs9iq+cPsTcW4+lpl3bvyH9eae90ie0SU9ok/XEfoiNVf2dba2",
-	"ymwTboxWrw2ddVxfR4XobLY714k2HdXx/SdFOis8R378NYfbVg7WShP4h/Su1m3k03a01kKd8UA2ZPlk",
-	"yJrpn25F6QxgR13pGs+sJbt7csva6dd5WNfN+fTqQNZR0EuGY1snapGkvxMvag1ZLBZbpXN7yTKRddS4",
-	"vmKRDQLooUpG5uRZo5mma8tZoygDfNnKkegKsblc67Qrd+Y/tXhkHW09mjt2KYAe2tyoA+65OGlXFmDr",
-	"c9ZmH1itwKSVE6tXmcyZK89eUixQt9bqU3XNtwT7Po5b9Xly7Hskak99VwHKemupZepmzcdeilHetRhl",
-	"W7WmSUwtW5fy3gXWd29uPnCRyjpWf8l4/Q5le3vp286uzHc7bVO4slSgslrBIrMr/fy1uWF1IGTITqPe",
-	"0YW3TMnLtLNqWnMLQKGaUtpb/Kr+ThKrs0TVC1LlMiMU6fpcTgfx0K72HnlWr7RtPcsqAp+28zVXmMQB",
-	"ekZyZr+L9JbvXVs5wz5SH4YgQFcopLF6o1NsPhPKATPKxe7bwVvdVqeUN0v9S8T6vyRjxAhSBdvSwEF5",
-	"MlOwqZsRlJn1Il1DxUusC6+YKhua7FSljTRxNjsbTaWIKoyqI2qpJbWzIaKZqFRxtt2EDR5yM61TIlQn",
-	"P1G7ncXPGUq4avzs3HvbRKuy9dWJ9cPaQrhyEaWytaqereGA7Fs1xX9uL27/fwAAAP//N/7UiqrpAAA=",
+	"H4sIAAAAAAAC/+x9+XfbONLgv4LV9nufndZld5Jv4n3z5jm2O/F0nHh8dM83kTcNkSUJYxJgA6Btddb/",
+	"+z4cvEGKkuUrk/lhOhZJoFCoKtSFqq8dj4URo0Cl6Ox87QhvBiHW/9w9PtxjdEKm+1hi9UPEWQRcEtCP",
+	"PUYl3Ej1Tx+Ex0kkCaOdnc5bLABFWM7QhHGEgwDtHh8izmIJAm2EsZBISMwluiZyhgZdRBmSHJOA0CkS",
+	"ARazzU63Azc4jALo7HQG14DlDHin2wnxzQegUznr7GwPh91OSGjy91a3E2EpgSsQ/u9oNPiMe3/u9v41",
+	"7L35Mhr1RqPBxYvP6veLHzrdjpxHamghOaHTzm234xMRBXj+EYdQXdH7OMS0xwH7eByAXg7FIdjFjAGd",
+	"n3zoTTgB6gdz1EOMBnMUgIJGdBGNw7H+h4iwB6KLZvNoBlR0UUx94MJjXP2KqY98JoXCGLsGv4gEi4Me",
+	"jkgRD1uNeMiQMBr1voxGfXTxo3P9amexWq6oLv8DERKxCXp/dnaMshcHZks73Q6REOrvfuAw6ex0/vcg",
+	"I6qBpajBp+RDNV1I6KH5aCsFBnOO5+phxALiWSpzQ7J7fNgL4AoClLyLcBQFBHwkmSa5DEwU0wCEQOwK",
+	"OCe+D7QtxMdqbA1RGcI4EpIDDqsQZpAl7yBPM1FsF98tsVGICV0EyHky3W23IzD1x+ym/Se33Q6HP2LC",
+	"we/sfDbzXaRLYuN/gyfVwFfAhV5DeUmnEGIqiYfsG2oD5EyzQYFEr7b6w06B+q5GI//H0aiv/uOkuqsZ",
+	"E9Kxz3uxkCxEV4TLGAdIvzXwmYJdaKmSze/G5sLh7Gh6sIgzP/bUu0oOTSbEK6wLR6Rv/+p7LOzUMlh/",
+	"NOrVsFdu15YCzX7nhMs+690dvnYkUnorLzEz6umm50KOSwrixUV76VGTcEnltMER+bWOQJU8FhF4ZEI8",
+	"/TnKoAEahwraKZZwjed9HJFeFGA5YTzsXwu2rVA2uNrCQTTDWwq4DMEtv3Fs9yWhvhtO/WoG1gkIuatF",
+	"OhZz6g2uYSziceFP5l2CTH8RAopAZiNUoAhBYt+e3U2y4ih5TxFqBJ7GN51/mnR2Pjd/WVQRbrvNb/8G",
+	"4xljl7vHh+b1i64DQQVpiSI8Dxj20cbJwekZYhztKizoE/gKc4KpFJsVyszRSg4JdlfsEuuokAOWcAIi",
+	"YlSAQ+nRz/0vWOs92S5sD7df9baGva2ts63hzk/DneHwX51uR1GMerXjYwk9STSrVPaJOGjlnJI/YkAz",
+	"TP1AKRp2FX2ld2ymItCCgyqIq9MdelZIO2hFCDyF4qqq+5FMKGLPAyEmcRDMnfJOYhmL4mj2G6f4ce3F",
+	"PkhMgvq9UKqQSystipFW5Btnmsnqm7GOTcgY9gHozocoYPNWo75qP2pu662Qi4D66mE2oxoMkwD8oizL",
+	"Pa4MG0f+ujFw6zriKpS4DlJWeqvSdxutKKfFU8HDPUqg5YiVWlOpzkZ5xoRRUIYrCm67LT/XYNVLr1VQ",
+	"3lJIW4ysV0i3Q/TWzstXd+LAbmdP4UhrcqDYpuEszl40GG1j0+VGT0d2GHhLokYyiYO3c+myWc/UMzRW",
+	"D5XlpIzTHORoQgJtQ6fzbG9vvXrzJp2EUAlT4Okseyymsm4W42pQ0zRO8VN19AU70bALbng+uiARiFB9",
+	"VCqI8gBtuZbbcBITH6gaFDjaOD8/3M9pRNlsheP31ash/OXlcNiD7Tfj3sst/2UP//fW697Ll69fv3r1",
+	"8uVwOHSyHBEiBu6w23L4Ne+g/Y9oQ4ExIVxIDQgiEzSOldJQdObsffzr0Rzt7XY/qf9+4lNMyZ+ad7t7",
+	"fz0/XcD6JevcUKXSjQk1PEcYxQFKvihMnIM6jpRmDb52PJ3un7YWG9TpI1N2YOIZqNuEcN7ztL3b87Bz",
+	"ZCZ3J3IRuuEmIlbSKYDbIn17uP26t7XV236Nhq93hv+9s/36DjpNJgyAc8aLx1WDpBCxYa/GFdqX7pOi",
+	"FvD7uSaOE/gjBiEbRW91JccHRz2gHlO09c/+q+GbPD1siM0+2sNUHVkSE4rCOJAkCgpEI/qFxfXU/94e",
+	"vDv8iPYOTs4Ofz7c2z070L+O6NHh4f4/z/b2di9/m+5eH77dnR7+ffeXD8Pzdz+GJ7/Ifx/tDt/tnf7x",
+	"7vRw/NP+Pw7e7l2f7x4dnN/s/bn797fTj7+OaL/fH1E92sHHfccM7XnASiftG3YIpD46sv7i2LyIPc6E",
+	"KB8JpdWXmGYF12//Syu3T5Fr9QpdVvLeDFMKgYOCzQO0IVlEvAFcAZXIeIA2kQ8TQolmWh0VSMx4vdgi",
+	"cY2J1gqNjef7xMiz49w7ksdQ9h0ccyaZx4Je4glCnoUnGQ9tYD4mkmM+R5cwH1zhIAYFYOzJmMNmv+NY",
+	"bWGSBXGB3MNUEhoYijv6jsj38dgcG0ijSeRfrBBbhDkOQQJvQEmZQ0twV+WQ1oeWQ/HfTz99RKf6QzTh",
+	"eBqqDU7oPAUSabw6kHm7CL2dYyxng2TbslWjjUuYg4/G89ws2vZ2blmEFTPUUacOTCmYFZHmFQkOAZbk",
+	"CpBkiSmvLLPi1g30pjkl++KoRSVWoeNEkiE5IyKLWKANG6oAfapj3xcWplLMY/PugYwoHgdEONB1rH3i",
+	"Sr8SQP3NHHQZJ1dZN6elNCrhZi+O7Nv6WAxDzOdFhfvYAFdglH67o0zEY7WasUNI7zEq4lCtjIMH5Aoe",
+	"Z3EnZvLlF1eS2praG+T0UZ3ieKCmHNhF5eWz5JiKiHGlCypKRDgvnRzuCyq/mNkdqFZPtdM7kYjWo9sv",
+	"hViiwPruB/8WbIkj9wObEi/TdrVYKI59qBCsF+uWrRqc1QUhh4iDACpxXu4n4IyZPy+AU3FierUiWlNG",
+	"7kmTHHUwQEpzJXthxrh0HVUW5CLyNN4QhEQqarieAUWYWpolInEH9xfqFtREiRJsO+nVBBLiMGp0+Trk",
+	"624QoMRDVPXCFgLU9+IsXtrKTI2OOCb+d0fwM3EEl8/Osv+pSpQcpkRI4OAX9Pu2x3ZLX1W94qFgsEa+",
+	"fmmeE/NiOeVhP/2wzl1GhCSecDkotCRC2TsIj1ksjX4cc64kTHOOhHZ87Tp5v+z3crJ/SiSv6t1qGa5X",
+	"8uMt5cJrJJwGT15xktrxj2sJojy2kyqWdRMu6yslIQiJw8gBXvLInDSaQPReIj9WP2KBpkCVrqZFQ5n3",
+	"t3rbr9fA+93OAeeM159C2uPjwK4JWIKvLCDiG33AvtuS135NP9QguFit1hH4nkxn1kDQk+bP+KKvqBAs",
+	"yMFqJXHLSIHxey06+O2XGdyuo//gRnKjCB2m9pgrYpJ/VtXIlPWI4EapYyZNiaMZYN/aisqEsiPMNWVJ",
+	"dgnUGKsF9PzQj7UeRGgUyzP1kpOMA+Zht1fgtxlwPd2EUD83Vc49m8sASVSibscAWzwIs6fNaE6h6ebR",
+	"5ML1hw9Hu5o3lXLOWeAg7xsPoppUQIvj5AVjvALCxgftmSFRyHxoS/InLJZwkIzopHg1WvVsc06ZYFXn",
+	"UH7BQaB1DTrX/yypGPbXhdlQauQaTFrDuoLCamx0HPtTkAnOnYaInLUPY6Vzqw1xIa02gFkTwnQo61kS",
+	"lYGtEQfH1ulSNpnljPnFZSVb9O7grNPtHH861f85V/+/f/Dh4OxA/bl7tve+0+18Oj47/PTxtNPtvD/Y",
+	"3c9BkDtOytoQ5jgUq9tz5smY0GnRrSU0kUfS+KG0x8acnn10pv4gUkAwUUYRRoXxmBeHQGWjqyrnYPJm",
+	"WOodDyA5kJt3S4/RTVGdYqBuuzi7Ij7wptRuXBYQC0ixKFBuu8Xc8AmOA3UIDzrd+84UZxFQTJZMFN+o",
+	"zRTf/NsP7T0RJWfwhw9HKMH1w2eLC7bdM8joRRaIe0kbf8JOz0w8O6SEhDAKnNGrM/skVRpikQRziCjs",
+	"agHjKeU57NUsVxwHQYusyly6d7sXd2N1CFysksRdu6BVs7mrU/+ay202WI0F+BqnitUJnfbRaRxFjEuh",
+	"+J36mCvi1knQ6n3FDPHYpn93FXlck8D3sreEjaxNmGIGdPLzXk9LUIKp1NPqWXkcgOij3+y3AmEOhhot",
+	"DyXZCQFMZC9U0AZ4DAHagP6030Uv8lnWm/0RrWSJO8XPq58aGG1jNHoxGvX/X8ZwFxt/2ymw38XXYff1",
+	"1m3ujc2/jUb9zR/tLxdft7u3Pyx/qKcsUEjULor+VmdIbc62Ows6FYo2HTfRB4IgHKSyqqCqFZ64rBOb",
+	"s7xIGlRPviaOSeFclFqOSW2GeHEdTS8u2r5s2kVZzPmV3imbeau3/WoNuYTr84k6kt+U+EpI4+GSk3Mo",
+	"XpSknNLt3ZzPtUyXem+VjvnlnlyuT83NvSJlLnBzp6O+WmrUZn/0SqA+UGJyjqgaEpSfk4xw5CS7NeGH",
+	"Clbk9cx2yqK/fmzfMZk5RyZnueW0OetTZbrhrO+lOKo99Hs5XeWup38C0sLzP4X9+Z7/yRIe8VbTY+gB",
+	"CbU8ikJQoC/HoZ84dqxneQHhOj3jS+UfVrDS0myNOAsjeTcouckfPWI+BKuOoSNadwHDZQe15JtFyt2y",
+	"ka9a6bmqLpjK428nF+GRwvstuXpVPemJydCqnrSqSrKmDXEie9krVI9wwjzvq1Y5nD9dXD8Kio2mvQYU",
+	"H+0dLzpFQi+644lwtHd8zNnNfI2XmY/2jhsuM4depKypm3lva+2Xmbd62y/vxbh/+Vxy2FbCwAP5DAyp",
+	"hZHjUhDmUx3pdASDPkX2Ulpgo0Lpu5rgzP0We2GpPl2z8S7GfjWjNZlktUtsTV9nCqUj+UPOgBdGQESg",
+	"9It0tDFjAWCT8UBkAA1YmxVDi/r1xWC2VXzLsbFGNNfBVEw2Wu6+VO4SRs5qUTTmTB9bClc0t6NmUD2H",
+	"LV6DophHTIBYHXtF2btkqTQlZfXXyW0TZKP5uZh2KmtXDkVns9ggkFOQ3098WKO8fV5LJl4chMlBsJh7",
+	"sNRwJ/YjZ9pqBF5tVSGFtVrXT1FiD1/3tv5yNlTi2kpsxw1xFiwF9xkzqRR1pccaQu5j7F0C9ZEAfkU8",
+	"nW/QOgPxaO84X22ssU7bVRPqDMG5UFbreWwMV1bLSokW/LhkbDIDvFSnSeloFyXGWXfJpfYa3kLfZbaO",
+	"Z+a8TNa5bMGURiF5L/pm2SBqoxJXze6i/HX6tn91ee/bip3no7/eOUyRl/XLqY6p7rBAiQlJCGfOi27p",
+	"CEeHRweJ7Gh5WJ/NilpKcso5t5P82TS7eowINZcUOs77AatrTwlcLfWnbifmZBmVr37dJWmixu02KmT6",
+	"7FyOBpqvck9i6hkMEekUMTpZ/DS9U92UXjohlNApgpsIPAl+LsN0HYqz0jOc9V1j2QBhuv/NoJpBsivz",
+	"a9bPFexO6mp9v7DIwPlNqaGU81xyXpFaYh64ShtXNCu0EeI5ItQLYt8ms0YcJuQGBeQS0ABHZHC1XUzP",
+	"nEkZiZ2Beta3dZ/0UWreLbjNOGnBD+5EraNaB0wjUVnHkIMtlylW1dZ8yqoC1ySPO1j17OwY2YfdpdLJ",
+	"dRJ5llVeOO7M9860/CoI+tKC2WydmswS6v6qufkWRQH2YMYC37B1TlP5qgsm8fkXj/lwO/jqETm/7ZRz",
+	"kvsvfvhGagyUb1Mk+1Z7b73uTgXcgBcr2PcYNYn9jjvt2e0fezFEp4p7yRc4QOkwqVfAzJffJBu37Cfa",
+	"/Gccy5kStZ7Sei7Q//orkjyG1fxKjvlwRH6BeXb5q7YIyJL3GnbTeie5awypi8Xc/duYcICeEjjOoiid",
+	"dVSKdiw5vYpSk2Bcn2fcbCjWU1TuBusKqgFqqvJi1vdfIjmwKhcQhsue7HZzKv6a3ePDMqU0X3VYqZjM",
+	"k7ojI+ZCQni8XrAxVWc2kQQH1u1cZZG1QL8ir+Su5D4I23Q7k4Bdiwb2WVCLMakC2Hw9OX9+rfXy+Z1i",
+	"GqUriE232Go1kYKDrb1O0u5Gm0sF0TcxEyrorvMGmYsGToFfue7dmt/d1b0YR7/B+DQe33OdL2FgeLwy",
+	"X0RYGEqFZ6jaGxwkWNA1v6iQmHrQr3GW66U5fARJSR6UvGPu0IzNVebc7Jby0jry+QrywpxMf0j1xyWe",
+	"XOKiCpx+VAtZrbP816IQExBY4zYBd4NMkK3yMw7MJmQT17jLBHgxVwa3g+zMkySsloUSc7uBNgB7M6S4",
+	"EoU4EkgLlexiV6q0C49FSmNWDKchSxm5rtZa+sJC5l0YbauxM4UxLhlXyisF053CTJNqcMkydSX8cQAC",
+	"KVN0rCiUMnsIf1WrvS3hO7E/zYb3ZvG4Tyyx7rwZvvnLQgu020nnXKYknb0JWg3d6gfmLn66umSGvjva",
+	"v1wouHEwwzSO4in6UpiGShTIYsGulxtl2HVfLKx/lyQ++SjbUlsnM7udZnf9/OSDu8Ze2TWQkysuCM5r",
+	"W9kkT9J4UrHK9IYgdBoAkphPQSpK5TABDtTTVgOjYK86VnwVt93ij+r8v7i9KJ8PWi2oWN7JHLrRD4o4",
+	"6LMH/LTfzn5ec3I4JR3stk84eDJdp2I8ycw95KTzCpKswkI7g0HEmd+z3+28Gg6HS/hwardCX+esplc4",
+	"f7VFI+qJMtNGcER6l6DMsDFgXigPkefroFB0rEZl0E8vWqWclGuaVJYwIRA43Dw/q5+RnGFpC5PkSpUU",
+	"++BE4PWz8GD70smlc91UTXGWTbbB+cqNdH0N28OUMokU5Zhf2+12qRtKVaU2NfcafD25Hle9cnMuLUZ1",
+	"0xSlfCnu1CUGB6bsZem9rBpr69JUtgjsohDxt9Ukjv6ndod7+h3ZzKm4ZFKEqa6dcslmyiZoFo9zb2T8",
+	"0dodag2mlVMo7q3pWvs8iwSl3UwUOSS+Dn5NWBKax6a2ueGUzm+nn7Y1QxzbtAF0ZhNLSqe63QItDEJM",
+	"8VSxebWWW6IDVcd9Z3t1jeiIns0g+RvZm+wBcOubEjXD/s/ukVa3tWfHnN2G6eYUh8TDQTAf0eQzEBoM",
+	"7TjgaOOAXrG5SbjYRFcEo5v909T0yRU3mMRBgPZOzvdRQCbgzb0ARlQt2QGSlnsccKDj5TYLOi24ZGbW",
+	"q33x4heYo58BK+tW7Lx4MaI9dBqPQyJbLFW9fJLOkisGptZuTkQOCnpCp+rdfwFnPZ9dU/2+q++IUK8d",
+	"K3oS0lQAZxxPwSzo9B8fiAT1xj9i4POmsp2m8LqJJnYc22k4IWWgjvGMmVaWVPeG6vzUH/Z/6uRqKw2S",
+	"AqJTkC7dUnICV4BwlqfaXFrULCpNoR7RE5AxpwKNsSBevuKXrXmoLVI1zobikG7C3d0k/6+LstvcSKHY",
+	"1plIheehb2WaPa25dcnpVW0Ph7mivKZgaqmwbtritb64aiv5lm9q5KqNWfEHOksv3tF1d1sRJLnjqFwG",
+	"8rbbebUkfhovmxVqBDpASd0/1mAz9fJu87V5DbiJ8lMpWynxVCgZrR4eKaGo/RzKfupEzkorlusxonBd",
+	"HTKRHVVe6qOzWYmZR5SIRByA30WRZWjfqCK6RrQxVSVDRv4poZemaJohjZga0TFMCRVJuZfUpsp3TlOc",
+	"RCh6hQR4jPrCyrbMekAncZDKt1TJ+jE9ID0Wjgk1r4aFPgvqgzoV/vfB73pBBQ3+98HvehKJAsCKoChk",
+	"7VzV2+qHLJaanKfqm591084wUwNT1k6B8hhNZKNtAGGXIBysbq7uGllnw5JvmT9vQca5ktMm2THXKjJJ",
+	"OUzV884gAqkkddr6YadzDPJU/WIlbb5D8OcsOm+d3MZJrYcZfI1AHvo6qJ3qjZ/dAdwlQq0WKkesNAuN",
+	"JtZw5589pZD+oq3dEFMfS6YYTg2V17qSeMqt9kmkS7Ie+9yaOsXn542PUx+/CymFN4u40/gfEKo0UAVu",
+	"E0zmXcbVcrXr5LlgupsqhwLkez2KKIxs4UweqfX8s2c70fRObX5fplkawWiQkByG5W/Nr40fu6mikG79",
+	"2SYFpb4fyzF9cY2nU+B9wgZX2/qr4lAFRb9tV9lCj47l6pLfdgsCYY7D4LtA+C4QvguE/1iBUDD67U6U",
+	"LIettWnG1TbKDu24ZWvh227n5cMq7VrnLYc6KkWyNw1kbx4OMrWlAfEk6qXqslE0tRqslNJEEcYBB+zP",
+	"EdwQIZ+m3WPoo85QaTJ9brvGiB98NXmqt8YKCsBVy/MEQqbMeeowhiachY3mkHXuCMkiMaLGeVQ1Xohw",
+	"Wy/okPYmAZnOJLLySyCbkwEjmqfx/6ORkL5kmxKhl8OX6COT6GcWU9/lBNjXizZHcT6p63MZC1kxlJwT",
+	"UZltBm2lK+AGMf+ze/Rhc1HKL6G6QrlOHrEi3GxKpyxu8qKrbNVfrNWJsWKdglVb7RoU3nuFoTby0wmK",
+	"llIvH475q2Apw3qiaPhJCiLDRE4J0eyAaXYgms4VhtvLcodxhNNreXra8RwRKdKKDJoBi2UZKsz/DuTu",
+	"8eHb+fuE31aQAM+c7xeoIKWqG3VG0erjtWJJ9Y34zoULuPAdOEIVii1SsmpyhcbSlbuiWwNjarQgZzTJ",
+	"HPMmaIHy3k6tTSXRSyyZDf/0TWTJ6gX2nDaBoKRGTXEBbZSCEU3lhFbp1GgsKI1UUhFiAfWzWr/pYRgx",
+	"LjGVOy9eoMNJuc2L6OoRUuQUAeegq2oj7ElyBS7lw+D3LsqHxftTEELLeFXX7JO5T4tureK0VB+qldBx",
+	"Vm564hbddyldK6XbyNRFplu5Z96COGwQ2NpA6OzDaaETWtI5LpgnHe5saoCX76OuvTFabItig3Fd+z9t",
+	"Q3AFnEzmakHvz86OT7NYT5Z7K+risHvF9mz3xoO5eQpXMRqCoAVkP+nwp93kUqu7hJLyrfFbxUFN93rr",
+	"XnATUBIMrZKLiYVmP49oErgjFB0fHNnkkD7anUhdnk7N1XUPpi8LxZKFWCYpJBwsvSol43T/FG2cgsdB",
+	"on0iPHYFfI5OTYrSpvo6kaGSoSgWRj+gcD2ipbWYEGzE2Q2BJHa6b1JXkGFcpQjszTCdKp0FXwKCyQQ8",
+	"iUgYgk+whGCuVRAWK+1Eh0iTC17TNLnGoQio5ewVWsevHKfMd6B/Cm3/rV5R6MDf2g2bw4lBknVZP7Q7",
+	"1tlF1OFfzNGToeknc3LnILNJ1U/zeMwLnQJDLBRk5aNxYKSEdm85JdwRprGSJ0hyMp3qHt3mE1dr0szX",
+	"OSEBmPuUWvwY4TKip/unyR1HbV1M4gCRCZqz+L+uAIXJXNj3obQdajwrSgsiSSBf59QzPrfC6CMzIkhP",
+	"A9SPGDGV8eQ8MrJRqz8UQAtHYYlQmCQ8sHfZRrQgTtPlm8U7D+kTKEmoNadNOT2F+elQReTfU0lTXSr7",
+	"y7h1+1oL1bJdbNu4J93rL4uTJ8fDKVtZZlpWIanw8VfiN0YoEv+jQwNC4zk63E/UjIQDahQNna5VZI0K",
+	"1RW1CW5iI+XRlKgY0cfSJgw6itpEs3thP3ErlPQhi/Du8qEAh2NBly7+JiMaeUpOAgj3KqWWFB5PI6qR",
+	"B+h5xDNWUkC0If/Fj01r7mUiHLaLu6KEtM6JI2XbVEkidLqj0yubc6uTV2ob2Ccv1HTZ12nwRtcxFKoJ",
+	"O3E3mnsCJVXEqj66BBWM4+mU0GkXhYwSybj+txpijL3LOMqKUznk2Dvd6ndCpvsKmffpFUhnac4dcIai",
+	"9E4/SSqOwyglqiLMmsRyFG122FLwDHBgLknWEa9OzlfUaV5NKKOWZCs7+15/tzcD73K9aqRLihog5wu7",
+	"6K9YH7yyNy6WFSiBorhHBhHIU5hImahuY4Ig7FWaOS19EcPZgqHWMedoKLFmzb96yeGnO19yyLrELNcM",
+	"vK5PietyeutbFG6EP21XYg3MGWEWGjMvf62iptNUNbCYPjMX1MWISnYJFEmOvUtTg8jXbesDBGnjIqW1",
+	"a6Urd6eo4RpEsVlx9daD7puUKxMpzDuxsFe99BUw29M/qZxWfwvB1XjofuJnzhZHdwqhuUd8UEfc4sZs",
+	"LlZs39jse66kI1cy5ZBywuQzS5J00kErqVZ//g5McZh2GZRuQmzKoqy1791ypNHOzxdQTCd3m/lpJyuH",
+	"IW9vO3+Tprx7gx4tQXEJcB7anHeD9lwSFVeXBOvLWqyDoWIFO1j97fyj4cLWDF832xPl+WUb0a4zUbHN",
+	"+K1Z9XGSF58jd74DWXNAjtMirq3sj5a5jG2MkNqsvTUev8ZFfM+s+E2bF/cqWhYn7S3R1fJ74t5zllBt",
+	"hchKJsWdPHlikffu3r127lLF+bUt64ZrKo1ybzVPikh9Nk66u/nm9nUAyWUkO1xy6TPrkkMzdq2OMV38",
+	"FHtyRLWXwCrZtlJYNwtbZYmhicNbdFHu1rSOz2O9lUn/ge6IYuqnRdH6bZxr9+9UW2dyesOwzZKzKNjd",
+	"Jbg6j+SgW9Ixl/jjTK6SDWl+d84tcs6lrP4N3WbO08Vqh6l1yw2+WhSs4qBr8MstdsqtapsXr+wItt0z",
+	"xkAv98I6rILugurjtTDVXx3K6h9++77Bp+ESfHqewOfoAHxEv98Cd59x8/2a8tV3ifJkPI/35XFc0tP4",
+	"JByMz8yvaN2JeQ1pDa5FWa7+qO30GlfBYq/id25/Is7NxzLzzq3/sN7c6zySZ3RJj+jTdYR+l5or+zpb",
+	"W2VJc24Cq9eMzjqxr6NydDbanetH207r5P6TIp2Vn0Mv+pLDbSsHa6U5/EN6V+s28mk7Wmuhzngge2X5",
+	"ZMia4Z9upekMYEe96RrPbEJ29+SWTYZf52FdN+bTqwNZR0HfMxzbOlGLJP2NeFFryGKx2Cqd20uWiayj",
+	"xvUVi2wQQA9VMjInzxrNNFNbLjGKMsCXrRwJV8Dnaq3TntqZ/9TikXW09Wju2KUAemhzow645+KkXVmA",
+	"rc9Zm02wWoHJRE6sXmUyZ648e0mxQN1aq0/VNd4S7Ps4btXnybHvQNae+q4ClPXWUsvUzZrJvhejvGsx",
+	"yrZqTZOYWrYu5b0LrG/e3HzgIpV1rP494/UblO3tpW87uzLfBbVN4cpSgcpqBYvMrvTy1+aOqy9iDskw",
+	"+htTeMuWvEw7rqY1txCWulllcotf19+JI32W6HpBulxmCKGpz+V0EB8nq71HnjUrbVvPsorAp+18zRUm",
+	"cYCekZzd7yK95XvaVs6wD8zDAfLhCgIW6S+6xVY0gXphxoTceTN8Y5rslPJmmXcJfPBLPAZOQRdsSwMH",
+	"5cFswaZeRlB21It0DRUvsSm8YqtsGLLTlTbSxNnsbLSVIqow6k6ppVbVzkaJdqBSxdl2AzZ4yO2wTolQ",
+	"HfxE73YWP+cQC90Q2rn3SUutytZXBzYPawvhqkWUytbqeraWA7K5aor/3F7c/v8AAAD//9OoMgcF6gAA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/gateway/gateway-controller/pkg/api/handlers/helpers.go
+++ b/gateway/gateway-controller/pkg/api/handlers/helpers.go
@@ -44,6 +44,16 @@ func uuidToOpenAPIUUID(id string) (*openapi_types.UUID, error) {
 	return &openapiUUID, nil
 }
 
+// convertHandleToUUID converts a handle string to an OpenAPI UUID pointer
+// Returns nil if the conversion fails (should not happen in normal operation)
+func convertHandleToUUID(handle string) *openapi_types.UUID {
+	uuid, err := uuidToOpenAPIUUID(handle)
+	if err != nil {
+		return nil
+	}
+	return uuid
+}
+
 func statusPtr(s string) *string {
 	return &s
 }

--- a/gateway/gateway-controller/pkg/api/handlers/policy_ordering_test.go
+++ b/gateway/gateway-controller/pkg/api/handlers/policy_ordering_test.go
@@ -149,7 +149,7 @@ func TestPolicyOrderingDeterministic(t *testing.T) {
 	}
 	specUnion := api.APIConfiguration_Spec{}
 	specUnion.FromAPIConfigData(api.APIConfigData{
-		Name:    "test-api",
+		DisplayName:    "test-api",
 		Version: "v1.0",
 		Context: "/test",
 		Upstream: struct {
@@ -173,9 +173,9 @@ func TestPolicyOrderingDeterministic(t *testing.T) {
 			// Build a minimal StoredAPIConfig
 			cfg := &models.StoredConfig{
 				Configuration: api.APIConfiguration{
-					Version: api.APIConfigurationVersion("api-platform.wso2.com/v1"),
-					Kind:    api.APIConfigurationKind(api.Httprest),
-					Spec:    specUnion,
+					ApiVersion: api.APIConfigurationApiVersion(api.GatewayApiPlatformWso2Comv1alpha1),
+					Kind:       api.APIConfigurationKind(api.RestApi),
+					Spec:       specUnion,
 				},
 			}
 
@@ -258,7 +258,7 @@ func TestMultipleOperationsIndependentPolicies(t *testing.T) {
 
 	specUnion := api.APIConfiguration_Spec{}
 	specUnion.FromAPIConfigData(api.APIConfigData{
-		Name:    "test-api",
+		DisplayName:    "test-api",
 		Version: "v1.0",
 		Context: "/test",
 		Upstream: struct {
@@ -301,8 +301,8 @@ func TestMultipleOperationsIndependentPolicies(t *testing.T) {
 
 	cfg := &models.StoredConfig{
 		Configuration: api.APIConfiguration{
-			Version: api.APIConfigurationVersion("api-platform.wso2.com/v1"),
-			Kind:    api.APIConfigurationKind(api.Httprest),
+			ApiVersion: api.APIConfigurationApiVersion(api.GatewayApiPlatformWso2Comv1alpha1),
+			Kind:    api.APIConfigurationKind(api.RestApi),
 			Spec:    specUnion,
 		},
 	}
@@ -402,7 +402,7 @@ func TestPolicyOrderingConsistency(t *testing.T) {
 
 	specUnion := api.APIConfiguration_Spec{}
 	specUnion.FromAPIConfigData(api.APIConfigData{
-		Name:    "test-api",
+		DisplayName:    "test-api",
 		Version: "v1.0",
 		Context: "/test",
 		Upstream: struct {
@@ -425,9 +425,9 @@ func TestPolicyOrderingConsistency(t *testing.T) {
 
 	cfg := &models.StoredConfig{
 		Configuration: api.APIConfiguration{
-			Version: api.APIConfigurationVersion("api-platform.wso2.com/v1"),
-			Kind:    api.Httprest,
-			Spec:    specUnion,
+			ApiVersion: api.APIConfigurationApiVersion(api.GatewayApiPlatformWso2Comv1alpha1),
+			Kind:       api.APIConfigurationKind(api.RestApi),
+			Spec:       specUnion,
 		},
 	}
 

--- a/gateway/gateway-controller/pkg/config/api_validator.go
+++ b/gateway/gateway-controller/pkg/config/api_validator.go
@@ -77,7 +77,7 @@ func (v *APIValidator) validateAPIConfiguration(config *api.APIConfiguration) []
 	var errors []ValidationError
 
 	// Validate version
-	if config.Version != "api-platform.wso2.com/v1" {
+	if config.ApiVersion != api.GatewayApiPlatformWso2Comv1alpha1 {
 		errors = append(errors, ValidationError{
 			Field:   "version",
 			Message: "Unsupported API version (must be 'api-platform.wso2.com/v1')",
@@ -85,20 +85,20 @@ func (v *APIValidator) validateAPIConfiguration(config *api.APIConfiguration) []
 	}
 
 	// Validate kind
-	if config.Kind != api.Httprest && config.Kind != api.Asyncwebsub {
+	if config.Kind != api.RestApi && config.Kind != api.Asyncwebsub {
 		errors = append(errors, ValidationError{
 			Field:   "kind",
-			Message: "Unsupported API kind (only 'http/rest' and 'async/websub' are supported)",
+			Message: "Unsupported API kind (only 'RestApi' and 'async/websub' are supported)",
 		})
 	}
 
 	switch config.Kind {
-	case api.Httprest:
+	case api.RestApi:
 		spec, err := config.Spec.AsAPIConfigData()
 		if err != nil {
 			errors = append(errors, ValidationError{
 				Field:   "spec",
-				Message: fmt.Sprintf("Invalid spec format for http/rest: %v", err),
+				Message: fmt.Sprintf("Invalid spec format for RestApi: %v", err),
 			})
 		} else {
 			// Validate data section
@@ -208,25 +208,25 @@ func (v *APIValidator) validateUpstreamRef(label string, ref *string) []Validati
 	return errors
 }
 
-// validateRestData validates the data section of the configuration for http/rest kind
+// validateRestData validates the data section of the configuration for RestApi kind
 func (v *APIValidator) validateRestData(spec *api.APIConfigData) []ValidationError {
 	var errors []ValidationError
 
 	// Validate name
-	if spec.Name == "" {
+	if spec.DisplayName == "" {
 		errors = append(errors, ValidationError{
-			Field:   "spec.name",
-			Message: "API name is required",
+			Field:   "spec.displayName",
+			Message: "API display name is required",
 		})
-	} else if len(spec.Name) > 100 {
+	} else if len(spec.DisplayName) > 100 {
 		errors = append(errors, ValidationError{
-			Field:   "spec.name",
-			Message: "API name must be 1-100 characters",
+			Field:   "spec.displayName",
+			Message: "API display name must be 1-100 characters",
 		})
-	} else if !v.urlFriendlyNameRegex.MatchString(spec.Name) {
+	} else if !v.urlFriendlyNameRegex.MatchString(spec.DisplayName) {
 		errors = append(errors, ValidationError{
-			Field:   "spec.name",
-			Message: "API name must be URL-friendly (only letters, numbers, spaces, hyphens, underscores, and dots allowed)",
+			Field:   "spec.displayName",
+			Message: "API display name must be URL-friendly (only letters, numbers, spaces, hyphens, underscores, and dots allowed)",
 		})
 	}
 
@@ -258,7 +258,7 @@ func (v *APIValidator) validateRestData(spec *api.APIConfigData) []ValidationErr
 	return errors
 }
 
-// validateAsyncData validates the data section of the configuration for http/rest kind
+// validateAsyncData validates the data section of the configuration for RestApi kind
 func (v *APIValidator) validateAsyncData(spec *api.WebhookAPIData) []ValidationError {
 	var errors []ValidationError
 

--- a/gateway/gateway-controller/pkg/config/policy_validator.go
+++ b/gateway/gateway-controller/pkg/config/policy_validator.go
@@ -42,7 +42,7 @@ func NewPolicyValidator(policyDefinitions map[string]api.PolicyDefinition) *Poli
 func (pv *PolicyValidator) ValidatePolicies(apiConfig *api.APIConfiguration) []ValidationError {
 	var errors []ValidationError
 	// TODO: Extend to other kinds if they support policies
-	if apiConfig.Kind == api.Httprest {
+	if apiConfig.Kind == api.RestApi {
 		apiData, err := apiConfig.Spec.AsAPIConfigData()
 		if err != nil {
 			errors = append(errors, ValidationError{

--- a/gateway/gateway-controller/pkg/config/policy_validator_test.go
+++ b/gateway/gateway-controller/pkg/config/policy_validator_test.go
@@ -49,7 +49,7 @@ func TestPolicyValidator_ValidatePolicies_Success(t *testing.T) {
 
 	specUnion := api.APIConfiguration_Spec{}
 	if err := specUnion.FromAPIConfigData(api.APIConfigData{
-		Name:    "Test API",
+		DisplayName:    "Test API",
 		Version: "v1.0",
 		Context: "/test",
 		Upstream: struct {
@@ -81,8 +81,8 @@ func TestPolicyValidator_ValidatePolicies_Success(t *testing.T) {
 	}
 	// Create API config with valid policy
 	apiConfig := &api.APIConfiguration{
-		Version: "api-platform.wso2.com/v1",
-		Kind:    api.Httprest,
+		ApiVersion: api.GatewayApiPlatformWso2Comv1alpha1,
+		Kind:    api.RestApi,
 		Spec:    specUnion,
 	}
 
@@ -99,7 +99,7 @@ func TestPolicyValidator_PolicyNotFound(t *testing.T) {
 
 	specUnion := api.APIConfiguration_Spec{}
 	specUnion.FromAPIConfigData(api.APIConfigData{
-		Name:    "Test API",
+		DisplayName:    "Test API",
 		Version: "v1.0",
 		Context: "/test",
 		Upstream: struct {
@@ -126,8 +126,8 @@ func TestPolicyValidator_PolicyNotFound(t *testing.T) {
 
 	// Create API config with non-existent policy
 	apiConfig := &api.APIConfiguration{
-		Version: "api-platform.wso2.com/v1",
-		Kind:    api.Httprest,
+		ApiVersion: api.GatewayApiPlatformWso2Comv1alpha1,
+		Kind:    api.RestApi,
 		Spec:    specUnion,
 	}
 
@@ -166,7 +166,7 @@ func TestPolicyValidator_InvalidParameters(t *testing.T) {
 	// Create API config with invalid params (missing required field)
 	specUnion := api.APIConfiguration_Spec{}
 	specUnion.FromAPIConfigData(api.APIConfigData{
-		Name:    "Test API",
+		DisplayName:    "Test API",
 		Version: "v1.0",
 		Context: "/test",
 		Upstream: struct {
@@ -195,8 +195,8 @@ func TestPolicyValidator_InvalidParameters(t *testing.T) {
 		},
 	})
 	apiConfig := &api.APIConfiguration{
-		Version: "api-platform.wso2.com/v1",
-		Kind:    api.Httprest,
+		ApiVersion: api.GatewayApiPlatformWso2Comv1alpha1,
+		Kind:    api.RestApi,
 		Spec:    specUnion,
 	}
 
@@ -229,7 +229,7 @@ func TestPolicyValidator_OperationLevelPolicies(t *testing.T) {
 	// Create API config with operation-level policy
 	specUnion := api.APIConfiguration_Spec{}
 	specUnion.FromAPIConfigData(api.APIConfigData{
-		Name:    "Test API",
+		DisplayName:    "Test API",
 		Version: "v1.0",
 		Context: "/test",
 		Upstream: struct {
@@ -257,8 +257,8 @@ func TestPolicyValidator_OperationLevelPolicies(t *testing.T) {
 		},
 	})
 	apiConfig := &api.APIConfiguration{
-		Version: "api-platform.wso2.com/v1",
-		Kind:    api.Httprest,
+		ApiVersion: api.GatewayApiPlatformWso2Comv1alpha1,
+		Kind:    api.RestApi,
 		Spec:    specUnion,
 	}
 
@@ -282,7 +282,7 @@ func TestPolicyValidator_MultipleErrors(t *testing.T) {
 	// Create API config with multiple invalid policies
 	specUnion := api.APIConfiguration_Spec{}
 	specUnion.FromAPIConfigData(api.APIConfigData{
-		Name:    "Test API",
+		DisplayName:    "Test API",
 		Version: "v1.0",
 		Context: "/test",
 		Upstream: struct {
@@ -317,8 +317,8 @@ func TestPolicyValidator_MultipleErrors(t *testing.T) {
 		},
 	})
 	apiConfig := &api.APIConfiguration{
-		Version: "api-platform.wso2.com/v1",
-		Kind:    api.Httprest,
+		ApiVersion: api.GatewayApiPlatformWso2Comv1alpha1,
+		Kind:    api.RestApi,
 		Spec:    specUnion,
 	}
 
@@ -350,7 +350,7 @@ func TestPolicyValidator_TypeMismatch(t *testing.T) {
 	// Create API config with wrong type (string instead of integer)
 	specUnion := api.APIConfiguration_Spec{}
 	specUnion.FromAPIConfigData(api.APIConfigData{
-		Name:    "Test API",
+		DisplayName:    "Test API",
 		Version: "v1.0",
 		Context: "/test",
 		Upstream: struct {
@@ -378,8 +378,8 @@ func TestPolicyValidator_TypeMismatch(t *testing.T) {
 		},
 	})
 	apiConfig := &api.APIConfiguration{
-		Version: "api-platform.wso2.com/v1",
-		Kind:    "http/rest",
+		ApiVersion: api.GatewayApiPlatformWso2Comv1alpha1,
+		Kind:    api.RestApi,
 		Spec:    specUnion,
 	}
 
@@ -415,7 +415,7 @@ func TestPolicyValidator_MissingRequiredParams(t *testing.T) {
 	// Test case 1: Policy with nil params (should fail validation for required field)
 	specUnion := api.APIConfiguration_Spec{}
 	specUnion.FromAPIConfigData(api.APIConfigData{
-		Name:    "Test API",
+		DisplayName:    "Test API",
 		Version: "v1.0",
 		Context: "/test",
 		Upstream: struct {
@@ -441,8 +441,8 @@ func TestPolicyValidator_MissingRequiredParams(t *testing.T) {
 		},
 	})
 	apiConfig := &api.APIConfiguration{
-		Version: "api-platform.wso2.com/v1",
-		Kind:    "http/rest",
+		ApiVersion: api.GatewayApiPlatformWso2Comv1alpha1,
+		Kind:    api.RestApi,
 		Spec:    specUnion,
 	}
 

--- a/gateway/gateway-controller/pkg/config/validator_test.go
+++ b/gateway/gateway-controller/pkg/config/validator_test.go
@@ -100,7 +100,7 @@ func TestValidator_URLFriendlyName(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			specUnion := api.APIConfiguration_Spec{}
 			specUnion.FromAPIConfigData(api.APIConfigData{
-				Name:    tt.apiName,
+				DisplayName:    tt.apiName,
 				Version: "v1.0",
 				Context: "/test",
 				Upstream: struct {
@@ -116,8 +116,8 @@ func TestValidator_URLFriendlyName(t *testing.T) {
 				},
 			})
 			config := &api.APIConfiguration{
-				Version: "api-platform.wso2.com/v1",
-				Kind:    "http/rest",
+				ApiVersion: api.GatewayApiPlatformWso2Comv1alpha1,
+				Kind:    api.RestApi,
 				Spec:    specUnion,
 			}
 

--- a/gateway/gateway-controller/pkg/models/stored_config.go
+++ b/gateway/gateway-controller/pkg/models/stored_config.go
@@ -60,7 +60,7 @@ func (c *StoredConfig) GetCompositeKey() string {
 	if err != nil {
 		return ""
 	}
-	return fmt.Sprintf("%s:%s", configData.Name, configData.Version)
+	return fmt.Sprintf("%s:%s", configData.DisplayName, configData.Version)
 }
 
 // GetName returns the API name
@@ -76,15 +76,12 @@ func (c *StoredConfig) GetName() string {
 	if err != nil {
 		return ""
 	}
-	return configData.Name
+	return configData.DisplayName
 }
 
 // GetHandle returns the API handle from metadata.name
 func (c *StoredConfig) GetHandle() string {
-	if c.Configuration.Metadata != nil {
-		return c.Configuration.Metadata.Name
-	}
-	return ""
+	return c.Configuration.Metadata.Name
 }
 
 // GetVersion returns the API version
@@ -120,7 +117,7 @@ func (c *StoredConfig) GetContext() string {
 }
 
 func (c *StoredConfig) GetPolicies() *[]api.Policy {
-	if c.Configuration.Kind == api.Httprest {
+	if c.Configuration.Kind == api.RestApi {
 		httpData, err := c.Configuration.Spec.AsAPIConfigData()
 		if err != nil {
 			return nil

--- a/gateway/gateway-controller/pkg/storage/gateway-controller-db.sql
+++ b/gateway/gateway-controller/pkg/storage/gateway-controller-db.sql
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS deployments (
     name TEXT NOT NULL,
     version TEXT NOT NULL,
     context TEXT NOT NULL,              -- Base path (e.g., "/weather")
-    kind TEXT NOT NULL,                 -- Deployment type: "http/rest", "graphql", "grpc", "asyncapi"
+    kind TEXT NOT NULL,                 -- Deployment type: "RestApi", "graphql", "grpc", "asyncapi"
     handle TEXT NOT NULL UNIQUE,        -- API handle from metadata.name in YAML (required and must be unique)
 
     -- Deployment status

--- a/gateway/gateway-controller/pkg/utils/api_deployment.go
+++ b/gateway/gateway-controller/pkg/utils/api_deployment.go
@@ -95,13 +95,13 @@ func (s *APIDeploymentService) DeployAPIConfiguration(params APIDeploymentParams
 	var apiVersion string
 
 	switch apiConfig.Kind {
-	case api.Httprest:
+	case api.RestApi:
 		apiData, err := apiConfig.Spec.AsAPIConfigData()
 		fmt.Println("APIData: ", apiData)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse REST API data: %w", err)
 		}
-		apiName = apiData.Name
+		apiName = apiData.DisplayName
 		apiVersion = apiData.Version
 	case api.Asyncwebsub:
 		webhookData, err := apiConfig.Spec.AsWebhookAPIData()
@@ -135,10 +135,8 @@ func (s *APIDeploymentService) DeployAPIConfiguration(params APIDeploymentParams
 		apiID = generateUUID()
 	}
 
-	var handle string
-	if apiConfig.Metadata != nil {
-		handle = apiConfig.Metadata.Name
-	}
+	handle := apiConfig.Metadata.Name
+	
 
 	if s.store != nil {
 		if _, err := s.store.GetByNameVersion(apiName, apiVersion); err == nil {

--- a/gateway/gateway-controller/pkg/utils/helpers.go
+++ b/gateway/gateway-controller/pkg/utils/helpers.go
@@ -9,12 +9,12 @@ import (
 // ExtractNameVersion returns the name and version from an API configuration
 // Supports both HTTP REST APIs and async/websub kinds.
 func ExtractNameVersion(cfg api.APIConfiguration) (string, string, error) {
-	if cfg.Kind == api.Httprest {
+	if cfg.Kind == api.RestApi {
 		d, err := cfg.Spec.AsAPIConfigData()
 		if err != nil {
-			return "", "", fmt.Errorf("failed to parse http/rest api config data: %w", err)
+			return "", "", fmt.Errorf("failed to parse RestApi api config data: %w", err)
 		}
-		return d.Name, d.Version, nil
+		return d.DisplayName, d.Version, nil
 	}
 	if cfg.Kind == api.Asyncwebsub {
 		d, err := cfg.Spec.AsWebhookAPIData()

--- a/gateway/gateway-controller/pkg/utils/llm_provider_transformer.go
+++ b/gateway/gateway-controller/pkg/utils/llm_provider_transformer.go
@@ -29,11 +29,11 @@ func (t *LLMProviderTransformer) Transform(input any, output *api.APIConfigurati
 		return nil, fmt.Errorf("failed to retrieve template '%s': %w", provider.Spec.Template, err)
 	}
 
-	output.Kind = api.Httprest
-	output.Version = api.ApiPlatformWso2Comv1
+	output.Kind = api.RestApi
+	output.ApiVersion = api.GatewayApiPlatformWso2Comv1alpha1
 
 	spec := api.APIConfigData{}
-	spec.Name = provider.Spec.Name
+	spec.DisplayName = provider.Spec.Name
 	spec.Version = provider.Spec.Version
 	spec.Context = constants.BASE_PATH
 	if provider.Spec.Context != nil {

--- a/gateway/gateway-controller/pkg/utils/mcp_deployment.go
+++ b/gateway/gateway-controller/pkg/utils/mcp_deployment.go
@@ -114,10 +114,8 @@ func (s *MCPDeploymentService) DeployMCPConfiguration(params MCPDeploymentParams
 	}
 	apiConfig = *apiConfigPtr
 
-	var handle string
-	if apiConfig.Metadata != nil {
-		handle = apiConfig.Metadata.Name
-	}
+	handle := apiConfig.Metadata.Name
+	
 
 	name, version, err := ExtractNameVersion(apiConfig)
 	if err != nil {

--- a/gateway/gateway-controller/pkg/utils/mcp_transformer.go
+++ b/gateway/gateway-controller/pkg/utils/mcp_transformer.go
@@ -80,8 +80,8 @@ func (t *MCPTransformer) Transform(input any, output *api.APIConfiguration) (*ap
 	if !ok || mcpConfig == nil {
 		return nil, fmt.Errorf("invalid input type: expected *api.MCPProxyConfiguration")
 	}
-	output.Version = api.ApiPlatformWso2Comv1
-	output.Kind = api.Httprest
+	output.ApiVersion = api.GatewayApiPlatformWso2Comv1alpha1
+	output.Kind = api.RestApi
 
 	if len(mcpConfig.Spec.Upstreams) == 0 {
 		return nil, fmt.Errorf("at least one upstream is required")
@@ -89,7 +89,7 @@ func (t *MCPTransformer) Transform(input any, output *api.APIConfiguration) (*ap
 
 	// Build APIConfigData and set it into the APIConfiguration_Spec union
 	apiData := api.APIConfigData{
-		Name:    mcpConfig.Spec.Name,
+		DisplayName:    mcpConfig.Spec.Name,
 		Version: mcpConfig.Spec.Version,
 		Context: mcpConfig.Spec.Context,
 		Upstream: struct {
@@ -112,12 +112,12 @@ func (t *MCPTransformer) Transform(input any, output *api.APIConfiguration) (*ap
 	// Copy metadata from MCP config to API config
 	// Ensure metadata is always set to prevent nil pointer dereference in downstream code
 	if mcpConfig.Metadata != nil {
-		output.Metadata = &api.Metadata{
+		output.Metadata = api.Metadata{
 			Name: mcpConfig.Metadata.Name,
 		}
 	} else {
 		// Create empty metadata if not present to prevent nil pointer issues
-		output.Metadata = &api.Metadata{}
+		output.Metadata = api.Metadata{}
 	}
 	return output, nil
 }

--- a/gateway/gateway-controller/pkg/utils/mcp_transformer_test.go
+++ b/gateway/gateway-controller/pkg/utils/mcp_transformer_test.go
@@ -136,7 +136,7 @@ func TestMCPTransformer_Transform(t *testing.T) {
 		t.Fatalf("Transform produced invalid API config data: %v", err)
 	}
 
-	if apiData.Name != name || apiData.Version != version || apiData.Context != context {
+	if apiData.DisplayName != name || apiData.Version != version || apiData.Context != context {
 		t.Fatalf("Transform did not copy basic fields correctly: got %+v", res.Spec)
 	}
 	if apiData.Upstream.Main.Url == nil {
@@ -151,10 +151,10 @@ func TestMCPTransformer_Transform(t *testing.T) {
 		t.Fatalf("expected at least 3 MCP operations, got %d", len(ops))
 	}
 	// Ensure kind and version set
-	if res.Kind != api.Httprest {
+	if res.Kind != api.RestApi {
 		t.Fatalf("expected Kind Httprest, got %s", res.Kind)
 	}
-	if res.Version != api.ApiPlatformWso2Comv1 {
-		t.Fatalf("expected Version ApiPlatformWso2Comv1, got %s", res.Version)
+	if res.ApiVersion != api.GatewayApiPlatformWso2Comv1alpha1 {
+		t.Fatalf("expected Version ApiPlatformWso2Comv1, got %s", res.ApiVersion)
 	}
 }

--- a/gateway/gateway-controller/pkg/xds/translator.go
+++ b/gateway/gateway-controller/pkg/xds/translator.go
@@ -377,7 +377,7 @@ func (t *Translator) translateAPIConfig(cfg *models.StoredConfig) ([]*route.Rout
 
 	for _, op := range apiData.Operations {
 		// Use mainClusterName by default; path rewrite based on main upstream path
-		r := t.createRoute(apiData.Name, apiData.Version, apiData.Context, string(op.Method), op.Path,
+		r := t.createRoute(apiData.DisplayName, apiData.Version, apiData.Context, string(op.Method), op.Path,
 			mainClusterName, parsedMainURL.Path, effectiveMainVHost)
 		mainRoutesList = append(mainRoutesList, r)
 	}
@@ -396,7 +396,7 @@ func (t *Translator) translateAPIConfig(cfg *models.StoredConfig) ([]*route.Rout
 		sbRoutesList := make([]*route.Route, 0)
 		for _, op := range apiData.Operations {
 			// Use sbClusterName for sandbox upstream path
-			r := t.createRoute(apiData.Name, apiData.Version, apiData.Context, string(op.Method), op.Path,
+			r := t.createRoute(apiData.DisplayName, apiData.Version, apiData.Context, string(op.Method), op.Path,
 				sbClusterName, parsedSbURL.Path, effectiveSandboxVHost)
 			sbRoutesList = append(sbRoutesList, r)
 		}

--- a/gateway/gateway-controller/tests/integration/storage_test.go
+++ b/gateway/gateway-controller/tests/integration/storage_test.go
@@ -60,7 +60,7 @@ func setupTestDB(t *testing.T) (storage.Storage, string, func()) {
 func createTestConfig(name, version string) *models.StoredConfig {
 	specUnion := api.APIConfiguration_Spec{}
 	specUnion.FromAPIConfigData(api.APIConfigData{
-		Name:    name,
+		DisplayName:    name,
 		Version: version,
 		Context: "/" + name,
 		Upstream: struct {
@@ -81,9 +81,9 @@ func createTestConfig(name, version string) *models.StoredConfig {
 	return &models.StoredConfig{
 		ID: uuid.New().String(),
 		Configuration: api.APIConfiguration{
-			Version:  api.ApiPlatformWso2Comv1,
-			Kind:     api.Httprest,
-			Metadata: &api.Metadata{Name: name + "-" + version},
+			ApiVersion:  api.GatewayApiPlatformWso2Comv1alpha1,
+			Kind:     api.RestApi,
+			Metadata: api.Metadata{Name: name + "-" + version},
 			Spec:     specUnion,
 		},
 		Status:          models.StatusPending,

--- a/gateway/spec/impls/1-basic-gateway-with-controller/data-model.md
+++ b/gateway/spec/impls/1-basic-gateway-with-controller/data-model.md
@@ -25,7 +25,7 @@ The API Configuration represents a complete REST API definition provided by user
 
 ```yaml
 version: api-platform.wso2.com/v1
-kind: http/rest
+kind: RestApi
 data:
   name: string              # Human-readable API name
   version: string           # Semantic version (e.g., v1.0, v2.1)
@@ -41,7 +41,7 @@ data:
 
 ```yaml
 version: api-platform.wso2.com/v1
-kind: http/rest
+kind: RestApi
 data:
   name: Weather API
   version: v1.0
@@ -100,8 +100,8 @@ type Operation struct {
 
 | Field | Constraint | Error if Violated |
 |-------|-----------|-------------------|
-| `version` | Must equal "api-platform.wso2.com/v1" | "Unsupported API version" |
-| `kind` | Must equal "http/rest" | "Unsupported API kind (only http/rest supported)" |
+| `version` | Must equal "gateway.api-platform.wso2.com/v1alpha1" | "Unsupported API version" |
+| `kind` | Must equal "RestApi" | "Unsupported API kind (only RestApi supported)" |
 | `spec.name` | Non-empty string, 1-100 characters | "API name is required and must be 1-100 characters" |
 | `spec.version` | Non-empty string, matches semantic version pattern (e.g., v1.0) | "API version is required and must follow format vX.Y" |
 | `spec.context` | Must start with `/`, no trailing slash, 1-200 characters | "Context must start with / and cannot end with /" |

--- a/gateway/spec/impls/2-use-sqlite/data-model.md
+++ b/gateway/spec/impls/2-use-sqlite/data-model.md
@@ -80,7 +80,7 @@ CREATE TABLE deployments (
     name TEXT NOT NULL,
     version TEXT NOT NULL,
     context TEXT NOT NULL,              -- Base path (e.g., "/weather")
-    kind TEXT NOT NULL,                  -- API type: "http/rest", "graphql", "grpc", "asyncapi"
+    kind TEXT NOT NULL,                  -- API type: "RestApi", "graphql", "grpc", "asyncapi"
     handle TEXT NOT NULL UNIQUE,        -- API handle from metadata.name in YAML (required and must be unique)
 
     -- Full API configuration as JSON
@@ -126,7 +126,7 @@ CREATE INDEX idx_kind ON deployments(kind);
 | `name` | TEXT | No | (required) | API name extracted from configuration (e.g., "Weather API") |
 | `version` | TEXT | No | (required) | API version extracted from configuration (e.g., "v1.0") |
 | `context` | TEXT | No | (required) | Base path extracted from configuration (e.g., "/weather") |
-| `kind` | TEXT | No | (required) | API type from configuration (e.g., "http/rest", "graphql") |
+| `kind` | TEXT | No | (required) | API type from configuration (e.g., "RestApi", "graphql") |
 | `handle` | TEXT | No | (required) | API handle from metadata.name in YAML (must be unique, e.g., "weather-api-v1.0") |
 | `configuration` | TEXT | No | (required) | Full JSON-serialized APIConfiguration object |
 | `status` | TEXT | No | (required) | Deployment status: "pending", "deployed", or "failed" |
@@ -153,8 +153,8 @@ INSERT INTO deployments (
     'Weather API',
     'v1.0',
     '/weather',
-    'http/rest',
-    '{"version":"api-platform.wso2.com/v1","kind":"http/rest","data":{"name":"Weather API","version":"v1.0","context":"/weather","upstream":[{"url":"http://api.weather.com"}],"operations":[{"method":"GET","path":"/{country}/{city}"}]}}',
+    'RestApi',
+    '{"version":"gateway.api-platform.wso2.com/v1alpha1","kind":"RestApi","data":{"name":"Weather API","version":"v1.0","context":"/weather","upstream":[{"url":"http://api.weather.com"}],"operations":[{"method":"GET","path":"/{country}/{city}"}]}}',
     'pending',
     '2025-10-19T10:00:00Z',
     '2025-10-19T10:00:00Z',
@@ -189,8 +189,8 @@ type StoredAPIConfig struct {
 **Example JSON** (stored in `configuration` column):
 ```json
 {
-  "version": "api-platform.wso2.com/v1",
-  "kind": "http/rest",
+  "version": "gateway.api-platform.wso2.com/v1alpha1",
+  "kind": "RestApi",
   "data": {
     "name": "Weather API",
     "version": "v1.0",

--- a/gateway/spec/impls/2-use-sqlite/research.md
+++ b/gateway/spec/impls/2-use-sqlite/research.md
@@ -153,7 +153,7 @@ CREATE TABLE api_configs (
     name TEXT NOT NULL,
     version TEXT NOT NULL,
     context TEXT NOT NULL,            -- Extracted for fast queries
-    kind TEXT NOT NULL,                -- 'http/rest', 'graphql', etc.
+    kind TEXT NOT NULL,                -- 'RestApi', 'graphql', etc.
     configuration TEXT NOT NULL,       -- Full JSON
     status TEXT NOT NULL CHECK(status IN ('pending', 'deployed', 'failed')),
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,


### PR DESCRIPTION
## Purpose
> $subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated API configuration schema format with new resource type identifier and version constraints
  * Replaced API kind from `http/rest` to `RestApi` in all configuration examples
  * Changed API version format from `api-platform.wso2.com/v1` to `gateway.api-platform.wso2.com/v1alpha1`
  * Renamed API name field from `name` to `displayName`
  * Added required `metadata` block to API configurations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->