### PR TITLE
Adding schema creation flag configuration for postgres

### DIFF
--- a/distribution/all-in-one/docker-compose.yaml
+++ b/distribution/all-in-one/docker-compose.yaml
@@ -70,6 +70,7 @@ services:
       - DATABASE_MAX_IDLE_CONNS=10
       - DATABASE_CONN_MAX_LIFETIME=300
       - DB_SCHEMA_PATH=./schema.postgres.sql
+      - DATABASE_EXECUTE_SCHEMA_DDL=true
     depends_on:
       postgres:
         condition: service_healthy

--- a/platform-api/src/config/config.go
+++ b/platform-api/src/config/config.go
@@ -86,6 +86,11 @@ type Database struct {
 	MaxOpenConns    int    `envconfig:"MAX_OPEN_CONNS" default:"25"`
 	MaxIdleConns    int    `envconfig:"MAX_IDLE_CONNS" default:"10"`
 	ConnMaxLifetime int    `envconfig:"CONN_MAX_LIFETIME" default:"300"` // seconds
+
+	// ExecuteSchemaDDL controls whether to run the schema DDL (CREATE TABLE, etc.) on startup.
+	// Set to false when the DB user lacks DDL privileges (e.g. deployed Postgres with restricted role).
+	// Env: DATABASE_EXECUTE_SCHEMA_DDL (default: true)
+	ExecuteSchemaDDL bool `envconfig:"EXECUTE_SCHEMA_DDL" default:"true"`
 }
 
 // DefaultDevPortal holds default DevPortal configuration for new organizations

--- a/platform-api/src/internal/server/server.go
+++ b/platform-api/src/internal/server/server.go
@@ -63,9 +63,13 @@ func StartPlatformAPIServer(cfg *config.Server) (*Server, error) {
 		return nil, err
 	}
 
-	// Initialize schema
-	if err := db.InitSchema(cfg.DBSchemaPath); err != nil {
-		return nil, err
+	// Initialize schema (skip when ExecuteSchemaDDL is false, e.g. deployed Postgres without DDL access)
+	if cfg.Database.ExecuteSchemaDDL {
+		if err := db.InitSchema(cfg.DBSchemaPath); err != nil {
+			return nil, err
+		}
+	} else {
+		log.Printf("Skipping schema DDL execution (DATABASE_EXECUTE_SCHEMA_DDL=false)\n")
 	}
 
 	// Initialize repositories


### PR DESCRIPTION
## Purpose
Adding schema creation flag configuration for postgres


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable control for database schema initialization during startup via the `DATABASE_EXECUTE_SCHEMA_DDL` environment variable (default: enabled).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->