### PR TITLE
fix: upstream auth header not injected when a policy buffers the request body

### DIFF
--- a/gateway/gateway-runtime/policy-engine/internal/kernel/body_mode.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/body_mode.go
@@ -125,3 +125,26 @@ func (k *Kernel) GetResponseBodyMode(routeKey string) BodyMode {
 	}
 	return determineResponseBodyMode(chain)
 }
+
+// splitPoliciesByBodyMode separates policies into header-only and body-requiring groups.
+// Header-only policies (RequestBodyMode == BodyModeSkip or empty) can execute in the
+// headers phase, while body-requiring policies must wait for the body phase.
+// Both returned slices preserve the original relative ordering within each group.
+func splitPoliciesByBodyMode(
+	policies []policy.Policy,
+	specs []policy.PolicySpec,
+) (headerPolicies []policy.Policy, headerSpecs []policy.PolicySpec,
+	bodyPolicies []policy.Policy, bodySpecs []policy.PolicySpec) {
+
+	for i, pol := range policies {
+		mode := pol.Mode()
+		if mode.RequestBodyMode == policy.BodyModeBuffer || mode.RequestBodyMode == policy.BodyModeStream {
+			bodyPolicies = append(bodyPolicies, pol)
+			bodySpecs = append(bodySpecs, specs[i])
+		} else {
+			headerPolicies = append(headerPolicies, pol)
+			headerSpecs = append(headerSpecs, specs[i])
+		}
+	}
+	return
+}

--- a/gateway/gateway-runtime/policy-engine/internal/kernel/body_mode_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/body_mode_test.go
@@ -204,3 +204,111 @@ func TestGetResponseBodyMode_WithChainNotRequiringBody(t *testing.T) {
 
 	assert.Equal(t, BodyModeSkip, mode)
 }
