### PR TITLE
Fixing REST API undeploy and restore bad request issues

### DIFF
--- a/platform-api/src/api/generated.go
+++ b/platform-api/src/api/generated.go
@@ -2328,19 +2328,19 @@ type GetLLMProviderDeploymentsParamsStatus string
 // RestoreLLMProviderDeploymentParams defines parameters for RestoreLLMProviderDeployment.
 type RestoreLLMProviderDeploymentParams struct {
 	// DeploymentId UUID of the deployment to restore (must be ARCHIVED or UNDEPLOYED)
-	DeploymentId openapi_types.UUID `form:"deploymentId" json:"deploymentId" yaml:"deploymentId"`
+	DeploymentId string `form:"deploymentId" json:"deploymentId" yaml:"deploymentId"`
 
 	// GatewayId UUID of the gateway (validated against deployment's bound gateway)
-	GatewayId openapi_types.UUID `form:"gatewayId" json:"gatewayId" yaml:"gatewayId"`
+	GatewayId string `form:"gatewayId" json:"gatewayId" yaml:"gatewayId"`
 }
 
 // UndeployLLMProviderDeploymentParams defines parameters for UndeployLLMProviderDeployment.
 type UndeployLLMProviderDeploymentParams struct {
 	// DeploymentId UUID of the deployment to undeploy
-	DeploymentId openapi_types.UUID `form:"deploymentId" json:"deploymentId" yaml:"deploymentId"`
+	DeploymentId string `form:"deploymentId" json:"deploymentId" yaml:"deploymentId"`
 
 	// GatewayId UUID of the gateway (validated against deployment's bound gateway)
-	GatewayId openapi_types.UUID `form:"gatewayId" json:"gatewayId" yaml:"gatewayId"`
+	GatewayId string `form:"gatewayId" json:"gatewayId" yaml:"gatewayId"`
 }
 
 // ListLLMProxiesByProviderParams defines parameters for ListLLMProxiesByProvider.
@@ -2379,19 +2379,19 @@ type GetLLMProxyDeploymentsParamsStatus string
 // RestoreLLMProxyDeploymentParams defines parameters for RestoreLLMProxyDeployment.
 type RestoreLLMProxyDeploymentParams struct {
 	// DeploymentId UUID of the deployment to restore (must be ARCHIVED or UNDEPLOYED)
-	DeploymentId openapi_types.UUID `form:"deploymentId" json:"deploymentId" yaml:"deploymentId"`
+	DeploymentId string `form:"deploymentId" json:"deploymentId" yaml:"deploymentId"`
 
 	// GatewayId UUID of the gateway (validated against deployment's bound gateway)
-	GatewayId openapi_types.UUID `form:"gatewayId" json:"gatewayId" yaml:"gatewayId"`
+	GatewayId string `form:"gatewayId" json:"gatewayId" yaml:"gatewayId"`
 }
 
 // UndeployLLMProxyDeploymentParams defines parameters for UndeployLLMProxyDeployment.
 type UndeployLLMProxyDeploymentParams struct {
 	// DeploymentId UUID of the deployment to undeploy
-	DeploymentId openapi_types.UUID `form:"deploymentId" json:"deploymentId" yaml:"deploymentId"`
+	DeploymentId string `form:"deploymentId" json:"deploymentId" yaml:"deploymentId"`
 
 	// GatewayId UUID of the gateway (validated against deployment's bound gateway)
-	GatewayId openapi_types.UUID `form:"gatewayId" json:"gatewayId" yaml:"gatewayId"`
+	GatewayId string `form:"gatewayId" json:"gatewayId" yaml:"gatewayId"`
 }
 
 // ListRESTAPIsParams defines parameters for ListRESTAPIs.
