### PR TITLE
Add org llm deployment limits

### DIFF
--- a/platform-api/src/internal/constants/constants.go
+++ b/platform-api/src/internal/constants/constants.go
@@ -119,4 +119,9 @@ const (
 const (
 	// DeploymentLimitBuffer is the buffer added to MaxPerAPIGateway for hard limit enforcement
 	DeploymentLimitBuffer = 5
+
+	// MaxLLMProvidersPerOrganization is the maximum number of LLM providers allowed per organization.
+	MaxLLMProvidersPerOrganization = 5
+	// MaxLLMProxiesPerOrganization is the maximum number of LLM proxies allowed per organization.
+	MaxLLMProxiesPerOrganization = 5
 )

--- a/platform-api/src/internal/constants/error.go
+++ b/platform-api/src/internal/constants/error.go
@@ -133,8 +133,10 @@ var (
 	ErrLLMProviderTemplateNotFound = errors.New("llm provider template not found")
 	ErrLLMProviderExists           = errors.New("llm provider already exists")
 	ErrLLMProviderNotFound         = errors.New("llm provider not found")
+	ErrLLMProviderLimitReached     = errors.New("llm provider limit reached for organization")
 	ErrLLMProxyExists              = errors.New("llm proxy already exists")
 	ErrLLMProxyNotFound            = errors.New("llm proxy not found")
+	ErrLLMProxyLimitReached        = errors.New("llm proxy limit reached for organization")
 )
 
 var (

--- a/platform-api/src/internal/handler/llm.go
+++ b/platform-api/src/internal/handler/llm.go
@@ -242,6 +242,9 @@ func (h *LLMHandler) CreateLLMProvider(c *gin.Context) {
 	created, err := h.providerService.Create(orgID, createdBy, &req)
 	if err != nil {
 		switch {
+		case errors.Is(err, constants.ErrLLMProviderLimitReached):
+			c.JSON(http.StatusConflict, utils.NewErrorResponse(409, "Conflict", "LLM provider limit reached for organization"))
+			return
 		case errors.Is(err, constants.ErrLLMProviderExists):
 			c.JSON(http.StatusConflict, utils.NewErrorResponse(409, "Conflict", "LLM provider already exists"))
 			return
@@ -401,6 +404,9 @@ func (h *LLMHandler) CreateLLMProxy(c *gin.Context) {
 	created, err := h.proxyService.Create(orgID, createdBy, &req)
 	if err != nil {
 		switch {
+		case errors.Is(err, constants.ErrLLMProxyLimitReached):
+			c.JSON(http.StatusConflict, utils.NewErrorResponse(409, "Conflict", "LLM proxy limit reached for organization"))
+			return
 		case errors.Is(err, constants.ErrLLMProxyExists):
 			c.JSON(http.StatusConflict, utils.NewErrorResponse(409, "Conflict", "LLM proxy already exists"))
 			return

--- a/platform-api/src/internal/service/llm_test.go
+++ b/platform-api/src/internal/service/llm_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"testing"
 
+	"platform-api/src/internal/constants"
 	"platform-api/src/internal/model"
 )
 
@@ -101,4 +102,27 @@ func TestMapUpstreamConfigToDTO_DoesNotExposeAuthValue(t *testing.T) {
 	if out.Sandbox.Auth.Value != "" {
 		t.Fatalf("expected sandbox auth value to be redacted")
 	}
+}
+
+func TestValidateLLMResourceLimit(t *testing.T) {
+	t.Run("below limit should pass", func(t *testing.T) {
+		err := validateLLMResourceLimit(4, constants.MaxLLMProvidersPerOrganization, constants.ErrLLMProviderLimitReached)
+		if err != nil {
+			t.Fatalf("expected no error below limit, got: %v", err)
+		}
+	})
+
+	t.Run("at limit should fail", func(t *testing.T) {
+		err := validateLLMResourceLimit(5, constants.MaxLLMProvidersPerOrganization, constants.ErrLLMProviderLimitReached)
+		if err != constants.ErrLLMProviderLimitReached {
+			t.Fatalf("expected ErrLLMProviderLimitReached, got: %v", err)
+		}
+	})
+
+	t.Run("above limit should fail", func(t *testing.T) {
+		err := validateLLMResourceLimit(6, constants.MaxLLMProxiesPerOrganization, constants.ErrLLMProxyLimitReached)
+		if err != constants.ErrLLMProxyLimitReached {
+			t.Fatalf("expected ErrLLMProxyLimitReached, got: %v", err)
+		}
+	})
 }


### PR DESCRIPTION
## Purpose
> Add org llm deployment limits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organizations can now create up to 5 LLM providers and 5 LLM proxies. Attempting to exceed these limits will return an error message preventing additional resource creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->