### PR TITLE
Update policy names to kebab-case

### DIFF
--- a/.github/workflows/operator-integration-test.yml
+++ b/.github/workflows/operator-integration-test.yml
@@ -974,7 +974,7 @@ jobs:
               main:
                 url: http://httpbin.default.svc.cluster.local:80
             policies:
-              - name: JwtAuthentication
+              - name: jwt-auth
                 version: v0.1.0
                 params:
                   issuers:
@@ -1052,7 +1052,7 @@ jobs:
               main:
                 url: http://httpbin.default.svc.cluster.local:80
             policies:
-              - name: JwtAuthentication
+              - name: jwt-auth
                 version: v0.1.0
                 params:
                   issuers:

--- a/cli/src/cmd/gateway/image/build.md
+++ b/cli/src/cmd/gateway/image/build.md
@@ -43,13 +43,13 @@ The `--path` flag must point to a directory containing:
 version: v1/alpha1
 versionResolution: minor  # Optional root-level default
 policies:
-  - name: BasicAuth
+  - name: basic-auth
     version: v1.0.0
     versionResolution: exact  # Override root-level
-  - name: BasicAuth
+  - name: basic-auth
     version: v1.0.1
     versionResolution: exact
-  - name: BasicAuth
+  - name: basic-auth
     version: v1.0.2
     versionResolution: minor
   - name: MyCustomPolicy
@@ -66,11 +66,11 @@ policies:
 ```yaml
 version: v1/alpha1
 policies:
-  - name: BasicAuth
+  - name: basic-auth
     version: v1.0.0
     checksum: sha256:abc123...
     source: hub
-  - name: BasicAuth
+  - name: basic-auth
     version: v1.0.8  # Resolved version
     checksum: sha256:def456...
     source: hub
@@ -96,7 +96,7 @@ policies:
 ### Policy Naming Convention
 - Format: `<policy-name>-v<version>.zip`
 - Policy name and version in kebab-case
-- Example: `BasicAuth v1.0.0` → `basic-auth-v1.0.0.zip`
+- Example: `basic-auth v1.0.0` → `basic-auth-v1.0.0.zip`
 
 ## Implementation Flow
 

--- a/docs/ai-gateway/llm/guardrails/content-length.md
+++ b/docs/ai-gateway/llm/guardrails/content-length.md
@@ -80,7 +80,7 @@ spec:
       - path: /models/{modelId}
         methods: [GET]
   policies:
-    - name: ContentLengthGuardrail
+    - name: content-length-guardrail
       version: v0.1.0
       paths:
         - path: /chat/completions
@@ -159,7 +159,7 @@ When validation fails, the guardrail returns an HTTP 422 status code with the fo
   "type": "CONTENT_LENGTH_GUARDRAIL",
   "message": {
     "action": "GUARDRAIL_INTERVENED",
-    "interveningGuardrail": "ContentLengthGuardrail",
+    "interveningGuardrail": "content-length-guardrail",
     "actionReason": "Violation of applied content length constraints detected.",
     "direction": "REQUEST"
   }
@@ -173,7 +173,7 @@ If `showAssessment` is enabled, additional details are included:
   "type": "CONTENT_LENGTH_GUARDRAIL",
   "message": {
     "action": "GUARDRAIL_INTERVENED",
-    "interveningGuardrail": "ContentLengthGuardrail",
+    "interveningGuardrail": "content-length-guardrail",
     "actionReason": "Violation of applied content length constraints detected.",
     "assessments": "Violation of content length detected. Expected between 10 and 100 bytes.",
     "direction": "REQUEST"

--- a/docs/ai-gateway/llm/guardrails/json-schema.md
+++ b/docs/ai-gateway/llm/guardrails/json-schema.md
@@ -89,7 +89,7 @@ spec:
       - path: /models/{modelId}
         methods: [GET]
   policies:
-    - name: JSONSchemaGuardrail
+    - name: json-schema-guardrail
       version: v0.1.0
       paths:
         - path: /chat/completions
@@ -179,7 +179,7 @@ When validation fails, the guardrail returns an HTTP 422 status code with the fo
   "type": "JSON_SCHEMA_GUARDRAIL",
   "message": {
     "action": "GUARDRAIL_INTERVENED",
-    "interveningGuardrail": "JSONSchemaGuardrail",
+    "interveningGuardrail": "json-schema-guardrail",
     "actionReason": "Violation of JSON schema detected.",
     "direction": "REQUEST"
   }
@@ -193,7 +193,7 @@ If `showAssessment` is enabled, detailed validation errors are included:
   "type": "JSON_SCHEMA_GUARDRAIL",
   "message": {
     "action": "GUARDRAIL_INTERVENED",
-    "interveningGuardrail": "JSONSchemaGuardrail",
+    "interveningGuardrail": "json-schema-guardrail",
     "actionReason": "Violation of JSON schema detected.",
     "assessments": [
       {

--- a/docs/ai-gateway/llm/guardrails/pii-masking-regex.md
+++ b/docs/ai-gateway/llm/guardrails/pii-masking-regex.md
@@ -97,7 +97,7 @@ spec:
       - path: /models/{modelId}
         methods: [GET]
   policies:
-    - name: PIIMaskingRegex
+    - name: pii-masking-regex
       version: v0.1.0
       paths:
         - path: /chat/completions

--- a/docs/ai-gateway/llm/guardrails/regex.md
+++ b/docs/ai-gateway/llm/guardrails/regex.md
@@ -89,7 +89,7 @@ spec:
       - path: /models/{modelId}
         methods: [GET]
   policies:
-    - name: RegexGuardrail
+    - name: regex-guardrail
       version: v0.1.0
       paths:
         - path: /chat/completions
@@ -168,7 +168,7 @@ When validation fails, the guardrail returns an HTTP 422 status code with the fo
   "type": "REGEX_GUARDRAIL",
   "message": {
     "action": "GUARDRAIL_INTERVENED",
-    "interveningGuardrail": "RegexGuardrail",
+    "interveningGuardrail": "regex-guardrail",
     "actionReason": "Violation of regular expression detected.",
     "direction": "REQUEST"
   }
@@ -182,7 +182,7 @@ If `showAssessment` is enabled, additional details are included:
   "type": "REGEX_GUARDRAIL",
   "message": {
     "action": "GUARDRAIL_INTERVENED",
-    "interveningGuardrail": "RegexGuardrail",
+    "interveningGuardrail": "regex-guardrail",
     "actionReason": "Violation of regular expression detected.",
     "assessments": "Violation of regular expression detected. (?i)ignore\\s+all\\s+previous\\s+instructions",
     "direction": "REQUEST"

--- a/docs/ai-gateway/llm/guardrails/sentence-count.md
+++ b/docs/ai-gateway/llm/guardrails/sentence-count.md
@@ -89,7 +89,7 @@ spec:
       - path: /models/{modelId}
         methods: [GET]
   policies:
-    - name: SentenceCountGuardrail
+    - name: sentence-count-guardrail
       version: v0.1.0
       paths:
         - path: /chat/completions
@@ -169,7 +169,7 @@ When validation fails, the guardrail returns an HTTP 422 status code with the fo
   "type": "SENTENCE_COUNT_GUARDRAIL",
   "message": {
     "action": "GUARDRAIL_INTERVENED",
-    "interveningGuardrail": "SentenceCountGuardrail",
+    "interveningGuardrail": "sentence-count-guardrail",
     "actionReason": "Violation of applied sentence count constraints detected.",
     "direction": "REQUEST"
   }
@@ -183,7 +183,7 @@ If `showAssessment` is enabled, additional details are included:
   "type": "SENTENCE_COUNT_GUARDRAIL",
   "message": {
     "action": "GUARDRAIL_INTERVENED",
-    "interveningGuardrail": "SentenceCountGuardrail",
+    "interveningGuardrail": "sentence-count-guardrail",
     "actionReason": "Violation of applied sentence count constraints detected.",
     "assessments": "Violation of sentence count detected. Expected between 1 and 3 sentences.",
     "direction": "REQUEST"

--- a/docs/ai-gateway/llm/guardrails/url.md
+++ b/docs/ai-gateway/llm/guardrails/url.md
@@ -97,7 +97,7 @@ spec:
       - path: /models/{modelId}
         methods: [GET]
   policies:
-    - name: URLGuardrail
+    - name: url-guardrail
       version: v0.1.0
       paths:
         - path: /chat/completions
@@ -181,7 +181,7 @@ When validation fails, the guardrail returns an HTTP 422 status code with the fo
   "type": "URL_GUARDRAIL",
   "message": {
     "action": "GUARDRAIL_INTERVENED",
-    "interveningGuardrail": "URLGuardrail",
+    "interveningGuardrail": "url-guardrail",
     "actionReason": "Violation of url validity detected.",
     "direction": "REQUEST"
   }
@@ -195,7 +195,7 @@ If `showAssessment` is enabled, additional details including invalid URLs are in
   "type": "URL_GUARDRAIL",
   "message": {
     "action": "GUARDRAIL_INTERVENED",
-    "interveningGuardrail": "URLGuardrail",
+    "interveningGuardrail": "url-guardrail",
     "actionReason": "Violation of url validity detected.",
     "assessments": {
       "invalidUrls": [

--- a/docs/ai-gateway/llm/guardrails/word-count.md
+++ b/docs/ai-gateway/llm/guardrails/word-count.md
@@ -80,7 +80,7 @@ spec:
       - path: /models/{modelId}
         methods: [GET]
   policies:
-    - name: WordCountGuardrail
+    - name: word-count-guardrail
       version: v0.1.0
       paths:
         - path: /chat/completions
@@ -159,7 +159,7 @@ When validation fails, the guardrail returns an HTTP 422 status code with the fo
   "type": "WORD_COUNT_GUARDRAIL",
   "message": {
     "action": "GUARDRAIL_INTERVENED",
-    "interveningGuardrail": "WordCountGuardrail",
+    "interveningGuardrail": "word-count-guardrail",
     "actionReason": "Violation of applied word count constraints detected.",
     "direction": "REQUEST"
   }
@@ -173,7 +173,7 @@ If `showAssessment` is enabled, additional details are included:
   "type": "WORD_COUNT_GUARDRAIL",
   "message": {
     "action": "GUARDRAIL_INTERVENED",
-    "interveningGuardrail": "WordCountGuardrail",
+    "interveningGuardrail": "word-count-guardrail",
     "actionReason": "Violation of applied word count constraints detected.",
     "assessments": "Violation of word count detected. Expected between 2 and 10 words.",
     "direction": "REQUEST"

--- a/docs/ai-gateway/mcp/policies/mcp-authentication.md
+++ b/docs/ai-gateway/mcp/policies/mcp-authentication.md
@@ -114,7 +114,7 @@ spec:
     main:
       url: https://mcp-backend:8080
   policies:
-    - name: McpAuthentication
+    - name: mcp-auth
       version: v0.1.0
       params:
         issuers:
@@ -141,7 +141,7 @@ spec:
     main:
       url: https://mcp-backend:8080
   policies:
-    - name: McpAuthentication
+    - name: mcp-auth
       version: v0.1.0
       params:
         issuers:

--- a/docs/gateway/README.md
+++ b/docs/gateway/README.md
@@ -119,7 +119,7 @@ spec:
     - method: GET
       path: /{country_code}/{city}
       policies:
-        - name: ModifyHeaders
+        - name: modify-headers
           version: v1.0.0
           params:
             requestHeaders:

--- a/docs/gateway/observability/tracing.md
+++ b/docs/gateway/observability/tracing.md
@@ -852,7 +852,7 @@ Example log entry with trace ID:
   "msg": "Policy executed",
   "trace_id": "0af7651916cd43dd8448eb211c80319c",
   "span_id": "b7ad6b7169203331",
-  "policy": "ModifyHeaders"
+  "policy": "modify-headers"
 }
 ```
 

