### PR TITLE
Use gw builder entrypoint to set system manifest lock

### DIFF
--- a/gateway/gateway-builder/Dockerfile
+++ b/gateway/gateway-builder/Dockerfile
@@ -81,6 +81,9 @@ COPY --from=sdk . /api-platform/sdk
 # Set working directory
 WORKDIR /workspace
 
-# Set entrypoint to builder binary
-ENTRYPOINT [ "/usr/local/bin/gateway-builder" ]
-CMD [ "-system-manifest-lock", "/api-platform/gateway/system-policies/system-policy-manifest-lock.yaml" ]
+# Set entrypoint to builder binary with system manifest lock
+ENTRYPOINT [ \
+    "/usr/local/bin/gateway-builder", \
+    "-system-manifest-lock", \
+    "/api-platform/gateway/system-policies/system-policy-manifest-lock.yaml" \
+]


### PR DESCRIPTION
## Purpose
Related Issue: https://github.com/wso2/api-platform/issues/876

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated gateway service deployment configuration to streamline container startup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->