### PR TITLE
feat(policy-engine)!: add context.Context to policy phase interface methods

### DIFF
--- a/gateway/gateway-runtime/policy-engine/internal/executor/chain.go
+++ b/gateway/gateway-runtime/policy-engine/internal/executor/chain.go
@@ -58,9 +58,9 @@ type RequestHeaderExecutionResult struct {
 // ExecuteRequestHeaderPolicies invokes each RequestHeaderPolicy in the chain.
 // Policies that do not implement RequestHeaderPolicy are skipped silently.
 func (c *ChainExecutor) ExecuteRequestHeaderPolicies(
-	traceCtx context.Context,
+	ctx context.Context,
 	policyList []policy.Policy,
-	ctx *policy.RequestHeaderContext,
+	reqCtx *policy.RequestHeaderContext,
 	specs []policy.PolicySpec,
 	api, route string,
 	hasExecutionConditions bool,
@@ -75,7 +75,7 @@ func (c *ChainExecutor) ExecuteRequestHeaderPolicies(
 		spec := specs[i]
 		policyStartTime := time.Now()
 
-		_, span := c.tracer.Start(traceCtx, fmt.Sprintf(constants.SpanPolicyRequestFormat, spec.Name),
+		_, span := c.tracer.Start(ctx, fmt.Sprintf(constants.SpanPolicyRequestFormat, spec.Name),
 			trace.WithSpanKind(trace.SpanKindInternal))
 		if span.IsRecording() {
 			span.SetAttributes(
@@ -109,7 +109,7 @@ func (c *ChainExecutor) ExecuteRequestHeaderPolicies(
 		// Evaluate execution condition if present and if chain has any CEL conditions
 		if hasExecutionConditions && spec.ExecutionCondition != nil && *spec.ExecutionCondition != "" {
 			if c.celEvaluator != nil {
-				conditionMet, err := c.celEvaluator.EvaluateRequestHeaderCondition(*spec.ExecutionCondition, ctx)
+				conditionMet, err := c.celEvaluator.EvaluateRequestHeaderCondition(*spec.ExecutionCondition, reqCtx)
 				if err != nil {
 					if span.IsRecording() {
 						span.RecordError(err)
@@ -142,12 +142,12 @@ func (c *ChainExecutor) ExecuteRequestHeaderPolicies(
 			return nil, fmt.Errorf("failed to clone parameters for policy %s:%s: %w", spec.Name, spec.Version, err)
 		}
 
-		action := headerPol.OnRequestHeaders(ctx, params)
+		action := headerPol.OnRequestHeaders(ctx, reqCtx, params)
 		executionTime := time.Since(policyStartTime)
 
-		// Apply header mutations to ctx so subsequent policies and CEL conditions see the mutated state
+		// Apply header mutations to reqCtx so subsequent policies and CEL conditions see the mutated state
 		if mod, ok := action.(policy.UpstreamRequestHeaderModifications); ok {
-			internalHeaders := ctx.Headers.UnsafeInternalValues()
+			internalHeaders := reqCtx.Headers.UnsafeInternalValues()
 			for k, v := range mod.HeadersToSet {
 				internalHeaders[strings.ToLower(k)] = []string{v}
 			}
@@ -155,10 +155,10 @@ func (c *ChainExecutor) ExecuteRequestHeaderPolicies(
 				delete(internalHeaders, strings.ToLower(k))
 			}
 			if mod.Path != nil {
-				ctx.Path = *mod.Path
+				reqCtx.Path = *mod.Path
 			}
 			if mod.Method != nil {
-				ctx.Method = *mod.Method
+				reqCtx.Method = *mod.Method
 			}
 		}
 
@@ -216,7 +216,7 @@ type RequestExecutionResult struct {
 
 // ExecuteRequestPolicies executes request policies with condition evaluation
 // hasExecutionConditions indicates if any policy in the chain has CEL conditions; when false, CEL evaluation is skipped entirely
-func (c *ChainExecutor) ExecuteRequestPolicies(traceCtx context.Context, policyList []policy.Policy, ctx *policy.RequestContext, specs []policy.PolicySpec, api, route string, hasExecutionConditions bool) (*RequestExecutionResult, error) {
+func (c *ChainExecutor) ExecuteRequestPolicies(ctx context.Context, policyList []policy.Policy, reqCtx *policy.RequestContext, specs []policy.PolicySpec, api, route string, hasExecutionConditions bool) (*RequestExecutionResult, error) {
 	startTime := time.Now()
 	result := &RequestExecutionResult{
 		Results:        make([]RequestPolicyResult, 0, len(policyList)),
@@ -229,7 +229,7 @@ func (c *ChainExecutor) ExecuteRequestPolicies(traceCtx context.Context, policyL
 		policyStartTime := time.Now()
 
 		// Create span for individual policy execution - NoOp if tracing disabled
-		_, span := c.tracer.Start(traceCtx, fmt.Sprintf(constants.SpanPolicyRequestFormat, spec.Name),
+		_, span := c.tracer.Start(ctx, fmt.Sprintf(constants.SpanPolicyRequestFormat, spec.Name),
 			trace.WithSpanKind(trace.SpanKindInternal))
 
 		// Add policy metadata attributes
@@ -274,7 +274,7 @@ func (c *ChainExecutor) ExecuteRequestPolicies(traceCtx context.Context, policyL
 		// Skip this block entirely when no policies in the chain have CEL conditions
 		if hasExecutionConditions && spec.ExecutionCondition != nil && *spec.ExecutionCondition != "" {
 			if c.celEvaluator != nil {
-				conditionMet, err := c.celEvaluator.EvaluateRequestBodyCondition(*spec.ExecutionCondition, ctx)
+				conditionMet, err := c.celEvaluator.EvaluateRequestBodyCondition(*spec.ExecutionCondition, reqCtx)
 				if err != nil {
 					if span.IsRecording() {
 						span.RecordError(err)
@@ -311,7 +311,7 @@ func (c *ChainExecutor) ExecuteRequestPolicies(traceCtx context.Context, policyL
 		}
 
 		slog.Debug("[body] calling OnRequestBody", "policy", spec.Name, "version", spec.Version, "route", route)
-		action := rp.OnRequestBody(ctx, params)
+		action := rp.OnRequestBody(ctx, reqCtx, params)
 		executionTime := time.Since(policyStartTime)
 
 		// Record policy execution metrics
@@ -349,7 +349,7 @@ func (c *ChainExecutor) ExecuteRequestPolicies(traceCtx context.Context, policyL
 
 			// Apply modifications to context
 			if mods, ok := action.(policy.UpstreamRequestModifications); ok {
-				applyRequestModifications(ctx, &mods)
+				applyRequestModifications(reqCtx, &mods)
 			}
 		}
 
@@ -382,9 +382,9 @@ type ResponseHeaderExecutionResult struct {
 // ExecuteResponseHeaderPolicies invokes each ResponseHeaderPolicy in the chain (reverse order).
 // Policies that do not implement ResponseHeaderPolicy are skipped silently.
 func (c *ChainExecutor) ExecuteResponseHeaderPolicies(
-	traceCtx context.Context,
+	ctx context.Context,
 	policyList []policy.Policy,
-	ctx *policy.ResponseHeaderContext,
+	respCtx *policy.ResponseHeaderContext,
 	specs []policy.PolicySpec,
 	api, route string,
 	hasExecutionConditions bool,
@@ -399,7 +399,7 @@ func (c *ChainExecutor) ExecuteResponseHeaderPolicies(
 		spec := specs[i]
 		policyStartTime := time.Now()
 
-		_, span := c.tracer.Start(traceCtx, fmt.Sprintf(constants.SpanPolicyResponseFormat, spec.Name),
+		_, span := c.tracer.Start(ctx, fmt.Sprintf(constants.SpanPolicyResponseFormat, spec.Name),
 			trace.WithSpanKind(trace.SpanKindInternal))
 		if span.IsRecording() {
 			span.SetAttributes(
@@ -430,7 +430,7 @@ func (c *ChainExecutor) ExecuteResponseHeaderPolicies(
 
 		if hasExecutionConditions && spec.ExecutionCondition != nil && *spec.ExecutionCondition != "" {
 			if c.celEvaluator != nil {
-				conditionMet, err := c.celEvaluator.EvaluateResponseHeaderCondition(*spec.ExecutionCondition, ctx)
+				conditionMet, err := c.celEvaluator.EvaluateResponseHeaderCondition(*spec.ExecutionCondition, respCtx)
 				if err != nil {
 					span.End()
 					return nil, fmt.Errorf("condition evaluation failed for policy %s:%s: %w", spec.Name, spec.Version, err)
@@ -459,12 +459,12 @@ func (c *ChainExecutor) ExecuteResponseHeaderPolicies(
 			return nil, fmt.Errorf("failed to clone parameters for policy %s:%s: %w", spec.Name, spec.Version, err)
 		}
 
-		action := headerPol.OnResponseHeaders(ctx, params)
+		action := headerPol.OnResponseHeaders(ctx, respCtx, params)
 		executionTime := time.Since(policyStartTime)
 
-		// Apply header mutations to ctx so subsequent policies and CEL conditions see the mutated state
+		// Apply header mutations to respCtx so subsequent policies and CEL conditions see the mutated state
 		if mod, ok := action.(policy.DownstreamResponseHeaderModifications); ok {
-			internalHeaders := ctx.ResponseHeaders.UnsafeInternalValues()
+			internalHeaders := respCtx.ResponseHeaders.UnsafeInternalValues()
 			for k, v := range mod.HeadersToSet {
 				internalHeaders[strings.ToLower(k)] = []string{v}
 			}
@@ -528,7 +528,7 @@ type ResponseExecutionResult struct {
 
 // ExecuteResponsePolicies executes response policies with condition evaluation
 // hasExecutionConditions indicates if any policy in the chain has CEL conditions; when false, CEL evaluation is skipped entirely
-func (c *ChainExecutor) ExecuteResponsePolicies(traceCtx context.Context, policyList []policy.Policy, ctx *policy.ResponseContext, specs []policy.PolicySpec, api, route string, hasExecutionConditions bool) (*ResponseExecutionResult, error) {
+func (c *ChainExecutor) ExecuteResponsePolicies(ctx context.Context, policyList []policy.Policy, respCtx *policy.ResponseContext, specs []policy.PolicySpec, api, route string, hasExecutionConditions bool) (*ResponseExecutionResult, error) {
 	startTime := time.Now()
 	result := &ResponseExecutionResult{
 		Results: make([]ResponsePolicyResult, 0, len(policyList)),
@@ -542,7 +542,7 @@ func (c *ChainExecutor) ExecuteResponsePolicies(traceCtx context.Context, policy
 		policyStartTime := time.Now()
 
 		// Create span for individual policy execution - NoOp if tracing disabled
-		_, span := c.tracer.Start(traceCtx, fmt.Sprintf(constants.SpanPolicyResponseFormat, spec.Name),
+		_, span := c.tracer.Start(ctx, fmt.Sprintf(constants.SpanPolicyResponseFormat, spec.Name),
 			trace.WithSpanKind(trace.SpanKindInternal))
 
 		// Add policy metadata attributes
@@ -587,7 +587,7 @@ func (c *ChainExecutor) ExecuteResponsePolicies(traceCtx context.Context, policy
 		// Skip this block entirely when no policies in the chain have CEL conditions
 		if hasExecutionConditions && spec.ExecutionCondition != nil && *spec.ExecutionCondition != "" {
 			if c.celEvaluator != nil {
-				conditionMet, err := c.celEvaluator.EvaluateResponseBodyCondition(*spec.ExecutionCondition, ctx)
+				conditionMet, err := c.celEvaluator.EvaluateResponseBodyCondition(*spec.ExecutionCondition, respCtx)
 				if err != nil {
 					if span.IsRecording() {
 						span.RecordError(err)
@@ -624,7 +624,7 @@ func (c *ChainExecutor) ExecuteResponsePolicies(traceCtx context.Context, policy
 		}
 
 		slog.Debug("[body] calling OnResponseBody", "policy", spec.Name, "version", spec.Version, "route", route)
-		action := rp.OnResponseBody(ctx, params)
+		action := rp.OnResponseBody(ctx, respCtx, params)
 		executionTime := time.Since(policyStartTime)
 
 		// Record policy execution metrics
@@ -661,7 +661,7 @@ func (c *ChainExecutor) ExecuteResponsePolicies(traceCtx context.Context, policy
 			}
 
 			if mods, ok := action.(policy.DownstreamResponseModifications); ok {
-				applyResponseModifications(ctx, &mods)
+				applyResponseModifications(respCtx, &mods)
 			}
 		}
 
@@ -695,9 +695,9 @@ type StreamingRequestExecutionResult struct {
 // Policies are executed in forward order (first to last). Each policy sees the
 // (possibly mutated) chunk from the previous policy.
 func (c *ChainExecutor) ExecuteStreamingRequestPolicies(
-	traceCtx context.Context,
+	ctx context.Context,
 	policyList []policy.Policy,
-	ctx *policy.RequestStreamContext,
+	reqCtx *policy.RequestStreamContext,
 	chunk *policy.StreamBody,
 	specs []policy.PolicySpec,
 	api, route string,
@@ -715,7 +715,7 @@ func (c *ChainExecutor) ExecuteStreamingRequestPolicies(
 		spec := specs[i]
 		policyStartTime := time.Now()
 
-		_, span := c.tracer.Start(traceCtx, fmt.Sprintf(constants.SpanPolicyRequestFormat, spec.Name),
+		_, span := c.tracer.Start(ctx, fmt.Sprintf(constants.SpanPolicyRequestFormat, spec.Name),
 			trace.WithSpanKind(trace.SpanKindInternal))
 		if span.IsRecording() {
 			span.SetAttributes(
@@ -749,7 +749,7 @@ func (c *ChainExecutor) ExecuteStreamingRequestPolicies(
 
 		if hasExecutionConditions && spec.ExecutionCondition != nil && *spec.ExecutionCondition != "" {
 			if c.celEvaluator != nil {
-				conditionMet, err := c.celEvaluator.EvaluateStreamingRequestCondition(*spec.ExecutionCondition, ctx)
+				conditionMet, err := c.celEvaluator.EvaluateStreamingRequestCondition(*spec.ExecutionCondition, reqCtx)
 				if err != nil {
 					if span.IsRecording() {
 						span.RecordError(err)
@@ -781,7 +781,7 @@ func (c *ChainExecutor) ExecuteStreamingRequestPolicies(
 		}
 
 		slog.Debug("[streaming] calling OnRequestBodyChunk", "policy", spec.Name, "version", spec.Version, "route", route, "end_of_stream", currentChunk.EndOfStream)
-		action := streamingPol.OnRequestBodyChunk(ctx, currentChunk, params)
+		action := streamingPol.OnRequestBodyChunk(ctx, reqCtx, currentChunk, params)
 		executionTime := time.Since(policyStartTime)
 
 		metrics.PolicyExecutionsTotal.WithLabelValues(spec.Name, spec.Version, api, route, "executed").Inc()
@@ -837,9 +837,9 @@ type StreamingResponseExecutionResult struct {
 // ExecuteStreamingResponsePolicies executes streaming response policies chunk-by-chunk.
 // Policies are executed in reverse order (last to first), mirroring the buffered response path.
 func (c *ChainExecutor) ExecuteStreamingResponsePolicies(
-	traceCtx context.Context,
+	ctx context.Context,
 	policyList []policy.Policy,
-	ctx *policy.ResponseStreamContext,
+	respCtx *policy.ResponseStreamContext,
 	chunk *policy.StreamBody,
 	specs []policy.PolicySpec,
 	api, route string,
@@ -857,7 +857,7 @@ func (c *ChainExecutor) ExecuteStreamingResponsePolicies(
 		spec := specs[i]
 		policyStartTime := time.Now()
 
-		_, span := c.tracer.Start(traceCtx, fmt.Sprintf(constants.SpanPolicyResponseFormat, spec.Name),
+		_, span := c.tracer.Start(ctx, fmt.Sprintf(constants.SpanPolicyResponseFormat, spec.Name),
 			trace.WithSpanKind(trace.SpanKindInternal))
 		if span.IsRecording() {
 			span.SetAttributes(
@@ -894,7 +894,7 @@ func (c *ChainExecutor) ExecuteStreamingResponsePolicies(
 
 		if hasExecutionConditions && spec.ExecutionCondition != nil && *spec.ExecutionCondition != "" {
 			if c.celEvaluator != nil {
-				conditionMet, err := c.celEvaluator.EvaluateStreamingResponseCondition(*spec.ExecutionCondition, ctx)
+				conditionMet, err := c.celEvaluator.EvaluateStreamingResponseCondition(*spec.ExecutionCondition, respCtx)
 				if err != nil {
 					if span.IsRecording() {
 						span.RecordError(err)
@@ -928,7 +928,7 @@ func (c *ChainExecutor) ExecuteStreamingResponsePolicies(
 		}
 
 		slog.Debug("[streaming] calling OnResponseBodyChunk", "policy", spec.Name, "version", spec.Version, "route", route, "end_of_stream", currentChunk.EndOfStream)
-		action := streamingPol.OnResponseBodyChunk(ctx, currentChunk, params)
+		action := streamingPol.OnResponseBodyChunk(ctx, respCtx, currentChunk, params)
 		executionTime := time.Since(policyStartTime)
 
 		metrics.PolicyExecutionsTotal.WithLabelValues(spec.Name, spec.Version, api, route, "executed").Inc()

--- a/gateway/gateway-runtime/policy-engine/internal/executor/chain_bench_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/executor/chain_bench_test.go
@@ -114,11 +114,11 @@ func (p *passthroughPolicy) Mode() policy.ProcessingMode {
 	}
 }
 
-func (p *passthroughPolicy) OnRequestBody(*policy.RequestContext, map[string]interface{}) policy.RequestAction {
+func (p *passthroughPolicy) OnRequestBody(_ context.Context, _ *policy.RequestContext, _ map[string]interface{}) policy.RequestAction {
 	return nil
 }
 
-func (p *passthroughPolicy) OnResponseBody(*policy.ResponseContext, map[string]interface{}) policy.ResponseAction {
+func (p *passthroughPolicy) OnResponseBody(_ context.Context, _ *policy.ResponseContext, _ map[string]interface{}) policy.ResponseAction {
 	return nil
 }
 
@@ -134,13 +134,13 @@ func (p *headerModifyPolicy) Mode() policy.ProcessingMode {
 	}
 }
 
-func (p *headerModifyPolicy) OnRequestBody(*policy.RequestContext, map[string]interface{}) policy.RequestAction {
+func (p *headerModifyPolicy) OnRequestBody(_ context.Context, _ *policy.RequestContext, _ map[string]interface{}) policy.RequestAction {
 	return policy.UpstreamRequestModifications{
 		HeadersToSet: map[string]string{"x-bench-header": "bench-value"},
 	}
 }
 
-func (p *headerModifyPolicy) OnResponseBody(*policy.ResponseContext, map[string]interface{}) policy.ResponseAction {
+func (p *headerModifyPolicy) OnResponseBody(_ context.Context, _ *policy.ResponseContext, _ map[string]interface{}) policy.ResponseAction {
 	return policy.DownstreamResponseModifications{
 		HeadersToSet: map[string]string{"x-bench-resp": "bench-resp-value"},
 	}
@@ -158,7 +158,7 @@ func (p *shortCircuitPolicy) Mode() policy.ProcessingMode {
 	}
 }
 
-func (p *shortCircuitPolicy) OnRequestBody(*policy.RequestContext, map[string]interface{}) policy.RequestAction {
+func (p *shortCircuitPolicy) OnRequestBody(_ context.Context, _ *policy.RequestContext, _ map[string]interface{}) policy.RequestAction {
 	return policy.ImmediateResponse{
 		StatusCode: 401,
 		Headers:    map[string]string{"content-type": "application/json"},
@@ -166,7 +166,7 @@ func (p *shortCircuitPolicy) OnRequestBody(*policy.RequestContext, map[string]in
 	}
 }
 
-func (p *shortCircuitPolicy) OnResponseBody(*policy.ResponseContext, map[string]interface{}) policy.ResponseAction {
+func (p *shortCircuitPolicy) OnResponseBody(_ context.Context, _ *policy.ResponseContext, _ map[string]interface{}) policy.ResponseAction {
 	return nil
 }
 

--- a/gateway/gateway-runtime/policy-engine/internal/executor/chain_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/executor/chain_test.go
@@ -446,12 +446,12 @@ func (p *trackingPolicyImpl) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{}
 }
 
-func (p *trackingPolicyImpl) OnRequestBody(*policy.RequestContext, map[string]interface{}) policy.RequestAction {
+func (p *trackingPolicyImpl) OnRequestBody(_ context.Context, _ *policy.RequestContext, _ map[string]interface{}) policy.RequestAction {
 	*p.executionOrder = append(*p.executionOrder, p.name)
 	return nil
 }
 
-func (p *trackingPolicyImpl) OnResponseBody(*policy.ResponseContext, map[string]interface{}) policy.ResponseAction {
+func (p *trackingPolicyImpl) OnResponseBody(_ context.Context, _ *policy.ResponseContext, _ map[string]interface{}) policy.ResponseAction {
 	*p.executionOrder = append(*p.executionOrder, p.name)
 	return nil
 }

--- a/gateway/gateway-runtime/policy-engine/internal/kernel/extproc_bench_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/extproc_bench_test.go
@@ -116,11 +116,11 @@ func (p *passthroughPolicy) Mode() policy.ProcessingMode {
 	}
 }
 
-func (p *passthroughPolicy) OnRequestBody(*policy.RequestContext, map[string]interface{}) policy.RequestAction {
+func (p *passthroughPolicy) OnRequestBody(_ context.Context, _ *policy.RequestContext, _ map[string]interface{}) policy.RequestAction {
 	return nil // passthrough - no modifications
 }
 
-func (p *passthroughPolicy) OnResponseBody(*policy.ResponseContext, map[string]interface{}) policy.ResponseAction {
+func (p *passthroughPolicy) OnResponseBody(_ context.Context, _ *policy.ResponseContext, _ map[string]interface{}) policy.ResponseAction {
 	return nil // passthrough - no modifications
 }
 
@@ -136,13 +136,13 @@ func (p *headerModifyPolicy) Mode() policy.ProcessingMode {
 	}
 }
 
-func (p *headerModifyPolicy) OnRequestBody(*policy.RequestContext, map[string]interface{}) policy.RequestAction {
+func (p *headerModifyPolicy) OnRequestBody(_ context.Context, _ *policy.RequestContext, _ map[string]interface{}) policy.RequestAction {
 	return policy.UpstreamRequestModifications{
 		HeadersToSet: map[string]string{"x-bench-header": "bench-value"},
 	}
 }
 
-func (p *headerModifyPolicy) OnResponseBody(*policy.ResponseContext, map[string]interface{}) policy.ResponseAction {
+func (p *headerModifyPolicy) OnResponseBody(_ context.Context, _ *policy.ResponseContext, _ map[string]interface{}) policy.ResponseAction {
 	return policy.DownstreamResponseModifications{
 		HeadersToSet: map[string]string{"x-bench-resp": "bench-resp-value"},
 	}
@@ -160,7 +160,7 @@ func (p *shortCircuitPolicy) Mode() policy.ProcessingMode {
 	}
 }
 
-func (p *shortCircuitPolicy) OnRequestBody(*policy.RequestContext, map[string]interface{}) policy.RequestAction {
+func (p *shortCircuitPolicy) OnRequestBody(_ context.Context, _ *policy.RequestContext, _ map[string]interface{}) policy.RequestAction {
 	return policy.ImmediateResponse{
 		StatusCode: 401,
 		Headers:    map[string]string{"content-type": "application/json"},
@@ -168,7 +168,7 @@ func (p *shortCircuitPolicy) OnRequestBody(*policy.RequestContext, map[string]in
 	}
 }
 
-func (p *shortCircuitPolicy) OnResponseBody(*policy.ResponseContext, map[string]interface{}) policy.ResponseAction {
+func (p *shortCircuitPolicy) OnResponseBody(_ context.Context, _ *policy.ResponseContext, _ map[string]interface{}) policy.ResponseAction {
 	return nil
 }
 

--- a/gateway/gateway-runtime/policy-engine/internal/testutils/policies.go
+++ b/gateway/gateway-runtime/policy-engine/internal/testutils/policies.go
@@ -19,6 +19,8 @@
 package testutils
 
 import (
+	"context"
+
 	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 )
 
@@ -32,11 +34,11 @@ func (p *NoopPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{}
 }
 
-func (p *NoopPolicy) OnRequestBody(*policy.RequestContext, map[string]interface{}) policy.RequestAction {
+func (p *NoopPolicy) OnRequestBody(_ context.Context, _ *policy.RequestContext, _ map[string]interface{}) policy.RequestAction {
 	return nil
 }
 
-func (p *NoopPolicy) OnResponseBody(*policy.ResponseContext, map[string]interface{}) policy.ResponseAction {
+func (p *NoopPolicy) OnResponseBody(_ context.Context, _ *policy.ResponseContext, _ map[string]interface{}) policy.ResponseAction {
 	return nil
 }
 
@@ -56,13 +58,13 @@ func (p *HeaderModifyingPolicy) Mode() policy.ProcessingMode {
 	}
 }
 
-func (p *HeaderModifyingPolicy) OnRequestBody(*policy.RequestContext, map[string]interface{}) policy.RequestAction {
+func (p *HeaderModifyingPolicy) OnRequestBody(_ context.Context, _ *policy.RequestContext, _ map[string]interface{}) policy.RequestAction {
 	return policy.UpstreamRequestModifications{
 		HeadersToSet: map[string]string{p.Key: p.Value},
 	}
 }
 
-func (p *HeaderModifyingPolicy) OnResponseBody(*policy.ResponseContext, map[string]interface{}) policy.ResponseAction {
+func (p *HeaderModifyingPolicy) OnResponseBody(_ context.Context, _ *policy.ResponseContext, _ map[string]interface{}) policy.ResponseAction {
 	return policy.DownstreamResponseModifications{
 		HeadersToSet: map[string]string{p.Key: p.Value},
 	}
@@ -83,14 +85,14 @@ func (p *ShortCircuitingPolicy) Mode() policy.ProcessingMode {
 	}
 }
 
-func (p *ShortCircuitingPolicy) OnRequestBody(*policy.RequestContext, map[string]interface{}) policy.RequestAction {
+func (p *ShortCircuitingPolicy) OnRequestBody(_ context.Context, _ *policy.RequestContext, _ map[string]interface{}) policy.RequestAction {
 	return policy.ImmediateResponse{
 		StatusCode: p.StatusCode,
 		Body:       p.Body,
 	}
 }
 
-func (p *ShortCircuitingPolicy) OnResponseBody(*policy.ResponseContext, map[string]interface{}) policy.ResponseAction {
+func (p *ShortCircuitingPolicy) OnResponseBody(_ context.Context, _ *policy.ResponseContext, _ map[string]interface{}) policy.ResponseAction {
 	return nil
 }
 
@@ -110,14 +112,14 @@ func (p *ConfigurableMockPolicy) Mode() policy.ProcessingMode {
 	return p.MockMode
 }
 
-func (p *ConfigurableMockPolicy) OnRequestBody(ctx *policy.RequestContext, params map[string]interface{}) policy.RequestAction {
+func (p *ConfigurableMockPolicy) OnRequestBody(_ context.Context, ctx *policy.RequestContext, params map[string]interface{}) policy.RequestAction {
 	if p.OnReqFn != nil {
 		return p.OnReqFn(ctx, params)
 	}
 	return nil
 }
 
-func (p *ConfigurableMockPolicy) OnResponseBody(ctx *policy.ResponseContext, params map[string]interface{}) policy.ResponseAction {
+func (p *ConfigurableMockPolicy) OnResponseBody(_ context.Context, ctx *policy.ResponseContext, params map[string]interface{}) policy.ResponseAction {
 	if p.OnRespFn != nil {
 		return p.OnRespFn(ctx, params)
 	}
@@ -137,11 +139,11 @@ func (p *SimpleMockPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{}
 }
 
-func (p *SimpleMockPolicy) OnRequestBody(*policy.RequestContext, map[string]interface{}) policy.RequestAction {
+func (p *SimpleMockPolicy) OnRequestBody(_ context.Context, _ *policy.RequestContext, _ map[string]interface{}) policy.RequestAction {
 	return nil
 }
 
-func (p *SimpleMockPolicy) OnResponseBody(*policy.ResponseContext, map[string]interface{}) policy.ResponseAction {
+func (p *SimpleMockPolicy) OnResponseBody(_ context.Context, _ *policy.ResponseContext, _ map[string]interface{}) policy.ResponseAction {
 	return nil
 }
 

--- a/gateway/sample-policies/count-letters/countletters.go
+++ b/gateway/sample-policies/count-letters/countletters.go
@@ -1,6 +1,7 @@
 package countletters
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -33,7 +34,7 @@ func (p *CountLettersPolicy) Mode() policy.ProcessingMode {
 }
 
 // OnResponseBody counts letters in the response body and replaces it with the count
-func (p *CountLettersPolicy) OnResponseBody(ctx *policy.ResponseContext, params map[string]interface{}) policy.ResponseAction {
+func (p *CountLettersPolicy) OnResponseBody(_ context.Context, ctx *policy.ResponseContext, params map[string]interface{}) policy.ResponseAction {
 	slog.Debug("[Count Letters]: OnResponseBody called", "hasBody", ctx.ResponseBody != nil && ctx.ResponseBody.Present)
 
 	// Check if response body is present

--- a/gateway/sample-policies/uppercase-body/uppercasebody.go
+++ b/gateway/sample-policies/uppercase-body/uppercasebody.go
@@ -1,6 +1,7 @@
 package uppercasebody
 
 import (
+	"context"
 	"log/slog"
 	"strings"
 
@@ -31,7 +32,7 @@ func (p *UppercaseBodyPolicy) Mode() policy.ProcessingMode {
 }
 
 // OnRequestBody transforms the request body to uppercase
-func (p *UppercaseBodyPolicy) OnRequestBody(ctx *policy.RequestContext, params map[string]interface{}) policy.RequestAction {
+func (p *UppercaseBodyPolicy) OnRequestBody(_ context.Context, ctx *policy.RequestContext, params map[string]interface{}) policy.RequestAction {
 	slog.Debug("[Uppercase Body]: OnRequestBody called", "hasBody", ctx.Body != nil && ctx.Body.Present)
 
 	// Check if body is present

--- a/gateway/system-policies/analytics/analytics.go
+++ b/gateway/system-policies/analytics/analytics.go
@@ -2,6 +2,7 @@ package analytics
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -132,7 +133,7 @@ func (a *AnalyticsPolicy) Mode() policy.ProcessingMode {
 }
 
 // OnRequestBody performs Analytics collection process during the request phase (buffered).
-func (a *AnalyticsPolicy) OnRequestBody(ctx *policy.RequestContext, params map[string]interface{}) policy.RequestAction {
+func (a *AnalyticsPolicy) OnRequestBody(_ context.Context, ctx *policy.RequestContext, params map[string]interface{}) policy.RequestAction {
 	slog.Debug("Analytics system policy: OnRequestBody called")
 	allowPayloads := getAllowPayloadsFlag(params)
 	analyticsMetadata := make(map[string]any)
@@ -213,7 +214,7 @@ func (a *AnalyticsPolicy) OnRequestBody(ctx *policy.RequestContext, params map[s
 
 // OnResponseBody performs Analytics collection during the response phase (buffered fallback).
 // Called when the chain is in buffered mode (e.g. another policy does not support streaming).
-func (a *AnalyticsPolicy) OnResponseBody(ctx *policy.ResponseContext, params map[string]interface{}) policy.ResponseAction {
+func (a *AnalyticsPolicy) OnResponseBody(_ context.Context, ctx *policy.ResponseContext, params map[string]interface{}) policy.ResponseAction {
 	slog.Debug("Analytics system policy: OnResponseBody called")
 	allowPayloads := getAllowPayloadsFlag(params)
 
@@ -325,7 +326,7 @@ func (a *AnalyticsPolicy) OnResponseBody(ctx *policy.ResponseContext, params map
 // OnResponseBodyChunk handles streaming response body chunks.
 // Chunks are accumulated in SharedContext.Metadata. On EndOfStream the accumulated
 // bytes are parsed and analytics metadata is emitted on the final ResponseChunkAction.
-func (a *AnalyticsPolicy) OnResponseBodyChunk(ctx *policy.ResponseStreamContext, chunk *policy.StreamBody, params map[string]interface{}) policy.ResponseChunkAction {
+func (a *AnalyticsPolicy) OnResponseBodyChunk(_ context.Context, ctx *policy.ResponseStreamContext, chunk *policy.StreamBody, params map[string]interface{}) policy.ResponseChunkAction {
 	slog.Debug("Analytics system policy: OnResponseBodyChunk called")
 	if ctx.SharedContext.Metadata == nil {
 		ctx.SharedContext.Metadata = make(map[string]interface{})

--- a/sdk/core/policy/v1alpha2/interface.go
+++ b/sdk/core/policy/v1alpha2/interface.go
@@ -5,6 +5,8 @@
 // at chain-build time — once at startup, with zero per-request overhead.
 package policyv1alpha2
 
+import "context"
+
 // Policy is the base interface all policies must implement.
 // Mode declares the policy's processing requirements for each phase; the kernel
 // uses this at chain-build time to configure buffering and ext_proc modes.
@@ -88,27 +90,27 @@ const (
 // RequestHeaderPolicy processes request headers.
 // Implement this to modify or inspect headers before the request body is read.
 type RequestHeaderPolicy interface {
-	OnRequestHeaders(ctx *RequestHeaderContext, params map[string]interface{}) RequestHeaderAction
+	OnRequestHeaders(ctx context.Context, reqCtx *RequestHeaderContext, params map[string]interface{}) RequestHeaderAction
 }
 
 // ResponseHeaderPolicy processes response headers.
 // Implement this to modify or inspect response headers before the response body is read.
 type ResponseHeaderPolicy interface {
-	OnResponseHeaders(ctx *ResponseHeaderContext, params map[string]interface{}) ResponseHeaderAction
+	OnResponseHeaders(ctx context.Context, respCtx *ResponseHeaderContext, params map[string]interface{}) ResponseHeaderAction
 }
 
 // RequestPolicy processes the complete buffered request body.
 // If any policy in the chain implements this interface, the request body is
 // buffered before any policy in the chain executes.
 type RequestPolicy interface {
-	OnRequestBody(ctx *RequestContext, params map[string]interface{}) RequestAction
+	OnRequestBody(ctx context.Context, reqCtx *RequestContext, params map[string]interface{}) RequestAction
 }
 
 // ResponsePolicy processes the complete buffered response body.
 // If any policy in the chain implements only ResponsePolicy (not
 // StreamingResponsePolicy), the entire chain uses BUFFERED mode.
 type ResponsePolicy interface {
-	OnResponseBody(ctx *ResponseContext, params map[string]interface{}) ResponseAction
+	OnResponseBody(ctx context.Context, respCtx *ResponseContext, params map[string]interface{}) ResponseAction
 }
 
 // StreamingRequestPolicy processes the request body chunk-by-chunk.
@@ -125,7 +127,7 @@ type ResponsePolicy interface {
 // hook on this interface.
 type StreamingRequestPolicy interface {
 	RequestPolicy
-	OnRequestBodyChunk(ctx *RequestStreamContext, chunk *StreamBody, params map[string]interface{}) RequestChunkAction
+	OnRequestBodyChunk(ctx context.Context, reqCtx *RequestStreamContext, chunk *StreamBody, params map[string]interface{}) RequestChunkAction
 	NeedsMoreRequestData(accumulated []byte) bool
 }
 
@@ -145,6 +147,6 @@ type StreamingRequestPolicy interface {
 // (open connections, partial buffers, token counters for billing).
 type StreamingResponsePolicy interface {
 	ResponsePolicy
-	OnResponseBodyChunk(ctx *ResponseStreamContext, chunk *StreamBody, params map[string]interface{}) ResponseChunkAction
+	OnResponseBodyChunk(ctx context.Context, respCtx *ResponseStreamContext, chunk *StreamBody, params map[string]interface{}) ResponseChunkAction
 	NeedsMoreResponseData(accumulated []byte) bool
 }


### PR DESCRIPTION
## Purpose

Policy phase methods (`OnRequestHeaders`, `OnRequestBody`, etc.) had no access to `context.Context`, so policies making external I/O calls (Redis, embedding providers, LLM endpoints) could not respect client disconnection, propagate deadlines, or carry OTel spans.

Fixes wso2/api-platform#1533

## Approach

- Add `ctx context.Context` as the first parameter to all six phase methods in the `v1alpha2` SDK interface, with domain context params renamed to `reqCtx`/`respCtx` for clarity
- The context originates from `stream.Context()` in the ext_proc gRPC handler — it was already flowing through executor methods as `traceCtx` but not being passed to policy calls; this change completes the plumbing
- Rename `traceCtx` → `ctx` in all six `ChainExecutor` methods for consistency
- Update all existing policy implementations (`analytics`, `uppercase-body`, `count-letters`) and test/bench helpers to match the new signatures

## Related Issues

Fixes wso2/api-platform#1533

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Automation tests

- Unit tests: all `internal/...` tests pass (`go test ./internal/...`)

## Security checks

- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin: N/A (Go)
- No keys, passwords, or secrets committed: yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the internal policy execution framework with improved context management across all policy processing phases
  * Standardized policy callback parameter conventions for consistent request and response handling
  * Updated all policy implementations and test utilities to align with the new interface structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->