### PR TITLE
Bug fixes in api key rotation

### DIFF
--- a/gateway/gateway-controller/pkg/utils/api_key.go
+++ b/gateway/gateway-controller/pkg/utils/api_key.go
@@ -717,7 +717,7 @@ func (s *APIKeyService) generateAPIKeyFromRequest(handle string, request *api.AP
 // Ignores the policies field from operations
 func (s *APIKeyService) generateOperationsString(operations []api.Operation) string {
 	if len(operations) == 0 {
-		return "[*]" // Default to all operations if none specified
+		return "[\"*\"]" // Default to all operations if none specified
 	}
 
 	var operationStrings []string
@@ -731,7 +731,7 @@ func (s *APIKeyService) generateOperationsString(operations []api.Operation) str
 	operationsJSON, err := json.Marshal(operationStrings)
 	if err != nil {
 		// Fallback to default if marshaling fails
-		return "[*]"
+		return "[\"*\"]"
 	}
 
 	return string(operationsJSON)


### PR DESCRIPTION
This pull request introduces improvements to the combined cache watcher lifecycle in the policy XDS gateway controller, as well as fixes and clarifications to API key operation string generation and key rotation logic. The changes ensure more robust cancellation of watcher goroutines, correct JSON formatting for operation strings, and proper handling of metadata during API key rotation.

Fixes: [wso2/api-platform/issues#618](https://github.com/wso2/api-platform/issues/618)

**Watcher lifecycle and cancellation improvements:**

* Added a `done` channel to the `combinedWatcher` struct and used it to signal goroutine cancellation, ensuring that response handler goroutines exit cleanly when a watch is canceled. Also, added a panic if `policyCache` or `apiKeyCache` are nil in `NewCombinedCache` and defaulted the logger to `zap.NewNop()` if nil. [[1]](diffhunk://#diff-2dff8c611c1ee5fd87f8a101a4e2c59168f1d32f42c2b2747998bc40dc6ffb2eR51-R62) [[2]](diffhunk://#diff-2dff8c611c1ee5fd87f8a101a4e2c59168f1d32f42c2b2747998bc40dc6ffb2eR87) [[3]](diffhunk://#diff-2dff8c611c1ee5fd87f8a101a4e2c59168f1d32f42c2b2747998bc40dc6ffb2eL98-R106) [[4]](diffhunk://#diff-2dff8c611c1ee5fd87f8a101a4e2c59168f1d32f42c2b2747998bc40dc6ffb2eL108-R117) [[5]](diffhunk://#diff-2dff8c611c1ee5fd87f8a101a4e2c59168f1d32f42c2b2747998bc40dc6ffb2eR126-R129) [[6]](diffhunk://#diff-2dff8c611c1ee5fd87f8a101a4e2c59168f1d32f42c2b2747998bc40dc6ffb2eR368-L367)

**API key operation string generation:**

* Fixed the default operations string to be a valid JSON array (`["*"]` instead of `[*]`) when no operations are specified, and applied this fix both in the default case and in the error fallback. [[1]](diffhunk://#diff-d41b0272042c043a01eaf740b1b497bae68cbbb34603fad2318540d5b46da9f9L720-R720) [[2]](diffhunk://#diff-d41b0272042c043a01eaf740b1b497bae68cbbb34603fad2318540d5b46da9f9L734-R734)

**API key rotation logic:**

* Updated the rotated API key logic to preserve the original key's `ID`, `CreatedAt`, and `CreatedBy` fields, ensuring that rotated keys maintain consistent metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rotated API keys now retain the original key ID, creation timestamp, and creator; rotation updates only update/expiration fields to preserve auditability.
  * Cache watching now properly signals cancellation to response handlers and validates inputs, improving stability when watchers are stopped or initialized with missing components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->