### PR TITLE
Make log level on Router configurable

### DIFF
--- a/gateway/docker-compose.yaml
+++ b/gateway/docker-compose.yaml
@@ -64,6 +64,7 @@ services:
     environment:
       - XDS_SERVER_HOST=${ROUTER_XDS_SERVER_HOST:-gateway-controller}
       - XDS_SERVER_PORT=18000
+      - LOG_LEVEL=info
     networks:
       - gateway-network
     healthcheck:

--- a/gateway/router/entrypoint.sh
+++ b/gateway/router/entrypoint.sh
@@ -23,8 +23,10 @@ set -e
 # Default XDS server configuration if not provided
 export XDS_SERVER_HOST="${XDS_SERVER_HOST:-gateway-controller}"
 export XDS_SERVER_PORT="${XDS_SERVER_PORT:-18000}"
+export LOG_LEVEL="${LOG_LEVEL:-info}"
 
 echo "Starting Envoy with xDS server at ${XDS_SERVER_HOST}:${XDS_SERVER_PORT}"
+echo "Log level: ${LOG_LEVEL}"
 
 # Generate config override by substituting environment variables
 CONFIG_OVERRIDE=$(envsubst < /etc/envoy/config-override.yaml)
@@ -33,4 +35,5 @@ CONFIG_OVERRIDE=$(envsubst < /etc/envoy/config-override.yaml)
 exec /usr/local/bin/envoy \
   -c /etc/envoy/envoy.yaml \
   --config-yaml "${CONFIG_OVERRIDE}" \
-  --log-level info
+  --log-level "${LOG_LEVEL}" \
+  "$@"


### PR DESCRIPTION
## Purpose
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Router service log level is now configurable via environment variable, defaulting to "info" level.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->