### PR TITLE
Add Authorized field to AuthContext

### DIFF
--- a/sdk/gateway/policy/v1alpha/auth_context.go
+++ b/sdk/gateway/policy/v1alpha/auth_context.go
@@ -7,13 +7,14 @@ type AuthContext struct {
 	// Authenticated indicates whether the request was successfully authenticated.
 	Authenticated bool
 
-	// AuthType identifies the authentication mechanism used.
-	// Common values: "jwt", "oauth2", "apikey", "basic".
-	AuthType string
+	// Authorized indicates the request passed an authorization check.
+	// Set by authorization policies (e.g., mcp-authz); always false for authentication-only policies.
+	Authorized bool
 
-	// PolicyName is the name of the policy that produced this AuthContext,
-	// e.g. "jwt-auth", "basic-auth", "api-key-auth".
-	PolicyName string
+	// AuthType identifies the authentication mechanism used.
+	// Common values: "jwt", "basic", "apikey".
+	// MCP convention: "mcp/oauth" for MCP OAuth authentication; "mcp/oauth+authz" after MCP authorization passes.
+	AuthType string
 
 	// Subject is the principal identity — JWT "sub" claim, basic-auth username,
 	// or API key owner.

--- a/sdk/gateway/policy/v1alpha/auth_context_test.go
+++ b/sdk/gateway/policy/v1alpha/auth_context_test.go
@@ -7,11 +7,11 @@ func TestAuthContext_ZeroValue(t *testing.T) {
 	if ac.Authenticated {
 		t.Error("zero-value AuthContext should have Authenticated=false")
 	}
+	if ac.Authorized {
+		t.Error("zero-value AuthContext should have Authorized=false")
+	}
 	if ac.AuthType != "" {
 		t.Error("zero-value AuthContext should have empty AuthType")
-	}
-	if ac.PolicyName != "" {
-		t.Error("zero-value AuthContext should have empty PolicyName")
 	}
 	if ac.Subject != "" {
 		t.Error("zero-value AuthContext should have empty Subject")
@@ -90,13 +90,11 @@ func TestAuthContext_PreviousChain(t *testing.T) {
 	first := &AuthContext{
 		Authenticated: true,
 		AuthType:      "basic",
-		PolicyName:    "basic-auth",
 		Subject:       "alice",
 	}
 	second := &AuthContext{
 		Authenticated: true,
 		AuthType:      "jwt",
-		PolicyName:    "jwt-auth",
 		Subject:       "alice@example.com",
 		Previous:      first,
 	}
@@ -118,6 +116,29 @@ func TestAuthContext_PreviousChain(t *testing.T) {
 	}
 	if count != 2 {
 		t.Errorf("expected chain length 2, got %d", count)
+	}
+}
+
+func TestAuthContext_Authorized(t *testing.T) {
+	ac := &AuthContext{
+		Authenticated: true,
+		Authorized:    true,
+		AuthType:      "mcp/oauth+authz",
+	}
+	if !ac.Authorized {
+		t.Error("expected Authorized=true")
+	}
+	if ac.AuthType != "mcp/oauth+authz" {
+		t.Errorf("expected AuthType='mcp/oauth+authz', got %q", ac.AuthType)
+	}
+
+	// Auth-only policy leaves Authorized=false
+	authOnly := &AuthContext{
+		Authenticated: true,
+		AuthType:      "mcp/oauth",
+	}
+	if authOnly.Authorized {
+		t.Error("auth-only AuthContext should have Authorized=false")
 	}
 }
 


### PR DESCRIPTION
## Purpose
> Discussion: https://github.com/wso2/api-platform/discussions/1048
> Updated AuthContext struct in SDK to include Authorized field and removed PolicyName

## Goals
> Describe **what solutions** this feature or fix introduces to address the problems outlined above.

## Approach
> Describe **how** you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **API Updates**
  * Enhanced authorization context with a new flag to indicate authorization check results.
  * Removed policy name field from authorization context.
  * Updated authentication type documentation with MCP convention references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->