### PR TITLE
Change health check endpoint method to HEAD

### DIFF
--- a/platform-api/src/internal/server/server.go
+++ b/platform-api/src/internal/server/server.go
@@ -240,7 +240,7 @@ func (s *Server) Start(port string) error {
 	}
 
 	// Add a health endpoint that works with self-signed certs
-	s.router.GET("/health", func(c *gin.Context) {
+	s.router.HEAD("/health", func(c *gin.Context) {
 		c.JSON(200, gin.H{"status": "ok"})
 	})
 


### PR DESCRIPTION
This pull request changes the server's health check endpoint to be compatible with the health check mechanism of the all-in-one docker compose.
```
wget --quiet --tries=1 --spider --no-check-certificate https://localhost:8443/health
```

- Changed the `/health` endpoint from a `GET` to a `HEAD` request handler in `server.go`, which can help with lightweight health checks and integration with some load balancers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated the health endpoint HTTP method from GET to HEAD.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->