### PR TITLE
Bump image and chart versions to 0.3.0 in gateway and operator Helm charts

### DIFF
--- a/kubernetes/helm/gateway-helm-chart/values.yaml
+++ b/kubernetes/helm/gateway-helm-chart/values.yaml
@@ -312,7 +312,7 @@ gateway:
   controller:
     image:
       repository: ghcr.io/wso2/api-platform/gateway-controller
-      tag: "0.2.0"
+      tag: "0.3.0"
       pullPolicy: Always
     imagePullSecrets: []
     service:
@@ -447,7 +447,7 @@ gateway:
   router:
     image:
       repository: ghcr.io/wso2/api-platform/gateway-router
-      tag: "0.2.0"
+      tag: "0.3.0"
       pullPolicy: Always
     imagePullSecrets: []
     service:
@@ -504,7 +504,7 @@ gateway:
   policyEngine:
     image:
       repository: ghcr.io/wso2/api-platform/policy-engine
-      tag: "0.2.0"
+      tag: "0.3.0"
       pullPolicy: Always
     imagePullSecrets: []
     service:

--- a/kubernetes/helm/operator-helm-chart/values.yaml
+++ b/kubernetes/helm/operator-helm-chart/values.yaml
@@ -12,7 +12,7 @@ image:
   # repository: ghcr.io/wso2/api-platform/gateway-operator
   # For local registry: host.docker.internal:5000/gateway-operator
   repository: ghcr.io/wso2/api-platform/gateway-operator
-  tag: "0.2.0"
+  tag: "0.3.0"
   pullPolicy: Always  # Uses locally loaded image from nerdctl load
 
 serviceAccount:
@@ -55,7 +55,7 @@ gateway:
   controlPlaneHost: "http://platform-api:3001"
   helm:
     chartName: "oci://ghcr.io/wso2/api-platform/helm-charts/gateway"
-    chartVersion: "0.2.0"
+    chartVersion: "0.3.0"
     valuesFilePath: "/config/gateway_values.yaml"
     # Allow insecure connections to OCI registries (skips TLS verification, still uses HTTPS)
     insecureRegistry: false
@@ -370,7 +370,7 @@ gateway:
       controller:
         image:
           repository: ghcr.io/wso2/api-platform/gateway-controller
-          tag: "0.2.0"
+          tag: "0.3.0"
           pullPolicy: Always
         imagePullSecrets: []
         service:
@@ -501,7 +501,7 @@ gateway:
       router:
         image:
           repository: ghcr.io/wso2/api-platform/gateway-router
-          tag: "0.2.0"
+          tag: "0.3.0"
           pullPolicy: Always
         imagePullSecrets: []
         service:
@@ -558,7 +558,7 @@ gateway:
       policyEngine:
         image:
           repository: ghcr.io/wso2/api-platform/policy-engine
-          tag: "0.2.0"
+          tag: "0.3.0"
           pullPolicy: Always
         imagePullSecrets: []
         service:


### PR DESCRIPTION
## Purpose
> Explain **why** this feature or fix is required. Describe the underlying problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

## Goals
> Describe **what solutions** this feature or fix introduces to address the problems outlined above.

## Approach
> Describe **how** you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart component image tags from 0.2.0 to 0.3.0 for gateway controller, router, and policy engine components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->