### PR TITLE
Add postman collection for gateway controller API

### DIFF
--- a/gateway/gateway-controller/Makefile
+++ b/gateway/gateway-controller/Makefile
@@ -134,3 +134,8 @@ generate-listener-certs: ## Generate listener certificates
 	@echo "Certificate and key generated successfully in listener-certs/"
 	@echo "  Certificate: listener-certs/default-listener.crt"
 	@echo "  Private Key: listener-certs/default-listener.key"
+
+generate-postman-collection: ## Generate Postman collection from OpenAPI spec
+	@echo "Generating Postman collection from OpenAPI spec..."
+	@npx openapi-to-postmanv2 -s api/openapi.yaml -o api/postman_collection.json -p
+	@echo "Postman collection generated at api/postman_collection.json"

--- a/gateway/gateway-controller/api/postman_collection.json
+++ b/gateway/gateway-controller/api/postman_collection.json
@@ -1,0 +1,5478 @@
+{
+    "item": [
+        {
+            "name": "health",
+            "description": "",
+            "item": [
+                {
+                    "id": "e3d59001-4008-4fb0-907d-719b54168ea1",
+                    "name": "Health check endpoint",
+                    "request": {
+                        "name": "Health check endpoint",
+                        "description": {
+                            "content": "Returns the health status of the Gateway Controller",
+                            "type": "text/plain"
+                        },
+                        "url": {
+                            "path": [
+                                "health"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {},
+                        "auth": null
+                    },
+                    "response": [
+                        {
+                            "id": "a5fbc892-1f9d-4c74-b330-858e334ab6d5",
+                            "name": "Gateway Controller is healthy",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "health"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"status\": \"<string>\",\n  \"timestamp\": \"<dateTime>\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
+                }
+            ]
+        },
+        {
+            "name": "apis",
+            "description": "",
+            "item": [
+                {
+                    "id": "8d67afa2-4713-4f2e-a5cb-8c8e2fcf2b9c",
+                    "name": "Create a new API configuration",
+                    "request": {
+                        "name": "Create a new API configuration",
+                        "description": {
+                            "content": "Submit a new API configuration to the Gateway Controller. The configuration\nis validated, persisted, and translated to Envoy xDS resources. The Router\nbegins routing traffic for the API within 5 seconds.\n\n**Validation Rules:**\n- API name + version combination must be unique\n- Context must start with `/` and not end with `/`\n- At least one upstream and one operation required\n- For same API name, context must be consistent across versions\n",
+                            "type": "text/plain"
+                        },
+                        "url": {
+                            "path": [
+                                "apis"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                            },
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            }
+                        ],
+                        "method": "POST",
+                        "body": {
+                            "mode": "raw",
+                            "raw": "{\n  \"apiVersion\": \"gateway.api-platform.wso2.com/v1alpha1\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"kind\": \"RestApi\",\n  \"spec\": {\n    \"displayName\": \" 2NEBa\",\n    \"version\": \"v26215326.7\",\n    \"context\": \"/Ta5wei0!\",\n    \"upstream\": {\n      \"main\": {\n        \"url\": 1061\n      },\n      \"sandbox\": {\n        \"url\": 4398.55100369791\n      }\n    },\n    \"operations\": [\n      {\n        \"method\": \"PUT\",\n        \"path\": \"/',w07g{gz\",\n        \"policies\": [\n          {\n            \"name\": \"<string>\",\n            \"version\": \"v504635326.11.884\",\n            \"executionCondition\": \"<string>\",\n            \"params\": {\n              \"key_0\": true,\n              \"key_1\": 9249.533117868556\n            }\n          },\n          {\n            \"name\": \"<string>\",\n            \"version\": \"v19525.835000097.109\",\n            \"executionCondition\": \"<string>\",\n            \"params\": {\n              \"key_0\": true,\n              \"key_1\": \"string\",\n              \"key_2\": true\n            }\n          }\n        ]\n      }\n    ],\n    \"vhosts\": {\n      \"main\": \"oD1\",\n      \"sandbox\": \"vY3WtsVwX\"\n    },\n    \"policies\": [\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v46512038081.0326461282.200816535\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": \"string\",\n          \"key_1\": 9679\n        }\n      },\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v01.1.86\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": 4526.646680407669\n        }\n      }\n    ]\n  }\n}",
+                            "options": {
+                                "raw": {
+                                    "headerFamily": "json",
+                                    "language": "json"
+                                }
+                            }
+                        },
+                        "auth": null
+                    },
+                    "response": [
+                        {
+                            "id": "cc2445d5-6609-47f8-b930-1d17cbf6f340",
+                            "name": "API configuration created successfully",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "apis"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"apiVersion\": \"gateway.api-platform.wso2.com/v1alpha1\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"kind\": \"RestApi\",\n  \"spec\": {\n    \"displayName\": \" 2NEBa\",\n    \"version\": \"v26215326.7\",\n    \"context\": \"/Ta5wei0!\",\n    \"upstream\": {\n      \"main\": {\n        \"url\": 1061\n      },\n      \"sandbox\": {\n        \"url\": 4398.55100369791\n      }\n    },\n    \"operations\": [\n      {\n        \"method\": \"PUT\",\n        \"path\": \"/',w07g{gz\",\n        \"policies\": [\n          {\n            \"name\": \"<string>\",\n            \"version\": \"v504635326.11.884\",\n            \"executionCondition\": \"<string>\",\n            \"params\": {\n              \"key_0\": true,\n              \"key_1\": 9249.533117868556\n            }\n          },\n          {\n            \"name\": \"<string>\",\n            \"version\": \"v19525.835000097.109\",\n            \"executionCondition\": \"<string>\",\n            \"params\": {\n              \"key_0\": true,\n              \"key_1\": \"string\",\n              \"key_2\": true\n            }\n          }\n        ]\n      }\n    ],\n    \"vhosts\": {\n      \"main\": \"oD1\",\n      \"sandbox\": \"vY3WtsVwX\"\n    },\n    \"policies\": [\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v46512038081.0326461282.200816535\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": \"string\",\n          \"key_1\": 9679\n        }\n      },\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v01.1.86\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": 4526.646680407669\n        }\n      }\n    ]\n  }\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Created",
+                            "code": 201,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"id\": \"<string>\",\n  \"created_at\": \"<dateTime>\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "1d043f30-8072-467e-9f46-f5408835d39f",
+                            "name": "Invalid configuration (validation failed)",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "apis"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"apiVersion\": \"gateway.api-platform.wso2.com/v1alpha1\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"kind\": \"RestApi\",\n  \"spec\": {\n    \"displayName\": \" 2NEBa\",\n    \"version\": \"v26215326.7\",\n    \"context\": \"/Ta5wei0!\",\n    \"upstream\": {\n      \"main\": {\n        \"url\": 1061\n      },\n      \"sandbox\": {\n        \"url\": 4398.55100369791\n      }\n    },\n    \"operations\": [\n      {\n        \"method\": \"PUT\",\n        \"path\": \"/',w07g{gz\",\n        \"policies\": [\n          {\n            \"name\": \"<string>\",\n            \"version\": \"v504635326.11.884\",\n            \"executionCondition\": \"<string>\",\n            \"params\": {\n              \"key_0\": true,\n              \"key_1\": 9249.533117868556\n            }\n          },\n          {\n            \"name\": \"<string>\",\n            \"version\": \"v19525.835000097.109\",\n            \"executionCondition\": \"<string>\",\n            \"params\": {\n              \"key_0\": true,\n              \"key_1\": \"string\",\n              \"key_2\": true\n            }\n          }\n        ]\n      }\n    ],\n    \"vhosts\": {\n      \"main\": \"oD1\",\n      \"sandbox\": \"vY3WtsVwX\"\n    },\n    \"policies\": [\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v46512038081.0326461282.200816535\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": \"string\",\n          \"key_1\": 9679\n        }\n      },\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v01.1.86\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": 4526.646680407669\n        }\n      }\n    ]\n  }\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "aa7712ac-a05e-4ddf-ac0a-4386fa2adb00",
+                            "name": "Conflict - API with same name and version already exists",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "apis"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"apiVersion\": \"gateway.api-platform.wso2.com/v1alpha1\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"kind\": \"RestApi\",\n  \"spec\": {\n    \"displayName\": \" 2NEBa\",\n    \"version\": \"v26215326.7\",\n    \"context\": \"/Ta5wei0!\",\n    \"upstream\": {\n      \"main\": {\n        \"url\": 1061\n      },\n      \"sandbox\": {\n        \"url\": 4398.55100369791\n      }\n    },\n    \"operations\": [\n      {\n        \"method\": \"PUT\",\n        \"path\": \"/',w07g{gz\",\n        \"policies\": [\n          {\n            \"name\": \"<string>\",\n            \"version\": \"v504635326.11.884\",\n            \"executionCondition\": \"<string>\",\n            \"params\": {\n              \"key_0\": true,\n              \"key_1\": 9249.533117868556\n            }\n          },\n          {\n            \"name\": \"<string>\",\n            \"version\": \"v19525.835000097.109\",\n            \"executionCondition\": \"<string>\",\n            \"params\": {\n              \"key_0\": true,\n              \"key_1\": \"string\",\n              \"key_2\": true\n            }\n          }\n        ]\n      }\n    ],\n    \"vhosts\": {\n      \"main\": \"oD1\",\n      \"sandbox\": \"vY3WtsVwX\"\n    },\n    \"policies\": [\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v46512038081.0326461282.200816535\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": \"string\",\n          \"key_1\": 9679\n        }\n      },\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v01.1.86\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": 4526.646680407669\n        }\n      }\n    ]\n  }\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Conflict",
+                            "code": 409,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "233eb765-de80-416d-beb0-d2d736a89bea",
+                            "name": "Internal server error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "apis"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"apiVersion\": \"gateway.api-platform.wso2.com/v1alpha1\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"kind\": \"RestApi\",\n  \"spec\": {\n    \"displayName\": \" 2NEBa\",\n    \"version\": \"v26215326.7\",\n    \"context\": \"/Ta5wei0!\",\n    \"upstream\": {\n      \"main\": {\n        \"url\": 1061\n      },\n      \"sandbox\": {\n        \"url\": 4398.55100369791\n      }\n    },\n    \"operations\": [\n      {\n        \"method\": \"PUT\",\n        \"path\": \"/',w07g{gz\",\n        \"policies\": [\n          {\n            \"name\": \"<string>\",\n            \"version\": \"v504635326.11.884\",\n            \"executionCondition\": \"<string>\",\n            \"params\": {\n              \"key_0\": true,\n              \"key_1\": 9249.533117868556\n            }\n          },\n          {\n            \"name\": \"<string>\",\n            \"version\": \"v19525.835000097.109\",\n            \"executionCondition\": \"<string>\",\n            \"params\": {\n              \"key_0\": true,\n              \"key_1\": \"string\",\n              \"key_2\": true\n            }\n          }\n        ]\n      }\n    ],\n    \"vhosts\": {\n      \"main\": \"oD1\",\n      \"sandbox\": \"vY3WtsVwX\"\n    },\n    \"policies\": [\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v46512038081.0326461282.200816535\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": \"string\",\n          \"key_1\": 9679\n        }\n      },\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v01.1.86\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": 4526.646680407669\n        }\n      }\n    ]\n  }\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
+                },
+                {
+                    "id": "5eaac5ab-e80b-443a-bba2-c9c9a7f07726",
+                    "name": "List all API configurations",
+                    "request": {
+                        "name": "List all API configurations",
+                        "description": {
+                            "content": "Retrieve a list of all deployed API configurations with metadata.\nReturns basic information about each API (name, version, context, deployment time).\n",
+                            "type": "text/plain"
+                        },
+                        "url": {
+                            "path": [
+                                "apis"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter by API display name",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "displayName",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter by API version",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "version",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter by API context/path",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "context",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter by deployment status (This can only be one of pending,deployed,failed)",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "status",
+                                    "value": "deployed"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {},
+                        "auth": null
+                    },
+                    "response": [
+                        {
+                            "id": "5f143f9d-05c6-429a-8ee1-e0eaa5a775e9",
+                            "name": "List of API configurations",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "apis"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter by API display name",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "displayName",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter by API version",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "version",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter by API context/path",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "context",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter by deployment status (This can only be one of pending,deployed,failed)",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "status",
+                                            "value": "deployed"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"status\": \"<string>\",\n  \"count\": \"<integer>\",\n  \"apis\": [\n    {\n      \"id\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"version\": \"<string>\",\n      \"context\": \"<string>\",\n      \"status\": \"pending\",\n      \"created_at\": \"<dateTime>\",\n      \"updated_at\": \"<dateTime>\"\n    },\n    {\n      \"id\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"version\": \"<string>\",\n      \"context\": \"<string>\",\n      \"status\": \"deployed\",\n      \"created_at\": \"<dateTime>\",\n      \"updated_at\": \"<dateTime>\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "9f0a6481-7545-412f-ae44-16a28b7f71d0",
+                            "name": "Internal server error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "apis"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter by API display name",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "displayName",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter by API version",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "version",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter by API context/path",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "context",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter by deployment status (This can only be one of pending,deployed,failed)",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "status",
+                                            "value": "deployed"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
+                },
+                {
+                    "name": "{id}",
+                    "description": "",
+                    "item": [
+                        {
+                            "id": "6a772b4a-5e13-43a4-bbb1-bdcabe950662",
+                            "name": "Get API configuration by id",
+                            "request": {
+                                "name": "Get API configuration by id",
+                                "description": {
+                                    "content": "Retrieve the complete configuration for a specific API by its id.\nThe id is a unique string identifier (not a UUID).\n",
+                                    "type": "text/plain"
+                                },
+                                "url": {
+                                    "path": [
+                                        "apis",
+                                        ":id"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "value": "<string>",
+                                            "key": "id",
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) Unique public identifier for the API.\n",
+                                                "type": "text/plain"
+                                            }
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {},
+                                "auth": null
+                            },
+                            "response": [
+                                {
+                                    "id": "ce3a51f3-a680-43a0-9112-9fcda92b780d",
+                                    "name": "API configuration details",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "apis",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Unique public identifier for the API.\n",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {}
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"api\": {\n    \"id\": \"<string>\",\n    \"configuration\": {\n      \"apiVersion\": \"gateway.api-platform.wso2.com/v1alpha1\",\n      \"metadata\": {\n        \"name\": \"<string>\"\n      },\n      \"kind\": \"RestApi\",\n      \"spec\": {\n        \"displayName\": \"MHPIHz0C3X3\",\n        \"version\": \"v469061.1\",\n        \"context\": \"/4\",\n        \"upstream\": {\n          \"main\": {\n            \"url\": \"string\"\n          },\n          \"sandbox\": {\n            \"url\": 3785\n          }\n        },\n        \"operations\": [\n          {\n            \"method\": \"PUT\",\n            \"path\": \"/lb$f,ym\",\n            \"policies\": [\n              {\n                \"name\": \"<string>\",\n                \"version\": \"v986.538437696.152338556\",\n                \"executionCondition\": \"<string>\",\n                \"params\": {\n                  \"key_0\": \"string\"\n                }\n              },\n              {\n                \"name\": \"<string>\",\n                \"version\": \"v6.5049.999878\",\n                \"executionCondition\": \"<string>\",\n                \"params\": {\n                  \"key_0\": true,\n                  \"key_1\": 878.7542832401041\n                }\n              }\n            ]\n          }\n        ],\n        \"vhosts\": {\n          \"main\": \"svVCukYCrud\",\n          \"sandbox\": \"Lud\"\n        },\n        \"policies\": [\n          {\n            \"name\": \"<string>\",\n            \"version\": \"v80.544.763509\",\n            \"executionCondition\": \"<string>\",\n            \"params\": {\n              \"key_0\": 63\n            }\n          },\n          {\n            \"name\": \"<string>\",\n            \"version\": \"v752.5933.482\",\n            \"executionCondition\": \"<string>\",\n            \"params\": {\n              \"key_0\": \"string\"\n            }\n          }\n        ]\n      }\n    },\n    \"metadata\": {\n      \"status\": \"deployed\",\n      \"created_at\": \"<dateTime>\",\n      \"updated_at\": \"<dateTime>\",\n      \"deployed_at\": \"<dateTime>\"\n    }\n  }\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                },
+                                {
+                                    "id": "29488419-8382-4641-b9a6-1ab55828ba79",
+                                    "name": "API configuration not found",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "apis",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Unique public identifier for the API.\n",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {}
+                                    },
+                                    "status": "Not Found",
+                                    "code": 404,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                },
+                                {
+                                    "id": "ff7b2c7c-6437-426c-b26e-4edbe6d5801d",
+                                    "name": "Internal server error",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "apis",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Unique public identifier for the API.\n",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {}
+                                    },
+                                    "status": "Internal Server Error",
+                                    "code": 500,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        },
+                        {
+                            "id": "f25d3460-0452-4dca-989e-fd63e9d7aad5",
+                            "name": "Update an existing API configuration",
+                            "request": {
+                                "name": "Update an existing API configuration",
+                                "description": {
+                                    "content": "Update an existing API configuration. The update is validated and applied atomically.\nThe Router receives the updated configuration within 5 seconds. In-flight requests\ncomplete with the old configuration; new requests use the updated configuration.\n\n**Important:** If validation fails, the existing configuration remains active.\n",
+                                    "type": "text/plain"
+                                },
+                                "url": {
+                                    "path": [
+                                        "apis",
+                                        ":id"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "value": "<string>",
+                                            "key": "id",
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) Unique public identifier of the API to update.\n",
+                                                "type": "text/plain"
+                                            }
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "PUT",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"apiVersion\": \"gateway.api-platform.wso2.com/v1alpha1\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"kind\": \"RestApi\",\n  \"spec\": {\n    \"displayName\": \" 2NEBa\",\n    \"version\": \"v26215326.7\",\n    \"context\": \"/Ta5wei0!\",\n    \"upstream\": {\n      \"main\": {\n        \"url\": 1061\n      },\n      \"sandbox\": {\n        \"url\": 4398.55100369791\n      }\n    },\n    \"operations\": [\n      {\n        \"method\": \"PUT\",\n        \"path\": \"/',w07g{gz\",\n        \"policies\": [\n          {\n            \"name\": \"<string>\",\n            \"version\": \"v504635326.11.884\",\n            \"executionCondition\": \"<string>\",\n            \"params\": {\n              \"key_0\": true,\n              \"key_1\": 9249.533117868556\n            }\n          },\n          {\n            \"name\": \"<string>\",\n            \"version\": \"v19525.835000097.109\",\n            \"executionCondition\": \"<string>\",\n            \"params\": {\n              \"key_0\": true,\n              \"key_1\": \"string\",\n              \"key_2\": true\n            }\n          }\n        ]\n      }\n    ],\n    \"vhosts\": {\n      \"main\": \"oD1\",\n      \"sandbox\": \"vY3WtsVwX\"\n    },\n    \"policies\": [\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v46512038081.0326461282.200816535\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": \"string\",\n          \"key_1\": 9679\n        }\n      },\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v01.1.86\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": 4526.646680407669\n        }\n      }\n    ]\n  }\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                },
+                                "auth": null
+                            },
+                            "response": [
+                                {
+                                    "id": "8a8e73df-3213-4963-a9b6-2b6b096aa33c",
+                                    "name": "API configuration updated successfully",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "apis",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Unique public identifier of the API to update.\n",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "PUT",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"apiVersion\": \"gateway.api-platform.wso2.com/v1alpha1\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"kind\": \"RestApi\",\n  \"spec\": {\n    \"displayName\": \" 2NEBa\",\n    \"version\": \"v26215326.7\",\n    \"context\": \"/Ta5wei0!\",\n    \"upstream\": {\n      \"main\": {\n        \"url\": 1061\n      },\n      \"sandbox\": {\n        \"url\": 4398.55100369791\n      }\n    },\n    \"operations\": [\n      {\n        \"method\": \"PUT\",\n        \"path\": \"/',w07g{gz\",\n        \"policies\": [\n          {\n            \"name\": \"<string>\",\n            \"version\": \"v504635326.11.884\",\n            \"executionCondition\": \"<string>\",\n            \"params\": {\n              \"key_0\": true,\n              \"key_1\": 9249.533117868556\n            }\n          },\n          {\n            \"name\": \"<string>\",\n            \"version\": \"v19525.835000097.109\",\n            \"executionCondition\": \"<string>\",\n            \"params\": {\n              \"key_0\": true,\n              \"key_1\": \"string\",\n              \"key_2\": true\n            }\n          }\n        ]\n      }\n    ],\n    \"vhosts\": {\n      \"main\": \"oD1\",\n      \"sandbox\": \"vY3WtsVwX\"\n    },\n    \"policies\": [\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v46512038081.0326461282.200816535\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": \"string\",\n          \"key_1\": 9679\n        }\n      },\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v01.1.86\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": 4526.646680407669\n        }\n      }\n    ]\n  }\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"id\": \"<string>\",\n  \"updated_at\": \"<dateTime>\"\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                },
+                                {
+                                    "id": "4f608c19-f766-4571-815b-92e792e08bea",
+                                    "name": "Invalid configuration (validation failed)",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "apis",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Unique public identifier of the API to update.\n",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "PUT",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"apiVersion\": \"gateway.api-platform.wso2.com/v1alpha1\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"kind\": \"RestApi\",\n  \"spec\": {\n    \"displayName\": \" 2NEBa\",\n    \"version\": \"v26215326.7\",\n    \"context\": \"/Ta5wei0!\",\n    \"upstream\": {\n      \"main\": {\n        \"url\": 1061\n      },\n      \"sandbox\": {\n        \"url\": 4398.55100369791\n      }\n    },\n    \"operations\": [\n      {\n        \"method\": \"PUT\",\n        \"path\": \"/',w07g{gz\",\n        \"policies\": [\n          {\n            \"name\": \"<string>\",\n            \"version\": \"v504635326.11.884\",\n            \"executionCondition\": \"<string>\",\n            \"params\": {\n              \"key_0\": true,\n              \"key_1\": 9249.533117868556\n            }\n          },\n          {\n            \"name\": \"<string>\",\n            \"version\": \"v19525.835000097.109\",\n            \"executionCondition\": \"<string>\",\n            \"params\": {\n              \"key_0\": true,\n              \"key_1\": \"string\",\n              \"key_2\": true\n            }\n          }\n        ]\n      }\n    ],\n    \"vhosts\": {\n      \"main\": \"oD1\",\n      \"sandbox\": \"vY3WtsVwX\"\n    },\n    \"policies\": [\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v46512038081.0326461282.200816535\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": \"string\",\n          \"key_1\": 9679\n        }\n      },\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v01.1.86\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": 4526.646680407669\n        }\n      }\n    ]\n  }\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "status": "Bad Request",
+                                    "code": 400,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                },
+                                {
+                                    "id": "ef350d38-299c-41e2-9947-ffbd3077c1c8",
+                                    "name": "API configuration not found",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "apis",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Unique public identifier of the API to update.\n",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "PUT",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"apiVersion\": \"gateway.api-platform.wso2.com/v1alpha1\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"kind\": \"RestApi\",\n  \"spec\": {\n    \"displayName\": \" 2NEBa\",\n    \"version\": \"v26215326.7\",\n    \"context\": \"/Ta5wei0!\",\n    \"upstream\": {\n      \"main\": {\n        \"url\": 1061\n      },\n      \"sandbox\": {\n        \"url\": 4398.55100369791\n      }\n    },\n    \"operations\": [\n      {\n        \"method\": \"PUT\",\n        \"path\": \"/',w07g{gz\",\n        \"policies\": [\n          {\n            \"name\": \"<string>\",\n            \"version\": \"v504635326.11.884\",\n            \"executionCondition\": \"<string>\",\n            \"params\": {\n              \"key_0\": true,\n              \"key_1\": 9249.533117868556\n            }\n          },\n          {\n            \"name\": \"<string>\",\n            \"version\": \"v19525.835000097.109\",\n            \"executionCondition\": \"<string>\",\n            \"params\": {\n              \"key_0\": true,\n              \"key_1\": \"string\",\n              \"key_2\": true\n            }\n          }\n        ]\n      }\n    ],\n    \"vhosts\": {\n      \"main\": \"oD1\",\n      \"sandbox\": \"vY3WtsVwX\"\n    },\n    \"policies\": [\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v46512038081.0326461282.200816535\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": \"string\",\n          \"key_1\": 9679\n        }\n      },\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v01.1.86\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": 4526.646680407669\n        }\n      }\n    ]\n  }\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "status": "Not Found",
+                                    "code": 404,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                },
+                                {
+                                    "id": "9260c17e-2e01-467a-ac75-d18836d4d0d3",
+                                    "name": "Internal server error",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "apis",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Unique public identifier of the API to update.\n",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "PUT",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"apiVersion\": \"gateway.api-platform.wso2.com/v1alpha1\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"kind\": \"RestApi\",\n  \"spec\": {\n    \"displayName\": \" 2NEBa\",\n    \"version\": \"v26215326.7\",\n    \"context\": \"/Ta5wei0!\",\n    \"upstream\": {\n      \"main\": {\n        \"url\": 1061\n      },\n      \"sandbox\": {\n        \"url\": 4398.55100369791\n      }\n    },\n    \"operations\": [\n      {\n        \"method\": \"PUT\",\n        \"path\": \"/',w07g{gz\",\n        \"policies\": [\n          {\n            \"name\": \"<string>\",\n            \"version\": \"v504635326.11.884\",\n            \"executionCondition\": \"<string>\",\n            \"params\": {\n              \"key_0\": true,\n              \"key_1\": 9249.533117868556\n            }\n          },\n          {\n            \"name\": \"<string>\",\n            \"version\": \"v19525.835000097.109\",\n            \"executionCondition\": \"<string>\",\n            \"params\": {\n              \"key_0\": true,\n              \"key_1\": \"string\",\n              \"key_2\": true\n            }\n          }\n        ]\n      }\n    ],\n    \"vhosts\": {\n      \"main\": \"oD1\",\n      \"sandbox\": \"vY3WtsVwX\"\n    },\n    \"policies\": [\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v46512038081.0326461282.200816535\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": \"string\",\n          \"key_1\": 9679\n        }\n      },\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v01.1.86\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": 4526.646680407669\n        }\n      }\n    ]\n  }\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "status": "Internal Server Error",
+                                    "code": 500,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        },
+                        {
+                            "id": "0f2b94bb-ac88-4508-bf20-af3e21c66efe",
+                            "name": "Delete an API configuration",
+                            "request": {
+                                "name": "Delete an API configuration",
+                                "description": {
+                                    "content": "Remove an API configuration from the Gateway Controller. The Router stops\naccepting traffic for this API within 5 seconds. In-flight requests complete\nsuccessfully; new requests receive 404 Not Found.\n",
+                                    "type": "text/plain"
+                                },
+                                "url": {
+                                    "path": [
+                                        "apis",
+                                        ":id"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "value": "<string>",
+                                            "key": "id",
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) Unique public identifier of the API to delete.\n",
+                                                "type": "text/plain"
+                                            }
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "DELETE",
+                                "body": {},
+                                "auth": null
+                            },
+                            "response": [
+                                {
+                                    "id": "27206106-008e-486c-950b-7459a0112237",
+                                    "name": "API configuration deleted successfully",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "apis",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Unique public identifier of the API to delete.\n",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "DELETE",
+                                        "body": {}
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"id\": \"<string>\"\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                },
+                                {
+                                    "id": "03f1fb9c-4afc-4209-a8ab-e06ba2e58d65",
+                                    "name": "API configuration not found",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "apis",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Unique public identifier of the API to delete.\n",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "DELETE",
+                                        "body": {}
+                                    },
+                                    "status": "Not Found",
+                                    "code": 404,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                },
+                                {
+                                    "id": "519290bc-4206-4027-911f-9d9eedc5f5df",
+                                    "name": "Internal server error",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "apis",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Unique public identifier of the API to delete.\n",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "DELETE",
+                                        "body": {}
+                                    },
+                                    "status": "Internal Server Error",
+                                    "code": 500,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "certificates",
+            "description": "",
+            "item": [
+                {
+                    "id": "5458120a-af9a-4d1e-a306-b8e4ba083221",
+                    "name": "List all custom certificates",
+                    "request": {
+                        "name": "List all custom certificates",
+                        "description": {
+                            "content": "Retrieve all custom TLS certificates currently loaded in the certificate store.\nThese certificates are used for verifying HTTPS upstream connections.\n",
+                            "type": "text/plain"
+                        },
+                        "url": {
+                            "path": [
+                                "certificates"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {},
+                        "auth": null
+                    },
+                    "response": [
+                        {
+                            "id": "fba97b8a-e256-42b9-8bef-5ceab60de3ba",
+                            "name": "List of certificates",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "certificates"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"certificates\": [\n    {\n      \"id\": \"<string>\",\n      \"name\": \"<string>\",\n      \"subject\": \"<string>\",\n      \"issuer\": \"<string>\",\n      \"notAfter\": \"<dateTime>\",\n      \"count\": \"<integer>\",\n      \"message\": \"<string>\",\n      \"status\": \"error\"\n    },\n    {\n      \"id\": \"<string>\",\n      \"name\": \"<string>\",\n      \"subject\": \"<string>\",\n      \"issuer\": \"<string>\",\n      \"notAfter\": \"<dateTime>\",\n      \"count\": \"<integer>\",\n      \"message\": \"<string>\",\n      \"status\": \"error\"\n    }\n  ],\n  \"totalCount\": \"<integer>\",\n  \"totalBytes\": \"<integer>\",\n  \"status\": \"<string>\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "807d1d5a-ddf1-490e-96a2-4b9c72e46e7e",
+                            "name": "Internal server error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "certificates"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
+                },
+                {
+                    "id": "4f819415-d6c8-4c47-8531-59641849b779",
+                    "name": "Upload a new certificate",
+                    "request": {
+                        "name": "Upload a new certificate",
+                        "description": {
+                            "content": "Upload a new custom TLS certificate to the certificate store. The certificate\nmust be in PEM format. After upload, the certificate store is automatically\nreloaded and SDS (Secret Discovery Service) is updated to push the new\ncertificate to Envoy proxies.\n\n**Dynamic Update:** Changes take effect immediately without restarting the gateway.\n",
+                            "type": "text/plain"
+                        },
+                        "url": {
+                            "path": [
+                                "certificates"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                            },
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            }
+                        ],
+                        "method": "POST",
+                        "body": {
+                            "mode": "raw",
+                            "raw": "{\n  \"certificate\": \"<string>\",\n  \"name\": \"BGb-ekd_\"\n}",
+                            "options": {
+                                "raw": {
+                                    "headerFamily": "json",
+                                    "language": "json"
+                                }
+                            }
+                        },
+                        "auth": null
+                    },
+                    "response": [
+                        {
+                            "id": "bf23c510-412e-42f5-99f0-2ff8c7aff373",
+                            "name": "Certificate uploaded successfully",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "certificates"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"certificate\": \"<string>\",\n  \"name\": \"BGb-ekd_\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Created",
+                            "code": 201,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"id\": \"<string>\",\n  \"name\": \"<string>\",\n  \"subject\": \"<string>\",\n  \"issuer\": \"<string>\",\n  \"notAfter\": \"<dateTime>\",\n  \"count\": \"<integer>\",\n  \"message\": \"<string>\",\n  \"status\": \"success\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "bebd9771-6a5d-402d-9e05-1e4dd828f35b",
+                            "name": "Invalid certificate format",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "certificates"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"certificate\": \"<string>\",\n  \"name\": \"BGb-ekd_\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "f36dc5b7-1638-4b2b-a461-00c3452303cd",
+                            "name": "Internal server error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "certificates"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"certificate\": \"<string>\",\n  \"name\": \"BGb-ekd_\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
+                },
+                {
+                    "name": "{id}",
+                    "description": "",
+                    "item": [
+                        {
+                            "id": "8a24a1db-a994-4120-aac6-7bad0687744b",
+                            "name": "Delete a certificate",
+                            "request": {
+                                "name": "Delete a certificate",
+                                "description": {
+                                    "content": "Delete a custom certificate by ID. After deletion, the certificate store\nis automatically reloaded and SDS is updated to remove the certificate from\nEnvoy proxies.\n\n**Dynamic Update:** Changes take effect immediately without restarting the gateway.\n",
+                                    "type": "text/plain"
+                                },
+                                "url": {
+                                    "path": [
+                                        "certificates",
+                                        ":id"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "value": "<string>",
+                                            "key": "id",
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ID of the certificate to delete",
+                                                "type": "text/plain"
+                                            }
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "DELETE",
+                                "body": {},
+                                "auth": null
+                            },
+                            "response": [
+                                {
+                                    "id": "626416aa-e6ff-4295-8106-26c6f2cf3039",
+                                    "name": "Certificate deleted successfully",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "certificates",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ID of the certificate to delete",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "DELETE",
+                                        "body": {}
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"id\": \"<string>\"\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                },
+                                {
+                                    "id": "d29cb240-20c0-4421-9e37-387ab0665670",
+                                    "name": "Certificate not found",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "certificates",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ID of the certificate to delete",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "DELETE",
+                                        "body": {}
+                                    },
+                                    "status": "Not Found",
+                                    "code": 404,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                },
+                                {
+                                    "id": "d49140b1-2f8e-4478-b8bb-d9af56dfd3a0",
+                                    "name": "Internal server error",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "certificates",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ID of the certificate to delete",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "DELETE",
+                                        "body": {}
+                                    },
+                                    "status": "Internal Server Error",
+                                    "code": 500,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "reload",
+                    "description": "",
+                    "item": [
+                        {
+                            "id": "bd88b856-82b2-415b-a8c5-9829377ddc50",
+                            "name": "Manually reload certificates",
+                            "request": {
+                                "name": "Manually reload certificates",
+                                "description": {
+                                    "content": "Manually trigger a reload of all certificates from the filesystem and update\nSDS. This is useful if you've manually added certificate files to the\ncertificates directory.\n\n**Note:** This endpoint is typically not needed as uploads and deletions\nautomatically trigger reloads.\n",
+                                    "type": "text/plain"
+                                },
+                                "url": {
+                                    "path": [
+                                        "certificates",
+                                        "reload"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {},
+                                "auth": null
+                            },
+                            "response": [
+                                {
+                                    "id": "3ba8a998-59ac-4292-a110-5fdef47670aa",
+                                    "name": "Certificates reloaded successfully",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "certificates",
+                                                "reload"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "POST",
+                                        "body": {}
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"total_bytes\": \"<integer>\"\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                },
+                                {
+                                    "id": "7a639f7e-6e65-4fa6-9619-23183970ded3",
+                                    "name": "Internal server error",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "certificates",
+                                                "reload"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "POST",
+                                        "body": {}
+                                    },
+                                    "status": "Internal Server Error",
+                                    "code": 500,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "policies",
+            "description": "",
+            "item": [
+                {
+                    "id": "50d522ff-20bc-4370-ae67-126797ae5cb9",
+                    "name": "List all registered policy definitions",
+                    "request": {
+                        "name": "List all registered policy definitions",
+                        "description": {
+                            "content": "Retrieve all currently loaded policy definitions from the controller.\nPolicy definitions are loaded from files in the policies directory at\ncontroller startup and stored in memory.\n",
+                            "type": "text/plain"
+                        },
+                        "url": {
+                            "path": [
+                                "policies"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {},
+                        "auth": null
+                    },
+                    "response": [
+                        {
+                            "id": "1ec6d051-232f-4829-b053-1716a4405ab4",
+                            "name": "List of policy definitions",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "policies"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"status\": \"<string>\",\n  \"count\": \"<integer>\",\n  \"policies\": [\n    {\n      \"name\": \"<string>\",\n      \"version\": \"v190843777.871.8710434\",\n      \"description\": \"<string>\",\n      \"parameters\": {\n        \"key_0\": 3627.223048001729,\n        \"key_1\": \"string\"\n      },\n      \"systemParameters\": {\n        \"key_0\": 4509,\n        \"key_1\": true,\n        \"key_2\": 7278\n      }\n    },\n    {\n      \"name\": \"<string>\",\n      \"version\": \"v8235768.22284305.940753\",\n      \"description\": \"<string>\",\n      \"parameters\": {\n        \"key_0\": 9777\n      },\n      \"systemParameters\": {\n        \"key_0\": true\n      }\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "58f3621e-8f17-435e-9a9e-c5ecc3248f00",
+                            "name": "Internal server error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "policies"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
+                }
+            ]
+        },
+        {
+            "name": "mcp-proxies",
+            "description": "",
+            "item": [
+                {
+                    "id": "907d816a-3c75-4993-9cc4-d6407f1c8913",
+                    "name": "Create a new MCP Proxy configuration",
+                    "request": {
+                        "name": "Create a new MCP Proxy configuration",
+                        "description": {
+                            "content": "Submit a new MCP Proxy configuration to the Gateway Controller. The configuration\nis validated, persisted, and translated to Envoy xDS resources. The Router\nbegins routing traffic for the MCP Proxy within 5 seconds.\n",
+                            "type": "text/plain"
+                        },
+                        "url": {
+                            "path": [
+                                "mcp-proxies"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                            },
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            }
+                        ],
+                        "method": "POST",
+                        "body": {
+                            "mode": "raw",
+                            "raw": "{\n  \"apiVersion\": \"gateway.api-platform.wso2.com/v1alpha1\",\n  \"kind\": \"Mcp\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"spec\": {\n    \"displayName\": \"t\",\n    \"version\": \"<string>\",\n    \"upstream\": {\n      \"auth\": {\n        \"type\": \"bearer\",\n        \"header\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    },\n    \"context\": \"<string>\",\n    \"specVersion\": \"<string>\",\n    \"vhost\": \"*.*.*.*.*.v.GCwZLt1QdZO6aLyxj2jrIayqSarJVEiH2XzzdtCJsrn0vWHAisS.x.3-PLMj2EtmH4QwLzpO.lrX\",\n    \"policies\": [\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v2409.61.3\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": true,\n          \"key_1\": \"string\"\n        }\n      },\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v1420872.889741801.188108295\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": 9590.272814343914,\n          \"key_1\": false\n        }\n      }\n    ],\n    \"tools\": [\n      {\n        \"name\": \"<string>\",\n        \"description\": \"<string>\",\n        \"inputSchema\": \"<string>\",\n        \"title\": \"<string>\",\n        \"outputSchema\": \"<string>\"\n      },\n      {\n        \"name\": \"<string>\",\n        \"description\": \"<string>\",\n        \"inputSchema\": \"<string>\",\n        \"title\": \"<string>\",\n        \"outputSchema\": \"<string>\"\n      }\n    ],\n    \"resources\": [\n      {\n        \"uri\": \"<string>\",\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"mimeType\": \"<string>\",\n        \"size\": \"<integer>\"\n      },\n      {\n        \"uri\": \"<string>\",\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"mimeType\": \"<string>\",\n        \"size\": \"<integer>\"\n      }\n    ],\n    \"prompts\": [\n      {\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"arguments\": [\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          },\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          }\n        ]\n      },\n      {\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"arguments\": [\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          },\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          }\n        ]\n      }\n    ]\n  }\n}",
+                            "options": {
+                                "raw": {
+                                    "headerFamily": "json",
+                                    "language": "json"
+                                }
+                            }
+                        },
+                        "auth": null
+                    },
+                    "response": [
+                        {
+                            "id": "4e290a2f-ed4a-4aa9-9ca7-8301fab6f627",
+                            "name": "MCP Proxy configuration created successfully",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "mcp-proxies"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"apiVersion\": \"gateway.api-platform.wso2.com/v1alpha1\",\n  \"kind\": \"Mcp\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"spec\": {\n    \"displayName\": \"t\",\n    \"version\": \"<string>\",\n    \"upstream\": {\n      \"auth\": {\n        \"type\": \"bearer\",\n        \"header\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    },\n    \"context\": \"<string>\",\n    \"specVersion\": \"<string>\",\n    \"vhost\": \"*.*.*.*.*.v.GCwZLt1QdZO6aLyxj2jrIayqSarJVEiH2XzzdtCJsrn0vWHAisS.x.3-PLMj2EtmH4QwLzpO.lrX\",\n    \"policies\": [\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v2409.61.3\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": true,\n          \"key_1\": \"string\"\n        }\n      },\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v1420872.889741801.188108295\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": 9590.272814343914,\n          \"key_1\": false\n        }\n      }\n    ],\n    \"tools\": [\n      {\n        \"name\": \"<string>\",\n        \"description\": \"<string>\",\n        \"inputSchema\": \"<string>\",\n        \"title\": \"<string>\",\n        \"outputSchema\": \"<string>\"\n      },\n      {\n        \"name\": \"<string>\",\n        \"description\": \"<string>\",\n        \"inputSchema\": \"<string>\",\n        \"title\": \"<string>\",\n        \"outputSchema\": \"<string>\"\n      }\n    ],\n    \"resources\": [\n      {\n        \"uri\": \"<string>\",\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"mimeType\": \"<string>\",\n        \"size\": \"<integer>\"\n      },\n      {\n        \"uri\": \"<string>\",\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"mimeType\": \"<string>\",\n        \"size\": \"<integer>\"\n      }\n    ],\n    \"prompts\": [\n      {\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"arguments\": [\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          },\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          }\n        ]\n      },\n      {\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"arguments\": [\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          },\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          }\n        ]\n      }\n    ]\n  }\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Created",
+                            "code": 201,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"id\": \"<string>\",\n  \"created_at\": \"<dateTime>\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "8d298c66-3cae-4d7b-8e62-f8dda27a4dab",
+                            "name": "Invalid configuration (validation failed)",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "mcp-proxies"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"apiVersion\": \"gateway.api-platform.wso2.com/v1alpha1\",\n  \"kind\": \"Mcp\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"spec\": {\n    \"displayName\": \"t\",\n    \"version\": \"<string>\",\n    \"upstream\": {\n      \"auth\": {\n        \"type\": \"bearer\",\n        \"header\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    },\n    \"context\": \"<string>\",\n    \"specVersion\": \"<string>\",\n    \"vhost\": \"*.*.*.*.*.v.GCwZLt1QdZO6aLyxj2jrIayqSarJVEiH2XzzdtCJsrn0vWHAisS.x.3-PLMj2EtmH4QwLzpO.lrX\",\n    \"policies\": [\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v2409.61.3\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": true,\n          \"key_1\": \"string\"\n        }\n      },\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v1420872.889741801.188108295\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": 9590.272814343914,\n          \"key_1\": false\n        }\n      }\n    ],\n    \"tools\": [\n      {\n        \"name\": \"<string>\",\n        \"description\": \"<string>\",\n        \"inputSchema\": \"<string>\",\n        \"title\": \"<string>\",\n        \"outputSchema\": \"<string>\"\n      },\n      {\n        \"name\": \"<string>\",\n        \"description\": \"<string>\",\n        \"inputSchema\": \"<string>\",\n        \"title\": \"<string>\",\n        \"outputSchema\": \"<string>\"\n      }\n    ],\n    \"resources\": [\n      {\n        \"uri\": \"<string>\",\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"mimeType\": \"<string>\",\n        \"size\": \"<integer>\"\n      },\n      {\n        \"uri\": \"<string>\",\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"mimeType\": \"<string>\",\n        \"size\": \"<integer>\"\n      }\n    ],\n    \"prompts\": [\n      {\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"arguments\": [\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          },\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          }\n        ]\n      },\n      {\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"arguments\": [\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          },\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          }\n        ]\n      }\n    ]\n  }\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "c62f4bd5-7dae-4b9c-9134-2e89c91d7f2e",
+                            "name": "Conflict - MCP Proxy with same name and version already exists",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "mcp-proxies"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"apiVersion\": \"gateway.api-platform.wso2.com/v1alpha1\",\n  \"kind\": \"Mcp\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"spec\": {\n    \"displayName\": \"t\",\n    \"version\": \"<string>\",\n    \"upstream\": {\n      \"auth\": {\n        \"type\": \"bearer\",\n        \"header\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    },\n    \"context\": \"<string>\",\n    \"specVersion\": \"<string>\",\n    \"vhost\": \"*.*.*.*.*.v.GCwZLt1QdZO6aLyxj2jrIayqSarJVEiH2XzzdtCJsrn0vWHAisS.x.3-PLMj2EtmH4QwLzpO.lrX\",\n    \"policies\": [\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v2409.61.3\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": true,\n          \"key_1\": \"string\"\n        }\n      },\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v1420872.889741801.188108295\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": 9590.272814343914,\n          \"key_1\": false\n        }\n      }\n    ],\n    \"tools\": [\n      {\n        \"name\": \"<string>\",\n        \"description\": \"<string>\",\n        \"inputSchema\": \"<string>\",\n        \"title\": \"<string>\",\n        \"outputSchema\": \"<string>\"\n      },\n      {\n        \"name\": \"<string>\",\n        \"description\": \"<string>\",\n        \"inputSchema\": \"<string>\",\n        \"title\": \"<string>\",\n        \"outputSchema\": \"<string>\"\n      }\n    ],\n    \"resources\": [\n      {\n        \"uri\": \"<string>\",\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"mimeType\": \"<string>\",\n        \"size\": \"<integer>\"\n      },\n      {\n        \"uri\": \"<string>\",\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"mimeType\": \"<string>\",\n        \"size\": \"<integer>\"\n      }\n    ],\n    \"prompts\": [\n      {\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"arguments\": [\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          },\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          }\n        ]\n      },\n      {\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"arguments\": [\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          },\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          }\n        ]\n      }\n    ]\n  }\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Conflict",
+                            "code": 409,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "fb8c6c75-71ac-4ccf-a054-7e746c2184b8",
+                            "name": "Internal server error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "mcp-proxies"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"apiVersion\": \"gateway.api-platform.wso2.com/v1alpha1\",\n  \"kind\": \"Mcp\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"spec\": {\n    \"displayName\": \"t\",\n    \"version\": \"<string>\",\n    \"upstream\": {\n      \"auth\": {\n        \"type\": \"bearer\",\n        \"header\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    },\n    \"context\": \"<string>\",\n    \"specVersion\": \"<string>\",\n    \"vhost\": \"*.*.*.*.*.v.GCwZLt1QdZO6aLyxj2jrIayqSarJVEiH2XzzdtCJsrn0vWHAisS.x.3-PLMj2EtmH4QwLzpO.lrX\",\n    \"policies\": [\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v2409.61.3\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": true,\n          \"key_1\": \"string\"\n        }\n      },\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v1420872.889741801.188108295\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": 9590.272814343914,\n          \"key_1\": false\n        }\n      }\n    ],\n    \"tools\": [\n      {\n        \"name\": \"<string>\",\n        \"description\": \"<string>\",\n        \"inputSchema\": \"<string>\",\n        \"title\": \"<string>\",\n        \"outputSchema\": \"<string>\"\n      },\n      {\n        \"name\": \"<string>\",\n        \"description\": \"<string>\",\n        \"inputSchema\": \"<string>\",\n        \"title\": \"<string>\",\n        \"outputSchema\": \"<string>\"\n      }\n    ],\n    \"resources\": [\n      {\n        \"uri\": \"<string>\",\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"mimeType\": \"<string>\",\n        \"size\": \"<integer>\"\n      },\n      {\n        \"uri\": \"<string>\",\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"mimeType\": \"<string>\",\n        \"size\": \"<integer>\"\n      }\n    ],\n    \"prompts\": [\n      {\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"arguments\": [\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          },\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          }\n        ]\n      },\n      {\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"arguments\": [\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          },\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          }\n        ]\n      }\n    ]\n  }\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
+                },
+                {
+                    "id": "e36dc490-5e35-4723-9b58-fb5fc7689752",
+                    "name": "List all MCP Proxy configurations",
+                    "request": {
+                        "name": "List all MCP Proxy configurations",
+                        "description": {
+                            "content": "Retrieve a list of all deployed MCP Proxy configurations with metadata.\nReturns basic information about each MCP Proxy (name, version, context, deployment time).\n",
+                            "type": "text/plain"
+                        },
+                        "url": {
+                            "path": [
+                                "mcp-proxies"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter by MCP proxy display name",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "displayName",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter by MCP proxy version",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "version",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter by MCP proxy context/path",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "context",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter by deployment status (This can only be one of pending,deployed,failed)",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "status",
+                                    "value": "deployed"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {},
+                        "auth": null
+                    },
+                    "response": [
+                        {
+                            "id": "7a64e0ce-93c9-4bb2-bb46-0093d863447b",
+                            "name": "List of MCP Proxy configurations",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "mcp-proxies"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter by MCP proxy display name",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "displayName",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter by MCP proxy version",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "version",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter by MCP proxy context/path",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "context",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter by deployment status (This can only be one of pending,deployed,failed)",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "status",
+                                            "value": "deployed"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"status\": \"<string>\",\n  \"count\": \"<integer>\",\n  \"mcp_proxies\": [\n    {\n      \"id\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"version\": \"<string>\",\n      \"context\": \"<string>\",\n      \"specVersion\": \"<string>\",\n      \"status\": \"pending\",\n      \"created_at\": \"<dateTime>\",\n      \"updated_at\": \"<dateTime>\"\n    },\n    {\n      \"id\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"version\": \"<string>\",\n      \"context\": \"<string>\",\n      \"specVersion\": \"<string>\",\n      \"status\": \"pending\",\n      \"created_at\": \"<dateTime>\",\n      \"updated_at\": \"<dateTime>\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "efe4caaf-806d-41bd-99b6-619180da4e81",
+                            "name": "Internal server error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "mcp-proxies"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter by MCP proxy display name",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "displayName",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter by MCP proxy version",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "version",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter by MCP proxy context/path",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "context",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter by deployment status (This can only be one of pending,deployed,failed)",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "status",
+                                            "value": "deployed"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
+                },
+                {
+                    "name": "{id}",
+                    "description": "",
+                    "item": [
+                        {
+                            "id": "0d2b1b7c-31a2-4de2-b656-5445149751cf",
+                            "name": "Get MCP Proxy configuration by id",
+                            "request": {
+                                "name": "Get MCP Proxy configuration by id",
+                                "description": {
+                                    "content": "Retrieve the complete configuration for a specific MCP Proxy by its id.\nThe id is a unique string identifier (not a UUID).\n",
+                                    "type": "text/plain"
+                                },
+                                "url": {
+                                    "path": [
+                                        "mcp-proxies",
+                                        ":id"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "value": "<string>",
+                                            "key": "id",
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) Unique public identifier of the MCP Proxy.\n",
+                                                "type": "text/plain"
+                                            }
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {},
+                                "auth": null
+                            },
+                            "response": [
+                                {
+                                    "id": "f7d93de3-eb8f-47b7-9e27-c15603586946",
+                                    "name": "MCP Proxy configuration details",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "mcp-proxies",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Unique public identifier of the MCP Proxy.\n",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {}
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"mcp\": {\n    \"id\": \"<string>\",\n    \"configuration\": {\n      \"apiVersion\": \"gateway.api-platform.wso2.com/v1alpha1\",\n      \"kind\": \"Mcp\",\n      \"metadata\": {\n        \"name\": \"<string>\"\n      },\n      \"spec\": {\n        \"displayName\": \"q_\",\n        \"version\": \"<string>\",\n        \"upstream\": {\n          \"auth\": {\n            \"type\": \"api-key\",\n            \"header\": \"<string>\",\n            \"value\": \"<string>\"\n          }\n        },\n        \"context\": \"<string>\",\n        \"specVersion\": \"<string>\",\n        \"vhost\": \"x-PFfSa9-FbeMXTUV0154bHFcQ483ekhHjCmlWA.*.*.*.o.r4P4kRzADOPb8cZHfAKdl25PrbIi8qDZJNiqfQ1.hS2bFJmQ7xts7HOmvS7S49.*.w.*.*.ADIE\",\n        \"policies\": [\n          {\n            \"name\": \"<string>\",\n            \"version\": \"v590287461.47.832003645\",\n            \"executionCondition\": \"<string>\",\n            \"params\": {\n              \"key_0\": false,\n              \"key_1\": \"string\",\n              \"key_2\": 3263.6078624599054\n            }\n          },\n          {\n            \"name\": \"<string>\",\n            \"version\": \"v0640726.749.617508189\",\n            \"executionCondition\": \"<string>\",\n            \"params\": {\n              \"key_0\": \"string\",\n              \"key_1\": true\n            }\n          }\n        ],\n        \"tools\": [\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"inputSchema\": \"<string>\",\n            \"title\": \"<string>\",\n            \"outputSchema\": \"<string>\"\n          },\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"inputSchema\": \"<string>\",\n            \"title\": \"<string>\",\n            \"outputSchema\": \"<string>\"\n          }\n        ],\n        \"resources\": [\n          {\n            \"uri\": \"<string>\",\n            \"name\": \"<string>\",\n            \"title\": \"<string>\",\n            \"description\": \"<string>\",\n            \"mimeType\": \"<string>\",\n            \"size\": \"<integer>\"\n          },\n          {\n            \"uri\": \"<string>\",\n            \"name\": \"<string>\",\n            \"title\": \"<string>\",\n            \"description\": \"<string>\",\n            \"mimeType\": \"<string>\",\n            \"size\": \"<integer>\"\n          }\n        ],\n        \"prompts\": [\n          {\n            \"name\": \"<string>\",\n            \"title\": \"<string>\",\n            \"description\": \"<string>\",\n            \"arguments\": [\n              {\n                \"name\": \"<string>\",\n                \"description\": \"<string>\",\n                \"required\": \"<boolean>\",\n                \"title\": \"<string>\"\n              },\n              {\n                \"name\": \"<string>\",\n                \"description\": \"<string>\",\n                \"required\": \"<boolean>\",\n                \"title\": \"<string>\"\n              }\n            ]\n          },\n          {\n            \"name\": \"<string>\",\n            \"title\": \"<string>\",\n            \"description\": \"<string>\",\n            \"arguments\": [\n              {\n                \"name\": \"<string>\",\n                \"description\": \"<string>\",\n                \"required\": \"<boolean>\",\n                \"title\": \"<string>\"\n              },\n              {\n                \"name\": \"<string>\",\n                \"description\": \"<string>\",\n                \"required\": \"<boolean>\",\n                \"title\": \"<string>\"\n              }\n            ]\n          }\n        ]\n      }\n    },\n    \"metadata\": {\n      \"status\": \"deployed\",\n      \"created_at\": \"<dateTime>\",\n      \"updated_at\": \"<dateTime>\",\n      \"deployed_at\": \"<dateTime>\"\n    }\n  }\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                },
+                                {
+                                    "id": "9d0df1cb-3845-45a3-b1d8-675aea69d173",
+                                    "name": "MCP Proxy configuration not found",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "mcp-proxies",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Unique public identifier of the MCP Proxy.\n",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {}
+                                    },
+                                    "status": "Not Found",
+                                    "code": 404,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                },
+                                {
+                                    "id": "ae504588-7a44-4b79-ba98-902d77ec635f",
+                                    "name": "Internal server error",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "mcp-proxies",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Unique public identifier of the MCP Proxy.\n",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {}
+                                    },
+                                    "status": "Internal Server Error",
+                                    "code": 500,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        },
+                        {
+                            "id": "e36eb9ca-b9c0-411b-9b96-db7c304e0831",
+                            "name": "Update an existing MCP Proxy configuration",
+                            "request": {
+                                "name": "Update an existing MCP Proxy configuration",
+                                "description": {
+                                    "content": "Update an existing MCP Proxy configuration. The update is validated and applied atomically.\nThe Router receives the updated configuration within 5 seconds. In-flight requests\ncomplete with the old configuration; new requests use the updated configuration.\n\n**Important:** If validation fails, the existing configuration remains active.\n",
+                                    "type": "text/plain"
+                                },
+                                "url": {
+                                    "path": [
+                                        "mcp-proxies",
+                                        ":id"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "value": "<string>",
+                                            "key": "id",
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) Unique public identifier of the MCP Proxy to update.\n",
+                                                "type": "text/plain"
+                                            }
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "PUT",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"apiVersion\": \"gateway.api-platform.wso2.com/v1alpha1\",\n  \"kind\": \"Mcp\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"spec\": {\n    \"displayName\": \"t\",\n    \"version\": \"<string>\",\n    \"upstream\": {\n      \"auth\": {\n        \"type\": \"bearer\",\n        \"header\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    },\n    \"context\": \"<string>\",\n    \"specVersion\": \"<string>\",\n    \"vhost\": \"*.*.*.*.*.v.GCwZLt1QdZO6aLyxj2jrIayqSarJVEiH2XzzdtCJsrn0vWHAisS.x.3-PLMj2EtmH4QwLzpO.lrX\",\n    \"policies\": [\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v2409.61.3\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": true,\n          \"key_1\": \"string\"\n        }\n      },\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v1420872.889741801.188108295\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": 9590.272814343914,\n          \"key_1\": false\n        }\n      }\n    ],\n    \"tools\": [\n      {\n        \"name\": \"<string>\",\n        \"description\": \"<string>\",\n        \"inputSchema\": \"<string>\",\n        \"title\": \"<string>\",\n        \"outputSchema\": \"<string>\"\n      },\n      {\n        \"name\": \"<string>\",\n        \"description\": \"<string>\",\n        \"inputSchema\": \"<string>\",\n        \"title\": \"<string>\",\n        \"outputSchema\": \"<string>\"\n      }\n    ],\n    \"resources\": [\n      {\n        \"uri\": \"<string>\",\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"mimeType\": \"<string>\",\n        \"size\": \"<integer>\"\n      },\n      {\n        \"uri\": \"<string>\",\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"mimeType\": \"<string>\",\n        \"size\": \"<integer>\"\n      }\n    ],\n    \"prompts\": [\n      {\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"arguments\": [\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          },\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          }\n        ]\n      },\n      {\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"arguments\": [\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          },\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          }\n        ]\n      }\n    ]\n  }\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                },
+                                "auth": null
+                            },
+                            "response": [
+                                {
+                                    "id": "c4658c49-fba6-41f2-a029-4c6109c7cd26",
+                                    "name": "MCP Proxy configuration updated successfully",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "mcp-proxies",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Unique public identifier of the MCP Proxy to update.\n",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "PUT",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"apiVersion\": \"gateway.api-platform.wso2.com/v1alpha1\",\n  \"kind\": \"Mcp\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"spec\": {\n    \"displayName\": \"t\",\n    \"version\": \"<string>\",\n    \"upstream\": {\n      \"auth\": {\n        \"type\": \"bearer\",\n        \"header\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    },\n    \"context\": \"<string>\",\n    \"specVersion\": \"<string>\",\n    \"vhost\": \"*.*.*.*.*.v.GCwZLt1QdZO6aLyxj2jrIayqSarJVEiH2XzzdtCJsrn0vWHAisS.x.3-PLMj2EtmH4QwLzpO.lrX\",\n    \"policies\": [\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v2409.61.3\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": true,\n          \"key_1\": \"string\"\n        }\n      },\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v1420872.889741801.188108295\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": 9590.272814343914,\n          \"key_1\": false\n        }\n      }\n    ],\n    \"tools\": [\n      {\n        \"name\": \"<string>\",\n        \"description\": \"<string>\",\n        \"inputSchema\": \"<string>\",\n        \"title\": \"<string>\",\n        \"outputSchema\": \"<string>\"\n      },\n      {\n        \"name\": \"<string>\",\n        \"description\": \"<string>\",\n        \"inputSchema\": \"<string>\",\n        \"title\": \"<string>\",\n        \"outputSchema\": \"<string>\"\n      }\n    ],\n    \"resources\": [\n      {\n        \"uri\": \"<string>\",\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"mimeType\": \"<string>\",\n        \"size\": \"<integer>\"\n      },\n      {\n        \"uri\": \"<string>\",\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"mimeType\": \"<string>\",\n        \"size\": \"<integer>\"\n      }\n    ],\n    \"prompts\": [\n      {\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"arguments\": [\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          },\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          }\n        ]\n      },\n      {\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"arguments\": [\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          },\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          }\n        ]\n      }\n    ]\n  }\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"id\": \"<string>\",\n  \"updated_at\": \"<dateTime>\"\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                },
+                                {
+                                    "id": "97a932c2-a5d5-416c-8164-981ba675be57",
+                                    "name": "Invalid configuration (validation failed)",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "mcp-proxies",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Unique public identifier of the MCP Proxy to update.\n",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "PUT",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"apiVersion\": \"gateway.api-platform.wso2.com/v1alpha1\",\n  \"kind\": \"Mcp\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"spec\": {\n    \"displayName\": \"t\",\n    \"version\": \"<string>\",\n    \"upstream\": {\n      \"auth\": {\n        \"type\": \"bearer\",\n        \"header\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    },\n    \"context\": \"<string>\",\n    \"specVersion\": \"<string>\",\n    \"vhost\": \"*.*.*.*.*.v.GCwZLt1QdZO6aLyxj2jrIayqSarJVEiH2XzzdtCJsrn0vWHAisS.x.3-PLMj2EtmH4QwLzpO.lrX\",\n    \"policies\": [\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v2409.61.3\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": true,\n          \"key_1\": \"string\"\n        }\n      },\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v1420872.889741801.188108295\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": 9590.272814343914,\n          \"key_1\": false\n        }\n      }\n    ],\n    \"tools\": [\n      {\n        \"name\": \"<string>\",\n        \"description\": \"<string>\",\n        \"inputSchema\": \"<string>\",\n        \"title\": \"<string>\",\n        \"outputSchema\": \"<string>\"\n      },\n      {\n        \"name\": \"<string>\",\n        \"description\": \"<string>\",\n        \"inputSchema\": \"<string>\",\n        \"title\": \"<string>\",\n        \"outputSchema\": \"<string>\"\n      }\n    ],\n    \"resources\": [\n      {\n        \"uri\": \"<string>\",\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"mimeType\": \"<string>\",\n        \"size\": \"<integer>\"\n      },\n      {\n        \"uri\": \"<string>\",\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"mimeType\": \"<string>\",\n        \"size\": \"<integer>\"\n      }\n    ],\n    \"prompts\": [\n      {\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"arguments\": [\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          },\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          }\n        ]\n      },\n      {\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"arguments\": [\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          },\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          }\n        ]\n      }\n    ]\n  }\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "status": "Bad Request",
+                                    "code": 400,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                },
+                                {
+                                    "id": "acaaf56c-8096-45d8-af3e-a55546ffca91",
+                                    "name": "MCP Proxy configuration not found",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "mcp-proxies",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Unique public identifier of the MCP Proxy to update.\n",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "PUT",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"apiVersion\": \"gateway.api-platform.wso2.com/v1alpha1\",\n  \"kind\": \"Mcp\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"spec\": {\n    \"displayName\": \"t\",\n    \"version\": \"<string>\",\n    \"upstream\": {\n      \"auth\": {\n        \"type\": \"bearer\",\n        \"header\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    },\n    \"context\": \"<string>\",\n    \"specVersion\": \"<string>\",\n    \"vhost\": \"*.*.*.*.*.v.GCwZLt1QdZO6aLyxj2jrIayqSarJVEiH2XzzdtCJsrn0vWHAisS.x.3-PLMj2EtmH4QwLzpO.lrX\",\n    \"policies\": [\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v2409.61.3\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": true,\n          \"key_1\": \"string\"\n        }\n      },\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v1420872.889741801.188108295\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": 9590.272814343914,\n          \"key_1\": false\n        }\n      }\n    ],\n    \"tools\": [\n      {\n        \"name\": \"<string>\",\n        \"description\": \"<string>\",\n        \"inputSchema\": \"<string>\",\n        \"title\": \"<string>\",\n        \"outputSchema\": \"<string>\"\n      },\n      {\n        \"name\": \"<string>\",\n        \"description\": \"<string>\",\n        \"inputSchema\": \"<string>\",\n        \"title\": \"<string>\",\n        \"outputSchema\": \"<string>\"\n      }\n    ],\n    \"resources\": [\n      {\n        \"uri\": \"<string>\",\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"mimeType\": \"<string>\",\n        \"size\": \"<integer>\"\n      },\n      {\n        \"uri\": \"<string>\",\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"mimeType\": \"<string>\",\n        \"size\": \"<integer>\"\n      }\n    ],\n    \"prompts\": [\n      {\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"arguments\": [\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          },\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          }\n        ]\n      },\n      {\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"arguments\": [\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          },\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          }\n        ]\n      }\n    ]\n  }\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "status": "Not Found",
+                                    "code": 404,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                },
+                                {
+                                    "id": "b5996559-a0da-4874-863e-d43bc6a4bdf1",
+                                    "name": "Internal server error",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "mcp-proxies",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Unique public identifier of the MCP Proxy to update.\n",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "PUT",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"apiVersion\": \"gateway.api-platform.wso2.com/v1alpha1\",\n  \"kind\": \"Mcp\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"spec\": {\n    \"displayName\": \"t\",\n    \"version\": \"<string>\",\n    \"upstream\": {\n      \"auth\": {\n        \"type\": \"bearer\",\n        \"header\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    },\n    \"context\": \"<string>\",\n    \"specVersion\": \"<string>\",\n    \"vhost\": \"*.*.*.*.*.v.GCwZLt1QdZO6aLyxj2jrIayqSarJVEiH2XzzdtCJsrn0vWHAisS.x.3-PLMj2EtmH4QwLzpO.lrX\",\n    \"policies\": [\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v2409.61.3\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": true,\n          \"key_1\": \"string\"\n        }\n      },\n      {\n        \"name\": \"<string>\",\n        \"version\": \"v1420872.889741801.188108295\",\n        \"executionCondition\": \"<string>\",\n        \"params\": {\n          \"key_0\": 9590.272814343914,\n          \"key_1\": false\n        }\n      }\n    ],\n    \"tools\": [\n      {\n        \"name\": \"<string>\",\n        \"description\": \"<string>\",\n        \"inputSchema\": \"<string>\",\n        \"title\": \"<string>\",\n        \"outputSchema\": \"<string>\"\n      },\n      {\n        \"name\": \"<string>\",\n        \"description\": \"<string>\",\n        \"inputSchema\": \"<string>\",\n        \"title\": \"<string>\",\n        \"outputSchema\": \"<string>\"\n      }\n    ],\n    \"resources\": [\n      {\n        \"uri\": \"<string>\",\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"mimeType\": \"<string>\",\n        \"size\": \"<integer>\"\n      },\n      {\n        \"uri\": \"<string>\",\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"mimeType\": \"<string>\",\n        \"size\": \"<integer>\"\n      }\n    ],\n    \"prompts\": [\n      {\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"arguments\": [\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          },\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          }\n        ]\n      },\n      {\n        \"name\": \"<string>\",\n        \"title\": \"<string>\",\n        \"description\": \"<string>\",\n        \"arguments\": [\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          },\n          {\n            \"name\": \"<string>\",\n            \"description\": \"<string>\",\n            \"required\": \"<boolean>\",\n            \"title\": \"<string>\"\n          }\n        ]\n      }\n    ]\n  }\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "status": "Internal Server Error",
+                                    "code": 500,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        },
+                        {
+                            "id": "b9b9f49b-fde9-464c-a046-a4647116044c",
+                            "name": "Delete an MCP Proxy configuration",
+                            "request": {
+                                "name": "Delete an MCP Proxy configuration",
+                                "description": {
+                                    "content": "Remove an MCP Proxy configuration from the Gateway Controller. The Router stops\naccepting traffic for this MCP Proxy within 5 seconds. In-flight requests complete\nsuccessfully; new requests receive 404 Not Found.\n",
+                                    "type": "text/plain"
+                                },
+                                "url": {
+                                    "path": [
+                                        "mcp-proxies",
+                                        ":id"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "value": "<string>",
+                                            "key": "id",
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) Unique public identifier of the MCP Proxy to delete.\n",
+                                                "type": "text/plain"
+                                            }
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "DELETE",
+                                "body": {},
+                                "auth": null
+                            },
+                            "response": [
+                                {
+                                    "id": "e992d747-5da5-4e1f-8af7-4e3085c81c11",
+                                    "name": "MCP Proxy configuration deleted successfully",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "mcp-proxies",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Unique public identifier of the MCP Proxy to delete.\n",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "DELETE",
+                                        "body": {}
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"id\": \"<string>\"\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                },
+                                {
+                                    "id": "ab61e8d4-8a5f-431b-a07a-b092c17e95db",
+                                    "name": "MCP Proxy configuration not found",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "mcp-proxies",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Unique public identifier of the MCP Proxy to delete.\n",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "DELETE",
+                                        "body": {}
+                                    },
+                                    "status": "Not Found",
+                                    "code": 404,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                },
+                                {
+                                    "id": "82f80f17-93a3-4eec-9605-7647a2c0b40c",
+                                    "name": "Internal server error",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "mcp-proxies",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Unique public identifier of the MCP Proxy to delete.\n",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "DELETE",
+                                        "body": {}
+                                    },
+                                    "status": "Internal Server Error",
+                                    "code": 500,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "llm-provider-templates",
+            "description": "",
+            "item": [
+                {
+                    "id": "7d6265c3-5470-430a-8099-cef890108ede",
+                    "name": "Create a new LLM provider template",
+                    "request": {
+                        "name": "Create a new LLM provider template",
+                        "description": {
+                            "content": "Submit a new LLM provider template configuration. The template defines\ntoken tracking and model extraction related metadata.\n\n**Validation Rules:**\n- Template name must be unique\n- Token identifiers must use valid JSONPath expressions\n",
+                            "type": "text/plain"
+                        },
+                        "url": {
+                            "path": [
+                                "llm-provider-templates"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                            },
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            }
+                        ],
+                        "method": "POST",
+                        "body": {
+                            "mode": "raw",
+                            "raw": "{\n  \"version\": \"ai.api-platform.wso2.com/v1\",\n  \"kind\": \"LlmProviderTemplate\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"spec\": {\n    \"displayName\": \"<string>\",\n    \"promptTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"completionTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"totalTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"remainingTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"requestModel\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"responseModel\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    }\n  }\n}",
+                            "options": {
+                                "raw": {
+                                    "headerFamily": "json",
+                                    "language": "json"
+                                }
+                            }
+                        },
+                        "auth": null
+                    },
+                    "response": [
+                        {
+                            "id": "e6cbb9ba-23dc-407f-9ab3-7db656cd1f50",
+                            "name": "LLM provider template created successfully",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "llm-provider-templates"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"version\": \"ai.api-platform.wso2.com/v1\",\n  \"kind\": \"LlmProviderTemplate\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"spec\": {\n    \"displayName\": \"<string>\",\n    \"promptTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"completionTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"totalTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"remainingTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"requestModel\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"responseModel\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    }\n  }\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Created",
+                            "code": 201,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"id\": \"<string>\",\n  \"created_at\": \"<dateTime>\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "7d3dcd66-ec53-45a8-8174-3726cd38209d",
+                            "name": "Invalid configuration (validation failed)",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "llm-provider-templates"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"version\": \"ai.api-platform.wso2.com/v1\",\n  \"kind\": \"LlmProviderTemplate\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"spec\": {\n    \"displayName\": \"<string>\",\n    \"promptTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"completionTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"totalTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"remainingTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"requestModel\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"responseModel\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    }\n  }\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "de8ab2d3-2b99-4b86-9b44-1f54fddf747b",
+                            "name": "Conflict - Template with same name already exists",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "llm-provider-templates"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"version\": \"ai.api-platform.wso2.com/v1\",\n  \"kind\": \"LlmProviderTemplate\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"spec\": {\n    \"displayName\": \"<string>\",\n    \"promptTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"completionTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"totalTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"remainingTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"requestModel\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"responseModel\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    }\n  }\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Conflict",
+                            "code": 409,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "dbf8fe6d-6eb8-45b8-8801-ed0e4309c7a6",
+                            "name": "Internal server error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "llm-provider-templates"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"version\": \"ai.api-platform.wso2.com/v1\",\n  \"kind\": \"LlmProviderTemplate\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"spec\": {\n    \"displayName\": \"<string>\",\n    \"promptTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"completionTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"totalTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"remainingTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"requestModel\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"responseModel\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    }\n  }\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
+                },
+                {
+                    "id": "6eabeccb-0279-4dbf-a2bf-4d96170f32fe",
+                    "name": "List all LLM provider templates",
+                    "request": {
+                        "name": "List all LLM provider templates",
+                        "description": {
+                            "content": "Retrieve a list of all LLM provider templates.\n",
+                            "type": "text/plain"
+                        },
+                        "url": {
+                            "path": [
+                                "llm-provider-templates"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter by template name",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "name",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {},
+                        "auth": null
+                    },
+                    "response": [
+                        {
+                            "id": "5f67605c-12bb-477b-aa9d-3cc6f893d804",
+                            "name": "List of LLM provider templates",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "llm-provider-templates"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter by template name",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "name",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"status\": \"<string>\",\n  \"count\": \"<integer>\",\n  \"templates\": [\n    {\n      \"id\": \"<string>\",\n      \"name\": \"<string>\",\n      \"created_at\": \"<dateTime>\",\n      \"updated_at\": \"<dateTime>\"\n    },\n    {\n      \"id\": \"<string>\",\n      \"name\": \"<string>\",\n      \"created_at\": \"<dateTime>\",\n      \"updated_at\": \"<dateTime>\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "a34fbf0b-d867-4646-ba41-4dd2e13fc1ee",
+                            "name": "Internal server error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "llm-provider-templates"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter by template name",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "name",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
+                },
+                {
+                    "name": "{id}",
+                    "description": "",
+                    "item": [
+                        {
+                            "id": "9d9b92ec-b541-4285-8db5-88a5af03ef2c",
+                            "name": "Get LLM provider template by id",
+                            "request": {
+                                "name": "Get LLM provider template by id",
+                                "description": {
+                                    "content": "Retrieve the complete configuration for a specific LLM provider template",
+                                    "type": "text/plain"
+                                },
+                                "url": {
+                                    "path": [
+                                        "llm-provider-templates",
+                                        ":id"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "value": "<string>",
+                                            "key": "id",
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) Unique public identifier for the LLM provider template",
+                                                "type": "text/plain"
+                                            }
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {},
+                                "auth": null
+                            },
+                            "response": [
+                                {
+                                    "id": "117afc2b-2b2e-42c0-8663-870709f30c3f",
+                                    "name": "LLM provider template details",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "llm-provider-templates",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Unique public identifier for the LLM provider template",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {}
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"template\": {\n    \"id\": \"<string>\",\n    \"configuration\": {\n      \"version\": \"ai.api-platform.wso2.com/v1\",\n      \"kind\": \"LlmProviderTemplate\",\n      \"metadata\": {\n        \"name\": \"<string>\"\n      },\n      \"spec\": {\n        \"displayName\": \"<string>\",\n        \"promptTokens\": {\n          \"location\": \"header\",\n          \"identifier\": \"<string>\"\n        },\n        \"completionTokens\": {\n          \"location\": \"header\",\n          \"identifier\": \"<string>\"\n        },\n        \"totalTokens\": {\n          \"location\": \"payload\",\n          \"identifier\": \"<string>\"\n        },\n        \"remainingTokens\": {\n          \"location\": \"header\",\n          \"identifier\": \"<string>\"\n        },\n        \"requestModel\": {\n          \"location\": \"payload\",\n          \"identifier\": \"<string>\"\n        },\n        \"responseModel\": {\n          \"location\": \"header\",\n          \"identifier\": \"<string>\"\n        }\n      }\n    },\n    \"metadata\": {\n      \"created_at\": \"<dateTime>\",\n      \"updated_at\": \"<dateTime>\"\n    }\n  }\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                },
+                                {
+                                    "id": "006eed55-3514-4da4-a1f5-ee02e4c1c824",
+                                    "name": "LLM provider template not found",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "llm-provider-templates",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Unique public identifier for the LLM provider template",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {}
+                                    },
+                                    "status": "Not Found",
+                                    "code": 404,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                },
+                                {
+                                    "id": "f4d2c729-6af6-4b5a-9590-2b8b5342e80d",
+                                    "name": "Internal server error",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "llm-provider-templates",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Unique public identifier for the LLM provider template",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {}
+                                    },
+                                    "status": "Internal Server Error",
+                                    "code": 500,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        },
+                        {
+                            "id": "27e5644c-75a1-4f80-9a14-7c4156de062d",
+                            "name": "Update an existing LLM provider template",
+                            "request": {
+                                "name": "Update an existing LLM provider template",
+                                "description": {
+                                    "content": "Update an existing LLM provider template configuration.\n",
+                                    "type": "text/plain"
+                                },
+                                "url": {
+                                    "path": [
+                                        "llm-provider-templates",
+                                        ":id"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "value": "<string>",
+                                            "key": "id",
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) Identifier of the template to update",
+                                                "type": "text/plain"
+                                            }
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "PUT",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"version\": \"ai.api-platform.wso2.com/v1\",\n  \"kind\": \"LlmProviderTemplate\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"spec\": {\n    \"displayName\": \"<string>\",\n    \"promptTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"completionTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"totalTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"remainingTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"requestModel\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"responseModel\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    }\n  }\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                },
+                                "auth": null
+                            },
+                            "response": [
+                                {
+                                    "id": "1d64d7f5-a841-4b0c-acdb-38eb99005b68",
+                                    "name": "LLM provider template updated successfully",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "llm-provider-templates",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Identifier of the template to update",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "PUT",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"version\": \"ai.api-platform.wso2.com/v1\",\n  \"kind\": \"LlmProviderTemplate\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"spec\": {\n    \"displayName\": \"<string>\",\n    \"promptTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"completionTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"totalTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"remainingTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"requestModel\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"responseModel\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    }\n  }\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"id\": \"<string>\",\n  \"updated_at\": \"<dateTime>\"\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                },
+                                {
+                                    "id": "48d1bf6c-de65-4a1c-bc10-5225770c26fd",
+                                    "name": "Invalid configuration (validation failed)",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "llm-provider-templates",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Identifier of the template to update",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "PUT",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"version\": \"ai.api-platform.wso2.com/v1\",\n  \"kind\": \"LlmProviderTemplate\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"spec\": {\n    \"displayName\": \"<string>\",\n    \"promptTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"completionTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"totalTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"remainingTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"requestModel\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"responseModel\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    }\n  }\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "status": "Bad Request",
+                                    "code": 400,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                },
+                                {
+                                    "id": "419c5085-489c-4b44-a8ef-6f23f554870d",
+                                    "name": "LLM provider template not found",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "llm-provider-templates",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Identifier of the template to update",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "PUT",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"version\": \"ai.api-platform.wso2.com/v1\",\n  \"kind\": \"LlmProviderTemplate\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"spec\": {\n    \"displayName\": \"<string>\",\n    \"promptTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"completionTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"totalTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"remainingTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"requestModel\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"responseModel\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    }\n  }\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "status": "Not Found",
+                                    "code": 404,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                },
+                                {
+                                    "id": "25e8470d-ed17-4beb-9305-f176c4d9f2f7",
+                                    "name": "Internal server error",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "llm-provider-templates",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Identifier of the template to update",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "PUT",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"version\": \"ai.api-platform.wso2.com/v1\",\n  \"kind\": \"LlmProviderTemplate\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"spec\": {\n    \"displayName\": \"<string>\",\n    \"promptTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"completionTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"totalTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"remainingTokens\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"requestModel\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    },\n    \"responseModel\": {\n      \"location\": \"payload\",\n      \"identifier\": \"<string>\"\n    }\n  }\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "status": "Internal Server Error",
+                                    "code": 500,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        },
+                        {
+                            "id": "66ac43ae-7e74-4a47-968b-68ce402571e2",
+                            "name": "Delete an LLM provider template",
+                            "request": {
+                                "name": "Delete an LLM provider template",
+                                "description": {
+                                    "content": "Remove an LLM provider template from the Gateway Controller.\n",
+                                    "type": "text/plain"
+                                },
+                                "url": {
+                                    "path": [
+                                        "llm-provider-templates",
+                                        ":id"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "value": "<string>",
+                                            "key": "id",
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) Identifier of the template to delete",
+                                                "type": "text/plain"
+                                            }
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "DELETE",
+                                "body": {},
+                                "auth": null
+                            },
+                            "response": [
+                                {
+                                    "id": "a92ea84a-df29-47a1-aef1-826a1e988d4a",
+                                    "name": "LLM provider template deleted successfully",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "llm-provider-templates",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Identifier of the template to delete",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "DELETE",
+                                        "body": {}
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"id\": \"<string>\"\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                },
+                                {
+                                    "id": "fc2ff5e5-f992-4472-9270-0adc1d667235",
+                                    "name": "LLM provider template not found",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "llm-provider-templates",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Identifier of the template to delete",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "DELETE",
+                                        "body": {}
+                                    },
+                                    "status": "Not Found",
+                                    "code": 404,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                },
+                                {
+                                    "id": "d543178c-23b4-44fd-b421-627efc1a11da",
+                                    "name": "Internal server error",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "llm-provider-templates",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Identifier of the template to delete",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "DELETE",
+                                        "body": {}
+                                    },
+                                    "status": "Internal Server Error",
+                                    "code": 500,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "llm-providers",
+            "description": "",
+            "item": [
+                {
+                    "id": "3216511e-0339-4a9b-8fc7-b45f45204d3a",
+                    "name": "Create a new LLM provider",
+                    "request": {
+                        "name": "Create a new LLM provider",
+                        "description": {
+                            "content": "Deploy a new LLM provider configuration. The provider defines how to interact\nwith an LLM service, including upstream endpoints, authentication, access control,\nand policies.\n",
+                            "type": "text/plain"
+                        },
+                        "url": {
+                            "path": [
+                                "llm-providers"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                            },
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            }
+                        ],
+                        "method": "POST",
+                        "body": {
+                            "mode": "raw",
+                            "raw": "{\n  \"version\": \"ai.api-platform.wso2.com/v1\",\n  \"kind\": \"LlmProvider\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"spec\": {\n    \"displayName\": \"ESg69U3d9z\",\n    \"version\": \"v271674313.398983\",\n    \"template\": \"<string>\",\n    \"upstream\": {\n      \"auth\": {\n        \"type\": \"api-key\",\n        \"header\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    },\n    \"accessControl\": {\n      \"mode\": \"deny_all\",\n      \"exceptions\": [\n        {\n          \"path\": \"<string>\",\n          \"methods\": [\n            \"DELETE\",\n            \"DELETE\"\n          ]\n        },\n        {\n          \"path\": \"<string>\",\n          \"methods\": [\n            \"PATCH\",\n            \"PATCH\"\n          ]\n        }\n      ]\n    },\n    \"context\": \"/\",\n    \"vhost\": \"d.*.V.*.*.*.E.4.*.*.*.Kmklk\",\n    \"policies\": [\n      {\n        \"name\": \"<string>\",\n        \"version\": \"<string>\",\n        \"paths\": [\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"POST\",\n              \"GET\"\n            ],\n            \"params\": {\n              \"key_0\": \"string\",\n              \"key_1\": 862\n            }\n          },\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"POST\",\n              \"HEAD\"\n            ],\n            \"params\": {\n              \"key_0\": 8877\n            }\n          }\n        ]\n      },\n      {\n        \"name\": \"<string>\",\n        \"version\": \"<string>\",\n        \"paths\": [\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"GET\",\n              \"DELETE\"\n            ],\n            \"params\": {\n              \"key_0\": 201.50526190058082\n            }\n          },\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"PATCH\",\n              \"GET\"\n            ],\n            \"params\": {\n              \"key_0\": 8135.660200166861,\n              \"key_1\": 3785\n            }\n          }\n        ]\n      }\n    ]\n  }\n}",
+                            "options": {
+                                "raw": {
+                                    "headerFamily": "json",
+                                    "language": "json"
+                                }
+                            }
+                        },
+                        "auth": null
+                    },
+                    "response": [
+                        {
+                            "id": "79bfe5b6-b6d4-4f9e-8bd4-2bf9e0ee872e",
+                            "name": "LLM provider created and deployed successfully",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "llm-providers"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"version\": \"ai.api-platform.wso2.com/v1\",\n  \"kind\": \"LlmProvider\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"spec\": {\n    \"displayName\": \"ESg69U3d9z\",\n    \"version\": \"v271674313.398983\",\n    \"template\": \"<string>\",\n    \"upstream\": {\n      \"auth\": {\n        \"type\": \"api-key\",\n        \"header\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    },\n    \"accessControl\": {\n      \"mode\": \"deny_all\",\n      \"exceptions\": [\n        {\n          \"path\": \"<string>\",\n          \"methods\": [\n            \"DELETE\",\n            \"DELETE\"\n          ]\n        },\n        {\n          \"path\": \"<string>\",\n          \"methods\": [\n            \"PATCH\",\n            \"PATCH\"\n          ]\n        }\n      ]\n    },\n    \"context\": \"/\",\n    \"vhost\": \"d.*.V.*.*.*.E.4.*.*.*.Kmklk\",\n    \"policies\": [\n      {\n        \"name\": \"<string>\",\n        \"version\": \"<string>\",\n        \"paths\": [\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"POST\",\n              \"GET\"\n            ],\n            \"params\": {\n              \"key_0\": \"string\",\n              \"key_1\": 862\n            }\n          },\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"POST\",\n              \"HEAD\"\n            ],\n            \"params\": {\n              \"key_0\": 8877\n            }\n          }\n        ]\n      },\n      {\n        \"name\": \"<string>\",\n        \"version\": \"<string>\",\n        \"paths\": [\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"GET\",\n              \"DELETE\"\n            ],\n            \"params\": {\n              \"key_0\": 201.50526190058082\n            }\n          },\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"PATCH\",\n              \"GET\"\n            ],\n            \"params\": {\n              \"key_0\": 8135.660200166861,\n              \"key_1\": 3785\n            }\n          }\n        ]\n      }\n    ]\n  }\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Created",
+                            "code": 201,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"id\": \"<string>\",\n  \"created_at\": \"<dateTime>\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "d4c38476-0dec-47f4-ba85-991ee4650ce8",
+                            "name": "Invalid configuration (validation failed)",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "llm-providers"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"version\": \"ai.api-platform.wso2.com/v1\",\n  \"kind\": \"LlmProvider\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"spec\": {\n    \"displayName\": \"ESg69U3d9z\",\n    \"version\": \"v271674313.398983\",\n    \"template\": \"<string>\",\n    \"upstream\": {\n      \"auth\": {\n        \"type\": \"api-key\",\n        \"header\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    },\n    \"accessControl\": {\n      \"mode\": \"deny_all\",\n      \"exceptions\": [\n        {\n          \"path\": \"<string>\",\n          \"methods\": [\n            \"DELETE\",\n            \"DELETE\"\n          ]\n        },\n        {\n          \"path\": \"<string>\",\n          \"methods\": [\n            \"PATCH\",\n            \"PATCH\"\n          ]\n        }\n      ]\n    },\n    \"context\": \"/\",\n    \"vhost\": \"d.*.V.*.*.*.E.4.*.*.*.Kmklk\",\n    \"policies\": [\n      {\n        \"name\": \"<string>\",\n        \"version\": \"<string>\",\n        \"paths\": [\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"POST\",\n              \"GET\"\n            ],\n            \"params\": {\n              \"key_0\": \"string\",\n              \"key_1\": 862\n            }\n          },\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"POST\",\n              \"HEAD\"\n            ],\n            \"params\": {\n              \"key_0\": 8877\n            }\n          }\n        ]\n      },\n      {\n        \"name\": \"<string>\",\n        \"version\": \"<string>\",\n        \"paths\": [\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"GET\",\n              \"DELETE\"\n            ],\n            \"params\": {\n              \"key_0\": 201.50526190058082\n            }\n          },\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"PATCH\",\n              \"GET\"\n            ],\n            \"params\": {\n              \"key_0\": 8135.660200166861,\n              \"key_1\": 3785\n            }\n          }\n        ]\n      }\n    ]\n  }\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "3317a2ad-68f3-4e2b-a01c-cf8122253386",
+                            "name": "Conflict - Provider with same name and version already exists",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "llm-providers"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"version\": \"ai.api-platform.wso2.com/v1\",\n  \"kind\": \"LlmProvider\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"spec\": {\n    \"displayName\": \"ESg69U3d9z\",\n    \"version\": \"v271674313.398983\",\n    \"template\": \"<string>\",\n    \"upstream\": {\n      \"auth\": {\n        \"type\": \"api-key\",\n        \"header\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    },\n    \"accessControl\": {\n      \"mode\": \"deny_all\",\n      \"exceptions\": [\n        {\n          \"path\": \"<string>\",\n          \"methods\": [\n            \"DELETE\",\n            \"DELETE\"\n          ]\n        },\n        {\n          \"path\": \"<string>\",\n          \"methods\": [\n            \"PATCH\",\n            \"PATCH\"\n          ]\n        }\n      ]\n    },\n    \"context\": \"/\",\n    \"vhost\": \"d.*.V.*.*.*.E.4.*.*.*.Kmklk\",\n    \"policies\": [\n      {\n        \"name\": \"<string>\",\n        \"version\": \"<string>\",\n        \"paths\": [\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"POST\",\n              \"GET\"\n            ],\n            \"params\": {\n              \"key_0\": \"string\",\n              \"key_1\": 862\n            }\n          },\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"POST\",\n              \"HEAD\"\n            ],\n            \"params\": {\n              \"key_0\": 8877\n            }\n          }\n        ]\n      },\n      {\n        \"name\": \"<string>\",\n        \"version\": \"<string>\",\n        \"paths\": [\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"GET\",\n              \"DELETE\"\n            ],\n            \"params\": {\n              \"key_0\": 201.50526190058082\n            }\n          },\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"PATCH\",\n              \"GET\"\n            ],\n            \"params\": {\n              \"key_0\": 8135.660200166861,\n              \"key_1\": 3785\n            }\n          }\n        ]\n      }\n    ]\n  }\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Conflict",
+                            "code": 409,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "3682657d-6460-4bb5-b973-a0418f092461",
+                            "name": "Internal server error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "llm-providers"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"version\": \"ai.api-platform.wso2.com/v1\",\n  \"kind\": \"LlmProvider\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"spec\": {\n    \"displayName\": \"ESg69U3d9z\",\n    \"version\": \"v271674313.398983\",\n    \"template\": \"<string>\",\n    \"upstream\": {\n      \"auth\": {\n        \"type\": \"api-key\",\n        \"header\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    },\n    \"accessControl\": {\n      \"mode\": \"deny_all\",\n      \"exceptions\": [\n        {\n          \"path\": \"<string>\",\n          \"methods\": [\n            \"DELETE\",\n            \"DELETE\"\n          ]\n        },\n        {\n          \"path\": \"<string>\",\n          \"methods\": [\n            \"PATCH\",\n            \"PATCH\"\n          ]\n        }\n      ]\n    },\n    \"context\": \"/\",\n    \"vhost\": \"d.*.V.*.*.*.E.4.*.*.*.Kmklk\",\n    \"policies\": [\n      {\n        \"name\": \"<string>\",\n        \"version\": \"<string>\",\n        \"paths\": [\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"POST\",\n              \"GET\"\n            ],\n            \"params\": {\n              \"key_0\": \"string\",\n              \"key_1\": 862\n            }\n          },\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"POST\",\n              \"HEAD\"\n            ],\n            \"params\": {\n              \"key_0\": 8877\n            }\n          }\n        ]\n      },\n      {\n        \"name\": \"<string>\",\n        \"version\": \"<string>\",\n        \"paths\": [\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"GET\",\n              \"DELETE\"\n            ],\n            \"params\": {\n              \"key_0\": 201.50526190058082\n            }\n          },\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"PATCH\",\n              \"GET\"\n            ],\n            \"params\": {\n              \"key_0\": 8135.660200166861,\n              \"key_1\": 3785\n            }\n          }\n        ]\n      }\n    ]\n  }\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
+                },
+                {
+                    "id": "711eafed-da0e-4aa7-bd90-1c74164037ab",
+                    "name": "List all LLM providers",
+                    "request": {
+                        "name": "List all LLM providers",
+                        "description": {
+                            "content": "Retrieve a list of all LLM providers",
+                            "type": "text/plain"
+                        },
+                        "url": {
+                            "path": [
+                                "llm-providers"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter by LLM provider name",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "name",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter by LLM provider version",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "version",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter by LLM provider context/path",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "context",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter by deployment status (This can only be one of pending,deployed,failed)",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "status",
+                                    "value": "deployed"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter by LLM provider vhost",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "vhost",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {},
+                        "auth": null
+                    },
+                    "response": [
+                        {
+                            "id": "3e273a30-2fee-42de-821d-a3ae8e663ef7",
+                            "name": "List of LLM providers",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "llm-providers"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter by LLM provider name",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "name",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter by LLM provider version",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "version",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter by LLM provider context/path",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "context",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter by deployment status (This can only be one of pending,deployed,failed)",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "status",
+                                            "value": "deployed"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter by LLM provider vhost",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "vhost",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"status\": \"<string>\",\n  \"count\": \"<integer>\",\n  \"providers\": [\n    {\n      \"id\": \"<string>\",\n      \"name\": \"<string>\",\n      \"version\": \"<string>\",\n      \"template\": \"<string>\",\n      \"status\": \"deployed\",\n      \"created_at\": \"<dateTime>\",\n      \"updated_at\": \"<dateTime>\"\n    },\n    {\n      \"id\": \"<string>\",\n      \"name\": \"<string>\",\n      \"version\": \"<string>\",\n      \"template\": \"<string>\",\n      \"status\": \"deployed\",\n      \"created_at\": \"<dateTime>\",\n      \"updated_at\": \"<dateTime>\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "caac89bb-24d6-469a-8708-28006645fe0f",
+                            "name": "Internal server error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "llm-providers"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter by LLM provider name",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "name",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter by LLM provider version",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "version",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter by LLM provider context/path",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "context",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter by deployment status (This can only be one of pending,deployed,failed)",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "status",
+                                            "value": "deployed"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter by LLM provider vhost",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "vhost",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
+                },
+                {
+                    "name": "{id}",
+                    "description": "",
+                    "item": [
+                        {
+                            "id": "2c0b2835-8096-4ee4-9d6c-446ee140b965",
+                            "name": "Get LLM provider by identifier",
+                            "request": {
+                                "name": "Get LLM provider by identifier",
+                                "description": {
+                                    "content": "Retrieve the complete configuration for a specific LLM provider",
+                                    "type": "text/plain"
+                                },
+                                "url": {
+                                    "path": [
+                                        "llm-providers",
+                                        ":id"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "value": "<string>",
+                                            "key": "id",
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) Handle of the LLM provider",
+                                                "type": "text/plain"
+                                            }
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {},
+                                "auth": null
+                            },
+                            "response": [
+                                {
+                                    "id": "d83c236e-3118-4b97-ba79-b979661e02c1",
+                                    "name": "LLM provider details",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "llm-providers",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Handle of the LLM provider",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {}
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"provider\": {\n    \"id\": \"<string>\",\n    \"configuration\": {\n      \"version\": \"ai.api-platform.wso2.com/v1\",\n      \"kind\": \"LlmProvider\",\n      \"metadata\": {\n        \"name\": \"<string>\"\n      },\n      \"spec\": {\n        \"displayName\": \"CWkB7ZVx4 C\",\n        \"version\": \"v5149940044.146\",\n        \"template\": \"<string>\",\n        \"upstream\": {\n          \"auth\": {\n            \"type\": \"bearer\",\n            \"header\": \"<string>\",\n            \"value\": \"<string>\"\n          }\n        },\n        \"accessControl\": {\n          \"mode\": \"allow_all\",\n          \"exceptions\": [\n            {\n              \"path\": \"<string>\",\n              \"methods\": [\n                \"POST\",\n                \"PUT\"\n              ]\n            },\n            {\n              \"path\": \"<string>\",\n              \"methods\": [\n                \"PUT\",\n                \"POST\"\n              ]\n            }\n          ]\n        },\n        \"context\": \"/\",\n        \"vhost\": \"*.qISqk62oYOWg8H5j7YcGPP8BbMc1T9-fy9QvAl0OFntlWKzJP0X29M.*.*.fdYD14ylGdOw29VuC9Lggk41YwyM.ivJdYkn8BDPGS46iaO9dxJI5QUE7Omvp3f.8pfSd6ftkbiB-ByXaYb8P8ryiBBzbR5FYwso.YaxMCtIc\",\n        \"policies\": [\n          {\n            \"name\": \"<string>\",\n            \"version\": \"<string>\",\n            \"paths\": [\n              {\n                \"path\": \"<string>\",\n                \"methods\": [\n                  \"PUT\",\n                  \"PUT\"\n                ],\n                \"params\": {\n                  \"key_0\": 9258.17526143324\n                }\n              },\n              {\n                \"path\": \"<string>\",\n                \"methods\": [\n                  \"HEAD\",\n                  \"POST\"\n                ],\n                \"params\": {\n                  \"key_0\": false,\n                  \"key_1\": 777,\n                  \"key_2\": \"string\"\n                }\n              }\n            ]\n          },\n          {\n            \"name\": \"<string>\",\n            \"version\": \"<string>\",\n            \"paths\": [\n              {\n                \"path\": \"<string>\",\n                \"methods\": [\n                  \"DELETE\",\n                  \"DELETE\"\n                ],\n                \"params\": {\n                  \"key_0\": \"string\"\n                }\n              },\n              {\n                \"path\": \"<string>\",\n                \"methods\": [\n                  \"HEAD\",\n                  \"HEAD\"\n                ],\n                \"params\": {\n                  \"key_0\": true,\n                  \"key_1\": 7928\n                }\n              }\n            ]\n          }\n        ]\n      }\n    },\n    \"deployment_status\": \"pending\",\n    \"metadata\": {\n      \"created_at\": \"<dateTime>\",\n      \"updated_at\": \"<dateTime>\",\n      \"deployed_at\": \"<dateTime>\"\n    }\n  }\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                },
+                                {
+                                    "id": "bbaa7c20-accb-46d9-b914-419002e5964b",
+                                    "name": "LLM provider not found",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "llm-providers",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Handle of the LLM provider",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {}
+                                    },
+                                    "status": "Not Found",
+                                    "code": 404,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                },
+                                {
+                                    "id": "c3864bf7-7df1-408d-a949-642a52e80047",
+                                    "name": "Internal server error",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "llm-providers",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Handle of the LLM provider",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {}
+                                    },
+                                    "status": "Internal Server Error",
+                                    "code": 500,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        },
+                        {
+                            "id": "c1a526a0-13ba-4844-b5ff-11cbf22de54d",
+                            "name": "Update an existing LLM provider",
+                            "request": {
+                                "name": "Update an existing LLM provider",
+                                "description": {
+                                    "content": "Update the configuration of an existing LLM provider",
+                                    "type": "text/plain"
+                                },
+                                "url": {
+                                    "path": [
+                                        "llm-providers",
+                                        ":id"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "value": "<string>",
+                                            "key": "id",
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) Handle of the LLM provider",
+                                                "type": "text/plain"
+                                            }
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "PUT",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"version\": \"ai.api-platform.wso2.com/v1\",\n  \"kind\": \"LlmProvider\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"spec\": {\n    \"displayName\": \"ESg69U3d9z\",\n    \"version\": \"v271674313.398983\",\n    \"template\": \"<string>\",\n    \"upstream\": {\n      \"auth\": {\n        \"type\": \"api-key\",\n        \"header\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    },\n    \"accessControl\": {\n      \"mode\": \"deny_all\",\n      \"exceptions\": [\n        {\n          \"path\": \"<string>\",\n          \"methods\": [\n            \"DELETE\",\n            \"DELETE\"\n          ]\n        },\n        {\n          \"path\": \"<string>\",\n          \"methods\": [\n            \"PATCH\",\n            \"PATCH\"\n          ]\n        }\n      ]\n    },\n    \"context\": \"/\",\n    \"vhost\": \"d.*.V.*.*.*.E.4.*.*.*.Kmklk\",\n    \"policies\": [\n      {\n        \"name\": \"<string>\",\n        \"version\": \"<string>\",\n        \"paths\": [\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"POST\",\n              \"GET\"\n            ],\n            \"params\": {\n              \"key_0\": \"string\",\n              \"key_1\": 862\n            }\n          },\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"POST\",\n              \"HEAD\"\n            ],\n            \"params\": {\n              \"key_0\": 8877\n            }\n          }\n        ]\n      },\n      {\n        \"name\": \"<string>\",\n        \"version\": \"<string>\",\n        \"paths\": [\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"GET\",\n              \"DELETE\"\n            ],\n            \"params\": {\n              \"key_0\": 201.50526190058082\n            }\n          },\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"PATCH\",\n              \"GET\"\n            ],\n            \"params\": {\n              \"key_0\": 8135.660200166861,\n              \"key_1\": 3785\n            }\n          }\n        ]\n      }\n    ]\n  }\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                },
+                                "auth": null
+                            },
+                            "response": [
+                                {
+                                    "id": "365b529c-86c4-4b9e-b072-f86ce5400a04",
+                                    "name": "LLM provider updated successfully",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "llm-providers",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Handle of the LLM provider",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "PUT",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"version\": \"ai.api-platform.wso2.com/v1\",\n  \"kind\": \"LlmProvider\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"spec\": {\n    \"displayName\": \"ESg69U3d9z\",\n    \"version\": \"v271674313.398983\",\n    \"template\": \"<string>\",\n    \"upstream\": {\n      \"auth\": {\n        \"type\": \"api-key\",\n        \"header\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    },\n    \"accessControl\": {\n      \"mode\": \"deny_all\",\n      \"exceptions\": [\n        {\n          \"path\": \"<string>\",\n          \"methods\": [\n            \"DELETE\",\n            \"DELETE\"\n          ]\n        },\n        {\n          \"path\": \"<string>\",\n          \"methods\": [\n            \"PATCH\",\n            \"PATCH\"\n          ]\n        }\n      ]\n    },\n    \"context\": \"/\",\n    \"vhost\": \"d.*.V.*.*.*.E.4.*.*.*.Kmklk\",\n    \"policies\": [\n      {\n        \"name\": \"<string>\",\n        \"version\": \"<string>\",\n        \"paths\": [\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"POST\",\n              \"GET\"\n            ],\n            \"params\": {\n              \"key_0\": \"string\",\n              \"key_1\": 862\n            }\n          },\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"POST\",\n              \"HEAD\"\n            ],\n            \"params\": {\n              \"key_0\": 8877\n            }\n          }\n        ]\n      },\n      {\n        \"name\": \"<string>\",\n        \"version\": \"<string>\",\n        \"paths\": [\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"GET\",\n              \"DELETE\"\n            ],\n            \"params\": {\n              \"key_0\": 201.50526190058082\n            }\n          },\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"PATCH\",\n              \"GET\"\n            ],\n            \"params\": {\n              \"key_0\": 8135.660200166861,\n              \"key_1\": 3785\n            }\n          }\n        ]\n      }\n    ]\n  }\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"id\": \"<string>\",\n  \"updated_at\": \"<dateTime>\"\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                },
+                                {
+                                    "id": "94674734-7152-48a9-9cd4-66bb16d9b290",
+                                    "name": "Invalid configuration",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "llm-providers",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Handle of the LLM provider",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "PUT",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"version\": \"ai.api-platform.wso2.com/v1\",\n  \"kind\": \"LlmProvider\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"spec\": {\n    \"displayName\": \"ESg69U3d9z\",\n    \"version\": \"v271674313.398983\",\n    \"template\": \"<string>\",\n    \"upstream\": {\n      \"auth\": {\n        \"type\": \"api-key\",\n        \"header\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    },\n    \"accessControl\": {\n      \"mode\": \"deny_all\",\n      \"exceptions\": [\n        {\n          \"path\": \"<string>\",\n          \"methods\": [\n            \"DELETE\",\n            \"DELETE\"\n          ]\n        },\n        {\n          \"path\": \"<string>\",\n          \"methods\": [\n            \"PATCH\",\n            \"PATCH\"\n          ]\n        }\n      ]\n    },\n    \"context\": \"/\",\n    \"vhost\": \"d.*.V.*.*.*.E.4.*.*.*.Kmklk\",\n    \"policies\": [\n      {\n        \"name\": \"<string>\",\n        \"version\": \"<string>\",\n        \"paths\": [\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"POST\",\n              \"GET\"\n            ],\n            \"params\": {\n              \"key_0\": \"string\",\n              \"key_1\": 862\n            }\n          },\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"POST\",\n              \"HEAD\"\n            ],\n            \"params\": {\n              \"key_0\": 8877\n            }\n          }\n        ]\n      },\n      {\n        \"name\": \"<string>\",\n        \"version\": \"<string>\",\n        \"paths\": [\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"GET\",\n              \"DELETE\"\n            ],\n            \"params\": {\n              \"key_0\": 201.50526190058082\n            }\n          },\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"PATCH\",\n              \"GET\"\n            ],\n            \"params\": {\n              \"key_0\": 8135.660200166861,\n              \"key_1\": 3785\n            }\n          }\n        ]\n      }\n    ]\n  }\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "status": "Bad Request",
+                                    "code": 400,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                },
+                                {
+                                    "id": "448f617e-efd5-4d7c-8311-c363ee56cfab",
+                                    "name": "LLM provider not found",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "llm-providers",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Handle of the LLM provider",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "PUT",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"version\": \"ai.api-platform.wso2.com/v1\",\n  \"kind\": \"LlmProvider\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"spec\": {\n    \"displayName\": \"ESg69U3d9z\",\n    \"version\": \"v271674313.398983\",\n    \"template\": \"<string>\",\n    \"upstream\": {\n      \"auth\": {\n        \"type\": \"api-key\",\n        \"header\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    },\n    \"accessControl\": {\n      \"mode\": \"deny_all\",\n      \"exceptions\": [\n        {\n          \"path\": \"<string>\",\n          \"methods\": [\n            \"DELETE\",\n            \"DELETE\"\n          ]\n        },\n        {\n          \"path\": \"<string>\",\n          \"methods\": [\n            \"PATCH\",\n            \"PATCH\"\n          ]\n        }\n      ]\n    },\n    \"context\": \"/\",\n    \"vhost\": \"d.*.V.*.*.*.E.4.*.*.*.Kmklk\",\n    \"policies\": [\n      {\n        \"name\": \"<string>\",\n        \"version\": \"<string>\",\n        \"paths\": [\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"POST\",\n              \"GET\"\n            ],\n            \"params\": {\n              \"key_0\": \"string\",\n              \"key_1\": 862\n            }\n          },\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"POST\",\n              \"HEAD\"\n            ],\n            \"params\": {\n              \"key_0\": 8877\n            }\n          }\n        ]\n      },\n      {\n        \"name\": \"<string>\",\n        \"version\": \"<string>\",\n        \"paths\": [\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"GET\",\n              \"DELETE\"\n            ],\n            \"params\": {\n              \"key_0\": 201.50526190058082\n            }\n          },\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"PATCH\",\n              \"GET\"\n            ],\n            \"params\": {\n              \"key_0\": 8135.660200166861,\n              \"key_1\": 3785\n            }\n          }\n        ]\n      }\n    ]\n  }\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "status": "Not Found",
+                                    "code": 404,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                },
+                                {
+                                    "id": "aa635095-f663-41c0-8649-0e4a5d865fc2",
+                                    "name": "Internal server error",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "llm-providers",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Handle of the LLM provider",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "PUT",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"version\": \"ai.api-platform.wso2.com/v1\",\n  \"kind\": \"LlmProvider\",\n  \"metadata\": {\n    \"name\": \"<string>\"\n  },\n  \"spec\": {\n    \"displayName\": \"ESg69U3d9z\",\n    \"version\": \"v271674313.398983\",\n    \"template\": \"<string>\",\n    \"upstream\": {\n      \"auth\": {\n        \"type\": \"api-key\",\n        \"header\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    },\n    \"accessControl\": {\n      \"mode\": \"deny_all\",\n      \"exceptions\": [\n        {\n          \"path\": \"<string>\",\n          \"methods\": [\n            \"DELETE\",\n            \"DELETE\"\n          ]\n        },\n        {\n          \"path\": \"<string>\",\n          \"methods\": [\n            \"PATCH\",\n            \"PATCH\"\n          ]\n        }\n      ]\n    },\n    \"context\": \"/\",\n    \"vhost\": \"d.*.V.*.*.*.E.4.*.*.*.Kmklk\",\n    \"policies\": [\n      {\n        \"name\": \"<string>\",\n        \"version\": \"<string>\",\n        \"paths\": [\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"POST\",\n              \"GET\"\n            ],\n            \"params\": {\n              \"key_0\": \"string\",\n              \"key_1\": 862\n            }\n          },\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"POST\",\n              \"HEAD\"\n            ],\n            \"params\": {\n              \"key_0\": 8877\n            }\n          }\n        ]\n      },\n      {\n        \"name\": \"<string>\",\n        \"version\": \"<string>\",\n        \"paths\": [\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"GET\",\n              \"DELETE\"\n            ],\n            \"params\": {\n              \"key_0\": 201.50526190058082\n            }\n          },\n          {\n            \"path\": \"<string>\",\n            \"methods\": [\n              \"PATCH\",\n              \"GET\"\n            ],\n            \"params\": {\n              \"key_0\": 8135.660200166861,\n              \"key_1\": 3785\n            }\n          }\n        ]\n      }\n    ]\n  }\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "status": "Internal Server Error",
+                                    "code": 500,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        },
+                        {
+                            "id": "ba482cdf-2796-44f6-826c-75366c133b59",
+                            "name": "Delete an LLM provider",
+                            "request": {
+                                "name": "Delete an LLM provider",
+                                "description": {
+                                    "content": "Remove an LLM provider from the Gateway Controller",
+                                    "type": "text/plain"
+                                },
+                                "url": {
+                                    "path": [
+                                        "llm-providers",
+                                        ":id"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "value": "<string>",
+                                            "key": "id",
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) Handle of the LLM provider",
+                                                "type": "text/plain"
+                                            }
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "DELETE",
+                                "body": {},
+                                "auth": null
+                            },
+                            "response": [
+                                {
+                                    "id": "b19ac954-75ea-4c8d-80aa-dcfa87f34386",
+                                    "name": "LLM provider deleted successfully",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "llm-providers",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Handle of the LLM provider",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "DELETE",
+                                        "body": {}
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"id\": \"<string>\"\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                },
+                                {
+                                    "id": "3150432e-5d13-45ee-a6a0-1ac8c843524f",
+                                    "name": "LLM provider not found",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "llm-providers",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Handle of the LLM provider",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "DELETE",
+                                        "body": {}
+                                    },
+                                    "status": "Not Found",
+                                    "code": 404,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                },
+                                {
+                                    "id": "d160f0db-986d-4e14-903c-54dfc389669b",
+                                    "name": "Internal server error",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "llm-providers",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) Handle of the LLM provider",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "DELETE",
+                                        "body": {}
+                                    },
+                                    "status": "Internal Server Error",
+                                    "code": 500,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "config_dump",
+            "description": "",
+            "item": [
+                {
+                    "id": "392da46f-d777-44bd-b4c6-4059b9500ec5",
+                    "name": "Dump current configuration state",
+                    "request": {
+                        "name": "Dump current configuration state",
+                        "description": {
+                            "content": "Retrieve the complete current state of the Gateway Controller including:\n- All deployed API configurations\n- All loaded policy definitions\n- All registered certificates\n- System status and metadata\n\nThis endpoint is useful for debugging, monitoring, and backup purposes.\n",
+                            "type": "text/plain"
+                        },
+                        "url": {
+                            "path": [
+                                "config_dump"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {},
+                        "auth": null
+                    },
+                    "response": [
+                        {
+                            "id": "2373400a-232f-42e2-a9c3-b4889ab43341",
+                            "name": "Complete configuration dump",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "config_dump"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"status\": \"<string>\",\n  \"timestamp\": \"<dateTime>\",\n  \"apis\": [\n    {\n      \"id\": \"<uuid>\",\n      \"configuration\": {\n        \"apiVersion\": \"gateway.api-platform.wso2.com/v1alpha1\",\n        \"metadata\": {\n          \"name\": \"<string>\"\n        },\n        \"kind\": \"async/sse\",\n        \"spec\": {\n          \"displayName\": \"2WubYOFxxd\",\n          \"version\": \"v29433511.1873487091\",\n          \"context\": \"/mv83ynOyDr\",\n          \"upstream\": {\n            \"main\": {\n              \"url\": \"string\"\n            },\n            \"sandbox\": {\n              \"url\": 5292\n            }\n          },\n          \"operations\": [\n            {\n              \"method\": \"HEAD\",\n              \"path\": \"/bT+)\",\n              \"policies\": [\n                {\n                  \"name\": \"<string>\",\n                  \"version\": \"v3.4059.852302\",\n                  \"executionCondition\": \"<string>\",\n                  \"params\": {\n                    \"key_0\": 1905.1214504703173,\n                    \"key_1\": true,\n                    \"key_2\": true\n                  }\n                },\n                {\n                  \"name\": \"<string>\",\n                  \"version\": \"v900.5415198343.625542216\",\n                  \"executionCondition\": \"<string>\",\n                  \"params\": {\n                    \"key_0\": \"string\",\n                    \"key_1\": 1411\n                  }\n                }\n              ]\n            }\n          ],\n          \"vhosts\": {\n            \"main\": \"dSyprVD0nmJ\",\n            \"sandbox\": \"5D\"\n          },\n          \"policies\": [\n            {\n              \"name\": \"<string>\",\n              \"version\": \"v7.9.77458129397\",\n              \"executionCondition\": \"<string>\",\n              \"params\": {\n                \"key_0\": 1357\n              }\n            },\n            {\n              \"name\": \"<string>\",\n              \"version\": \"v752.992968572.1589591778\",\n              \"executionCondition\": \"<string>\",\n              \"params\": {\n                \"key_0\": 784\n              }\n            }\n          ]\n        }\n      },\n      \"metadata\": {\n        \"status\": \"failed\",\n        \"created_at\": \"<dateTime>\",\n        \"updated_at\": \"<dateTime>\",\n        \"deployed_at\": \"<dateTime>\"\n      }\n    },\n    {\n      \"id\": \"<uuid>\",\n      \"configuration\": {\n        \"apiVersion\": \"gateway.api-platform.wso2.com/v1alpha1\",\n        \"metadata\": {\n          \"name\": \"<string>\"\n        },\n        \"kind\": \"RestApi\",\n        \"spec\": {\n          \"displayName\": \"Ro_08b1A\",\n          \"version\": \"v5741065374.8957\",\n          \"context\": \"/wZi\",\n          \"upstream\": {\n            \"main\": {\n              \"url\": \"string\"\n            },\n            \"sandbox\": {\n              \"url\": \"string\"\n            }\n          },\n          \"operations\": [\n            {\n              \"method\": \"OPTIONS\",\n              \"path\": \"/&`_P!X+J\",\n              \"policies\": [\n                {\n                  \"name\": \"<string>\",\n                  \"version\": \"v1370044328.325016372.725881\",\n                  \"executionCondition\": \"<string>\",\n                  \"params\": {\n                    \"key_0\": 9609.985390994487\n                  }\n                },\n                {\n                  \"name\": \"<string>\",\n                  \"version\": \"v241603686.19431594.86\",\n                  \"executionCondition\": \"<string>\",\n                  \"params\": {\n                    \"key_0\": 2849.2754882468384\n                  }\n                }\n              ]\n            }\n          ],\n          \"vhosts\": {\n            \"main\": \".rsU0I5\",\n            \"sandbox\": \"mJdgncYb\"\n          },\n          \"policies\": [\n            {\n              \"name\": \"<string>\",\n              \"version\": \"v35745023.643.976\",\n              \"executionCondition\": \"<string>\",\n              \"params\": {\n                \"key_0\": 7419.181972797377,\n                \"key_1\": \"string\"\n              }\n            },\n            {\n              \"name\": \"<string>\",\n              \"version\": \"v2136063696.61.3244168978\",\n              \"executionCondition\": \"<string>\",\n              \"params\": {\n                \"key_0\": 4745.07986249107,\n                \"key_1\": \"string\",\n                \"key_2\": \"string\"\n              }\n            }\n          ]\n        }\n      },\n      \"metadata\": {\n        \"status\": \"failed\",\n        \"created_at\": \"<dateTime>\",\n        \"updated_at\": \"<dateTime>\",\n        \"deployed_at\": \"<dateTime>\"\n      }\n    }\n  ],\n  \"policies\": [\n    {\n      \"name\": \"<string>\",\n      \"version\": \"v41.2692.681797569\",\n      \"description\": \"<string>\",\n      \"parameters\": {\n        \"key_0\": false,\n        \"key_1\": 8035.234538648259,\n        \"key_2\": 1218.2497285281247\n      },\n      \"systemParameters\": {\n        \"key_0\": \"string\",\n        \"key_1\": 1947.4883805219645\n      }\n    },\n    {\n      \"name\": \"<string>\",\n      \"version\": \"v1048.655987.1\",\n      \"description\": \"<string>\",\n      \"parameters\": {\n        \"key_0\": true,\n        \"key_1\": true\n      },\n      \"systemParameters\": {\n        \"key_0\": \"string\",\n        \"key_1\": false\n      }\n    }\n  ],\n  \"certificates\": [\n    {\n      \"id\": \"<string>\",\n      \"name\": \"<string>\",\n      \"subject\": \"<string>\",\n      \"issuer\": \"<string>\",\n      \"notAfter\": \"<dateTime>\",\n      \"count\": \"<integer>\",\n      \"message\": \"<string>\",\n      \"status\": \"success\"\n    },\n    {\n      \"id\": \"<string>\",\n      \"name\": \"<string>\",\n      \"subject\": \"<string>\",\n      \"issuer\": \"<string>\",\n      \"notAfter\": \"<dateTime>\",\n      \"count\": \"<integer>\",\n      \"message\": \"<string>\",\n      \"status\": \"error\"\n    }\n  ],\n  \"statistics\": {\n    \"totalApis\": \"<integer>\",\n    \"totalPolicies\": \"<integer>\",\n    \"totalCertificates\": \"<integer>\",\n    \"totalCertificateBytes\": \"<integer>\"\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "3dd7d176-2f69-4125-807a-2f54eaabe443",
+                            "name": "Internal server error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "config_dump"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"status\": \"<string>\",\n  \"message\": \"<string>\",\n  \"errors\": [\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    },\n    {\n      \"field\": \"<string>\",\n      \"message\": \"<string>\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
+                }
+            ]
+        }
+    ],
+    "event": [],
+    "variable": [
+        {
+            "key": "baseUrl",
+            "value": "http://localhost:9090"
+        }
+    ],
+    "info": {
+        "_postman_id": "66e6855d-8e2d-4f52-83ab-ab6a1d12f148",
+        "name": "Gateway Controller API",
+        "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+        "description": {
+            "content": "REST API for managing API configurations in the WSO2 API Platform Gateway.\n\nThe Gateway Controller accepts API configurations in YAML or JSON format and dynamically\nconfigures the Router (Envoy Proxy) via xDS protocol. Supports full CRUD lifecycle\nfor API configurations with real-time updates to the Router.\n\n**Key Features:**\n- Submit API configurations in YAML or JSON\n- Real-time validation and error reporting\n- Zero-downtime configuration updates\n- Persistent storage with SQLite\n- Query deployed API configurations\n\n\nContact Support:\n Name: WSO2 API Platform Team",
+            "type": "text/plain"
+        }
+    }
+}


### PR DESCRIPTION
## Purpose

This PR adds a postman collection to the gateway controller REST APIs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated Postman collection generation from the OpenAPI specification, enabling developers to quickly export pre-configured API collections with all endpoints and documentation for streamlined testing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->