### PR TITLE
[Metrics] Add Integration test for metrics support

### DIFF
--- a/gateway/it/docker-compose.test.yaml
+++ b/gateway/it/docker-compose.test.yaml
@@ -30,6 +30,7 @@ services:
       - "9010:9090"   # REST API
       - "18000:18000" # xDS gRPC
       - "18001:18001"
+      - "9091:9091"   # Metrics
     environment:
       - GATEWAY_STORAGE_TYPE=sqlite
       - GATEWAY_STORAGE_SQLITE_PATH=./data/gateway.db
@@ -59,6 +60,7 @@ services:
     command: ["-xds-server", "it-gateway-controller:18001"]
     ports:
       - "9002:9002"   # Admin API
+      - "9003:9003"   # Metrics
     volumes:
       - ./test-config.yaml:/app/configs/config.yaml:ro
     depends_on:

--- a/gateway/it/features/metrics.feature
+++ b/gateway/it/features/metrics.feature
@@ -1,0 +1,67 @@
+# --------------------------------------------------------------------
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# --------------------------------------------------------------------
+
+Feature: Gateway Metrics
+  As an operator
+  I want to verify that gateway components expose Prometheus metrics
+  So that I can monitor the health and performance of the gateway
+
+  Background:
+    Given the gateway services are running
+
+  Scenario: Gateway controller metrics endpoint is accessible
+    When I send a GET request to the gateway controller metrics endpoint
+    Then the response status code should be 200
+    And the response should contain Prometheus metrics
+
+  Scenario: Policy engine metrics endpoint is accessible
+    When I send a GET request to the policy engine metrics endpoint
+    Then the response status code should be 200
+    And the response should contain Prometheus metrics
+
+  Scenario: Gateway controller metrics reflect API operations
+    Given I am authenticated as "admin" with password "admin"
+    When I create a new API with name "metrics-test-api"
+    And I send a GET request to the gateway controller metrics endpoint
+    Then the response should contain metric "gateway_controller_api_operations_total"
+    And the response should contain metric "gateway_controller_apis_total"
+
+  Scenario: Policy engine metrics reflect request processing
+    Given I am authenticated as "admin" with password "admin"
+    And I create a new API with the following configuration:
+      """
+      {
+        "name": "metrics-api",
+        "version": "1.0",
+        "basePath": "/metrics-api",
+        "backend": {
+          "url": "http://sample-backend:9080"
+        },
+        "routes": [
+          {
+            "path": "/test",
+            "methods": ["GET"]
+          }
+        ]
+      }
+      """
+    And I wait for API deployment to complete
+    When I send a GET request to "/metrics-api/test" through the router
+    Then the response status code should be 200
+    When I send a GET request to the policy engine metrics endpoint
+    Then the response should contain metric "policy_engine_requests_total"

--- a/gateway/it/steps_metrics.go
+++ b/gateway/it/steps_metrics.go
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package it
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cucumber/godog"
+	"github.com/wso2/api-platform/gateway/it/steps"
+)
+
+const (
+	// GatewayControllerMetricsPort is the port for gateway-controller metrics
+	GatewayControllerMetricsPort = "9091"
+
+	// PolicyEngineMetricsPort is the port for policy-engine metrics
+	PolicyEngineMetricsPort = "9003"
+)
+
+// MetricsSteps wraps TestState and HTTPSteps for metrics step definitions
+type MetricsSteps struct {
+	state     *TestState
+	httpSteps *steps.HTTPSteps
+}
+
+// RegisterMetricsSteps registers all metrics step definitions
+func RegisterMetricsSteps(ctx *godog.ScenarioContext, state *TestState, httpSteps *steps.HTTPSteps) {
+	m := &MetricsSteps{state: state, httpSteps: httpSteps}
+	ctx.Step(`^I send a GET request to the gateway controller metrics endpoint$`, m.iSendGETRequestToGatewayControllerMetrics)
+	ctx.Step(`^I send a GET request to the policy engine metrics endpoint$`, m.iSendGETRequestToPolicyEngineMetrics)
+	ctx.Step(`^the response should contain Prometheus metrics$`, m.theResponseShouldContainPrometheusMetrics)
+	ctx.Step(`^the response should contain metric "([^"]*)"$`, m.theResponseShouldContainMetric)
+}
+
+// iSendGETRequestToGatewayControllerMetrics sends a GET request to the gateway controller metrics endpoint
+func (m *MetricsSteps) iSendGETRequestToGatewayControllerMetrics() error {
+	url := fmt.Sprintf("http://localhost:%s/metrics", GatewayControllerMetricsPort)
+	return m.httpSteps.SendGETRequest(url)
+}
+
+// iSendGETRequestToPolicyEngineMetrics sends a GET request to the policy engine metrics endpoint
+func (m *MetricsSteps) iSendGETRequestToPolicyEngineMetrics() error {
+	url := fmt.Sprintf("http://localhost:%s/metrics", PolicyEngineMetricsPort)
+	return m.httpSteps.SendGETRequest(url)
+}
+
+// theResponseShouldContainPrometheusMetrics verifies the response contains valid Prometheus metrics
+func (m *MetricsSteps) theResponseShouldContainPrometheusMetrics() error {
+	resp := m.httpSteps.LastResponse()
+	if resp == nil {
+		return fmt.Errorf("no response received")
+	}
+
+	body := m.httpSteps.LastBody()
+	bodyStr := string(body)
+
+	// Check for Prometheus metric format indicators
+	// Valid metrics should have lines starting with # (comments) or metric names
+	if !strings.Contains(bodyStr, "# HELP") && !strings.Contains(bodyStr, "# TYPE") {
+		return fmt.Errorf("response does not contain Prometheus metric format headers")
+	}
+
+	// Ensure there's actual metric data (not just comments)
+	lines := strings.Split(bodyStr, "\n")
+	hasMetricData := false
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		// Skip empty lines and comments
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		// If we find a non-empty, non-comment line, it's metric data
+		hasMetricData = true
+		break
+	}
+
+	if !hasMetricData {
+		return fmt.Errorf("response contains Prometheus headers but no actual metric data")
+	}
+
+	return nil
+}
+
+// theResponseShouldContainMetric verifies the response contains a specific metric
+func (m *MetricsSteps) theResponseShouldContainMetric(metricName string) error {
+	body := m.httpSteps.LastBody()
+	bodyStr := string(body)
+
+	if !strings.Contains(bodyStr, metricName) {
+		return fmt.Errorf("response does not contain metric '%s'", metricName)
+	}
+
+	return nil
+}

