### PR TITLE
Refactor API key operation endpoints

### DIFF
--- a/docs/gateway/policies/apikey-authentication.md
+++ b/docs/gateway/policies/apikey-authentication.md
@@ -225,7 +225,7 @@ The gateway controller uses the authentication context of the requesting user to
 #### Basic Authentication Example
 
 ```bash
-curl -X POST "http://localhost:9090/apis/weather-api-v1.0/api-key" \
+curl -X POST "http://localhost:9090/apis/weather-api-v1.0/generate-api-key" \
   -H "Content-Type: application/json" \
   -u "username:password" \
   -d '{"name": "production-key"}'
@@ -234,7 +234,7 @@ curl -X POST "http://localhost:9090/apis/weather-api-v1.0/api-key" \
 #### JWT Authentication Example
 
 ```bash
-curl -X POST "http://localhost:9090/apis/weather-api-v1.0/api-key" \
+curl -X POST "http://localhost:9090/apis/weather-api-v1.0/generate-api-key" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..." \
   -d '{"name": "production-key"}'
@@ -244,7 +244,7 @@ curl -X POST "http://localhost:9090/apis/weather-api-v1.0/api-key" \
 
 Generate a new API key for a specific API.
 
-**Endpoint**: `POST /apis/{id}/api-key`
+**Endpoint**: `POST /apis/{id}/generate-api-key`
 
 #### Request Parameters
 
@@ -269,7 +269,7 @@ Generate a new API key for a specific API.
 | Field                | Type | Required | Description |
 |----------------------|------|----------|-------------|
 | `name`               | string | No | Custom name for the API key. If not provided, a default name will be generated |
-| `expires_at`         | string (ISO 8601) | No | Specific expiration timestamp for the API key |
+| `expires_at`         | string (ISO 8601) | No | Specific expiration timestamp for the API key. If both `expires_in` and `expires_at` are provided, `expires_at` takes precedence |
 | `expires_in`         | object | No | Relative expiration time from creation |
 | `expires_in.duration` | integer | Yes (if expiresIn used) | Duration value |
 | `expires_in.unit`     | string | Yes (if expiresIn used) | Time unit: `seconds`, `minutes`, `hours`, `days`, `weeks`, `months` |
@@ -278,7 +278,7 @@ Generate a new API key for a specific API.
 
 **Using Basic Authentication:**
 ```bash
-curl -X POST "http://localhost:9090/apis/weather-api-v1.0/api-key" \
+curl -X POST "http://localhost:9090/apis/weather-api-v1.0/generate-api-key" \
   -H "Content-Type: application/json" \
   -u "username:password" \
   -d '{
@@ -292,7 +292,7 @@ curl -X POST "http://localhost:9090/apis/weather-api-v1.0/api-key" \
 
 **Using JWT Authentication:**
 ```bash
-curl -X POST "http://localhost:9090/apis/weather-api-v1.0/api-key" \
+curl -X POST "http://localhost:9090/apis/weather-api-v1.0/generate-api-key" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..." \
   -d '{
@@ -338,12 +338,12 @@ curl -X POST "http://localhost:9090/apis/weather-api-v1.0/api-key" \
 | `apiKey.expires_at` | string | ISO 8601 expiration timestamp (if set)         |
 | `apiKey.operations` | array | Allowed operations (currently `["*"]` for all) |
 
-### View API Keys
+### List API Keys
 
-Retrieve a list of all active API keys for a specific API created by the authenticated user.
+Retrieve all active API keys for the specified API created by the user.
 If the user is an admin, all API keys for the API are returned.
 
-**Endpoint**: `GET /apis/{id}/api-key`
+**Endpoint**: `GET /apis/{id}/api-keys`
 
 #### Request Parameters
 
