### PR TITLE
Add deployment ack and transitional status support for MCP proxy deploy/undeploy

### DIFF
--- a/gateway/gateway-controller/pkg/controlplane/client.go
+++ b/gateway/gateway-controller/pkg/controlplane/client.go
@@ -1972,6 +1972,8 @@ func (c *Client) handleMCPProxyDeploymentEvent(event map[string]any) {
 			slog.String("proxy_id", proxyID),
 			slog.Any("error", err),
 		)
+		c.sendDeploymentAck(deployedEvent.Payload.DeploymentID, proxyID, "mcpproxy", "deploy", "failed",
+			deployedEvent.Payload.PerformedAt, "GATEWAY_PROCESSING_ERROR")
 		return
 	}
 
@@ -1982,6 +1984,8 @@ func (c *Client) handleMCPProxyDeploymentEvent(event map[string]any) {
 			slog.String("proxy_id", proxyID),
 			slog.Any("error", err),
 		)
+		c.sendDeploymentAck(deployedEvent.Payload.DeploymentID, proxyID, "mcpproxy", "deploy", "failed",
+			deployedEvent.Payload.PerformedAt, "GATEWAY_PROCESSING_ERROR")
 		return
 	}
 
@@ -1990,6 +1994,8 @@ func (c *Client) handleMCPProxyDeploymentEvent(event map[string]any) {
 			slog.String("proxy_id", proxyID),
 			slog.String("correlation_id", deployedEvent.CorrelationID),
 		)
+		c.sendDeploymentAck(deployedEvent.Payload.DeploymentID, proxyID, "mcpproxy", "deploy", "failed",
+			deployedEvent.Payload.PerformedAt, "GATEWAY_PROCESSING_ERROR")
 		return
 	}
 
@@ -2000,14 +2006,21 @@ func (c *Client) handleMCPProxyDeploymentEvent(event map[string]any) {
 			slog.String("proxy_id", proxyID),
 			slog.Any("error", err),
 		)
+		c.sendDeploymentAck(deployedEvent.Payload.DeploymentID, proxyID, "mcpproxy", "deploy", "failed",
+			deployedEvent.Payload.PerformedAt, "GATEWAY_PROCESSING_ERROR")
 		return
 	}
 
 	// Update policy engine xDS snapshot (best-effort)
 	if err := c.updatePolicyForDeployment(proxyID, deployedEvent.CorrelationID, result); err != nil {
 		// Error already logged in updatePolicyForDeployment
+		c.sendDeploymentAck(deployedEvent.Payload.DeploymentID, proxyID, "mcpproxy", "deploy", "failed",
+			deployedEvent.Payload.PerformedAt, "GATEWAY_PROCESSING_ERROR")
 		return
 	}
+
+	c.sendDeploymentAck(deployedEvent.Payload.DeploymentID, proxyID, "mcpproxy", "deploy", "success",
+		deployedEvent.Payload.PerformedAt, "")
 
 	c.logger.Info("Successfully processed MCP proxy deployment event",
 		slog.String("proxy_id", proxyID),
@@ -2053,6 +2066,8 @@ func (c *Client) handleMCPProxyUndeploymentEvent(event map[string]any) {
 				slog.String("proxy_id", proxyID),
 			)
 			// Not an error - the MCP proxy might already be undeployed or deleted
+			c.sendDeploymentAck(undeployedEvent.Payload.DeploymentID, proxyID, "mcpproxy", "undeploy", "success",
+				undeployedEvent.Payload.PerformedAt, "")
 			return
 		}
 		// Real storage error - log and abort
@@ -2061,6 +2076,8 @@ func (c *Client) handleMCPProxyUndeploymentEvent(event map[string]any) {
 			slog.String("correlation_id", undeployedEvent.CorrelationID),
 			slog.Any("error", err),
 		)
+		c.sendDeploymentAck(undeployedEvent.Payload.DeploymentID, proxyID, "mcpproxy", "undeploy", "failed",
+			undeployedEvent.Payload.PerformedAt, "GATEWAY_PROCESSING_ERROR")
 		return
 	}
 
@@ -2075,6 +2092,8 @@ func (c *Client) handleMCPProxyUndeploymentEvent(event map[string]any) {
 				slog.String("proxy_id", proxyID),
 				slog.Any("error", err),
 			)