--- a/gateway/it/suite_test.go
+++ b/gateway/it/suite_test.go
@@ -70,6 +70,7 @@ func TestFeatures(t *testing.T) {
 			Format: "pretty",
 			Paths: []string{
 				"features/health.feature",
+				"features/metrics.feature",
 				"features/api_deploy.feature",
 				"features/mcp_deploy.feature",
 				"features/ratelimit.feature",
@@ -218,6 +219,7 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	// Register step definitions
 	if testState != nil {
 		RegisterHealthSteps(ctx, testState, httpSteps)
+		RegisterMetricsSteps(ctx, testState, httpSteps)
 		RegisterAuthSteps(ctx, testState, httpSteps)
 		RegisterAPISteps(ctx, testState, httpSteps)
 		RegisterMCPSteps(ctx, testState, httpSteps)

--- a/gateway/it/test-config.yaml
+++ b/gateway/it/test-config.yaml
@@ -217,6 +217,14 @@ gateway_controller:
       # Expected issuer value in the JWT `iss` claim
       issuer: ""
 
+  # Metrics configuration
+  metrics:
+    # Enable or disable Prometheus metrics endpoint
+    enabled: true
+
+    # Port for metrics HTTP server
+    port: 9091
+
   # Logging configuration
   logging:
     # Log level: "debug", "info", "warn", or "error"
@@ -290,6 +298,14 @@ policy_engine:
   # File-based configuration (not used in xDS mode)
   file_config:
     path: ""
+
+  # Metrics configuration
+  metrics:
+    # Enable or disable Prometheus metrics endpoint
+    enabled: true
+
+    # Port for metrics HTTP server
+    port: 9003
 
   # Logging configuration
   logging:

--- a/gateway/policies/jwt-auth/v0.1.0/go.mod
+++ b/gateway/policies/jwt-auth/v0.1.0/go.mod
@@ -1,6 +1,6 @@
 module github.com/policy-engine/policies/jwt-auth
 
-go 1.23.0
+go 1.25.1
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.2.2

--- a/gateway/policies/jwt-auth/v0.1.0/go.sum
+++ b/gateway/policies/jwt-auth/v0.1.0/go.sum
@@ -1,2 +1,4 @@
 github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
 github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
+github.com/wso2/api-platform/sdk v0.3.1 h1:Wr4n+xiJMOH1oqOMyGhiw9bTxCR97OTO5VZMPpp07lc=
+github.com/wso2/api-platform/sdk v0.3.1/go.mod h1:amQIiBlKZEeFFbDhYzIOj47ADc5mDPMNzhR40SByqB8=


### PR DESCRIPTION
This PR introduces a integration test for Prometheus metrics support across the API Platform Gateway components, primarily targeting the `gateway-controller` and `policy-engine`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled Prometheus metrics endpoints for gateway controller and policy engine monitoring.
  * Added wildcard issuer support in JWT authentication for flexible token validation.

* **Tests**
  * Added metrics integration tests to validate endpoint accessibility and metric data integrity.

* **Chores**
  * Updated Go language version requirement.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->