### PR TITLE
fix(models): use Configuration in GetPolicies to fix MCP policy drop

### DIFF
--- a/gateway/gateway-controller/pkg/models/stored_config.go
+++ b/gateway/gateway-controller/pkg/models/stored_config.go
@@ -95,7 +95,7 @@ func (c *StoredConfig) GetContext() (string, error) {
 }
 
 func (c *StoredConfig) GetPolicies() *[]api.Policy {
-	if sc, ok := c.SourceConfiguration.(api.RestAPI); ok {
+	if sc, ok := c.Configuration.(api.RestAPI); ok {
 		return sc.Spec.Policies
 	}
 	// TODO: enable when policies are supported for WebSubHub


### PR DESCRIPTION
## Purpose
GetPolicies was reading from SourceConfiguration, which for MCP proxies holds the original MCPProxyConfiguration (not api.RestAPI). The type assertion always failed, returning nil and causing all MCP API-level policies to be silently dropped before reaching the Policy Engine xDS.

Configuration holds the transformed api.RestAPI for both RestApi and Mcp kinds, so the assertion now succeeds for both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved policy handling in the gateway configuration to correctly read policies from the appropriate source with enhanced type validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->