### PR TITLE
Update subscription-validation policy to 0.3.0

### DIFF
--- a/gateway/build-lock.yaml
+++ b/gateway/build-lock.yaml
@@ -103,7 +103,7 @@ policies:
       version: v0.8.0
       gomodule: github.com/wso2/gateway-controllers/policies/json-xml-mediator@v0
     - name: subscription-validation
-      version: v0.2.0
+      version: v0.3.0
       gomodule: github.com/wso2/gateway-controllers/policies/subscription-validation@v0
     - name: llm-cost
       version: v0.1.1

--- a/gateway/gateway-controller/default-policies/subscription-validation.yaml
+++ b/gateway/gateway-controller/default-policies/subscription-validation.yaml
@@ -1,5 +1,5 @@
 name: subscription-validation
-version: v0.2.0
+version: v0.3.0
 description: |
   Validates that the request has an active subscription to the
   requested API. Checks the Subscription-Key header first; if not found,
@@ -12,13 +12,6 @@ parameters:
   type: object
   additionalProperties: false
   properties:
-    enabled:
-      type: boolean
-      default: true
-      x-wso2-policy-advanced-param: false
-      description: >
-        When false, the subscription validation check is disabled and the
-        policy is effectively a no-op.
     subscriptionKeyHeader:
       type: string
       default: Subscription-Key

--- a/gateway/it/features/subscription-validation.feature
+++ b/gateway/it/features/subscription-validation.feature
@@ -55,7 +55,6 @@ Feature: Subscription Validation
               - name: subscription-validation
                 version: v0
                 params:
-                  enabled: true
                   subscriptionKeyHeader: "Subscription-Key"
       """
     Then the response should be successful


### PR DESCRIPTION
## Purpose
Update subscription-validation policy to 0.3.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated subscription-validation policy to v0.3.0; the `enabled` parameter has been removed from policy configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->