### PR TITLE
Remove gatewayClassName from APIGateway CRD

### DIFF
--- a/.github/workflows/operator-integration-test.yml
+++ b/.github/workflows/operator-integration-test.yml
@@ -841,7 +841,6 @@ jobs:
             name: test-gateway
             namespace: default
           spec:
-            gatewayClassName: "test"
             apiSelector:
               scope: Cluster
             configRef:
@@ -1296,7 +1295,6 @@ jobs:
             name: scoped-gateway
             namespace: scoped-test
           spec:
-            gatewayClassName: "test"
             apiSelector:
               scope: Cluster
             configRef:

--- a/kubernetes/gateway-operator/api/v1alpha1/apigateway_types.go
+++ b/kubernetes/gateway-operator/api/v1alpha1/apigateway_types.go
@@ -99,11 +99,6 @@ type GatewayInfrastructure struct {
 
 // GatewaySpec defines the desired state of APIGateway
 type GatewaySpec struct {
-	// GatewayClassName is an optional identifier for grouping gateways
-	// This can be used to categorize gateways (e.g., "production", "development")
-	// +optional
-	GatewayClassName string `json:"gatewayClassName,omitempty"`
-
 	// APISelector defines how this gateway selects which APIs to route
 	// +kubebuilder:validation:Required
 	APISelector APISelector `json:"apiSelector"`

--- a/kubernetes/gateway-operator/config/crd/bases/gateway.api-platform.wso2.com_apigateways.yaml
+++ b/kubernetes/gateway-operator/config/crd/bases/gateway.api-platform.wso2.com_apigateways.yaml
@@ -185,11 +185,6 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                 type: object
-              gatewayClassName:
-                description: |-
-                  GatewayClassName is an optional identifier for grouping gateways
-                  This can be used to categorize gateways (e.g., "production", "development")
-                type: string
               infrastructure:
                 description: Infrastructure defines the deployment configuration for
                   the gateway

--- a/kubernetes/gateway-operator/config/samples/api_v1_apigateway.yaml
+++ b/kubernetes/gateway-operator/config/samples/api_v1_apigateway.yaml
@@ -6,8 +6,6 @@ kind: APIGateway
 metadata:
   name: cluster-gateway
 spec:
-  gatewayClassName: "production"
-  
   apiSelector:
     scope: Cluster
   

--- a/kubernetes/gateway-operator/config/samples/gateway-custom-config.yaml
+++ b/kubernetes/gateway-operator/config/samples/gateway-custom-config.yaml
@@ -586,8 +586,6 @@ data:
 #   name: custom-gateway
 #   namespace: default
 # spec:
-#   gatewayClassName: production
-
 #   apiSelector:
 #     scope: LabelSelector
 #     matchLabels:
@@ -615,8 +613,6 @@ metadata:
   name: default-gateway
   namespace: default
 spec:
-  gatewayClassName: development-1
-
   apiSelector:
     scope: Cluster
 

--- a/kubernetes/gateway-operator/internal/controller/apigateway_controller.go
+++ b/kubernetes/gateway-operator/internal/controller/apigateway_controller.go
@@ -885,12 +885,11 @@ func (r *GatewayReconciler) registerGateway(ctx context.Context, gatewayConfig *
 
 	// Create gateway info for registry
 	gatewayInfo := &registry.GatewayInfo{
-		Name:             gatewayConfig.Name,
-		Namespace:        namespace,
-		GatewayClassName: gatewayConfig.Spec.GatewayClassName,
-		APISelector:      &gatewayConfig.Spec.APISelector,
-		ServiceName:      service.Name,
-		ServicePort:      restPort,
+		Name:        gatewayConfig.Name,
+		Namespace:   namespace,
+		APISelector: &gatewayConfig.Spec.APISelector,
+		ServiceName: service.Name,
+		ServicePort: restPort,
 	}
 
 	if gatewayConfig.Spec.ControlPlane != nil {

--- a/kubernetes/gateway-operator/internal/registry/gateway_registry.go
+++ b/kubernetes/gateway-operator/internal/registry/gateway_registry.go
@@ -28,7 +28,6 @@ import (
 type GatewayInfo struct {
 	Name             string
 	Namespace        string
-	GatewayClassName string
 	APISelector      *apiv1.APISelector
 	ServiceName      string // Name of the gateway controller service
 	ServicePort      int32  // Port of the gateway controller API

--- a/kubernetes/helm/operator-helm-chart/crds/gateway.api-platform.wso2.com_apigateways.yaml
+++ b/kubernetes/helm/operator-helm-chart/crds/gateway.api-platform.wso2.com_apigateways.yaml
@@ -185,11 +185,6 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                 type: object
-              gatewayClassName:
-                description: |-
-                  GatewayClassName is an optional identifier for grouping gateways
-                  This can be used to categorize gateways (e.g., "production", "development")
-                type: string
               infrastructure:
                 description: Infrastructure defines the deployment configuration for
                   the gateway


### PR DESCRIPTION
Fixes: https://github.com/wso2/api-platform/issues/780

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the `gatewayClassName` field from APIGateway specifications. Gateway classes are now determined through default or global settings rather than per-resource configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->