--- a/docs/gateway/policies/jwt-authentication.md
+++ b/docs/gateway/policies/jwt-authentication.md
@@ -125,7 +125,7 @@ spec:
     main:
       url: https://backend-service:8080/api
   policies:
-    - name: JwtAuthentication
+    - name: jwt-auth
       version: v0.1.0
       params:
         issuers:
@@ -152,7 +152,7 @@ spec:
     main:
       url: https://customer-service:8080
   policies:
-    - name: JwtAuthentication
+    - name: jwt-auth
       version: v0.1.0
       params:
         issuers:
@@ -184,7 +184,7 @@ spec:
     main:
       url: https://data-service:8080
   policies:
-    - name: JwtAuthentication
+    - name: jwt-auth
       version: v0.1.0
       params:
         issuers:
@@ -216,7 +216,7 @@ spec:
     main:
       url: https://admin-service:8080
   policies:
-    - name: JwtAuthentication
+    - name: jwt-auth
       version: v0.1.0
       params:
         issuers:
@@ -248,7 +248,7 @@ spec:
     main:
       url: https://user-service:8080
   policies:
-    - name: JwtAuthentication
+    - name: jwt-auth
       version: v0.1.0
       params:
         issuers:
@@ -279,7 +279,7 @@ spec:
     main:
       url: https://backend-service:8080
   policies:
-    - name: JwtAuthentication
+    - name: jwt-auth
       version: v0.1.0
       params:
         issuers:

--- a/docs/gateway/quick-start-guide.md
+++ b/docs/gateway/quick-start-guide.md
@@ -52,7 +52,7 @@ spec:
     - method: GET
       path: /{country_code}/{city}
       policies:
-        - name: ModifyHeaders
+        - name: modify-headers
           version: v1.0.0
           params:
             requestHeaders:

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -105,7 +105,7 @@ spec:
     - method: GET
       path: /{country_code}/{city}
       policies:
-        - name: ModifyHeaders
+        - name: modify-headers
           version: v1.0.0
           params:
             requestHeaders:

--- a/gateway/examples/mcp-proxy.yaml
+++ b/gateway/examples/mcp-proxy.yaml
@@ -29,7 +29,7 @@ spec:
   upstream:
     url: http://everything:3001
   # policies:
-  #   - name: McpAuthentication
+  #   - name: mcp-auth
   #     version: v0.1.0
   #     params:
   #       issuers:

--- a/gateway/examples/self-signed-secure-api.yaml
+++ b/gateway/examples/self-signed-secure-api.yaml
@@ -28,7 +28,7 @@ spec:
       url: https://secure-backend:5443/api/v2
       # url: http://httpbin.org/anything
   policies:
-    - name: JwtAuthentication
+    - name: jwt-auth
       version: v0.1.0
       params:
         issuers:

--- a/gateway/examples/weather-api.yaml
+++ b/gateway/examples/weather-api.yaml
@@ -28,7 +28,7 @@ spec:
     main:
       url: http://sample-backend:5000/api/v2
   policies:
-    - name: ModifyHeaders
+    - name: modify-headers
       version: v1.0.0
       params:
         requestHeaders:
@@ -46,7 +46,7 @@ spec:
     - method: GET
       path: /{country_code}/{city}
       policies:
-        - name: ModifyHeaders
+        - name: modify-headers
           version: v1.0.0
           params:
             requestHeaders:
@@ -62,7 +62,7 @@ spec:
     - method: POST
       path: /alerts/active
       policies:
-        - name: Respond
+        - name: respond
           version: v1.0.0
           params:
             statusCode: 201

--- a/gateway/gateway-controller/default-policies/basic-auth-v1.0.0.yaml
+++ b/gateway/gateway-controller/default-policies/basic-auth-v1.0.0.yaml
@@ -1,4 +1,4 @@
-name: BasicAuth
+name: basic-auth
 version: v1.0.0
 description: |
   Implements HTTP Basic Authentication to protect APIs with username and password credentials.

--- a/gateway/gateway-controller/default-policies/content-length-guardrail-v0.1.0.yaml
+++ b/gateway/gateway-controller/default-policies/content-length-guardrail-v0.1.0.yaml
@@ -1,9 +1,9 @@
-name: SentenceCountGuardrail
+name: content-length-guardrail
 version: v0.1.0
 description: |
-  Validates the sentence count of request or response body content.
+  Validates the byte length of request or response body content.
   Supports JSONPath extraction to validate specific fields within JSON payloads.
-  Can be configured with min/max sentence count constraints and inverted logic.
+  Can be configured with min/max byte length constraints and inverted logic.
   Supports separate configuration for request and response phases.
 
 parameters:
@@ -15,11 +15,11 @@ parameters:
       properties:
         min:
           type: integer
-          description: Minimum allowed sentence count (inclusive)
+          description: Minimum allowed byte length (inclusive)
           minimum: 0
         max:
           type: integer
-          description: Maximum allowed sentence count (inclusive)
+          description: Maximum allowed byte length (inclusive)
           minimum: 1
         jsonPath:
           type: string
@@ -31,8 +31,8 @@ parameters:
         invert:
           type: boolean
           description: |
-            If true, validation passes when sentence count is NOT within the min-max range (inverted logic).
-            If false (default), validation passes when sentence count is within the min-max range.
+            If true, validation passes when content length is NOT within the min-max range (inverted logic).
+            If false (default), validation passes when content length is within the min-max range.
           default: false
         showAssessment:
           type: boolean
@@ -49,11 +49,11 @@ parameters:
       properties:
         min:
           type: integer
-          description: Minimum allowed sentence count (inclusive)
+          description: Minimum allowed byte length (inclusive)
           minimum: 0
         max:
           type: integer
-          description: Maximum allowed sentence count (inclusive)
+          description: Maximum allowed byte length (inclusive)
           minimum: 1
         jsonPath:
           type: string
@@ -65,8 +65,8 @@ parameters:
         invert:
           type: boolean
           description: |
-            If true, validation passes when sentence count is NOT within the min-max range (inverted logic).
-            If false (default), validation passes when sentence count is within the min-max range.
+            If true, validation passes when content length is NOT within the min-max range (inverted logic).
+            If false (default), validation passes when content length is within the min-max range.
           default: false
         showAssessment:
           type: boolean
@@ -78,6 +78,6 @@ parameters:
       - min
       - max
 
-systemParameters:
+systemParameters:         
   type: object
   properties: {}

--- a/gateway/gateway-controller/default-policies/json-schema-guardrail-v0.1.0.yaml
+++ b/gateway/gateway-controller/default-policies/json-schema-guardrail-v0.1.0.yaml
@@ -1,4 +1,4 @@
-name: JSONSchemaGuardrail
+name: json-schema-guardrail
 version: v0.1.0
 description: |
   Validates request or response body content against a JSON Schema.

--- a/gateway/gateway-controller/default-policies/jwt-auth-v0.1.0.yaml
+++ b/gateway/gateway-controller/default-policies/jwt-auth-v0.1.0.yaml
@@ -1,10 +1,9 @@
-name: McpAuthentication
+name: jwt-auth
 version: v0.1.0
 description: |
-  This policy is used to secure traffic to Model Context Protocol server as defined in the specification 
-  (https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization). The Gateway acts as the 
-  resource server and protects the MCP resources by validating the access tokens presented in the requests.
-  This uses the JwtAuthentication policy underneath to validate the access tokens.
+  Validates JWT access tokens using one or more JWKS providers (key managers).
+  System-level configuration holds key manager endpoints and fetch behavior.
+  User-level configuration holds per-route assertions (selected issuers, audiences, scopes, claims and mappings).
 
 parameters:
   type: object
@@ -13,26 +12,21 @@ parameters:
     issuers:
       type: array
       description: >-
-        List of issuer names (referencing entries in `system.keyManagers`).
-        This list will be sent as the authorization servers in the protected resource
-        metadata response. If omitted, all configured key managers will be used. The
-        selection will be based on the MCP client Implementation.
-        Furthermore, this list will also be used for validating tokens. If omitted, 
-        runtime will try to match token `iss` claim to available key managers or try all providers.
-      items:
-        type: string
-
-    requiredScopes:
-      type: array
-      description: >-
-        List of scopes that should be included in the token generated through MCP auth flow.
-        List of scopes that must be present in the token (space-delimited 'scope' claim or array 'scp').
+        List of issuer names (referencing entries in `system.keyManagers`) to use
+        for validating tokens for this route. If omitted, runtime will try to
+        match token `iss` claim to available key managers or try all providers.
       items:
         type: string
 
     audiences:
       type: array
       description: List of acceptable audience values; token must contain at least one.
