### PR TITLE
Refresh test tags only when version images exist

### DIFF
--- a/gateway/it/Makefile
+++ b/gateway/it/Makefile
@@ -24,22 +24,23 @@ COVERAGE_IMAGES := gateway-controller-coverage gateway-runtime-coverage
 
 COMPOSE_FILE ?= docker-compose.test.yaml
 
-# Ensure :test tagged images exist; if not, tag from :VERSION
+# Refresh :test tags from :VERSION images when available.
+# If :VERSION is unavailable but :test already exists, keep using :test.
 # Tries coverage image first (from make build-coverage), then falls back to
 # non-coverage image (from make build-local) for local development convenience.
 ensure-test-tags:
 	@for img in $(COVERAGE_IMAGES); do \
-		if ! docker image inspect $(DOCKER_REGISTRY)/$$img:test >/dev/null 2>&1; then \
-			base=$${img%-coverage}; \
-			if docker image inspect $(DOCKER_REGISTRY)/$$img:$(VERSION) >/dev/null 2>&1; then \
-				echo "Tagging $(DOCKER_REGISTRY)/$$img:$(VERSION) -> :test"; \
-				docker tag $(DOCKER_REGISTRY)/$$img:$(VERSION) $(DOCKER_REGISTRY)/$$img:test; \
-			elif docker image inspect $(DOCKER_REGISTRY)/$$base:$(VERSION) >/dev/null 2>&1; then \
-				echo "Tagging $(DOCKER_REGISTRY)/$$base:$(VERSION) -> $(DOCKER_REGISTRY)/$$img:test"; \
-				docker tag $(DOCKER_REGISTRY)/$$base:$(VERSION) $(DOCKER_REGISTRY)/$$img:test; \
-			else \
-				echo "Error: No image found for $$img. Run 'make build-coverage' or 'make build-local' in gateway/ first." && exit 1; \
-			fi; \
+		base=$${img%-coverage}; \
+		if docker image inspect $(DOCKER_REGISTRY)/$$img:$(VERSION) >/dev/null 2>&1; then \
+			echo "Tagging $(DOCKER_REGISTRY)/$$img:$(VERSION) -> $(DOCKER_REGISTRY)/$$img:test"; \
+			docker tag $(DOCKER_REGISTRY)/$$img:$(VERSION) $(DOCKER_REGISTRY)/$$img:test; \
+		elif docker image inspect $(DOCKER_REGISTRY)/$$base:$(VERSION) >/dev/null 2>&1; then \
+			echo "Tagging $(DOCKER_REGISTRY)/$$base:$(VERSION) -> $(DOCKER_REGISTRY)/$$img:test"; \
+			docker tag $(DOCKER_REGISTRY)/$$base:$(VERSION) $(DOCKER_REGISTRY)/$$img:test; \
+		elif docker image inspect $(DOCKER_REGISTRY)/$$img:test >/dev/null 2>&1; then \
+			echo "Using existing $(DOCKER_REGISTRY)/$$img:test (no :$(VERSION) image found)"; \
+		else \
+			echo "Error: No image found for $$img (:$(VERSION) or :test). Run 'make build-coverage' or 'make build-local' in gateway/ first." && exit 1; \
 		fi; \
 	done
 


### PR DESCRIPTION
## Summary
- update `gateway/it/Makefile` `ensure-test-tags` flow
- retag `:test` from `:<VERSION>` when a version image is available
- keep existing `:test` image when version images are unavailable
- fail only when neither `:<VERSION>` nor `:test` image exists

## Why
This avoids stale `:test` tags when new version images exist, while keeping local test runs working when only `:test` is present.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved test-environment image tagging and fallback logic to make automated test setups more reliable. Now the process handles multiple fallback cases when the preferred image is unavailable and provides clearer console messages about which image was used or if an error occurred, aiding troubleshooting during builds and tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->