### PR TITLE
Enhance API key management by adding optional 'name' field to UpdateAPIKeyRequest

### DIFF
--- a/platform-api/src/api/generated.go
+++ b/platform-api/src/api/generated.go
@@ -2052,6 +2052,9 @@ type UpdateAPIKeyRequest struct {
 	// ExternalRefId Optional reference ID for tracing purposes (from external platforms)
 	ExternalRefId *string `json:"externalRefId" yaml:"externalRefId"`
 
+	// Name Unique identifier for this API key within the API (optional; if omitted, generated from displayName)
+	Name *string `json:"name,omitempty" yaml:"name,omitempty"`
+
 	// Operations Specifies which API operations this key can access. Use "*" for all operations.
 	Operations *string `json:"operations,omitempty" yaml:"operations,omitempty"`
 }

--- a/platform-api/src/internal/handler/api_key.go
+++ b/platform-api/src/internal/handler/api_key.go
@@ -187,11 +187,11 @@ func (h *APIKeyHandler) UpdateAPIKey(c *gin.Context) {
 		return
 	}
 
-	// Validate that the display name in the request body (if provided) matches the URL path parameter
-	if req.DisplayName != nil && *req.DisplayName != "" && *req.DisplayName != keyName {
-		h.slogger.Warn("API key name mismatch", "orgId", orgId, "apiHandle", apiHandle, "urlKeyName", keyName, "bodyKeyName", *req.DisplayName)
+	// Validate that the name in the request body (if provided) matches the URL path parameter
+	if req.Name != nil && *req.Name != "" && *req.Name != keyName {
+		h.slogger.Warn("API key name mismatch", "orgId", orgId, "apiHandle", apiHandle, "urlKeyName", keyName, "bodyKeyName", *req.Name)
 		c.JSON(http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request",
-			fmt.Sprintf("API key name mismatch: name in request body '%s' must match the key name in URL '%s'", *req.DisplayName, keyName)))
+			fmt.Sprintf("API key name mismatch: name in request body '%s' must match the key name in URL '%s'", *req.Name, keyName)))
 		return
 	}
 

--- a/platform-api/src/resources/openapi.yaml
+++ b/platform-api/src/resources/openapi.yaml
@@ -4032,6 +4032,11 @@ components:
       required:
         - apiKey
       properties:
+        name:
+          type: string
+          description: Unique identifier for this API key within the API (optional; if omitted,
+            generated from displayName)
+          example: "production-key-01"
         displayName:
           type: string
           description: Display name of the API key


### PR DESCRIPTION
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an optional `name` field when updating API keys, enabling you to assign and update a unique identifier for each API key for better organization and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->