### PR TITLE
Add missing policy validation for MCP proxies

### DIFF
--- a/gateway/gateway-controller/pkg/api/handlers/handlers.go
+++ b/gateway/gateway-controller/pkg/api/handlers/handlers.go
@@ -124,7 +124,7 @@ func NewAPIServer(
 		validator:            validator,
 		logger:               logger,
 		deploymentService:    deploymentService,
-		mcpDeploymentService: utils.NewMCPDeploymentService(store, db, snapshotManager, policyManager),
+		mcpDeploymentService: utils.NewMCPDeploymentService(store, db, snapshotManager, policyManager, policyValidator),
 		llmDeploymentService: utils.NewLLMDeploymentService(store, db, snapshotManager, lazyResourceManager, templateDefinitions,
 			deploymentService, routerConfig, policyVersionResolver, policyValidator),
 		apiKeyService:      apiKeyService,

--- a/gateway/gateway-controller/pkg/config/mcp_validator.go
+++ b/gateway/gateway-controller/pkg/config/mcp_validator.go
@@ -37,6 +37,8 @@ type MCPValidator struct {
 	urlFriendlyNameRegex *regexp.Regexp
 	// supported MCP specification version
 	supportedSpecVersions []string
+	// policyValidator validates policies referenced in the MCP configuration
+	policyValidator *PolicyValidator
 }
 
 // NewMCPValidator creates a new API configuration validator
@@ -45,6 +47,12 @@ func NewMCPValidator() *MCPValidator {
 		versionRegex:          regexp.MustCompile(`^v?\d+(\.\d+)?(\.\d+)?$`),
 		urlFriendlyNameRegex:  regexp.MustCompile(`^[a-zA-Z0-9\-_\. ]+$`),
 		supportedSpecVersions: []string{constants.SPEC_VERSION_2025_JUNE, constants.SPEC_VERSION_2025_NOVEMBER}}
+}
+
+// WithPolicyValidator sets the policy validator on the MCPValidator and returns it for chaining
+func (v *MCPValidator) WithPolicyValidator(pv *PolicyValidator) *MCPValidator {
+	v.policyValidator = pv
+	return v
 }
 
 // Validate performs comprehensive validation on a configuration
@@ -90,6 +98,11 @@ func (v *MCPValidator) validateMCPConfiguration(config *api.MCPProxyConfiguratio
 
 	// Validate data section
 	errors = append(errors, v.validateSpec(&config.Spec)...)
+
+	// Validate policies if a policy validator is configured
+	if v.policyValidator != nil {
+		errors = append(errors, v.policyValidator.ValidateMCPProxyPolicies(config)...)
+	}
 
 	return errors
 }

--- a/gateway/gateway-controller/pkg/config/policy_validator.go
+++ b/gateway/gateway-controller/pkg/config/policy_validator.go
@@ -40,6 +40,22 @@ func NewPolicyValidator(policyDefinitions map[string]models.PolicyDefinition) *P
 	}
 }
 
