### PR TITLE
Refactor port handling

### DIFF
--- a/platform-api/Dockerfile
+++ b/platform-api/Dockerfile
@@ -15,6 +15,9 @@
 # under the License.
 # -----------------------------------------------------------------------
 
+# Global build arguments
+ARG PORT=9243
+
 # Build stage
 FROM --platform=$BUILDPLATFORM golang:1.25.5-bookworm AS builder
 ARG TARGETARCH
@@ -85,12 +88,14 @@ RUN mkdir -p /app/data && \
     chown -R wso2:appgroup /app
 COPY src/internal/database/schema.sql ./schema.sql
 
-EXPOSE 9243
+ARG PORT
+EXPOSE ${PORT}
 
 ENV DRIVER=sqlite3
 ENV LOG_LEVEL=INFO
 ENV DB_SCHEMA_PATH=./schema.sql
 ENV DATABASE_PATH=/app/data/api_platform.db
+ENV PORT=${PORT}
 
 USER $USERNAME
 

--- a/platform-api/Makefile
+++ b/platform-api/Makefile
@@ -26,6 +26,7 @@ BUILD_DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 # Docker image configuration
 DOCKER_REGISTRY ?= ghcr.io/wso2/api-platform
 IMAGE_NAME := $(DOCKER_REGISTRY)/platform-api
+PORT ?= 9243
 
 .PHONY: help build test push build-and-push-multiarch
 
@@ -43,6 +44,7 @@ build: ## Build Docker image
 	@echo "Building Docker image ($(IMAGE_NAME):$(VERSION))..."
 	docker buildx build -f Dockerfile \
 		--build-arg VERSION=$(VERSION) \
+		--build-arg PORT=$(PORT) \
 		-t $(IMAGE_NAME):$(VERSION) \
 		-t $(IMAGE_NAME):latest \
 		--load \
@@ -59,6 +61,7 @@ build-and-push-multiarch: ## Build and push multi-architecture Docker image (lin
 		--platform linux/amd64,linux/arm64 \
 		--build-arg VERSION=$(VERSION) \
 		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
+		--build-arg PORT=$(PORT) \
 		-t $(IMAGE_NAME):$(VERSION) \
 		--push \
 		.

--- a/platform-api/src/cmd/main.go
+++ b/platform-api/src/cmd/main.go
@@ -32,8 +32,8 @@ func main() {
 		log.Fatal("Failed to create server:", err)
 	}
 
-	log.Println("Starting HTTPS server on port 9243...")
-	if err := srv.Start(":9243"); err != nil {
+	log.Printf("Starting HTTPS server on port %s...", cfg.Port)
+	if err := srv.Start(cfg.Port); err != nil {
 		log.Fatal("Failed to start HTTPS server:", err)
 	}
 }

--- a/platform-api/src/config/config.go
+++ b/platform-api/src/config/config.go
@@ -29,6 +29,9 @@ type Server struct {
 	LogLevel string `envconfig:"LOG_LEVEL" default:"DEBUG"`
 	//Logger   logging.Logger
 
+	// Server configurations
+	Port string `envconfig:"PORT" default:"9243"`
+
 	// Database configurations
 	Database     Database `envconfig:"DATABASE"`
 	DBSchemaPath string   `envconfig:"DB_SCHEMA_PATH" default:"./internal/database/schema.sql"`

--- a/platform-api/src/internal/server/server.go
+++ b/platform-api/src/internal/server/server.go
@@ -203,7 +203,7 @@ func generateSelfSignedCert() (tls.Certificate, error) {
 // Start starts the HTTPS server
 func (s *Server) Start(port string) error {
 	if port == "" {
-		port = ":9243"
+		return fmt.Errorf("port cannot be empty")
 	}
 
 	var cert tls.Certificate
@@ -250,13 +250,14 @@ func (s *Server) Start(port string) error {
 		MinVersion:   tls.VersionTLS12,
 	}
 
+	address := fmt.Sprintf(":%s", port)
 	server := &http.Server{
-		Addr:      port,
+		Addr:      address,
 		Handler:   s.router,
 		TLSConfig: tlsConfig,
 	}
 
-	log.Printf("Starting HTTPS server on https://localhost%s", port)
+	log.Printf("Starting HTTPS server on https://localhost:%s", port)
 	log.Println("Note: Using self-signed certificate for development. Browsers will show security warnings.")
 	return server.ListenAndServeTLS("", "")
 }


### PR DESCRIPTION
## Purpose
Refactor port handling of the platform api for easier maintenance.

This will be further enhanced by fixes to - https://github.com/wso2/api-platform/issues/83

## Approach
This pull request introduces support for configuring the server's listening port via a build argument and environment variable, making the port easily customizable for different deployment environments. The changes ensure that the port is set consistently across the Dockerfile, Makefile, and Go application code, replacing hardcoded values with configurable parameters.

**Port configuration and customization:**

* Added a global `PORT` build argument to the `Dockerfile`, and updated the `EXPOSE` and `ENV` instructions to use this argument, allowing the exposed and runtime port to be set dynamically. [[1]](diffhunk://#diff-4080b5fb2fe1499ce6374dea6e5b6c206530f0f0e673bbfb4634e23a96c42148R18-R20) [[2]](diffhunk://#diff-4080b5fb2fe1499ce6374dea6e5b6c206530f0f0e673bbfb4634e23a96c42148L88-R98)
* Updated the `Makefile` to include a `PORT` variable, and passed it as a build argument in both the `build` and `build-and-push-multiarch` targets, ensuring the Docker image can be built with a custom port. [[1]](diffhunk://#diff-942e6de724fa92fb4159411be1a70514e0afa0e7a118bdce00f3fe8159729c3eR29) [[2]](diffhunk://#diff-942e6de724fa92fb4159411be1a70514e0afa0e7a118bdce00f3fe8159729c3eR47) [[3]](diffhunk://#diff-942e6de724fa92fb4159411be1a70514e0afa0e7a118bdce00f3fe8159729c3eR64)
* Modified the Go configuration struct (`config.go`) to include a `Port` field sourced from the `PORT` environment variable, defaulting to `9243`.

**Application code updates for dynamic port:**

* Changed the main application entrypoint (`main.go`) to use the configured port instead of a hardcoded value when starting the HTTPS server and logging startup information.
* Updated the server startup logic (`server.go`) to validate that the port is not empty, format the address string correctly, and log the server address using the dynamic port. [[1]](diffhunk://#diff-5e894ed9fe307e169bfef527b6af74587172cd898a43fbfcd4fedef1faac2010L206-R206) [[2]](diffhunk://#diff-5e894ed9fe307e169bfef527b6af74587172cd898a43fbfcd4fedef1faac2010R253-R260)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Platform API server port configuration is now flexible and dynamic, configurable via environment variables and Docker build arguments, replacing the previously hard-coded setting and enabling easy deployment to different environments and infrastructure configurations.
  * Improved port configuration validation with enhanced error handling for missing or invalid settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->