### PR TITLE
Gateway Controller - API Key Update Restrictions

### DIFF
--- a/gateway/gateway-controller/pkg/api/handlers/handlers.go
+++ b/gateway/gateway-controller/pkg/api/handlers/handlers.go
@@ -2550,7 +2550,12 @@ func (s *APIServer) UpdateAPIKey(c *gin.Context, id string, apiKeyName string) {
 	result, err := s.apiKeyService.UpdateAPIKey(params)
 	if err != nil {
 		// Check error type to determine appropriate status code
-		if strings.Contains(err.Error(), "not found") {
+		if storage.IsOperationNotAllowedError(err) {
+			c.JSON(http.StatusBadRequest, api.ErrorResponse{
+				Status:  "error",
+				Message: err.Error(),
+			})
+		} else if strings.Contains(err.Error(), "not found") {
 			c.JSON(http.StatusNotFound, api.ErrorResponse{
 				Status:  "error",
 				Message: err.Error(),

--- a/gateway/gateway-controller/pkg/storage/errors.go
+++ b/gateway/gateway-controller/pkg/storage/errors.go
@@ -33,6 +33,9 @@ var (
 
 	// ErrDatabaseUnavailable is returned when the database storage is unavailable
 	ErrDatabaseUnavailable = errors.New("database storage is unavailable")
+
+	// ErrOperationNotAllowed is returned when an operation is not permitted
+	ErrOperationNotAllowed = errors.New("operation not allowed")
 )
 
 // IsConflictError checks if an error is a conflict error
@@ -49,4 +52,9 @@ func IsNotFoundError(err error) bool {
 
 func IsDatabaseUnavailableError(err error) bool {
 	return errors.Is(err, ErrDatabaseUnavailable)
+}
+
+// IsOperationNotAllowedError checks if an error is an operation not allowed error
+func IsOperationNotAllowedError(err error) bool {
+	return errors.Is(err, ErrOperationNotAllowed)
 }

--- a/gateway/gateway-controller/pkg/storage/sqlite.go
+++ b/gateway/gateway-controller/pkg/storage/sqlite.go
@@ -1544,7 +1544,7 @@ func (s *SQLiteStorage) UpdateAPIKey(apiKey *models.APIKey) error {
 			LIMIT 1
 		`
 		var duplicateID, duplicateName string
-		err := s.db.QueryRow(duplicateCheckQuery, apiKey.APIId, apiKey.IndexKey, apiKey.Name).Scan(&duplicateID, &duplicateName)
+		err := tx.QueryRow(duplicateCheckQuery, apiKey.APIId, apiKey.IndexKey, apiKey.Name).Scan(&duplicateID, &duplicateName)
 		if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			tx.Rollback()
 			return fmt.Errorf("failed to check for duplicate API key: %w", err)


### PR DESCRIPTION
## Purpose
Improvements for https://github.com/wso2/api-platform/pull/845

## Changes
Added
                                                                                                           
  - New error type: ErrOperationNotAllowed in pkg/storage/errors.go
    - Standardized error for operations that are not permitted
    - Added IsOperationNotAllowedError() helper function for error type checking

  Changed

  - API Key Update Validation (pkg/utils/api_key.go)
    - Added validation to restrict PUT operations on API keys to only externally generated keys
    - Locally generated keys (source: "local") now return a validation error
    - Error message guides users to use the regenerate endpoint instead
  - Error Handling (pkg/api/handlers/handlers.go)
    - Updated UpdateAPIKey handler to check for IsOperationNotAllowedError
    - Returns 400 Bad Request status code for operation not allowed errors
    - Provides clear, actionable error message to API consumers

  Fixed

  - SQLite Transaction (pkg/storage/sqlite.go)
    - Fixed duplicate check query in UpdateAPIKey to use transaction context (tx.QueryRow) instead of
  direct database connection (s.db.QueryRow)
    - Ensures proper transaction isolation and consistency

  Behavior Change

  Breaking Change: API key updates via PUT endpoint are now restricted:
  - ✅ Allowed: Updating API keys with source: "external"
  - ❌ Blocked: Updating API keys with source: "local" (returns 400 Bad Request)
  - Migration Path: Use the /regenerate endpoint for locally generated keys


## Approach
> Describe **how** you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced transactional consistency for API key duplicate validation checks.

* **New Features**
  * API key updates are now restricted to externally generated keys only. Users must use the regenerate endpoint to modify locally generated keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->