### PR TITLE
Implement subscriber_id and multi subscriptions per API support

### DIFF
--- a/docs/api-subscriptions/IMPLEMENTATION_NOTES.md
+++ b/docs/api-subscriptions/IMPLEMENTATION_NOTES.md
@@ -15,16 +15,18 @@ This document captures how the **Subscription Design** (including Subscription P
     - Status: `ACTIVE`, `INACTIVE`.
   - Go model: `SubscriptionPlan` in `platform-api/src/internal/model/subscription_plan.go`.
 
-- **Subscriptions**
-  - `subscriptions` table updated:
-    - `application_id` is now **nullable** (optional).
-    - `subscription_token VARCHAR(512)` — stores **encrypted** token (AES-256-GCM) for retrieval on GET; legacy rows have hash.
-    - `subscription_token_hash VARCHAR(64) NOT NULL` — SHA-256 hash for uniqueness and gateway sync.
-    - New `subscription_plan_uuid VARCHAR(40)` — FK to `subscription_plans(uuid)`.
-    - Unique constraint: `(api_uuid, subscription_token_hash)` for token-based; `(api_uuid, application_id, organization_uuid)` for app-based.
-    - Index on `subscription_token_hash`.
+- **Subscriptions** (subscriber-scoped within an organization)
+  - `subscriptions` table includes:
+    - `subscriber_id VARCHAR(255) NOT NULL` — identifies the subscriber for this API; pairs with `api_uuid` for uniqueness within the org.
+    - `application_id VARCHAR(255)` — **nullable** / **optional** (legacy or app-linked metadata; not the primary subscription key).
+    - `subscription_token VARCHAR(512) NOT NULL` — stores the **encrypted** opaque token (AES-256-GCM) for retrieval; older rows may contain a legacy **hash-only** payload in this column.
+    - `subscription_token_hash VARCHAR(64) NOT NULL` — SHA-256 hex hash for uniqueness and gateway sync (DB/repo concern; not a field on the `Subscription` struct).
+    - `subscription_plan_uuid VARCHAR(40)` — **optional** FK to `subscription_plans(uuid, organization_uuid)`.
+    - **Uniqueness:** `UNIQUE(api_uuid, subscriber_id, organization_uuid)` (at most one subscription per API + subscriber in the org) and `UNIQUE(api_uuid, subscription_token_hash)` (distinct tokens).
+    - Indexes include `subscription_token_hash` and `(organization_uuid, subscriber_id)` for list filters (see `schema.postgres.sql` / `schema.sqlite.sql`).
   - Encryption key: `DATABASE_SUBSCRIPTION_TOKEN_ENCRYPTION_KEY` (32 bytes, 64 hex or 44 base64); falls back to `JWT_SECRET_KEY`.
-  - Go model: `Subscription` with `ApplicationID *string`, `SubscriptionToken string` (decrypted for API), `SubscriptionTokenHash` (internal).
+  - Go model `Subscription` (`platform-api/src/internal/model/subscription.go`): `SubscriberID string` (`subscriber_id`), `ApplicationID *string` (**optional**), `SubscriptionPlanID *string` (**optional**), `SubscriptionToken string` (plaintext for JSON on create **response** / after decrypt on read — the column is encrypted at rest).
+  - **Repository token behaviour:** `Create` generates a random token if missing, encrypts for `subscription_token`, stores hash in `subscription_token_hash`. `GetByID` / `ListByFilters` decrypt `subscription_token` for the API; if decryption fails (e.g. legacy hash-only row), `subscriptionToken` in the model is left **empty** so the handler omits or returns an empty token without contradicting “decrypted for API”.
 
 ### 1.2 Repositories, Services, and Handlers
 
@@ -40,9 +42,9 @@ This document captures how the **Subscription Design** (including Subscription P
   - `PUT /api/v1/subscription-plans/{planId}`
   - `DELETE /api/v1/subscription-plans/{planId}`
 
-- **Subscription Repository** — Updated to handle new columns; generates subscription token via `crypto/rand`; encrypts before storage; decrypts on read for GET/List. Legacy hashed tokens return empty string.
-- **Subscription Service** — `CreateSubscription` now accepts optional `applicationId *string` and `subscriptionPlanId *string`.
-- **Subscription Handler** — `POST /api/v1/subscriptions` body: `{ apiId (required), applicationId?, subscriptionPlanId?, status? }`. Only `apiId` is required; `applicationId` is optional for token-based subscriptions. Response includes `subscriptionToken` (decrypted, visible on GET/List), `subscriptionPlanId`, and all other subscription fields.
+- **Subscription Repository** — Persists `subscriber_id`; generates token when absent; encrypts before storage; decrypts on `GetByID` / list reads (legacy non-decryptable rows → empty `subscriptionToken`). See bullets above.
+- **Subscription Service** — `CreateSubscription(apiId, orgUUID, subscriberID string, applicationId *string, subscriptionPlanId *string, status string)` requires non-empty **`subscriberID`**; **`applicationId`** and **`subscriptionPlanId`** remain **optional** pointers.
+- **Subscription Handler** — `POST /api/v1/subscriptions` JSON: **`apiId`** and **`subscriberId`** required; **`applicationId`**, **`subscriptionPlanId`**, **`status`** optional. Response includes **`subscriberId`**, generated **`subscriptionToken`** (when present/decryptable), optional plan id, etc. `GET`/`PUT`/`DELETE /api/v1/subscriptions/{subscriptionId}` require query **`subscriberId`** (non-empty); must match the stored subscriber or the API returns **`403 Forbidden`**.
 
 ### 1.3 API Configuration
 

--- a/docs/api-subscriptions/NEW_DESIGN.md
+++ b/docs/api-subscriptions/NEW_DESIGN.md
@@ -199,7 +199,7 @@ policies: [Gold, Silver]
               - name: subscription-validation
                 version: v0
                 params:
-                  enabled: true
+                  subscriptionKeyHeader: Subscription-Key
 ```                   
 
 
@@ -224,38 +224,49 @@ API developers need to manually attach the subscription validation policy to the
 
 - This option is only available for Self Hosted GW APIs.
 - Subscription Token will be generated(Opaque String) and will be visible in the API Overview UI.
-- Implement UI/REST CRUD/DB for Subscription Token in Platform-API+Choreo APIM(Here, we can’t reuse existing choreo-apim /subscriptions POST as it is since applicationId is a required value).
-   Remove applicationId required field. Only apiId will be required.
-   If the subscription is for a Self Hosted GW API, /subscription POST response will have a subscriptionToken otherwise for a normal API existing behaviour is preserved.
-- Subscription Token will be preserved in the platform-api DB and will be propagated to gateway and will be stored in gateway DB as well.
+- Implement UI/REST CRUD/DB for Subscription Token in Platform-API+Choreo APIM (existing Choreo `/subscriptions` flows that require `applicationId` do not match this contract; here **`applicationId` is optional**).
+- **Create subscription (Platform-API JSON):** **`apiId`** and **`subscriberId`** are **required**. **`subscriptionPlanId`**, **`applicationId`**, and **`status`** are **optional**. The server generates **`subscriptionToken`** (opaque); clients do **not** send it on `POST`.
+- Subscription token is stored in the platform-api DB (encrypted at rest), propagated to the gateway, and stored in the gateway DB for validation.
 
-	Following REST APIs will be created in Both Platform-API and Gateway Controller to persist subscriptions.
+Following REST APIs persist subscriptions (Platform-API uses **camelCase** in JSON; the database uses **snake_case** columns below).
 
 ```
-POST /api/v1/subscriptions with apiId,subscriptionToken,subscription-plan and applicationId(optional) in the body
-GET /api/v1/subscriptions?apiId={apiId}
-GET /api/v1/subscriptions?applicationId={appId}
-GET/PUT/DELETE /api/v1/subscriptions/{subscriptionId}
+POST   /api/v1/subscriptions
+         Body (required):  apiId, subscriberId
+         Body (optional): subscriptionPlanId, applicationId, status
+         Response: includes subscriptionToken (generated), subscriptionPlanId (if set), subscriberId, apiId, etc.
+
+GET    /api/v1/subscriptions?apiId={apiId}&subscriberId={subscriberId}&applicationId={applicationId}&status={status}&limit={n}&offset={n}
+         Query parameters are all optional filters; apiId may be API UUID or handle. subscriberId must be non-empty when provided (min length 1).
+
+GET    /api/v1/subscriptions/{subscriptionId}?subscriberId={subscriberId}   (required; must match subscription)
+PUT    /api/v1/subscriptions/{subscriptionId}?subscriberId={subscriberId}     e.g. update status
+DELETE /api/v1/subscriptions/{subscriptionId}?subscriberId={subscriberId}
 ```
 
-DB changes
+DB changes (column names match `schema.postgres.sql` / `schema.sqlite.sql`; JSON field `subscriberId` maps to **`subscriber_id`**, `subscriptionPlanId` to **`subscription_plan_uuid`**, etc.)
+
 ```
 CREATE TABLE IF NOT EXISTS subscriptions (
    uuid VARCHAR(40) PRIMARY KEY,
    api_uuid VARCHAR(40) NOT NULL,
+   subscriber_id VARCHAR(255) NOT NULL,
    application_id VARCHAR(255),
-   subscriptionToken VARCHAR(255),
-   subscription_plan_uuid VARCHAR(255),
+   subscription_token VARCHAR(512) NOT NULL,
+   subscription_token_hash VARCHAR(64) NOT NULL,
+   subscription_plan_uuid VARCHAR(40),
    organization_uuid VARCHAR(40) NOT NULL,
    status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
    FOREIGN KEY (api_uuid) REFERENCES rest_apis(uuid) ON DELETE CASCADE,
    FOREIGN KEY (organization_uuid) REFERENCES organizations(uuid) ON DELETE CASCADE,
-  FOREIGN KEY (subscription_plan_uuid) REFERENCES subscription_plans(uuid) ON DELETE CASCADE,
+   FOREIGN KEY (subscription_plan_uuid, organization_uuid)
+     REFERENCES subscription_plans(uuid, organization_uuid) ON DELETE RESTRICT,
    FOREIGN KEY (api_uuid, organization_uuid)
      REFERENCES artifacts(uuid, organization_uuid) ON DELETE CASCADE,
-   UNIQUE(api_uuid, subscriptionToken),
+   UNIQUE(api_uuid, subscription_token_hash),
+   UNIQUE(api_uuid, subscriber_id, organization_uuid),
    CHECK (status IN ('ACTIVE', 'INACTIVE', 'REVOKED'))
 );
 ```
@@ -268,16 +279,16 @@ CREATE TABLE IF NOT EXISTS subscriptions (
 
 - During the API request flow,
 
-#### If the API has subscription validation enabled.**
+#### If the API has subscription validation enabled
 
 - If the request has a subscription-key request header (or token in the configured cookie), use it to check SubscriptionDataStore and validate the subscription for that particular API.
-- If the request doesn’t have a subscription-key request header, fallback to validate against applicationId which was set to request context by the OAuth2/JWT/API-Key token validation. (This is to cater old way of subscription validation for old APIs)
+- If the request doesn’t have a subscription-key request header, fall back to validating against **`applicationId`** carried in request metadata (e.g. `x-wso2-application-id` from OAuth2/JWT/API-Key policy claim mappings). This is legacy behaviour for older APIs; it is separate from the optional **`applicationId`** field on the subscription record.
 - If this Subscription has a usage limit, rate limit based on the counts.
 - Implement subscription-rate-limit keys in SubscriptionDataStore
 
 Ratelimit Key : Subscription Token
 Ratelimit Count: Available Count
 
-#### If the API subscription validation disabled.
+#### If the API subscription validation is disabled
 
 - No subscription validation happens.

--- a/docs/api-subscriptions/SUBSCRIPTION_API_EXAMPLES.md
+++ b/docs/api-subscriptions/SUBSCRIPTION_API_EXAMPLES.md
@@ -47,7 +47,6 @@ curl -X POST "$BASE_URL/api/v1/rest-apis" \
         "name": "subscription-validation",
         "version": "v0",
         "params": {
-          "enabled": true,
           "subscriptionKeyHeader": "Subscription-Key"
         }
       }
@@ -133,6 +132,7 @@ curl -X POST "$BASE_URL/api/v1/subscriptions" \
   -H "Content-Type: application/json" \
   -d '{
     "apiId": "c9f2b6ae-1234-5678-9abc-def012345678",
+    "subscriberId": "user-123",
     "subscriptionPlanId": "plan-uuid-1"
   }'
 ```
@@ -142,6 +142,7 @@ curl -X POST "$BASE_URL/api/v1/subscriptions" \
 {
   "id": "sub-uuid-1",
   "apiId": "c9f2b6ae-1234-5678-9abc-def012345678",
+  "subscriberId": "user-123",
   "subscriptionToken": "a3f8c9d2e1b0...64-char-hex-token",
   "subscriptionPlanId": "plan-uuid-1",
   "organizationId": "org-uuid",
@@ -151,7 +152,7 @@ curl -X POST "$BASE_URL/api/v1/subscriptions" \
 }
 ```
 
-### 2.2 Create a Subscription (Legacy with ApplicationId)
+### 2.2 Create a Subscription (Optional ApplicationId)
 
 ```bash
 curl -X POST "$BASE_URL/api/v1/subscriptions" \
@@ -159,6 +160,7 @@ curl -X POST "$BASE_URL/api/v1/subscriptions" \
   -H "Content-Type: application/json" \
   -d '{
     "apiId": "c9f2b6ae-1234-5678-9abc-def012345678",
+    "subscriberId": "user-123",
     "applicationId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
     "status": "ACTIVE"
   }'
@@ -171,9 +173,35 @@ curl -X GET "$BASE_URL/api/v1/subscriptions?apiId=c9f2b6ae-1234-5678-9abc-def012
   -H "$AUTH_HEADER"
 ```
 
-### 2.4 Update / Delete Subscriptions
+```bash
+curl -X GET "$BASE_URL/api/v1/subscriptions?subscriberId=user-123" \
+  -H "$AUTH_HEADER"
+```
 
-Same as before — use subscription UUID in path.
+```bash
+curl -X GET "$BASE_URL/api/v1/subscriptions?apiId=c9f2b6ae-1234-5678-9abc-def012345678&subscriberId=user-123" \
+  -H "$AUTH_HEADER"
+```
+
+### 2.4 Get, Update, Delete subscription by ID
+
+`subscriberId` is a **required query parameter** on get/update/delete; it must match the subscription's subscriber (returns `403` if it does not).
+
+```bash
+# Get
+curl -X GET "$BASE_URL/api/v1/subscriptions/$SUBSCRIPTION_ID?subscriberId=user-123" \
+  -H "$AUTH_HEADER"
+
+# Update status
+curl -X PUT "$BASE_URL/api/v1/subscriptions/$SUBSCRIPTION_ID?subscriberId=user-123" \
+  -H "$AUTH_HEADER" \
+  -H "Content-Type: application/json" \
+  -d '{"status":"INACTIVE"}'
+
+# Delete
+curl -X DELETE "$BASE_URL/api/v1/subscriptions/$SUBSCRIPTION_ID?subscriberId=user-123" \
+  -H "$AUTH_HEADER"
+```
 
 ---
 
@@ -234,7 +262,6 @@ spec:
     - name: subscription-validation
       version: v0
       params:
-        enabled: true
         subscriptionKeyHeader: Subscription-Key
   operations:
     - method: GET

--- a/platform-api/src/api/generated.go
+++ b/platform-api/src/api/generated.go
@@ -938,12 +938,40 @@ type CreateSubscriptionRequest struct {
 	// Status Subscription status (default ACTIVE)
 	Status *CreateSubscriptionRequestStatus `json:"status,omitempty" yaml:"status,omitempty"`
 
+	// SubscriberId Unique subscriber identifier for the subscription (required)
+	SubscriberId string `binding:"required" json:"subscriberId" yaml:"subscriberId"`
+
 	// SubscriptionPlanId Subscription plan UUID. Links the subscription to rate limit and billing configuration.
 	SubscriptionPlanId *string `json:"subscriptionPlanId,omitempty" yaml:"subscriptionPlanId,omitempty"`
 }
 
 // CreateSubscriptionRequestStatus Subscription status (default ACTIVE)
 type CreateSubscriptionRequestStatus string
+
+// CustomPolicyResponse A custom policy stored in the platform's custom policy registry.
+type CustomPolicyResponse struct {
+	CreatedAt *time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
+
+	// Description Human-readable description of the policy
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	// Name Policy name
+	Name string `binding:"required" json:"name" yaml:"name"`
+
+	// OrganizationUuid Organization this policy belongs to
+	OrganizationUuid openapi_types.UUID `binding:"required" json:"organizationUuid" yaml:"organizationUuid"`
+
+	// PolicyDefinition The full policy schema as declared in the policy's policy-definition.yaml.
+	// Contains `parameters` and `systemParameters` JSON Schema documents.
+	PolicyDefinition map[string]interface{} `binding:"required" json:"policyDefinition" yaml:"policyDefinition"`
+	UpdatedAt        *time.Time             `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
+
+	// Uuid Unique identifier of the custom policy record
+	Uuid openapi_types.UUID `binding:"required" json:"uuid" yaml:"uuid"`
+
+	// Version Policy version
+	Version string `binding:"required" json:"version" yaml:"version"`
+}
 
 // DeployRequest defines model for DeployRequest.
 type DeployRequest struct {
@@ -1160,6 +1188,26 @@ type GatewayListResponse struct {
 	Count      int               `binding:"required" json:"count" yaml:"count"`
 	List       []GatewayResponse `binding:"required" json:"list" yaml:"list"`
 	Pagination Pagination        `json:"pagination" yaml:"pagination"`
+}
+
+// GatewayPolicyDefinition A policy installed on a gateway controller.
+type GatewayPolicyDefinition struct {
+	// Description Human-readable description of the policy
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	// IsCustomPolicy Whether this is a user-installed custom policy.
+	IsCustomPolicy bool `binding:"required" json:"isCustomPolicy" yaml:"isCustomPolicy"`
+
+	// Name Unique policy name
+	Name string `binding:"required" json:"name" yaml:"name"`
+
+	// PolicyDefinition The full policy schema as declared in the policy's policy-definition.yaml.
+	// Contains `parameters` and `systemParameters` JSON Schema documents.
+	// Only present for custom policies.
+	PolicyDefinition *map[string]interface{} `json:"policyDefinition,omitempty" yaml:"policyDefinition,omitempty"`
+
+	// Version Semantic version of the policy
+	Version string `binding:"required" json:"version" yaml:"version"`
 }
 
 // GatewayResponse defines model for GatewayResponse.
@@ -1576,8 +1624,8 @@ type LLMProviderTemplate struct {
 	Name             string                               `binding:"required" json:"name" yaml:"name"`
 	PromptTokens     *ExtractionIdentifier                `json:"promptTokens,omitempty" yaml:"promptTokens,omitempty"`
 	RemainingTokens  *ExtractionIdentifier                `json:"remainingTokens,omitempty" yaml:"remainingTokens,omitempty"`
-	ResourceMappings *LLMProviderTemplateResourceMappings `json:"resourceMappings,omitempty" yaml:"resourceMappings,omitempty"`
 	RequestModel     *ExtractionIdentifier                `json:"requestModel,omitempty" yaml:"requestModel,omitempty"`
+	ResourceMappings *LLMProviderTemplateResourceMappings `json:"resourceMappings,omitempty" yaml:"resourceMappings,omitempty"`
 	ResponseModel    *ExtractionIdentifier                `json:"responseModel,omitempty" yaml:"responseModel,omitempty"`
 	TotalTokens      *ExtractionIdentifier                `json:"totalTokens,omitempty" yaml:"totalTokens,omitempty"`
 
@@ -1614,6 +1662,20 @@ type LLMProviderTemplateListResponse struct {
 	Pagination Pagination                    `json:"pagination" yaml:"pagination"`
 }
 
+// LLMProviderTemplateMetadata defines model for LLMProviderTemplateMetadata.
+type LLMProviderTemplateMetadata struct {
+	Auth *LLMProviderTemplateAuth `json:"auth,omitempty" yaml:"auth,omitempty"`
+
+	// EndpointUrl Default endpoint URL for the template
+	EndpointUrl *string `json:"endpointUrl,omitempty" yaml:"endpointUrl,omitempty"`
+
+	// LogoUrl URL of the provider logo
+	LogoUrl *string `json:"logoUrl,omitempty" yaml:"logoUrl,omitempty"`
+
+	// OpenapiSpecUrl URL to the OpenAPI specification for the provider
+	OpenapiSpecUrl *string `json:"openapiSpecUrl,omitempty" yaml:"openapiSpecUrl,omitempty"`
+}
+
 // LLMProviderTemplateResourceMapping defines model for LLMProviderTemplateResourceMapping.
 type LLMProviderTemplateResourceMapping struct {
 	CompletionTokens *ExtractionIdentifier `json:"completionTokens,omitempty" yaml:"completionTokens,omitempty"`
@@ -1630,20 +1692,6 @@ type LLMProviderTemplateResourceMapping struct {
 // LLMProviderTemplateResourceMappings defines model for LLMProviderTemplateResourceMappings.
 type LLMProviderTemplateResourceMappings struct {
 	Resources *[]LLMProviderTemplateResourceMapping `json:"resources,omitempty" yaml:"resources,omitempty"`
-}
-
-// LLMProviderTemplateMetadata defines model for LLMProviderTemplateMetadata.
-type LLMProviderTemplateMetadata struct {
-	Auth *LLMProviderTemplateAuth `json:"auth,omitempty" yaml:"auth,omitempty"`
-
-	// EndpointUrl Default endpoint URL for the template
-	EndpointUrl *string `json:"endpointUrl,omitempty" yaml:"endpointUrl,omitempty"`
-
-	// LogoUrl URL of the provider logo
-	LogoUrl *string `json:"logoUrl,omitempty" yaml:"logoUrl,omitempty"`
-
-	// OpenapiSpecUrl URL to the OpenAPI specification for the provider
-	OpenapiSpecUrl *string `json:"openapiSpecUrl,omitempty" yaml:"openapiSpecUrl,omitempty"`
 }
 
 // LLMProxy defines model for LLMProxy.
@@ -1858,6 +1906,13 @@ type MCPServerInfoFetchResponse struct {
 	Resources  *[]map[string]interface{} `json:"resources,omitempty" yaml:"resources,omitempty"`
 	ServerInfo *map[string]interface{}   `json:"serverInfo,omitempty" yaml:"serverInfo,omitempty"`
 	Tools      *[]map[string]interface{} `json:"tools,omitempty" yaml:"tools,omitempty"`
+}
+
+// ManifestSyncResponse defines model for ManifestSyncResponse.
+type ManifestSyncResponse struct {
+	// Policies All policies installed on the gateway. Each entry includes name, version, and isCustomPolicy.
+	// Custom policies additionally include policyDefinition with their parameters and systemParameters schemas.
+	Policies *[]GatewayPolicyDefinition `json:"policies,omitempty" yaml:"policies,omitempty"`
 }
 
 // MappedAPIKey defines model for MappedAPIKey.
@@ -2524,8 +2579,14 @@ type Subscription struct {
 	OrganizationId *openapi_types.UUID `json:"organizationId,omitempty" yaml:"organizationId,omitempty"`
 	Status         *SubscriptionStatus `json:"status,omitempty" yaml:"status,omitempty"`
 
+	// SubscriberId Unique subscriber identifier for this API (required)
+	SubscriberId *string `json:"subscriberId,omitempty" yaml:"subscriberId,omitempty"`
+
 	// SubscriptionPlanId Subscription plan UUID
 	SubscriptionPlanId *string `json:"subscriptionPlanId,omitempty" yaml:"subscriptionPlanId,omitempty"`
+
+	// SubscriptionPlanName Subscription plan display name (e.g. Bronze, Gold)
+	SubscriptionPlanName *string `json:"subscriptionPlanName,omitempty" yaml:"subscriptionPlanName,omitempty"`
 
 	// SubscriptionToken Opaque subscription token for API invocation via Subscription-Key header
 	SubscriptionToken *string    `json:"subscriptionToken,omitempty" yaml:"subscriptionToken,omitempty"`
@@ -2980,6 +3041,18 @@ type ListDevPortalsParams struct {
 	Active *bool `form:"active,omitempty" json:"active,omitempty" yaml:"active,omitempty"`
 }
 
+// SyncCustomPolicyParams defines parameters for SyncCustomPolicy.
+type SyncCustomPolicyParams struct {
+	// GatewayId UUID of the gateway whose manifest contains the policy
+	GatewayId openapi_types.UUID `form:"gatewayId" json:"gatewayId" yaml:"gatewayId"`
+
+	// PolicyName Name of the custom policy (case-insensitive)
+	PolicyName string `form:"policyName" json:"policyName" yaml:"policyName"`
+
+	// PolicyVersion Version of the custom policy in MAJOR.MINOR.PATCH format
+	PolicyVersion string `form:"policyVersion" json:"policyVersion" yaml:"policyVersion"`
+}
+
 // GetGatewayArtifactsParams defines parameters for GetGatewayArtifacts.
 type GetGatewayArtifactsParams struct {
 	// ArtifactType Filter artifacts by type
@@ -3215,6 +3288,9 @@ type ListSubscriptionsParams struct {
 	// ApiId Filter by API ID (UUID or handle)
 	ApiId *string `form:"apiId,omitempty" json:"apiId,omitempty" yaml:"apiId,omitempty"`
 
+	// SubscriberId Filter by subscriber ID
+	SubscriberId *string `form:"subscriberId,omitempty" json:"subscriberId,omitempty" yaml:"subscriberId,omitempty"`
+
 	// ApplicationId Filter by application ID
 	ApplicationId *string `form:"applicationId,omitempty" json:"applicationId,omitempty" yaml:"applicationId,omitempty"`
 
@@ -3230,6 +3306,24 @@ type ListSubscriptionsParams struct {
 
 // ListSubscriptionsParamsStatus defines parameters for ListSubscriptions.
 type ListSubscriptionsParamsStatus string
+
+// DeleteSubscriptionParams defines parameters for DeleteSubscription.
+type DeleteSubscriptionParams struct {
+	// SubscriberId Subscriber ID; must match the subscription's subscriberId.
+	SubscriberId string `form:"subscriberId" json:"subscriberId" yaml:"subscriberId"`
+}
+
+// GetSubscriptionParams defines parameters for GetSubscription.
+type GetSubscriptionParams struct {
+	// SubscriberId Subscriber ID; must match the subscription's subscriberId.
+	SubscriberId string `form:"subscriberId" json:"subscriberId" yaml:"subscriberId"`
+}
+
+// UpdateSubscriptionParams defines parameters for UpdateSubscription.
+type UpdateSubscriptionParams struct {
+	// SubscriberId Subscriber ID; must match the subscription's subscriberId.
+	SubscriberId string `form:"subscriberId" json:"subscriberId" yaml:"subscriberId"`
+}
 
 // CreateApplicationJSONRequestBody defines body for CreateApplication for application/json ContentType.
 type CreateApplicationJSONRequestBody = CreateApplicationRequest

--- a/platform-api/src/internal/constants/error.go
+++ b/platform-api/src/internal/constants/error.go
@@ -77,8 +77,8 @@ var (
 )
 
 var (
-	ErrCustomPolicyNotFound    = errors.New("custom policy not found")
-	ErrCustomPolicyInUse       = errors.New("custom policy is in use by one or more APIs")
+	ErrCustomPolicyNotFound        = errors.New("custom policy not found")
+	ErrCustomPolicyInUse           = errors.New("custom policy is in use by one or more APIs")
 	ErrCustomPolicyVersionMismatch = errors.New("custom policy version does not match")
 )
 
@@ -179,8 +179,9 @@ var (
 
 var (
 	// Subscription errors (application-level subscriptions for REST APIs)
-	ErrSubscriptionNotFound      = errors.New("subscription not found")
-	ErrSubscriptionAlreadyExists = errors.New("application is already subscribed to this API")
+	ErrSubscriptionNotFound           = errors.New("subscription not found")
+	ErrSubscriptionAlreadyExists      = errors.New("application is already subscribed to this API")
+	ErrSubscriptionSubscriberMismatch = errors.New("subscriber does not match this subscription")
 )
 
 var (

--- a/platform-api/src/internal/database/schema.postgres.sql
+++ b/platform-api/src/internal/database/schema.postgres.sql
@@ -115,6 +115,7 @@ CREATE TABLE IF NOT EXISTS subscription_plans (
 CREATE TABLE IF NOT EXISTS subscriptions (
     uuid VARCHAR(40) PRIMARY KEY,
     api_uuid VARCHAR(40) NOT NULL,
+    subscriber_id VARCHAR(255) NOT NULL,
     application_id VARCHAR(255),
     subscription_token VARCHAR(512) NOT NULL,
     subscription_token_hash VARCHAR(64) NOT NULL,
@@ -130,10 +131,13 @@ CREATE TABLE IF NOT EXISTS subscriptions (
     FOREIGN KEY (api_uuid, organization_uuid)
       REFERENCES artifacts(uuid, organization_uuid) ON DELETE CASCADE,
     UNIQUE(api_uuid, subscription_token_hash),
-    UNIQUE(api_uuid, application_id, organization_uuid),
+    UNIQUE(api_uuid, subscriber_id, organization_uuid),
     CHECK (status IN ('ACTIVE', 'INACTIVE', 'REVOKED'))
 );
 CREATE INDEX IF NOT EXISTS idx_subscriptions_token ON subscriptions(subscription_token_hash);
+-- Supports list/count filters: WHERE organization_uuid = ? AND subscriber_id = ? (no api_uuid).
+-- The unique constraint on (api_uuid, subscriber_id, organization_uuid) is not ordered for this access path.
+CREATE INDEX IF NOT EXISTS idx_subscriptions_org_subscriber ON subscriptions(organization_uuid, subscriber_id);
 
 -- Gateways table (scoped to organizations)
 -- Must be created before deployments which references it

--- a/platform-api/src/internal/database/schema.sql
+++ b/platform-api/src/internal/database/schema.sql
@@ -110,11 +110,12 @@ CREATE TABLE IF NOT EXISTS subscription_plans (
 );
 
 -- Subscriptions table (application-level subscriptions for REST APIs)
--- application_id references applications in DevPortal/STS (no FK in platform), optional for token-based subscriptions
 -- subscription_token: encrypted (AES-256-GCM) for retrieval; subscription_token_hash for uniqueness and gateway sync
+-- application_id references applications in DevPortal/STS (no FK in platform), optional for token-based subscriptions
 CREATE TABLE IF NOT EXISTS subscriptions (
     uuid VARCHAR(40) PRIMARY KEY,
     api_uuid VARCHAR(40) NOT NULL,
+    subscriber_id VARCHAR(255) NOT NULL,
     application_id VARCHAR(255),
     subscription_token VARCHAR(512) NOT NULL,
     subscription_token_hash VARCHAR(64) NOT NULL,
@@ -385,6 +386,7 @@ CREATE INDEX IF NOT EXISTS idx_subscriptions_application_id ON subscriptions(app
 CREATE INDEX IF NOT EXISTS idx_subscriptions_organization_uuid ON subscriptions(organization_uuid);
 CREATE INDEX IF NOT EXISTS idx_subscriptions_status ON subscriptions(status);
 CREATE INDEX IF NOT EXISTS idx_subscriptions_token ON subscriptions(subscription_token_hash);
+CREATE INDEX IF NOT EXISTS idx_subscriptions_org_subscriber ON subscriptions(organization_uuid, subscriber_id);
 CREATE INDEX IF NOT EXISTS idx_gateways_org ON gateways(organization_uuid);
 CREATE INDEX IF NOT EXISTS idx_gateway_tokens_status ON gateway_tokens(gateway_uuid, status);
 CREATE INDEX IF NOT EXISTS idx_gateway_tokens_hash ON gateway_tokens(token_hash);

--- a/platform-api/src/internal/database/schema.sqlite.sql
+++ b/platform-api/src/internal/database/schema.sqlite.sql
@@ -115,6 +115,7 @@ CREATE TABLE IF NOT EXISTS subscription_plans (
 CREATE TABLE IF NOT EXISTS subscriptions (
     uuid VARCHAR(40) PRIMARY KEY,
     api_uuid VARCHAR(40) NOT NULL,
+    subscriber_id VARCHAR(255) NOT NULL,
     application_id VARCHAR(255),
     subscription_token VARCHAR(512) NOT NULL,
     subscription_token_hash VARCHAR(64) NOT NULL,
@@ -130,10 +131,12 @@ CREATE TABLE IF NOT EXISTS subscriptions (
     FOREIGN KEY (api_uuid, organization_uuid)
       REFERENCES artifacts(uuid, organization_uuid) ON DELETE CASCADE,
     UNIQUE(api_uuid, subscription_token_hash),
-    UNIQUE(api_uuid, application_id, organization_uuid),
+    UNIQUE(api_uuid, subscriber_id, organization_uuid),
     CHECK (status IN ('ACTIVE', 'INACTIVE', 'REVOKED'))
 );
 CREATE INDEX IF NOT EXISTS idx_subscriptions_token ON subscriptions(subscription_token_hash);
+-- Supports list/count filters: WHERE organization_uuid = ? AND subscriber_id = ? (no api_uuid).
+CREATE INDEX IF NOT EXISTS idx_subscriptions_org_subscriber ON subscriptions(organization_uuid, subscriber_id);
 
 -- Gateways table (scoped to organizations)
 -- Must be created before deployments which references it

--- a/platform-api/src/internal/handler/subscription_handler.go
+++ b/platform-api/src/internal/handler/subscription_handler.go
@@ -22,6 +22,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"platform-api/src/internal/constants"
 	"platform-api/src/internal/middleware"
@@ -54,6 +55,7 @@ func NewSubscriptionHandler(subscriptionService *service.SubscriptionService, su
 // CreateSubscriptionRequest is the body for POST /api/v1/subscriptions
 type CreateSubscriptionRequest struct {
 	APIID              string  `json:"apiId" binding:"required"`
+	SubscriberID       string  `json:"subscriberId" binding:"required"`
 	ApplicationID      *string `json:"applicationId,omitempty"`
 	SubscriptionPlanID *string `json:"subscriptionPlanId,omitempty"`
 	Status             string  `json:"status,omitempty"`
@@ -83,13 +85,17 @@ func (h *SubscriptionHandler) CreateSubscription(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", "API ID is required"))
 		return
 	}
+	if req.SubscriberID == "" {
+		c.JSON(http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", "subscriberId is required"))
+		return
+	}
 	switch req.Status {
 	case "", "ACTIVE", "INACTIVE", "REVOKED":
 	default:
 		c.JSON(http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", "Invalid status value"))
 		return
 	}
-	sub, err := h.subscriptionService.CreateSubscription(req.APIID, orgId, req.ApplicationID, req.SubscriptionPlanID, req.Status)
+	sub, err := h.subscriptionService.CreateSubscription(req.APIID, orgId, req.SubscriberID, req.ApplicationID, req.SubscriptionPlanID, req.Status)
 	if err != nil {
 		if errors.Is(err, constants.ErrAPINotFound) {
 			c.JSON(http.StatusNotFound, utils.NewErrorResponse(404, "Not Found", "API not found"))
@@ -109,6 +115,7 @@ func (h *SubscriptionHandler) CreateSubscription(c *gin.Context) {
 // ListSubscriptions handles GET /api/v1/subscriptions
 func (h *SubscriptionHandler) ListSubscriptions(c *gin.Context) {
 	apiId := c.Query("apiId")
+	subscriberID := c.Query("subscriberId")
 	applicationID := c.Query("applicationId")
 	status := c.Query("status")
 
@@ -119,9 +126,12 @@ func (h *SubscriptionHandler) ListSubscriptions(c *gin.Context) {
 		return
 	}
 
-	var apiIDPtr, appIDPtr, statusPtr *string
+	var apiIDPtr, subscriberIDPtr, appIDPtr, statusPtr *string
 	if apiId != "" {
 		apiIDPtr = &apiId
+	}
+	if subscriberID != "" {
+		subscriberIDPtr = &subscriberID
 	}
 	if applicationID != "" {
 		appIDPtr = &applicationID
@@ -148,7 +158,7 @@ func (h *SubscriptionHandler) ListSubscriptions(c *gin.Context) {
 	if err != nil || offset < 0 {
 		offset = 0
 	}
-	list, total, err := h.subscriptionService.ListSubscriptionsByFilters(orgId, apiIDPtr, appIDPtr, statusPtr, limit, offset)
+	list, total, err := h.subscriptionService.ListSubscriptionsByFilters(orgId, apiIDPtr, subscriberIDPtr, appIDPtr, statusPtr, limit, offset)
 	if err != nil {
 		if errors.Is(err, constants.ErrAPINotFound) {
 			c.JSON(http.StatusNotFound, utils.NewErrorResponse(404, "Not Found", "API not found"))
@@ -195,7 +205,7 @@ func (h *SubscriptionHandler) ListSubscriptions(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, gin.H{
 		"subscriptions": items,
-		"count":          len(items),
+		"count":         len(items),
 		"pagination": gin.H{
 			"total":  total,
 			"offset": offset,
@@ -254,10 +264,18 @@ func (h *SubscriptionHandler) UpdateSubscription(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", "Invalid subscription status"))
 		return
 	}
-	sub, err := h.subscriptionService.UpdateSubscription(subscriptionId, orgId, req.Status)
+	subscriberID, ok := requireSubscriptionSubscriberQuery(c)
+	if !ok {
+		return
+	}
+	sub, err := h.subscriptionService.UpdateSubscription(subscriptionId, orgId, subscriberID, req.Status)
 	if err != nil {
 		if errors.Is(err, constants.ErrSubscriptionNotFound) {
 			c.JSON(http.StatusNotFound, utils.NewErrorResponse(404, "Not Found", "Subscription not found"))
+			return
+		}
+		if errors.Is(err, constants.ErrSubscriptionSubscriberMismatch) {
+			c.JSON(http.StatusForbidden, utils.NewErrorResponse(403, "Forbidden", "subscriberId does not match this subscription"))
 			return
 		}
 		h.slogger.Error("Failed to update subscription", "subscriptionId", subscriptionId, "organizationId", orgId, "error", err)
@@ -280,10 +298,18 @@ func (h *SubscriptionHandler) DeleteSubscription(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", "Subscription ID is required"))
 		return
 	}
-	err := h.subscriptionService.DeleteSubscription(subscriptionId, orgId)
+	subscriberID, ok := requireSubscriptionSubscriberQuery(c)
+	if !ok {
+		return
+	}
+	err := h.subscriptionService.DeleteSubscription(subscriptionId, orgId, subscriberID)
 	if err != nil {
 		if errors.Is(err, constants.ErrSubscriptionNotFound) {
 			c.JSON(http.StatusNotFound, utils.NewErrorResponse(404, "Not Found", "Subscription not found"))
+			return
+		}
+		if errors.Is(err, constants.ErrSubscriptionSubscriberMismatch) {
+			c.JSON(http.StatusForbidden, utils.NewErrorResponse(403, "Forbidden", "subscriberId does not match this subscription"))
 			return
 		}
 		h.slogger.Error("Failed to delete subscription", "subscriptionId", subscriptionId, "organizationId", orgId, "error", err)
@@ -294,6 +320,15 @@ func (h *SubscriptionHandler) DeleteSubscription(c *gin.Context) {
 }
 
 // RegisterRoutes registers subscription routes under the given router
+func requireSubscriptionSubscriberQuery(c *gin.Context) (string, bool) {
+	q := strings.TrimSpace(c.Query("subscriberId"))
+	if q == "" {
+		c.JSON(http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", "subscriberId query parameter is required"))
+		return "", false
+	}
+	return q, true
+}
+
 func (h *SubscriptionHandler) RegisterRoutes(r *gin.Engine) {
 	subGroup := r.Group("/api/v1/subscriptions")
 	{
@@ -314,6 +349,7 @@ func (h *SubscriptionHandler) toSubscriptionResponse(sub *model.Subscription, or
 	resp := gin.H{
 		"id":             sub.UUID,
 		"apiId":          apiIdForResponse,
+		"subscriberId":   sub.SubscriberID,
 		"organizationId": sub.OrganizationUUID,
 		"status":         string(sub.Status),
 		"createdAt":      sub.CreatedAt,
@@ -349,6 +385,7 @@ func (h *SubscriptionHandler) toSubscriptionResponseWithMaps(sub *model.Subscrip
 	resp := gin.H{
 		"id":             sub.UUID,
 		"apiId":          apiIdForResponse,
+		"subscriberId":   sub.SubscriberID,
 		"organizationId": sub.OrganizationUUID,
 		"status":         string(sub.Status),
 		"createdAt":      sub.CreatedAt,

--- a/platform-api/src/internal/model/subscription.go
+++ b/platform-api/src/internal/model/subscription.go
@@ -32,6 +32,7 @@ const (
 type Subscription struct {
 	UUID               string             `json:"id" db:"uuid"`
 	APIUUID            string             `json:"apiId" db:"api_uuid"`
+	SubscriberID      string             `json:"subscriberId" db:"subscriber_id"`
 	ApplicationID      *string            `json:"applicationId,omitempty" db:"application_id"`
 	SubscriptionToken  string             `json:"subscriptionToken" db:"subscription_token"` // Decrypted for API response
 	SubscriptionPlanID *string            `json:"subscriptionPlanId,omitempty" db:"subscription_plan_uuid"`

--- a/platform-api/src/internal/repository/interfaces.go
+++ b/platform-api/src/internal/repository/interfaces.go
@@ -190,12 +190,12 @@ type SubscriptionRepository interface {
 	GetByID(subscriptionID, orgUUID string) (*model.Subscription, error)
 	// ListByFilters returns subscriptions filtered by API and/or application for an organization.
 	// If apiUUID is nil, all APIs are considered. If applicationID is nil, all applications are considered.
-	ListByFilters(orgUUID string, apiUUID *string, applicationID *string, status *string, limit, offset int) ([]*model.Subscription, error)
+	ListByFilters(orgUUID string, apiUUID *string, subscriberID *string, applicationID *string, status *string, limit, offset int) ([]*model.Subscription, error)
 	// CountByFilters returns the total count of subscriptions matching the same filters as ListByFilters.
-	CountByFilters(orgUUID string, apiUUID *string, applicationID *string, status *string) (int, error)
+	CountByFilters(orgUUID string, apiUUID *string, subscriberID *string, applicationID *string, status *string) (int, error)
 	Update(sub *model.Subscription) error
 	Delete(subscriptionID, orgUUID string) error
-	ExistsByAPIAndApplication(apiUUID, applicationID, orgUUID string) (bool, error)
+	ExistsByAPIAndSubscriber(apiUUID, subscriberID, orgUUID string) (bool, error)
 }
 
 // APIPublicationRepository interface defines operations for API publication tracking

--- a/platform-api/src/internal/repository/subscription_repository.go
+++ b/platform-api/src/internal/repository/subscription_repository.go
@@ -109,12 +109,12 @@ func (r *SubscriptionRepo) Create(sub *model.Subscription) error {
 	sub.UpdatedAt = now
 
 	query := `
-		INSERT INTO subscriptions (uuid, api_uuid, application_id, subscription_token, subscription_token_hash, subscription_plan_uuid,
+		INSERT INTO subscriptions (uuid, api_uuid, subscriber_id, application_id, subscription_token, subscription_token_hash, subscription_plan_uuid,
 			organization_uuid, status, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`
 	_, err = r.db.Exec(r.db.Rebind(query),
-		sub.UUID, sub.APIUUID, sub.ApplicationID, encryptedToken, hashedToken,
+		sub.UUID, sub.APIUUID, sub.SubscriberID, sub.ApplicationID, encryptedToken, hashedToken,
 		sub.SubscriptionPlanID, sub.OrganizationUUID, string(sub.Status),
 		sub.CreatedAt, sub.UpdatedAt,
 	)
@@ -127,13 +127,14 @@ func (r *SubscriptionRepo) Create(sub *model.Subscription) error {
 	return nil
 }
 
-// isSubscriptionUniqueViolation detects DB unique-constraint violations on (api_uuid, application_id, organization_uuid).
+// isSubscriptionUniqueViolation detects DB unique-constraint violations on subscriptions.
 func isSubscriptionUniqueViolation(err error) bool {
 	if err == nil {
 		return false
 	}
 	s := err.Error()
-	// SQLite: UNIQUE constraint failed: subscriptions.api_uuid, subscriptions.application_id, subscriptions.organization_uuid
+	// SQLite: UNIQUE constraint failed on subscriptions (e.g. duplicate (api_uuid, subscriber_id, organization_uuid)
+	// or (api_uuid, subscription_token_hash); see schema.sqlite.sql / schema.postgres.sql).
 	if strings.Contains(s, "UNIQUE constraint failed") && strings.Contains(s, "subscriptions") {
 		return true
 	}
@@ -153,7 +154,7 @@ func isSubscriptionUniqueViolation(err error) bool {
 // Decrypts subscription_token for API response.
 func (r *SubscriptionRepo) GetByID(subscriptionID, orgUUID string) (*model.Subscription, error) {
 	query := `
-		SELECT uuid, api_uuid, application_id, subscription_token, subscription_plan_uuid,
+		SELECT uuid, api_uuid, subscriber_id, application_id, subscription_token, subscription_plan_uuid,
 			organization_uuid, status, created_at, updated_at
 		FROM subscriptions
 		WHERE uuid = ? AND organization_uuid = ?
@@ -161,7 +162,7 @@ func (r *SubscriptionRepo) GetByID(subscriptionID, orgUUID string) (*model.Subsc
 	sub := &model.Subscription{}
 	var storedToken string
 	err := r.db.QueryRow(r.db.Rebind(query), subscriptionID, orgUUID).Scan(
-		&sub.UUID, &sub.APIUUID, &sub.ApplicationID, &storedToken,
+		&sub.UUID, &sub.APIUUID, &sub.SubscriberID, &sub.ApplicationID, &storedToken,
 		&sub.SubscriptionPlanID, &sub.OrganizationUUID, &sub.Status,
 		&sub.CreatedAt, &sub.UpdatedAt,
 	)
@@ -175,11 +176,11 @@ func (r *SubscriptionRepo) GetByID(subscriptionID, orgUUID string) (*model.Subsc
 	return sub, nil
 }
 
-// ListByFilters returns subscriptions filtered by API and/or application for an organization.
+// ListByFilters returns subscriptions filtered by API/subscriber and/or application for an organization.
 // Decrypts subscription_token for each row.
-func (r *SubscriptionRepo) ListByFilters(orgUUID string, apiUUID *string, applicationID *string, status *string, limit, offset int) ([]*model.Subscription, error) {
+func (r *SubscriptionRepo) ListByFilters(orgUUID string, apiUUID *string, subscriberID *string, applicationID *string, status *string, limit, offset int) ([]*model.Subscription, error) {
 	query := `
-		SELECT uuid, api_uuid, application_id, subscription_token, subscription_plan_uuid,
+		SELECT uuid, api_uuid, subscriber_id, application_id, subscription_token, subscription_plan_uuid,
 			organization_uuid, status, created_at, updated_at
 		FROM subscriptions
 		WHERE organization_uuid = ?
@@ -188,6 +189,10 @@ func (r *SubscriptionRepo) ListByFilters(orgUUID string, apiUUID *string, applic
 	if apiUUID != nil && *apiUUID != "" {
 		query += ` AND api_uuid = ?`
 		args = append(args, *apiUUID)
+	}
+	if subscriberID != nil && *subscriberID != "" {
+		query += ` AND subscriber_id = ?`
+		args = append(args, *subscriberID)
 	}
 	if applicationID != nil && *applicationID != "" {
 		query += ` AND application_id = ?`
@@ -211,7 +216,7 @@ func (r *SubscriptionRepo) ListByFilters(orgUUID string, apiUUID *string, applic
 		sub := &model.Subscription{}
 		var storedToken string
 		if err := rows.Scan(
-			&sub.UUID, &sub.APIUUID, &sub.ApplicationID, &storedToken,
+			&sub.UUID, &sub.APIUUID, &sub.SubscriberID, &sub.ApplicationID, &storedToken,
 			&sub.SubscriptionPlanID, &sub.OrganizationUUID, &sub.Status,
 			&sub.CreatedAt, &sub.UpdatedAt,
 		); err != nil {
@@ -240,12 +245,16 @@ func (r *SubscriptionRepo) decryptSubscriptionToken(stored string) string {
 }
 
 // CountByFilters returns the total count of subscriptions matching the same filters as ListByFilters.
-func (r *SubscriptionRepo) CountByFilters(orgUUID string, apiUUID *string, applicationID *string, status *string) (int, error) {
+func (r *SubscriptionRepo) CountByFilters(orgUUID string, apiUUID *string, subscriberID *string, applicationID *string, status *string) (int, error) {
 	query := `SELECT COUNT(*) FROM subscriptions WHERE organization_uuid = ?`
 	args := []interface{}{orgUUID}
 	if apiUUID != nil && *apiUUID != "" {
 		query += ` AND api_uuid = ?`
 		args = append(args, *apiUUID)
+	}
+	if subscriberID != nil && *subscriberID != "" {
+		query += ` AND subscriber_id = ?`
+		args = append(args, *subscriberID)
 	}
 	if applicationID != nil && *applicationID != "" {
 		query += ` AND application_id = ?`
@@ -299,17 +308,16 @@ func (r *SubscriptionRepo) Delete(subscriptionID, orgUUID string) error {
 	return nil
 }
 
-// ExistsByAPIAndApplication returns true if a subscription exists for the given API and application.
-// applicationID empty string matches application_id IS NULL (token-based subscriptions).
-func (r *SubscriptionRepo) ExistsByAPIAndApplication(apiUUID, applicationID, orgUUID string) (bool, error) {
+// ExistsByAPIAndSubscriber returns true if a subscription exists for the given API and subscriber.
+func (r *SubscriptionRepo) ExistsByAPIAndSubscriber(apiUUID, subscriberID, orgUUID string) (bool, error) {
 	query := `
 		SELECT 1 FROM subscriptions
 		WHERE api_uuid = ? AND organization_uuid = ?
-		  AND COALESCE(application_id, '') = COALESCE(?, '')
+		  AND subscriber_id = ?
 		LIMIT 1
 	`
 	var exists int
-	err := r.db.QueryRow(r.db.Rebind(query), apiUUID, orgUUID, applicationID).Scan(&exists)
+	err := r.db.QueryRow(r.db.Rebind(query), apiUUID, orgUUID, subscriberID).Scan(&exists)
 	if err == sql.ErrNoRows {
 		return false, nil
 	}

--- a/platform-api/src/internal/service/gateway_internal.go
+++ b/platform-api/src/internal/service/gateway_internal.go
@@ -199,7 +199,7 @@ func (s *GatewayInternalAPIService) ListSubscriptionsForAPI(apiID, orgID string)
 	const pageSize = 1000
 	var subs []*model.Subscription
 	for offset := 0; ; offset += pageSize {
-		page, err := s.subscriptionRepo.ListByFilters(orgID, &apiID, nil, nil, pageSize, offset)
+		page, err := s.subscriptionRepo.ListByFilters(orgID, &apiID, nil, nil, nil, pageSize, offset)
 		if err != nil {
 			return nil, fmt.Errorf("failed to list subscriptions for API %s: %w", apiID, err)
 		}

--- a/platform-api/src/internal/service/subscription_service.go
+++ b/platform-api/src/internal/service/subscription_service.go
@@ -105,7 +105,7 @@ func (s *SubscriptionService) GetAPIHandleMap(uuids []string, orgUUID string) (m
 }
 
 // CreateSubscription creates a new subscription for an API
-func (s *SubscriptionService) CreateSubscription(apiId, orgUUID string, applicationId *string, subscriptionPlanId *string, status string) (*model.Subscription, error) {
+func (s *SubscriptionService) CreateSubscription(apiId, orgUUID string, subscriberID string, applicationId *string, subscriptionPlanId *string, status string) (*model.Subscription, error) {
 	apiUUID, err := s.resolveAPIUUID(apiId, orgUUID)
 	if err != nil {
 		return nil, err
@@ -120,8 +120,10 @@ func (s *SubscriptionService) CreateSubscription(apiId, orgUUID string, applicat
 		}
 	}
 
-	appID := derefString(applicationId)
-	exists, err := s.subscriptionRepo.ExistsByAPIAndApplication(apiUUID, appID, orgUUID)
+	if subscriberID == "" {
+		return nil, fmt.Errorf("subscriberId is required")
+	}
+	exists, err := s.subscriptionRepo.ExistsByAPIAndSubscriber(apiUUID, subscriberID, orgUUID)
 	if err != nil {
 		return nil, err
 	}
@@ -131,6 +133,7 @@ func (s *SubscriptionService) CreateSubscription(apiId, orgUUID string, applicat
 
 	sub := &model.Subscription{
 		APIUUID:            apiUUID,
+		SubscriberID:       subscriberID,
 		ApplicationID:      applicationId,
 		SubscriptionPlanID: subscriptionPlanId,
 		OrganizationUUID:   orgUUID,
@@ -184,9 +187,9 @@ func (s *SubscriptionService) GetSubscription(subscriptionId, orgUUID string) (*
 	return sub, nil
 }
 
-// ListSubscriptionsByFilters returns subscriptions filtered by API and/or application with pagination.
+// ListSubscriptionsByFilters returns subscriptions filtered by API, subscriber and/or application with pagination.
 // It returns the list, total count matching filters, and any error.
-func (s *SubscriptionService) ListSubscriptionsByFilters(orgUUID string, apiId *string, applicationID *string, status *string, limit, offset int) ([]*model.Subscription, int, error) {
+func (s *SubscriptionService) ListSubscriptionsByFilters(orgUUID string, apiId *string, subscriberID *string, applicationID *string, status *string, limit, offset int) ([]*model.Subscription, int, error) {
 	var apiUUID *string
 	if apiId != nil && *apiId != "" {
 		resolved, err := s.resolveAPIUUID(*apiId, orgUUID)
@@ -195,19 +198,19 @@ func (s *SubscriptionService) ListSubscriptionsByFilters(orgUUID string, apiId *
 		}
 		apiUUID = &resolved
 	}
-	list, err := s.subscriptionRepo.ListByFilters(orgUUID, apiUUID, applicationID, status, limit, offset)
+	list, err := s.subscriptionRepo.ListByFilters(orgUUID, apiUUID, subscriberID, applicationID, status, limit, offset)
 	if err != nil {
 		return nil, 0, err
 	}
-	total, err := s.subscriptionRepo.CountByFilters(orgUUID, apiUUID, applicationID, status)
+	total, err := s.subscriptionRepo.CountByFilters(orgUUID, apiUUID, subscriberID, applicationID, status)
 	if err != nil {
 		return nil, 0, err
 	}
 	return list, total, nil
 }
 
-// UpdateSubscription updates a subscription (e.g. status)
-func (s *SubscriptionService) UpdateSubscription(subscriptionId, orgUUID, status string) (*model.Subscription, error) {
+// UpdateSubscription updates a subscription (e.g. status). subscriberID must match the stored subscriber_id.
+func (s *SubscriptionService) UpdateSubscription(subscriptionId, orgUUID, subscriberID, status string) (*model.Subscription, error) {
 	sub, err := s.subscriptionRepo.GetByID(subscriptionId, orgUUID)
 	if err != nil {
 		if errors.Is(err, constants.ErrSubscriptionNotFound) {
@@ -217,6 +220,9 @@ func (s *SubscriptionService) UpdateSubscription(subscriptionId, orgUUID, status
 	}
 	if sub == nil {
 		return nil, constants.ErrSubscriptionNotFound
+	}
+	if sub.SubscriberID != subscriberID {
+		return nil, constants.ErrSubscriptionSubscriberMismatch
 	}
 	if status != "" {
 		st := model.SubscriptionStatus(status)
@@ -260,8 +266,8 @@ func (s *SubscriptionService) UpdateSubscription(subscriptionId, orgUUID, status
 	return sub, nil
 }
 
-// DeleteSubscription removes a subscription
-func (s *SubscriptionService) DeleteSubscription(subscriptionId, orgUUID string) error {
+// DeleteSubscription removes a subscription. subscriberID must match the stored subscriber_id.
+func (s *SubscriptionService) DeleteSubscription(subscriptionId, orgUUID, subscriberID string) error {
 	sub, err := s.subscriptionRepo.GetByID(subscriptionId, orgUUID)
 	if err != nil {
 		if errors.Is(err, constants.ErrSubscriptionNotFound) {
@@ -271,6 +277,9 @@ func (s *SubscriptionService) DeleteSubscription(subscriptionId, orgUUID string)
 	}
 	if sub == nil {
 		return constants.ErrSubscriptionNotFound
+	}
+	if sub.SubscriberID != subscriberID {
+		return constants.ErrSubscriptionSubscriberMismatch
 	}
 
 	if err := s.subscriptionRepo.Delete(subscriptionId, orgUUID); err != nil {

--- a/platform-api/src/resources/openapi.yaml
+++ b/platform-api/src/resources/openapi.yaml
@@ -1097,8 +1097,8 @@ paths:
     post:
       summary: Create subscription
       description: |
-        Creates an application-level subscription for the specified API.
-        The application is identified by applicationId (from DevPortal/STS). Only one subscription per API-application pair is allowed.
+        Creates a subscription for the specified API.
+        `subscriberId` identifies the unique subscriber for this API, allowing multiple subscribers to create subscriptions for the same API.
       operationId: CreateSubscription
       tags:
         - Subscriptions
@@ -1128,8 +1128,8 @@ paths:
     get:
       summary: List subscriptions
       description: |
-        Returns application-level subscriptions filtered by API and/or application.
-        Optional query parameters apiId, applicationId and status filter the list.
+        Returns subscriptions filtered by API and/or application.
+        Optional query parameters apiId, subscriberId, applicationId and status filter the list.
         Supports pagination via limit and offset.
       operationId: ListSubscriptions
       tags:
@@ -1141,6 +1141,13 @@ paths:
           description: Filter by API ID (UUID or handle)
           schema:
             type: string
+        - name: subscriberId
+          in: query
+          required: false
+          description: Filter by subscriber ID
+          schema:
+            type: string
+            minLength: 1
         - name: applicationId
           in: query
           required: false
@@ -1186,7 +1193,9 @@ paths:
   /subscriptions/{subscriptionId}:
     get:
       summary: Get subscription by ID
-      description: Returns a single subscription by ID (scoped to organization).
+      description: |
+        Returns a single subscription by ID (scoped to organization).
+        Query parameter `subscriberId` is required and must match the subscription's subscriber for access control.
       operationId: GetSubscription
       tags:
         - Subscriptions
@@ -1198,6 +1207,13 @@ paths:
           schema:
             type: string
             format: uuid
+        - name: subscriberId
+          in: query
+          required: true
+          description: Subscriber ID; must match the subscription's subscriberId.
+          schema:
+            type: string
+            minLength: 1
       responses:
         '200':
           description: Subscription details
@@ -1209,13 +1225,17 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
     put:
       summary: Update subscription
-      description: Updates a subscription (e.g. status).
+      description: |
+        Updates a subscription (e.g. status).
+        Query parameter `subscriberId` is required and must match the subscription's subscriber for access control.
       operationId: UpdateSubscription
       tags:
         - Subscriptions
@@ -1227,6 +1247,13 @@ paths:
           schema:
             type: string
             format: uuid
+        - name: subscriberId
+          in: query
+          required: true
+          description: Subscriber ID; must match the subscription's subscriberId.
+          schema:
+            type: string
+            minLength: 1
       requestBody:
         required: true
         content:
@@ -1244,13 +1271,17 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
     delete:
       summary: Delete subscription
-      description: Removes the application subscription for the API.
+      description: |
+        Removes the subscription for the API.
+        Query parameter `subscriberId` is required and must match the subscription's subscriber for access control.
       operationId: DeleteSubscription
       tags:
         - Subscriptions
@@ -1262,6 +1293,13 @@ paths:
           schema:
             type: string
             format: uuid
+        - name: subscriberId
+          in: query
+          required: true
+          description: Subscriber ID; must match the subscription's subscriberId.
+          schema:
+            type: string
+            minLength: 1
       responses:
         '204':
           description: Subscription deleted (no content)
@@ -1269,6 +1307,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
@@ -5992,11 +6032,17 @@ components:
       type: object
       required:
         - apiId
+        - subscriberId
       properties:
         apiId:
           type: string
           description: API handle or UUID (REST API identifier)
           example: "c9f2b6ae-1234-5678-9abc-def012345678"
+        subscriberId:
+          type: string
+          minLength: 1
+          description: Unique subscriber identifier for the subscription (required)
+          example: "user-123"
         applicationId:
           type: string
           description: Application ID (from DevPortal/STS). Optional in token-based subscriptions.
@@ -6030,6 +6076,10 @@ components:
           type: string
           format: uuid
           description: REST API UUID
+        subscriberId:
+          type: string
+          minLength: 1
+          description: Unique subscriber identifier for this API (required)
         applicationId:
           type: string
           description: Application ID (optional for token-based subscriptions)


### PR DESCRIPTION
## Purpose
Implement subscriber_id and multi subscriptions per API support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subscriptions now require and surface a subscriberId for subscriber-scoped records
  * List operations can be filtered by subscriberId

* **API Changes**
  * Create subscription now requires subscriberId; responses include subscriberId
  * Get/Update/Delete by ID require a matching subscriberId query param and return 403 when mismatched
  * Listing supports subscriberId, status, limit, offset filters

* **Documentation**
  * Examples and policy snippets updated to use subscriberId and server-generated tokens
<!-- end of auto-generated comment: release notes by coderabbit.ai -->