### PR TITLE
Change subscriptions and subscriptions-plans table primary key to uuid

### DIFF
--- a/gateway/gateway-controller/pkg/storage/gateway-controller-db.postgres.sql
+++ b/gateway/gateway-controller/pkg/storage/gateway-controller-db.postgres.sql
@@ -122,7 +122,7 @@ CREATE INDEX IF NOT EXISTS idx_api_keys_gateway_id ON api_keys(gateway_id);
 
 -- Subscription plans table (organization-scoped rate/billing plans)
 CREATE TABLE IF NOT EXISTS subscription_plans (
-    id TEXT PRIMARY KEY,
+    uuid TEXT PRIMARY KEY,
     gateway_id TEXT NOT NULL,
     plan_name TEXT NOT NULL,
     billing_plan TEXT,
@@ -139,7 +139,7 @@ CREATE TABLE IF NOT EXISTS subscription_plans (
 -- Subscriptions table (application-level subscriptions for REST APIs)
 -- subscription_token_hash: for xDS validation and request validation (Platform-API stores original token)
 CREATE TABLE IF NOT EXISTS subscriptions (
-    id TEXT PRIMARY KEY,
+    uuid TEXT PRIMARY KEY,
     gateway_id TEXT NOT NULL,
     api_id TEXT NOT NULL,
     application_id TEXT,
@@ -149,7 +149,7 @@ CREATE TABLE IF NOT EXISTS subscriptions (
     created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (api_id) REFERENCES rest_apis(uuid) ON DELETE CASCADE,
-    FOREIGN KEY (subscription_plan_id) REFERENCES subscription_plans(id) ON DELETE SET NULL,
+    FOREIGN KEY (subscription_plan_id) REFERENCES subscription_plans(uuid) ON DELETE SET NULL,
     UNIQUE(api_id, subscription_token_hash, gateway_id)
 );
 CREATE INDEX IF NOT EXISTS idx_subscriptions_api_id ON subscriptions(api_id);

--- a/gateway/gateway-controller/pkg/storage/gateway-controller-db.sql
+++ b/gateway/gateway-controller/pkg/storage/gateway-controller-db.sql
@@ -188,7 +188,7 @@ CREATE INDEX IF NOT EXISTS idx_api_key_external_ref ON api_keys(external_ref_id)
 
 -- Subscription plans table (organization-scoped rate/billing plans)
 CREATE TABLE IF NOT EXISTS subscription_plans (
-    id TEXT PRIMARY KEY,
+    uuid TEXT PRIMARY KEY,
     gateway_id TEXT NOT NULL,
     plan_name TEXT NOT NULL,
     billing_plan TEXT,
@@ -205,7 +205,7 @@ CREATE TABLE IF NOT EXISTS subscription_plans (
 -- Subscriptions table (application-level subscriptions for REST APIs)
 -- subscription_token_hash: for xDS validation and request validation (Platform-API stores original token)
 CREATE TABLE IF NOT EXISTS subscriptions (
-    id TEXT PRIMARY KEY,
+    uuid TEXT PRIMARY KEY,
     gateway_id TEXT NOT NULL,
     api_id TEXT NOT NULL,
     application_id TEXT,
@@ -215,7 +215,7 @@ CREATE TABLE IF NOT EXISTS subscriptions (
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (api_id) REFERENCES rest_apis(uuid) ON DELETE CASCADE,
-    FOREIGN KEY (subscription_plan_id) REFERENCES subscription_plans(id) ON DELETE SET NULL,
+    FOREIGN KEY (subscription_plan_id) REFERENCES subscription_plans(uuid) ON DELETE SET NULL,
     UNIQUE(api_id, subscription_token_hash, gateway_id)
 );
 CREATE INDEX IF NOT EXISTS idx_subscriptions_api_id ON subscriptions(api_id);

--- a/gateway/gateway-controller/pkg/storage/sql_store.go
+++ b/gateway/gateway-controller/pkg/storage/sql_store.go
@@ -1758,7 +1758,7 @@ func (s *sqlStore) SaveSubscriptionPlan(plan *models.SubscriptionPlan) error {
 	plan.CreatedAt = now
 	plan.UpdatedAt = now
 	query := `
-		INSERT INTO subscription_plans (id, gateway_id, plan_name, billing_plan, stop_on_quota_reach,
+		INSERT INTO subscription_plans (uuid, gateway_id, plan_name, billing_plan, stop_on_quota_reach,
 			throttle_limit_count, throttle_limit_unit, expiry_time, status, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`
@@ -1777,10 +1777,10 @@ func (s *sqlStore) SaveSubscriptionPlan(plan *models.SubscriptionPlan) error {
 // GetSubscriptionPlanByID retrieves a subscription plan by ID and gateway.
 func (s *sqlStore) GetSubscriptionPlanByID(id, gatewayID string) (*models.SubscriptionPlan, error) {
 	query := `
-		SELECT id, gateway_id, plan_name, billing_plan, stop_on_quota_reach,
+		SELECT uuid, gateway_id, plan_name, billing_plan, stop_on_quota_reach,
 			throttle_limit_count, throttle_limit_unit, expiry_time, status, created_at, updated_at
 		FROM subscription_plans
-		WHERE id = ? AND gateway_id = ?
+		WHERE uuid = ? AND gateway_id = ?
 	`
 	plan := &models.SubscriptionPlan{}
 	err := s.queryRow(query, id, s.gatewayId).Scan(
@@ -1800,7 +1800,7 @@ func (s *sqlStore) GetSubscriptionPlanByID(id, gatewayID string) (*models.Subscr
 // ListSubscriptionPlans returns all subscription plans for a gateway.
 func (s *sqlStore) ListSubscriptionPlans(gatewayID string) ([]*models.SubscriptionPlan, error) {
 	query := `
-		SELECT id, gateway_id, plan_name, billing_plan, stop_on_quota_reach,
+		SELECT uuid, gateway_id, plan_name, billing_plan, stop_on_quota_reach,
 			throttle_limit_count, throttle_limit_unit, expiry_time, status, created_at, updated_at
 		FROM subscription_plans
 		WHERE gateway_id = ?
@@ -1837,7 +1837,7 @@ func (s *sqlStore) UpdateSubscriptionPlan(plan *models.SubscriptionPlan) error {
 		UPDATE subscription_plans
 		SET plan_name = ?, billing_plan = ?, stop_on_quota_reach = ?, throttle_limit_count = ?,
 			throttle_limit_unit = ?, expiry_time = ?, status = ?, updated_at = ?
-		WHERE id = ? AND gateway_id = ?
+		WHERE uuid = ? AND gateway_id = ?
 	`
 	result, err := s.exec(query,
 		plan.PlanName, plan.BillingPlan, plan.StopOnQuotaReach,
@@ -1860,7 +1860,7 @@ func (s *sqlStore) UpdateSubscriptionPlan(plan *models.SubscriptionPlan) error {
 
 // DeleteSubscriptionPlan removes a subscription plan by ID and gateway.
 func (s *sqlStore) DeleteSubscriptionPlan(id, gatewayID string) error {
-	query := `DELETE FROM subscription_plans WHERE id = ? AND gateway_id = ?`
+	query := `DELETE FROM subscription_plans WHERE uuid = ? AND gateway_id = ?`
 	result, err := s.exec(query, id, s.gatewayId)
 	if err != nil {
 		return fmt.Errorf("failed to delete subscription plan: %w", err)
@@ -1894,7 +1894,7 @@ func (s *sqlStore) DeleteSubscriptionPlansNotIn(ids []string) error {
 		placeholders[i] = "?"
 		args = append(args, ids[i])
 	}
-	query := fmt.Sprintf(`DELETE FROM subscription_plans WHERE gateway_id = ? AND id NOT IN (%s)`,
+	query := fmt.Sprintf(`DELETE FROM subscription_plans WHERE gateway_id = ? AND uuid NOT IN (%s)`,
 		strings.Join(placeholders, ","))
 	_, err := s.exec(query, args...)
 	if err != nil {
@@ -1921,7 +1921,7 @@ func (s *sqlStore) SaveSubscription(sub *models.Subscription) error {
 	sub.CreatedAt = now
 	sub.UpdatedAt = now
 	query := `
-		INSERT INTO subscriptions (id, gateway_id, api_id, application_id, subscription_token_hash,
+		INSERT INTO subscriptions (uuid, gateway_id, api_id, application_id, subscription_token_hash,
 			subscription_plan_id, status, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`
@@ -1940,10 +1940,10 @@ func (s *sqlStore) SaveSubscription(sub *models.Subscription) error {
 // SubscriptionToken is not stored; use Platform-API to retrieve the original token.
 func (s *sqlStore) GetSubscriptionByID(id, gatewayID string) (*models.Subscription, error) {
 	query := `
-		SELECT id, api_id, application_id, subscription_token_hash, subscription_plan_id,
+		SELECT uuid, api_id, application_id, subscription_token_hash, subscription_plan_id,
 			gateway_id, status, created_at, updated_at
 		FROM subscriptions
-		WHERE id = ? AND gateway_id = ?
+		WHERE uuid = ? AND gateway_id = ?
 	`
 	sub := &models.Subscription{}
 	err := s.queryRow(query, id, s.gatewayId).Scan(
@@ -1963,7 +1963,7 @@ func (s *sqlStore) GetSubscriptionByID(id, gatewayID string) (*models.Subscripti
 // ListSubscriptionsByAPI returns subscriptions for an API with optional filters.
 func (s *sqlStore) ListSubscriptionsByAPI(apiID, gatewayID string, applicationID *string, status *string) ([]*models.Subscription, error) {
 	query := `
-		SELECT id, api_id, application_id, subscription_token_hash, subscription_plan_id,
+		SELECT uuid, api_id, application_id, subscription_token_hash, subscription_plan_id,
 			gateway_id, status, created_at, updated_at
 		FROM subscriptions
 		WHERE gateway_id = ?
@@ -2002,7 +2002,7 @@ func (s *sqlStore) ListSubscriptionsByAPI(apiID, gatewayID string, applicationID
 // ListActiveSubscriptions returns all ACTIVE subscriptions for this gateway in one query.
 func (s *sqlStore) ListActiveSubscriptions() ([]*models.Subscription, error) {
 	query := `
-		SELECT id, api_id, application_id, subscription_token_hash, subscription_plan_id,
+		SELECT uuid, api_id, application_id, subscription_token_hash, subscription_plan_id,
 			gateway_id, status, created_at, updated_at
 		FROM subscriptions
 		WHERE gateway_id = ? AND status = ?
@@ -2048,7 +2048,7 @@ func (s *sqlStore) UpdateSubscription(sub *models.Subscription) error {
 		UPDATE subscriptions
 		SET api_id = ?, application_id = ?, subscription_token_hash = ?,
 			subscription_plan_id = ?, status = ?, updated_at = ?
-		WHERE id = ? AND gateway_id = ?
+		WHERE uuid = ? AND gateway_id = ?
 	`
 	result, err := s.exec(query, sub.APIID, sub.ApplicationID, sub.SubscriptionTokenHash,
 		sub.SubscriptionPlanID, string(sub.Status), sub.UpdatedAt, sub.ID, s.gatewayId)
@@ -2067,7 +2067,7 @@ func (s *sqlStore) UpdateSubscription(sub *models.Subscription) error {
 
 // DeleteSubscription removes a subscription by ID and gateway.
 func (s *sqlStore) DeleteSubscription(id, gatewayID string) error {
-	query := `DELETE FROM subscriptions WHERE id = ? AND gateway_id = ?`
+	query := `DELETE FROM subscriptions WHERE uuid = ? AND gateway_id = ?`
 	result, err := s.exec(query, id, s.gatewayId)
 	if err != nil {
 		return fmt.Errorf("failed to delete subscription: %w", err)
@@ -2104,7 +2104,7 @@ func (s *sqlStore) DeleteSubscriptionsForAPINotIn(apiID string, ids []string) er
 		placeholders[i] = "?"
 		args = append(args, ids[i])
 	}
-	query := fmt.Sprintf(`DELETE FROM subscriptions WHERE gateway_id = ? AND api_id = ? AND id NOT IN (%s)`,
+	query := fmt.Sprintf(`DELETE FROM subscriptions WHERE gateway_id = ? AND api_id = ? AND uuid NOT IN (%s)`,
 		strings.Join(placeholders, ","))
 	_, err := s.exec(query, args...)
 	if err != nil {


### PR DESCRIPTION
## Purpose
Change subscriptions and subscriptions-plans table primary key to uuid

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated database schema to use UUID identifiers for subscription records and plans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->