### PR TITLE
Fix controller /config_dump error message to return actual failure

### DIFF
--- a/gateway/gateway-controller/pkg/api/handlers/handlers.go
+++ b/gateway/gateway-controller/pkg/api/handlers/handlers.go
@@ -2159,7 +2159,7 @@ func (s *APIServer) GetConfigDump(c *gin.Context) {
 		log.Error("Failed to retrieve configuration dump", slog.Any("error", err))
 		c.JSON(http.StatusInternalServerError, api.ErrorResponse{
 			Status:  "error",
-			Message: "Failed to retrieve certificates",
+			Message: err.Error(),
 		})
 		return
 	}


### PR DESCRIPTION
## Summary
Fix controller `/config_dump` error response message to reflect the actual failure reason.

Previously, when `BuildConfigDumpResponse(...)` failed, the handler always returned:
- `"Failed to retrieve certificates"`

Now it returns the real error text via `err.Error()`, so failures are accurate and easier to debug.

## Change
- updated `GetConfigDump` error handling in:
  - `gateway/gateway-controller/pkg/api/handlers/handlers.go`

## Testing
- `go test ./gateway/gateway-controller/pkg/api/handlers`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting in configuration dump functionality to return specific failure details instead of generic error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->