### PR TITLE
Bumping jwt auth policy version to v0.1.2

### DIFF
--- a/.github/workflows/operator-integration-test.yml
+++ b/.github/workflows/operator-integration-test.yml
@@ -974,7 +974,7 @@ jobs:
                 url: http://httpbin.default.svc.cluster.local:80
             policies:
               - name: jwt-auth
-                version: v0.1.1
+                version: v0.1.2
                 params:
                   issuers:
                     - MockKeyManager
@@ -1052,7 +1052,7 @@ jobs:
                 url: http://httpbin.default.svc.cluster.local:80
             policies:
               - name: jwt-auth
-                version: v0.1.1
+                version: v0.1.2
                 params:
                   issuers:
                     - DummyKeyManager

--- a/gateway/gateway-controller/default-policies/jwt-auth.yaml
+++ b/gateway/gateway-controller/default-policies/jwt-auth.yaml
@@ -1,5 +1,5 @@
 name: jwt-auth
-version: v0.1.1
+version: v0.1.2
 description: |
   Validates JWT access tokens using one or more JWKS providers (key managers).
   System-level configuration holds key manager endpoints and fetch behavior.
@@ -45,6 +45,13 @@ parameters:
     authHeaderPrefix:
       type: string
       description: Override for the authorization header scheme prefix (e.g., "Bearer", "JWT"). If specified at user-level, takes precedence over system configuration for this route.
+
+    userIdClaim:
+      type: string
+      description: >-
+        Claim name to extract the user ID from the JWT token for analytics.
+        If not specified, defaults to "sub" claim.
+      default: sub
 
 systemParameters:          
   type: object

--- a/gateway/it/features/jwt-auth.feature
+++ b/gateway/it/features/jwt-auth.feature
@@ -47,7 +47,7 @@ Feature: JWT Authentication
             path: /protected
             policies:
               - name: jwt-auth
-                version: v0.1.1
+                version: v0.1.2
                 params:
                   issuers:
                     - mock-jwks
@@ -81,7 +81,7 @@ Feature: JWT Authentication
             path: /protected
             policies:
               - name: jwt-auth
-                version: v0.1.1
+                version: v0.1.2
                 params:
                   issuers:
                     - mock-jwks
@@ -116,7 +116,7 @@ Feature: JWT Authentication
             path: /protected
             policies:
               - name: jwt-auth
-                version: v0.1.1
+                version: v0.1.2
                 params:
                   issuers:
                     - mock-jwks
@@ -152,7 +152,7 @@ Feature: JWT Authentication
             path: /protected
             policies:
               - name: jwt-auth
-                version: v0.1.1
+                version: v0.1.2
                 params:
                   issuers:
                     - mock-jwks
@@ -187,7 +187,7 @@ Feature: JWT Authentication
             path: /protected
             policies:
               - name: jwt-auth
-                version: v0.1.1
+                version: v0.1.2
                 params:
                   issuers:
                     - wrong-issuer-km
@@ -223,7 +223,7 @@ Feature: JWT Authentication
             path: /protected
             policies:
               - name: jwt-auth
-                version: v0.1.1
+                version: v0.1.2
                 params:
                   issuers:
                     - mock-jwks
@@ -259,7 +259,7 @@ Feature: JWT Authentication
             path: /protected
             policies:
               - name: jwt-auth
-                version: v0.1.1
+                version: v0.1.2
                 params:
                   issuers:
                     - mock-jwks
@@ -297,7 +297,7 @@ Feature: JWT Authentication
             path: /protected
             policies:
               - name: jwt-auth
-                version: v0.1.1
+                version: v0.1.2
                 params:
                   issuers:
                     - mock-jwks
@@ -333,7 +333,7 @@ Feature: JWT Authentication
             path: /protected
             policies:
               - name: jwt-auth
-                version: v0.1.1
+                version: v0.1.2
                 params:
                   issuers:
                     - mock-jwks
@@ -372,7 +372,7 @@ Feature: JWT Authentication
             path: /protected
             policies:
               - name: jwt-auth
-                version: v0.1.1
+                version: v0.1.2
                 params:
                   issuers:
                     - mock-jwks
@@ -407,7 +407,7 @@ Feature: JWT Authentication
             path: /protected
             policies:
               - name: jwt-auth
-                version: v0.1.1
+                version: v0.1.2
                 params:
                   issuers:
                     - mock-jwks


### PR DESCRIPTION
## Purpose
- $subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JWT authentication policy now exposes a configurable userIdClaim parameter (string), defaulting to "sub".

* **Version Updates**
  * JWT authentication policy bumped to v0.1.2.

* **Tests / Chores**
  * Integration tests and CI workflows updated to reference the new JWT policy version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->