### PR TITLE
Add API key support for on-prem APIM

### DIFF
--- a/gateway/gateway-controller/pkg/constants/constants.go
+++ b/gateway/gateway-controller/pkg/constants/constants.go
@@ -151,9 +151,10 @@ const (
 	APIKeyPrefix = "apip_"
 	APIKeyLen    = 32 // Length of the random part of the API key in bytes
 
-	// API Key length constants
+	// API Key length constants.
+	// Max is 2048 to support external JWT keys (e.g. from WSO2 APIM internal keys) which exceed 128 chars.
 	DefaultMinAPIKeyLength = 36
-	DefaultMaxAPIKeyLength = 128
+	DefaultMaxAPIKeyLength = 2048
 
 	// API Key name and display name length constants
 	APIKeyNameMinLength  = 3

--- a/gateway/gateway-controller/pkg/utils/api_key.go
+++ b/gateway/gateway-controller/pkg/utils/api_key.go
@@ -172,13 +172,23 @@ func (s *APIKeyService) CreateAPIKey(params APIKeyCreationParams) (*APIKeyCreati
 		operationType = "register"
 	}
 
-	// Validate that API exists
-	config, err := s.store.GetByHandle(params.Handle)
-	if err != nil {
-		logger.Error("API configuration not found for API Key generation",
+	// Validate that API exists. Look up by UUID first (e.g. apikey.created event sends apiId;
+	// deployed APIs are stored with UUID = apiId). Fall back to handle (REST uses handle).
+	config, err := s.db.GetConfig(params.Handle)
+	if err != nil && !storage.IsNotFoundError(err) {
+		logger.Error("API configuration lookup by ID failed",
 			slog.String("operation", operationType+"_key"),
 			slog.Any("error", err))
-		return nil, fmt.Errorf("API configuration handle '%s' not found", params.Handle)
+		return nil, fmt.Errorf("API configuration lookup failed: %w", err)
+	}
+	if config == nil || err != nil {
+		config, err = s.store.GetByHandle(params.Handle)
+		if err != nil {
+			logger.Error("API configuration not found for API Key generation",
+				slog.String("operation", operationType+"_key"),
+				slog.Any("error", err))
+			return nil, fmt.Errorf("API configuration handle '%s' not found", params.Handle)
+		}
 	}
 
 	// Check API key limit enforcement
@@ -211,10 +221,26 @@ func (s *APIKeyService) CreateAPIKey(params APIKeyCreationParams) (*APIKeyCreati
 			if errors.Is(err, storage.ErrConflict) {
 				// Handle collision - only retry for locally generated keys
 				if isExternalKeyInjection {
-					// For external keys, collision means the key already exists
-					logger.Error("External API key already exists in the system",
-						slog.String("operation", operationType+"_key"))
-					return nil, fmt.Errorf("%w: provided API key already exists", storage.ErrConflict)
+					// For external keys (e.g. from apikey.created), same name = update existing key with new value (e.g. regenerated JWT)
+					logger.Info("External API key name already exists, updating with new value",
+						slog.String("operation", operationType+"_key"),
+						slog.String("name", apiKey.Name))
+					updateParams := APIKeyUpdateParams{
+						Handle:        config.Handle,
+						APIKeyName:    apiKey.Name,
+						Request:       params.Request,
+						User:          params.User,
+						Logger:        logger,
+						CorrelationID: params.CorrelationID,
+					}
+					updateResult, updateErr := s.UpdateAPIKey(updateParams)
+					if updateErr != nil {
+						logger.Error("Failed to update existing external API key after conflict",
+							slog.String("operation", operationType+"_key"),
+							slog.Any("error", updateErr))
+						return nil, fmt.Errorf("failed to update existing API key: %w", updateErr)
+					}
+					return &APIKeyCreationResult{Response: updateResult.Response}, nil
 				}
 
 				// For local keys, retry with a new generated key
@@ -1200,7 +1226,7 @@ func (s *APIKeyService) updateAPIKeyFromRequest(existingKey *models.APIKey, requ
 		return nil, fmt.Errorf("invalid API key value: %w", err)
 	}
 
-	// Handle displayName - optional during update
+	// Handle displayName - optional during update (e.g. apikey.created event may not send it)
 	// If not provided or empty, keep the existing displayName
 	var displayName string
 	if request.DisplayName != nil && strings.TrimSpace(*request.DisplayName) != "" {
@@ -1211,7 +1237,7 @@ func (s *APIKeyService) updateAPIKeyFromRequest(existingKey *models.APIKey, requ
 			return nil, fmt.Errorf("invalid display name: %w", err)
 		}
 	} else {
-		return nil, fmt.Errorf("display name is required for update")
+		displayName = existingKey.DisplayName
 	}
 
 	operations := "[\"*\"]" // Default to all operations


### PR DESCRIPTION
### Purpose

This pull request introduces several improvements to API key handling in the gateway controller, focusing on better support for external API keys (such as JWT keys from [on-prem APIM](https://github.com/wso2/api-platform/pull/1302)), enhanced conflict resolution, and more flexible display name management during updates.

Improvements for external API key support:

* Increased the maximum allowed API key length from 128 to 2048 characters in `constants.go` to support long external JWT keys.
* Enhanced API configuration lookup in `CreateAPIKey` to try searching by UUID first, then by handle, improving compatibility with externally provisioned keys.

Conflict resolution enhancements:

* Changed conflict handling for external API keys: instead of erroring when a key name already exists, the system now updates the existing key with the new value (e.g., for regenerated JWTs).

Display name flexibility:

* Improved display name handling during API key updates: if a display name is not provided, the existing display name is retained, making updates from external sources more robust. [[1]](diffhunk://#diff-d41b0272042c043a01eaf740b1b497bae68cbbb34603fad2318540d5b46da9f9L1203-R1229) [[2]](diffhunk://#diff-d41b0272042c043a01eaf740b1b497bae68cbbb34603fad2318540d5b46da9f9L1214-R1240)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced configuration lookup with improved error handling for API key creation
  * Display name is now optional when updating existing API keys

* **Improvements**
  * Extended maximum API key length to accommodate larger external authentication tokens
  * External API keys now automatically update on collision instead of returning an error

<!-- end of auto-generated comment: release notes by coderabbit.ai -->