### PR TITLE
Avoid generating self-signed cert everytime platform-api server starts

### DIFF
--- a/platform-api/src/cmd/main.go
+++ b/platform-api/src/cmd/main.go
@@ -33,7 +33,7 @@ func main() {
 	}
 
 	log.Printf("Starting HTTPS server on port %s...", cfg.Port)
-	if err := srv.Start(cfg.Port); err != nil {
+	if err := srv.Start(cfg.Port, cfg.TLS.CertDir); err != nil {
 		log.Fatal("Failed to start HTTPS server:", err)
 	}
 }

--- a/platform-api/src/config/config.go
+++ b/platform-api/src/config/config.go
@@ -44,6 +44,14 @@ type Server struct {
 
 	// Default DevPortal configurations
 	DefaultDevPortal DefaultDevPortal `envconfig:"DEFAULT_DEVPORTAL"`
+
+	// TLS configurations
+	TLS TLS `envconfig:"TLS"`
+}
+
+// TLS holds TLS certificate configuration
+type TLS struct {
+	CertDir string `envconfig:"CERT_DIR" default:"./data/certs"`
 }
 
 // JWT holds JWT-specific configuration

--- a/platform-api/src/internal/server/server.go
+++ b/platform-api/src/internal/server/server.go
@@ -30,6 +30,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"platform-api/src/internal/middleware"
 	"time"
 
@@ -154,8 +155,8 @@ func StartPlatformAPIServer(cfg *config.Server) (*Server, error) {
 	}, nil
 }
 
-// generateSelfSignedCert creates a self-signed certificate for development
-func generateSelfSignedCert() (tls.Certificate, error) {
+// generateSelfSignedCert creates a self-signed certificate for development and saves it to disk
+func generateSelfSignedCert(certPath, keyPath string) (tls.Certificate, error) {
 	// Generate private key
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
@@ -191,6 +192,15 @@ func generateSelfSignedCert() (tls.Certificate, error) {
 	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
 	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)})
 
+	// Save certificate and key to disk for persistence
+	if err := os.WriteFile(certPath, certPEM, 0644); err != nil {
+		return tls.Certificate{}, fmt.Errorf("failed to save certificate: %v", err)
+	}
+	if err := os.WriteFile(keyPath, keyPEM, 0600); err != nil {
+		return tls.Certificate{}, fmt.Errorf("failed to save private key: %v", err)
+	}
+	log.Printf("Saved certificate to %s and key to %s", certPath, keyPath)
+
 	// CreateOrganization TLS certificate
 	cert, err := tls.X509KeyPair(certPEM, keyPEM)
 	if err != nil {
@@ -201,42 +211,42 @@ func generateSelfSignedCert() (tls.Certificate, error) {
 }
 
 // Start starts the HTTPS server
-func (s *Server) Start(port string) error {
+func (s *Server) Start(port string, certDir string) error {
 	if port == "" {
 		return fmt.Errorf("port cannot be empty")
 	}
 
+	// Build certificate paths
+	certPath := filepath.Join(certDir, "cert.pem")
+	keyPath := filepath.Join(certDir, "key.pem")
+
 	var cert tls.Certificate
 
 	// Try to load existing certificates first
-	if _, err := os.Stat("cert.pem"); err == nil {
-		if _, err := os.Stat("key.pem"); err == nil {
-			cert, err = tls.LoadX509KeyPair("cert.pem", "key.pem")
+	if _, certErr := os.Stat(certPath); certErr == nil {
+		if _, keyErr := os.Stat(keyPath); keyErr == nil {
+			loadedCert, err := tls.LoadX509KeyPair(certPath, keyPath)
 			if err != nil {
 				log.Printf("Failed to load certificates: %v", err)
-				log.Println("Generating self-signed certificate for development...")
-				cert, err = generateSelfSignedCert()
-				if err != nil {
-					return fmt.Errorf("failed to generate self-signed certificate: %v", err)
-				}
 			} else {
-				log.Println("Using existing certificates: cert.pem and key.pem")
-			}
-		} else {
-			log.Println("Generating self-signed certificate for development...")
-			var err error
-			cert, err = generateSelfSignedCert()
-			if err != nil {
-				return fmt.Errorf("failed to generate self-signed certificate: %v", err)
+				log.Printf("Using existing certificates from %s", certDir)
+				cert = loadedCert
 			}
 		}
-	} else {
+	}
+
+	// Generate new certificate if not loaded
+	if cert.Certificate == nil {
 		log.Println("Generating self-signed certificate for development...")
-		var err error
-		cert, err = generateSelfSignedCert()
+		// Ensure cert directory exists
+		if err := os.MkdirAll(certDir, 0755); err != nil {
+			return fmt.Errorf("failed to create cert directory: %v", err)
+		}
+		generatedCert, err := generateSelfSignedCert(certPath, keyPath)
 		if err != nil {
 			return fmt.Errorf("failed to generate self-signed certificate: %v", err)
 		}
+		cert = generatedCert
 	}
 
 	// Add a health endpoint that works with self-signed certs


### PR DESCRIPTION
## Purpose
Fix: https://github.com/wso2/api-platform/issues/660

## Goals
> Describe **what solutions** this feature or fix introduces to address the problems outlined above.

## Approach
```
Persist generated certificates to disk so they survive restarts.                                                                                                                           
                                                                                                                                                                                                       
  Changes Made                                                                                                                                                                                         
  ┌───────────────────────────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐                                     
  │             File              │                                                            Change                                                            │                                     
  ├───────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤                                     
  │ src/config/config.go          │ Added TLS struct with CertDir field (default: ./data/certs)                                                                  │                                     
  ├───────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤                                     
  │ src/internal/server/server.go │ Modified generateSelfSignedCert() to save certs to disk; Updated Start() to load existing certs or generate+persist new ones │                                     
  ├───────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤                                     
  │ src/cmd/main.go               │ Pass cfg.TLS.CertDir to Start()                                                                                              │                                     
  └───────────────────────────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘                                     
  How It Works Now                                                                                                                                                                                     
                                                                                                                                                                                                       
  Server Start                                                                                                                                                                                         
      │                                                                                                                                                                                                
      ├─► Check if ./data/certs/cert.pem and key.pem exist                                                                                                                                             
      │       │                                                                                                                                                                                        
      │       ├─► YES: Load and use existing certs                                                                                                                                                     
      │       │        (log: "Using existing certificates from ./data/certs")                                                                                                                          
      │       │                                                                                                                                                                                        
      │       └─► NO: Generate new certs AND save to disk                                                                                                                                              
      │                (log: "Saved certificate to ./data/certs/cert.pem...")                                                                                                                          
      │                                                                                                                                                                                                
      └─► Start HTTPS server                                                                                                                                                                           
                                                                                                                                                                                                       
  Docker Integration                                                                                                                                                                                   
                                                                                                                                                                                                       
  The platform-api-data volume at /api-platform/data now stores both:                                                                                                                                  
  - Database: /api-platform/data/api_platform.db                                                                                                                                                       
  - Certificates: /api-platform/data/certs/cert.pem and key.pem                                                                                                                                        
                                                                                                                                                                                                       
  Configuration                                                                                                                                                                                        
                                                                                                                                                                                                       
  Override cert directory via environment variable:                                                                                                                                                    
  TLS_CERT_DIR=/custom/path ./platform-api                                                                                                                                                             
                                                      
```

## User stories
> Summary of user stories addressed by this change>

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TLS certificates are now persisted to disk and reused across server restarts, eliminating regeneration on each startup
  * Configurable certificate storage directory via server settings (defaults to ./data/certs)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->