+// ValidateMCPProxyPolicies validates all policies in an MCP proxy configuration
+func (pv *PolicyValidator) ValidateMCPProxyPolicies(mcpConfig *api.MCPProxyConfiguration) []ValidationError {
+	var errors []ValidationError
+
+	if mcpConfig.Spec.Policies == nil {
+		return errors
+	}
+
+	for i, policy := range *mcpConfig.Spec.Policies {
+		errs := pv.validatePolicy(policy, fmt.Sprintf("spec.policies[%d]", i))
+		errors = append(errors, errs...)
+	}
+
+	return errors
+}
+
 // ValidateRestAPIPolicies validates all policies in a REST API configuration
 func (pv *PolicyValidator) ValidateRestAPIPolicies(apiConfig *api.RestAPI) []ValidationError {
 	var errors []ValidationError

--- a/gateway/gateway-controller/pkg/controlplane/client.go
+++ b/gateway/gateway-controller/pkg/controlplane/client.go
@@ -207,6 +207,7 @@ func NewClient(
 		db,
 		snapshotManager,
 		policyManager,
+		policyValidator,
 	)
 
 	// Initialize API utils service with the proper base URL using the method

--- a/gateway/gateway-controller/pkg/utils/mcp_deployment.go
+++ b/gateway/gateway-controller/pkg/utils/mcp_deployment.go
@@ -62,13 +62,14 @@ func NewMCPDeploymentService(
 	db storage.Storage,
 	snapshotManager *xds.SnapshotManager,
 	policyManager *policyxds.PolicyManager,
+	policyValidator *config.PolicyValidator,
 ) *MCPDeploymentService {
 	return &MCPDeploymentService{
 		store:           store,
 		db:              db,
 		snapshotManager: snapshotManager,
 		parser:          config.NewParser(),
-		validator:       config.NewMCPValidator(),
+		validator:       config.NewMCPValidator().WithPolicyValidator(policyValidator),
 		transformer:     NewMCPTransformer(),
 		policyManager:   policyManager,
 	}

--- a/gateway/gateway-controller/pkg/utils/mcp_deployment_test.go
+++ b/gateway/gateway-controller/pkg/utils/mcp_deployment_test.go
@@ -32,7 +32,7 @@ import (
 
 func TestNewMCPDeploymentService(t *testing.T) {
 	store := storage.NewConfigStore()
-	service := NewMCPDeploymentService(store, nil, nil, nil)
+	service := NewMCPDeploymentService(store, nil, nil, nil, nil)
 
 	assert.NotNil(t, service)
 	assert.NotNil(t, service.store)
@@ -60,7 +60,7 @@ func TestMCPDeploymentParams(t *testing.T) {
 
 func TestMCPDeploymentService_ListMCPProxies(t *testing.T) {
 	store := storage.NewConfigStore()
-	service := NewMCPDeploymentService(store, nil, nil, nil)
+	service := NewMCPDeploymentService(store, nil, nil, nil, nil)
 
 	t.Run("Empty store returns empty list", func(t *testing.T) {
 		proxies := service.ListMCPProxies()
@@ -118,7 +118,7 @@ func TestMCPDeploymentService_ListMCPProxies(t *testing.T) {
 
 func TestMCPDeploymentService_GetMCPProxyByHandle_NoDatabase(t *testing.T) {
 	store := storage.NewConfigStore()
-	service := NewMCPDeploymentService(store, nil, nil, nil)
+	service := NewMCPDeploymentService(store, nil, nil, nil, nil)
 
 	_, err := service.GetMCPProxyByHandle("0000-test-handle-0000-000000000000")
 	assert.Error(t, err)
@@ -127,7 +127,7 @@ func TestMCPDeploymentService_GetMCPProxyByHandle_NoDatabase(t *testing.T) {
 
 func TestMCPDeploymentService_CreateMCPProxy_ParseError(t *testing.T) {
 	store := storage.NewConfigStore()
-	service := NewMCPDeploymentService(store, nil, nil, nil)
+	service := NewMCPDeploymentService(store, nil, nil, nil, nil)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
 	params := MCPDeploymentParams{
@@ -144,7 +144,7 @@ func TestMCPDeploymentService_CreateMCPProxy_ParseError(t *testing.T) {
 
 func TestMCPDeploymentService_CreateMCPProxy_ValidationError(t *testing.T) {
 	store := storage.NewConfigStore()
-	service := NewMCPDeploymentService(store, nil, nil, nil)
+	service := NewMCPDeploymentService(store, nil, nil, nil, nil)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
 	// Invalid MCP config that will fail validation
@@ -170,7 +170,7 @@ spec:
 
 func TestMCPDeploymentService_CreateMCPProxy_ConflictError(t *testing.T) {
 	store := storage.NewConfigStore()
-	service := NewMCPDeploymentService(store, nil, nil, nil)
+	service := NewMCPDeploymentService(store, nil, nil, nil, nil)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
 	// First, add an existing config with the same name/version
@@ -225,7 +225,7 @@ spec:
 
 func TestMCPDeploymentService_DeleteMCPProxy_NoDatabase(t *testing.T) {
 	store := storage.NewConfigStore()
-	service := NewMCPDeploymentService(store, nil, nil, nil)
+	service := NewMCPDeploymentService(store, nil, nil, nil, nil)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
 	_, err := service.DeleteMCPProxy("0000-test-handle-0000-000000000000", "corr-id", logger)
@@ -235,7 +235,7 @@ func TestMCPDeploymentService_DeleteMCPProxy_NoDatabase(t *testing.T) {
 
 func TestMCPDeploymentService_UpdateMCPProxy_NoDatabase(t *testing.T) {
 	store := storage.NewConfigStore()
-	service := NewMCPDeploymentService(store, nil, nil, nil)
+	service := NewMCPDeploymentService(store, nil, nil, nil, nil)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
 	params := MCPDeploymentParams{
@@ -255,7 +255,7 @@ func TestMCPDeploymentService_SaveOrUpdateConfig(t *testing.T) {
 
 	t.Run("Save new config without DB", func(t *testing.T) {
 		store := storage.NewConfigStore()
-		service := NewMCPDeploymentService(store, nil, nil, nil)
+		service := NewMCPDeploymentService(store, nil, nil, nil, nil)
 
 		apiData := api.APIConfigData{
 			DisplayName: "Test MCP",
@@ -295,7 +295,7 @@ func TestMCPDeploymentService_UpdateExistingConfig(t *testing.T) {
 
 	t.Run("Updates existing config", func(t *testing.T) {
 		store := storage.NewConfigStore()
-		service := NewMCPDeploymentService(store, nil, nil, nil)
+		service := NewMCPDeploymentService(store, nil, nil, nil, nil)
 
 		apiData := api.APIConfigData{
 			DisplayName: "Original MCP",
@@ -349,7 +349,7 @@ func TestMCPDeploymentService_UpdateExistingConfig(t *testing.T) {
 
 	t.Run("Error when config not found", func(t *testing.T) {
 		store := storage.NewConfigStore()
-		service := NewMCPDeploymentService(store, nil, nil, nil)
+		service := NewMCPDeploymentService(store, nil, nil, nil, nil)
 
 		apiData := api.APIConfigData{
 			DisplayName: "Non-existent MCP",
@@ -378,7 +378,7 @@ func TestMCPDeploymentService_UpdateExistingConfig(t *testing.T) {
 
 func TestMCPDeploymentService_ParseValidateAndTransform(t *testing.T) {
 	store := storage.NewConfigStore()
-	service := NewMCPDeploymentService(store, nil, nil, nil)
+	service := NewMCPDeploymentService(store, nil, nil, nil, nil)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
 	t.Run("Valid MCP config", func(t *testing.T) {


### PR DESCRIPTION
## Purpose

$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced MCP proxy configuration validation to include policy validation for MCP configurations, with validation errors properly aggregated and reported.

* **Tests**
  * Updated test suite to reflect new validation capability in deployment service initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->