### PR TITLE
Fix deployed APIs requiring trailing slash to be accessible

### DIFF
--- a/gateway/gateway-controller/pkg/xds/route_sorter.go
+++ b/gateway/gateway-controller/pkg/xds/route_sorter.go
@@ -20,6 +20,7 @@ package xds
 
 import (
 	"sort"
+	"strings"
 
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 )
@@ -118,16 +119,29 @@ func getPathMatchType(match *route.RouteMatch) int {
 		return pathMatchTypeNone
 	}
 
-	switch match.GetPathSpecifier().(type) {
+	switch ps := match.GetPathSpecifier().(type) {
 	case *route.RouteMatch_Path:
 		return pathMatchTypeExact
 	case *route.RouteMatch_SafeRegex:
+		// Exact-like regex (no wildcard patterns) gets exact priority
+		if ps.SafeRegex != nil && isExactLikeRegex(ps.SafeRegex.GetRegex()) {
+			return pathMatchTypeExact
+		}
 		return pathMatchTypeRegex
 	case *route.RouteMatch_Prefix:
 		return pathMatchTypePrefix
 	default:
 		return pathMatchTypeNone
 	}
+}
+
+// isExactLikeRegex returns true if the regex pattern represents an exact path
+// (possibly with optional trailing slash) rather than a parameterized or wildcard path.
+// It detects character classes ([...]) and quantified wildcards (.*, .+) as non-exact patterns.
+func isExactLikeRegex(regex string) bool {
+	return !strings.ContainsAny(regex, "[]") &&
+		!strings.Contains(regex, ".*") &&
+		!strings.Contains(regex, ".+")
 }
 
 // pathMatchCount returns the length of the path pattern.
@@ -142,7 +156,12 @@ func pathMatchCount(match *route.RouteMatch) int {
 		return len(ps.Path)
 	case *route.RouteMatch_SafeRegex:
 		if ps.SafeRegex != nil {
-			return len(ps.SafeRegex.GetRegex())
+			// Strip regex anchoring to get effective path length
+			r := ps.SafeRegex.GetRegex()
+			r = strings.TrimPrefix(r, "^")
+			r = strings.TrimSuffix(r, "/?$")
+			r = strings.TrimSuffix(r, "$")
+			return len(r)
 		}
 		return 0
 	case *route.RouteMatch_Prefix:

--- a/gateway/gateway-controller/pkg/xds/route_sorter_test.go
+++ b/gateway/gateway-controller/pkg/xds/route_sorter_test.go
@@ -241,3 +241,51 @@ func TestSortRoutesByPriority_ComplexScenario(t *testing.T) {
 	assert.Equal(t, "api-prefix", sorted[2].Name, "Longer prefix should be third")
 	assert.Equal(t, "catch-all", sorted[3].Name, "Root catch-all should be last")
 }
+
+func TestSortRoutesByPriority_ExactLikeRegexVsParameterizedRegex(t *testing.T) {
+	// Exact-like regex (no wildcard patterns) should sort above parameterized regex
+	// at the same path depth, matching the priority of true exact matches
+	exactLikeRegex := &route.Route{
+		Name: "exact-like",
+		Match: &route.RouteMatch{
+			PathSpecifier: &route.RouteMatch_SafeRegex{
+				SafeRegex: &matcher.RegexMatcher{Regex: "^/api/v1/users/?$"},
+			},
+		},
+	}
+	paramRegex := &route.Route{
+		Name: "parameterized",
+		Match: &route.RouteMatch{
+			PathSpecifier: &route.RouteMatch_SafeRegex{
+				SafeRegex: &matcher.RegexMatcher{Regex: "^/api/v1/[^/]+/?$"},
+			},
+		},
+	}
+
+	routes := []*route.Route{paramRegex, exactLikeRegex}
+	sorted := SortRoutesByPriority(routes)
+
+	assert.Equal(t, "exact-like", sorted[0].Name, "Exact-like regex should be first")
+	assert.Equal(t, "parameterized", sorted[1].Name, "Parameterized regex should be second")
+}
+
+func TestIsExactLikeRegex(t *testing.T) {
+	tests := []struct {
+		name     string
+		regex    string
+		expected bool
+	}{
+		{"exact-like with trailing slash", "^/api/users/?$", true},
+		{"exact-like without trailing slash", "^/api/users$", true},
+		{"parameterized path", "^/api/users/[^/]+/?$", false},
+		{"wildcard path", "^/api/users/.*$", false},
+		{"one-or-more wildcard", "^/api/users/.+$", false},
+		{"root path", "^/$", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isExactLikeRegex(tt.regex))
+		})
+	}
+}

