### PR TITLE
Add test key on namespace scoped-test

### DIFF
--- a/.github/workflows/operator-integration-test.yml
+++ b/.github/workflows/operator-integration-test.yml
@@ -1189,6 +1189,9 @@ jobs:
           # 2. Install Scoped Operator
           echo "Creating scoped-test namespace..."
           kubectl create ns scoped-test --dry-run=client -o yaml | kubectl apply -f -
+          kubectl create secret generic gateway-encryption-keys \
+            --from-file=default-aesgcm256-v1.bin=gateway/it/it-aesgcm-keys/default-aesgcm256-v1.bin \
+            --namespace scoped-test
           
           echo "Installing operator in scoped mode (watchNamespaces={scoped-test})..."
           helm install gateway-operator ./kubernetes/helm/operator-helm-chart \


### PR DESCRIPTION
## Purpose
${subject}

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Operator integration test now provisions an additional Kubernetes Secret named `gateway-encryption-keys` in the `scoped-test` namespace, containing encryption key material for the scoped test environment.
  * Improves reliability and coverage of scoped-mode integration testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->