### PR TITLE
Handle optional system params without failing policy creation

### DIFF
--- a/gateway/gateway-builder/internal/discovery/schema.go
+++ b/gateway/gateway-builder/internal/discovery/schema.go
@@ -24,6 +24,8 @@ import (
 	policyv1alpha "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
 )
 
+const systemParamRequiredKey = "__wso2_internal_required"
+
 // ExtractDefaultValues extracts default values from a JSON schema structure.
 // It processes the "properties" object and extracts either "default" or "wso2/defaultValue"
 // with precedence given to "wso2/defaultValue" when both exist.
@@ -47,7 +49,7 @@ import (
 //
 //	{
 //	  policyv1alpha.SystemParamConfigRefKey: "${config.Path.To.Config}",
-//	  policyv1alpha.SystemParamRequiredKey: true|false,
+//	  systemParamRequiredKey: true|false,
 //	  policyv1alpha.SystemParamDefaultValueKey: "fallback-value" // only when schema default exists
 //	}
 //
@@ -153,12 +155,12 @@ func extractPropertyValue(propDefMap map[string]interface{}, required bool) (int
 		return map[string]interface{}{
 			policyv1alpha.SystemParamConfigRefKey:    wso2Default,
 			policyv1alpha.SystemParamDefaultValueKey: defaultValue,
-			policyv1alpha.SystemParamRequiredKey:     required,
+			systemParamRequiredKey:                   required,
 		}, true
 	case hasWso2Default:
 		return map[string]interface{}{
 			policyv1alpha.SystemParamConfigRefKey: wso2Default,
-			policyv1alpha.SystemParamRequiredKey:  required,
+			systemParamRequiredKey:                required,
 		}, true
 	case hasDefault:
 		return defaultValue, true

--- a/gateway/gateway-builder/internal/discovery/schema_test.go
+++ b/gateway/gateway-builder/internal/discovery/schema_test.go
@@ -90,7 +90,7 @@ func TestExtractDefaultValues_Precedence(t *testing.T) {
 				"prop1": map[string]interface{}{
 					policyv1alpha.SystemParamConfigRefKey:    "${config.Prop1}",
 					policyv1alpha.SystemParamDefaultValueKey: "default-value",
-					policyv1alpha.SystemParamRequiredKey:     false,
+					systemParamRequiredKey:                   false,
 				},
 			},
 		},
@@ -123,7 +123,7 @@ func TestExtractDefaultValues_Precedence(t *testing.T) {
 			want: map[string]interface{}{
 				"prop1": map[string]interface{}{
 					policyv1alpha.SystemParamConfigRefKey: "${config.Prop1}",
-					policyv1alpha.SystemParamRequiredKey:  false,
+					systemParamRequiredKey:                false,
 				},
 			},
 		},
@@ -223,25 +223,25 @@ func TestExtractDefaultValues_JWTAuthRealWorld(t *testing.T) {
 		"authHeaderScheme": map[string]interface{}{
 			policyv1alpha.SystemParamConfigRefKey:    "${config.JWTAuth.AuthHeaderScheme}",
 			policyv1alpha.SystemParamDefaultValueKey: "Bearer",
-			policyv1alpha.SystemParamRequiredKey:     false,
+			systemParamRequiredKey:                   false,
 		},
 		"headerName": map[string]interface{}{
 			policyv1alpha.SystemParamConfigRefKey:    "${config.JWTAuth.HeaderName}",
 			policyv1alpha.SystemParamDefaultValueKey: "Authorization",
-			policyv1alpha.SystemParamRequiredKey:     false,
+			systemParamRequiredKey:                   false,
 		},
 		"onFailureStatusCode": map[string]interface{}{
 			policyv1alpha.SystemParamConfigRefKey:    "${config.JWTAuth.OnFailureStatusCode}",
 			policyv1alpha.SystemParamDefaultValueKey: 401,
-			policyv1alpha.SystemParamRequiredKey:     false,
+			systemParamRequiredKey:                   false,
 		},
 		"jwksCacheTtl": map[string]interface{}{
 			policyv1alpha.SystemParamConfigRefKey: "${config.JWTAuth.JwksCacheTtl}",
-			policyv1alpha.SystemParamRequiredKey:  false,
+			systemParamRequiredKey:                false,
 		},
 		"keyManagers": map[string]interface{}{
 			policyv1alpha.SystemParamConfigRefKey: "${config.JWTAuth.KeyManagers}",
-			policyv1alpha.SystemParamRequiredKey:  false,
+			systemParamRequiredKey:                false,
 		},
 	}
 
@@ -279,12 +279,12 @@ func TestExtractDefaultValues_MixedProperties(t *testing.T) {
 		"withDefault": "value1",
 		"withWso2Default": map[string]interface{}{
 			policyv1alpha.SystemParamConfigRefKey: "${config.Value2}",
-			policyv1alpha.SystemParamRequiredKey:  false,
+			systemParamRequiredKey:                false,
 		},
 		"withBothDefaults": map[string]interface{}{
 			policyv1alpha.SystemParamConfigRefKey:    "${config.Value3}",
 			policyv1alpha.SystemParamDefaultValueKey: 100,
-			policyv1alpha.SystemParamRequiredKey:     false,
+			systemParamRequiredKey:                   false,
 		},
 	}
 
@@ -328,18 +328,18 @@ func TestExtractDefaultValues_NestedObjectProperties(t *testing.T) {
 		"algorithm": map[string]interface{}{
 			policyv1alpha.SystemParamConfigRefKey:    "${config.policy.algorithm}",
 			policyv1alpha.SystemParamDefaultValueKey: "gcra",
-			policyv1alpha.SystemParamRequiredKey:     false,
+			systemParamRequiredKey:                   false,
 		},
 		"redis": map[string]interface{}{
 			"host": map[string]interface{}{
 				policyv1alpha.SystemParamConfigRefKey:    "${config.policy.redis.host}",
 				policyv1alpha.SystemParamDefaultValueKey: "localhost",
-				policyv1alpha.SystemParamRequiredKey:     false,
+				systemParamRequiredKey:                   false,
 			},
 			"port": 6379,
 			"password": map[string]interface{}{
 				policyv1alpha.SystemParamConfigRefKey: "${config.policy.redis.password}",
-				policyv1alpha.SystemParamRequiredKey:  false,
+				systemParamRequiredKey:                false,
 			},
 		},
 	}
@@ -411,20 +411,20 @@ func TestExtractDefaultValues_RequiredMetadata(t *testing.T) {
 	want := map[string]interface{}{
 		"requiredProp": map[string]interface{}{
 			policyv1alpha.SystemParamConfigRefKey: "${config.required}",
-			policyv1alpha.SystemParamRequiredKey:  true,
+			systemParamRequiredKey:                true,
 		},
 		"optionalProp": map[string]interface{}{
 			policyv1alpha.SystemParamConfigRefKey: "${config.optional}",
-			policyv1alpha.SystemParamRequiredKey:  false,
+			systemParamRequiredKey:                false,
 		},
 		"nested": map[string]interface{}{
 			"nestedRequired": map[string]interface{}{
 				policyv1alpha.SystemParamConfigRefKey: "${config.nested.required}",
-				policyv1alpha.SystemParamRequiredKey:  true,
+				systemParamRequiredKey:                true,
 			},
 			"nestedOptional": map[string]interface{}{
 				policyv1alpha.SystemParamConfigRefKey: "${config.nested.optional}",
-				policyv1alpha.SystemParamRequiredKey:  false,
+				systemParamRequiredKey:                false,
 			},
 		},
 	}

--- a/gateway/gateway-runtime/policy-engine/internal/registry/config_resolver.go
+++ b/gateway/gateway-runtime/policy-engine/internal/registry/config_resolver.go
@@ -56,6 +56,8 @@ func NewConfigResolver(config map[string]interface{}) (*ConfigResolver, error) {
 // Regular expression to match ${...} pattern anywhere in the string
 var configRefPattern = regexp.MustCompile(`\$\{([^}]+)\}`)
 
+const systemParamRequiredKey = "__wso2_internal_required"
+
 // ResolveValue resolves a value that may contain one or more ${...} CEL expressions
 // Supports:
 //   - Single expression: "${config.timeout}" -> evaluates to the value
@@ -294,7 +296,7 @@ func parseSystemParamMarker(value map[string]interface{}) (systemParamMarker, bo
 		marker.hasDefault = true
 	}
 
-	if requiredRaw, hasRequired := value[policyv1alpha.SystemParamRequiredKey]; hasRequired {
+	if requiredRaw, hasRequired := value[systemParamRequiredKey]; hasRequired {
 		required, ok := requiredRaw.(bool)
 		if !ok {
 			return systemParamMarker{}, false

--- a/gateway/gateway-runtime/policy-engine/internal/registry/config_resolver_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/registry/config_resolver_test.go
@@ -767,7 +767,7 @@ func TestConfigResolver_FallbackMarkers(t *testing.T) {
 		input := map[string]interface{}{
 			"optionalTimeout": map[string]interface{}{
 				policyv1alpha.SystemParamConfigRefKey: "${config.policy.timeout}",
-				policyv1alpha.SystemParamRequiredKey:  false,
+				systemParamRequiredKey:                false,
 			},
 			"staticValue": 42,
 		}
@@ -794,7 +794,7 @@ func TestConfigResolver_FallbackMarkers(t *testing.T) {
 		input := map[string]interface{}{
 			"requiredTimeout": map[string]interface{}{
 				policyv1alpha.SystemParamConfigRefKey: "${config.policy.timeout}",
-				policyv1alpha.SystemParamRequiredKey:  true,
+				systemParamRequiredKey:                true,
 			},
 		}
 

--- a/gateway/gateway-runtime/policy-engine/internal/registry/registry_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/registry/registry_test.go
@@ -522,7 +522,7 @@ func TestCreateInstance(t *testing.T) {
 			SystemParameters: map[string]interface{}{
 				"optionalTimeout": map[string]interface{}{
 					policy.SystemParamConfigRefKey: "${config.policy.optional_timeout}",
-					policy.SystemParamRequiredKey:  false,
+					systemParamRequiredKey:         false,
 				},
 			},
 		}
@@ -548,7 +548,7 @@ func TestCreateInstance(t *testing.T) {
 			SystemParameters: map[string]interface{}{
 				"requiredTimeout": map[string]interface{}{
 					policy.SystemParamConfigRefKey: "${config.policy.required_timeout}",
-					policy.SystemParamRequiredKey:  true,
+					systemParamRequiredKey:         true,
 				},
 			},
 		}

--- a/sdk/gateway/policy/v1alpha/system_parameters.go
+++ b/sdk/gateway/policy/v1alpha/system_parameters.go
@@ -8,8 +8,4 @@ const (
 	// SystemParamDefaultValueKey stores the schema default value paired with
 	// SystemParamConfigRefKey for runtime fallback on missing config keys.
 	SystemParamDefaultValueKey = "__wso2_internal_default"
-
-	// SystemParamRequiredKey stores whether the source schema marks the system
-	// parameter as required at its object level.
-	SystemParamRequiredKey = "__wso2_internal_required"
 )


### PR DESCRIPTION
## Summary
- preserve system parameter precedence by resolving `wso2/defaultValue` (config ref) first and falling back to schema `default` when available
- skip missing optional system params (no schema default) instead of failing policy creation
- keep missing required system params as errors
- propagate system-param required metadata from schema extraction into builder output
- include `gateway/it/test-config.toml` cleanup updates in this changeset

## Testing
- go test ./internal/discovery (gateway/gateway-builder)
- go test ./internal/registry (gateway/gateway-runtime/policy-engine)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced configuration parameter resolution to distinguish between required and optional parameters with proper default handling.
  * Improved metadata tracking for parameter defaults and required status.

* **Tests**
  * Added comprehensive test coverage for required vs. optional parameter resolution scenarios, including error handling and omission logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->