### PR TITLE
Change template lookup by type

### DIFF
--- a/gateway/gateway-runtime/policy-engine/internal/analytics/analytics.go
+++ b/gateway/gateway-runtime/policy-engine/internal/analytics/analytics.go
@@ -301,17 +301,35 @@ func (c *Analytics) prepareAnalyticEvent(logEntry *v3.HTTPAccessLogEntry) *dto.E
 		event.Properties["aiMetadata"] = aiMetadata
 
 		aiTokenUsage := dto.AITokenUsage{}
-		if promptToken, err := strconv.Atoi(keyValuePairsFromMetadata[PromptTokenCountMetadataKey]); err == nil {
+		// Prompt tokens
+		if raw, ok := keyValuePairsFromMetadata[PromptTokenCountMetadataKey]; !ok {
+			slog.Debug(
+				"Prompt token count not found in response",
+				"metadataKey", PromptTokenCountMetadataKey,
+			)
+		} else if promptToken, err := strconv.Atoi(raw); err == nil {
 			aiTokenUsage.PromptToken = promptToken
 		} else {
 			slog.Error("Error converting PromptTokenCountMetadataKey to integer", "error", err)
 		}
-		if completionToken, err := strconv.Atoi(keyValuePairsFromMetadata[CompletionTokenCountMetadataKey]); err == nil {
+		// Completion tokens
+		if raw, ok := keyValuePairsFromMetadata[CompletionTokenCountMetadataKey]; !ok {
+			slog.Debug(
+				"Completion token count not found in response",
+				"metadataKey", CompletionTokenCountMetadataKey,
+			)
+		} else if completionToken, err := strconv.Atoi(raw); err == nil {
 			aiTokenUsage.CompletionToken = completionToken
 		} else {
 			slog.Error("Error converting CompletionTokenCountMetadataKey to integer", "error", err)
 		}
-		if totalToken, err := strconv.Atoi(keyValuePairsFromMetadata[TotalTokenCountMetadataKey]); err == nil {
+		// Total tokens
+		if raw, ok := keyValuePairsFromMetadata[TotalTokenCountMetadataKey]; !ok {
+			slog.Debug(
+				"Total token count not found in response",
+				"metadataKey", TotalTokenCountMetadataKey,
+			)
+		} else if totalToken, err := strconv.Atoi(raw); err == nil {
 			aiTokenUsage.TotalToken = totalToken
 		} else {
 			slog.Error("Error converting TotalTokenCountMetadataKey to integer", "error", err)

--- a/gateway/system-policies/analytics/analytics.go
+++ b/gateway/system-policies/analytics/analytics.go
@@ -32,7 +32,7 @@ const (
 	AIProviderDisplayNameMetadataKey = "ai:providerdisplayname"
 
 	// AuthContext key for user ID (used for analytics)
-	AuthContextKeyUserID    = "x-wso2-user-id"
+	AuthContextKeyUserID = "x-wso2-user-id"
 
 	// Lazy resource type for LLM provider templates
 	lazyResourceTypeLLMProviderTemplate = "LlmProviderTemplate"
@@ -59,22 +59,22 @@ var (
 type AnalyticsPolicy struct{}
 
 type McpRequestAnalyticsProperties struct {
-    JsonRpcMethod  string         `json:"jsonRpcMethod,omitempty"`
-    Capability     string         `json:"capability,omitempty"`
-    CapabilityName string         `json:"capabilityName,omitempty"`
-    ClientInfo     *McpClientInfo `json:"clientInfo,omitempty"`
+	JsonRpcMethod  string         `json:"jsonRpcMethod,omitempty"`
+	Capability     string         `json:"capability,omitempty"`
+	CapabilityName string         `json:"capabilityName,omitempty"`
+	ClientInfo     *McpClientInfo `json:"clientInfo,omitempty"`
 	ServerInfo     *McpServerInfo `json:"serverInfo,omitempty"`
 }
 
 type McpClientInfo struct {
-    RequestedProtocolVersion string `json:"requestedProtocolVersion"`
-    Name                     string `json:"name"`
-    Version                  string `json:"version"`
+	RequestedProtocolVersion string `json:"requestedProtocolVersion"`
+	Name                     string `json:"name"`
+	Version                  string `json:"version"`
 }
 
 type McpServerInfo struct {
-	ProtocolVersion string                 `json:"protocolVersion,omitempty"`
-	ServerInfo      *McpServerInfoDetails  `json:"serverInfo,omitempty"`
+	ProtocolVersion string                `json:"protocolVersion,omitempty"`
+	ServerInfo      *McpServerInfoDetails `json:"serverInfo,omitempty"`
 }
 
 type McpServerInfoDetails struct {
@@ -83,8 +83,8 @@ type McpServerInfoDetails struct {
 }
 
 type McpResponseAnalyticsProperties struct {
-    IsError   bool `json:"isError,omitempty"`
-    ErrorCode int  `json:"errorCode,omitempty"`
+	IsError   bool `json:"isError,omitempty"`
+	ErrorCode int  `json:"errorCode,omitempty"`
 }
 
 // LLMTokenInfo holds extracted token-related information from LLM provider responses
@@ -123,7 +123,7 @@ func (a *AnalyticsPolicy) Mode() policy.ProcessingMode {
 func (a *AnalyticsPolicy) OnRequest(ctx *policy.RequestContext, params map[string]interface{}) policy.RequestAction {
 	slog.Debug("Analytics system policy: OnRequest called")
 	allowPayloads := getAllowPayloadsFlag(params)
-    // Store tokenInfo in analytics metadata for publishing
+	// Store tokenInfo in analytics metadata for publishing
 	analyticsMetadata := make(map[string]any)
 
 	// When allow_payloads is enabled, capture the raw request body into analytics metadata.
@@ -131,7 +131,6 @@ func (a *AnalyticsPolicy) OnRequest(ctx *policy.RequestContext, params map[strin
 		slog.Debug("Capturing request payload for analytics")
 		analyticsMetadata["request_payload"] = string(ctx.Body.Content)
 	}
-
 
 	// Extract common analytics data from the request
 	// Based on the API kind, collect the analytics data
@@ -147,7 +146,7 @@ func (a *AnalyticsPolicy) OnRequest(ctx *policy.RequestContext, params map[strin
 		// Currently no data is collected
 	case KindMCP:
 		// Collect analytics data specific for MCP scenario from request
-		if ctx.Headers != nil  && len(ctx.Headers.GetAll()) > 0 {
+		if ctx.Headers != nil && len(ctx.Headers.GetAll()) > 0 {
 			// Need to get the mcp-session-id from headers
 			sessionIDs := ctx.Headers.Get("mcp-session-id")
 			if len(sessionIDs) > 0 {
@@ -184,9 +183,9 @@ func (a *AnalyticsPolicy) OnRequest(ctx *policy.RequestContext, params map[strin
 
 			// Populate client info
 			clientInfo := McpClientInfo{
-				RequestedProtocolVersion: extractStringFromJsonpath(mcpPayload,ProtocolVersionJsonPath),
-				Name:                     extractStringFromJsonpath(mcpPayload,ClientNameJsonPath),
-				Version:                  extractStringFromJsonpath(mcpPayload,ClientVersionJsonPath),
+				RequestedProtocolVersion: extractStringFromJsonpath(mcpPayload, ProtocolVersionJsonPath),
+				Name:                     extractStringFromJsonpath(mcpPayload, ClientNameJsonPath),
+				Version:                  extractStringFromJsonpath(mcpPayload, ClientVersionJsonPath),
 			}
 			// Only set ClientInfo pointer if at least one field is non-empty so that omitempty can exclude it from JSON
 			if clientInfo.RequestedProtocolVersion != "" || clientInfo.Name != "" || clientInfo.Version != "" {
@@ -222,10 +221,16 @@ func getTemplateByHandle(templateHandle string) (map[string]interface{}, error) 
 		return nil, fmt.Errorf("lazy resource store is not available")
 	}
 
-	// Direct lookup by ID (handle)
-	resource, err := store.GetResource(templateHandle)
+	// Use ID + resource type lookup to avoid ambiguous matches when the same ID
+	// exists under different lazy resource types (e.g., ProviderTemplateMapping).
+	resource, err := store.GetResourceByIDAndType(templateHandle, lazyResourceTypeLLMProviderTemplate)
 	if err != nil {
-		return nil, fmt.Errorf("template with handle '%s' not found in cache: %w", templateHandle, err)
+		return nil, fmt.Errorf(
+			"template with handle '%s' and type '%s' not found in cache: %w",
+			templateHandle,
+			lazyResourceTypeLLMProviderTemplate,
+			err,
+		)
 	}
 
 	if resource.Resource == nil {
@@ -315,7 +320,7 @@ func (p *AnalyticsPolicy) OnResponse(ctx *policy.ResponseContext, params map[str
 		}
 	case KindMCP:
 		// Collect the analytics data specific for MCP specific scenario
-		if ctx.ResponseHeaders != nil  && len(ctx.ResponseHeaders.GetAll()) > 0 {
+		if ctx.ResponseHeaders != nil && len(ctx.ResponseHeaders.GetAll()) > 0 {
 			if analyticsMetadata["mcp_session_id"] == nil {
 				sessionIDs := ctx.ResponseHeaders.Get("mcp-session-id")
 				if len(sessionIDs) > 0 {
@@ -328,7 +333,7 @@ func (p *AnalyticsPolicy) OnResponse(ctx *policy.ResponseContext, params map[str
 		if ctx != nil && ctx.ResponseBody != nil && len(ctx.ResponseBody.Content) > 0 {
 			var mcpResponsePayload map[string]interface{}
 			responseContent := ctx.ResponseBody.Content
-			
+
 			// Check if response is in SSE format by inspecting content-type or content structure
 			isSSE := false
 			if ctx.ResponseHeaders != nil {
@@ -337,12 +342,12 @@ func (p *AnalyticsPolicy) OnResponse(ctx *policy.ResponseContext, params map[str
 					isSSE = true
 				}
 			}
-			
+
 			// Also check content structure if header check didn't confirm SSE
 			if !isSSE && (strings.HasPrefix(string(responseContent), "event:") || strings.Contains(string(responseContent), "\ndata:")) {
 				isSSE = true
 			}
-			
+
 			// Parse SSE format if detected
 			if isSSE {
 				jsonData, err := parseSSEResponse(responseContent)
@@ -352,7 +357,7 @@ func (p *AnalyticsPolicy) OnResponse(ctx *policy.ResponseContext, params map[str
 					responseContent = jsonData
 				}
 			}
-			
+
 			// Unmarshal the JSON (either from SSE data field or direct response)
 			if err := json.Unmarshal(responseContent, &mcpResponsePayload); err != nil {
 				slog.Error("Failed to unmarshal MCP response body for server info analytics", "error", err)
@@ -362,12 +367,12 @@ func (p *AnalyticsPolicy) OnResponse(ctx *policy.ResponseContext, params map[str
 					Name:    extractStringFromJsonpath(mcpResponsePayload, ServerInfoNameJsonPath),
 					Version: extractStringFromJsonpath(mcpResponsePayload, ServerInfoVersionJsonPath),
 				}
-				
+
 				// Populate server info
 				serverInfo := McpServerInfo{
 					ProtocolVersion: extractStringFromJsonpath(mcpResponsePayload, ServerProtocolVersionJsonPath),
 				}
-				
+
 				// Only set ServerInfo pointer if at least one field is non-empty
 				if serverInfoDetails.Name != "" || serverInfoDetails.Version != "" {
 					serverInfo.ServerInfo = &serverInfoDetails

--- a/sdk/gateway/policy/v1alpha/lazy_resource.go
+++ b/sdk/gateway/policy/v1alpha/lazy_resource.go
@@ -97,21 +97,6 @@ func (lrs *LazyResourceStore) StoreResource(resource *LazyResource) error {
 	return nil
 }
 
-// GetResource retrieves a resource by ID (ambiguous if multiple types have same ID)
-func (lrs *LazyResourceStore) GetResource(id string) (*LazyResource, error) {
-	lrs.mu.RLock()
-	defer lrs.mu.RUnlock()
-
-	// Search through all resources for matching ID
-	for _, resource := range lrs.resources {
-		if resource.ID == id {
-			return resource, nil
-		}
-	}
-
-	return nil, ErrLazyResourceNotFound
-}
-
 // GetResourceByIDAndType retrieves a resource by ID and type (precise)
 func (lrs *LazyResourceStore) GetResourceByIDAndType(id, resourceType string) (*LazyResource, error) {
 	lrs.mu.RLock()


### PR DESCRIPTION
## Purpose
This pull request addresses an intermittent issue where token usage extraction fails due to incorrect template resolution from lazily loaded resources.  

In addition, it improves debug logging by ensuring token metadata is converted only when present and valid, using `strconv.Atoi`, which helps avoid misleading logs and makes debugging provider responses more reliable.

## Issues
Fix https://github.com/wso2-enterprise/apim-saas/issues/2027

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved analytics parsing to gracefully handle missing or malformed token metadata and emit diagnostics instead of causing runtime failures.

* **Refactor**
  * Made resource lookup type-aware to avoid ambiguous matches and adjusted retrieval paths for more precise results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->