### PR TITLE
 Try to fix set array values in Gateway config.toml

### DIFF
--- a/gateway/gateway-controller/pkg/config/config.go
+++ b/gateway/gateway-controller/pkg/config/config.go
@@ -33,6 +33,11 @@ import (
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/constants"
 )
 
+import (
+	"encoding/json"
+	"os"
+)
+
 const (
 	// EnvPrefix is the prefix for environment variables used to configure the gateway-controller
 	EnvPrefix = "APIP_GW_"
@@ -390,6 +395,10 @@ func LoadConfig(configPath string) (*Config, error) {
 		return nil, fmt.Errorf("failed to load environment variables: %w", err)
 	}
 
+	if err := loadBasicAuthUsersFromEnv(k); err != nil {
+		return nil, err
+	}
+	
 	// Unmarshal into Config struct with DecodeHook for duration strings
 	if err := k.UnmarshalWithConf("", cfg, koanf.UnmarshalConf{
 		DecoderConfig: &mapstructure.DecoderConfig{
@@ -408,6 +417,26 @@ func LoadConfig(configPath string) (*Config, error) {
 	}
 
 	return cfg, nil
+}
+
+func loadBasicAuthUsersFromEnv(k *koanf.Koanf) error {
+	envKey := EnvPrefix + "GATEWAY_CONTROLLER_AUTH_BASIC_USERS_JSON"
+
+	raw := os.Getenv(envKey)
+	if strings.TrimSpace(raw) == "" {
+		return nil // env var not set - do nothing
+	}
+
+	var users []AuthUser
+	if err := json.Unmarshal([]byte(raw), &users); err != nil {
+		return fmt.Errorf(
+			"invalid JSON in %s: %w", envKey, err,
+		)
+	}
+
+	//Override the users array directly in Koanf
+	k.Set("gateway_controller.auth.basic.users", users)
+	return nil
 }
 
 // defaultConfig returns a Config struct with default configuration values


### PR DESCRIPTION
Purpose

The Gateway Controller fails to initialize the SQLite database on Windows due to a CGO limitation. This prevents the gateway from starting and blocks testing on Windows systems.
Resolves issue: SQLite initialization fails on Windows due to CGO_DISABLED.

Goals

Allow developers to run and test the Gateway Controller on Windows without needing to build the binary from source with CGO enabled. Provide clear instructions and configuration for database compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added environment-based configuration support for basic authentication users. Gateway controller authentication settings can now be dynamically provisioned at deployment time through environment variables, eliminating the need to modify configuration files. This enhancement provides greater operational flexibility for containerized and cloud-native deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->