@@ -2430,19 +2430,19 @@ type GetDeploymentsParamsStatus string
 // RestoreDeploymentParams defines parameters for RestoreDeployment.
 type RestoreDeploymentParams struct {
 	// DeploymentId UUID of the deployment to restore (must be ARCHIVED or UNDEPLOYED)
-	DeploymentId openapi_types.UUID `form:"deploymentId" json:"deploymentId" yaml:"deploymentId"`
+	DeploymentId string `form:"deploymentId" json:"deploymentId" yaml:"deploymentId"`
 
 	// GatewayId UUID of the gateway (validated against deployment's bound gateway)
-	GatewayId openapi_types.UUID `form:"gatewayId" json:"gatewayId" yaml:"gatewayId"`
+	GatewayId string `form:"gatewayId" json:"gatewayId" yaml:"gatewayId"`
 }
 
 // UndeployDeploymentParams defines parameters for UndeployDeployment.
 type UndeployDeploymentParams struct {
 	// DeploymentId UUID of the deployment to undeploy
-	DeploymentId openapi_types.UUID `form:"deploymentId" json:"deploymentId" yaml:"deploymentId"`
+	DeploymentId string `form:"deploymentId" json:"deploymentId" yaml:"deploymentId"`
 
 	// GatewayId UUID of the gateway (validated against deployment's bound gateway)
-	GatewayId openapi_types.UUID `form:"gatewayId" json:"gatewayId" yaml:"gatewayId"`
+	GatewayId string `form:"gatewayId" json:"gatewayId" yaml:"gatewayId"`
 }
 
 // AddGatewaysToAPIJSONBody defines parameters for AddGatewaysToAPI.

--- a/platform-api/src/internal/handler/deployment.go
+++ b/platform-api/src/internal/handler/deployment.go
@@ -145,8 +145,8 @@ func (h *DeploymentHandler) UndeployDeployment(c *gin.Context) {
 		return
 	}
 
-	deploymentId := utils.OpenAPIUUIDToString(params.DeploymentId)
-	gatewayId := utils.OpenAPIUUIDToString(params.GatewayId)
+	deploymentId := params.DeploymentId
+	gatewayId := params.GatewayId
 	if deploymentId == "00000000-0000-0000-0000-000000000000" || gatewayId == "00000000-0000-0000-0000-000000000000" {
 		c.JSON(http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request",
 			"deploymentId/gatewayId cannot be zero-value UUID"))
@@ -210,8 +210,8 @@ func (h *DeploymentHandler) RestoreDeployment(c *gin.Context) {
 		return
 	}
 
-	deploymentId := utils.OpenAPIUUIDToString(params.DeploymentId)
-	gatewayId := utils.OpenAPIUUIDToString(params.GatewayId)
+	deploymentId := params.DeploymentId
+	gatewayId := params.GatewayId
 	if deploymentId == "00000000-0000-0000-0000-000000000000" || gatewayId == "00000000-0000-0000-0000-000000000000" {
 		c.JSON(http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request",
 			"deploymentId/gatewayId cannot be zero-value UUID"))

--- a/platform-api/src/internal/handler/llm_deployment.go
+++ b/platform-api/src/internal/handler/llm_deployment.go
@@ -152,8 +152,8 @@ func (h *LLMProviderDeploymentHandler) UndeployLLMProviderDeployment(c *gin.Cont
 		return
 	}
 
