### PR TITLE
remove deployment check on gateway delete

### DIFF
--- a/platform-api/spec/impls/gateway-management/artifacts/openapi-gateways.yaml
+++ b/platform-api/spec/impls/gateway-management/artifacts/openapi-gateways.yaml
@@ -121,8 +121,9 @@ paths:
     delete:
       summary: Delete gateway
       description: |
-        Deletes a gateway and all associated tokens. Access is validated against the organization 
-        in the JWT token.
+        Deletes a gateway and all associated data including tokens, deployments, and deployment status.
+        All deletions are performed via database CASCADE constraints. Access is validated against the 
+        organization in the JWT token.
       operationId: deleteGateway
       tags:
         - Gateways

--- a/platform-api/src/internal/handler/gateway.go
+++ b/platform-api/src/internal/handler/gateway.go
@@ -23,11 +23,12 @@ import (
 	"platform-api/src/internal/constants"
 	"strings"
 
-	"github.com/gin-gonic/gin"
 	"platform-api/src/internal/dto"
 	"platform-api/src/internal/middleware"
 	"platform-api/src/internal/service"
 	"platform-api/src/internal/utils"
+
+	"github.com/gin-gonic/gin"
 )
 
 // GatewayHandler handles HTTP requests for gateway operations
@@ -261,12 +262,6 @@ func (h *GatewayHandler) DeleteGateway(c *gin.Context) {
 			utils.LogError("Gateway has associated APIs during deletion", err)
 			c.JSON(http.StatusConflict, utils.NewErrorResponse(409, "Conflict",
 				"The gateway has associated APIs. Please remove all API associations before deleting the gateway"))
-			return
-		}
-		if errors.Is(err, constants.ErrGatewayHasDeployments) {
-			utils.LogError("Gateway has active API deployments during deletion", err)
-			c.JSON(http.StatusConflict, utils.NewErrorResponse(409, "Conflict",
-				"Cannot delete gateway: it has active API deployments. Please undeploy all APIs before deleting the gateway"))
 			return
 		}
 

--- a/platform-api/src/internal/service/gateway.go
+++ b/platform-api/src/internal/service/gateway.go
@@ -311,7 +311,7 @@ func (s *GatewayService) DeleteGateway(gatewayID, orgID string) error {
 		return constants.ErrGatewayNotFound
 	}
 
-	// Delete gateway (CASCADE will remove tokens, deployements automatically, association_mappings cleanup handled by repository)
+	// Delete gateway (FK CASCADE will automatically remove tokens and deployments; association_mappings cleanup is handled by the repository)
 	err = s.gatewayRepo.Delete(gatewayID, orgID)
 	if err != nil {
 		return err


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Gateway deletion now reliably cascades to related tokens, deployments, and status entries; pre-deletion checks for existing deployments were removed to streamline removal.

* **Documentation**
  * Updated gateway deletion docs and API description to reflect CASCADE behavior and clarify which related data is removed automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->