### PR TITLE
Remove all-in-one distribution mgt-portal -> platform-api healthcheck temporarily

### DIFF
--- a/distribution/all-in-one/docker-compose.yaml
+++ b/distribution/all-in-one/docker-compose.yaml
@@ -71,9 +71,6 @@ services:
       dockerfile: Dockerfile
     ports:
       - "5173:5173"
-    depends_on:
-      platform-api:
-        condition: service_healthy
 
 volumes:
   platform-api-data:


### PR DESCRIPTION
## Purpose
There is a failing heathcheck and it causes the distribution startup to fail. Disabling it temporarilty until a proper solution is added.

Tracked via - https://github.com/wso2/api-platform/issues/658

## Goals
> Describe **what solutions** this feature or fix introduces to address the problems outlined above.

## Approach
> Describe **how** you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service startup configuration to adjust initialization sequencing in the deployment stack.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->