### PR TITLE
[DO NOT MERGE] fix(gateway): make route matching slash-agnostic for deployed APIs

### DIFF
--- a/gateway/gateway-controller/pkg/xds/route_sorter_test.go
+++ b/gateway/gateway-controller/pkg/xds/route_sorter_test.go
@@ -193,6 +193,42 @@ func TestSortRoutesByPriority_EmptyAndSingleRoute(t *testing.T) {
 	assert.Equal(t, "single", result[0].Name)
 }
 
+func TestSortRoutesByPriority_RegexOnlyRoutes(t *testing.T) {
+	// After the trailing slash fix, all non-wildcard routes are regex.
+	// Verify that regex routes sort correctly by pattern length (longer = higher priority).
+	shortRegex := &route.Route{
+		Name: "short-regex",
+		Match: &route.RouteMatch{
+			PathSpecifier: &route.RouteMatch_SafeRegex{
+				SafeRegex: &matcher.RegexMatcher{Regex: "^/api/?$"},
+			},
+		},
+	}
+	longRegex := &route.Route{
+		Name: "long-regex",
+		Match: &route.RouteMatch{
+			PathSpecifier: &route.RouteMatch_SafeRegex{
+				SafeRegex: &matcher.RegexMatcher{Regex: "^/api/users/profile/?$"},
+			},
+		},
+	}
+	paramRegex := &route.Route{
+		Name: "param-regex",
+		Match: &route.RouteMatch{
+			PathSpecifier: &route.RouteMatch_SafeRegex{
+				SafeRegex: &matcher.RegexMatcher{Regex: "^/api/users/[^/]+/?$"},
+			},
+		},
+	}
+
+	routes := []*route.Route{shortRegex, paramRegex, longRegex}
+	sorted := SortRoutesByPriority(routes)
+
+	assert.Equal(t, "long-regex", sorted[0].Name, "Longest regex should be first")
+	assert.Equal(t, "param-regex", sorted[1].Name, "Medium regex should be second")
+	assert.Equal(t, "short-regex", sorted[2].Name, "Shortest regex should be last")
+}
+
 func TestSortRoutesByPriority_ComplexScenario(t *testing.T) {
 	// A complex scenario mixing all criteria
 	catchAll := &route.Route{

--- a/gateway/gateway-controller/pkg/xds/translator.go
+++ b/gateway/gateway-controller/pkg/xds/translator.go
@@ -166,6 +166,17 @@ func ConstructFullPath(context, apiVersion, path string) string {
 	return contextWithVersion + path
 }
 
+// slashAgnosticRegex builds a regex that matches fullPath with or without a trailing slash.
+// It normalizes a trailing slash from the input (e.g. "/api/users/" becomes "/api/users")
+// and produces a pattern like "^/api/users/?$".
+func slashAgnosticRegex(fullPath string) string {
+	normalizedPath := strings.TrimSuffix(fullPath, "/")
+	if normalizedPath == "" {
+		normalizedPath = "/"
+	}
+	return "^" + regexp.QuoteMeta(normalizedPath) + "/?$"
+}
+
 // GetCertStore returns the certificate store instance
 func (t *Translator) GetCertStore() *certstore.CertStore {
 	return t.certStore
@@ -315,8 +326,11 @@ func (t *Translator) createRouteFromRDC(routeKey string, rdcRoute *models.Route,
 	if isWildcardPath || hasParams {
 		r.Match.PathSpecifier = pathSpecifier
 	} else {
-		r.Match.PathSpecifier = &route.RouteMatch_Path{
-			Path: fullPath,
+		// Use regex with optional trailing slash for slash-agnostic matching
+		r.Match.PathSpecifier = &route.RouteMatch_SafeRegex{
+			SafeRegex: &matcher.RegexMatcher{
+				Regex: slashAgnosticRegex(fullPath),
+			},
 		}
 	}
 
@@ -341,9 +355,9 @@ func (t *Translator) createRouteFromRDC(routeKey string, rdcRoute *models.Route,
 	escapedContext := regexp.QuoteMeta(contextWithVersion)
 	r.GetRoute().RegexRewrite = &matcher.RegexMatchAndSubstitute{
 		Pattern: &matcher.RegexMatcher{
-			Regex: "^" + escapedContext + "(.*)$",
+			Regex: "^" + escapedContext + "/?(.*)$",
 		},
-		Substitution: upstreamPath + "\\1",
+		Substitution: upstreamPath + "/\\1",
 	}
 
 	return r
@@ -1825,9 +1839,11 @@ func (t *Translator) createRoute(apiId, apiName, apiVersion, context, method, pa
 	if isWildcardPath || hasParams {
 		r.Match.PathSpecifier = pathSpecifier
 	} else {
-		// Use exact path matching for non-parameterized paths
-		r.Match.PathSpecifier = &route.RouteMatch_Path{
-			Path: fullPath,
+		// Use regex with optional trailing slash for slash-agnostic matching
+		r.Match.PathSpecifier = &route.RouteMatch_SafeRegex{
+			SafeRegex: &matcher.RegexMatcher{
+				Regex: slashAgnosticRegex(fullPath),
+			},
 		}
 	}
 
@@ -1857,9 +1873,9 @@ func (t *Translator) createRoute(apiId, apiName, apiVersion, context, method, pa
 	escapedContext := regexp.QuoteMeta(contextWithVersion)
 	r.GetRoute().RegexRewrite = &matcher.RegexMatchAndSubstitute{
 		Pattern: &matcher.RegexMatcher{
-			Regex: "^" + escapedContext + "(.*)$",
+			Regex: "^" + escapedContext + "/?(.*)$",
 		},
-		Substitution: upstreamPath + "\\1",
+		Substitution: upstreamPath + "/\\1",
 	}
 
 	return r
@@ -2636,8 +2652,8 @@ func (t *Translator) pathToRegex(path string) string {
 		}
 	}
 
-	// Anchor the regex to match the entire path
-	return "^" + regex + "$"
+	// Anchor the regex to match the entire path, with optional trailing slash
+	return "^" + regex + "/?$"
 }
 
 // sanitizeClusterName creates a valid cluster name from a hostname and scheme

--- a/gateway/gateway-controller/pkg/xds/translator_test.go
+++ b/gateway/gateway-controller/pkg/xds/translator_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"math"
 	"net/url"
+	"regexp"
 	"testing"
 	"time"
 
@@ -467,32 +468,32 @@ func TestTranslator_PathToRegex(t *testing.T) {
 		{
 			name:     "Simple path",
 			path:     "/api/users",
-			expected: "^/api/users$",
+			expected: "^/api/users/?$",
 		},
 		{
 			name:     "Path with parameter",
 			path:     "/api/users/{id}",
-			expected: "^/api/users/[^/]+$",
+			expected: "^/api/users/[^/]+/?$",
 		},
 		{
 			name:     "Path with multiple parameters",
 			path:     "/api/{resource}/{id}",
-			expected: "^/api/[^/]+/[^/]+$",
+			expected: "^/api/[^/]+/[^/]+/?$",
 		},
 		{
 			name:     "Path with dots (version)",
 			path:     "/api/v1.0/users",
-			expected: "^/api/v1\\.0/users$",
+			expected: "^/api/v1\\.0/users/?$",
 		},
 		{
 			name:     "Root path",
 			path:     "/",
-			expected: "^/$",
+			expected: "^//?$",
 		},
 		{
 			name:     "Path with special chars",
 			path:     "/api/data.json",
-			expected: "^/api/data\\.json$",
+			expected: "^/api/data\\.json/?$",
 		},
 	}
 
@@ -1402,6 +1403,381 @@ func TestTranslator_CreateRoute_Basic(t *testing.T) {
 	assert.NotNil(t, route)
 	assert.Contains(t, route.Name, "GET")
 	assert.Contains(t, route.Name, "/api/users")
+	// Verify regex matching with optional trailing slash
+	safeRegex := route.Match.GetSafeRegex()
+	assert.NotNil(t, safeRegex)
+	assert.Equal(t, "^/api/users/?$", safeRegex.GetRegex())
+}
+
+func TestTranslator_CreateRoute_TrailingSlash(t *testing.T) {
+	translator := createTestTranslator()
+
+	tests := []struct {
+		name          string
+		context       string
+		apiVersion    string
+		path          string
+		expectedRegex string
+	}{
+		{
+			name:          "Root operation path — primary bug scenario (context + / = trailing slash)",
+			context:       "/v1/users",
+			apiVersion:    "v1",
+			path:          "/",
+			expectedRegex: "^/v1/users/?$",
+		},
+		{
+			name:          "Standard path creates slash-agnostic route",
+			context:       "/api",
+			apiVersion:    "v1",
+			path:          "/users",
+			expectedRegex: "^/api/users/?$",
+		},
+		{
+			name:          "Root context with path",
+			context:       "/",
+			apiVersion:    "v1",
+			path:          "/status",
+			expectedRegex: "^/status/?$",
+		},
+		{
+			name:          "Path with special characters (dots)",
+			context:       "/api",
+			apiVersion:    "v1",
+			path:          "/data.json",
+			expectedRegex: "^/api/data\\.json/?$",
+		},
+		{
+			name:          "Version placeholder in context with root path",
+			context:       "/api/$version",
+			apiVersion:    "v1.0",
+			path:          "/",
+			expectedRegex: "^/api/v1\\.0/?$",
+		},
+		{
+			name:          "Version placeholder in context with operation path",
+			context:       "/test-api/$version",
+			apiVersion:    "v1.0",
+			path:          "/users",
+			expectedRegex: "^/test-api/v1\\.0/users/?$",
+		},
+		{
+			name:          "Deep nested context with root path",
+			context:       "/api/v1/internal",
+			apiVersion:    "v1",
+			path:          "/",
+			expectedRegex: "^/api/v1/internal/?$",
+		},
+		{
+			name:          "Multi-segment operation path",
+			context:       "/api",
+			apiVersion:    "v1",
+			path:          "/users/profile",
+			expectedRegex: "^/api/users/profile/?$",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := translator.createRoute(
+				"api-123", "test-api", tt.apiVersion, tt.context, "GET", tt.path,
+				"test-cluster", "", "localhost", "API", "", "", nil, "proj-001", nil, false, "", nil,
+			)
+			assert.NotNil(t, r)
+			safeRegex := r.Match.GetSafeRegex()
+			assert.NotNil(t, safeRegex, "expected SafeRegex match, got %T", r.Match.GetPathSpecifier())
+			assert.Equal(t, tt.expectedRegex, safeRegex.GetRegex())
+		})
+	}
+}
+
+func TestTranslator_CreateRoute_TrailingSlash_RegexActuallyMatches(t *testing.T) {
+	translator := createTestTranslator()
+
+	tests := []struct {
+		name       string
+		context    string
+		apiVersion string
+		opPath     string
+		matchPaths []string
+		noMatch    []string
+	}{
+		{
+			name:       "Root operation — matches with and without trailing slash",
+			context:    "/v1/users",
+			apiVersion: "v1",
+			opPath:     "/",
+			matchPaths: []string{"/v1/users", "/v1/users/"},
+			noMatch:    []string{"/v1/users/extra", "/v1/user", "/v1/users//"},
+		},
+		{
+			name:       "Standard path — matches with and without trailing slash",
+			context:    "/test-api/$version",
+			apiVersion: "v1.0",
+			opPath:     "/users",
+			matchPaths: []string{"/test-api/v1.0/users", "/test-api/v1.0/users/"},
+			noMatch:    []string{"/test-api/v1.0/users/123", "/test-api/v1.0/user"},
+		},
+		{
+			name:       "Root context with path",
+			context:    "/",
+			apiVersion: "v1",
+			opPath:     "/health",
+			matchPaths: []string{"/health", "/health/"},
+			noMatch:    []string{"/health/check", "/healthz"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := translator.createRoute(
+				"api-123", "test-api", tt.apiVersion, tt.context, "GET", tt.opPath,
+				"test-cluster", "", "localhost", "API", "", "", nil, "proj-001", nil, false, "", nil,
+			)
+			require.NotNil(t, r)
+			safeRegex := r.Match.GetSafeRegex()
+			require.NotNil(t, safeRegex)
+
+			re := regexp.MustCompile(safeRegex.GetRegex())
+			for _, path := range tt.matchPaths {
+				assert.True(t, re.MatchString(path), "regex %s should match %s", safeRegex.GetRegex(), path)
+			}
+			for _, path := range tt.noMatch {
+				assert.False(t, re.MatchString(path), "regex %s should NOT match %s", safeRegex.GetRegex(), path)
+			}
+		})
+	}
+}
+
+func TestTranslator_CreateRoute_ParameterizedTrailingSlash(t *testing.T) {
+	translator := createTestTranslator()
+
+	tests := []struct {
+		name          string
+		context       string
+		apiVersion    string
+		path          string
+		expectedRegex string
+		matchPaths    []string
+		noMatch       []string
+	}{
+		{
+			name:          "Single parameter",
+			context:       "/api",
+			apiVersion:    "v1",
+			path:          "/{id}",
+			expectedRegex: "^/api/[^/]+/?$",
+			matchPaths:    []string{"/api/123", "/api/123/", "/api/abc"},
+			noMatch:       []string{"/api/", "/api/123/extra", "/api"},
+		},
+		{
+			name:          "Multiple parameters",
+			context:       "/weather/$version",
+			apiVersion:    "v1.0",
+			path:          "/{country_code}/{city}",
+			expectedRegex: "^/weather/v1\\.0/[^/]+/[^/]+/?$",
+			matchPaths:    []string{"/weather/v1.0/us/seattle", "/weather/v1.0/us/seattle/"},
+			noMatch:       []string{"/weather/v1.0/us", "/weather/v1.0/us/seattle/extra"},
+		},
+		{
+			name:          "Parameter after static segment",
+			context:       "/v1/users",
+			apiVersion:    "v1",
+			path:          "/{id}",
+			expectedRegex: "^/v1/users/[^/]+/?$",
+			matchPaths:    []string{"/v1/users/123", "/v1/users/123/"},
+			noMatch:       []string{"/v1/users", "/v1/users/", "/v1/users/123/orders"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := translator.createRoute(
+				"api-123", "test-api", tt.apiVersion, tt.context, "GET", tt.path,
+				"test-cluster", "", "localhost", "API", "", "", nil, "proj-001", nil, false, "", nil,
+			)
+			require.NotNil(t, r)
+			safeRegex := r.Match.GetSafeRegex()
+			require.NotNil(t, safeRegex)
+			assert.Equal(t, tt.expectedRegex, safeRegex.GetRegex())
+
+			re := regexp.MustCompile(safeRegex.GetRegex())
+			for _, path := range tt.matchPaths {
+				assert.True(t, re.MatchString(path), "regex %s should match %s", safeRegex.GetRegex(), path)
+			}
+			for _, path := range tt.noMatch {
+				assert.False(t, re.MatchString(path), "regex %s should NOT match %s", safeRegex.GetRegex(), path)
+			}
+		})
+	}
+}
+
+func TestTranslator_CreateRouteFromRDC_TrailingSlash(t *testing.T) {
+	translator := createTestTranslator()
+
+	tests := []struct {
+		name          string
+		fullPath      string
+		opPath        string
+		expectedRegex string
+		matchPaths    []string
+		noMatch       []string
+	}{
+		{
+			name:          "Plain path gets slash-agnostic regex",
+			fullPath:      "/api/users",
+			opPath:        "/users",
+			expectedRegex: "^/api/users/?$",
+			matchPaths:    []string{"/api/users", "/api/users/"},
+			noMatch:       []string{"/api/users/123"},
+		},
+		{
+			name:          "Root operation path (context + /)",
+			fullPath:      "/v1/users/",
+			opPath:        "/",
+			expectedRegex: "^/v1/users/?$",
+			matchPaths:    []string{"/v1/users", "/v1/users/"},
+			noMatch:       []string{"/v1/users/extra"},
+		},
+		{
+			name:          "Parameterized path gets slash-agnostic regex",
+			fullPath:      "/api/users/{id}",
+			opPath:        "/users/{id}",
+			expectedRegex: "^/api/users/[^/]+/?$",
+			matchPaths:    []string{"/api/users/123", "/api/users/123/"},
+			noMatch:       []string{"/api/users", "/api/users/123/extra"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rdc := &models.RuntimeDeployConfig{
+				UpstreamClusters: map[string]*models.UpstreamCluster{
+					"test-cluster": {BasePath: "/backend"},
+				},
+			}
+			rdcRoute := &models.Route{
+				Method:        "GET",
+				Path:          tt.fullPath,
+				OperationPath: tt.opPath,
+				Upstream: models.RouteUpstream{
+					ClusterKey: "test-cluster",
+				},
+			}
+
+			r := translator.createRouteFromRDC("test-route", rdcRoute, rdc)
+			require.NotNil(t, r)
+			safeRegex := r.Match.GetSafeRegex()
+			require.NotNil(t, safeRegex, "expected SafeRegex match for path %s", tt.fullPath)
+			assert.Equal(t, tt.expectedRegex, safeRegex.GetRegex())
+
+			re := regexp.MustCompile(safeRegex.GetRegex())
+			for _, path := range tt.matchPaths {
+				assert.True(t, re.MatchString(path), "regex %s should match %s", safeRegex.GetRegex(), path)
+			}
+			for _, path := range tt.noMatch {
+				assert.False(t, re.MatchString(path), "regex %s should NOT match %s", safeRegex.GetRegex(), path)
+			}
+		})
+	}
+}
+
+func TestTranslator_CreateRoute_WildcardUnchanged(t *testing.T) {
+	translator := createTestTranslator()
+
+	r := translator.createRoute(
+		"api-123", "test-api", "v1", "/api", "GET", "/*",
+		"test-cluster", "", "localhost", "API", "", "", nil, "proj-001", nil, false, "", nil,
+	)
+	require.NotNil(t, r)
+	safeRegex := r.Match.GetSafeRegex()
+	require.NotNil(t, safeRegex)
+	// Wildcard routes use prefix matching, not the trailing slash pattern
+	assert.Contains(t, safeRegex.GetRegex(), "/.*$")
+	assert.NotContains(t, safeRegex.GetRegex(), "/?$")
+}
+
+func TestTranslator_CreateRoute_MixedOperations(t *testing.T) {
+	translator := createTestTranslator()
+
+	// Simulate an API with multiple operations mixing root and non-root paths
+	operations := []struct {
+		method string
+		path   string
+	}{
+		{"GET", "/"},
+		{"GET", "/{id}"},
+		{"POST", "/"},
+	}
+
+	context := "/v1/users"
+	for _, op := range operations {
+		r := translator.createRoute(
+			"api-123", "test-api", "v1", context, op.method, op.path,
+			"test-cluster", "", "localhost", "API", "", "", nil, "proj-001", nil, false, "", nil,
+		)
+		require.NotNil(t, r)
+		safeRegex := r.Match.GetSafeRegex()
+		require.NotNil(t, safeRegex, "expected SafeRegex for method=%s path=%s", op.method, op.path)
+		assert.Contains(t, safeRegex.GetRegex(), "/?$",
+			"all non-wildcard routes should have optional trailing slash for method=%s path=%s", op.method, op.path)
+	}
+}
+
+func TestTranslator_CreateRoute_RegexRewrite(t *testing.T) {
+	translator := createTestTranslator()
+
+	tests := []struct {
+		name                 string
+		context              string
+		apiVersion           string
+		path                 string
+		upstreamPath         string
+		expectedRewriteRegex string
+		expectedSubstitution string
+	}{
+		{
+			name:                 "Root operation rewrites to upstream root",
+			context:              "/v1/users",
+			apiVersion:           "v1",
+			path:                 "/",
+			upstreamPath:         "",
+			expectedRewriteRegex: "^/v1/users/?(.*)$",
+			expectedSubstitution: "/\\1",
+		},
+		{
+			name:                 "Standard path rewrites correctly",
+			context:              "/api",
+			apiVersion:           "v1",
+			path:                 "/users",
+			upstreamPath:         "/backend",
+			expectedRewriteRegex: "^/api/?(.*)$",
+			expectedSubstitution: "/backend/\\1",
+		},
+		{
+			name:                 "Version placeholder in context",
+			context:              "/weather/$version",
+			apiVersion:           "v1.0",
+			path:                 "/{country}/{city}",
+			upstreamPath:         "/api/v2",
+			expectedRewriteRegex: "^/weather/v1\\.0/?(.*)$",
+			expectedSubstitution: "/api/v2/\\1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := translator.createRoute(
+				"api-123", "test-api", tt.apiVersion, tt.context, "GET", tt.path,
+				"test-cluster", tt.upstreamPath, "localhost", "API", "", "", nil, "proj-001", nil, false, "", nil,
+			)
+			require.NotNil(t, r)
+			rewrite := r.GetRoute().GetRegexRewrite()
+			require.NotNil(t, rewrite)
+			assert.Equal(t, tt.expectedRewriteRegex, rewrite.GetPattern().GetRegex())
+			assert.Equal(t, tt.expectedSubstitution, rewrite.GetSubstitution())
+		})
+	}
 }
 
 func TestTranslator_ExtractTemplateHandle_ValidLLMProvider(t *testing.T) {

--- a/gateway/it/features/api_deploy.feature
+++ b/gateway/it/features/api_deploy.feature
@@ -62,6 +62,54 @@ Feature: API Deployment and Invocation
     And the response should be valid JSON
     And the JSON response field "status" should be "success"
 
+  Scenario: API routes match both with and without trailing slash
+    Given I authenticate using basic auth as "admin"
+    When I deploy this API configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1alpha1
+      kind: RestApi
+      metadata:
+        name: slash-test-api-v1.0
+      spec:
+        displayName: Slash-Test-API
+        version: v1.0
+        context: /slashtest/$version
+        upstream:
+          main:
+            url: http://sample-backend:9080/api/v2
+        operations:
+          - method: GET
+            path: /users
+          - method: GET
+            path: /
+      """
+    Then the response should be successful
+    And the response should be valid JSON
+    And the JSON response field "status" should be "success"
+    And I wait for 2 seconds
+
+    # Test /users without trailing slash
+    When I send a GET request to "http://localhost:8080/slashtest/v1.0/users"
+    Then the response should be successful
+
+    # Test /users with trailing slash
+    When I send a GET request to "http://localhost:8080/slashtest/v1.0/users/"
+    Then the response should be successful
+
+    # Test root path without trailing slash (context only)
+    When I send a GET request to "http://localhost:8080/slashtest/v1.0"
+    Then the response should be successful
+
+    # Test root path with trailing slash
+    When I send a GET request to "http://localhost:8080/slashtest/v1.0/"
+    Then the response should be successful
+
+    Given I authenticate using basic auth as "admin"
+    When I delete the API "slash-test-api-v1.0"
+    Then the response should be successful
+    And the response should be valid JSON
+    And the JSON response field "status" should be "success"
+
   Scenario: Deploy an HTTP API with labels and verify they are stored
     Given I authenticate using basic auth as "admin"
     When I deploy this API configuration:


### PR DESCRIPTION
## Summary

- Routes generated by the xDS translator now match both with and without a trailing slash, fixing the issue where `GET /v1/users` returned 404 while `GET /v1/users/` returned 200
- Converts exact-match routes to regex with optional trailing slash (`/?$`) via a new `slashAgnosticRegex()` helper
- Updates regex rewrite patterns to handle optional trailing slash during context stripping
- Applies consistently to both `createRoute` (standard APIs) and `createRouteFromRDC` (runtime deploy config) code paths

Fixes #1414

## Test plan

- [x] 22 new/expanded unit tests covering trailing slash scenarios (all pass)
- [x] New integration test scenario in `api_deploy.feature` verifying with/without trailing slash
- [x] Full `gateway-controller/pkg/xds` test suite passes with no regressions
- [x] Manual verification against live gateway stack — all 8 scenarios return HTTP 200
- [ ] CI gateway integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)