### PR TITLE
refactor(cli): switch table output to kubectl-style format

### DIFF
--- a/cli/src/utils/print.go
+++ b/cli/src/utils/print.go
@@ -2,81 +2,37 @@ package utils
 
 import (
 	"fmt"
+	"os"
 	"strings"
+	"text/tabwriter"
 )
 
-// PrintTable prints a table with ASCII borders. Headers and each row
-// should have the same number of columns; rows may be shorter and will be
-// padded.
+// PrintTable prints a table with kubectl-style whitespace-aligned columns.
+// Headers and each row should have the same number of columns; rows may be
+// shorter and will be padded with empty strings.
 func PrintTable(headers []string, rows [][]string) {
-	cols := len(headers)
-	if cols == 0 {
+	if len(headers) == 0 {
 		return
 	}
 
-	// compute column widths
-	widths := make([]int, cols)
-	for i, h := range headers {
-		widths[i] = len(h)
-	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 8, 3, ' ', 0)
+
+	// Header row
+	fmt.Fprintln(w, strings.Join(headers, "\t"))
+
+	// Data rows
+	cols := len(headers)
 	for _, r := range rows {
-		for i := 0; i < cols && i < len(r); i++ {
-			if len(r[i]) > widths[i] {
-				widths[i] = len(r[i])
-			}
-		}
-	}
-
-	// helper to build separator like +-----+------+
-	buildSep := func() string {
-		var b strings.Builder
-		b.WriteString("+")
-		for _, w := range widths {
-			b.WriteString(strings.Repeat("-", w+2))
-			b.WriteString("+")
-		}
-		return b.String()
-	}
-
-	pad := func(s string, w int) string {
-		if len(s) >= w {
-			return s
-		}
-		return s + strings.Repeat(" ", w-len(s))
-	}
-
-	sep := buildSep()
-	fmt.Println(sep)
-
-	// header
-	var hb strings.Builder
-	hb.WriteString("|")
-	for i, h := range headers {
-		hb.WriteString(" ")
-		hb.WriteString(pad(h, widths[i]))
-		hb.WriteString(" |")
-	}
-	fmt.Println(hb.String())
-	fmt.Println(sep)
-
-	// rows
-	for _, r := range rows {
-		var rb strings.Builder
-		rb.WriteString("|")
+		cells := make([]string, cols)
 		for i := 0; i < cols; i++ {
-			var cell string
 			if i < len(r) {
-				cell = r[i]
-			} else {
-				cell = ""
+				cells[i] = r[i]
 			}
-			rb.WriteString(" ")
-			rb.WriteString(pad(cell, widths[i]))
-			rb.WriteString(" |")
 		}
-		fmt.Println(rb.String())
-		fmt.Println(sep)
+		fmt.Fprintln(w, strings.Join(cells, "\t"))
 	}
+
+	w.Flush()
 }
 
 // PrintBoxedMessage prints a message in a box with borders


### PR DESCRIPTION
## Purpose

The `ap` CLI prints tables with bordered ASCII format (`+---+`, `| |`), which is inconsistent with standard CLI tools like kubectl, docker, gh, and helm. This PR switches to kubectl-style whitespace-aligned columns for a cleaner, more familiar output.

Fixes #1345

## Goals

- Replace bordered ASCII table output with kubectl-style whitespace-aligned columns
- Maintain the same `PrintTable` function signature so all callers are unaffected

## Approach

- Rewrite `PrintTable` in `cli/src/utils/print.go` to use Go stdlib `text/tabwriter` (the same package kubectl uses internally)
- Configure with `minwidth=0, tabwidth=8, padding=3` for consistent 3-space column gaps
- No changes needed in any of the 3 callers (`gateway/list.go`, `gateway/restapi/list.go`, `gateway/mcp/list.go`)

**Before:**
```
+------+-----------------------+-------+
| NAME | SERVER                | AUTH  |
+------+-----------------------+-------+
| dev  | http://localhost:9090 | basic |
+------+-----------------------+-------+
```

**After:**
```
NAME   SERVER                  AUTH
dev    http://localhost:9090   basic
```

## User stories

As a CLI user, I want table output that matches the style of standard tools like kubectl so the experience feels consistent and professional.

## Documentation

N/A — no new user-facing commands or flags; output format change only.

## Automation tests

- Unit tests
  - Added `cli/src/utils/print_test.go` with tests for normal output, empty headers, short rows, and no-rows cases (not included in this PR, available on branch)
- Integration tests
  - N/A — output formatting only

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (Go project)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

N/A

## Test environment

- Go 1.24, macOS Darwin 25.3.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated CLI table formatting for improved alignment and readability. Table output now uses automatic column width calculation for cleaner, more consistent display across different data sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->