@@ -355,13 +355,13 @@ If the user is an admin, all API keys for the API are returned.
 
 **Using Basic Authentication:**
 ```bash
-curl -X GET "http://localhost:9090/apis/weather-api-v1.0/api-key" \
+curl -X GET "http://localhost:9090/apis/weather-api-v1.0/api-keys" \
   -u "username:password"
 ```
 
 **Using JWT Authentication:**
 ```bash
-curl -X GET "http://localhost:9090/apis/weather-api-v1.0/api-key" \
+curl -X GET "http://localhost:9090/apis/weather-api-v1.0/api-keys" \
   -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
 ```
 
@@ -372,7 +372,6 @@ curl -X GET "http://localhost:9090/apis/weather-api-v1.0/api-key" \
   "apiKeys": [
     {
       "apiId": "weather-api-v1.0",
-      "api_key": "",
       "created_at": "2025-12-22T13:02:24.504957558Z",
       "created_by": "john",
       "expires_at": "2025-12-23T13:02:24.504957558Z",
@@ -382,7 +381,6 @@ curl -X GET "http://localhost:9090/apis/weather-api-v1.0/api-key" \
     },
     {
       "apiId": "weather-api-v1.0",
-      "api_key": "",
       "created_at": "2025-12-22T13:02:24.504957558Z",
       "created_by": "admin",
       "expires_at": "2026-03-22T13:02:24.504957558Z",
@@ -411,7 +409,7 @@ curl -X GET "http://localhost:9090/apis/weather-api-v1.0/api-key" \
 Rotate an existing API key, generating a new key value while maintaining the same name and metadata.
 Only the user who created the key can perform this operation.
 
-**Endpoint**: `PUT /apis/{id}/api-key/{apiKeyName}`
+**Endpoint**: `POST /apis/{id}/api-keys/{apiKeyName}/regenerate`
 
 #### Request Parameters
 
@@ -437,7 +435,7 @@ Only the user who created the key can perform this operation.
 
 **Using Basic Authentication:**
 ```bash
-curl -X PUT "http://localhost:9090/apis/weather-api-v1.0/api-key/production-key" \
+curl -X POST "http://localhost:9090/apis/weather-api-v1.0/api-keys/production-key/regenerate" \
   -H "Content-Type: application/json" \
   -u "username:password" \
   -d '{
@@ -450,7 +448,7 @@ curl -X PUT "http://localhost:9090/apis/weather-api-v1.0/api-key/production-key"
 
 **Using JWT Authentication:**
 ```bash
-curl -X PUT "http://localhost:9090/apis/weather-api-v1.0/api-key/production-key" \
+curl -X POST "http://localhost:9090/apis/weather-api-v1.0/api-keys/production-key/regenerate" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..." \
   -d '{
@@ -487,32 +485,58 @@ curl -X PUT "http://localhost:9090/apis/weather-api-v1.0/api-key/production-key"
 Revoke an existing API key, making it permanently invalid for authentication.
 The user who created the key or an admin can perform this operation.
 
-**Endpoint**: `DELETE /apis/{id}/api-key/{apiKey}`
+**Endpoint**: `POST /apis/{id}/revoke-api-key`
 
 #### Request Parameters
 
 | Parameter | Type | Location | Required | Description |
 |-----------|------|----------|----------|-------------|
 | `id` | string | path | Yes | Unique public identifier of the API |
-| `apiKey` | string | path | Yes | The actual API key value to revoke |
+
+#### Request Body
+
+```json
+{
+  "api_key": "apip_4f3c2e1d5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d"
+}
+```
+
+**Request Body Schema:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `api_key` | string | Yes | The actual API key value to revoke |
 
 #### Example Request
 
 **Using Basic Authentication:**
 ```bash
-curl -X DELETE "http://localhost:9090/apis/weather-api-v1.0/api-key/apip_4f3c2e1d5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d" \
-  -u "username:password"
+curl -X POST "http://localhost:9090/apis/weather-api-v1.0/revoke-api-key" \
+  -H "Content-Type: application/json" \
+  -u "username:password" \
+  -d '{
+    "api_key": "apip_4f3c2e1d5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d"
+  }'
 ```
 
 **Using JWT Authentication:**
 ```bash
-curl -X DELETE "http://localhost:9090/apis/weather-api-v1.0/api-key/apip_4f3c2e1d5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d" \
-  -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+curl -X POST "http://localhost:9090/apis/weather-api-v1.0/revoke-api-key" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..." \
+  -d '{
+    "api_key": "apip_4f3c2e1d5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d"
+  }'
 ```
 
-#### Successful Response (204 No Content)
+#### Successful Response (200 OK)
 
-No response body is returned for successful revocation.
+```json
+{
+  "status": "success",
+  "message": "API key revoked successfully"
+}
+```
 
 **Note**: Once revoked, an API key cannot be restored. Generate a new API key if needed.
 

--- a/gateway/gateway-controller/api/openapi.yaml
+++ b/gateway/gateway-controller/api/openapi.yaml
@@ -347,7 +347,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
-  /apis/{id}/api-key:
+  /apis/{id}/generate-api-key:
     post:
       summary: Generate API key for an API
       description: |
@@ -402,10 +402,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
+  /apis/{id}/api-keys:
     get:
       summary: Get the list of API keys for an API
       description: |
-        Retrieve the list of all the active API keys for the specified API by the user.
+        Retrieve all active API keys for the specified API created by the user. If the user is an admin, retrieves all
+        active API keys for the API.
       operationId: listAPIKeys
       tags:
         - API Management
@@ -438,8 +440,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
-  /apis/{id}/api-key/{apiKeyName}:
-    put:
+  /apis/{id}/api-keys/{apiKeyName}/regenerate:
+    post:
       summary: Rotate API key for an API
       description: |
         Rotate the given API key for the specified API. The newly rotated key can be
@@ -501,8 +503,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
-  /apis/{id}/api-key/{apiKey}:
-    delete:
+  /apis/{id}/revoke-api-key:
+    post:
       summary: Revoke an API key
       description: |
         Revoke a previously generated API key for the specified API. Once revoked,
@@ -519,16 +521,22 @@ paths:
           schema:
             type: string
           example: weather-api-v1.0
-        - name: apiKey
-          in: path
-          required: true
-          description: The API key to revoke
-          schema:
-            type: string
-          example: apip_4f3c2e1d5a6b7c8d9e0f1a2b3c4d5e6f
+      requestBody:
+        required: true
+        content:
+          application/yaml:
+            schema:
+              $ref: "#/components/schemas/APIKeyRevocationRequest"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/APIKeyRevocationRequest"
       responses:
-        '204':
+        '200':
           description: API key revoked successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIKeyRevocationResponse"
         "400":
           description: Invalid configuration (validation failed)
           content:
@@ -2224,7 +2232,7 @@ components:
         expires_at:
           type: string
           format: date-time
-          description: Expiration timestamp
+          description: Expiration timestamp. If both expires_in and expires_at are provided, expires_at takes precedence.
           example: "2026-12-08T10:30:00Z"
     APIKeyGenerationResponse:
       type: object
@@ -2285,7 +2293,6 @@ components:
           example: "2025-12-08T10:30:00Z"
       required:
         - name
-        - api_key
         - apiId
         - operations
         - status
@@ -2322,6 +2329,27 @@ components:
           format: date-time
           description: Expiration timestamp
           example: "2026-12-08T10:30:00Z"
+    APIKeyRevocationRequest:
+      type: object
+      properties:
+        api_key:
+          type: string
+          description: API key to be revoked
+          example: "apip_1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+      required:
+        - api_key
+    APIKeyRevocationResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          example: success
+        message:
+          type: string
+          example: API key revoked successfully
+      required:
+        - status
+        - message
 
     APIListItem:
       type: object

--- a/gateway/gateway-controller/cmd/controller/main.go
+++ b/gateway/gateway-controller/cmd/controller/main.go
@@ -389,10 +389,10 @@ func generateAuthConfig(config *config.Config) commonmodels.AuthConfig {
 		"PUT /llm-proxies/:id":    {"admin", "developer"},
 		"DELETE /llm-proxies/:id": {"admin", "developer"},
 
-		"POST /apis/:id/api-key":            {"admin", "consumer"},
-		"GET /apis/:id/api-key":             {"admin", "consumer"},
-		"PUT /apis/:id/api-key/:apiKeyName": {"admin", "consumer"},
-		"DELETE /apis/:id/api-key/:apiKey":  {"admin", "consumer"},
+		"POST /apis/:id/generate-api-key":                {"admin", "consumer"},
+		"GET /apis/:id/api-keys":                         {"admin", "consumer"},
+		"POST /apis/:id/api-keys/:apiKeyName/regenerate": {"admin", "consumer"},
+		"POST /apis/:id/revoke-api-key":                  {"admin", "consumer"},
 
 		"GET /config_dump": {"admin"},
 	}


### PR DESCRIPTION
## Purpose
This pull request refactors and standardizes the API key management endpoints for the gateway controller, updating both the OpenAPI specification and documentation to reflect new RESTful naming conventions and improved request/response schemas.
Fixes: [wso2/api-platform/issues#612](https://github.com/wso2/api-platform/issues/612)

## Approach
The changes affect endpoint paths, request/response formats, and authentication documentation for API key generation, listing, rotation, and revocation.

Key changes include:

**API Endpoint Renaming and Standardization:**

- Renamed and restructured API key management endpoints for clarity and RESTful consistency, such as changing `POST /apis/{id}/api-key` to `POST /apis/{id}/generate-api-key`, `GET /apis/{id}/api-key` to `GET /apis/{id}/api-keys`, and introducing `POST /apis/{id}/api-keys/{apiKeyName}/regenerate` and `POST /apis/{id}/revoke-api-key` for rotation and revocation, respectively. [[1]](diffhunk://#diff-3a1e1e57bf74685d4db74eb5ba2bee8eb2cf4a6f8b603671904780930708e00bL350-R350) [[2]](diffhunk://#diff-3a1e1e57bf74685d4db74eb5ba2bee8eb2cf4a6f8b603671904780930708e00bR405-R410) [[3]](diffhunk://#diff-3a1e1e57bf74685d4db74eb5ba2bee8eb2cf4a6f8b603671904780930708e00bL441-R444) [[4]](diffhunk://#diff-3a1e1e57bf74685d4db74eb5ba2bee8eb2cf4a6f8b603671904780930708e00bL504-R507) [[5]](diffhunk://#diff-8a2e610ad42a25eef18e3b7000b3c9fc4d59aaba36d2db2ff77a2d0a787361ebL392-R395) [[6]](diffhunk://#diff-f401cc25eb936818080460b51942f4243ffa4a25804dc59cb272a9ab844544deL2293-R2293) [[7]](diffhunk://#diff-f401cc25eb936818080460b51942f4243ffa4a25804dc59cb272a9ab844544deL2362-R2363)

**Request and Response Schema Improvements:**

- Updated the revocation endpoint to accept the API key in the request body (as JSON or YAML) instead of as a path parameter, and changed the successful response to return a JSON body with status and message. [[1]](diffhunk://#diff-3a1e1e57bf74685d4db74eb5ba2bee8eb2cf4a6f8b603671904780930708e00bL522-R539) [[2]](diffhunk://#diff-3a1e1e57bf74685d4db74eb5ba2bee8eb2cf4a6f8b603671904780930708e00bR2332-R2352) [[3]](diffhunk://#diff-f401cc25eb936818080460b51942f4243ffa4a25804dc59cb272a9ab844544deL2380-R2403) [[4]](diffhunk://#diff-f401cc25eb936818080460b51942f4243ffa4a25804dc59cb272a9ab844544deL2429-R2431) [[5]](diffhunk://#diff-23f782030c80062599914e1b5b3569acf80627088add93c9d4fad45c6db6426fL490-R539)
- Clarified that if both `expires_in` and `expires_at` are provided for API key creation, `expires_at` takes precedence. [[1]](diffhunk://#diff-3a1e1e57bf74685d4db74eb5ba2bee8eb2cf4a6f8b603671904780930708e00bL2227-R2235) [[2]](diffhunk://#diff-23f782030c80062599914e1b5b3569acf80627088add93c9d4fad45c6db6426fL272-R272)

**Documentation Updates:**

- Updated all relevant documentation and example `curl` commands to use the new endpoint names and request formats, ensuring consistency and clarity for users. [[1]](diffhunk://#diff-23f782030c80062599914e1b5b3569acf80627088add93c9d4fad45c6db6426fL228-R228) [[2]](diffhunk://#diff-23f782030c80062599914e1b5b3569acf80627088add93c9d4fad45c6db6426fL237-R237) [[3]](diffhunk://#diff-23f782030c80062599914e1b5b3569acf80627088add93c9d4fad45c6db6426fL247-R247) [[4]](diffhunk://#diff-23f782030c80062599914e1b5b3569acf80627088add93c9d4fad45c6db6426fL281-R281) [[5]](diffhunk://#diff-23f782030c80062599914e1b5b3569acf80627088add93c9d4fad45c6db6426fL295-R295) [[6]](diffhunk://#diff-23f782030c80062599914e1b5b3569acf80627088add93c9d4fad45c6db6426fL341-R346) [[7]](diffhunk://#diff-23f782030c80062599914e1b5b3569acf80627088add93c9d4fad45c6db6426fL358-R364) [[8]](diffhunk://#diff-23f782030c80062599914e1b5b3569acf80627088add93c9d4fad45c6db6426fL414-R412) [[9]](diffhunk://#diff-23f782030c80062599914e1b5b3569acf80627088add93c9d4fad45c6db6426fL440-R438) [[10]](diffhunk://#diff-23f782030c80062599914e1b5b3569acf80627088add93c9d4fad45c6db6426fL453-R451) [[11]](diffhunk://#diff-23f782030c80062599914e1b5b3569acf80627088add93c9d4fad45c6db6426fL490-R539)

**OpenAPI Specification Enhancements:**

- Added new schema definitions for API key revocation requests and responses, and updated operation descriptions and examples for all affected endpoints. [[1]](diffhunk://#diff-3a1e1e57bf74685d4db74eb5ba2bee8eb2cf4a6f8b603671904780930708e00bR2332-R2352) [[2]](diffhunk://#diff-3a1e1e57bf74685d4db74eb5ba2bee8eb2cf4a6f8b603671904780930708e00bL2227-R2235) [[3]](diffhunk://#diff-3a1e1e57bf74685d4db74eb5ba2bee8eb2cf4a6f8b603671904780930708e00bL2288)

**Codebase Alignment:**

- Updated handler signatures and internal logic in `handlers.go` to match the new endpoint paths and request/response formats, including parsing the API key from the request body for revocation. [[1]](diffhunk://#diff-f401cc25eb936818080460b51942f4243ffa4a25804dc59cb272a9ab844544deL2293-R2293) [[2]](diffhunk://#diff-f401cc25eb936818080460b51942f4243ffa4a25804dc59cb272a9ab844544deL2362-R2363) [[3]](diffhunk://#diff-f401cc25eb936818080460b51942f4243ffa4a25804dc59cb272a9ab844544deL2380-R2403) [[4]](diffhunk://#diff-f401cc25eb936818080460b51942f4243ffa4a25804dc59cb272a9ab844544deL2429-R2431)

These changes improve the clarity, usability, and maintainability of the API key management functionality across the gateway controller.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **API Changes**
  * Reorganized API key management endpoints with updated paths and HTTP methods
  * Revoke endpoint now uses POST instead of DELETE with JSON request body
  * Generate, list, and rotate endpoints renamed for improved clarity
  * Response codes standardized (revoke now returns 200 OK instead of 204)
  * Enhanced API key expiration handling with detailed expires_in/expires_at precedence

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->