### PR TITLE
Bump image and chart versions to 0.4.0 for gateway components

### DIFF
--- a/kubernetes/helm/gateway-helm-chart/values.yaml
+++ b/kubernetes/helm/gateway-helm-chart/values.yaml
@@ -312,7 +312,7 @@ gateway:
   controller:
     image:
       repository: ghcr.io/wso2/api-platform/gateway-controller
-      tag: "0.3.0"
+      tag: "0.4.0"
       pullPolicy: Always
     imagePullSecrets: []
     service:
@@ -447,7 +447,7 @@ gateway:
   router:
     image:
       repository: ghcr.io/wso2/api-platform/gateway-router
-      tag: "0.3.0"
+      tag: "0.4.0"
       pullPolicy: Always
     imagePullSecrets: []
     service:
@@ -504,7 +504,7 @@ gateway:
   policyEngine:
     image:
       repository: ghcr.io/wso2/api-platform/policy-engine
-      tag: "0.3.0"
+      tag: "0.4.0"
       pullPolicy: Always
     imagePullSecrets: []
     service:

--- a/kubernetes/helm/operator-helm-chart/values.yaml
+++ b/kubernetes/helm/operator-helm-chart/values.yaml
@@ -12,7 +12,7 @@ image:
   # repository: ghcr.io/wso2/api-platform/gateway-operator
   # For local registry: host.docker.internal:5000/gateway-operator
   repository: ghcr.io/wso2/api-platform/gateway-operator
-  tag: "0.3.0"
+  tag: "0.4.0"
   pullPolicy: Always  # Uses locally loaded image from nerdctl load
 
 serviceAccount:
@@ -55,7 +55,7 @@ gateway:
   controlPlaneHost: "http://platform-api:3001"
   helm:
     chartName: "oci://ghcr.io/wso2/api-platform/helm-charts/gateway"
-    chartVersion: "0.3.0"
+    chartVersion: "0.4.0"
     valuesFilePath: "/config/gateway_values.yaml"
     # Allow insecure connections to OCI registries (skips TLS verification, still uses HTTPS)
     insecureRegistry: false
@@ -370,7 +370,7 @@ gateway:
       controller:
         image:
           repository: ghcr.io/wso2/api-platform/gateway-controller
-          tag: "0.3.0"
+          tag: "0.4.0"
           pullPolicy: Always
         imagePullSecrets: []
         service:
@@ -501,7 +501,7 @@ gateway:
       router:
         image:
           repository: ghcr.io/wso2/api-platform/gateway-router
-          tag: "0.3.0"
+          tag: "0.4.0"
           pullPolicy: Always
         imagePullSecrets: []
         service:
@@ -558,7 +558,7 @@ gateway:
       policyEngine:
         image:
           repository: ghcr.io/wso2/api-platform/policy-engine
-          tag: "0.3.0"
+          tag: "0.4.0"
           pullPolicy: Always
         imagePullSecrets: []
         service:


### PR DESCRIPTION
## Purpose
> $subect

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart configurations to version 0.4.0 for the operator and associated gateway components (controller, router, and policy engine).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->