### PR TITLE
Optimize APIGateway ConfigMap fan-out

### DIFF
--- a/kubernetes/gateway-operator/internal/controller/apigateway_controller.go
+++ b/kubernetes/gateway-operator/internal/controller/apigateway_controller.go
@@ -114,7 +114,8 @@ func (t *GatewayTracker) Delete(key string) {
 }
 
 const (
-	apigatewayFinalizerName = "gateway.api-platform.wso2.com/apigateway-finalizer"
+	apigatewayFinalizerName  = "gateway.api-platform.wso2.com/apigateway-finalizer"
+	apigatewayConfigRefIndex = "spec.configRef.name"
 )
 
 // GatewayReconciler reconciles an APIGateway object
@@ -1007,9 +1008,13 @@ func (r *GatewayReconciler) enqueueGatewaysForConfigMap(ctx context.Context, obj
 
 	logger := log.FromContext(ctx)
 
-	// Find all Gateways that reference this ConfigMap
+	// Find only Gateways that reference this ConfigMap through the indexed spec.configRef.name field.
 	gatewayList := &apiv1.APIGatewayList{}
-	if err := r.List(ctx, gatewayList); err != nil {
+	if err := r.List(ctx, gatewayList,
+		client.InNamespace(configMap.Namespace),
+		client.MatchingFields{
+			apigatewayConfigRefIndex: configMap.Name,
+		}); err != nil {
 		logger.Error(err, "failed to list Gateways for ConfigMap event",
 			"configMap", configMap.Name,
 			"namespace", configMap.Namespace)
@@ -1048,6 +1053,16 @@ func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	opts := controller.Options{MaxConcurrentReconciles: r.Config.Reconciliation.MaxConcurrentReconciles}
 	if opts.MaxConcurrentReconciles <= 0 {
 		opts.MaxConcurrentReconciles = 1
+	}
+
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &apiv1.APIGateway{}, apigatewayConfigRefIndex, func(rawObj client.Object) []string {
+		gateway, ok := rawObj.(*apiv1.APIGateway)
+		if !ok || gateway.Spec.ConfigRef == nil || gateway.Spec.ConfigRef.Name == "" {
+			return nil
+		}
+		return []string{gateway.Spec.ConfigRef.Name}
+	}); err != nil {
+		return fmt.Errorf("failed to index APIGateway configRef field: %w", err)
 	}
 
 	// Predicate to only watch ConfigMap updates and deletes (not creates)

--- a/kubernetes/gateway-operator/internal/controller/apigateway_controller_test.go
+++ b/kubernetes/gateway-operator/internal/controller/apigateway_controller_test.go
@@ -1,0 +1,77 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	apiv1 "github.com/wso2/api-platform/kubernetes/gateway-operator/api/v1alpha1"
+	"github.com/wso2/api-platform/kubernetes/gateway-operator/internal/config"
+)
+
+func TestEnqueueGatewaysForConfigMap_UsesIndexedLookup(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := apiv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add APIGateway scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 scheme: %v", err)
+	}
+
+	indexedClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithIndex(&apiv1.APIGateway{}, apigatewayConfigRefIndex, func(rawObj client.Object) []string {
+			gateway, ok := rawObj.(*apiv1.APIGateway)
+			if !ok || gateway.Spec.ConfigRef == nil || gateway.Spec.ConfigRef.Name == "" {
+				return nil
+			}
+			return []string{gateway.Spec.ConfigRef.Name}
+		}).
+		WithObjects(
+			&apiv1.APIGateway{
+				ObjectMeta: metav1.ObjectMeta{Name: "gw-a", Namespace: "ns-a"},
+				Spec: apiv1.GatewaySpec{
+					ConfigRef: &corev1.LocalObjectReference{Name: "shared-values"},
+				},
+			},
+			&apiv1.APIGateway{
+				ObjectMeta: metav1.ObjectMeta{Name: "gw-b", Namespace: "ns-a"},
+				Spec: apiv1.GatewaySpec{
+					ConfigRef: &corev1.LocalObjectReference{Name: "other-values"},
+				},
+			},
+			&apiv1.APIGateway{
+				ObjectMeta: metav1.ObjectMeta{Name: "gw-c", Namespace: "ns-b"},
+				Spec: apiv1.GatewaySpec{
+					ConfigRef: &corev1.LocalObjectReference{Name: "shared-values"},
+				},
+			},
+		).
+		Build()
+
+	reconciler := &GatewayReconciler{
+		Client: indexedClient,
+		Config: &config.OperatorConfig{},
+		Logger: zap.NewNop(),
+	}
+
+	requests := reconciler.enqueueGatewaysForConfigMap(context.Background(), &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "shared-values", Namespace: "ns-a"},
+	})
+
+	if len(requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(requests))
+	}
+
+	want := reconcile.Request{NamespacedName: client.ObjectKey{Namespace: "ns-a", Name: "gw-a"}}
+	if requests[0] != want {
+		t.Fatalf("unexpected request: got %#v want %#v", requests[0], want)
+	}
+}


### PR DESCRIPTION
## Summary\n- Index APIGateway objects by  in the gateway operator\n- Use the index to enqueue only matching gateways for ConfigMap updates\n- Add a focused controller test covering same-namespace matching\n\n## Validation\n- FAIL	./... [setup failed]
FAIL in 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized how API gateways resolve configuration references with improved lookup efficiency and namespace scoping.

* **Tests**
  * Added validation coverage for configuration reference resolution in gateways.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->