-	deploymentId := utils.OpenAPIUUIDToString(params.DeploymentId)
-	gatewayId := utils.OpenAPIUUIDToString(params.GatewayId)
+	deploymentId := params.DeploymentId
+	gatewayId := params.GatewayId
 
 	if providerId == "" {
 		c.JSON(http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request",
@@ -209,8 +209,8 @@ func (h *LLMProviderDeploymentHandler) RestoreLLMProviderDeployment(c *gin.Conte
 		return
 	}
 
-	deploymentId := utils.OpenAPIUUIDToString(params.DeploymentId)
-	gatewayId := utils.OpenAPIUUIDToString(params.GatewayId)
+	deploymentId := params.DeploymentId
+	gatewayId := params.GatewayId
 
 	if providerId == "" {
 		c.JSON(http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request",
@@ -506,8 +506,8 @@ func (h *LLMProxyDeploymentHandler) UndeployLLMProxyDeployment(c *gin.Context) {
 		return
 	}
 
-	deploymentId := utils.OpenAPIUUIDToString(params.DeploymentId)
-	gatewayId := utils.OpenAPIUUIDToString(params.GatewayId)
+	deploymentId := params.DeploymentId
+	gatewayId := params.GatewayId
 
 	if proxyId == "" {
 		c.JSON(http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request",
@@ -563,8 +563,8 @@ func (h *LLMProxyDeploymentHandler) RestoreLLMProxyDeployment(c *gin.Context) {
 		return
 	}
 
-	deploymentId := utils.OpenAPIUUIDToString(params.DeploymentId)
-	gatewayId := utils.OpenAPIUUIDToString(params.GatewayId)
+	deploymentId := params.DeploymentId
+	gatewayId := params.GatewayId
 
 	if proxyId == "" {
 		c.JSON(http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request",

--- a/platform-api/src/resources/openapi.yaml
+++ b/platform-api/src/resources/openapi.yaml
@@ -1063,14 +1063,12 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
           description: UUID of the deployment to undeploy
         - name: gatewayId
           in: query
           required: true
           schema:
             type: string
-            format: uuid
           description: UUID of the gateway (validated against deployment's bound gateway)
       responses:
         '200':
@@ -1111,14 +1109,12 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
           description: UUID of the deployment to restore (must be ARCHIVED or UNDEPLOYED)
         - name: gatewayId
           in: query
           required: true
           schema:
             type: string
-            format: uuid
           description: UUID of the gateway (validated against deployment's bound gateway)
       responses:
         '200':
@@ -2398,14 +2394,12 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
           description: UUID of the deployment to undeploy
         - name: gatewayId
           in: query
           required: true
           schema:
             type: string
-            format: uuid
           description: UUID of the gateway (validated against deployment's bound gateway)
       responses:
         '200':
@@ -2451,14 +2445,12 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
           description: UUID of the deployment to restore (must be ARCHIVED or UNDEPLOYED)
         - name: gatewayId
           in: query
           required: true
           schema:
             type: string
-            format: uuid
           description: UUID of the gateway (validated against deployment's bound gateway)
       responses:
         '200':
@@ -2651,14 +2643,12 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
           description: UUID of the deployment to undeploy
         - name: gatewayId
           in: query
           required: true
           schema:
             type: string
-            format: uuid
           description: UUID of the gateway (validated against deployment's bound gateway)
       responses:
         '200':
@@ -2704,14 +2694,12 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
           description: UUID of the deployment to restore (must be ARCHIVED or UNDEPLOYED)
         - name: gatewayId
           in: query
           required: true
           schema:
             type: string
-            format: uuid
           description: UUID of the gateway (validated against deployment's bound gateway)
       responses:
         '200':


### PR DESCRIPTION
## Purpose
Fixing following,

platform-api-1       | [GIN] 2026/02/14 - 02:09:51 | 400 |       624.5µs |      172.19.0.1 | POST     "/api/v1/rest-apis/698fd8552f4967645d5b868f/deployments/undeploy?deploymentId=8b81f81a-ad87-4dee-8675-cef51c42679e&gatewayId=d7448580-34fa-43ea-9e9b-be2efcdb6016"

{
    "code": 400,
    "message": "Bad Request",
    "description": "[\"8b81f81a-ad87-4dee-8675-cef51c42679e\"] is not valid value for uuid.UUID"
}

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Relaxed strict UUID format validation for deploymentId and gatewayId on undeploy/restore endpoints, allowing plain string identifiers.
  * Removed unnecessary identifier conversion in deployment restore/undeploy flows, improving consistency while preserving existing behavior and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->