+      items:
+        type: string
+
+    requiredScopes:
+      type: array
+      description: List of scopes that must be present in the token (space-delimited 'scope' claim or array 'scp').
       items:
         type: string
 
@@ -47,6 +41,10 @@ parameters:
       description: Map claimName -> downstream header or context key to expose for downstream services.
       additionalProperties:
         type: string
+
+    authHeaderPrefix:
+      type: string
+      description: Override for the authorization header scheme prefix (e.g., "Bearer", "JWT"). If specified at user-level, takes precedence over system configuration for this route.
 
 systemParameters:          
   type: object
@@ -182,13 +180,5 @@ systemParameters:
       type: boolean
       description: Whether to validate the token's issuer claim against configured key managers.
       "wso2/defaultValue": "${config.policy_configurations.jwtauth_v010.validateissuer}"
-    
-    gatewayHost:
-      type: string
-      description: The host of the gateway to be included in the protected metadata URL and response.
-      example: mcp1.api-platform.com
-      default: localhost
-      "wso2/defaultValue": "${config.policy_configurations.mcpauth_v010.gatewayhost}"
-
 
   required: ["keyManagers"]

--- a/gateway/gateway-controller/default-policies/mcp-auth-v0.1.0.yaml
+++ b/gateway/gateway-controller/default-policies/mcp-auth-v0.1.0.yaml
@@ -1,9 +1,10 @@
-name: JwtAuthentication
+name: mcp-auth
 version: v0.1.0
 description: |
-  Validates JWT access tokens using one or more JWKS providers (key managers).
-  System-level configuration holds key manager endpoints and fetch behavior.
-  User-level configuration holds per-route assertions (selected issuers, audiences, scopes, claims and mappings).
+  This policy is used to secure traffic to Model Context Protocol server as defined in the specification 
+  (https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization). The Gateway acts as the 
+  resource server and protects the MCP resources by validating the access tokens presented in the requests.
+  This uses the JwtAuthentication policy underneath to validate the access tokens.
 
 parameters:
   type: object
@@ -12,21 +13,26 @@ parameters:
     issuers:
       type: array
       description: >-
-        List of issuer names (referencing entries in `system.keyManagers`) to use
-        for validating tokens for this route. If omitted, runtime will try to
-        match token `iss` claim to available key managers or try all providers.
+        List of issuer names (referencing entries in `system.keyManagers`).
+        This list will be sent as the authorization servers in the protected resource
+        metadata response. If omitted, all configured key managers will be used. The
+        selection will be based on the MCP client Implementation.
+        Furthermore, this list will also be used for validating tokens. If omitted, 
+        runtime will try to match token `iss` claim to available key managers or try all providers.
+      items:
+        type: string
+
+    requiredScopes:
+      type: array
+      description: >-
+        List of scopes that should be included in the token generated through MCP auth flow.
+        List of scopes that must be present in the token (space-delimited 'scope' claim or array 'scp').
       items:
         type: string
 
     audiences:
       type: array
       description: List of acceptable audience values; token must contain at least one.
-      items:
-        type: string
-
-    requiredScopes:
-      type: array
-      description: List of scopes that must be present in the token (space-delimited 'scope' claim or array 'scp').
       items:
         type: string
 
@@ -41,10 +47,6 @@ parameters:
       description: Map claimName -> downstream header or context key to expose for downstream services.
       additionalProperties:
         type: string
-
-    authHeaderPrefix:
-      type: string
-      description: Override for the authorization header scheme prefix (e.g., "Bearer", "JWT"). If specified at user-level, takes precedence over system configuration for this route.
 
 systemParameters:          
   type: object
@@ -180,5 +182,13 @@ systemParameters:
       type: boolean
       description: Whether to validate the token's issuer claim against configured key managers.
       "wso2/defaultValue": "${config.policy_configurations.jwtauth_v010.validateissuer}"
+    
+    gatewayHost:
+      type: string
+      description: The host of the gateway to be included in the protected metadata URL and response.
+      example: mcp1.api-platform.com
+      default: localhost
+      "wso2/defaultValue": "${config.policy_configurations.mcpauth_v010.gatewayhost}"
+
 
   required: ["keyManagers"]

--- a/gateway/gateway-controller/default-policies/modify-headers-v1.0.0.yaml
+++ b/gateway/gateway-controller/default-policies/modify-headers-v1.0.0.yaml
@@ -1,4 +1,4 @@
-name: ModifyHeaders
+name: modify-headers
 version: v1.0.0
 description: |
   Comprehensive header manipulation policy for both request and response flows.

--- a/gateway/gateway-controller/default-policies/pii-masking-regex-v0.1.0.yaml
+++ b/gateway/gateway-controller/default-policies/pii-masking-regex-v0.1.0.yaml
@@ -1,4 +1,4 @@
-name: PIIMaskingRegex
+name: pii-masking-regex
 version: v0.1.0
 description: |
   Masks or redacts Personally Identifiable Information (PII) from request/response bodies using regex patterns.

--- a/gateway/gateway-controller/default-policies/regex-guardrail-v0.1.0.yaml
+++ b/gateway/gateway-controller/default-policies/regex-guardrail-v0.1.0.yaml
@@ -1,9 +1,9 @@
-name: ContentLengthGuardrail
+name: regex-guardrail
 version: v0.1.0
 description: |
-  Validates the byte length of request or response body content.
+  Validates request or response body content against a regular expression pattern.
   Supports JSONPath extraction to validate specific fields within JSON payloads.
-  Can be configured with min/max byte length constraints and inverted logic.
+  Can be configured to match or invert the regex pattern.
   Supports separate configuration for request and response phases.
 
 parameters:
@@ -13,14 +13,10 @@ parameters:
       type: object
       description: Configuration for request phase validation
       properties:
-        min:
-          type: integer
-          description: Minimum allowed byte length (inclusive)
-          minimum: 0
-        max:
-          type: integer
-          description: Maximum allowed byte length (inclusive)
-          minimum: 1
+        regex:
+          type: string
+          description: Regular expression pattern to match against the content
+          minLength: 1
         jsonPath:
           type: string
           description: |
@@ -31,8 +27,8 @@ parameters:
         invert:
           type: boolean
           description: |
-            If true, validation passes when content length is NOT within the min-max range (inverted logic).
-            If false (default), validation passes when content length is within the min-max range.
+            If true, validation passes when regex does NOT match (inverted logic).
+            If false (default), validation passes when regex matches.
           default: false
         showAssessment:
           type: boolean
@@ -41,20 +37,15 @@ parameters:
             If false, returns minimal error information.
           default: false
       required:
-      - min
-      - max
+      - regex
     response:
       type: object
       description: Configuration for response phase validation
       properties:
-        min:
-          type: integer
-          description: Minimum allowed byte length (inclusive)
-          minimum: 0
-        max:
-          type: integer
-          description: Maximum allowed byte length (inclusive)
-          minimum: 1
+        regex:
+          type: string
+          description: Regular expression pattern to match against the content
+          minLength: 1
         jsonPath:
           type: string
           description: |
@@ -65,8 +56,8 @@ parameters:
         invert:
           type: boolean
           description: |
-            If true, validation passes when content length is NOT within the min-max range (inverted logic).
-            If false (default), validation passes when content length is within the min-max range.
+            If true, validation passes when regex does NOT match (inverted logic).
+            If false (default), validation passes when regex matches.
           default: false
         showAssessment:
           type: boolean
@@ -75,9 +66,8 @@ parameters:
             If false, returns minimal error information.
           default: false
       required:
-      - min
-      - max
+      - regex
 
-systemParameters:         
+systemParameters:
   type: object
   properties: {}

--- a/gateway/gateway-controller/default-policies/respond-v1.0.0.yaml
+++ b/gateway/gateway-controller/default-policies/respond-v1.0.0.yaml
@@ -1,4 +1,4 @@
-name: Respond
+name: respond
 version: v1.0.0
 description: |
   Returns an immediate response to the client without forwarding the request to the upstream backend.

--- a/gateway/gateway-controller/default-policies/sentence-count-guardrail-v0.1.0.yaml
+++ b/gateway/gateway-controller/default-policies/sentence-count-guardrail-v0.1.0.yaml
@@ -1,9 +1,9 @@
-name: WordCountGuardrail
+name: sentence-count-guardrail
 version: v0.1.0
 description: |
-  Validates the word count of request or response body content.
+  Validates the sentence count of request or response body content.
   Supports JSONPath extraction to validate specific fields within JSON payloads.
-  Can be configured with min/max word count constraints and inverted logic.
+  Can be configured with min/max sentence count constraints and inverted logic.
   Supports separate configuration for request and response phases.
 
 parameters:
@@ -15,11 +15,11 @@ parameters:
       properties:
         min:
           type: integer
-          description: Minimum allowed word count (inclusive)
+          description: Minimum allowed sentence count (inclusive)
           minimum: 0
         max:
           type: integer
-          description: Maximum allowed word count (inclusive)
+          description: Maximum allowed sentence count (inclusive)
           minimum: 1
         jsonPath:
           type: string
@@ -31,8 +31,8 @@ parameters:
         invert:
           type: boolean
           description: |
-            If true, validation passes when word count is NOT within the min-max range (inverted logic).
-            If false (default), validation passes when word count is within the min-max range.
+            If true, validation passes when sentence count is NOT within the min-max range (inverted logic).
+            If false (default), validation passes when sentence count is within the min-max range.
           default: false
         showAssessment:
           type: boolean
@@ -49,11 +49,11 @@ parameters:
       properties:
         min:
           type: integer
-          description: Minimum allowed word count (inclusive)
+          description: Minimum allowed sentence count (inclusive)
           minimum: 0
         max:
           type: integer
-          description: Maximum allowed word count (inclusive)
+          description: Maximum allowed sentence count (inclusive)
           minimum: 1
         jsonPath:
           type: string
@@ -65,8 +65,8 @@ parameters:
         invert:
           type: boolean
           description: |
