### PR TITLE
Improve mcp server info fetch path

### DIFF
--- a/platform-api/src/api/generated.go
+++ b/platform-api/src/api/generated.go
@@ -845,7 +845,7 @@ type DeployRequest struct {
 	// GatewayId The target gateway UUID for this deployment
 	GatewayId openapi_types.UUID `binding:"required" json:"gatewayId" yaml:"gatewayId"`
 
-	// Metadata Optional metadata for the deployment (e.g., endpointUrl, vhostMain, vhostSandbox overrides)
+	// Metadata Optional metadata for the deployment. Supported keys include `endpointUrl`, `vhostMain`, and `vhostSandbox`.
 	Metadata *map[string]interface{} `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 
 	// Name Name/label for this deployment (e.g., "v1.0-prod", "hotfix-2024-01-15")
@@ -1699,8 +1699,15 @@ type MCPServerInfoFetchRequest struct {
 	// Auth Authentication configuration for upstream endpoints
 	Auth *UpstreamAuth `json:"auth,omitempty" yaml:"auth,omitempty"`
 
-	// Url Endpoint URL of the MCP server to fetch information from
-	Url string `binding:"required" json:"url" yaml:"url"`
+	// ProxyId MCP proxy handle (identifier) for refresh operations. When provided,
+	// the server fetches URL and auth from the stored proxy configuration.
+	// Auth override is not allowed in refetch mode.
+	ProxyId *string `json:"proxyId,omitempty" yaml:"proxyId,omitempty"`
+
+	// Url Endpoint URL of the MCP server to fetch information from.
+	// Required when proxyId is not provided. When proxyId is provided,
+	// the URL from the stored proxy configuration is used.
+	Url *string `json:"url,omitempty" yaml:"url,omitempty"`
 }
 
 // MCPServerInfoFetchResponse defines model for MCPServerInfoFetchResponse.

--- a/platform-api/src/internal/handler/mcp.go
+++ b/platform-api/src/internal/handler/mcp.go
@@ -213,7 +213,7 @@ func (h *MCPProxyHandler) FetchMCPProxyServerInfo(c *gin.Context) {
 		return
 	}
 
-	resp, err := h.service.FetchServerInfo(&req)
+	resp, err := h.service.FetchServerInfo(orgID, &req)
 	if err != nil {
 		switch {
 		case errors.Is(err, constants.ErrInvalidURL):

--- a/platform-api/src/internal/service/mcp.go
+++ b/platform-api/src/internal/service/mcp.go
@@ -331,24 +331,60 @@ func (s *MCPProxyService) Delete(orgUUID, handle string) error {
 	return nil
 }
 
-// FetchServerInfo fetches server information from an MCP backend
-func (s *MCPProxyService) FetchServerInfo(req *api.MCPServerInfoFetchRequest) (*api.MCPServerInfoFetchResponse, error) {
-	if req == nil || req.Url == "" {
+// FetchServerInfo fetches server information from an MCP backend.
+// When proxyId is provided, the URL and auth are fetched from the stored proxy configuration.
+// When proxyId is not provided, url is required and auth is optional.
+func (s *MCPProxyService) FetchServerInfo(orgUUID string, req *api.MCPServerInfoFetchRequest) (*api.MCPServerInfoFetchResponse, error) {
+	if req == nil {
 		return nil, constants.ErrInvalidInput
 	}
 
-	if err := utils.ValidateURL(context.Background(), req.Url); err != nil {
+	var url string
+	var headerName, headerValue string
+
+	if req.ProxyId != nil && *req.ProxyId != "" {
+		if req.Auth != nil {
+			s.slogger.Warn("Auth override is not allowed when proxyId is provided. Ignoring auth in request and using stored auth from proxy configuration.", "org_id", orgUUID, "proxy_id", *req.ProxyId)
+		}
+		// ProxyId provided - fetch stored configuration (refetch flow)
+		// Auth override is NOT allowed in refetch - use exactly what's stored
+		proxy, err := s.repo.GetByHandle(*req.ProxyId, orgUUID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get MCP proxy: %w", err)
+		}
+		if proxy == nil {
+			return nil, constants.ErrMCPProxyNotFound
+		}
+
+		// Use stored URL from proxy configuration
+		if proxy.Configuration.Upstream.Main != nil && proxy.Configuration.Upstream.Main.URL != "" {
+			url = proxy.Configuration.Upstream.Main.URL
+		}
+
+		// Use stored auth from proxy configuration
+		if proxy.Configuration.Upstream.Main != nil && proxy.Configuration.Upstream.Main.Auth != nil {
+			headerName = proxy.Configuration.Upstream.Main.Auth.Header
+			headerValue = proxy.Configuration.Upstream.Main.Auth.Value
+		}
+	} else {
+		// No proxyId - initial creation flow, url is required
+		if req.Url == nil || *req.Url == "" {
+			return nil, constants.ErrInvalidInput
+		}
+		url = *req.Url
+
+		// Use provided auth (optional for initial fetch)
+		if req.Auth != nil && req.Auth.Header != nil && req.Auth.Value != nil {
+			headerName = *req.Auth.Header
+			headerValue = *req.Auth.Value
+		}
+	}
+
+	if err := utils.ValidateURL(context.Background(), url); err != nil {
 		return nil, fmt.Errorf("%w: %v", constants.ErrInvalidURL, err)
 	}
 
-	// Extract header info from auth if provided
-	var headerName, headerValue string
-	if req.Auth != nil && req.Auth.Header != nil && req.Auth.Value != nil {
-		headerName = *req.Auth.Header
-		headerValue = *req.Auth.Value
-	}
-
-	return utils.FetchMCPServerInfo(req.Url, headerName, headerValue)
+	return utils.FetchMCPServerInfo(url, headerName, headerValue)
 }
 
 // Helper functions

--- a/platform-api/src/resources/openapi.yaml
+++ b/platform-api/src/resources/openapi.yaml
@@ -3976,6 +3976,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
 
@@ -7248,16 +7250,27 @@ components:
     
     MCPServerInfoFetchRequest:
       type: object
-      required:
-        - url
       properties:
         url:
           type: string
           format: uri
-          description: Endpoint URL of the MCP server to fetch information from
+          description: |
+            Endpoint URL of the MCP server to fetch information from.
+            Required when proxyId is not provided. When proxyId is provided,
+            the URL from the stored proxy configuration is used.
           example: https://mcp.server.com/mcp
+        proxyId:
+          type: string
+          description: |
+            MCP proxy handle (identifier) for refresh operations. When provided,
+            the server fetches URL and auth from the stored proxy configuration.
+            Auth override is not allowed in refetch mode.
+          example: my-mcp-proxy
         auth:
           $ref: '#/components/schemas/UpstreamAuth'
+          description: |
+            Authentication configuration for the fetch request.
+            Only allowed when proxyId is not provided (initial creation flow).
 
     MCPServerInfoFetchResponse:
       type: object


### PR DESCRIPTION
## Purpose

Improves the MCP server info fetch path to handle backend auth scenarios

Related issue: https://github.com/wso2/api-platform/issues/1362



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional ProxyId to support proxy-based MCP server info retrieval
  * Added a 404 Not Found response for MCP server info fetches

* **API Changes**
  * URL in MCP server info requests is now optional when ProxyId is provided
  * Organization context is now required for server info operations
  * Auth is only used for initial creation flow (proxy-based fetches use stored credentials)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->