### PR TITLE
Use lock file to build gateway controller

### DIFF
--- a/gateway/gateway-controller/Makefile
+++ b/gateway/gateway-controller/Makefile
@@ -54,7 +54,7 @@ copy-policy-definitions: ## Copy policy definitions from policy-manifest.yaml
 	fi
 	@echo "Copying policy definitions..."
 	@mkdir -p policies
-	@yq e '.policies[] | .name + "|" + .version + "|" + .filePath' ../policies/policy-manifest.yaml | \
+	@yq e '.policies[] | .name + "|" + .version + "|" + .filePath' ../policies/policy-manifest-lock.yaml | \
 	while IFS= read -r line; do \
 		name=$$(echo "$$line" | cut -d'|' -f1); \
 		version=$$(echo "$$line" | cut -d'|' -f2); \


### PR DESCRIPTION
## Purpose
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated policy definition source to use a locked manifest version, changing the set of policies processed during the build process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->