-            If true, validation passes when word count is NOT within the min-max range (inverted logic).
-            If false (default), validation passes when word count is within the min-max range.
+            If true, validation passes when sentence count is NOT within the min-max range (inverted logic).
+            If false (default), validation passes when sentence count is within the min-max range.
           default: false
         showAssessment:
           type: boolean

--- a/gateway/gateway-controller/default-policies/url-guardrail-v0.1.0.yaml
+++ b/gateway/gateway-controller/default-policies/url-guardrail-v0.1.0.yaml
@@ -1,9 +1,9 @@
-name: RegexGuardrail
+name: url-guardrail
 version: v0.1.0
 description: |
-  Validates request or response body content against a regular expression pattern.
+  Validates URLs found in request or response body content.
   Supports JSONPath extraction to validate specific fields within JSON payloads.
-  Can be configured to match or invert the regex pattern.
+  Can validate URLs via DNS resolution only or HTTP HEAD request reachability.
   Supports separate configuration for request and response phases.
 
 parameters:
@@ -13,10 +13,6 @@ parameters:
       type: object
       description: Configuration for request phase validation
       properties:
-        regex:
-          type: string
-          description: Regular expression pattern to match against the content
-          minLength: 1
         jsonPath:
           type: string
           description: |
@@ -24,28 +20,28 @@ parameters:
             If empty, validates the entire payload as a string.
             Examples: "$.message", "$.data.content", "$.items[0].text"
           default: ""
-        invert:
+        onlyDNS:
           type: boolean
           description: |
-            If true, validation passes when regex does NOT match (inverted logic).
-            If false (default), validation passes when regex matches.
+            If true, validates URLs only via DNS resolution (faster, less reliable).
+            If false (default), validates URLs via HTTP HEAD request (slower, more reliable).
           default: false
+        timeout:
+          type: integer
+          description: |
+            Timeout in milliseconds for DNS lookup or HTTP HEAD request.
+            Default is 3000ms (3 seconds).
+          default: 3000
         showAssessment:
           type: boolean
           description: |
-            If true, includes detailed assessment information in error responses.
+            If true, includes detailed assessment information including invalid URLs in error responses.
             If false, returns minimal error information.
           default: false
-      required:
-      - regex
     response:
       type: object
       description: Configuration for response phase validation
       properties:
-        regex:
-          type: string
-          description: Regular expression pattern to match against the content
-          minLength: 1
         jsonPath:
           type: string
           description: |
@@ -53,20 +49,24 @@ parameters:
             If empty, validates the entire payload as a string.
             Examples: "$.message", "$.data.content", "$.items[0].text"
           default: ""
-        invert:
+        onlyDNS:
           type: boolean
           description: |
-            If true, validation passes when regex does NOT match (inverted logic).
-            If false (default), validation passes when regex matches.
+            If true, validates URLs only via DNS resolution (faster, less reliable).
+            If false (default), validates URLs via HTTP HEAD request (slower, more reliable).
           default: false
+        timeout:
+          type: integer
+          description: |
+            Timeout in milliseconds for DNS lookup or HTTP HEAD request.
+            Default is 3000ms (3 seconds).
+          default: 3000
         showAssessment:
           type: boolean
           description: |
-            If true, includes detailed assessment information in error responses.
+            If true, includes detailed assessment information including invalid URLs in error responses.
             If false, returns minimal error information.
           default: false
-      required:
-      - regex
 
 systemParameters:
   type: object

--- a/gateway/gateway-controller/default-policies/word-count-guardrail-v0.1.0.yaml
+++ b/gateway/gateway-controller/default-policies/word-count-guardrail-v0.1.0.yaml
@@ -1,9 +1,9 @@
-name: URLGuardrail
+name: word-count-guardrail
 version: v0.1.0
 description: |
-  Validates URLs found in request or response body content.
+  Validates the word count of request or response body content.
   Supports JSONPath extraction to validate specific fields within JSON payloads.
-  Can validate URLs via DNS resolution only or HTTP HEAD request reachability.
+  Can be configured with min/max word count constraints and inverted logic.
   Supports separate configuration for request and response phases.
 
 parameters:
@@ -13,6 +13,14 @@ parameters:
       type: object
       description: Configuration for request phase validation
       properties:
+        min:
+          type: integer
+          description: Minimum allowed word count (inclusive)
+          minimum: 0
+        max:
+          type: integer
+          description: Maximum allowed word count (inclusive)
+          minimum: 1
         jsonPath:
           type: string
           description: |
@@ -20,28 +28,33 @@ parameters:
             If empty, validates the entire payload as a string.
             Examples: "$.message", "$.data.content", "$.items[0].text"
           default: ""
-        onlyDNS:
+        invert:
           type: boolean
           description: |
-            If true, validates URLs only via DNS resolution (faster, less reliable).
-            If false (default), validates URLs via HTTP HEAD request (slower, more reliable).
+            If true, validation passes when word count is NOT within the min-max range (inverted logic).
+            If false (default), validation passes when word count is within the min-max range.
           default: false
-        timeout:
-          type: integer
-          description: |
-            Timeout in milliseconds for DNS lookup or HTTP HEAD request.
-            Default is 3000ms (3 seconds).
-          default: 3000
         showAssessment:
           type: boolean
           description: |
-            If true, includes detailed assessment information including invalid URLs in error responses.
+            If true, includes detailed assessment information in error responses.
             If false, returns minimal error information.
           default: false
+      required:
+      - min
+      - max
     response:
       type: object
       description: Configuration for response phase validation
       properties:
+        min:
+          type: integer
+          description: Minimum allowed word count (inclusive)
+          minimum: 0
+        max:
+          type: integer
+          description: Maximum allowed word count (inclusive)
+          minimum: 1
         jsonPath:
           type: string
           description: |
@@ -49,24 +62,21 @@ parameters:
             If empty, validates the entire payload as a string.
             Examples: "$.message", "$.data.content", "$.items[0].text"
           default: ""
-        onlyDNS:
+        invert:
           type: boolean
           description: |
-            If true, validates URLs only via DNS resolution (faster, less reliable).
-            If false (default), validates URLs via HTTP HEAD request (slower, more reliable).
+            If true, validation passes when word count is NOT within the min-max range (inverted logic).
+            If false (default), validation passes when word count is within the min-max range.
           default: false
-        timeout:
-          type: integer
-          description: |
-            Timeout in milliseconds for DNS lookup or HTTP HEAD request.
-            Default is 3000ms (3 seconds).
-          default: 3000
         showAssessment:
           type: boolean
           description: |
-            If true, includes detailed assessment information including invalid URLs in error responses.
+            If true, includes detailed assessment information in error responses.
             If false, returns minimal error information.
           default: false
+      required:
+      - min
+      - max
 
 systemParameters:
   type: object

--- a/gateway/gateway-controller/pkg/config/llm_parser_test.go
+++ b/gateway/gateway-controller/pkg/config/llm_parser_test.go
@@ -425,7 +425,7 @@ spec:
         methods:
           - POST
   policies:
-    - name: ContentLengthGuardrail
+    - name: content-length-guardrail
       version: v0.1.0
       paths:
         - path: /v1/chat/completions
@@ -434,7 +434,7 @@ spec:
           params:
             maxRequestBodySize: 10240
             maxResponseBodySize: 51200
-    - name: RegexGuardrail
+    - name: regex-guardrail
       version: v0.1.0
       paths:
         - path: /v1/chat/completions
@@ -956,7 +956,7 @@ spec:
         methods:
           - POST
   policies:
-    - name: ContentLengthGuardrail
+    - name: content-length-guardrail
       version: v0.1.0
       paths:
         - path: /v1/chat/completions
@@ -964,7 +964,7 @@ spec:
             - POST
           params:
             maxRequestBodySize: 10240
-    - name: RegexGuardrail
+    - name: regex-guardrail
       version: v0.1.0
       paths:
         - path: /v1/chat/completions
@@ -988,14 +988,14 @@ spec:
 	assert.Len(t, policies, 2, "Should have 2 policies")
 
 	// Verify first policy
-	assert.Equal(t, "ContentLengthGuardrail", policies[0].Name)
+	assert.Equal(t, "content-length-guardrail", policies[0].Name)
 	assert.Equal(t, "v0.1.0", policies[0].Version)
 	assert.Len(t, policies[0].Paths, 1)
 	assert.Equal(t, "/v1/chat/completions", policies[0].Paths[0].Path)
 	assert.NotNil(t, policies[0].Paths[0].Params)
 
 	// Verify second policy
-	assert.Equal(t, "RegexGuardrail", policies[1].Name)
+	assert.Equal(t, "regex-guardrail", policies[1].Name)
 	assert.Equal(t, "v0.1.0", policies[1].Version)
 	assert.Len(t, policies[1].Paths, 1)
 	assert.Equal(t, "/v1/chat/completions", policies[1].Paths[0].Path)

