### PR TITLE
Add API key endpoints to the OpenAPI specification

### DIFF
--- a/platform-api/src/resources/openapi.yaml
+++ b/platform-api/src/resources/openapi.yaml
@@ -645,7 +645,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/Error'
         '500':
           $ref: '#/components/responses/InternalServerError'
 
@@ -694,7 +694,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/Error'
         '500':
           $ref: '#/components/responses/InternalServerError'
 
@@ -731,7 +731,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/Error'
         '500':
           $ref: '#/components/responses/InternalServerError'
 
@@ -3674,7 +3674,7 @@ components:
         apiKey:
           type: string
           description: The plain text API key value that will be hashed before storage
-          example: "sk_live_1234567890abcdef"
+          example: "sk_example_1234567890abcdef"
         externalRefId:
           type: string
           description: Optional reference ID for tracing purposes (from external platforms)
@@ -3725,7 +3725,7 @@ components:
         apiKey:
           type: string
           description: The new plain text API key value that will be hashed before storage
-          example: "sk_live_new1234567890abcdef"
+          example: "sk_example_new1234567890abcdef"
         externalRefId:
           type: string
           description: Optional reference ID for tracing purposes (from external platforms)


### PR DESCRIPTION
Endpoints Added:                                                                                           
                 
  1. POST /apis/{apiId}/api-keys - Create a new API key                                                      
  2. PUT /apis/{apiId}/api-keys/{keyName} - Update an existing API key                                       
  3. DELETE /apis/{apiId}/api-keys/{keyName} - Revoke an API key                                             
                                                                                                             
  Schemas Added:

  1. TimeUnit - Enum for time units (seconds, minutes, hours, days, weeks, months)
  2. ExpirationDuration - Object with duration and unit for expiration
  3. CreateAPIKeyRequest - Request schema for creating API keys
  4. CreateAPIKeyResponse - Response schema for API key creation
  5. UpdateAPIKeyRequest - Request schema for updating API keys (includes optional expiresIn field)
  6. UpdateAPIKeyResponse - Response schema for API key updates

  All the endpoints match your handler implementation, including:
  - Proper response codes (201, 200, 204, 400, 401, 404, 503, 500)
  - All request/response fields from your DTOs
  - The 503 Service Unavailable response when no gateways are connected
  - Security validations and organization context from JWT tokens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API key management: create, update (rotate), and revoke API keys for your APIs via new endpoints.
  * Configurable API key expiration with customizable time units and duration settings.
  * Improved API responses including error handling related to key lifecycle operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->