### PR TITLE
Run unit tests of Policy Engine when building coverage image

### DIFF
--- a/gateway/policy-engine/Makefile
+++ b/gateway/policy-engine/Makefile
@@ -121,7 +121,7 @@ build-local:
 	@echo "Image built successfully: $(RUNTIME_TAG)"
 
 ## build-coverage-image: Build the Policy Engine Docker image with coverage instrumentation
-build-coverage-image:
+build-coverage-image: test
 	@echo "Building Policy Engine coverage image: $(RUNTIME_IMAGE)-coverage:$(RUNTIME_VERSION)"
 	@mkdir -p target && cp ../build.yaml target/
 	DOCKER_BUILDKIT=1 docker build -f Dockerfile \

--- a/gateway/policy-engine/internal/kernel/translator_test.go
+++ b/gateway/policy-engine/internal/kernel/translator_test.go
@@ -347,7 +347,7 @@ func TestBuildDynamicMetadata_WithoutPath(t *testing.T) {
 		"key": "value",
 	})
 
-	result := buildDynamicMetadata(analyticsStruct, nil)
+	result := buildDynamicMetadata(analyticsStruct, nil, nil)
 
 	require.NotNil(t, result)
 	require.NotNil(t, result.Fields)
@@ -361,7 +361,7 @@ func TestBuildDynamicMetadata_WithPath(t *testing.T) {
 	})
 	path := "/new/path"
 
-	result := buildDynamicMetadata(analyticsStruct, &path)
+	result := buildDynamicMetadata(analyticsStruct, &path, nil)
 
 	require.NotNil(t, result)
 	// Should include path in metadata
@@ -391,7 +391,7 @@ func TestTranslateRequestActionsCore_EmptyResult(t *testing.T) {
 		Results: []executor.RequestPolicyResult{},
 	}
 
-	headerMutation, bodyMutation, analyticsData, pathMutation, immResp, err := translateRequestActionsCore(result, execCtx)
+	headerMutation, bodyMutation, analyticsData, _, pathMutation, immResp, err := translateRequestActionsCore(result, execCtx)
 
 	assert.NoError(t, err)
 	assert.Nil(t, immResp)
@@ -426,7 +426,7 @@ func TestTranslateRequestActionsCore_WithSetHeaders(t *testing.T) {
 		},
 	}
 
-	headerMutation, _, _, _, immResp, err := translateRequestActionsCore(result, execCtx)
+	headerMutation, _, _, _, _, immResp, err := translateRequestActionsCore(result, execCtx)
 
 	assert.NoError(t, err)
 	assert.Nil(t, immResp)
@@ -457,7 +457,7 @@ func TestTranslateRequestActionsCore_WithBodyModification(t *testing.T) {
 		},
 	}
 
-	headerMutation, bodyMutation, _, _, immResp, err := translateRequestActionsCore(result, execCtx)
+	headerMutation, bodyMutation, _, _, _, immResp, err := translateRequestActionsCore(result, execCtx)
 
 	assert.NoError(t, err)
 	assert.Nil(t, immResp)
@@ -498,7 +498,7 @@ func TestTranslateRequestActionsCore_ShortCircuit(t *testing.T) {
 		},
 	}
 
-	_, _, _, _, immResp, err := translateRequestActionsCore(result, execCtx)
+	_, _, _, _, _, immResp, err := translateRequestActionsCore(result, execCtx)
 
 	assert.NoError(t, err)
 	require.NotNil(t, immResp)
@@ -533,7 +533,7 @@ func TestTranslateRequestActionsCore_SkippedPolicy(t *testing.T) {
 		},
 	}
 
-	headerMutation, _, _, _, _, err := translateRequestActionsCore(result, execCtx)
+	headerMutation, _, _, _, _, _, err := translateRequestActionsCore(result, execCtx)
 
 	assert.NoError(t, err)
 	// Skipped policy actions should not be applied
@@ -565,7 +565,7 @@ func TestTranslateRequestActionsCore_WithQueryParams(t *testing.T) {
 		},
 	}
 
-	_, _, _, pathMutation, _, err := translateRequestActionsCore(result, execCtx)
+	_, _, _, _, pathMutation, _, err := translateRequestActionsCore(result, execCtx)
 
 	assert.NoError(t, err)
 	require.NotNil(t, pathMutation)
@@ -596,7 +596,7 @@ func TestTranslateRequestActionsCore_WithPathOverride(t *testing.T) {
 		},
 	}
 
-	_, _, _, pathMutation, _, err := translateRequestActionsCore(result, execCtx)
+	_, _, _, _, pathMutation, _, err := translateRequestActionsCore(result, execCtx)
 
 	assert.NoError(t, err)
 	require.NotNil(t, pathMutation)


### PR DESCRIPTION
## Purpose
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated build process to run tests before generating coverage images.

* **Tests**
  * Updated test infrastructure to align with internal function signature changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->