### PR TITLE
Adding policy to exclude headers from analytics

### DIFF
--- a/gateway/gateway-controller/default-policies/analytics-header-filter-v0.1.0.yaml
+++ b/gateway/gateway-controller/default-policies/analytics-header-filter-v0.1.0.yaml
@@ -1,0 +1,41 @@
+name: analytics-header-filter
+version: v0.1.0
+description: |
+  Filters specified headers from being sent to analytics publishers.
+  This policy allows users to exclude sensitive or unwanted headers from analytics data.
+  The policy only operates when analytics is enabled at the system level.
+  Users must explicitly add this policy to their policy chain for it to take effect.
+
+parameters:
+  type: object
+  properties:
+    requestHeadersToFilter:
+      type: array
+      description: |
+        List of request header names to exclude from analytics data.
+        Header names are case-insensitive.
+      items:
+        type: string
+        description: Header name to filter from request analytics
+        minLength: 1
+        maxLength: 256
+    responseHeadersToFilter:
+      type: array
+      description: |
+        List of response header names to exclude from analytics data.
+        Header names are case-insensitive.
+      items:
+        type: string
+        description: Header name to filter from response analytics
+        minLength: 1
+        maxLength: 256
+
+systemParameters:
+  type: object
+  properties:
+    analyticsEnabled:
+      type: boolean
+      description: System-level flag indicating whether analytics is enabled. This policy only operates when this is set to true.
+      default: false
+      "wso2/defaultValue": "${config.analytics.enabled}"
+

--- a/gateway/policies/analytics-header-filter/v0.1.0/analyticsheaderfilter.go
+++ b/gateway/policies/analytics-header-filter/v0.1.0/analyticsheaderfilter.go
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package analyticsheaderfilter
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+
+	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+)
+
+const (
+	// Analytics metadata keys for filtered headers
+	// These keys are used to pass the filtered header information to the analytics publisher
+	RequestHeadersFilteredKey  = "analytics:request-headers-filtered"
+	ResponseHeadersFilteredKey = "analytics:response-headers-filtered"
+)
+
+// AnalyticsHeaderFilterPolicy filters specified headers from analytics data
+type AnalyticsHeaderFilterPolicy struct {
+	analyticsEnabled bool
+}
+
+// GetPolicy creates a new instance of the AnalyticsHeaderFilterPolicy
+func GetPolicy(
+	metadata policy.PolicyMetadata,
+	params map[string]interface{},
+) (policy.Policy, error) {
+	// Extract analyticsEnabled from system parameters
+	analyticsEnabled := false
+	if enabled, ok := params["analyticsEnabled"].(bool); ok {
+		analyticsEnabled = enabled
+	}
+
+	return &AnalyticsHeaderFilterPolicy{
+		analyticsEnabled: analyticsEnabled,
+	}, nil
+}
+
+// Mode returns the processing mode for this policy
+// Only processes headers (request and response), no body processing needed
+func (p *AnalyticsHeaderFilterPolicy) Mode() policy.ProcessingMode {
+	return policy.ProcessingMode{
+		RequestHeaderMode:  policy.HeaderModeProcess,
+		RequestBodyMode:    policy.BodyModeSkip,
+		ResponseHeaderMode: policy.HeaderModeProcess,
+		ResponseBodyMode:   policy.BodyModeSkip,
+	}
+}
+
+// OnRequest processes request headers and filters specified headers from analytics
+func (p *AnalyticsHeaderFilterPolicy) OnRequest(ctx *policy.RequestContext, params map[string]interface{}) policy.RequestAction {
+	// If analytics is not enabled, skip processing
+	if !p.analyticsEnabled {
+		return nil
+	}
+
+	// Get the list of request headers to filter
+	headersToFilter := p.parseHeaderList(params, "requestHeadersToFilter")
+	if len(headersToFilter) == 0 {
+		slog.Debug("[analytics-header-filter] No request headers provided from the user")
+		return nil
+	}
+
+	// Build the filtered headers list by checking which headers actually exist
+	filteredHeaders := p.getMatchingHeaders(ctx.Headers, headersToFilter)
+	if len(filteredHeaders) == 0 {
+		slog.Debug("[analytics-header-filter] No matching headers found in request headers")
+		return nil
+	}
+
+	// Return analytics metadata with the list of filtered headers
+	// The analytics publisher will use this to exclude these headers
+	slog.Debug(fmt.Sprintf("[analytics-header-filter] Returning analytics metadata with the list of filtered request headers: %s", strings.Join(filteredHeaders, ",")))
+	return policy.UpstreamRequestModifications{
+		AnalyticsMetadata: map[string]any{
+			RequestHeadersFilteredKey: strings.Join(filteredHeaders, ","),
+		},
+	}
+}
+
+// OnResponse processes response headers and filters specified headers from analytics
+func (p *AnalyticsHeaderFilterPolicy) OnResponse(ctx *policy.ResponseContext, params map[string]interface{}) policy.ResponseAction {
+	// If analytics is not enabled, skip processing
+	if !p.analyticsEnabled {
+		return nil
+	}
+
+	// Get the list of response headers to filter
+	headersToFilter := p.parseHeaderList(params, "responseHeadersToFilter")
+	if len(headersToFilter) == 0 {
+		slog.Debug("[analytics-header-filter] No response headers provided from the user to filter")
+		return nil
+	}
+
+	// Build the filtered headers list by checking which headers actually exist
+	filteredHeaders := p.getMatchingHeaders(ctx.ResponseHeaders, headersToFilter)
+	if len(filteredHeaders) == 0 {
+		slog.Debug("[analytics-header-filter] No matching headers found in response headers")
+		return nil
+	}
+
+	// Return analytics metadata with the list of filtered headers
+	// The analytics publisher will use this to exclude these headers
+	slog.Debug(fmt.Sprintf("[analytics-header-filter] Returning analytics metadata with the list of filtered response headers: %s", strings.Join(filteredHeaders, ",")))
+	return policy.UpstreamResponseModifications{
+		AnalyticsMetadata: map[string]any{
+			ResponseHeadersFilteredKey: strings.Join(filteredHeaders, ","),
+		},
+	}
+}
+
+// parseHeaderList extracts a list of header names from the parameters
+func (p *AnalyticsHeaderFilterPolicy) parseHeaderList(params map[string]interface{}, key string) []string {
+	headersRaw, ok := params[key]
+	if !ok {
+		return nil
+	}
+
+	headersList, ok := headersRaw.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	headers := make([]string, 0, len(headersList))
+	for _, h := range headersList {
+		if headerName, ok := h.(string); ok && headerName != "" {
+			// Normalize header names to lowercase for case-insensitive matching
+			headers = append(headers, strings.ToLower(headerName))
+		}
+	}
+
+	return headers
+}
+
+// getMatchingHeaders returns headers that exist in the context and match the filter list
+func (p *AnalyticsHeaderFilterPolicy) getMatchingHeaders(headers *policy.Headers, filterList []string) []string {
+	if headers == nil {
+		return nil
+	}
+
+	matched := make([]string, 0)
+	for _, headerToFilter := range filterList {
+		// Headers.Has performs case-insensitive lookup
+		if headers.Has(headerToFilter) {
+			matched = append(matched, headerToFilter)
+		}
+	}
+
+	return matched
+}

