### PR TITLE
Remove xDS version in Stored Config

### DIFF
--- a/gateway/gateway-controller/pkg/api/handlers/handlers.go
+++ b/gateway/gateway-controller/pkg/api/handlers/handlers.go
@@ -140,7 +140,7 @@ func NewAPIServer(
 }
 
 // handleStatusUpdate is called by SnapshotManager after xDS deployment
-func (s *APIServer) handleStatusUpdate(configID string, success bool, version int64, correlationID string) {
+func (s *APIServer) handleStatusUpdate(configID string, success bool, correlationID string) {
 	// Create a logger with correlation ID if provided
 	log := s.logger
 	if correlationID != "" {
@@ -157,7 +157,6 @@ func (s *APIServer) handleStatusUpdate(configID string, success bool, version in
 	if success {
 		cfg.Status = models.StatusDeployed
 		cfg.DeployedAt = &now
-		cfg.DeployedVersion = version
 		log.Info("Configuration deployed successfully",
 			slog.String("id", configID),
 			slog.String("kind", cfg.Kind),
@@ -165,7 +164,6 @@ func (s *APIServer) handleStatusUpdate(configID string, success bool, version in
 	} else {
 		cfg.Status = models.StatusFailed
 		cfg.DeployedAt = nil
-		cfg.DeployedVersion = 0
 		log.Error("Configuration deployment failed",
 			slog.String("id", configID),
 			slog.String("kind", cfg.Kind),

--- a/gateway/gateway-controller/pkg/api/handlers/handlers_test.go
+++ b/gateway/gateway-controller/pkg/api/handlers/handlers_test.go
@@ -1120,13 +1120,12 @@ func TestHandleStatusUpdate(t *testing.T) {
 	_ = server.store.Add(cfg)
 
 	// Test successful deployment
-	server.handleStatusUpdate("0000-test-id-0000-000000000000", true, 1, "corr-id-1")
+	server.handleStatusUpdate("0000-test-id-0000-000000000000", true, "corr-id-1")
 
 	// Verify status updated
 	updatedCfg, _ := server.store.Get("0000-test-id-0000-000000000000")
 	assert.Equal(t, models.StatusDeployed, updatedCfg.Status)
 	assert.NotNil(t, updatedCfg.DeployedAt)
-	assert.Equal(t, int64(1), updatedCfg.DeployedVersion)
 }
 
 // TestHandleStatusUpdateFailure tests status update for failed deployment
@@ -1138,7 +1137,7 @@ func TestHandleStatusUpdateFailure(t *testing.T) {
 	_ = server.store.Add(cfg)
 
 	// Test failed deployment
-	server.handleStatusUpdate("0000-test-id-0000-000000000000", false, 0, "")
+	server.handleStatusUpdate("0000-test-id-0000-000000000000", false, "")
 
 	// Verify status updated
 	updatedCfg, _ := server.store.Get("0000-test-id-0000-000000000000")
@@ -1151,7 +1150,7 @@ func TestHandleStatusUpdateNotFound(t *testing.T) {
 	server := createTestAPIServer()
 
 	// Should not panic
-	server.handleStatusUpdate("nonexistent", true, 1, "")
+	server.handleStatusUpdate("nonexistent", true, "")
 }
 
 // TestCreateRestAPIInvalidBody tests CreateRestAPI with invalid request body
@@ -1625,7 +1624,7 @@ func TestWaitForDeploymentAndNotifyTimeout(t *testing.T) {
 
 	case <-time.After(2 * time.Second):
 		// Trigger graceful exit by updating status to deployed
-		server.handleStatusUpdate("0000-test-id-0000-000000000000", true, 1, "")
+		server.handleStatusUpdate("0000-test-id-0000-000000000000", true, "")
 		require.NoError(t, <-done)
 
 		retrievedCfg, err := server.store.Get("0000-test-id-0000-000000000000")
@@ -1822,7 +1821,7 @@ func TestHandleStatusUpdateWithDB(t *testing.T) {
 	mockDB.configs["0000-test-id-0000-000000000000"] = cfg
 
 	// Test successful deployment
-	server.handleStatusUpdate("0000-test-id-0000-000000000000", true, 1, "corr-id-1")
+	server.handleStatusUpdate("0000-test-id-0000-000000000000", true, "corr-id-1")
 
 	// Verify both store and DB are updated
 	updatedCfg, _ := server.store.Get("0000-test-id-0000-000000000000")
@@ -1841,7 +1840,7 @@ func TestHandleStatusUpdateDBError(t *testing.T) {
 	mockDB.configs["0000-test-id-0000-000000000000"] = cfg
 
 	// Should not panic even with DB error
-	server.handleStatusUpdate("0000-test-id-0000-000000000000", true, 1, "corr-id-1")
+	server.handleStatusUpdate("0000-test-id-0000-000000000000", true, "corr-id-1")
 }
 
 // TestBuildStoredPolicyFromAPIInvalidKind tests buildStoredPolicyFromAPI with invalid kind
@@ -2097,7 +2096,7 @@ func TestHandleStatusUpdateStoreError(t *testing.T) {
 
 	// Corrupt the store to cause an error on update
 	// Since we can't easily corrupt the store, just verify it doesn't panic
-	server.handleStatusUpdate("0000-test-id-0000-000000000000", true, 1, "")
+	server.handleStatusUpdate("0000-test-id-0000-000000000000", true, "")
 
 	updatedCfg, _ := server.store.Get("0000-test-id-0000-000000000000")
 	assert.Equal(t, models.StatusDeployed, updatedCfg.Status)
@@ -2384,7 +2383,7 @@ func TestHandleStatusUpdateEmptyCorrelationID(t *testing.T) {
 	_ = server.store.Add(cfg)
 
 	// Test with empty correlation ID
-	server.handleStatusUpdate("0000-test-id-0000-000000000000", true, 1, "")
+	server.handleStatusUpdate("0000-test-id-0000-000000000000", true, "")
 
 	updatedCfg, _ := server.store.Get("0000-test-id-0000-000000000000")
 	assert.Equal(t, models.StatusDeployed, updatedCfg.Status)

--- a/gateway/gateway-controller/pkg/controlplane/client.go
+++ b/gateway/gateway-controller/pkg/controlplane/client.go
@@ -35,7 +35,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/config"
-"github.com/wso2/api-platform/gateway/gateway-controller/pkg/lazyresourcexds"
+	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/lazyresourcexds"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/policy"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/policyxds"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/storage"
@@ -1036,7 +1036,6 @@ func (c *Client) handleAPIUndeployedEvent(event map[string]interface{}) {
 	// Set status to undeployed (preserve config, keys, and policies)
 	apiConfig.Status = models.StatusUndeployed
 	apiConfig.UpdatedAt = time.Now()
-	// Keep DeployedVersion as-is - it tracks when it was last deployed
 
 	// Update database (only if persistent mode)
 	if c.db != nil {
@@ -1823,7 +1822,6 @@ func (c *Client) handleMCPProxyUndeploymentEvent(event map[string]any) {
 	// Set status to undeployed (preserve config, keys, and policies)
 	mcpConfig.Status = models.StatusUndeployed
 	mcpConfig.UpdatedAt = time.Now()
-	// Keep DeployedVersion as-is - it tracks when it was last deployed
 
 	// Update database (only if persistent mode)
 	if c.db != nil {

--- a/gateway/gateway-controller/pkg/models/stored_config.go
+++ b/gateway/gateway-controller/pkg/models/stored_config.go
@@ -61,7 +61,6 @@ type StoredConfig struct {
 	CreatedAt           time.Time    `json:"createdAt"`
 	UpdatedAt           time.Time    `json:"updatedAt"`
 	DeployedAt          *time.Time   `json:"deployedAt,omitempty"`
-	DeployedVersion     int64        `json:"deployed_version"` // Runtime-only: xDS snapshot version, not persisted to DB
 }
 
 // GetCompositeKey returns the composite key "kind:displayName:version" for indexing

--- a/gateway/gateway-controller/pkg/models/stored_config_test.go
+++ b/gateway/gateway-controller/pkg/models/stored_config_test.go
@@ -52,13 +52,12 @@ func TestStoredConfig_Fields(t *testing.T) {
 	deployedAt := now.Add(time.Hour)
 
 	config := &StoredConfig{
-		UUID:            "0000-test-id-123-0000-000000000000",
-		Kind:            "API",
-		Status:          StatusDeployed,
-		CreatedAt:       now,
-		UpdatedAt:       now,
-		DeployedAt:      &deployedAt,
-		DeployedVersion: 5,
+		UUID:       "0000-test-id-123-0000-000000000000",
+		Kind:       "API",
+		Status:     StatusDeployed,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+		DeployedAt: &deployedAt,
 	}
 
 	assert.Equal(t, "0000-test-id-123-0000-000000000000", config.UUID)
@@ -68,7 +67,6 @@ func TestStoredConfig_Fields(t *testing.T) {
 	assert.Equal(t, now, config.UpdatedAt)
 	assert.NotNil(t, config.DeployedAt)
 	assert.Equal(t, deployedAt, *config.DeployedAt)
-	assert.Equal(t, int64(5), config.DeployedVersion)
 }
 
 func TestStoredConfig_NilDeployedAt(t *testing.T) {

--- a/gateway/gateway-controller/pkg/service/restapi/service.go
+++ b/gateway/gateway-controller/pkg/service/restapi/service.go
@@ -263,7 +263,6 @@ func (s *RestAPIService) Update(params UpdateParams) (*UpdateResult, error) {
 	existing.Status = models.StatusPending
 	existing.UpdatedAt = now
 	existing.DeployedAt = nil
-	existing.DeployedVersion = 0
 
 	// Dual-write: database first, then in-memory
 	if err := s.db.UpdateConfig(existing); err != nil {

--- a/gateway/gateway-controller/pkg/utils/api_deployment.go
+++ b/gateway/gateway-controller/pkg/utils/api_deployment.go
@@ -207,7 +207,6 @@ func (s *APIDeploymentService) DeployAPIConfiguration(params APIDeploymentParams
 		CreatedAt:           now,
 		UpdatedAt:           now,
 		DeployedAt:          nil,
-		DeployedVersion:     0,
 	}
 
 	if kind == "WebSubApi" {
@@ -461,7 +460,6 @@ func (s *APIDeploymentService) updateExistingConfig(newConfig *models.StoredConf
 	existing.Status = models.StatusPending
 	existing.UpdatedAt = now
 	existing.DeployedAt = nil
-	existing.DeployedVersion = 0
 
 	// Update database first (only if persistent mode)
 	if s.db != nil {

--- a/gateway/gateway-controller/pkg/utils/api_utils.go
+++ b/gateway/gateway-controller/pkg/utils/api_utils.go
@@ -496,14 +496,13 @@ func (s *APIUtilsService) SaveAPIDefinition(apiID string, zipData []byte) error 
 
 // APIDeploymentPush represents the request body for pushing API deployment details to the control plane
 type APIDeploymentPush struct {
-	ID                string               `json:"id" yaml:"id"`
-	Configuration     any                  `json:"configuration" yaml:"configuration"`
-	Status            string               `json:"status" yaml:"status"`
-	CreatedAt         time.Time            `json:"createdAt" yaml:"createdAt"`
-	UpdatedAt         time.Time            `json:"updatedAt" yaml:"updatedAt"`
-	DeployedAt        *time.Time           `json:"deployedAt,omitempty" yaml:"deployedAt,omitempty"`
-	DeployedVersion   int64                `json:"deployedVersion" yaml:"deployedVersion"`
-	ProjectIdentifier string               `json:"projectIdentifier" yaml:"projectIdentifier"`
+	ID                string     `json:"id" yaml:"id"`
+	Configuration     any        `json:"configuration" yaml:"configuration"`
+	Status            string     `json:"status" yaml:"status"`
+	CreatedAt         time.Time  `json:"createdAt" yaml:"createdAt"`
+	UpdatedAt         time.Time  `json:"updatedAt" yaml:"updatedAt"`
+	DeployedAt        *time.Time `json:"deployedAt,omitempty" yaml:"deployedAt,omitempty"`
+	ProjectIdentifier string     `json:"projectIdentifier" yaml:"projectIdentifier"`
 }
 
 // PushAPIDeployment sends API deployment details to the control plane via a REST call
@@ -522,7 +521,6 @@ func (s *APIUtilsService) PushAPIDeployment(apiID string, apiConfig *models.Stor
 		CreatedAt:         apiConfig.CreatedAt,
 		UpdatedAt:         apiConfig.UpdatedAt,
 		DeployedAt:        apiConfig.DeployedAt,
-		DeployedVersion:   apiConfig.DeployedVersion,
 		ProjectIdentifier: "default", // Set a default value or fetch from config if needed
 	}
 

--- a/gateway/gateway-controller/pkg/utils/api_utils_test.go
+++ b/gateway/gateway-controller/pkg/utils/api_utils_test.go
@@ -383,7 +383,6 @@ func TestAPIDeploymentPush_JSON(t *testing.T) {
 		CreatedAt:         now,
 		UpdatedAt:         now,
 		DeployedAt:        &now,
-		DeployedVersion:   1,
 		ProjectIdentifier: "default",
 	}
 

--- a/gateway/gateway-controller/pkg/utils/llm_deployment.go
+++ b/gateway/gateway-controller/pkg/utils/llm_deployment.go
@@ -161,7 +161,6 @@ func (s *LLMDeploymentService) DeployLLMProviderConfiguration(params LLMDeployme
 		CreatedAt:           now,
 		UpdatedAt:           now,
 		DeployedAt:          nil,
-		DeployedVersion:     0,
 	}
 
 	// Save or update
@@ -285,7 +284,6 @@ func (s *LLMDeploymentService) DeployLLMProxyConfiguration(params LLMDeploymentP
 		CreatedAt:           now,
 		UpdatedAt:           now,
 		DeployedAt:          nil,
-		DeployedVersion:     0,
 	}
 
 	// Save or update

--- a/gateway/gateway-controller/pkg/utils/mcp_deployment.go
+++ b/gateway/gateway-controller/pkg/utils/mcp_deployment.go
@@ -140,7 +140,6 @@ func (s *MCPDeploymentService) DeployMCPConfiguration(params MCPDeploymentParams
 		CreatedAt:           now,
 		UpdatedAt:           now,
 		DeployedAt:          nil,
-		DeployedVersion:     0,
 	}
 
 	// Try to save/update the configuration
@@ -245,7 +244,6 @@ func (s *MCPDeploymentService) updateExistingConfig(newConfig *models.StoredConf
 	existing.Status = models.StatusPending
 	existing.UpdatedAt = now
 	existing.DeployedAt = nil
-	existing.DeployedVersion = 0
 
 	// Update database first (only if persistent mode)
 	if s.db != nil {

--- a/gateway/gateway-controller/pkg/utils/websub_topic_registration_test.go
+++ b/gateway/gateway-controller/pkg/utils/websub_topic_registration_test.go
@@ -46,17 +46,16 @@ spec:
 	}
 
 	cfg := &models.StoredConfig{
-		UUID:            "0000-test-config-1-0000-000000000000",
-		Kind:            string(api.WebSubApi),
-		Handle:          "testapi",
-		DisplayName:     "testapi",
-		Version:         "v1",
-		Configuration:   apiCfg,
-		Status:          models.StatusPending,
-		CreatedAt:       time.Now(),
-		UpdatedAt:       time.Now(),
-		DeployedAt:      nil,
-		DeployedVersion: 0,
+		UUID:          "0000-test-config-1-0000-000000000000",
+		Kind:          string(api.WebSubApi),
+		Handle:        "testapi",
+		DisplayName:   "testapi",
+		Version:       "v1",
+		Configuration: apiCfg,
+		Status:        models.StatusPending,
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+		DeployedAt:    nil,
 	}
 
 	err := service.store.Add(cfg)
@@ -99,17 +98,16 @@ spec:
 	}
 
 	cfg := &models.StoredConfig{
-		UUID:            "0000-test-config-1-0000-000000000000",
-		Kind:            string(api.WebSubApi),
-		Handle:          "testapi",
-		DisplayName:     "testapi",
-		Version:         "v1",
-		Configuration:   apiCfg,
-		Status:          models.StatusPending,
-		CreatedAt:       time.Now(),
-		UpdatedAt:       time.Now(),
-		DeployedAt:      nil,
-		DeployedVersion: 0,
+		UUID:          "0000-test-config-1-0000-000000000000",
+		Kind:          string(api.WebSubApi),
+		Handle:        "testapi",
+		DisplayName:   "testapi",
+		Version:       "v1",
+		Configuration: apiCfg,
+		Status:        models.StatusPending,
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+		DeployedAt:    nil,
 	}
 
 	err := service.store.Add(cfg)
@@ -147,7 +145,6 @@ spec:
 	cfg.Configuration = apiCfg
 	cfg.CreatedAt = time.Now()
 	cfg.UpdatedAt = time.Now()
-	cfg.DeployedVersion += 1
 	cfg.Status = models.StatusPending
 	cfg.DeployedAt = nil
 
@@ -207,31 +204,29 @@ spec:
 	}
 
 	cfgA := &models.StoredConfig{
-		UUID:            "0000-cfg-a-0000-000000000000",
-		Kind:            string(api.WebSubApi),
-		Handle:          "testapiA",
-		DisplayName:     "testapiA",
-		Version:         "v1",
-		Configuration:   apiCfgA,
-		Status:          models.StatusPending,
-		CreatedAt:       time.Now(),
-		UpdatedAt:       time.Now(),
-		DeployedAt:      nil,
-		DeployedVersion: 0,
+		UUID:          "0000-cfg-a-0000-000000000000",
+		Kind:          string(api.WebSubApi),
+		Handle:        "testapiA",
+		DisplayName:   "testapiA",
+		Version:       "v1",
+		Configuration: apiCfgA,
+		Status:        models.StatusPending,
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+		DeployedAt:    nil,
 	}
 
 	cfgB := &models.StoredConfig{
-		UUID:            "0000-cfg-b-0000-000000000000",
-		Kind:            string(api.WebSubApi),
-		Handle:          "testapiB",
-		DisplayName:     "testapiB",
-		Version:         "v1",
-		Configuration:   apiCfgB,
-		Status:          models.StatusPending,
-		CreatedAt:       time.Now(),
-		UpdatedAt:       time.Now(),
-		DeployedAt:      nil,
-		DeployedVersion: 0,
+		UUID:          "0000-cfg-b-0000-000000000000",
+		Kind:          string(api.WebSubApi),
+		Handle:        "testapiB",
+		DisplayName:   "testapiB",
+		Version:       "v1",
+		Configuration: apiCfgB,
+		Status:        models.StatusPending,
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+		DeployedAt:    nil,
 	}
 
 	var wg sync.WaitGroup
@@ -301,17 +296,16 @@ spec:
 	}
 
 	cfg := &models.StoredConfig{
-		UUID:            "0000-test-config-1-0000-000000000000",
-		Kind:            string(api.WebSubApi),
-		Handle:          "testapi",
-		DisplayName:     "testapi",
-		Version:         "v1",
-		Configuration:   apiCfg,
-		Status:          models.StatusPending,
-		CreatedAt:       time.Now(),
-		UpdatedAt:       time.Now(),
-		DeployedAt:      nil,
-		DeployedVersion: 0,
+		UUID:          "0000-test-config-1-0000-000000000000",
+		Kind:          string(api.WebSubApi),
+		Handle:        "testapi",
+		DisplayName:   "testapi",
+		Version:       "v1",
+		Configuration: apiCfg,
+		Status:        models.StatusPending,
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+		DeployedAt:    nil,
 	}
 
 	err := service.store.Add(cfg)

--- a/gateway/gateway-controller/pkg/xds/snapshot.go
+++ b/gateway/gateway-controller/pkg/xds/snapshot.go
@@ -58,7 +58,7 @@ func (a *slogAdapter) Errorf(format string, args ...interface{}) {
 var _ xdslog.Logger = (*slogAdapter)(nil)
 
 // StatusUpdateCallback is called after xDS snapshot update completes
-type StatusUpdateCallback func(configID string, success bool, version int64, correlationID string)
+type StatusUpdateCallback func(configID string, success bool, correlationID string)
 
 // SnapshotManager manages xDS snapshots for Envoy
 type SnapshotManager struct {
@@ -125,7 +125,7 @@ func (sm *SnapshotManager) UpdateSnapshot(ctx context.Context, correlationID str
 		// Mark all pending configs as failed
 		if sm.statusCallback != nil {
 			for _, cfg := range configs {
-				sm.statusCallback(cfg.UUID, false, 0, correlationID)
+				sm.statusCallback(cfg.UUID, false, correlationID)
 			}
 		}
 		return fmt.Errorf("failed to translate configurations: %w", err)
@@ -157,7 +157,7 @@ func (sm *SnapshotManager) UpdateSnapshot(ctx context.Context, correlationID str
 		// Mark all pending configs as failed
 		if sm.statusCallback != nil {
 			for _, cfg := range configs {
-				sm.statusCallback(cfg.UUID, false, 0, correlationID)
+				sm.statusCallback(cfg.UUID, false, correlationID)
 			}
 		}
 		return fmt.Errorf("failed to create snapshot: %w", err)
@@ -171,7 +171,7 @@ func (sm *SnapshotManager) UpdateSnapshot(ctx context.Context, correlationID str
 		// Mark all pending configs as failed
 		if sm.statusCallback != nil {
 			for _, cfg := range configs {
-				sm.statusCallback(cfg.UUID, false, 0, correlationID)
+				sm.statusCallback(cfg.UUID, false, correlationID)
 			}
 		}
 		return fmt.Errorf("snapshot is inconsistent: %w", err)
@@ -185,7 +185,7 @@ func (sm *SnapshotManager) UpdateSnapshot(ctx context.Context, correlationID str
 		// Mark all pending configs as failed
 		if sm.statusCallback != nil {
 			for _, cfg := range configs {
-				sm.statusCallback(cfg.UUID, false, 0, correlationID)
+				sm.statusCallback(cfg.UUID, false, correlationID)
 			}
 		}
 		return fmt.Errorf("failed to set snapshot: %w", err)
@@ -219,7 +219,7 @@ func (sm *SnapshotManager) UpdateSnapshot(ctx context.Context, correlationID str
 	// Mark all successfully deployed configs
 	if sm.statusCallback != nil {
 		for _, cfg := range configs {
-			sm.statusCallback(cfg.UUID, true, version, correlationID)
+			sm.statusCallback(cfg.UUID, true, correlationID)
 		}
 	}
 

--- a/gateway/gateway-controller/tests/integration/concurrency_test.go
+++ b/gateway/gateway-controller/tests/integration/concurrency_test.go
@@ -211,7 +211,6 @@ func TestConcurrentMixedOperations(t *testing.T) {
 			}
 
 			cfg.Status = models.StatusDeployed
-			cfg.DeployedVersion = int64(id)
 			if err := db.UpdateConfig(cfg); err != nil {
 				errors <- fmt.Errorf("updater %d failed to update: %w", id, err)
 			}
@@ -275,8 +274,7 @@ func TestConcurrentUpdatesOnSameConfig(t *testing.T) {
 			}
 
 			// Update it
-			cfg.DeployedVersion = int64(id)
-			if err := db.UpdateConfig(cfg); err != nil {
+				if err := db.UpdateConfig(cfg); err != nil {
 				errors <- fmt.Errorf("goroutine %d failed to update config: %w", id, err)
 			}
 		}(i)
@@ -299,9 +297,6 @@ func TestConcurrentUpdatesOnSameConfig(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, finalCfg)
 	assert.Equal(t, "SharedAPI", finalCfg.DisplayName)
-
-	// The final DeployedVersion will be whichever goroutine completed last
-	t.Logf("Final deployed version: %d", finalCfg.DeployedVersion)
 }
 
 // TestConcurrentGetAllConfigs tests concurrent GetAllConfigs calls

--- a/gateway/gateway-controller/tests/integration/persistence_test.go
+++ b/gateway/gateway-controller/tests/integration/persistence_test.go
@@ -104,7 +104,6 @@ func TestDatabasePersistenceAcrossRestarts(t *testing.T) {
 		cfg, err := db.GetConfigByKindAndHandle(models.KindRestApi,"PersistAPI1-v1.0")
 		require.NoError(t, err)
 		cfg.Status = "deployed"
-		cfg.DeployedVersion = 5
 
 		require.NoError(t, db.UpdateConfig(cfg))
 		require.NoError(t, db.Close())
@@ -121,7 +120,6 @@ func TestDatabasePersistenceAcrossRestarts(t *testing.T) {
 		cfg, err := db.GetConfigByKindAndHandle(models.KindRestApi,"PersistAPI1-v1.0")
 		assert.NoError(t, err)
 		assert.Equal(t, models.StatusDeployed, cfg.Status)
-		// DeployedVersion is runtime-only (not persisted to DB), so it resets to 0 after reload
 	}
 
 	// Phase 5: Delete a configuration and verify deletion persists

--- a/gateway/gateway-controller/tests/integration/storage_test.go
+++ b/gateway/gateway-controller/tests/integration/storage_test.go
@@ -96,7 +96,6 @@ func createTestConfig(name, version string) *models.StoredConfig {
 		Configuration:       apiConfig,
 		SourceConfiguration: apiConfig,
 		Status:              models.StatusPending,
-		DeployedVersion:     0,
 	}
 }
 
@@ -132,7 +131,6 @@ func TestSQLiteStorage_CRUD(t *testing.T) {
 
 		// Update the configuration
 		cfg.Status = "deployed"
-		cfg.DeployedVersion = 1
 		err = db.UpdateConfig(cfg)
 		assert.NoError(t, err, "UpdateConfig should succeed")
 
@@ -140,7 +138,6 @@ func TestSQLiteStorage_CRUD(t *testing.T) {
 		retrieved, err := db.GetConfig(cfg.UUID)
 		require.NoError(t, err)
 		assert.Equal(t, models.StatusDeployed, retrieved.Status)
-		// DeployedVersion is runtime-only (not persisted to DB)
 	})
 
 	// Test DeleteConfig
@@ -340,7 +337,6 @@ func createTestConfigWithLabels(name, version string, labels map[string]string) 
 		Configuration:       apiConfig,
 		SourceConfiguration: apiConfig,
 		Status:              models.StatusPending,
-		DeployedVersion:     0,
 	}
 }
 
@@ -549,7 +545,6 @@ func TestConfigStore_LabelsWithAddUpdateDelete(t *testing.T) {
 			Configuration:       newApiConfig,
 			SourceConfiguration: newApiConfig,
 			Status:              cfg.Status,
-			DeployedVersion:     cfg.DeployedVersion,
 		}
 		newHandle := updatedCfg.Handle
 
@@ -636,7 +631,6 @@ func TestConfigStore_LabelsWithAllAPITypes(t *testing.T) {
 			Configuration:       asyncApiConfig,
 			SourceConfiguration: asyncApiConfig,
 			Status:              models.StatusPending,
-			DeployedVersion:     0,
 		}
 
 		err := configStore.Add(cfg)

--- a/go.work.sum
+++ b/go.work.sum
@@ -2412,6 +2412,7 @@ golang.org/x/mod v0.27.0/go.mod h1:rWI627Fq0DEoudcK+MBkNkCe0EetEaDSwJJkCcjpazc=
 golang.org/x/mod v0.29.0/go.mod h1:NyhrlYXJ2H4eJiRy/WDBO6HMqZQ6q9nk4JzS3NuCK+w=
 golang.org/x/mod v0.31.0 h1:HaW9xtz0+kOcWKwli0ZXy79Ix+UW/vOfmWI5QVd2tgI=
 golang.org/x/mod v0.31.0/go.mod h1:43JraMp9cGx1Rx3AqioxrbrhNsLl2l/iNAvuBkrezpg=
+golang.org/x/mod v0.33.0 h1:tHFzIWbBifEmbwtGz65eaWyGiGZatSrT9prnU8DbVL8=
 golang.org/x/mod v0.33.0/go.mod h1:swjeQEj+6r7fODbD2cqrnje9PnziFuw4bmLbBZFrQ5w=
 golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/platform-api/src/internal/dto/gateway_internal.go
+++ b/platform-api/src/internal/dto/gateway_internal.go
@@ -27,7 +27,6 @@ type DeploymentNotification struct {
 	CreatedAt         time.Time        `json:"createdAt" binding:"required"`
 	UpdatedAt         time.Time        `json:"updatedAt" binding:"required"`
 	DeployedAt        *time.Time       `json:"deployedAt,omitempty"`
-	DeployedVersion   *int             `json:"deployedVersion,omitempty"`
 	ProjectIdentifier string           `json:"projectIdentifier" binding:"required"`
 }
 


### PR DESCRIPTION
## Purpose
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed deployment version tracking from configuration management, simplifying the deployment model across API, LLM, and MCP deployments.
  * Eliminated version information from deployment notifications and status updates, reducing tracked deployment metadata.
  * Updated deployment handlers and callbacks to streamline status update flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->