### PR TITLE
Adding subscription plan name to subscriptions response

### DIFF
--- a/platform-api/src/internal/handler/subscription_handler.go
+++ b/platform-api/src/internal/handler/subscription_handler.go
@@ -34,18 +34,20 @@ import (
 
 // SubscriptionHandler handles application-level subscription CRUD
 type SubscriptionHandler struct {
-	subscriptionService *service.SubscriptionService
-	slogger             *slog.Logger
+	subscriptionService     *service.SubscriptionService
+	subscriptionPlanService *service.SubscriptionPlanService
+	slogger                 *slog.Logger
 }
 
 // NewSubscriptionHandler creates a new subscription handler
-func NewSubscriptionHandler(subscriptionService *service.SubscriptionService, slogger *slog.Logger) *SubscriptionHandler {
+func NewSubscriptionHandler(subscriptionService *service.SubscriptionService, subscriptionPlanService *service.SubscriptionPlanService, slogger *slog.Logger) *SubscriptionHandler {
 	if slogger == nil {
 		slogger = slog.Default()
 	}
 	return &SubscriptionHandler{
-		subscriptionService: subscriptionService,
-		slogger:             slogger,
+		subscriptionService:     subscriptionService,
+		subscriptionPlanService: subscriptionPlanService,
+		slogger:                 slogger,
 	}
 }
 
@@ -101,7 +103,7 @@ func (h *SubscriptionHandler) CreateSubscription(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error", "Failed to create subscription"))
 		return
 	}
-	c.JSON(http.StatusCreated, toSubscriptionResponse(sub))
+	c.JSON(http.StatusCreated, h.toSubscriptionResponse(sub, orgId))
 }
 
 // ListSubscriptions handles GET /api/v1/subscriptions
@@ -156,9 +158,40 @@ func (h *SubscriptionHandler) ListSubscriptions(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error", "Failed to list subscriptions"))
 		return
 	}
+	// Bulk fetch API handles and plan names to avoid N+1 queries
+	apiUUIDSet := make(map[string]struct{})
+	planIDSet := make(map[string]struct{})
+	for _, sub := range list {
+		if sub.APIUUID != "" {
+			apiUUIDSet[sub.APIUUID] = struct{}{}
+		}
+		if sub.SubscriptionPlanID != nil && *sub.SubscriptionPlanID != "" {
+			planIDSet[*sub.SubscriptionPlanID] = struct{}{}
+		}
+	}
+	apiUUIDs := make([]string, 0, len(apiUUIDSet))
+	for u := range apiUUIDSet {
+		apiUUIDs = append(apiUUIDs, u)
+	}
+	planIDs := make([]string, 0, len(planIDSet))
+	for id := range planIDSet {
+		planIDs = append(planIDs, id)
+	}
+	apiHandleMap, err := h.subscriptionService.GetAPIHandleMap(apiUUIDs, orgId)
+	if err != nil {
+		h.slogger.Error("Failed to bulk fetch API handles for list", "organizationId", orgId, "error", err)
+		c.JSON(http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error", "Failed to list subscriptions"))
+		return
+	}
+	planNameMap, err := h.subscriptionPlanService.GetPlanNameMap(planIDs, orgId)
+	if err != nil {
+		h.slogger.Error("Failed to bulk fetch plan names for list", "organizationId", orgId, "error", err)
+		c.JSON(http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error", "Failed to list subscriptions"))
+		return
+	}
 	items := make([]gin.H, 0, len(list))
 	for _, sub := range list {
-		items = append(items, toSubscriptionResponse(sub))
+		items = append(items, h.toSubscriptionResponseWithMaps(sub, orgId, apiHandleMap, planNameMap))
 	}
 	c.JSON(http.StatusOK, gin.H{
 		"subscriptions": items,
@@ -194,7 +227,7 @@ func (h *SubscriptionHandler) GetSubscription(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error", "Failed to get subscription"))
 		return
 	}
-	c.JSON(http.StatusOK, toSubscriptionResponse(sub))
+	c.JSON(http.StatusOK, h.toSubscriptionResponse(sub, orgId))
 }
 
 // UpdateSubscription handles PUT /api/v1/subscriptions/:subscriptionId
@@ -231,7 +264,7 @@ func (h *SubscriptionHandler) UpdateSubscription(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error", "Failed to update subscription"))
 		return
 	}
-	c.JSON(http.StatusOK, toSubscriptionResponse(sub))
+	c.JSON(http.StatusOK, h.toSubscriptionResponse(sub, orgId))
 }
 
 // DeleteSubscription handles DELETE /api/v1/subscriptions/:subscriptionId
@@ -272,10 +305,15 @@ func (h *SubscriptionHandler) RegisterRoutes(r *gin.Engine) {
 	}
 }
 
-func toSubscriptionResponse(sub *model.Subscription) gin.H {
+func (h *SubscriptionHandler) toSubscriptionResponse(sub *model.Subscription, orgId string) gin.H {
+	// apiId in response should be the handle (e.g. "samp1"), not the internal UUID
+	apiIdForResponse := h.subscriptionService.ResolveAPIHandle(sub.APIUUID, orgId)
+	if apiIdForResponse == "" {
+		apiIdForResponse = sub.APIUUID // fallback to UUID
+	}
 	resp := gin.H{
 		"id":             sub.UUID,
-		"apiId":          sub.APIUUID,
+		"apiId":          apiIdForResponse,
 		"organizationId": sub.OrganizationUUID,
 		"status":         string(sub.Status),
 		"createdAt":      sub.CreatedAt,
@@ -286,8 +324,45 @@ func toSubscriptionResponse(sub *model.Subscription) gin.H {
 	}
 	if sub.SubscriptionPlanID != nil {
 		resp["subscriptionPlanId"] = *sub.SubscriptionPlanID
+		// Resolve plan name for display (subscription_plans.plan_name)
+		if h.subscriptionPlanService != nil {
+			plan, err := h.subscriptionPlanService.GetPlan(*sub.SubscriptionPlanID, orgId)
+			if err == nil && plan != nil {
+				resp["subscriptionPlanName"] = plan.PlanName
+			}
+		}
 	}
 	// subscriptionToken is decrypted from DB; empty for legacy hashed tokens
+	if sub.SubscriptionToken != "" {
+		resp["subscriptionToken"] = sub.SubscriptionToken
+	}
+	return resp
+}
+
+// toSubscriptionResponseWithMaps builds a subscription response using pre-fetched lookup maps.
+// Used by ListSubscriptions to avoid N+1 queries.
+func (h *SubscriptionHandler) toSubscriptionResponseWithMaps(sub *model.Subscription, orgId string, apiHandleMap, planNameMap map[string]string) gin.H {
+	apiIdForResponse := apiHandleMap[sub.APIUUID]
+	if apiIdForResponse == "" {
+		apiIdForResponse = sub.APIUUID // fallback to UUID
+	}
+	resp := gin.H{
+		"id":             sub.UUID,
+		"apiId":          apiIdForResponse,
+		"organizationId": sub.OrganizationUUID,
+		"status":         string(sub.Status),
+		"createdAt":      sub.CreatedAt,
+		"updatedAt":      sub.UpdatedAt,
+	}
+	if sub.ApplicationID != nil {
+		resp["applicationId"] = *sub.ApplicationID
+	}
+	if sub.SubscriptionPlanID != nil {
+		resp["subscriptionPlanId"] = *sub.SubscriptionPlanID
+		if name := planNameMap[*sub.SubscriptionPlanID]; name != "" {
+			resp["subscriptionPlanName"] = name
+		}
+	}
 	if sub.SubscriptionToken != "" {
 		resp["subscriptionToken"] = sub.SubscriptionToken
 	}

--- a/platform-api/src/internal/repository/api.go
+++ b/platform-api/src/internal/repository/api.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"platform-api/src/internal/constants"
@@ -144,6 +145,40 @@ func (r *APIRepo) GetAPIByUUID(apiUUID, orgUUID string) (*model.API, error) {
 	}
 
 	return api, nil
+}
+
+// GetAPIsByUUIDs returns a map of API UUID to handle for the given UUIDs in the organization.
+// Used for bulk lookup to avoid N+1 queries. Returns empty map for empty input.
+func (r *APIRepo) GetAPIsByUUIDs(uuids []string, orgUUID string) (map[string]string, error) {
+	if len(uuids) == 0 {
+		return map[string]string{}, nil
+	}
+	placeholders := make([]string, len(uuids))
+	args := make([]interface{}, 0, len(uuids)+1)
+	for i, u := range uuids {
+		placeholders[i] = "?"
+		args = append(args, u)
+	}
+	args = append(args, orgUUID)
+	query := fmt.Sprintf(`
+		SELECT art.uuid, art.handle
+		FROM rest_apis r INNER JOIN artifacts art ON r.uuid = art.uuid
+		WHERE art.uuid IN (%s) AND art.organization_uuid = ?
+	`, strings.Join(placeholders, ","))
+	rows, err := r.db.Query(r.db.Rebind(query), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	m := make(map[string]string)
+	for rows.Next() {
+		var uuid, handle string
+		if err := rows.Scan(&uuid, &handle); err != nil {
+			return nil, err
+		}
+		m[uuid] = handle
+	}
+	return m, rows.Err()
 }
 
 // GetAPIMetadataByHandle retrieves minimal API information by handle and organization ID

--- a/platform-api/src/internal/repository/interfaces.go
+++ b/platform-api/src/internal/repository/interfaces.go
@@ -79,6 +79,7 @@ type ApplicationRepository interface {
 type APIRepository interface {
 	CreateAPI(api *model.API) error
 	GetAPIByUUID(apiUUID, orgUUID string) (*model.API, error)
+	GetAPIsByUUIDs(uuids []string, orgUUID string) (map[string]string, error)
 	GetAPIMetadataByHandle(handle, orgUUID string) (*model.APIMetadata, error)
 	GetAPIsByProjectUUID(projectUUID, orgUUID string) ([]*model.API, error)
 	GetAPIsByOrganizationUUID(orgUUID string, projectUUID string) ([]*model.API, error)
@@ -171,6 +172,7 @@ type DevPortalRepository interface {
 type SubscriptionPlanRepository interface {
 	Create(plan *model.SubscriptionPlan) error
 	GetByID(planID, orgUUID string) (*model.SubscriptionPlan, error)
+	GetByIDs(planIDs []string, orgUUID string) (map[string]string, error)
 	GetByNameAndOrg(planName, orgUUID string) (*model.SubscriptionPlan, error)
 	ListByOrganization(orgUUID string, limit, offset int) ([]*model.SubscriptionPlan, error)
 	Update(plan *model.SubscriptionPlan) error

--- a/platform-api/src/internal/repository/subscription_plan_repository.go
+++ b/platform-api/src/internal/repository/subscription_plan_repository.go
@@ -20,6 +20,7 @@ package repository
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	"platform-api/src/internal/database"
@@ -104,6 +105,40 @@ func (r *SubscriptionPlanRepo) GetByID(planID, orgUUID string) (*model.Subscript
 		return nil, err
 	}
 	return plan, nil
+}
+
+// GetByIDs returns a map of plan UUID to plan name for the given IDs in the organization.
+// Used for bulk lookup to avoid N+1 queries. Returns empty map for empty input.
+func (r *SubscriptionPlanRepo) GetByIDs(planIDs []string, orgUUID string) (map[string]string, error) {
+	if len(planIDs) == 0 {
+		return map[string]string{}, nil
+	}
+	placeholders := make([]string, len(planIDs))
+	args := make([]interface{}, 0, len(planIDs)+1)
+	for i, id := range planIDs {
+		placeholders[i] = "?"
+		args = append(args, id)
+	}
+	args = append(args, orgUUID)
+	query := fmt.Sprintf(`
+		SELECT uuid, plan_name
+		FROM subscription_plans
+		WHERE uuid IN (%s) AND organization_uuid = ?
+	`, strings.Join(placeholders, ","))
+	rows, err := r.db.Query(r.db.Rebind(query), args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get plans by IDs: %w", err)
+	}
+	defer rows.Close()
+	m := make(map[string]string)
+	for rows.Next() {
+		var id, planName string
+		if err := rows.Scan(&id, &planName); err != nil {
+			return nil, err
+		}
+		m[id] = planName
+	}
+	return m, rows.Err()
 }
 
 // ListByOrganization returns subscription plans for an organization with pagination

--- a/platform-api/src/internal/server/server.go
+++ b/platform-api/src/internal/server/server.go
@@ -221,7 +221,7 @@ func StartPlatformAPIServer(cfg *config.Server, slogger *slog.Logger) (*Server, 
 	apiHandler := handler.NewAPIHandler(apiService, slogger)
 	devPortalHandler := handler.NewDevPortalHandler(devPortalService, slogger)
 	gatewayHandler := handler.NewGatewayHandler(gatewayService, slogger)
-	subscriptionHandler := handler.NewSubscriptionHandler(subscriptionService, slogger)
+	subscriptionHandler := handler.NewSubscriptionHandler(subscriptionService, subscriptionPlanService, slogger)
 	subscriptionPlanHandler := handler.NewSubscriptionPlanHandler(subscriptionPlanService, slogger)
 	appHandler := handler.NewApplicationHandler(appService, slogger)
 	wsHandler := handler.NewWebSocketHandler(wsManager, gatewayService, deploymentService, cfg.WebSocket.RateLimitPerMin, slogger)

--- a/platform-api/src/internal/service/subscription_plan_service.go
+++ b/platform-api/src/internal/service/subscription_plan_service.go
@@ -106,6 +106,11 @@ func (s *SubscriptionPlanService) GetPlan(planID, orgUUID string) (*model.Subscr
 	return plan, nil
 }
 
+// GetPlanNameMap returns a map of plan UUID to plan name for bulk lookup (avoids N+1 queries).
+func (s *SubscriptionPlanService) GetPlanNameMap(planIDs []string, orgUUID string) (map[string]string, error) {
+	return s.planRepo.GetByIDs(planIDs, orgUUID)
+}
+
 // ListPlans returns subscription plans for an organization with pagination
 func (s *SubscriptionPlanService) ListPlans(orgUUID string, limit, offset int) ([]*model.SubscriptionPlan, error) {
 	return s.planRepo.ListByOrganization(orgUUID, limit, offset)

--- a/platform-api/src/internal/service/subscription_service.go
+++ b/platform-api/src/internal/service/subscription_service.go
@@ -87,6 +87,23 @@ func derefString(s *string) string {
 	return *s
 }
 
+// ResolveAPIHandle returns the API handle for display (apiId in responses should be the handle, not UUID).
+func (s *SubscriptionService) ResolveAPIHandle(apiUUID, orgUUID string) string {
+	if apiUUID == "" {
+		return ""
+	}
+	api, err := s.apiRepo.GetAPIByUUID(apiUUID, orgUUID)
+	if err != nil || api == nil {
+		return apiUUID // fallback to UUID if lookup fails
+	}
+	return api.Handle
+}
+
+// GetAPIHandleMap returns a map of API UUID to handle for bulk lookup (avoids N+1 queries).
+func (s *SubscriptionService) GetAPIHandleMap(uuids []string, orgUUID string) (map[string]string, error) {
+	return s.apiRepo.GetAPIsByUUIDs(uuids, orgUUID)
+}
+
 // CreateSubscription creates a new subscription for an API
 func (s *SubscriptionService) CreateSubscription(apiId, orgUUID string, applicationId *string, subscriptionPlanId *string, status string) (*model.Subscription, error) {
 	apiUUID, err := s.resolveAPIUUID(apiId, orgUUID)

--- a/platform-api/src/resources/openapi.yaml
+++ b/platform-api/src/resources/openapi.yaml
@@ -5764,6 +5764,9 @@ components:
         subscriptionPlanId:
           type: string
           description: Subscription plan UUID
+        subscriptionPlanName:
+          type: string
+          description: Subscription plan display name (e.g. Bronze, Gold)
         organizationId:
           type: string
           format: uuid


### PR DESCRIPTION
## Purpose
Adding subscription plan name to subscriptions response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subscription responses now include subscription plan display names (e.g., Bronze, Gold).
  * API identifiers in subscription details are resolved to user-friendly handles with UUID fallback.
  * List view now pre-fetches API and plan names to reduce latency and improve response completeness.
  * Subscription payloads include updated timestamps and conditionally expose plan IDs and tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->