--- a/gateway/policies/analytics-header-filter/v0.1.0/go.mod
+++ b/gateway/policies/analytics-header-filter/v0.1.0/go.mod
@@ -1,0 +1,8 @@
+module github.com/policy-engine/policies/analytics-header-filter
+
+go 1.23.0
+
+require github.com/wso2/api-platform/sdk v1.0.0
+
+replace github.com/wso2/api-platform/sdk => ../../../../sdk
+

--- a/gateway/policies/analytics-header-filter/v0.1.0/policy-definition.yaml
+++ b/gateway/policies/analytics-header-filter/v0.1.0/policy-definition.yaml
@@ -1,0 +1,41 @@
+name: analytics-header-filter
+version: v0.1.0
+description: |
+  Filters specified headers from being sent to analytics publishers.
+  This policy allows users to exclude sensitive or unwanted headers from analytics data.
+  The policy only operates when analytics is enabled at the system level.
+  Users must explicitly add this policy to their policy chain for it to take effect.
+
+parameters:
+  type: object
+  properties:
+    requestHeadersToFilter:
+      type: array
+      description: |
+        List of request header names to exclude from analytics data.
+        Header names are case-insensitive.
+      items:
+        type: string
+        description: Header name to filter from request analytics
+        minLength: 1
+        maxLength: 256
+    responseHeadersToFilter:
+      type: array
+      description: |
+        List of response header names to exclude from analytics data.
+        Header names are case-insensitive.
+      items:
+        type: string
+        description: Header name to filter from response analytics
+        minLength: 1
+        maxLength: 256
+
+systemParameters:
+  type: object
+  properties:
+    analyticsEnabled:
+      type: boolean
+      description: System-level flag indicating whether analytics is enabled. This policy only operates when this is set to true.
+      default: false
+      "wso2/defaultValue": "${config.analytics.enabled}"
+

--- a/gateway/policies/policy-manifest-lock.yaml
+++ b/gateway/policies/policy-manifest-lock.yaml
@@ -77,3 +77,7 @@ policies:
   - name: semantic-prompt-guard
     version: v0.1.0
     filePath: ./semantic-prompt-guard/v0.1.0
+
+  - name: analytics-header-filter
+    version: v0.1.0
+    filePath: ./analytics-header-filter/v0.1.0

--- a/gateway/policy-engine/internal/kernel/execution_context.go
+++ b/gateway/policy-engine/internal/kernel/execution_context.go
@@ -53,6 +53,10 @@ type PolicyExecutionContext struct {
 
 	// Reference to server components
 	server *ExternalProcessorServer
+
+	// Accumulated analytics metadata from all phases
+    // This accumulates across request headers, request body, response headers, response body
+    accumulatedAnalyticsData map[string]any
 }
 
 // newPolicyExecutionContext creates a new execution context for a request


### PR DESCRIPTION
## Purpose
This PR introduces a new analytics-header-filter policy that allows users to exclude sensitive headers from analytics data, along with a critical fix to ensure analytics metadata is properly preserved across all ext_proc processing phases.

Fix for: https://github.com/wso2/api-platform/issues/361

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added analytics header filter policy that excludes specified request and response headers from analytics data collection. The policy operates only when system-wide analytics is enabled and must be added to the policy chain to take effect.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->