### PR TITLE
Control plane WS/REST URLs from gateway well-known

### DIFF
--- a/gateway/gateway-controller/pkg/controlplane/client.go
+++ b/gateway/gateway-controller/pkg/controlplane/client.go
@@ -233,7 +233,7 @@ func (c *Client) Start() error {
 
 	c.logger.Info("Starting control plane client",
 		slog.String("host", c.config.Host),
-		slog.String("websocket_url", c.resolveWebSocketConnectURL()),
+		slog.String("websocket_url", c.getWebSocketConnectURL()),
 	)
 
 	// Start connection in background
@@ -378,8 +378,8 @@ func (c *Client) Connect() error {
 	return nil
 }
 
-// gatewayWellKnownResponse matches APIM well-known JSON: {"gatewayPath":"internal/data/v1/ws"}.
-// Extra fields from the server are ignored. gateway_path is accepted as a legacy alias.
+// gatewayWellKnownResponse matches APIM well-known JSON: gatewayPath is the internal REST base (optional /ws suffix).
+// Extra fields from the server are ignored. gateway_path is a legacy snake_case alias for the same field.
 type gatewayWellKnownResponse struct {
 	GatewayPath      string `json:"gatewayPath"`
 	GatewayPathSnake string `json:"gateway_path"`
@@ -402,6 +402,10 @@ func (c *Client) resolveGatewayPathWithCache() (string, error) {
 	c.gatewayPathMu.Lock()
 	c.resolvedGatewayPath = p
 	c.gatewayPathMu.Unlock()
+
+	if c.apiUtilsService != nil && c.config.Token != "" {
+		c.apiUtilsService.SetBaseURL(fmt.Sprintf("https://%s%s", c.config.Host, restAPIBasePathFromGatewayWebSocketPath(p)))
+	}
 	return p, nil
 }
 
@@ -473,6 +477,10 @@ func (c *Client) discoverGatewayPath() (string, error) {
 	}
 	gatewayPath := normalizeGatewayPath(rawPath)
 	if gatewayPath == "" {
+		return "", fmt.Errorf("well-known response missing gatewayPath")
+	}
+	restBase := strings.TrimSuffix(gatewayPath, "/ws")
+	if restBase == "" {
 		return "", fmt.Errorf("well-known response missing gatewayPath")
 	}
 

--- a/gateway/gateway-controller/pkg/controlplane/controlplane_test.go
+++ b/gateway/gateway-controller/pkg/controlplane/controlplane_test.go
@@ -404,6 +404,22 @@ func TestClient_restUsesWellKnownDerivedBaseURL(t *testing.T) {
 	}
 }
 
+func TestClient_discoverGatewayPath_InvalidRestBase(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"gatewayPath":"ws"}`))
+	}))
+	defer server.Close()
+
+	host := strings.TrimPrefix(server.URL, "https://")
+	client := createTestClientWithHost(t, host)
+
+	_, err := client.discoverGatewayPath()
+	if err == nil {
+		t.Fatal("discoverGatewayPath() want error for gatewayPath that yields empty REST base")
+	}
+}
+
 func TestClient_discoverGatewayPath_SnakeCaseJSON(t *testing.T) {
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/gateway/gateway-controller/pkg/utils/api_utils.go
+++ b/gateway/gateway-controller/pkg/utils/api_utils.go
@@ -29,6 +29,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/models"
@@ -44,6 +45,7 @@ type PlatformAPIConfig struct {
 
 // APIUtilsService provides utilities for API operations
 type APIUtilsService struct {
+	mu     sync.RWMutex
 	config PlatformAPIConfig
 	logger *slog.Logger
 	client *http.Client
@@ -80,10 +82,23 @@ func NewAPIUtilsService(config PlatformAPIConfig, logger *slog.Logger) *APIUtils
 	}
 }
 
+func (s *APIUtilsService) baseURL() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.config.BaseURL
+}
+
+// SetBaseURL updates the control plane REST base URL (e.g. after well-known discovery succeeds post-startup).
+func (s *APIUtilsService) SetBaseURL(baseURL string) {
+	s.mu.Lock()
+	s.config.BaseURL = baseURL
+	s.mu.Unlock()
+}
+
 // FetchAPIDefinition downloads the API definition as a zip file from the control plane
 func (s *APIUtilsService) FetchAPIDefinition(apiID string) ([]byte, error) {
 	// Construct the API URL by appending the resource path
-	apiURL := s.config.BaseURL + "/apis/" + apiID
+	apiURL := s.baseURL() + "/apis/" + apiID
 
 	s.logger.Info("Fetching API definition",
 		slog.String("api_id", apiID),
@@ -130,7 +145,7 @@ func (s *APIUtilsService) FetchAPIDefinition(apiID string) ([]byte, error) {
 // FetchLLMProviderDefinition downloads the LLM provider definition as a zip file from the control plane
 func (s *APIUtilsService) FetchLLMProviderDefinition(providerID string) ([]byte, error) {
 	// Construct the LLM provider URL by appending the resource path
-	providerURL := s.config.BaseURL + "/llm-providers/" + providerID
+	providerURL := s.baseURL() + "/llm-providers/" + providerID
 
 	s.logger.Info("Fetching LLM provider definition",
 		slog.String("provider_id", providerID),
@@ -177,7 +192,7 @@ func (s *APIUtilsService) FetchLLMProviderDefinition(providerID string) ([]byte,
 // FetchLLMProxyDefinition downloads the LLM proxy definition as a zip file from the control plane
 func (s *APIUtilsService) FetchLLMProxyDefinition(proxyID string) ([]byte, error) {
 	// Construct the LLM proxy URL by appending the resource path
-	proxyURL := s.config.BaseURL + "/llm-proxies/" + proxyID
+	proxyURL := s.baseURL() + "/llm-proxies/" + proxyID
 
 	s.logger.Info("Fetching LLM proxy definition",
 		slog.String("proxy_id", proxyID),
@@ -223,7 +238,7 @@ func (s *APIUtilsService) FetchLLMProxyDefinition(proxyID string) ([]byte, error
 
 // FetchSubscriptionsForAPI fetches subscriptions for the given API from the control plane.
 func (s *APIUtilsService) FetchSubscriptionsForAPI(apiID string) ([]models.Subscription, error) {
-	subURL := s.config.BaseURL + "/apis/" + apiID + "/subscriptions"
+	subURL := s.baseURL() + "/apis/" + apiID + "/subscriptions"
 
 	s.logger.Info("Fetching subscriptions for API",
 		slog.String("api_id", apiID),
@@ -272,7 +287,7 @@ func (s *APIUtilsService) FetchSubscriptionsForAPI(apiID string) ([]models.Subsc
 
 // FetchSubscriptionPlans fetches all subscription plans from the control plane for the organization.
 func (s *APIUtilsService) FetchSubscriptionPlans() ([]models.SubscriptionPlan, error) {
-	planURL := s.config.BaseURL + "/subscription-plans"
+	planURL := s.baseURL() + "/subscription-plans"
 
 	s.logger.Info("Fetching subscription plans", slog.String("url", planURL))
 
@@ -409,7 +424,7 @@ func (s *APIUtilsService) CreateLLMProxyFromYAML(yamlData []byte, proxyID string
 // FetchMCPProxyDefinition downloads the MCP proxy definition as a zip file from the control plane
 func (s *APIUtilsService) FetchMCPProxyDefinition(proxyID string) ([]byte, error) {
 	// Construct the MCP proxy URL by appending the resource path
-	proxyURL := s.config.BaseURL + "/mcp-proxies/" + proxyID
+	proxyURL := s.baseURL() + "/mcp-proxies/" + proxyID
 
 	s.logger.Debug("Fetching MCP proxy definition",
 		slog.String("proxy_id", proxyID),
@@ -508,7 +523,7 @@ type APIDeploymentPush struct {
 // PushAPIDeployment sends API deployment details to the control plane via a REST call
 func (s *APIUtilsService) PushAPIDeployment(apiID string, apiConfig *models.StoredConfig, deploymentID string) error {
 	// Construct the deployment URL
-	deployURL := s.config.BaseURL + "/apis/" + apiID + "/gateway-deployments"
+	deployURL := s.baseURL() + "/apis/" + apiID + "/gateway-deployments"
 	if deploymentID != "" {
 		deployURL += "?deploymentId=" + deploymentID
 	}


### PR DESCRIPTION
### Summary
Gateway controller discovers the control plane gateway WebSocket base path from /internal/gateway/.well-known and uses it for the WebSocket connect URL. If discovery fails or returns an invalid payload, behavior falls back to the existing cloud defaults (/api/internal/v1/ws and /api/internal/v1).

### REST base URL
When a registration token is configured, the internal REST base is https://{host}{gatewayPath without trailing /ws}, matching the previous on-prem vs cloud path split without a dedicated OnPrem flag. If well-known is unavailable, REST uses https://{host}/api/internal/v1. If no token is configured, well-known is not called for REST (default base only).

### Details

- Accepts gatewayPath (camelCase) and gateway_path (legacy) in JSON.
- Normalizes path segments (trim, leading /).
- Caches a successful gateway path for the process lifetime to avoid repeated well-known calls.
- APIUtilsService is constructed with the REST base computed at NewClient time when discovery succeeds at startup.

### Testing

- Unit tests for normalization, well-known success/fallback, REST path derivation.
- Integration-style test: FetchAPIDefinition hits /internal/data/v1/apis/... when well-known returns the on-prem-style gateway path.
- Tests use a closed local host for fast failure when discovery is expected to fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Gateway path discovery now caches results to reduce repeated lookups and improve connection performance.
  * Discovery accepts alternate/legacy well-known naming (e.g., snake_case) and trims/normalizes discovered paths.
  * WebSocket and REST URL resolution is more robust with sensible fallbacks when discovery is unavailable.
  * API client base URL handling made thread-safe and can be updated at runtime for safer reconfiguration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->