### PR TITLE
fix: wait for mock-openapi to be healthy before starting nginx proxy

### DIFF
--- a/gateway/it/docker-compose.test.yaml
+++ b/gateway/it/docker-compose.test.yaml
@@ -158,7 +158,7 @@ services:
     volumes:
       - ./mock-api:/api:ro
     healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "http://127.0.0.1:4010/health"]
+      test: ["CMD", "wget", "--spider", "--quiet", "--tries=1", "http://127.0.0.1:4010/health"]
       interval: 5s
       timeout: 3s
       retries: 10


### PR DESCRIPTION
## Purpose
> Fixes intermittent test suite startup failure where `it-mock-openapi-https` exits due to nginx failing to resolve upstream `mock-openapi` host before it's ready.

## Goals
> Ensure reliable test suite startup by waiting for mock-openapi to be healthy before starting the nginx proxy.

## Approach
> Added `depends_on` with `service_healthy` condition to `mock-openapi-https` in `docker-compose.test.yaml`.

## User stories
> Summary of user stories addressed by this change>

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved test infrastructure reliability by enforcing service startup ordering so the HTTPS wrapper waits for the mock OpenAPI service to be healthy.
  * Updated the mock service healthcheck to use a quieter, spider-style wget invocation, reducing noisy logs during tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->