--- a/gateway/gateway-controller/pkg/constants/constants.go
+++ b/gateway/gateway-controller/pkg/constants/constants.go
@@ -96,34 +96,34 @@ const (
 	WILD_CARD = "*"
 
 	// LLM Transformer constants
-	UPSTREAM_AUTH_APIKEY_POLICY_NAME    = "ModifyHeaders"
+	UPSTREAM_AUTH_APIKEY_POLICY_NAME    = "modify-headers"
 	UPSTREAM_AUTH_APIKEY_POLICY_VERSION = "v1.0.0"
 	UPSTREAM_AUTH_APIKEY_POLICY_PARAMS  = "requestHeaders:\n" +
 		"  - action: SET\n" +
-		"    name: %s\n" +
-		"    value: %s\n"
-	PROXY_HOST__HEADER_POLICY_NAME    = "ModifyHeaders"
+		"    name: '%s'\n" +
+		"    value: '%s'\n"
+	PROXY_HOST__HEADER_POLICY_NAME    = "modify-Headers"
 	PROXY_HOST__HEADER_POLICY_VERSION = "v1.0.0"
 	PROXY_HOST__HEADER_POLICY_PARAMS  = "requestHeaders:\n" +
 		"  - action: SET\n" +
 		"    name: Host\n" +
-		"    value: %s\n"
+		"    value: '%s'\n"
 
-	ACCESS_CONTROL_DENY_POLICY_NAME    = "Respond"
+	ACCESS_CONTROL_DENY_POLICY_NAME    = "respond"
 	ACCESS_CONTROL_DENY_POLICY_VERSION = "v1.0.0"
-	// YAML for default 404 Respond policy params
+	// YAML for default 404 respond policy params
 	ACCESS_CONTROL_DENY_POLICY_PARAMS = "statusCode: 404\n" +
 		"body: \"{\\\"message\\\": \\\"Resource not found.\\\"}\"\n" +
 		"headers:\n" +
 		"  - name: Content-Type\n" +
 		"    value: application/json\n"
 
-	MODIFY_HEADERS_POLICY_NAME    = "ModifyHeaders"
-	MODIFY_HEADERS_POLICY_VERSION = "v1.0.0"
+	MODIFY_HEADERS_POLICY_NAME    = "modify-headers"
+	MODIFY_HEADERS_POLICY_VERSION = "v0.1.0"
 	MODIFY_HEADERS_POLICY_PARAMS  = "requestHeaders:\n" +
 		"  - action: SET\n" +
-		"    name: %s\n" +
-		"    value: %s\n"
+		"    name: '%s'\n" +
+		"    value: '%s'\n"
 )
 
 var WILDCARD_HTTP_METHODS = []string{

--- a/gateway/gateway-controller/pkg/utils/llm_provider_transformer_test.go
+++ b/gateway/gateway-controller/pkg/utils/llm_provider_transformer_test.go
@@ -230,7 +230,7 @@ func TestTransform_FullProvider(t *testing.T) {
 	require.NotNil(t, spec.Policies)
 	assert.Len(t, *spec.Policies, 1)
 	authPolicy := (*spec.Policies)[0]
-	assert.Equal(t, "ModifyHeaders", authPolicy.Name)
+	assert.Equal(t, "modify-headers", authPolicy.Name)
 	assert.Equal(t, "v1.0.0", authPolicy.Version)
 	assert.NotNil(t, authPolicy.Params)
 }
@@ -627,7 +627,7 @@ func TestTransform_AllowAll_WithSingleException(t *testing.T) {
 	// Should have 2 exception operations + 1 catch-all = 3 total
 	require.Len(t, spec.Operations, 2+len(constants.WILDCARD_HTTP_METHODS))
 
-	// Verify exception operations have Respond policy
+	// Verify exception operations have respond policy
 	foundGET := false
 	foundPOST := false
 	catchAllCount := 0
@@ -708,7 +708,7 @@ func TestTransform_AllowAll_WithSingleExceptionWithWildCardMethod(t *testing.T) 
 	// Should have 12
 	require.Len(t, spec.Operations, 2*len(constants.WILDCARD_HTTP_METHODS))
 
-	// Verify exception operations have Respond policy
+	// Verify exception operations have respond policy
 	foundWildCardCount := 0
 	foundCatchCount := 0
 
@@ -773,7 +773,7 @@ func TestTransform_AllowAll_WithSingleExceptionWithWildCardResource(t *testing.T
 	// Should have 12
 	require.Len(t, spec.Operations, 2*len(constants.WILDCARD_HTTP_METHODS))
 
-	// Verify exception operations have Respond policy
+	// Verify exception operations have respond policy
 	foundWildCardCount := 0
 	foundCatchCount := 0
 
@@ -945,9 +945,9 @@ func TestTransform_DenyAll_WithSingleException(t *testing.T) {
 	assert.Equal(t, api.OperationMethod("POST"), spec.Operations[0].Method)
 	assert.Equal(t, "/v1/chat/completions", spec.Operations[0].Path)
 
-	// Exception operations in deny_all mode should NOT have Respond policy
+	// Exception operations in deny_all mode should NOT have respond policy
 	if spec.Operations[0].Policies != nil {
-		assert.Len(t, *spec.Operations[0].Policies, 0, "Deny all exceptions should not have Respond policy")
+		assert.Len(t, *spec.Operations[0].Policies, 0, "Deny all exceptions should not have respond policy")
 	}
 }
 
@@ -995,9 +995,9 @@ func TestTransform_DenyAll_WithSingleExceptionWithWildCardMethod(t *testing.T) {
 		assert.Contains(t, constants.WILDCARD_HTTP_METHODS, string(op.Method),
 			"Operation %d method %s should be in WILDCARD_HTTP_METHODS", i, op.Method)
 
-		// Exception operations in deny_all mode should NOT have Respond policy
+		// Exception operations in deny_all mode should NOT have respond policy
 		if op.Policies != nil {
-			assert.Len(t, *op.Policies, 0, "Operation %d (%s) should not have Respond policy", i, op.Method)
+			assert.Len(t, *op.Policies, 0, "Operation %d (%s) should not have respond policy", i, op.Method)
 		}
 	}
 
@@ -1011,9 +1011,9 @@ func TestTransform_DenyAll_WithSingleExceptionWithWildCardMethod(t *testing.T) {
 		assert.True(t, foundMethods[expectedMethod], "Expected method %s should be present in operations", expectedMethod)
 	}
 
-	// Exception operations in deny_all mode should NOT have Respond policy
+	// Exception operations in deny_all mode should NOT have respond policy
 	if spec.Operations[0].Policies != nil {
-		assert.Len(t, *spec.Operations[0].Policies, 0, "Deny all exceptions should not have Respond policy")
+		assert.Len(t, *spec.Operations[0].Policies, 0, "Deny all exceptions should not have respond policy")
 	}
 }
 
@@ -1064,9 +1064,9 @@ func TestTransform_DenyAll_WithSingleExceptionWithWildCardResource(t *testing.T)
 		assert.Contains(t, constants.WILDCARD_HTTP_METHODS, string(op.Method),
 			"Operation %d method %s should be in WILDCARD_HTTP_METHODS", i, op.Method)
 
-		// Exception operations in deny_all mode should NOT have Respond policy
+		// Exception operations in deny_all mode should NOT have respond policy
 		if op.Policies != nil {
-			assert.Len(t, *op.Policies, 0, "Operation %d (%s) should not have Respond policy", i, op.Method)
+			assert.Len(t, *op.Policies, 0, "Operation %d (%s) should not have respond policy", i, op.Method)
 		}
 	}
 
@@ -1178,7 +1178,7 @@ func TestTransform_WithSinglePolicy(t *testing.T) {
 
 	policies := []api.LLMPolicy{
 		{
-			Name:    "ContentLengthGuardrail",
+			Name:    "content-length-guardrail",
 			Version: "v0.1.0",
 			Paths: []api.LLMPolicyPath{
 				{
@@ -1235,7 +1235,7 @@ func TestTransform_WithSinglePolicy(t *testing.T) {
 	assert.Len(t, *op.Policies, 1)
 
 	policy := (*op.Policies)[0]
-	assert.Equal(t, "ContentLengthGuardrail", policy.Name)
+	assert.Equal(t, "content-length-guardrail", policy.Name)
 	assert.Equal(t, "v0.1.0", policy.Version)
 	require.NotNil(t, policy.Params)
 
@@ -1248,7 +1248,7 @@ func TestTransform_WithMultiplePoliciesSameRoute(t *testing.T) {
 
 	policies := []api.LLMPolicy{
 		{
-			Name:    "ContentLengthGuardrail",
+			Name:    "content-length-guardrail",
 			Version: "v0.1.0",
 			Paths: []api.LLMPolicyPath{
 				{
@@ -1261,7 +1261,7 @@ func TestTransform_WithMultiplePoliciesSameRoute(t *testing.T) {
 			},
 		},
 		{
-			Name:    "RegexGuardrail",
+			Name:    "regex-guardrail",
 			Version: "v0.1.0",
 			Paths: []api.LLMPolicyPath{
 				{
@@ -1322,8 +1322,8 @@ func TestTransform_WithMultiplePoliciesSameRoute(t *testing.T) {
 
 	// Verify policies are in order
 	policyList := *op.Policies
-	assert.Equal(t, "ContentLengthGuardrail", policyList[0].Name)
-	assert.Equal(t, "RegexGuardrail", policyList[1].Name)
+	assert.Equal(t, "content-length-guardrail", policyList[0].Name)
+	assert.Equal(t, "regex-guardrail", policyList[1].Name)
 }
 
 func TestTransform_PolicyOnDifferentRoutes(t *testing.T) {
@@ -1331,7 +1331,7 @@ func TestTransform_PolicyOnDifferentRoutes(t *testing.T) {
 
 	policies := []api.LLMPolicy{
 		{
-			Name:    "ContentLengthGuardrail",
+			Name:    "content-length-guardrail",
 			Version: "v0.1.0",
 			Paths: []api.LLMPolicyPath{
 				{
@@ -1344,7 +1344,7 @@ func TestTransform_PolicyOnDifferentRoutes(t *testing.T) {
 			},
 		},
 		{
-			Name:    "RegexGuardrail",
+			Name:    "regex-guardrail",
 			Version: "v0.1.0",
 			Paths: []api.LLMPolicyPath{
 				{
@@ -1407,9 +1407,9 @@ func TestTransform_PolicyOnDifferentRoutes(t *testing.T) {
 
 		policy := (*op.Policies)[0]
 		if op.Path == "/v1/chat/completions" {
-			assert.Equal(t, "ContentLengthGuardrail", policy.Name)
+			assert.Equal(t, "content-length-guardrail", policy.Name)
 		} else if op.Path == "/v1/embeddings" {
-			assert.Equal(t, "RegexGuardrail", policy.Name)
+			assert.Equal(t, "regex-guardrail", policy.Name)
 		}
 	}
 }
@@ -1420,7 +1420,7 @@ func TestTransform_PolicyOnWildcardMethod_1(t *testing.T) {
 
 	policies := []api.LLMPolicy{
 		{
-			Name:    "ModifyHeaders",
+			Name:    "modify-headers",
 			Version: "v1.0.0",
 			Paths: []api.LLMPolicyPath{
 				{
@@ -1478,9 +1478,9 @@ func TestTransform_PolicyOnWildcardMethod_1(t *testing.T) {
 		require.NotNil(t, op.Policies, "Operation %s %s should have policies", op.Method, op.Path)
 		require.Len(t, *op.Policies, 1, "Operation %s %s should have exactly 1 policy", op.Method, op.Path)
 
-		// The policy should be ModifyHeaders
+		// The policy should be modify-headers
 		policy := (*op.Policies)[0]
-		assert.Equal(t, "ModifyHeaders", policy.Name, "Operation %s %s should have ModifyHeaders policy", op.Method, op.Path)
+		assert.Equal(t, "modify-headers", policy.Name, "Operation %s %s should have modify-headers policy", op.Method, op.Path)
 		assert.Equal(t, "v1.0.0", policy.Version, "Operation %s %s should have correct policy version", op.Method, op.Path)
 
 		// Verify the policy params are set correctly
@@ -1495,7 +1495,7 @@ func TestTransform_PolicyOnWildcardMethod_2(t *testing.T) {
 
 	policies := []api.LLMPolicy{
 		{
-			Name:    "ModifyHeaders",
+			Name:    "modify-headers",
 			Version: "v1.0.0",
 			Paths: []api.LLMPolicyPath{
 				{
@@ -1560,9 +1560,9 @@ func TestTransform_PolicyOnWildcardMethod_2(t *testing.T) {
 		require.NotNil(t, op.Policies, "Operation %s %s should have policies", op.Method, op.Path)
 		require.Len(t, *op.Policies, 1, "Operation %s %s should have exactly 1 policy", op.Method, op.Path)
 
-		// The policy should be ModifyHeaders
+		// The policy should be modify-headers
 		policy := (*op.Policies)[0]
-		assert.Equal(t, "ModifyHeaders", policy.Name, "Operation %s %s should have ModifyHeaders policy", op.Method, op.Path)
+		assert.Equal(t, "modify-headers", policy.Name, "Operation %s %s should have modify-headers policy", op.Method, op.Path)
 		assert.Equal(t, "v1.0.0", policy.Version, "Operation %s %s should have correct policy version", op.Method, op.Path)
 
 		// Verify the policy params are set correctly
@@ -1577,7 +1577,7 @@ func TestTransform_PolicyOnNonExistentRoute(t *testing.T) {
 	// Policy for route that doesn't exist in operations
 	policies := []api.LLMPolicy{
 		{
-			Name:    "ContentLengthGuardrail",
+			Name:    "content-length-guardrail",
 			Version: "v0.1.0",
 			Paths: []api.LLMPolicyPath{
 				{
@@ -1692,7 +1692,7 @@ func TestTransform_AuthWithAllowAll(t *testing.T) {
 	// Should have 1 exception + 6 catch-all operations (one per HTTP method) = 7 total
 	require.Len(t, spec.Operations, 7)
 
-	// Exception operation should have Respond policy
+	// Exception operation should have respond policy
 	foundException := false
 	catchAllCount := 0
 	for _, op := range spec.Operations {
@@ -1863,12 +1863,12 @@ func TestTransform_DuplicateExceptionPaths(t *testing.T) {
 func TestTransform_AllowAllWithPolicies(t *testing.T) {
 	transformer, _ := setupTestTransformer(t)
 
-	// BUG POTENTIAL: Policies might be applied to exception operations with Respond policy
+	// BUG POTENTIAL: Policies might be applied to exception operations with respond policy
 	// This could cause unexpected behavior
 
 	policies := []api.LLMPolicy{
 		{
-			Name:    "ContentLengthGuardrail",
+			Name:    "content-length-guardrail",
 			Version: "v0.1.0",
 			Paths: []api.LLMPolicyPath{
 				{
@@ -1928,7 +1928,7 @@ func TestTransform_AllowAllWithPolicies(t *testing.T) {
 	require.NotNil(t, adminOp)
 	require.NotNil(t, adminOp.Policies)
 
-	// ISSUE: Should have both Respond (from exception) and ContentLengthGuardrail (from policy)
+	// ISSUE: Should have both respond (from exception) and content-length-guardrail (from policy)
 	// Current implementation might have ordering issues
 	t.Logf("Admin operation has %d policies", len(*adminOp.Policies))
 	for i, p := range *adminOp.Policies {
@@ -1936,7 +1936,7 @@ func TestTransform_AllowAllWithPolicies(t *testing.T) {
 	}
 
 	// Verify policies
-	assert.GreaterOrEqual(t, len(*adminOp.Policies), 1, "Should have at least Respond policy")
+	assert.GreaterOrEqual(t, len(*adminOp.Policies), 1, "Should have at least respond policy")
 }
 
 // ============================================================================
@@ -3507,7 +3507,7 @@ func TestTransform_Auth_Plus_APILevel_Plus_OperationLevel_AllowAll(t *testing.T)
 	require.NotNil(t, adminOp, "/admin/delete DELETE should exist")
 	if adminOp.Policies != nil {
 		assert.Len(t, *adminOp.Policies, 1, "/admin/delete should have Deny policy only")
-		assert.Equal(t, "Respond", (*adminOp.Policies)[0].Name)
+		assert.Equal(t, "respond", (*adminOp.Policies)[0].Name)
 	}
 
 	// Verify total operations count
@@ -3744,7 +3744,7 @@ func TestTransform_MultipleAPILevelPolicies_Plus_Exceptions_Plus_OperationPolici
 	}
 	assert.Equal(t, len(constants.WILDCARD_HTTP_METHODS), catchAllCount, "Should have 6 catch-all operations")
 
-	// Verify /internal/* wildcard exception operations exist with deny policy (Respond)
+	// Verify /internal/* wildcard exception operations exist with deny policy (respond)
 	internalWildcardCount := 0
 	for _, op := range spec.Operations {
 		if op.Path == "/internal/*" {
@@ -3756,14 +3756,14 @@ func TestTransform_MultipleAPILevelPolicies_Plus_Exceptions_Plus_OperationPolici
 	}
 	assert.Equal(t, len(constants.WILDCARD_HTTP_METHODS), internalWildcardCount, "Should have /internal/* for all 6 HTTP methods")
 
-	// Verify /admin/users DELETE exception operation with deny policy (Respond)
+	// Verify /admin/users DELETE exception operation with deny policy (respond)
 	adminDeleteOp := findOperation(spec.Operations, "/admin/users", "DELETE")
 	require.NotNil(t, adminDeleteOp, "/admin/users DELETE should exist")
 	require.NotNil(t, adminDeleteOp.Policies, "Operation should have policies")
 	require.Len(t, *adminDeleteOp.Policies, 1, "Should have 1 policy (deny policy)")
 	assert.Equal(t, constants.ACCESS_CONTROL_DENY_POLICY_NAME, (*adminDeleteOp.Policies)[0].Name)
 
-	// Verify /admin/users POST exception operation with deny policy (Respond)
+	// Verify /admin/users POST exception operation with deny policy (respond)
 	adminPostOp := findOperation(spec.Operations, "/admin/users", "POST")
 	require.NotNil(t, adminPostOp, "/admin/users POST should exist")
 	require.NotNil(t, adminPostOp.Policies, "Operation should have policies")

--- a/gateway/gateway-controller/pkg/xds/translator.go
+++ b/gateway/gateway-controller/pkg/xds/translator.go
@@ -29,16 +29,16 @@ import (
 	"time"
 
 	accesslog "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
-	grpc_accesslogv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/grpc/v3"
-	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	mutationrules "github.com/envoyproxy/go-control-plane/envoy/config/common/mutation_rules/v3"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	tracev3 "github.com/envoyproxy/go-control-plane/envoy/config/trace/v3"
 	fileaccesslog "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/file/v3"
+	grpc_accesslogv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/grpc/v3"
 	dfpcluster "github.com/envoyproxy/go-control-plane/envoy/extensions/clusters/dynamic_forward_proxy/v3"
 	common_dfp "github.com/envoyproxy/go-control-plane/envoy/extensions/common/dynamic_forward_proxy/v3"
 	dfpv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/dynamic_forward_proxy/v3"
@@ -46,8 +46,8 @@ import (
 	router "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
-	typev3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+	typev3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	"github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
@@ -1105,44 +1105,44 @@ func (t *Translator) createPolicyEngineCluster() *cluster.Cluster {
 
 // createALSCluster creates an Envoy cluster for the gRPC access log service
 func (t *Translator) createALSCluster() *cluster.Cluster {
-    grpcConfig := t.config.Analytics.GRPCAccessLogCfg
+	grpcConfig := t.config.Analytics.GRPCAccessLogCfg
 
-    address := &core.Address{
-        Address: &core.Address_SocketAddress{
-            SocketAddress: &core.SocketAddress{
-                Protocol: core.SocketAddress_TCP,
-                Address:  grpcConfig.Host,
-                PortSpecifier: &core.SocketAddress_PortValue{
-                    PortValue: uint32(t.config.Analytics.AccessLogsServiceCfg["als_server_port"].(int)),
-                },
-            },
-        },
-    }
+	address := &core.Address{
+		Address: &core.Address_SocketAddress{
+			SocketAddress: &core.SocketAddress{
+				Protocol: core.SocketAddress_TCP,
+				Address:  grpcConfig.Host,
+				PortSpecifier: &core.SocketAddress_PortValue{
+					PortValue: uint32(t.config.Analytics.AccessLogsServiceCfg["als_server_port"].(int)),
+				},
+			},
+		},
+	}
 
-    lbEndpoint := &endpoint.LbEndpoint{
-        HostIdentifier: &endpoint.LbEndpoint_Endpoint{
-            Endpoint: &endpoint.Endpoint{
-                Address: address,
-            },
-        },
-    }
+	lbEndpoint := &endpoint.LbEndpoint{
+		HostIdentifier: &endpoint.LbEndpoint_Endpoint{
+			Endpoint: &endpoint.Endpoint{
+				Address: address,
+			},
+		},
+	}
 
-    localityLbEndpoints := &endpoint.LocalityLbEndpoints{
-        LbEndpoints: []*endpoint.LbEndpoint{lbEndpoint},
-    }
+	localityLbEndpoints := &endpoint.LocalityLbEndpoints{
+		LbEndpoints: []*endpoint.LbEndpoint{lbEndpoint},
+	}
 
-    return &cluster.Cluster{
-        Name:                 constants.GRPCAccessLogClusterName,
-        ConnectTimeout:       durationpb.New(5 * time.Second),
-        ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_STRICT_DNS},
-        LbPolicy:             cluster.Cluster_ROUND_ROBIN,
-        LoadAssignment: &endpoint.ClusterLoadAssignment{
-            ClusterName: constants.GRPCAccessLogClusterName,
-            Endpoints:   []*endpoint.LocalityLbEndpoints{localityLbEndpoints},
-        },
-        // Enable HTTP/2 for gRPC
-        Http2ProtocolOptions: &core.Http2ProtocolOptions{},
-    }
+	return &cluster.Cluster{
+		Name:                 constants.GRPCAccessLogClusterName,
+		ConnectTimeout:       durationpb.New(5 * time.Second),
+		ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_STRICT_DNS},
+		LbPolicy:             cluster.Cluster_ROUND_ROBIN,
+		LoadAssignment: &endpoint.ClusterLoadAssignment{
+			ClusterName: constants.GRPCAccessLogClusterName,
+			Endpoints:   []*endpoint.LocalityLbEndpoints{localityLbEndpoints},
+		},
+		// Enable HTTP/2 for gRPC
+		Http2ProtocolOptions: &core.Http2ProtocolOptions{},
+	}
 }
 
 // createOTELCollectorCluster creates an Envoy cluster for OpenTelemetry collector
@@ -1700,25 +1700,25 @@ func (t *Translator) createAccessLogConfig() ([]*accesslog.AccessLog, error) {
 	})
 
 	// If gRPC access log is enabled, create the configuration and append to existing access logs
-    if t.config.Analytics.Enabled {
+	if t.config.Analytics.Enabled {
 		t.logger.Info("Creating gRPC access log configuration")
-        grpcAccessLog, err := t.createGRPCAccessLog()
-        if err != nil {
-            t.logger.Warn("Failed to create gRPC access log config, continuing without it", 
-                zap.Error(err))
-        } else {
-            accessLogs = append(accessLogs, grpcAccessLog)
-        }
-    }
+		grpcAccessLog, err := t.createGRPCAccessLog()
+		if err != nil {
+			t.logger.Warn("Failed to create gRPC access log config, continuing without it",
+				zap.Error(err))
+		} else {
+			accessLogs = append(accessLogs, grpcAccessLog)
+		}
+	}
 
-    return accessLogs, nil
+	return accessLogs, nil
 }
 
 // createGRPCAccessLog creates a gRPC access log configuration for the gateway controller
 func (t *Translator) createGRPCAccessLog() (*accesslog.AccessLog, error) {
-    grpcConfig := t.config.Analytics.GRPCAccessLogCfg
+	grpcConfig := t.config.Analytics.GRPCAccessLogCfg
 
-    httpGrpcAccessLog := &grpc_accesslogv3.HttpGrpcAccessLogConfig{
+	httpGrpcAccessLog := &grpc_accesslogv3.HttpGrpcAccessLogConfig{
 		CommonConfig: &grpc_accesslogv3.CommonGrpcAccessLogConfig{
 			TransportApiVersion: corev3.ApiVersion_V3,
 			LogName:             grpcConfig.LogName,
@@ -1735,17 +1735,17 @@ func (t *Translator) createGRPCAccessLog() (*accesslog.AccessLog, error) {
 		},
 	}
 
-    grpcAccessLogAny, err := anypb.New(httpGrpcAccessLog)
-    if err != nil {
-        return nil, fmt.Errorf("failed to marshal gRPC access log config: %w", err)
-    }
+	grpcAccessLogAny, err := anypb.New(httpGrpcAccessLog)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal gRPC access log config: %w", err)
+	}
 
-    return &accesslog.AccessLog{
-        Name: "envoy.access_loggers.http_grpc",
-        ConfigType: &accesslog.AccessLog_TypedConfig{
-            TypedConfig: grpcAccessLogAny,
-        },
-    }, nil
+	return &accesslog.AccessLog{
+		Name: "envoy.access_loggers.http_grpc",
+		ConfigType: &accesslog.AccessLog_TypedConfig{
+			TypedConfig: grpcAccessLogAny,
+		},
+	}, nil
 }
 
 // createTracingConfig creates tracing configuration for HCM if tracing is enabled
@@ -1823,7 +1823,7 @@ func (t *Translator) createExtProcFilter() (*hcm.HttpFilter, error) {
 
 	// Convert route cache action string to enum
 	routeCacheAction := extproc.ExternalProcessor_DEFAULT
-	switch policyEngine.RouteCacheAction {
+	switch policyEngine.RouteCacheAction { // TODO: (renuka) This is not a config. Fix it.
 	case constants.ExtProcRouteCacheActionRetain:
 		routeCacheAction = extproc.ExternalProcessor_RETAIN
 	case constants.ExtProcRouteCacheActionClear:

--- a/gateway/policies/basic-auth/v1.0.0/policy-definition.yaml
+++ b/gateway/policies/basic-auth/v1.0.0/policy-definition.yaml
@@ -1,4 +1,4 @@
-name: BasicAuth
+name: basic-auth
 version: v1.0.0
 description: |
   Implements HTTP Basic Authentication to protect APIs with username and password credentials.

--- a/gateway/policies/content-length-guardrail/v0.1.0/contentlengthguardrail.go
+++ b/gateway/policies/content-length-guardrail/v0.1.0/contentlengthguardrail.go
@@ -274,7 +274,7 @@ func (p *ContentLengthGuardrailPolicy) buildErrorResponse(reason string, validat
 func (p *ContentLengthGuardrailPolicy) buildAssessmentObject(reason string, validationError error, isResponse bool, showAssessment bool, min, max int) map[string]interface{} {
 	assessment := map[string]interface{}{
 		"action":               "GUARDRAIL_INTERVENED",
-		"interveningGuardrail": "ContentLengthGuardrail",
+		"interveningGuardrail": "content-length-guardrail",
 	}
 
 	if isResponse {

--- a/gateway/policies/content-length-guardrail/v0.1.0/policy-definition.yaml
+++ b/gateway/policies/content-length-guardrail/v0.1.0/policy-definition.yaml
@@ -1,4 +1,4 @@
-name: ContentLengthGuardrail
+name: content-length-guardrail
 version: v0.1.0
 description: |
   Validates the byte length of request or response body content.

--- a/gateway/policies/json-schema-guardrail/v0.1.0/jsonschemaguardrail.go
+++ b/gateway/policies/json-schema-guardrail/v0.1.0/jsonschemaguardrail.go
@@ -263,7 +263,7 @@ func (p *JSONSchemaGuardrailPolicy) buildErrorResponse(reason string, validation
 func (p *JSONSchemaGuardrailPolicy) buildAssessmentObject(reason string, validationError error, isResponse bool, showAssessment bool, errors []gojsonschema.ResultError) map[string]interface{} {
 	assessment := map[string]interface{}{
 		"action":               "GUARDRAIL_INTERVENED",
-		"interveningGuardrail": "JSONSchemaGuardrail",
+		"interveningGuardrail": "json-schema-guardrail",
 	}
 
 	if isResponse {

--- a/gateway/policies/json-schema-guardrail/v0.1.0/policy-definition.yaml
+++ b/gateway/policies/json-schema-guardrail/v0.1.0/policy-definition.yaml
@@ -1,4 +1,4 @@
-name: JSONSchemaGuardrail
+name: json-schema-guardrail
 version: v0.1.0
 description: |
   Validates request or response body content against a JSON Schema.

--- a/gateway/policies/jwt-auth/v0.1.0/policy-definition.yaml
+++ b/gateway/policies/jwt-auth/v0.1.0/policy-definition.yaml
@@ -1,4 +1,4 @@
-name: JwtAuthentication
+name: jwt-auth
 version: v0.1.0
 description: |
   Validates JWT access tokens using one or more JWKS providers (key managers).

--- a/gateway/policies/mcp-auth/v0.1.0/go.mod
+++ b/gateway/policies/mcp-auth/v0.1.0/go.mod
@@ -4,10 +4,10 @@ go 1.25.1
 
 require github.com/wso2/api-platform/sdk v1.0.0
 
-require github.com/policy-engine/policies/jwtauthentication v0.1.0
+require github.com/policy-engine/policies/jwt-auth v0.1.0
 
 require github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
 
 replace github.com/wso2/api-platform/sdk => ../../../../sdk
 
-replace github.com/policy-engine/policies/jwtauthentication => ../../jwt-auth/v0.1.0
+replace github.com/policy-engine/policies/jwt-auth => ../../jwt-auth/v0.1.0

--- a/gateway/policies/mcp-auth/v0.1.0/mcp-auth.go
+++ b/gateway/policies/mcp-auth/v0.1.0/mcp-auth.go
@@ -25,7 +25,7 @@ import (
 	"strconv"
 	"strings"
 
-	jwtauth "github.com/policy-engine/policies/jwtauthentication"
+	jwtauth "github.com/policy-engine/policies/jwt-auth"
 	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
 )
 

--- a/gateway/policies/mcp-auth/v0.1.0/policy-definition.yaml
+++ b/gateway/policies/mcp-auth/v0.1.0/policy-definition.yaml
@@ -1,4 +1,4 @@
-name: McpAuthentication
+name: mcp-auth
 version: v0.1.0
 description: |
   This policy is used to secure traffic to Model Context Protocol server as defined in the specification 

--- a/gateway/policies/modify-headers/v1.0.0/policy-definition.yaml
+++ b/gateway/policies/modify-headers/v1.0.0/policy-definition.yaml
@@ -1,4 +1,4 @@
-name: ModifyHeaders
+name: modify-headers
 version: v1.0.0
 description: |
   Comprehensive header manipulation policy for both request and response flows.

--- a/gateway/policies/pii-masking-regex/v0.1.0/piimaskingregex.go
+++ b/gateway/policies/pii-masking-regex/v0.1.0/piimaskingregex.go
@@ -347,7 +347,7 @@ func (p *PIIMaskingRegexPolicy) updatePayloadWithMaskedContent(originalPayload [
 func (p *PIIMaskingRegexPolicy) buildErrorResponse(reason string) interface{} {
 	responseBody := map[string]interface{}{
 		"code":    APIMInternalExceptionCode,
-		"message": "Error occurred during PIIMaskingRegex mediation: " + reason,
+		"message": "Error occurred during pii-masking-regex mediation: " + reason,
 	}
 
 	bodyBytes, err := json.Marshal(responseBody)

--- a/gateway/policies/pii-masking-regex/v0.1.0/policy-definition.yaml
+++ b/gateway/policies/pii-masking-regex/v0.1.0/policy-definition.yaml
@@ -1,4 +1,4 @@
-name: PIIMaskingRegex
+name: pii-masking-regex
 version: v0.1.0
 description: |
   Masks or redacts Personally Identifiable Information (PII) from request/response bodies using regex patterns.

--- a/gateway/policies/policy-manifest-lock.yaml
+++ b/gateway/policies/policy-manifest-lock.yaml
@@ -1,60 +1,50 @@
 version: v1
 
 policies:
-  # Respond Policy
-  - name: Respond
+  - name: respond
     version: v1.0.0
     filePath: ./respond/v1.0.0
 
-  # ModifyHeaders Policy
-  - name: ModifyHeaders
+  - name: modify-headers
     version: v1.0.0
     filePath: ./modify-headers/v1.0.0
 
-  # BasicAuth Policy
-  - name: BasicAuth
+  - name: basic-auth
     version: v1.0.0
     filePath: ./basic-auth/v1.0.0
 
-  - name: JwtAuthentication
+  - name: jwt-auth
     version: v0.1.0
     filePath: ./jwt-auth/v0.1.0
 
-  # WordCountGuardrail Policy
-  - name: WordCountGuardrail
+  - name: word-count-guardrail
     version: v0.1.0
     filePath: ./word-count-guardrail/v0.1.0
 
-  # SentenceCountGuardrail Policy
-  - name: SentenceCountGuardrail
+  - name: sentence-count-guardrail
     version: v0.1.0
     filePath: ./sentence-count-guardrail/v0.1.0
 
-  # UrlGuardrail Policy
-  - name: URLGuardrail
+  - name: url-guardrail
     version: v0.1.0
     filePath: ./url-guardrail/v0.1.0
 
-  # RegexGuardrail Policy
-  - name: RegexGuardrail
+  - name: regex-guardrail
     version: v0.1.0
     filePath: ./regex-guardrail/v0.1.0
 
-  # ContentLengthGuardrail Policy
-  - name: ContentLengthGuardrail
+  - name: content-length-guardrail
     version: v0.1.0
     filePath: ./content-length-guardrail/v0.1.0
 
-  # PIIMaskingRegex Policy
-  - name: PIIMaskingRegex
+  - name: pii-masking-regex
     version: v0.1.0
     filePath: ./pii-masking-regex/v0.1.0
 
-  # JSONSchemaGuardrail Policy
-  - name: JSONSchemaGuardrail
+  - name: json-schema-guardrail
     version: v0.1.0
     filePath: ./json-schema-guardrail/v0.1.0
 
-  - name: McpAuthentication
+  - name: mcp-auth
     version: v0.1.0
     filePath: ./mcp-auth/v0.1.0

--- a/gateway/policies/regex-guardrail/v0.1.0/policy-definition.yaml
+++ b/gateway/policies/regex-guardrail/v0.1.0/policy-definition.yaml
@@ -1,4 +1,4 @@
-name: RegexGuardrail
+name: regex-guardrail
 version: v0.1.0
 description: |
   Validates request or response body content against a regular expression pattern.

--- a/gateway/policies/regex-guardrail/v0.1.0/regexguardrail.go
+++ b/gateway/policies/regex-guardrail/v0.1.0/regexguardrail.go
@@ -230,7 +230,7 @@ func (p *RegexGuardrailPolicy) buildErrorResponse(reason string, validationError
 func (p *RegexGuardrailPolicy) buildAssessmentObject(reason string, validationError error, isResponse bool, showAssessment bool) map[string]interface{} {
 	assessment := map[string]interface{}{
 		"action":               "GUARDRAIL_INTERVENED",
-		"interveningGuardrail": "RegexGuardrail",
+		"interveningGuardrail": "regex-guardrail",
 	}
 
 	if isResponse {

--- a/gateway/policies/respond/v1.0.0/policy-definition.yaml
+++ b/gateway/policies/respond/v1.0.0/policy-definition.yaml
@@ -1,4 +1,4 @@
-name: Respond
+name: respond
 version: v1.0.0
 description: |
   Returns an immediate response to the client without forwarding the request to the upstream backend.

--- a/gateway/policies/sentence-count-guardrail/v0.1.0/policy-definition.yaml
+++ b/gateway/policies/sentence-count-guardrail/v0.1.0/policy-definition.yaml
@@ -1,4 +1,4 @@
-name: SentenceCountGuardrail
+name: sentence-count-guardrail
 version: v0.1.0
 description: |
   Validates the sentence count of request or response body content.

--- a/gateway/policies/sentence-count-guardrail/v0.1.0/sentencecountguardrail.go
+++ b/gateway/policies/sentence-count-guardrail/v0.1.0/sentencecountguardrail.go
@@ -284,7 +284,7 @@ func (p *SentenceCountGuardrailPolicy) buildErrorResponse(reason string, validat
 func (p *SentenceCountGuardrailPolicy) buildAssessmentObject(reason string, validationError error, isResponse bool, showAssessment bool, min, max int) map[string]interface{} {
 	assessment := map[string]interface{}{
 		"action":               "GUARDRAIL_INTERVENED",
-		"interveningGuardrail": "SentenceCountGuardrail",
+		"interveningGuardrail": "sentence-count-guardrail",
 	}
 
 	if isResponse {

--- a/gateway/policies/url-guardrail/v0.1.0/policy-definition.yaml
+++ b/gateway/policies/url-guardrail/v0.1.0/policy-definition.yaml
@@ -1,4 +1,4 @@
-name: URLGuardrail
+name: url-guardrail
 version: v0.1.0
 description: |
   Validates URLs found in request or response body content.

--- a/gateway/policies/url-guardrail/v0.1.0/urlguardrail.go
+++ b/gateway/policies/url-guardrail/v0.1.0/urlguardrail.go
@@ -321,7 +321,7 @@ func (p *URLGuardrailPolicy) buildErrorResponse(reason string, validationError e
 func (p *URLGuardrailPolicy) buildAssessmentObject(reason string, validationError error, isResponse bool, showAssessment bool, invalidURLs []string) map[string]interface{} {
 	assessment := map[string]interface{}{
 		"action":               "GUARDRAIL_INTERVENED",
-		"interveningGuardrail": "URLGuardrail",
+		"interveningGuardrail": "url-guardrail",
 	}
 
 	if isResponse {

--- a/gateway/policies/word-count-guardrail/v0.1.0/policy-definition.yaml
+++ b/gateway/policies/word-count-guardrail/v0.1.0/policy-definition.yaml
@@ -1,4 +1,4 @@
-name: WordCountGuardrail
+name: word-count-guardrail
 version: v0.1.0
 description: |
   Validates the word count of request or response body content.

--- a/gateway/policies/word-count-guardrail/v0.1.0/wordcountguardrail.go
+++ b/gateway/policies/word-count-guardrail/v0.1.0/wordcountguardrail.go
@@ -284,7 +284,7 @@ func (p *WordCountGuardrailPolicy) buildErrorResponse(reason string, validationE
 func (p *WordCountGuardrailPolicy) buildAssessmentObject(reason string, validationError error, isResponse bool, showAssessment bool, min, max int) map[string]interface{} {
 	assessment := map[string]interface{}{
 		"action":               "GUARDRAIL_INTERVENED",
-		"interveningGuardrail": "WordCountGuardrail",
+		"interveningGuardrail": "word-count-guardrail",
 	}
 
 	if isResponse {

--- a/gateway/policy-engine/configs/policy-chains.yaml
+++ b/gateway/policy-engine/configs/policy-chains.yaml
@@ -21,7 +21,7 @@
 
 - route_key: my_upstream_service_route
   policies:
-    - name: ModifyHeaders
+    - name: modify-headers
       version: v1.0.0
       enabled: true
       parameters:
@@ -40,7 +40,7 @@
             value: nosniff
           - action: DELETE
             name: server
-    # - name: Respond
+    # - name: respond
     #   version: v1.0.0
     #   enabled: true
     #   parameters:
@@ -54,7 +54,7 @@
     # - name: UppercaseBody
     #   version: v1.0.0
     #   enabled: true
-    - name: BasicAuth
+    - name: basic-auth
       version: v1.0.0
       enabled: true
       parameters:
@@ -62,14 +62,14 @@
         password: secret123
         allowUnauthenticated: true
         realm: "Admin API"
-    - name: ModifyHeaders
+    - name: modify-headers
       version: v1.0.0
       enabled: true
       parameters:
         requestHeaders:
           - action: DELETE
             name: authorization  # Remove auth header after validation
-    - name: ModifyHeaders
+    - name: modify-headers
       version: v1.0.0
       enabled: true
       executionCondition: request.Metadata['auth.success'] == false
@@ -78,7 +78,7 @@
           - action: SET
             name: auth-failed
             value: "true"
-    - name: ModifyHeaders
+    - name: modify-headers
       version: v1.0.0
       enabled: true
       executionCondition: request.Metadata['auth.success'] == true

--- a/kubernetes/gateway-operator/config/samples/api_v1_apiconfiguration.yaml
+++ b/kubernetes/gateway-operator/config/samples/api_v1_apiconfiguration.yaml
@@ -16,7 +16,7 @@ spec:
     main:
       url: https://secure-backend:5443/api/v2
   policies:
-    - name: JwtAuthentication
+    - name: jwt-auth
       version: v0.1.0
       params:
         issuers:
@@ -50,7 +50,7 @@ spec:
     main:
       url: https://secure-backend:5443/api/v2
   policies:
-    - name: JwtAuthentication
+    - name: jwt-auth
       version: v0.1.0
       params:
         issuers:


### PR DESCRIPTION
## Purpose
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Gateway policy names have been standardized from CamelCase to kebab-case format (e.g., "BasicAuth" → "basic-auth"). Update all policy references in API configurations and deployments to reflect the new naming convention.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->