+			c.sendDeploymentAck(undeployedEvent.Payload.DeploymentID, proxyID, "mcpproxy", "undeploy", "failed",
+				undeployedEvent.Payload.PerformedAt, "GATEWAY_PROCESSING_ERROR")
 			return
 		}
 	}
@@ -2085,11 +2104,16 @@ func (c *Client) handleMCPProxyUndeploymentEvent(event map[string]any) {
 			slog.String("proxy_id", proxyID),
 			slog.Any("error", err),
 		)
+		c.sendDeploymentAck(undeployedEvent.Payload.DeploymentID, proxyID, "mcpproxy", "undeploy", "failed",
+			undeployedEvent.Payload.PerformedAt, "GATEWAY_PROCESSING_ERROR")
 		return
 	}
 
 	// Update xDS snapshot asynchronously (undeployed APIs will be filtered out)
 	c.updateXDSSnapshotAsync(proxyID, undeployedEvent.CorrelationID, false, true)
+
+	c.sendDeploymentAck(undeployedEvent.Payload.DeploymentID, proxyID, "mcpproxy", "undeploy", "success",
+		undeployedEvent.Payload.PerformedAt, "")
 
 	c.logger.Info("Successfully processed MCP proxy undeployment event",
 		slog.String("proxy_id", proxyID),

--- a/gateway/gateway-controller/pkg/controlplane/events.go
+++ b/gateway/gateway-controller/pkg/controlplane/events.go
@@ -215,8 +215,9 @@ type APIKeyRevokedEvent struct {
 
 // MCPProxyDeployedEventPayload represents the payload of an MCP proxy deployment event
 type MCPProxyDeployedEventPayload struct {
-	ProxyID      string `json:"proxyId"`
-	DeploymentID string `json:"deploymentId"`
+	ProxyID      string    `json:"proxyId"`
+	DeploymentID string    `json:"deploymentId"`
+	PerformedAt  time.Time `json:"performedAt"`
 }
 
 // MCPProxyDeployedEvent represents the complete MCP proxy deployment event
@@ -229,7 +230,9 @@ type MCPProxyDeployedEvent struct {
 
 // MCPProxyUndeployedEventPayload represents the payload of an MCP proxy undeployment event
 type MCPProxyUndeployedEventPayload struct {
-	ProxyID string `json:"proxyId"`
+	ProxyID      string    `json:"proxyId"`
+	DeploymentID string    `json:"deploymentId"`
+	PerformedAt  time.Time `json:"performedAt"`
 }
 
 // MCPProxyUndeployedEvent represents the complete MCP proxy undeployment event

--- a/platform-api/src/internal/model/gateway_event.go
+++ b/platform-api/src/internal/model/gateway_event.go
@@ -149,6 +149,9 @@ type MCPProxyDeploymentEvent struct {
 
 	// DeploymentID identifies the specific deployment artifact
 	DeploymentID string `json:"deploymentId"`
+
+	// PerformedAt is the timestamp when the deployment was initiated (concurrency token)
+	PerformedAt time.Time `json:"performedAt"`
 }
 
 // MCPProxyUndeploymentEvent contains payload data for "mcpproxy.undeployed" event type.
@@ -156,6 +159,12 @@ type MCPProxyDeploymentEvent struct {
 type MCPProxyUndeploymentEvent struct {
 	// ProxyId identifies the undeployed MCP proxy (handle)
 	ProxyId string `json:"proxyId"`
+
+	// DeploymentID identifies the specific deployment being undeployed
+	DeploymentID string `json:"deploymentId"`
+
+	// PerformedAt is the timestamp when the undeployment was initiated (concurrency token)
+	PerformedAt time.Time `json:"performedAt"`
 }
 
 // MCPProxyDeletionEvent contains payload data for "mcpproxy.deleted" event type.

--- a/platform-api/src/internal/service/mcp_deployment.go
+++ b/platform-api/src/internal/service/mcp_deployment.go
@@ -29,6 +29,7 @@ import (
 	"platform-api/src/internal/model"
 	"platform-api/src/internal/repository"
 	"platform-api/src/internal/utils"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -257,11 +258,26 @@ func (s *MCPDeploymentService) deployMCPProxy(proxyUUID string, req *api.DeployR
 		return nil, fmt.Errorf("failed to create deployment: %w", err)
 	}
 
+	// Set initial status based on config; transitional (DEPLOYING) only when enabled
+	initialStatus := model.DeploymentStatusDeployed
+	if s.cfg.Deployments.TransitionalStatusEnabled {
+		initialStatus = model.DeploymentStatusDeploying
+	}
+	performedAt := time.Now()
+	if _, err := s.deploymentRepo.SetCurrentWithDetails(
+		proxyUUID, orgId, gatewayID, deploymentID,
+		initialStatus, string(model.DeploymentStatusDeployed),
+		&performedAt, "",
+	); err != nil {
+		return nil, fmt.Errorf("failed to set deployment status for MCP proxy: %w", err)
+	}
+
 	// Send deployment event to gateway
 	if s.gatewayEventsService != nil {
 		deploymentEvent := &model.MCPProxyDeploymentEvent{
 			ProxyId:      proxyUUID,
 			DeploymentID: deploymentID,
+			PerformedAt:  performedAt,
 		}
 
 		if err := s.gatewayEventsService.BroadcastMCPProxyDeploymentEvent(gatewayID, deploymentEvent); err != nil {
@@ -269,12 +285,12 @@ func (s *MCPDeploymentService) deployMCPProxy(proxyUUID string, req *api.DeployR
 		}
 	}
 
-	// Return deployment response (status and updatedAt are set by CreateDeploymentWithLimitEnforcement)
+	// Return deployment response
 	return toAPIDeploymentResponse(
 		deployment.DeploymentID,
 		deployment.Name,
 		deployment.GatewayID,
-		model.DeploymentStatusDeployed,
+		initialStatus,
 		deployment.BaseDeploymentID,
 		deployment.Metadata,
 		deployment.CreatedAt,
@@ -337,8 +353,17 @@ func (s *MCPDeploymentService) undeployMCPProxyDeployment(proxyUUID string, depl
 		return nil, constants.ErrGatewayNotFound
 	}
 
-	// Update status to UNDEPLOYED using SetCurrent
-	newUpdatedAt, err := s.deploymentRepo.SetCurrent(proxyUUID, orgId, deployment.GatewayID, deployment.DeploymentID, model.DeploymentStatusUndeployed)
+	// Set initial status based on config; transitional (UNDEPLOYING) only when enabled
+	initialStatus := model.DeploymentStatusUndeployed
+	if s.cfg.Deployments.TransitionalStatusEnabled {
+		initialStatus = model.DeploymentStatusUndeploying
+	}
+	performedAt := time.Now()
+	newUpdatedAt, err := s.deploymentRepo.SetCurrentWithDetails(
+		proxyUUID, orgId, deployment.GatewayID, deployment.DeploymentID,
+		initialStatus, string(model.DeploymentStatusUndeployed),
+		&performedAt, "",
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update deployment status: %w", err)
 	}
@@ -346,7 +371,9 @@ func (s *MCPDeploymentService) undeployMCPProxyDeployment(proxyUUID string, depl
 	// Send undeployment event to gateway
 	if s.gatewayEventsService != nil {
 		undeploymentEvent := &model.MCPProxyUndeploymentEvent{
-			ProxyId: proxyUUID,
+			ProxyId:      proxyUUID,
+			DeploymentID: deployment.DeploymentID,
+			PerformedAt:  performedAt,
 		}
 
 		if err := s.gatewayEventsService.BroadcastMCPProxyUndeploymentEvent(deployment.GatewayID, undeploymentEvent); err != nil {
@@ -358,7 +385,7 @@ func (s *MCPDeploymentService) undeployMCPProxyDeployment(proxyUUID string, depl
 		deployment.DeploymentID,
 		deployment.Name,
 		deployment.GatewayID,
-		model.DeploymentStatusUndeployed,
+		initialStatus,
 		deployment.BaseDeploymentID,
 		deployment.Metadata,
 		deployment.CreatedAt,
@@ -401,8 +428,17 @@ func (s *MCPDeploymentService) restoreMCPProxyDeployment(proxyUUID string, deplo
 		return nil, constants.ErrGatewayNotFound
 	}
 
-	// Use SetCurrentDeployment to activate the target deployment with status='DEPLOYED'
-	updatedAt, err := s.deploymentRepo.SetCurrent(proxyUUID, orgId, targetDeployment.GatewayID, *deploymentId, model.DeploymentStatusDeployed)
+	// Set initial status based on config; transitional (DEPLOYING) only when enabled
+	initialStatus := model.DeploymentStatusDeployed
+	if s.cfg.Deployments.TransitionalStatusEnabled {
+		initialStatus = model.DeploymentStatusDeploying
+	}
+	performedAt := time.Now()
+	updatedAt, err := s.deploymentRepo.SetCurrentWithDetails(
+		proxyUUID, orgId, targetDeployment.GatewayID, *deploymentId,
+		initialStatus, string(model.DeploymentStatusDeployed),
+		&performedAt, "",
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set current deployment: %w", err)
 	}
@@ -412,6 +448,7 @@ func (s *MCPDeploymentService) restoreMCPProxyDeployment(proxyUUID string, deplo
 		deploymentEvent := &model.MCPProxyDeploymentEvent{
 			ProxyId:      proxyUUID,
 			DeploymentID: *deploymentId,
+			PerformedAt:  performedAt,
 		}
 
 		if err := s.gatewayEventsService.BroadcastMCPProxyDeploymentEvent(targetDeployment.GatewayID, deploymentEvent); err != nil {
@@ -423,7 +460,7 @@ func (s *MCPDeploymentService) restoreMCPProxyDeployment(proxyUUID string, deplo
 		targetDeployment.DeploymentID,
 		targetDeployment.Name,
 		targetDeployment.GatewayID,
-		model.DeploymentStatusDeployed,
+		initialStatus,
 		targetDeployment.BaseDeploymentID,
 		targetDeployment.Metadata,
 		targetDeployment.CreatedAt,
@@ -479,9 +516,12 @@ func (s *MCPDeploymentService) getMCPProxyDeployments(proxyUUID string, orgId st
 	// Validate status parameter
 	if status != nil {
 		validStatuses := map[string]bool{
-			string(model.DeploymentStatusDeployed):   true,
-			string(model.DeploymentStatusUndeployed): true,
-			string(model.DeploymentStatusArchived):   true,
+			string(model.DeploymentStatusDeployed):    true,
+			string(model.DeploymentStatusUndeployed):  true,
+			string(model.DeploymentStatusArchived):    true,
+			string(model.DeploymentStatusDeploying):   true,
+			string(model.DeploymentStatusUndeploying): true,
+			string(model.DeploymentStatusFailed):      true,
 		}
 		if !validStatuses[*status] {
 			return nil, constants.ErrInvalidDeploymentStatus


### PR DESCRIPTION
## Purpose

https://github.com/wso2/api-platform/issues/1325

Extends deployment event acknowledgement and transitional status support (from PR #1373) to MCP proxy deploy/undeploy/restore operations.

## Goals
- MCP proxy deploy/undeploy/restore operations use transitional statuses (`DEPLOYING`/`UNDEPLOYING`) when enabled
- Gateway sends deployment acks back to control plane after processing MCP proxy events
- MCP deployment events include `PerformedAt` and `DeploymentID` for ack routing

## Approach
- Add `PerformedAt` and `DeploymentID` fields to MCP event structs in both platform-api and gateway-controller
- Switch MCP deploy/undeploy/restore from `SetCurrent` to `SetCurrentWithDetails` with conditional transitional status
- Add explicit `sendDeploymentAck` calls in gateway MCP deploy/undeploy handlers on success and failure paths
- Add `DEPLOYING`, `UNDEPLOYING`, `FAILED` to valid status filter in `ListMCPProxyDeployments`

## User stories
N/A - infrastructure improvement for deployment lifecycle tracking

## Documentation
N/A - internal event protocol change, no user-facing doc impact

## Automation tests
 - Unit tests
   > Existing tests cover the deployment flows. No new tests needed as this follows the same pattern established in PR #1373.
 - Integration tests
   > Covered by existing MCP deployment integration tests.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (Go project)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
- #1373 - deployment event notification for REST APIs, LLMProvider, LLMProxy (prerequisite)

## Test environment
> Go 1.24, Linux