+
+// =============================================================================
+// splitPoliciesByBodyMode Tests
+// =============================================================================
+
+// mockPolicyWithBodyMode is a test helper that creates a policy with a specific body mode
+type mockPolicyWithBodyMode struct {
+	name     string
+	bodyMode policy.BodyProcessingMode
+}
+
+func (m *mockPolicyWithBodyMode) Mode() policy.ProcessingMode {
+	return policy.ProcessingMode{
+		RequestHeaderMode: policy.HeaderModeProcess,
+		RequestBodyMode:   m.bodyMode,
+	}
+}
+func (m *mockPolicyWithBodyMode) OnRequest(*policy.RequestContext, map[string]interface{}) policy.RequestAction {
+	return nil
+}
+func (m *mockPolicyWithBodyMode) OnResponse(*policy.ResponseContext, map[string]interface{}) policy.ResponseAction {
+	return nil
+}
+
+func TestSplitPoliciesByBodyMode_AllHeaderOnly(t *testing.T) {
+	pol1 := &mockPolicyWithBodyMode{name: "auth", bodyMode: policy.BodyModeSkip}
+	pol2 := &mockPolicyWithBodyMode{name: "rate-limit", bodyMode: policy.BodyModeSkip}
+	policies := []policy.Policy{pol1, pol2}
+	specs := []policy.PolicySpec{
+		{Name: "auth", Version: "v1"},
+		{Name: "rate-limit", Version: "v1"},
+	}
+
+	headerPols, headerSpecs, bodyPols, bodySpecs := splitPoliciesByBodyMode(policies, specs)
+
+	assert.Len(t, headerPols, 2)
+	assert.Len(t, headerSpecs, 2)
+	assert.Len(t, bodyPols, 0)
+	assert.Len(t, bodySpecs, 0)
+	assert.Equal(t, "auth", headerSpecs[0].Name)
+	assert.Equal(t, "rate-limit", headerSpecs[1].Name)
+}
+
+func TestSplitPoliciesByBodyMode_AllBodyRequired(t *testing.T) {
+	pol1 := &mockPolicyWithBodyMode{name: "analytics", bodyMode: policy.BodyModeBuffer}
+	pol2 := &mockPolicyWithBodyMode{name: "llm-cost", bodyMode: policy.BodyModeBuffer}
+	policies := []policy.Policy{pol1, pol2}
+	specs := []policy.PolicySpec{
+		{Name: "analytics", Version: "v1"},
+		{Name: "llm-cost", Version: "v1"},
+	}
+
+	headerPols, headerSpecs, bodyPols, bodySpecs := splitPoliciesByBodyMode(policies, specs)
+
+	assert.Len(t, headerPols, 0)
+	assert.Len(t, headerSpecs, 0)
+	assert.Len(t, bodyPols, 2)
+	assert.Len(t, bodySpecs, 2)
+}
+
+func TestSplitPoliciesByBodyMode_MixedPolicies(t *testing.T) {
+	pol1 := &mockPolicyWithBodyMode{name: "rate-limit", bodyMode: policy.BodyModeSkip}
+	pol2 := &mockPolicyWithBodyMode{name: "llm-cost", bodyMode: policy.BodyModeBuffer}
+	pol3 := &mockPolicyWithBodyMode{name: "set-headers", bodyMode: policy.BodyModeSkip}
+	policies := []policy.Policy{pol1, pol2, pol3}
+	specs := []policy.PolicySpec{
+		{Name: "rate-limit", Version: "v1"},
+		{Name: "llm-cost", Version: "v1"},
+		{Name: "set-headers", Version: "v1"},
+	}
+
+	headerPols, headerSpecs, bodyPols, bodySpecs := splitPoliciesByBodyMode(policies, specs)
+
+	assert.Len(t, headerPols, 2)
+	assert.Len(t, headerSpecs, 2)
+	assert.Equal(t, "rate-limit", headerSpecs[0].Name)
+	assert.Equal(t, "set-headers", headerSpecs[1].Name)
+
+	assert.Len(t, bodyPols, 1)
+	assert.Len(t, bodySpecs, 1)
+	assert.Equal(t, "llm-cost", bodySpecs[0].Name)
+}
+
+func TestSplitPoliciesByBodyMode_StreamModeTreatedAsBody(t *testing.T) {
+	pol1 := &mockPolicyWithBodyMode{name: "streaming", bodyMode: policy.BodyModeStream}
+	pol2 := &mockPolicyWithBodyMode{name: "auth", bodyMode: policy.BodyModeSkip}
+	policies := []policy.Policy{pol1, pol2}
+	specs := []policy.PolicySpec{
+		{Name: "streaming", Version: "v1"},
+		{Name: "auth", Version: "v1"},
+	}
+
+	headerPols, headerSpecs, bodyPols, bodySpecs := splitPoliciesByBodyMode(policies, specs)
+
+	assert.Len(t, headerPols, 1)
+	assert.Equal(t, "auth", headerSpecs[0].Name)
+	assert.Len(t, bodyPols, 1)
+	assert.Equal(t, "streaming", bodySpecs[0].Name)
+}
+
+func TestSplitPoliciesByBodyMode_EmptyInput(t *testing.T) {
+	headerPols, headerSpecs, bodyPols, bodySpecs := splitPoliciesByBodyMode(nil, nil)
+
+	assert.Nil(t, headerPols)
+	assert.Nil(t, headerSpecs)
+	assert.Nil(t, bodyPols)
+	assert.Nil(t, bodySpecs)
+}

--- a/gateway/gateway-runtime/policy-engine/internal/kernel/execution_context.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/execution_context.go
@@ -74,6 +74,12 @@ type PolicyExecutionContext struct {
 	// Used when UpstreamName is set to compute the correct path transformation
 	upstreamDefinitionPaths map[string]string
 
+	// Deferred policies and specs for body phase execution
+	// When body buffering is needed, header-only policies execute in the headers phase
+	// and body-requiring policies are deferred to the body phase
+	deferredPolicies []policy.Policy
+	deferredSpecs    []policy.PolicySpec
+
 	// Reference to server components
 	server *ExternalProcessorServer
 }
