### PR TITLE
Address CodeRabbit comments

### DIFF
--- a/docs/gateway/policies/apikey-authentication.md
+++ b/docs/gateway/policies/apikey-authentication.md
@@ -383,9 +383,9 @@ curl -X GET "http://localhost:9090/apis/weather-api-v1.0/api-key" \
     {
       "apiId": "weather-api-v1.0",
       "api_key": "",
-      "createdAt": "2025-12-22T13:02:24.504957558Z",
+      "created_at": "2025-12-22T13:02:24.504957558Z",
       "created_by": "admin",
-      "expiresAt": "2026-03-22T13:02:24.504957558Z",
+      "expires_at": "2026-03-22T13:02:24.504957558Z",
       "name": "production-key",
       "operations": "[\"*\"]",
       "status": "active"


### PR DESCRIPTION
This pull request makes a minor update to the API key authentication documentation, standardizing the timestamp field names in the example response to use snake_case for consistency.

* Updated the example API response in `apikey-authentication.md` to use `created_at` and `expires_at` instead of `createdAt` and `expiresAt`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API key response examples in documentation to reflect accurate field naming conventions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->