### PR TITLE
Revert changes for renaming revisionId to deploymentId in API DeploymentEvent

### DIFF
--- a/gateway/gateway-controller/pkg/api/handlers/handlers_test.go
+++ b/gateway/gateway-controller/pkg/api/handlers/handlers_test.go
@@ -394,7 +394,7 @@ func (m *MockControlPlaneClient) IsConnected() bool {
 	return m.connected
 }
 
-func (m *MockControlPlaneClient) NotifyAPIDeployment(apiID string, cfg *models.StoredConfig, deploymentID string) error {
+func (m *MockControlPlaneClient) NotifyAPIDeployment(apiID string, cfg *models.StoredConfig, revisionID string) error {
 	return nil
 }
 

--- a/gateway/gateway-controller/pkg/controlplane/client.go
+++ b/gateway/gateway-controller/pkg/controlplane/client.go
@@ -590,7 +590,7 @@ func (c *Client) handleAPIDeployedEvent(event map[string]interface{}) {
 	c.logger.Info("Processing API deployment",
 		slog.String("api_id", apiID),
 		slog.String("environment", deployedEvent.Payload.Environment),
-		slog.String("deployment_id", deployedEvent.Payload.DeploymentID),
+		slog.String("revision_id", deployedEvent.Payload.RevisionID),
 		slog.String("vhost", deployedEvent.Payload.VHost),
 		slog.String("correlation_id", deployedEvent.CorrelationID),
 	)

--- a/gateway/gateway-controller/pkg/controlplane/client_integration_test.go
+++ b/gateway/gateway-controller/pkg/controlplane/client_integration_test.go
@@ -116,10 +116,10 @@ func TestClient_handleMessage_APIDeployedEvent(t *testing.T) {
 	event := map[string]interface{}{
 		"type": "api.deployed",
 		"payload": map[string]interface{}{
-			"apiId":        "test-api-123",
-			"environment":  "production",
-			"deploymentId": "rev-1",
-			"vhost":        "api.example.com",
+			"apiId":       "test-api-123",
+			"environment": "production",
+			"revisionId":  "rev-1",
+			"vhost":       "api.example.com",
 		},
 		"timestamp":     time.Now().Format(time.RFC3339),
 		"correlationId": "corr-12345",
@@ -440,7 +440,7 @@ func TestAPIDeployedEvent_JSONParsing(t *testing.T) {
 		"payload": {
 			"apiId": "api-123",
 			"environment": "production",
-			"deploymentId": "rev-1",
+			"revisionId": "rev-1",
 			"vhost": "api.example.com"
 		},
 		"timestamp": "2025-01-30T12:00:00Z",

--- a/gateway/gateway-controller/pkg/controlplane/controlplane_test.go
+++ b/gateway/gateway-controller/pkg/controlplane/controlplane_test.go
@@ -90,10 +90,10 @@ func TestAPIDeployedEvent(t *testing.T) {
 	event := APIDeployedEvent{
 		Type: "api.deployed",
 		Payload: APIDeployedEventPayload{
-			APIID:        "api-123",
-			Environment:  "production",
-			DeploymentID: "rev-1",
-			VHost:        "api.example.com",
+			APIID:       "api-123",
+			Environment: "production",
+			RevisionID:  "rev-1",
+			VHost:       "api.example.com",
 		},
 		Timestamp:     "2025-01-30T12:00:00Z",
 		CorrelationID: "corr-789",
@@ -108,8 +108,8 @@ func TestAPIDeployedEvent(t *testing.T) {
 	if event.Payload.Environment != "production" {
 		t.Errorf("Payload.Environment = %q, want %q", event.Payload.Environment, "production")
 	}
-	if event.Payload.DeploymentID != "rev-1" {
-		t.Errorf("Payload.DeploymentID = %q, want %q", event.Payload.DeploymentID, "rev-1")
+	if event.Payload.RevisionID != "rev-1" {
+		t.Errorf("Payload.RevisionID = %q, want %q", event.Payload.RevisionID, "rev-1")
 	}
 	if event.Payload.VHost != "api.example.com" {
 		t.Errorf("Payload.VHost = %q, want %q", event.Payload.VHost, "api.example.com")
@@ -121,10 +121,10 @@ func TestAPIDeployedEvent(t *testing.T) {
 
 func TestAPIDeployedEventPayload(t *testing.T) {
 	payload := APIDeployedEventPayload{
-		APIID:        "test-api",
-		Environment:  "staging",
-		DeploymentID: "rev-2",
-		VHost:        "staging.example.com",
+		APIID:       "test-api",
+		Environment: "staging",
+		RevisionID:  "rev-2",
+		VHost:       "staging.example.com",
 	}
 
 	if payload.APIID != "test-api" {
@@ -133,8 +133,8 @@ func TestAPIDeployedEventPayload(t *testing.T) {
 	if payload.Environment != "staging" {
 		t.Errorf("Environment = %q, want %q", payload.Environment, "staging")
 	}
-	if payload.DeploymentID != "rev-2" {
-		t.Errorf("DeploymentID = %q, want %q", payload.DeploymentID, "rev-2")
+	if payload.RevisionID != "rev-2" {
+		t.Errorf("RevisionID = %q, want %q", payload.RevisionID, "rev-2")
 	}
 	if payload.VHost != "staging.example.com" {
 		t.Errorf("VHost = %q, want %q", payload.VHost, "staging.example.com")

--- a/gateway/gateway-controller/pkg/controlplane/events.go
+++ b/gateway/gateway-controller/pkg/controlplane/events.go
@@ -29,10 +29,10 @@ type ConnectionAckMessage struct {
 
 // APIDeployedEventPayload represents the payload of an API deployment event
 type APIDeployedEventPayload struct {
-	APIID        string `json:"apiId"`
-	Environment  string `json:"environment"`
-	DeploymentID string `json:"deploymentId"`
-	VHost        string `json:"vhost"`
+	APIID       string `json:"apiId"`
+	Environment string `json:"environment"`
+	RevisionID  string `json:"revisionId"`
+	VHost       string `json:"vhost"`
 }
 
 // APIDeployedEvent represents the complete API deployment event

--- a/platform-api/src/internal/dto/gateway_event.go
+++ b/platform-api/src/internal/dto/gateway_event.go
@@ -55,8 +55,8 @@ type DeploymentEventDTO struct {
 	// ApiId identifies the deployed API
 	ApiId string `json:"apiId"`
 
-	// DeploymentID identifies the specific API deployment
-	DeploymentId string `json:"deploymentId"`
+	// RevisionID identifies the specific API deployment
+	RevisionID string `json:"revisionId"`
 
 	// Vhost specifies the virtual host
 	Vhost string `json:"vhost"`

--- a/platform-api/src/internal/model/gateway_event.go
+++ b/platform-api/src/internal/model/gateway_event.go
@@ -51,8 +51,8 @@ type DeploymentEvent struct {
 	// ApiId identifies the deployed API
 	ApiId string `json:"apiId"`
 
-	// DeploymentID identifies the specific deployment artifact
-	DeploymentID string `json:"deploymentId"`
+	// RevisionID identifies the specific API revision
+	RevisionID string `json:"revisionId"`
 
 	// Vhost specifies the virtual host where the API is deployed
 	Vhost string `json:"vhost"`

--- a/platform-api/src/internal/service/deployment.go
+++ b/platform-api/src/internal/service/deployment.go
@@ -188,10 +188,10 @@ func (s *DeploymentService) DeployAPI(apiUUID string, req *dto.DeployAPIRequest,
 	// Send deployment event to gateway
 	if s.gatewayEventsService != nil {
 		deploymentEvent := &model.DeploymentEvent{
-			ApiId:        apiUUID,
-			DeploymentID: deploymentID,
-			Vhost:        gateway.Vhost,
-			Environment:  "production",
+			ApiId:       apiUUID,
+			RevisionID:  deploymentID,
+			Vhost:       gateway.Vhost,
+			Environment: "production",
 		}
 
 		if err := s.gatewayEventsService.BroadcastDeploymentEvent(req.GatewayID, deploymentEvent); err != nil {
@@ -256,10 +256,10 @@ func (s *DeploymentService) RestoreDeployment(apiUUID, deploymentID, gatewayID, 
 	// Send deployment event to gateway
 	if s.gatewayEventsService != nil {
 		deploymentEvent := &model.DeploymentEvent{
-			ApiId:        apiUUID,
-			DeploymentID: deploymentID,
-			Vhost:        gateway.Vhost,
-			Environment:  "production",
+			ApiId:       apiUUID,
+			RevisionID:  deploymentID,
+			Vhost:       gateway.Vhost,
+			Environment: "production",
 		}
 
 		if err := s.gatewayEventsService.BroadcastDeploymentEvent(targetDeployment.GatewayID, deploymentEvent); err != nil {


### PR DESCRIPTION
Temporarily reverting naming change in both gw side and platform api side since we are only releasing the gateway for immediate release and it needs to work with old platform-api release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated API deployment event payload structure: the `deploymentId` field has been renamed to `revisionId` to better reflect the identifier's semantic meaning. This is a breaking change for consumers of deployment event payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->