@@ -179,10 +185,40 @@ func (ec *PolicyExecutionContext) processRequestHeaders(
 	// Check if this is end of stream (no body coming)
 	endOfStream := ec.requestContext.Body != nil && ec.requestContext.Body.EndOfStream
 
-	// If policy chain requires request body AND body is coming, skip processing headers separately
-	// Headers and body will be processed together in processRequestBody phase
-	// However, if EndOfStream is true, there's no body coming, so process immediately
+	// If policy chain requires request body AND body is coming, split execution:
+	// - Header-only policies (BodyModeSkip) execute now in the headers phase
+	// - Body-requiring policies are deferred to the body phase
+	// This ensures header mutations (e.g., upstream auth) are applied in the headers phase
+	// where Envoy reliably processes them, rather than deferring everything to the body
+	// phase where header mutations may not be applied to the upstream request.
 	if ec.policyChain.RequiresRequestBody && !endOfStream {
+		headerPolicies, headerSpecs, bodyPolicies, bodySpecs := splitPoliciesByBodyMode(
+			ec.policyChain.Policies, ec.policyChain.PolicySpecs)
+
+		// Store body-requiring policies for deferred execution in processRequestBody
+		ec.deferredPolicies = bodyPolicies
+		ec.deferredSpecs = bodySpecs
+
+		if len(headerPolicies) > 0 {
+			// Execute header-only policies now
+			execResult, err := ec.server.executor.ExecuteRequestPolicies(
+				ctx,
+				headerPolicies,
+				ec.requestContext,
+				headerSpecs,
+				ec.requestContext.SharedContext.APIName,
+				ec.routeKey,
+				ec.policyChain.HasExecutionConditions,
+			)
+			if err != nil {
+				return ec.handlePolicyError(ctx, err, "request_headers"), nil
+			}
+
+			// Translate result — this includes ModeOverride to tell Envoy to buffer body
+			return TranslateRequestHeadersActions(execResult, ec.policyChain, ec)
+		}
+
+		// No header-only policies; return empty response with ModeOverride
 		return &extprocv3.ProcessingResponse{
 			Response: &extprocv3.ProcessingResponse_RequestHeaders{
 				RequestHeaders: &extprocv3.HeadersResponse{},
@@ -214,7 +250,7 @@ func (ec *PolicyExecutionContext) processRequestBody(
 	ctx context.Context,
 	body *extprocv3.HttpBody,
 ) (*extprocv3.ProcessingResponse, error) {
-	// If policy chain requires request body, execute policies with both headers and body
+	// If policy chain requires request body, execute body-requiring policies with both headers and body
 	if ec.policyChain.RequiresRequestBody {
 		// Update request context with body data
 		ec.requestContext.Body = &policy.Body{
@@ -223,12 +259,21 @@ func (ec *PolicyExecutionContext) processRequestBody(
 			Present:     true,
 		}
 
-		// Execute request policy chain with headers and body
+		// Use deferred (body-requiring) policies if available from split execution,
+		// otherwise fall back to full chain (e.g., when EndOfStream was true in headers phase)
+		policies := ec.policyChain.Policies
+		specs := ec.policyChain.PolicySpecs
+		if ec.deferredPolicies != nil {
+			policies = ec.deferredPolicies
+			specs = ec.deferredSpecs
+		}
+
+		// Execute body-requiring policies with headers and body
 		execResult, err := ec.server.executor.ExecuteRequestPolicies(
 			ctx,
-			ec.policyChain.Policies,
+			policies,
 			ec.requestContext,
-			ec.policyChain.PolicySpecs,
+			specs,
 			ec.requestContext.SharedContext.APIName,
 			ec.routeKey,
 			ec.policyChain.HasExecutionConditions,

--- a/gateway/gateway-runtime/policy-engine/internal/kernel/execution_context_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/execution_context_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/wso2/api-platform/gateway/gateway-runtime/policy-engine/internal/registry"
 	"github.com/wso2/api-platform/gateway/gateway-runtime/policy-engine/internal/testutils"
 	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+	"go.opentelemetry.io/otel/trace/noop"
 )
 
 // =============================================================================
@@ -422,6 +423,228 @@ func TestBuildResponseContext_EndOfStream(t *testing.T) {
 	require.NotNil(t, execCtx.responseContext.ResponseBody)
 	assert.True(t, execCtx.responseContext.ResponseBody.EndOfStream)
 	assert.False(t, execCtx.responseContext.ResponseBody.Present)
+}
+
+// =============================================================================
+// processRequestHeaders Split Execution Tests
+// =============================================================================
+
+func TestProcessRequestHeaders_SplitExecution_HeaderOnlyPoliciesRunInHeadersPhase(t *testing.T) {
+	// When body buffering is needed, header-only policies (like set-headers for upstream auth)
+	// should execute in the headers phase so their header mutations are applied by Envoy.
+	kernel := NewKernel()
+	tracer := noop.NewTracerProvider().Tracer("test")
+	chainExecutor := executor.NewChainExecutor(nil, nil, tracer)
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+
+	// Create a header-only policy that sets an auth header
+	authPolicy := &testutils.ConfigurableMockPolicy{
+		Name:    "set-headers",
+		Version: "v0",
+		MockMode: policy.ProcessingMode{
+			RequestHeaderMode: policy.HeaderModeProcess,
+			RequestBodyMode:   policy.BodyModeSkip,
+		},
+		OnReqFn: func(ctx *policy.RequestContext, params map[string]interface{}) policy.RequestAction {
+			return policy.UpstreamRequestModifications{
+				SetHeaders: map[string]string{"x-api-key": "sk-test-key"},
+			}
+		},
+	}
+
+	// Create a body-requiring policy
+	bodyPolicy := &testutils.ConfigurableMockPolicy{
+		Name:    "llm-cost",
+		Version: "v1",
+		MockMode: policy.ProcessingMode{
+			RequestHeaderMode: policy.HeaderModeProcess,
+			RequestBodyMode:   policy.BodyModeBuffer,
+		},
+		OnReqFn: func(ctx *policy.RequestContext, params map[string]interface{}) policy.RequestAction {
+			return policy.UpstreamRequestModifications{}
+		},
+	}
+
+	chain := &registry.PolicyChain{
+		Policies:            []policy.Policy{bodyPolicy, authPolicy},
+		PolicySpecs:         []policy.PolicySpec{
+			{Name: "llm-cost", Version: "v1", Enabled: true},
+			{Name: "set-headers", Version: "v0", Enabled: true},
+		},
+		RequiresRequestBody: true,
+	}
+
+	execCtx := newPolicyExecutionContext(server, "test-route", chain)
+
+	// Build request context with body coming (EndOfStream = false)
+	headers := &extprocv3.HttpHeaders{
+		Headers: &corev3.HeaderMap{
+			Headers: []*corev3.HeaderValue{
+				{Key: ":path", RawValue: []byte("/v1/messages")},
+				{Key: ":method", RawValue: []byte("POST")},
+			},
+		},
+		EndOfStream: false,
+	}
+	execCtx.buildRequestContext(headers, RouteMetadata{})
+
+	resp, err := execCtx.processRequestHeaders(context.Background())
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Response should be a HeadersResponse (not empty) with header mutations
+	headersResp := resp.GetRequestHeaders()
+	require.NotNil(t, headersResp, "expected HeadersResponse, got %T", resp.Response)
+
+	// Should have header mutation with the auth header
+	require.NotNil(t, headersResp.Response, "expected CommonResponse with header mutations")
+	require.NotNil(t, headersResp.Response.HeaderMutation, "expected header mutation")
+
+	// Find the x-api-key header in mutations
+	found := false
+	for _, hdr := range headersResp.Response.HeaderMutation.SetHeaders {
+		if hdr.Header.Key == "x-api-key" {
+			assert.Equal(t, "sk-test-key", string(hdr.Header.RawValue))
+			found = true
+		}
+	}
+	assert.True(t, found, "x-api-key header should be in header mutations")
+
+	// ModeOverride should still request body buffering
+	require.NotNil(t, resp.ModeOverride)
+	assert.Equal(t, extprocconfigv3.ProcessingMode_BUFFERED, resp.ModeOverride.RequestBodyMode)
+
+	// Body policies should be deferred
+	assert.Len(t, execCtx.deferredPolicies, 1)
+	assert.Len(t, execCtx.deferredSpecs, 1)
+	assert.Equal(t, "llm-cost", execCtx.deferredSpecs[0].Name)
+}
+
+func TestProcessRequestHeaders_SplitExecution_NoHeaderOnlyPolicies(t *testing.T) {
+	// When all policies require body, headers phase should return empty response
+	kernel := NewKernel()
+	tracer := noop.NewTracerProvider().Tracer("test")
+	chainExecutor := executor.NewChainExecutor(nil, nil, tracer)
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+
+	bodyPolicy := &testutils.ConfigurableMockPolicy{
+		MockMode: policy.ProcessingMode{
+			RequestHeaderMode: policy.HeaderModeProcess,
+			RequestBodyMode:   policy.BodyModeBuffer,
+		},
+	}
+
+	chain := &registry.PolicyChain{
+		Policies:            []policy.Policy{bodyPolicy},
+		PolicySpecs:         []policy.PolicySpec{{Name: "body-pol", Version: "v1", Enabled: true}},
+		RequiresRequestBody: true,
+	}
+
+	execCtx := newPolicyExecutionContext(server, "test-route", chain)
+	headers := &extprocv3.HttpHeaders{
+		Headers: &corev3.HeaderMap{
+			Headers: []*corev3.HeaderValue{
+				{Key: ":path", RawValue: []byte("/test")},
+			},
+		},
+		EndOfStream: false,
+	}
+	execCtx.buildRequestContext(headers, RouteMetadata{})
+
+	resp, err := execCtx.processRequestHeaders(context.Background())
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	headersResp := resp.GetRequestHeaders()
+	require.NotNil(t, headersResp)
+	// Should be empty (no CommonResponse mutations)
+	assert.Nil(t, headersResp.Response)
+	// ModeOverride should still request buffering
+	require.NotNil(t, resp.ModeOverride)
+	assert.Equal(t, extprocconfigv3.ProcessingMode_BUFFERED, resp.ModeOverride.RequestBodyMode)
+}
+
+func TestProcessRequestBody_UsesDeferredPolicies(t *testing.T) {
+	// Body phase should only execute deferred (body-requiring) policies
+	kernel := NewKernel()
+	tracer := noop.NewTracerProvider().Tracer("test")
+	chainExecutor := executor.NewChainExecutor(nil, nil, tracer)
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+
+	bodyPolicyExecuted := false
+	bodyPolicy := &testutils.ConfigurableMockPolicy{
+		MockMode: policy.ProcessingMode{
+			RequestHeaderMode: policy.HeaderModeProcess,
+			RequestBodyMode:   policy.BodyModeBuffer,
+		},
+		OnReqFn: func(ctx *policy.RequestContext, params map[string]interface{}) policy.RequestAction {
+			bodyPolicyExecuted = true
+			return policy.UpstreamRequestModifications{}
+		},
+	}
+
+	authPolicyExecuted := false
+	authPolicy := &testutils.ConfigurableMockPolicy{
+		MockMode: policy.ProcessingMode{
+			RequestHeaderMode: policy.HeaderModeProcess,
+			RequestBodyMode:   policy.BodyModeSkip,
+		},
+		OnReqFn: func(ctx *policy.RequestContext, params map[string]interface{}) policy.RequestAction {
+			authPolicyExecuted = true
+			return policy.UpstreamRequestModifications{
+				SetHeaders: map[string]string{"x-api-key": "sk-test-key"},
+			}
+		},
+	}
+
+	chain := &registry.PolicyChain{
+		Policies:            []policy.Policy{bodyPolicy, authPolicy},
+		PolicySpecs:         []policy.PolicySpec{
+			{Name: "llm-cost", Version: "v1", Enabled: true},
+			{Name: "set-headers", Version: "v0", Enabled: true},
+		},
+		RequiresRequestBody: true,
+	}
+
+	execCtx := newPolicyExecutionContext(server, "test-route", chain)
+
+	// Build request context
+	headers := &extprocv3.HttpHeaders{
+		Headers: &corev3.HeaderMap{
+			Headers: []*corev3.HeaderValue{
+				{Key: ":path", RawValue: []byte("/v1/messages")},
+				{Key: ":method", RawValue: []byte("POST")},
+			},
+		},
+		EndOfStream: false,
+	}
+	execCtx.buildRequestContext(headers, RouteMetadata{})
+
+	// First: process headers phase (splits and executes header-only policies)
+	_, err := execCtx.processRequestHeaders(context.Background())
+	require.NoError(t, err)
+
+	// Auth policy should have executed in headers phase
+	assert.True(t, authPolicyExecuted, "auth policy should execute in headers phase")
+	assert.False(t, bodyPolicyExecuted, "body policy should NOT execute in headers phase")
+
+	// Reset flags
+	authPolicyExecuted = false
+
+	// Now: process body phase (should only execute deferred body policies)
+	body := &extprocv3.HttpBody{
+		Body:        []byte(`{"model":"claude-3"}`),
+		EndOfStream: true,
+	}
+	resp, err := execCtx.processRequestBody(context.Background(), body)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	assert.True(t, bodyPolicyExecuted, "body policy should execute in body phase")
+	assert.False(t, authPolicyExecuted, "auth policy should NOT execute again in body phase")
 }
 
 func TestBuildResponseContext_InvalidStatus(t *testing.T) {

--- a/gateway/gateway-runtime/policy-engine/internal/kernel/extproc_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/extproc_test.go
@@ -627,3 +627,167 @@ func TestInitializeExecutionContext_WithPolicyChain(t *testing.T) {
 	assert.Equal(t, "/api/v1/pets", execCtx.requestContext.Path)
 	assert.Equal(t, "GET", execCtx.requestContext.Method)
 }
+
+// =============================================================================
+// Integration Test: Upstream auth header with body buffering (Issue #1474)
+// =============================================================================
+
+func TestProcess_UpstreamAuthHeader_WithBodyBuffering(t *testing.T) {
+	// Regression test for https://github.com/wso2/api-platform/issues/1474
+	// Verifies that upstream auth headers (from set-headers policy) are included
+	// in the headers-phase response even when another policy requires body buffering.
+	// Previously, ALL policies were deferred to the body phase, causing Envoy to
+	// not apply the auth header mutations to the upstream request.
+
+	kernel := NewKernel()
+	tracer := otel.Tracer("test")
+	chainExecutor := executor.NewChainExecutor(nil, nil, tracer)
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+
+	// Body-requiring policy (e.g., llm-cost reads the request body)
+	bodyPolicy := &bodyBufferingMockPolicy{
+		name: "llm-cost",
+		onReqFn: func(ctx *policy.RequestContext, params map[string]interface{}) policy.RequestAction {
+			return policy.UpstreamRequestModifications{}
+		},
+	}
+
+	// Header-only policy that sets upstream auth (e.g., set-headers for Anthropic x-api-key)
+	authPolicy := &headerOnlyMockPolicy{
+		name: "set-headers",
+		onReqFn: func(ctx *policy.RequestContext, params map[string]interface{}) policy.RequestAction {
+			return policy.UpstreamRequestModifications{
+				SetHeaders: map[string]string{
+					"x-api-key":     "sk-ant-test-key-123",
+					"authorization": "Bearer sk-ant-test-key-123",
+				},
+			}
+		},
+	}
+
+	chain := &registry.PolicyChain{
+		Policies:    []policy.Policy{bodyPolicy, authPolicy},
+		PolicySpecs: []policy.PolicySpec{
+			{Name: "llm-cost", Version: "v1", Enabled: true},
+			{Name: "set-headers", Version: "v0", Enabled: true},
+		},
+		RequiresRequestBody: true,
+	}
+	kernel.RegisterRoute("llm-route", chain)
+
+	// Simulate the ext_proc stream: request headers → request body
+	reqHeaders := &extprocv3.ProcessingRequest{
+		Request: &extprocv3.ProcessingRequest_RequestHeaders{
+			RequestHeaders: &extprocv3.HttpHeaders{
+				Headers: &corev3.HeaderMap{
+					Headers: []*corev3.HeaderValue{
+						{Key: ":path", RawValue: []byte("/v1/messages")},
+						{Key: ":method", RawValue: []byte("POST")},
+						{Key: ":authority", RawValue: []byte("llm.example.com")},
+						{Key: ":scheme", RawValue: []byte("https")},
+						{Key: "content-type", RawValue: []byte("application/json")},
+					},
+				},
+				EndOfStream: false,
+			},
+		},
+		Attributes: map[string]*structpb.Struct{
+			constants.ExtProcFilter: {
+				Fields: map[string]*structpb.Value{
+					"xds.route_name": structpb.NewStringValue("llm-route"),
+				},
+			},
+		},
+	}
+
+	reqBody := &extprocv3.ProcessingRequest{
+		Request: &extprocv3.ProcessingRequest_RequestBody{
+			RequestBody: &extprocv3.HttpBody{
+				Body:        []byte(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"Hello"}]}`),
+				EndOfStream: true,
+			},
+		},
+	}
+
+	stream := newMockStream([]*extprocv3.ProcessingRequest{reqHeaders, reqBody})
+
+	err := server.Process(stream)
+
+	require.NoError(t, err)
+	require.Len(t, stream.responses, 2, "expected 2 responses: headers + body")
+
+	// === Verify headers-phase response ===
+	headersResp := stream.responses[0].GetRequestHeaders()
+	require.NotNil(t, headersResp, "first response should be RequestHeaders")
+
+	// Header mutations should include the auth headers from set-headers policy
+	require.NotNil(t, headersResp.Response, "headers response should have CommonResponse")
+	require.NotNil(t, headersResp.Response.HeaderMutation, "headers response should have header mutations")
+
+	authHeaderFound := false
+	for _, hdr := range headersResp.Response.HeaderMutation.SetHeaders {
+		if hdr.Header.Key == "x-api-key" {
+			assert.Equal(t, "sk-ant-test-key-123", string(hdr.Header.RawValue))
+			authHeaderFound = true
+		}
+	}
+	assert.True(t, authHeaderFound,
+		"x-api-key header MUST be in headers-phase response so Envoy applies it to the upstream request")
+
+	// ModeOverride should request body buffering
+	require.NotNil(t, stream.responses[0].ModeOverride)
+	assert.Equal(t, extprocconfigv3.ProcessingMode_BUFFERED,
+		stream.responses[0].ModeOverride.RequestBodyMode)
+
+	// === Verify body-phase response ===
+	bodyResp := stream.responses[1].GetRequestBody()
+	require.NotNil(t, bodyResp, "second response should be RequestBody")
+}
+
+// headerOnlyMockPolicy - policy that only processes headers (BodyModeSkip)
+type headerOnlyMockPolicy struct {
+	name    string
+	onReqFn func(*policy.RequestContext, map[string]interface{}) policy.RequestAction
+}
+
+func (p *headerOnlyMockPolicy) Mode() policy.ProcessingMode {
+	return policy.ProcessingMode{
+		RequestHeaderMode:  policy.HeaderModeProcess,
+		RequestBodyMode:    policy.BodyModeSkip,
+		ResponseHeaderMode: policy.HeaderModeProcess,
+		ResponseBodyMode:   policy.BodyModeSkip,
+	}
+}
+func (p *headerOnlyMockPolicy) OnRequest(ctx *policy.RequestContext, params map[string]interface{}) policy.RequestAction {
+	if p.onReqFn != nil {
+		return p.onReqFn(ctx, params)
+	}
+	return nil
+}
+func (p *headerOnlyMockPolicy) OnResponse(*policy.ResponseContext, map[string]interface{}) policy.ResponseAction {
+	return nil
+}
+
+// bodyBufferingMockPolicy - policy that requires body buffering
+type bodyBufferingMockPolicy struct {
+	name    string
+	onReqFn func(*policy.RequestContext, map[string]interface{}) policy.RequestAction
+}
+
+func (p *bodyBufferingMockPolicy) Mode() policy.ProcessingMode {
+	return policy.ProcessingMode{
+		RequestHeaderMode:  policy.HeaderModeProcess,
+		RequestBodyMode:    policy.BodyModeBuffer,
+		ResponseHeaderMode: policy.HeaderModeProcess,
+		ResponseBodyMode:   policy.BodyModeSkip,
+	}
+}
+func (p *bodyBufferingMockPolicy) OnRequest(ctx *policy.RequestContext, params map[string]interface{}) policy.RequestAction {
+	if p.onReqFn != nil {
+		return p.onReqFn(ctx, params)
+	}
+	return nil
+}
+func (p *bodyBufferingMockPolicy) OnResponse(*policy.ResponseContext, map[string]interface{}) policy.ResponseAction {
+	return nil
+}


### PR DESCRIPTION
## Summary

- Fixes #1474: When a policy (e.g., `llm-cost`) sets `RequestBodyMode: BodyModeBuffer`, all policy execution was deferred to the body phase. Header mutations returned in the body-phase `BodyResponse` are not reliably applied by Envoy to the upstream request, causing upstream auth headers (e.g., `x-api-key` for Anthropic) to be dropped → 401 from upstream.
- **Fix**: Split policy execution so header-only policies (`RequestBodyMode == BodyModeSkip`, like `set-headers`) execute in the headers phase where Envoy reliably processes their mutations, while body-requiring policies are deferred to the body phase as before.
- Added `splitPoliciesByBodyMode` helper and updated `processRequestHeaders`/`processRequestBody` to use split execution.

## Changes

| File | Change |
|------|--------|
| `body_mode.go` | Added `splitPoliciesByBodyMode()` helper |
| `execution_context.go` | Split execution in `processRequestHeaders`; `processRequestBody` uses deferred policies |
| `body_mode_test.go` | 5 new tests for `splitPoliciesByBodyMode` |
| `execution_context_test.go` | 3 new tests for split execution behavior |
| `extproc_test.go` | 1 full-stream integration test simulating the exact bug scenario |

## Test plan

- [x] `splitPoliciesByBodyMode` correctly separates header-only vs body-requiring policies
- [x] Header-only policies execute in headers phase and their mutations appear in `HeadersResponse`
- [x] Body-requiring policies are deferred and execute only in body phase
- [x] Auth header (`x-api-key`) is present in headers-phase response (not deferred to body phase)
- [x] Full ext_proc stream test validates headers+body flow with mixed policy chain
- [x] All existing tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)