### PR TITLE
Move Moesif default settings to default config

### DIFF
--- a/gateway/gateway-controller/pkg/config/config.go
+++ b/gateway/gateway-controller/pkg/config/config.go
@@ -596,7 +596,20 @@ func defaultConfig() *Config {
 		},
 		Analytics: AnalyticsConfig{
 			Enabled:    false,
-			Publishers: make([]map[string]interface{}, 0),
+			Publishers: []map[string]interface{}{
+				{
+					"type":    "moesif",
+					"enabled": true,
+					"settings": map[string]interface{}{
+						"application_id":       "",
+						"moesif_base_url":      "https://api.moesif.net",
+						"publish_interval":     5,
+						"event_queue_size":     10000,
+						"batch_size":           50,
+						"timer_wakeup_seconds": 3,
+					},
+				},
+			},
 			GRPCAccessLogCfg: GRPCAccessLogConfig{
 				Mode:                "uds",           // UDS mode by default
 				Host:                "policy-engine", // Only used in TCP mode

--- a/gateway/gateway-runtime/policy-engine/internal/analytics/publishers/moesif.go
+++ b/gateway/gateway-runtime/policy-engine/internal/analytics/publishers/moesif.go
@@ -73,12 +73,6 @@ func NewMoesif(pubCfg *config.PublisherConfig) *Moesif {
 		moesifApplicationId = moesifCfg.ApplicationID
 	}
 
-	// Apply default for BaseURL if not set
-	if moesifCfg.BaseURL == "" {
-		slog.Debug("No Moesif base URL provided, backing off to the default URL")
-		moesifCfg.BaseURL = "https://api.moesif.net"
-	}
-
 	// Moesif Client Configs
 	eventQueueSize, batchSize, timerWakeupSeconds :=
 		moesifCfg.EventQueueSize,

--- a/gateway/gateway-runtime/policy-engine/internal/config/config.go
+++ b/gateway/gateway-runtime/policy-engine/internal/config/config.go
@@ -315,7 +315,20 @@ func defaultConfig() *Config {
 		},
 		Analytics: AnalyticsConfig{
 			Enabled:    false,
-			Publishers: []PublisherConfig{},
+			Publishers: []PublisherConfig{
+				{
+					Type:    "moesif",
+					Enabled: true,
+					Settings: map[string]interface{}{
+						"application_id":       "",
+						"moesif_base_url":      "https://api.moesif.net",
+						"publish_interval":     5,
+						"event_queue_size":     10000,
+						"batch_size":           50,
+						"timer_wakeup_seconds": 3,
+					},
+				},
+			},
 			GRPCAccessLogCfg: map[string]interface{}{
 				"host":                  "policy-engine",
 				"port":                  18090,


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/api-platform/issues/1039

## Goals
> Describe **what solutions** this feature or fix introduces to address the problems outlined above.

## Approach
> Describe **how** you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Analytics publishing now enabled by default using Moesif integration with pre-configured settings.
  * Moesif configuration includes application ID, base URL, publish interval, event queue size, batch size, and timer settings.
  * Important: Moesif base URL must now be explicitly configured rather than defaulting to a built-in endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->