### PR TITLE
Add support for optional x-user-id header in API key operations

### DIFF
--- a/platform-api/src/internal/dto/gateway_event.go
+++ b/platform-api/src/internal/dto/gateway_event.go
@@ -30,6 +30,9 @@ type GatewayEventDTO struct {
 
 	// CorrelationID provides request tracing identifier
 	CorrelationID string `json:"correlationId"`
+
+	// UserId is an optional temporary user identifier (from x-user-id header)
+	UserId string `json:"userId,omitempty"`
 }
 
 // ConnectionAckDTO represents the acknowledgment message sent when a gateway connects.

--- a/platform-api/src/internal/handler/api_key.go
+++ b/platform-api/src/internal/handler/api_key.go
@@ -95,8 +95,11 @@ func (h *APIKeyHandler) CreateAPIKey(c *gin.Context) {
 		req.DisplayName = name
 	}
 
+	// Extract optional x-user-id header for temporary user identification
+	userId := c.GetHeader("x-user-id")
+
 	// Create the API key and broadcast to gateways
-	err := h.apiKeyService.CreateAPIKey(c.Request.Context(), apiHandle, orgId, &req)
+	err := h.apiKeyService.CreateAPIKey(c.Request.Context(), apiHandle, orgId, userId, &req)
 	if err != nil {
 		// Handle specific error cases
 		if errors.Is(err, constants.ErrAPINotFound) {
@@ -170,8 +173,11 @@ func (h *APIKeyHandler) UpdateAPIKey(c *gin.Context) {
 		return
 	}
 
+	// Extract optional x-user-id header for temporary user identification
+	userId := c.GetHeader("x-user-id")
+
 	// Update the API key and broadcast to gateways
-	err := h.apiKeyService.UpdateAPIKey(c.Request.Context(), apiHandle, orgId, keyName, &req)
+	err := h.apiKeyService.UpdateAPIKey(c.Request.Context(), apiHandle, orgId, keyName, userId, &req)
 	if err != nil {
 		// Handle specific error cases
 		if errors.Is(err, constants.ErrAPINotFound) {
@@ -229,8 +235,11 @@ func (h *APIKeyHandler) RevokeAPIKey(c *gin.Context) {
 		return
 	}
 
+	// Extract optional x-user-id header for temporary user identification
+	userId := c.GetHeader("x-user-id")
+
 	// Revoke the API key and broadcast to gateways
-	err := h.apiKeyService.RevokeAPIKey(c.Request.Context(), apiHandle, orgId, keyName)
+	err := h.apiKeyService.RevokeAPIKey(c.Request.Context(), apiHandle, orgId, keyName, userId)
 	if err != nil {
 		// Handle specific error cases
 		if errors.Is(err, constants.ErrAPINotFound) {

--- a/platform-api/src/internal/service/apikey.go
+++ b/platform-api/src/internal/service/apikey.go
@@ -44,7 +44,7 @@ func NewAPIKeyService(apiRepo repository.APIRepository, gatewayEventsService *Ga
 
 // CreateAPIKey hashes an external API key and broadcasts it to gateways where the API is deployed.
 // This method is used when external platforms inject API keys to hybrid gateways.
-func (s *APIKeyService) CreateAPIKey(ctx context.Context, apiHandle, orgId string, req *dto.CreateAPIKeyRequest) error {
+func (s *APIKeyService) CreateAPIKey(ctx context.Context, apiHandle, orgId, userId string, req *dto.CreateAPIKeyRequest) error {
 	// Resolve API handle to UUID
 	apiMetadata, err := s.apiRepo.GetAPIMetadataByHandle(apiHandle, orgId)
 	if err != nil {
@@ -104,7 +104,7 @@ func (s *APIKeyService) CreateAPIKey(ctx context.Context, apiHandle, orgId strin
 			apiId, gatewayID, req.Name)
 
 		// Broadcast with retries
-		err := s.gatewayEventsService.BroadcastAPIKeyCreatedEvent(gatewayID, event)
+		err := s.gatewayEventsService.BroadcastAPIKeyCreatedEvent(gatewayID, userId, event)
 		if err != nil {
 			failureCount++
 			lastError = err
@@ -133,7 +133,7 @@ func (s *APIKeyService) CreateAPIKey(ctx context.Context, apiHandle, orgId strin
 
 // UpdateAPIKey updates/regenerates an API key and broadcasts it to all gateways where the API is deployed.
 // This method is used when external platforms rotates/regenerates API keys on hybrid gateways.
-func (s *APIKeyService) UpdateAPIKey(ctx context.Context, apiHandle, orgId, keyName string, req *dto.UpdateAPIKeyRequest) error {
+func (s *APIKeyService) UpdateAPIKey(ctx context.Context, apiHandle, orgId, keyName, userId string, req *dto.UpdateAPIKeyRequest) error {
 	// Resolve API handle to UUID
 	apiMetadata, err := s.apiRepo.GetAPIMetadataByHandle(apiHandle, orgId)
 	if err != nil {
@@ -191,7 +191,7 @@ func (s *APIKeyService) UpdateAPIKey(ctx context.Context, apiHandle, orgId, keyN
 			apiId, gatewayID, keyName)
 
 		// Broadcast with retries
-		err := s.gatewayEventsService.BroadcastAPIKeyUpdatedEvent(gatewayID, event)
+		err := s.gatewayEventsService.BroadcastAPIKeyUpdatedEvent(gatewayID, userId, event)
 		if err != nil {
 			failureCount++
 			lastError = err
@@ -219,7 +219,7 @@ func (s *APIKeyService) UpdateAPIKey(ctx context.Context, apiHandle, orgId, keyN
 }
 
 // RevokeAPIKey broadcasts API key revocation to all gateways where the API is deployed
-func (s *APIKeyService) RevokeAPIKey(ctx context.Context, apiHandle, orgId, keyName string) error {
+func (s *APIKeyService) RevokeAPIKey(ctx context.Context, apiHandle, orgId, keyName, userId string) error {
 	// Resolve API handle to UUID
 	apiMetadata, err := s.apiRepo.GetAPIMetadataByHandle(apiHandle, orgId)
 	if err != nil {
@@ -269,7 +269,7 @@ func (s *APIKeyService) RevokeAPIKey(ctx context.Context, apiHandle, orgId, keyN
 			apiId, gatewayID, keyName)
 
 		// Broadcast with retries
-		err := s.gatewayEventsService.BroadcastAPIKeyRevokedEvent(gatewayID, event)
+		err := s.gatewayEventsService.BroadcastAPIKeyRevokedEvent(gatewayID, userId, event)
 		if err != nil {
 			failureCount++
 			lastError = err

--- a/platform-api/src/internal/service/gateway_events.go
+++ b/platform-api/src/internal/service/gateway_events.go
@@ -216,13 +216,13 @@ func (s *GatewayEventsService) BroadcastUndeploymentEvent(gatewayID string, unde
 // - Up to 2 attempts per call (no backoff; caller should handle broader retry logic if needed)
 // - Payload size validation
 // - Delivery statistics tracking
-func (s *GatewayEventsService) BroadcastAPIKeyCreatedEvent(gatewayID string, event *model.APIKeyCreatedEvent) error {
+func (s *GatewayEventsService) BroadcastAPIKeyCreatedEvent(gatewayID, userId string, event *model.APIKeyCreatedEvent) error {
 	const maxAttempts = 2
 
 	var lastError error
 
 	for attempt := 0; attempt < maxAttempts; attempt++ {
-		err := s.broadcastAPIKeyCreated(gatewayID, event)
+		err := s.broadcastAPIKeyCreated(gatewayID, userId, event)
 		if err == nil {
 			return nil
 		}
@@ -245,14 +245,14 @@ func (s *GatewayEventsService) BroadcastAPIKeyCreatedEvent(gatewayID string, eve
 // - Up to 2 attempts per call (no backoff; caller should handle broader retry logic if needed)
 // - Payload size validation
 // - Delivery statistics tracking
-func (s *GatewayEventsService) BroadcastAPIKeyRevokedEvent(gatewayID string, event *model.APIKeyRevokedEvent) error {
+func (s *GatewayEventsService) BroadcastAPIKeyRevokedEvent(gatewayID, userId string, event *model.APIKeyRevokedEvent) error {
 	const maxAttempts = 2
 
 	var lastError error
 
 	// Up to 2 attempts (no backoff)
 	for attempt := 0; attempt < maxAttempts; attempt++ {
-		err := s.broadcastAPIKeyRevoked(gatewayID, event)
+		err := s.broadcastAPIKeyRevoked(gatewayID, userId, event)
 		if err == nil {
 			return nil
 		}
@@ -268,7 +268,7 @@ func (s *GatewayEventsService) BroadcastAPIKeyRevokedEvent(gatewayID string, eve
 }
 
 // broadcastAPIKeyCreated is the internal implementation for broadcasting API key created events
-func (s *GatewayEventsService) broadcastAPIKeyCreated(gatewayID string, event *model.APIKeyCreatedEvent) error {
+func (s *GatewayEventsService) broadcastAPIKeyCreated(gatewayID, userId string, event *model.APIKeyCreatedEvent) error {
 	// Create correlation ID for tracing
 	correlationID := uuid.New().String()
 
@@ -290,6 +290,7 @@ func (s *GatewayEventsService) broadcastAPIKeyCreated(gatewayID string, event *m
 		Payload:       event,
 		Timestamp:     time.Now().Format(time.RFC3339),
 		CorrelationID: correlationID,
+		UserId:        userId,
 	}
 
 	// Serialize complete event
@@ -338,7 +339,7 @@ func (s *GatewayEventsService) broadcastAPIKeyCreated(gatewayID string, event *m
 }
 
 // broadcastAPIKeyRevoked is the internal implementation for broadcasting API key revoked events
-func (s *GatewayEventsService) broadcastAPIKeyRevoked(gatewayID string, event *model.APIKeyRevokedEvent) error {
+func (s *GatewayEventsService) broadcastAPIKeyRevoked(gatewayID, userId string, event *model.APIKeyRevokedEvent) error {
 	// Create correlation ID for tracing
 	correlationID := uuid.New().String()
 
@@ -360,6 +361,7 @@ func (s *GatewayEventsService) broadcastAPIKeyRevoked(gatewayID string, event *m
 		Payload:       event,
 		Timestamp:     time.Now().Format(time.RFC3339),
 		CorrelationID: correlationID,
+		UserId:        userId,
 	}
 
 	// Serialize complete event
@@ -415,14 +417,14 @@ func (s *GatewayEventsService) broadcastAPIKeyRevoked(gatewayID string, event *m
 // - Up to 2 attempts per call (no backoff; caller should handle broader retry logic if needed)
 // - Payload size validation
 // - Delivery statistics tracking
-func (s *GatewayEventsService) BroadcastAPIKeyUpdatedEvent(gatewayID string, event *model.APIKeyUpdatedEvent) error {
+func (s *GatewayEventsService) BroadcastAPIKeyUpdatedEvent(gatewayID, userId string, event *model.APIKeyUpdatedEvent) error {
 	const maxAttempts = 2
 
 	var lastError error
 
 	// Up to 2 attempts (no backoff)
 	for attempt := 0; attempt < maxAttempts; attempt++ {
-		err := s.broadcastAPIKeyUpdated(gatewayID, event)
+		err := s.broadcastAPIKeyUpdated(gatewayID, userId, event)
 		if err == nil {
 			return nil
 		}
@@ -438,7 +440,7 @@ func (s *GatewayEventsService) BroadcastAPIKeyUpdatedEvent(gatewayID string, eve
 }
 
 // broadcastAPIKeyUpdated is the internal implementation for broadcasting API key updated events
-func (s *GatewayEventsService) broadcastAPIKeyUpdated(gatewayID string, event *model.APIKeyUpdatedEvent) error {
+func (s *GatewayEventsService) broadcastAPIKeyUpdated(gatewayID, userId string, event *model.APIKeyUpdatedEvent) error {
 	// Create correlation ID for tracing
 	correlationID := uuid.New().String()
 
@@ -460,6 +462,7 @@ func (s *GatewayEventsService) broadcastAPIKeyUpdated(gatewayID string, event *m
 		Payload:       event,
 		Timestamp:     time.Now().Format(time.RFC3339),
 		CorrelationID: correlationID,
+		UserId:        userId,
 	}
 
 	// Serialize complete event


### PR DESCRIPTION
## Description                                                                         
                                                                                      
  ### Summary

  This PR adds support for an optional x-user-id header in API key operations (create,
   update, and revoke). This header allows temporary user identification to be passed
  through the platform-api and included in gateway events for improved traceability
  and auditing.

  ### Changes Made

  1. Handler Layer (platform-api/src/internal/handler/api_key.go)

  - CreateAPIKey: Extract optional x-user-id header and pass to service layer
  - UpdateAPIKey: Extract optional x-user-id header and pass to service layer
  - RevokeAPIKey: Extract optional x-user-id header and pass to service layer

  2. Service Layer (platform-api/src/internal/service/apikey.go)

  - Updated CreateAPIKey method signature to accept userId parameter
  - Updated UpdateAPIKey method signature to accept userId parameter
  - Updated RevokeAPIKey method signature to accept userId parameter
  - All methods now pass userId to gateway events service

  3. Gateway Events Service (platform-api/src/internal/service/gateway_events.go)

  - Updated BroadcastAPIKeyCreatedEvent to accept and include userId in events
  - Updated BroadcastAPIKeyUpdatedEvent to accept and include userId in events
  - Updated BroadcastAPIKeyRevokedEvent to accept and include userId in events
  - Internal broadcast methods now populate UserId field in GatewayEventDTO

  4. DTO Layer (platform-api/src/internal/dto/gateway_event.go)

  - Added UserId field to GatewayEventDTO structure
  - Field is marked as omitempty to maintain backward compatibility

  ### Technical Details

  - Header Name: x-user-id
  - Optional: Yes - if not provided, empty string is used
  - Backward Compatible: Yes - the userId field uses omitempty in JSON serialization
  - Gateway Ready: The gateway-controller already has full support for receiving and
  processing the userId field in all API key events

 ### API Usage Example

  #### Create API key with user ID
  curl -X POST /api/v1/apis/{apiId}/api-keys \
    -H "Authorization: Bearer <token>" \
    -H "x-user-id: user@example.com" \
    -H "Content-Type: application/json" \
    -d '{
      "apiKey": "my-api-key-value",
      "name": "my-key",
      "displayName": "My API Key"
    }'

  #### Update API key with user ID
  curl -X PUT /api/v1/apis/{apiId}/api-keys/{keyName} \
    -H "Authorization: Bearer <token>" \
    -H "x-user-id: user@example.com" \
    -H "Content-Type: application/json" \
    -d '{
      "apiKey": "new-api-key-value"
    }'

  #### Revoke API key with user ID
  curl -X DELETE /api/v1/apis/{apiId}/api-keys/{keyName} \
    -H "Authorization: Bearer <token>" \
    -H "x-user-id: user@example.com"

 ### Event Flow

  1. Client sends API key operation request with optional x-user-id header
  2. Handler extracts header value (empty string if not provided)
  3. Service layer receives userId and passes it through to events service
  4. Gateway event is created with userId field populated
  5. Event is broadcasted to gateways via WebSocket
  6. Gateway processes the event and includes userId in its AuthContext


###  Related Components

  - Gateway Controller: Already prepared to handle userId field in events
  - API Key Service: Uses userId in AuthContext for operations
  - Event Handlers: Include userId in structured logging for traceability


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API key management operations now capture and include user identification in event tracking, providing enhanced audit visibility for API key creation, updates, and revocation actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->