### PR TITLE
Fix role mapping example

### DIFF
--- a/docs/gateway/gateway-rest-api/authentication.md
+++ b/docs/gateway/gateway-rest-api/authentication.md
@@ -54,7 +54,7 @@ gateway_controller:
         admin: ["gateway-admins", "platform-admins"]
         developer: ["api-developers", "ops"]
         # Optional: give any authenticated user a baseline role
-        viewer: ["*"]
+        consumer: ["*"]
 ```
 
 ## Role Mapping Semantics

--- a/gateway/gateway-controller/authentication.md
+++ b/gateway/gateway-controller/authentication.md
@@ -54,7 +54,7 @@ gateway_controller:
         admin: ["gateway-admins", "platform-admins"]
         developer: ["api-developers", "ops"]
         # Optional: give any authenticated user a baseline role
-        viewer: ["*"]
+        consumer: ["*"]
 ```
 
 ## Role Mapping Semantics


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated JWT authentication role mapping configuration: the default baseline role has been renamed from "viewer" to "consumer" in configuration examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->