### PR TITLE
Enabling manifest sending support only for cloud gateway and custom policy deletion improvement

### DIFF
--- a/gateway/gateway-controller/pkg/controlplane/client.go
+++ b/gateway/gateway-controller/pkg/controlplane/client.go
@@ -470,6 +470,11 @@ func (c *Client) GetGatewayPath() string {
 	return c.gatewayPath
 }
 
+// isOnPrem returns true when the control plane is an on-prem deployment.
+func (c *Client) isOnPrem() bool {
+	return c.GetGatewayPath() != ""
+}
+
 // discoverGatewayPath fetches the gateway websocket base path from the control plane well-known endpoint.
 func (c *Client) discoverGatewayPath() (string, error) {
 	wellKnownURL := fmt.Sprintf("https://%s/internal/gateway/.well-known", c.config.Host)
@@ -3277,6 +3282,14 @@ func (c *Client) pushGatewayManifest(gatewayID string, policies []models.PolicyD
 // pushGatewayManifestOnConnect collects all loaded policy definitions and POSTs
 // them to the control plane immediately after the connection is established.
 func (c *Client) pushGatewayManifestOnConnect(gatewayID string) {
+	// Skip for on-prem control planes
+	if c.isOnPrem() {
+		c.logger.Debug("Skipping gateway manifest push: on-prem control plane detected",
+			slog.String("gateway_id", gatewayID),
+		)
+		return
+	}
+
 	c.logger.Info("Pushing gateway manifest on connect",
 		slog.String("gateway_id", gatewayID),
 	)

--- a/platform-api/src/internal/service/api.go
+++ b/platform-api/src/internal/service/api.go
@@ -1815,16 +1815,39 @@ func (s *APIService) refreshCustomPolicyUsages(apiUUID, orgUUID string, apiModel
 		}
 	}
 
-	// Step 2: resolve which refs are synced custom policies for this org
+	// Step 2: resolve which refs are synced custom policies for this org.
+	// Policies are stored with a full semver (e.g. "v1.1.0") but APIs store
+	// only the major version (e.g. "v1"). Match by major version, similar to the
+	// same logic used in SyncCustomPolicy.
 	newSet := make(map[string]bool)
 	for _, ref := range refs {
-		cp, err := s.customPolicyRepo.GetCustomPolicyByNameAndVersion(orgUUID, ref.name, ref.version)
+		identifiedSyncedPolicies, err := s.customPolicyRepo.GetCustomPoliciesByName(orgUUID, strings.ToLower(ref.name))
 		if err != nil {
 			s.slogger.Warn("Failed to lookup custom policy during usage refresh", "name", ref.name, "version", ref.version, "orgUUID", orgUUID, "error", err)
 			continue
 		}
-		if cp != nil {
-			newSet[cp.UUID] = true
+		parsedPolicyVersion, err := parseVersion(ref.version)
+		if err != nil {
+			// if version parse error happens, exact version will be evaluated
+			for _, cp := range identifiedSyncedPolicies {
+				if cp.Version == ref.version {
+					newSet[cp.UUID] = true
+					break
+				}
+			}
+			continue
+		}
+		// evaluates parsed policy version
+		for _, syncedPolicy := range identifiedSyncedPolicies {
+			cpVer, err := parseVersion(syncedPolicy.Version)
+			if err != nil {
+				s.slogger.Warn("Failed to parse stored custom policy version during usage refresh", "name", syncedPolicy.Name, "version", syncedPolicy.Version, "error", err)
+				continue
+			}
+			if cpVer.Major == parsedPolicyVersion.Major {
+				newSet[syncedPolicy.UUID] = true
+				break
+			}
 		}
 	}
 


### PR DESCRIPTION
## Purpose
$subject


## Goals
> Describe **what solutions** this feature or fix introduces to address the problems outlined above.

## Approach
> Describe **how** you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Gateway manifest synchronization now correctly skips on-premise control planes, reducing unnecessary sync attempts.
  * Enhanced custom policy synchronization with improved version matching to ensure accurate policy resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->