--- a/gateway/gateway-controller/pkg/xds/translator.go
+++ b/gateway/gateway-controller/pkg/xds/translator.go
@@ -315,8 +315,11 @@ func (t *Translator) createRouteFromRDC(routeKey string, rdcRoute *models.Route,
 	if isWildcardPath || hasParams {
 		r.Match.PathSpecifier = pathSpecifier
 	} else {
-		r.Match.PathSpecifier = &route.RouteMatch_Path{
-			Path: fullPath,
+		// Use regex matching with optional trailing slash for non-parameterized paths
+		r.Match.PathSpecifier = &route.RouteMatch_SafeRegex{
+			SafeRegex: &matcher.RegexMatcher{
+				Regex: "^" + regexp.QuoteMeta(fullPath) + "/?$",
+			},
 		}
 	}
 
@@ -1825,9 +1828,11 @@ func (t *Translator) createRoute(apiId, apiName, apiVersion, context, method, pa
 	if isWildcardPath || hasParams {
 		r.Match.PathSpecifier = pathSpecifier
 	} else {
-		// Use exact path matching for non-parameterized paths
-		r.Match.PathSpecifier = &route.RouteMatch_Path{
-			Path: fullPath,
+		// Use regex matching with optional trailing slash for non-parameterized paths
+		r.Match.PathSpecifier = &route.RouteMatch_SafeRegex{
+			SafeRegex: &matcher.RegexMatcher{
+				Regex: "^" + regexp.QuoteMeta(fullPath) + "/?$",
+			},
 		}
 	}
 
@@ -2636,8 +2641,12 @@ func (t *Translator) pathToRegex(path string) string {
 		}
 	}
 
-	// Anchor the regex to match the entire path
-	return "^" + regex + "$"
+	// Anchor the regex to match the entire path, with optional trailing slash
+	// Special-case root path to avoid matching "//"
+	if path == "/" {
+		return "^/$"
+	}
+	return "^" + regex + "/?$"
 }
 
 // sanitizeClusterName creates a valid cluster name from a hostname and scheme

--- a/gateway/gateway-controller/pkg/xds/translator_test.go
+++ b/gateway/gateway-controller/pkg/xds/translator_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"math"
 	"net/url"
+	"regexp"
 	"testing"
 	"time"
 
@@ -467,22 +468,22 @@ func TestTranslator_PathToRegex(t *testing.T) {
 		{
 			name:     "Simple path",
 			path:     "/api/users",
-			expected: "^/api/users$",
+			expected: "^/api/users/?$",
 		},
 		{
 			name:     "Path with parameter",
 			path:     "/api/users/{id}",
-			expected: "^/api/users/[^/]+$",
+			expected: "^/api/users/[^/]+/?$",
 		},
 		{
 			name:     "Path with multiple parameters",
 			path:     "/api/{resource}/{id}",
-			expected: "^/api/[^/]+/[^/]+$",
+			expected: "^/api/[^/]+/[^/]+/?$",
 		},
 		{
 			name:     "Path with dots (version)",
 			path:     "/api/v1.0/users",
-			expected: "^/api/v1\\.0/users$",
+			expected: "^/api/v1\\.0/users/?$",
 		},
 		{
 			name:     "Root path",
@@ -492,7 +493,7 @@ func TestTranslator_PathToRegex(t *testing.T) {
 		{
 			name:     "Path with special chars",
 			path:     "/api/data.json",
-			expected: "^/api/data\\.json$",
+			expected: "^/api/data\\.json/?$",
 		},
 	}
 
@@ -1886,4 +1887,281 @@ func TestTranslator_CreateDynamicFwdListenerForWebSubHub(t *testing.T) {
 		assert.Equal(t, "0.0.0.0", listener.GetAddress().GetSocketAddress().GetAddress())
 		assert.Equal(t, core.SocketAddress_TCP, listener.GetAddress().GetSocketAddress().GetProtocol())
 	})
+}
+
+// Tests for issue #1414: Trailing slash handling
+// Verifies that generated regex patterns match paths both with and without trailing slash
+
+func TestTrailingSlash_PathToRegex_MatchesBothForms(t *testing.T) {
+	translator := createTestTranslator()
+
+	tests := []struct {
+		name          string
+		path          string
+		shouldMatch   []string
+		shouldNotMatch []string
+	}{
+		{
+			name: "Simple path matches with and without trailing slash",
+			path: "/api/users",
+			shouldMatch: []string{
+				"/api/users",
+				"/api/users/",
+			},
+			shouldNotMatch: []string{
+				"/api/users/extra",
+				"/api/usersx",
+				"/api/user",
+				"/other/api/users",
+			},
+		},
+		{
+			name: "Parameterized path matches with and without trailing slash",
+			path: "/api/users/{id}",
+			shouldMatch: []string{
+				"/api/users/123",
+				"/api/users/123/",
+				"/api/users/abc",
+				"/api/users/abc/",
+			},
+			shouldNotMatch: []string{
+				"/api/users/",
+				"/api/users/123/extra",
+				"/api/users",
+			},
+		},
+		{
+			name: "Version path with dots matches with and without trailing slash",
+			path: "/api/v1.0/data",
+			shouldMatch: []string{
+				"/api/v1.0/data",
+				"/api/v1.0/data/",
+			},
+			shouldNotMatch: []string{
+				"/api/v1X0/data",
+				"/api/v1.0/data/extra",
+			},
+		},
+		{
+			name: "Root path only matches exact root",
+			path: "/",
+			shouldMatch: []string{
+				"/",
+			},
+			shouldNotMatch: []string{
+				"//",
+				"/anything",
+			},
+		},
+		{
+			name: "Multiple parameters match with and without trailing slash",
+			path: "/api/{resource}/{id}",
+			shouldMatch: []string{
+				"/api/users/123",
+				"/api/users/123/",
+				"/api/items/abc",
+				"/api/items/abc/",
+			},
+			shouldNotMatch: []string{
+				"/api/users",
+				"/api/users/",
+				"/api/users/123/extra",
+			},
+		},
+		{
+			name: "Nested path matches with and without trailing slash",
+			path: "/v1/organizations/{orgId}/users/{userId}",
+			shouldMatch: []string{
+				"/v1/organizations/org1/users/user1",
+				"/v1/organizations/org1/users/user1/",
+			},
+			shouldNotMatch: []string{
+				"/v1/organizations/org1/users",
+				"/v1/organizations/org1/users/user1/extra",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			regexPattern := translator.pathToRegex(tt.path)
+			re := regexp.MustCompile(regexPattern)
+
+			for _, path := range tt.shouldMatch {
+				assert.True(t, re.MatchString(path),
+					"Pattern %q should match %q", regexPattern, path)
+			}
+			for _, path := range tt.shouldNotMatch {
+				assert.False(t, re.MatchString(path),
+					"Pattern %q should NOT match %q", regexPattern, path)
+			}
+		})
+	}
+}
+
+func TestTrailingSlash_CreateRoute_ExactPath_UsesOptionalTrailingSlashRegex(t *testing.T) {
+	translator := createTestTranslator()
+
+	r := translator.createRoute(
+		"api-123",
+		"test-api",
+		"v1",
+		"/api",
+		"GET",
+		"/users",
+		"test-cluster",
+		"",
+		"localhost",
+		"API",
+		"",
+		"",
+		nil,
+		"proj-001",
+		nil,
+		false,
+		"",
+		nil,
+	)
+
+	require.NotNil(t, r)
+	require.NotNil(t, r.Match)
+
+	// Verify the path specifier is SafeRegex (not exact path)
+	safeRegex := r.Match.GetSafeRegex()
+	require.NotNil(t, safeRegex, "Exact paths should use SafeRegex for optional trailing slash")
+
+	regexPattern := safeRegex.GetRegex()
+	assert.Contains(t, regexPattern, "/?$",
+		"Regex should end with /?$ for optional trailing slash")
+
+	// Verify the regex matches both forms
+	re := regexp.MustCompile(regexPattern)
+	assert.True(t, re.MatchString("/api/users"), "Should match without trailing slash")
+	assert.True(t, re.MatchString("/api/users/"), "Should match with trailing slash")
+	assert.False(t, re.MatchString("/api/users/extra"), "Should not match with extra path segments")
+}
+
+func TestTrailingSlash_CreateRoute_ParameterizedPath_UsesOptionalTrailingSlashRegex(t *testing.T) {
+	translator := createTestTranslator()
+
+	r := translator.createRoute(
+		"api-123",
+		"test-api",
+		"v1",
+		"/api",
+		"GET",
+		"/users/{id}",
+		"test-cluster",
+		"",
+		"localhost",
+		"API",
+		"",
+		"",
+		nil,
+		"proj-001",
+		nil,
+		false,
+		"",
+		nil,
+	)
+
+	require.NotNil(t, r)
+	require.NotNil(t, r.Match)
+
+	safeRegex := r.Match.GetSafeRegex()
+	require.NotNil(t, safeRegex, "Parameterized paths should use SafeRegex")
+
+	regexPattern := safeRegex.GetRegex()
+	assert.Contains(t, regexPattern, "/?$",
+		"Regex should end with /?$ for optional trailing slash")
+
+	re := regexp.MustCompile(regexPattern)
+	assert.True(t, re.MatchString("/api/users/123"), "Should match without trailing slash")
+	assert.True(t, re.MatchString("/api/users/123/"), "Should match with trailing slash")
+	assert.False(t, re.MatchString("/api/users/"), "Should not match empty parameter")
+	assert.False(t, re.MatchString("/api/users/123/extra"), "Should not match with extra segments")
+}
+
+func TestTrailingSlash_CreateRoute_VersionContext_UsesOptionalTrailingSlashRegex(t *testing.T) {
+	translator := createTestTranslator()
+
+	r := translator.createRoute(
+		"api-123",
+		"test-api",
+		"v1.0",
+		"/weather/$version",
+		"GET",
+		"/data",
+		"test-cluster",
+		"/api/v2",
+		"localhost",
+		"API",
+		"",
+		"",
+		nil,
+		"proj-001",
+		nil,
+		false,
+		"",
+		nil,
+	)
+
+	require.NotNil(t, r)
+	safeRegex := r.Match.GetSafeRegex()
+	require.NotNil(t, safeRegex)
+
+	regexPattern := safeRegex.GetRegex()
+	re := regexp.MustCompile(regexPattern)
+
+	// After version substitution, context becomes /weather/v1.0, full path = /weather/v1.0/data
+	assert.True(t, re.MatchString("/weather/v1.0/data"), "Should match without trailing slash")
+	assert.True(t, re.MatchString("/weather/v1.0/data/"), "Should match with trailing slash")
+	assert.False(t, re.MatchString("/weather/v1.0/datax"), "Should not match modified path")
+}
+
+func TestTrailingSlash_CreateRoute_PreservesTrailingSlashInRewrite(t *testing.T) {
+	translator := createTestTranslator()
+
+	r := translator.createRoute(
+		"api-123",
+		"test-api",
+		"v1.0",
+		"/weather/$version",
+		"GET",
+		"/data",
+		"test-cluster",
+		"/api/v2",
+		"localhost",
+		"API",
+		"",
+		"",
+		nil,
+		"proj-001",
+		nil,
+		false,
+		"",
+		nil,
+	)
+
+	require.NotNil(t, r)
+
+	// Verify regex rewrite captures the trailing slash
+	rewrite := r.GetRoute().GetRegexRewrite()
+	require.NotNil(t, rewrite)
+
+	rewritePattern := regexp.MustCompile(rewrite.GetPattern().GetRegex())
+	substitution := rewrite.GetSubstitution()
+
+	// Without trailing slash: /weather/v1.0/data -> captures /data
+	matches := rewritePattern.FindStringSubmatch("/weather/v1.0/data")
+	require.Len(t, matches, 2, "Should have one capture group")
+	assert.Equal(t, "/data", matches[1])
+
+	// With trailing slash: /weather/v1.0/data/ -> captures /data/
+	matches = rewritePattern.FindStringSubmatch("/weather/v1.0/data/")
+	require.Len(t, matches, 2, "Should have one capture group")
+	assert.Equal(t, "/data/", matches[1])
+
+	// Verify the substitution pattern preserves the captured path
+	assert.Contains(t, substitution, "\\1", "Substitution should reference capture group")
 }

--- a/gateway/it/features/trailing-slash.feature
+++ b/gateway/it/features/trailing-slash.feature
@@ -1,0 +1,99 @@
+# --------------------------------------------------------------------
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# --------------------------------------------------------------------
+
+Feature: Trailing Slash Handling
+  As an API consumer
+  I want to invoke APIs with or without trailing slashes
+  So that the gateway accepts both URL forms and preserves them when forwarding
+
+  Background:
+    Given the gateway services are running
+
+  Scenario: Exact path accepts both with and without trailing slash
+    Given I authenticate using basic auth as "admin"
+    When I deploy this API configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1alpha1
+      kind: RestApi
+      metadata:
+        name: trailing-slash-exact-api
+      spec:
+        displayName: Trailing-Slash-Exact-API
+        version: v1.0
+        context: /tslash/$version
+        upstream:
+          main:
+            url: http://sample-backend:9080/api/v2
+        operations:
+          - method: GET
+            path: /data
+      """
+    Then the response should be successful
+    And I wait for 2 seconds
+
+    # Without trailing slash
+    When I send a GET request to "http://localhost:8080/tslash/v1.0/data"
+    Then the response should be successful
+    And the response body should contain "/api/v2/data"
+
+    # With trailing slash
+    When I send a GET request to "http://localhost:8080/tslash/v1.0/data/"
+    Then the response should be successful
+    And the response body should contain "/api/v2/data/"
+
+    # Cleanup
+    Given I authenticate using basic auth as "admin"
+    When I delete the API "trailing-slash-exact-api"
+    Then the response should be successful
+
+  Scenario: Parameterized path accepts both with and without trailing slash
+    Given I authenticate using basic auth as "admin"
+    When I deploy this API configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1alpha1
+      kind: RestApi
+      metadata:
+        name: trailing-slash-param-api
+      spec:
+        displayName: Trailing-Slash-Param-API
+        version: v1.0
+        context: /tslash-param/$version
+        upstream:
+          main:
+            url: http://sample-backend:9080/api/v2
+        operations:
+          - method: GET
+            path: /{id}
+      """
+    Then the response should be successful
+    And I wait for 2 seconds
+
+    # Without trailing slash
+    When I send a GET request to "http://localhost:8080/tslash-param/v1.0/123"
+    Then the response should be successful
+    And the response body should contain "/api/v2/123"
+
+    # With trailing slash - should succeed and preserve trailing slash
+    When I send a GET request to "http://localhost:8080/tslash-param/v1.0/123/"
+    Then the response should be successful
+    And the response body should contain "/api/v2/123/"
+
+    # Cleanup
+    Given I authenticate using basic auth as "admin"
+    When I delete the API "trailing-slash-param-api"
+    Then the response should be successful


### PR DESCRIPTION
## Summary
- APIs deployed via the platform gateway returned 404 when invoked without a trailing slash (e.g., `GET /v1/users` failed while `GET /v1/users/` worked)
- Changed Envoy route matching from exact path to `SafeRegex` with optional trailing slash pattern (`/?$`) for both exact and parameterized paths
- The trailing slash is preserved when forwarding to the backend, so backends that require it continue to work correctly

## Changes
- **`translator.go`** — `createRoute()`, `createRouteFromRDC()`: use `SafeRegex` with `^<path>/?$` instead of exact path match; `pathToRegex()`: append `/?$` to parameterized path regexes (special-case root `/`)
- **`route_sorter.go`** — `getPathMatchType()`: treat exact-like regex (no wildcards/char classes) as exact priority; add `isExactLikeRegex()` helper
- **`translator_test.go`** — unit tests for regex matching (with/without trailing slash), `createRoute` path specifier verification, rewrite preservation
- **`route_sorter_test.go`** — tests for `isExactLikeRegex` and route sorting with regex patterns
- **`trailing-slash.feature`** — BDD integration tests for exact and parameterized paths

Fixes #1414

## Test plan
- [x] Unit tests pass: `go test ./pkg/xds/ -v` (all pass)
- [x] New `TestTrailingSlash_*` tests verify regex matches both path forms
- [x] New `TestIsExactLikeRegex` tests verify route sorting priority
- [ ] Integration tests: `trailing-slash.feature` covers exact path, parameterized path, and trailing slash preservation to backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)