### PR TITLE
Adding new subscription-validation policy version

### DIFF
--- a/gateway/build-lock.yaml
+++ b/gateway/build-lock.yaml
@@ -103,7 +103,7 @@ policies:
       version: v0.9.0
       gomodule: github.com/wso2/gateway-controllers/policies/json-xml-mediator@v0
     - name: subscription-validation
-      version: v0.9.1
+      version: v0.9.2
       gomodule: github.com/wso2/gateway-controllers/policies/subscription-validation@v0
     - name: llm-cost
       version: v0.9.1

--- a/gateway/gateway-controller/default-policies/subscription-validation.yaml
+++ b/gateway/gateway-controller/default-policies/subscription-validation.yaml
@@ -1,10 +1,10 @@
 name: subscription-validation
-version: v0.9.1
+version: v0.9.2
 description: |
   Validates that the request has an active subscription to the
   requested API. Checks the Subscription-Key header first; if not found,
-  checks the subscription key cookie (when configured); falls back to
-  application_id from request metadata (set by auth policy).
+  checks the subscription key cookie (when configured).
+  
   If the subscription plan has throttle limits, enforces rate limiting
   keyed by the subscription token.
 


### PR DESCRIPTION
## Purpose
Adding new subscription-validation policy version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Subscription validation updated: when a subscription key is absent, the system no longer falls back to application ID from request metadata and will check only the configured subscription-key cookie.

* **Chores**
  * Subscription-validation policy bumped to a newer version in build configuration to deliver the updated behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->