### PR TITLE
Update policy system configuration from v0 to v1

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -101,18 +101,18 @@ systemParameters:
     keyManagers:
       type: array
       description: List of key manager definitions
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v010.keymanagers}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.keymanagers}"
     jwksCacheTtl:
       type: string
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v010.jwkscachettl}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.jwkscachettl}"
 ```
 
-The `"wso2/defaultValue"` path `${config.policy_configurations.jwtauth_v010.keymanagers}` tells the gateway to fetch the value from:
+The `"wso2/defaultValue"` path `${config.policy_configurations.jwtauth_v1.keymanagers}` tells the gateway to fetch the value from:
 
 ```yaml
 # In gateway/it/test-config.yaml
 policy_configurations:
-  jwtauth_v010:
+  jwtauth_v1:
     keyManagers:
       - name: test-jwks
         issuer: http://mock-jwks.default.svc.cluster.local:8080/token
@@ -162,7 +162,7 @@ operations:
 2. **Add to test-config.yaml**:
 ```yaml
 policy_configurations:
-  jwtauth_v010:
+  jwtauth_v1:
     keyManagers:
       - name: test-jwks
         issuer: http://mock-jwks:8080/token

--- a/.github/workflows/operator-integration-test.yml
+++ b/.github/workflows/operator-integration-test.yml
@@ -549,7 +549,7 @@ jobs:
                       format: json
 
                   policy_configurations:
-                    jwtauth_v0:
+                    jwtauth_v1:
                       keymanagers:
                       - name: WSO2KeyManager1
                         issuer: https://api.asgardeo.io/t/tharsanan1995/oauth2/token

--- a/docs/ai-gateway/mcp/policies/mcp-authentication.md
+++ b/docs/ai-gateway/mcp/policies/mcp-authentication.md
@@ -23,24 +23,24 @@ The MCP Authentication policy uses a two-level configuration model:
 
 ### System Parameters (config.toml)
 
-Configured by the administrator in `config.toml` under `policy_configurations.mcpauth_v0` or `policy_configurations.jwtauth_v0` depending on the parameter.
+Configured by the administrator in `config.toml` under `policy_configurations.mcpauth_v1` or `policy_configurations.jwtauth_v1` depending on the parameter.
 
 | Parameter | Type | Required | Default | Path | Description |
 |-----------|------|----------|---------|------|-------------|
-| `keyManagers` | `KeyManager` array | Yes | - | jwtauth_v0 | List of key manager definitions. Each entry must include a unique `name` and `issuer`, and either `jwks.remote` or `jwks.local` configuration. |
-| `jwksCacheTtl` | string | No | - | jwtauth_v0 | Duration string for JWKS caching (e.g., `"5m"`). If omitted a default is used. |
-| `jwksFetchTimeout` | string | No | - | jwtauth_v0 | Timeout for HTTP fetch of JWKS (e.g., `"5s"`). |
-| `jwksFetchRetryCount` | integer | No | - | jwtauth_v0 | Number of retries for JWKS fetch on transient failures. |
-| `jwksFetchRetryInterval` | string | No | - | jwtauth_v0 | Interval between JWKS fetch retries (e.g., `"2s"`). |
-| `allowedAlgorithms` | string array | No | - | jwtauth_v0 | Allowed JWT signing algorithms (e.g., `["RS256", "ES256"]`). |
-| `leeway` | string | No | - | jwtauth_v0 | Clock skew allowance for `exp`/`nbf` checks (e.g., `"30s"`). |
-| `authHeaderScheme` | string | No | `"Bearer"` | jwtauth_v0 | Expected scheme prefix in the authorization header. |
-| `headerName` | string | No | `"Authorization"` | jwtauth_v0 | Header name to extract the token from. |
-| `onFailureStatusCode` | integer | No | `401` | jwtauth_v0 | HTTP status code returned on authentication failure. Allowed values: `401`, `403`. |
-| `errorMessageFormat` | string | No | `"json"` | jwtauth_v0 | Format of the error response. Allowed values: `"json"`, `"plain"`, `"minimal"`. |
-| `errorMessage` | string | No | - | jwtauth_v0 | Custom error message to include in the response body on authentication failure. |
-| `validateIssuer` | boolean | No | - | jwtauth_v0 | Whether to validate the token's issuer claim against configured key managers. |
-| `gatewayHost` | string | No | `"localhost"` | mcpauth_v0 | The outward-facing gateway host name used when deriving the protected resource metadata URL and response. |
+| `keyManagers` | `KeyManager` array | Yes | - | jwtauth_v1 | List of key manager definitions. Each entry must include a unique `name` and `issuer`, and either `jwks.remote` or `jwks.local` configuration. |
+| `jwksCacheTtl` | string | No | - | jwtauth_v1 | Duration string for JWKS caching (e.g., `"5m"`). If omitted a default is used. |
+| `jwksFetchTimeout` | string | No | - | jwtauth_v1 | Timeout for HTTP fetch of JWKS (e.g., `"5s"`). |
+| `jwksFetchRetryCount` | integer | No | - | jwtauth_v1 | Number of retries for JWKS fetch on transient failures. |
+| `jwksFetchRetryInterval` | string | No | - | jwtauth_v1 | Interval between JWKS fetch retries (e.g., `"2s"`). |
+| `allowedAlgorithms` | string array | No | - | jwtauth_v1 | Allowed JWT signing algorithms (e.g., `["RS256", "ES256"]`). |
+| `leeway` | string | No | - | jwtauth_v1 | Clock skew allowance for `exp`/`nbf` checks (e.g., `"30s"`). |
+| `authHeaderScheme` | string | No | `"Bearer"` | jwtauth_v1 | Expected scheme prefix in the authorization header. |
+| `headerName` | string | No | `"Authorization"` | jwtauth_v1 | Header name to extract the token from. |
+| `onFailureStatusCode` | integer | No | `401` | jwtauth_v1 | HTTP status code returned on authentication failure. Allowed values: `401`, `403`. |
+| `errorMessageFormat` | string | No | `"json"` | jwtauth_v1 | Format of the error response. Allowed values: `"json"`, `"plain"`, `"minimal"`. |
+| `errorMessage` | string | No | - | jwtauth_v1 | Custom error message to include in the response body on authentication failure. |
+| `validateIssuer` | boolean | No | - | jwtauth_v1 | Whether to validate the token's issuer claim against configured key managers. |
+| `gatewayHost` | string | No | `"localhost"` | mcpauth_v1 | The outward-facing gateway host name used when deriving the protected resource metadata URL and response. |
 
 #### KeyManager Configuration
 
@@ -61,10 +61,10 @@ Each key manager in the `keyManagers` array supports the following structure:
 #### System Configuration Example
 
 ```toml
-[policy_configurations.mcpauth_v0]
+[policy_configurations.mcpauth_v1]
 gatewayHost = "gw.example.com"
 
-[policy_configurations.jwtauth_v0]
+[policy_configurations.jwtauth_v1]
 jwksCacheTtl = "5m"
 jwksFetchTimeout = "5s"
 jwksFetchRetryCount = 3
@@ -78,19 +78,19 @@ errorMessageFormat = "json"
 errorMessage = "Authentication failed."
 validateIssuer = true
 
-[[policy_configurations.jwtauth_v0.keyManagers]]
+[[policy_configurations.jwtauth_v1.keyManagers]]
 name = "PrimaryIDP"
 issuer = "https://idp.example.com/oauth2/token"
 
-[policy_configurations.jwtauth_v0.keyManagers.jwks.remote]
+[policy_configurations.jwtauth_v1.keyManagers.jwks.remote]
 uri = "https://idp.example.com/oauth2/jwks"
 skipTlsVerify = false
 
-[[policy_configurations.jwtauth_v0.keyManagers]]
+[[policy_configurations.jwtauth_v1.keyManagers]]
 name = "SecondaryIDP"
 issuer = "https://auth.example.org/oauth2/token"
 
-[policy_configurations.jwtauth_v0.keyManagers.jwks.remote]
+[policy_configurations.jwtauth_v1.keyManagers.jwks.remote]
 uri = "https://auth.example.org/oauth2/jwks"
 skipTlsVerify = false
 ```

--- a/docs/gateway/policies/advanced-ratelimit.md
+++ b/docs/gateway/policies/advanced-ratelimit.md
@@ -201,15 +201,15 @@ Configures per-quota dynamic cost extraction from request or response data. Valu
 ##### Memory Backend Configuration
 
 ```toml
-[policy_configurations.ratelimit_v0]
+[policy_configurations.ratelimit_v1]
 algorithm = "fixed-window"
 backend = "memory"
 
-[policy_configurations.ratelimit_v0.memory]
+[policy_configurations.ratelimit_v1.memory]
 max_entries = 10000
 cleanup_interval = "5m"
 
-[policy_configurations.ratelimit_v0.headers]
+[policy_configurations.ratelimit_v1.headers]
 include_x_rate_limit = true
 include_ietf = true
 include_retry_after = true
@@ -220,11 +220,11 @@ include_retry_after = true
 For distributed rate limiting across multiple gateway instances:
 
 ```toml
-[policy_configurations.ratelimit_v0]
+[policy_configurations.ratelimit_v1]
 algorithm = "fixed-window"
 backend = "redis"
 
-[policy_configurations.ratelimit_v0.redis]
+[policy_configurations.ratelimit_v1.redis]
 host = "redis.example.com"
 port = 6379
 password = "your-redis-password"
@@ -235,7 +235,7 @@ connection_timeout = "5s"
 read_timeout = "3s"
 write_timeout = "3s"
 
-[policy_configurations.ratelimit_v0.headers]
+[policy_configurations.ratelimit_v1.headers]
 include_x_rate_limit = true
 include_ietf = true
 include_retry_after = true

--- a/docs/gateway/policies/jwt-authentication.md
+++ b/docs/gateway/policies/jwt-authentication.md
@@ -58,7 +58,7 @@ Each entry in `keymanagers` must include a unique `name` and either `jwks.remote
 #### Sample System Configuration
 
 ```toml
-[policy_configurations.jwtauth_v0]
+[policy_configurations.jwtauth_v1]
 jwkscachettl = "5m"
 jwksfetchtimeout = "5s"
 jwksfetchretrycount = 3
@@ -72,19 +72,19 @@ errormessageformat = "json"
 errormessage = "Authentication failed"
 validateissuer = true
 
-[[policy_configurations.jwtauth_v0.keymanagers]]
+[[policy_configurations.jwtauth_v1.keymanagers]]
 name = "PrimaryIDP"
 issuer = "https://idp.example.com/oauth2/token"
 
-[policy_configurations.jwtauth_v0.keymanagers.jwks.remote]
+[policy_configurations.jwtauth_v1.keymanagers.jwks.remote]
 uri = "https://idp.example.com/oauth2/jwks"
 skipTlsVerify = false
 
-[[policy_configurations.jwtauth_v0.keymanagers]]
+[[policy_configurations.jwtauth_v1.keymanagers]]
 name = "SecondaryIDP"
 issuer = "https://auth.example.org/oauth2/token"
 
-[policy_configurations.jwtauth_v0.keymanagers.jwks.remote]
+[policy_configurations.jwtauth_v1.keymanagers.jwks.remote]
 uri = "https://auth.example.org/oauth2/jwks"
 skipTlsVerify = false
 ```

--- a/gateway/configs/config-template.toml
+++ b/gateway/configs/config-template.toml
@@ -269,7 +269,7 @@ max_header_limit = 8192
 # POLICY CONFIGURATIONS
 # =============================================================================
 
-[policy_configurations.llm_cost_v0]
+[policy_configurations.llm_cost_v1]
 pricing_file = "/home/wso2/conf/llm-pricing/model_prices.json"
 
 # =============================================================================

--- a/gateway/gateway-controller/default-policies/advanced-ratelimit.yaml
+++ b/gateway/gateway-controller/default-policies/advanced-ratelimit.yaml
@@ -256,7 +256,7 @@ systemParameters:
         fixed-window for simple interval counting.
       enum: ["gcra", "fixed-window"]
       default: "fixed-window"
-      "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.algorithm}"
+      "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.algorithm}"
 
     backend:
       type: string
@@ -265,7 +265,7 @@ systemParameters:
         for distributed limits.
       enum: ["memory", "redis"]
       default: "memory"
-      "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.backend}"
+      "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.backend}"
 
     redis:
       type: object
@@ -276,7 +276,7 @@ systemParameters:
           type: string
           description: Specifies the Redis host name or IP address.
           default: "localhost"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.host}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.host}"
 
         port:
           type: integer
@@ -284,17 +284,17 @@ systemParameters:
           minimum: 1
           maximum: 65535
           default: 6379
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.port}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.port}"
 
         password:
           type: string
           description: Specifies the optional Redis authentication password.
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.password}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.password}"
 
         username:
           type: string
           description: Specifies the optional Redis ACL username.
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.username}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.username}"
 
         db:
           type: integer
@@ -302,13 +302,13 @@ systemParameters:
           minimum: 0
           maximum: 15
           default: 0
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.db}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.db}"
 
         keyPrefix:
           type: string
           description: Specifies the prefix used for all Redis keys.
           default: "ratelimit:v1:"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.key_prefix}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.key_prefix}"
 
         failureMode:
           type: string
@@ -317,7 +317,7 @@ systemParameters:
             closed blocks requests.
           enum: ["open", "closed"]
           default: "open"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.failure_mode}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.failure_mode}"
 
         connectionTimeout:
           type: string
@@ -326,7 +326,7 @@ systemParameters:
             composite and fractional values (for example "500ms", "1.5s",
             "1m30s").
           default: "5s"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.connection_timeout}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.connection_timeout}"
 
         readTimeout:
           type: string
@@ -335,7 +335,7 @@ systemParameters:
             composite and fractional values (for example "500ms", "1.5s",
             "1m30s").
           default: "3s"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.read_timeout}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.read_timeout}"
 
         writeTimeout:
           type: string
@@ -344,7 +344,7 @@ systemParameters:
             composite and fractional values (for example "500ms", "1.5s",
             "1m30s").
           default: "3s"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.write_timeout}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.write_timeout}"
 
     memory:
       type: object
@@ -358,7 +358,7 @@ systemParameters:
           minimum: 100
           maximum: 10000000
           default: 10000
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.memory.max_entries}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.memory.max_entries}"
 
         cleanupInterval:
           type: string
@@ -368,7 +368,7 @@ systemParameters:
             fractional values (for example "500ms", "1.5s", "1m30s").
             Use "0" to disable cleanup.
           default: "5m"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.memory.cleanup_interval}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.memory.cleanup_interval}"
 
     headers:
       type: object
@@ -380,7 +380,7 @@ systemParameters:
           description: |
             Includes X-RateLimit-Limit, X-RateLimit-Remaining, and X-RateLimit-Reset headers.
           default: true
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.headers.include_x_rate_limit}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.headers.include_x_rate_limit}"
 
         includeIETF:
           type: boolean
@@ -388,11 +388,11 @@ systemParameters:
             Includes RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset, and
             RateLimit-Policy headers.
           default: true
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.headers.include_ietf}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.headers.include_ietf}"
 
         includeRetryAfter:
           type: boolean
           description: |
             Includes the Retry-After header on 429 responses.
           default: true
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.headers.include_retry_after}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.headers.include_retry_after}"

--- a/gateway/gateway-controller/default-policies/basic-ratelimit.yaml
+++ b/gateway/gateway-controller/default-policies/basic-ratelimit.yaml
@@ -51,7 +51,7 @@ systemParameters:
           but can allow up to 2x burst at window boundaries.
       enum: ["gcra", "fixed-window"]
       default: "fixed-window"
-      "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.algorithm}"
+      "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.algorithm}"
 
     backend:
       type: string
@@ -60,7 +60,7 @@ systemParameters:
         'redis' for distributed rate limiting across multiple gateway instances.
       enum: ["memory", "redis"]
       default: "memory"
-      "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.backend}"
+      "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.backend}"
 
     redis:
       type: object
@@ -71,7 +71,7 @@ systemParameters:
           type: string
           description: Redis server hostname or IP address
           default: "localhost"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.host}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.host}"
 
         port:
           type: integer
@@ -79,17 +79,17 @@ systemParameters:
           minimum: 1
           maximum: 65535
           default: 6379
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.port}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.port}"
 
         password:
           type: string
           description: Redis authentication password (optional)
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.password}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.password}"
 
         username:
           type: string
           description: Redis ACL username (optional, Redis 6+)
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.username}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.username}"
 
         db:
           type: integer
@@ -97,13 +97,13 @@ systemParameters:
           minimum: 0
           maximum: 15
           default: 0
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.db}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.db}"
 
         keyPrefix:
           type: string
           description: Prefix for all Redis keys to avoid conflicts
           default: "ratelimit:v1:"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.key_prefix}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.key_prefix}"
 
         failureMode:
           type: string
@@ -112,7 +112,7 @@ systemParameters:
             'closed' denies requests. Recommended: 'open' for availability.
           enum: ["open", "closed"]
           default: "open"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.failure_mode}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.failure_mode}"
 
         connectionTimeout:
           type: string
@@ -120,7 +120,7 @@ systemParameters:
             Supports units ns, us, µs, ms, s, m, h, including composite and
             fractional values (for example "500ms", "1.5s", "1m30s").
           default: "5s"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.connection_timeout}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.connection_timeout}"
 
         readTimeout:
           type: string
@@ -128,7 +128,7 @@ systemParameters:
             units ns, us, µs, ms, s, m, h, including composite and fractional
             values (for example "500ms", "1.5s", "1m30s").
           default: "3s"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.read_timeout}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.read_timeout}"
 
         writeTimeout:
           type: string
@@ -136,7 +136,7 @@ systemParameters:
             units ns, us, µs, ms, s, m, h, including composite and fractional
             values (for example "500ms", "1.5s", "1m30s").
           default: "3s"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.write_timeout}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.write_timeout}"
 
     memory:
       type: object
@@ -151,7 +151,7 @@ systemParameters:
           minimum: 100
           maximum: 10000000
           default: 10000
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.memory.max_entries}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.memory.max_entries}"
 
         cleanupInterval:
           type: string
@@ -161,4 +161,4 @@ systemParameters:
             fractional values (for example "500ms", "1.5s", "1m30s").
             Use "0" to disable periodic cleanup.
           default: "5m"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.memory.cleanup_interval}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.memory.cleanup_interval}"

--- a/gateway/gateway-controller/default-policies/jwt-auth.yaml
+++ b/gateway/gateway-controller/default-policies/jwt-auth.yaml
@@ -140,31 +140,31 @@ systemParameters:
                   certificatePath:
                     type: string
                     description: Path to certificate or public key file (e.g., /etc/certs/public.pem).
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.keymanagers}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.keymanagers}"
 
     jwksCacheTtl:
       type: string
       description: Duration string for JWKS caching (e.g., "5m"). If omitted a default is used.
       default: "5m"
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.jwkscachettl}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.jwkscachettl}"
 
     jwksFetchTimeout:
       type: string
       description: Timeout for HTTP fetch of JWKS, e.g., "5s".
       default: "5s"
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.jwksfetchtimeout}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.jwksfetchtimeout}"
 
     jwksFetchRetryCount:
       type: integer
       description: Number of retries for JWKS fetch on transient failures.
       default: 3
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.jwksfetchretrycount}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.jwksfetchretrycount}"
 
     jwksFetchRetryInterval:
       type: string
       description: Interval between JWKS fetch retries, e.g., "2s".
       default: "2s"
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.jwksfetchretryinterval}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.jwksfetchretryinterval}"
 
     allowedAlgorithms:
       type: array
@@ -172,19 +172,19 @@ systemParameters:
       items:
         type: string
       default: ["RS256", "ES256"]
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.allowedalgorithms}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.allowedalgorithms}"
 
     leeway:
       type: string
       description: Clock skew allowance for exp/nbf checks, e.g., "30s".
       default: "30s"
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.leeway}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.leeway}"
 
     authHeaderScheme:
       type: string
       description: Expected scheme prefix in the authorization header (e.g., "Bearer"). If set, runtime enforces the scheme; if omitted, runtime may accept raw header values or strip known schemes.
       default: Bearer
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.authheaderscheme}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.authheaderscheme}"
 
     headerName:
       type: string
@@ -192,30 +192,30 @@ systemParameters:
       pattern: "^[!#$%&'*+.^_`|~0-9A-Za-z-]+$"
       description: Header name to extract token from (default "Authorization").
       default: Authorization
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.headername}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.headername}"
 
     onFailureStatusCode:
       type: integer
       description: HTTP status code to return on authentication failure (401 for Unauthorized, 403 for Forbidden).
       default: 401
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.onfailurestatuscode}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.onfailurestatuscode}"
 
     errorMessageFormat:
       type: string
       description: Format of error response on JWT validation failure. Supported values are "json" (structured error), "plain" (plain text), or "minimal" (minimal response).
       default: json
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.errormessageformat}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.errormessageformat}"
     
     errorMessage:
       type: string
       description: Custom error message to include in the response body on authentication failure.
       default: "Authentication failed"
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.errormessage}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.errormessage}"
 
     validateIssuer:
       type: boolean
       description: Whether to validate the token's issuer claim against configured key managers.
       default: true
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.validateissuer}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.validateissuer}"
 
   required: ["keyManagers"]

--- a/gateway/gateway-controller/default-policies/llm-cost-based-ratelimit.yaml
+++ b/gateway/gateway-controller/default-policies/llm-cost-based-ratelimit.yaml
@@ -65,7 +65,7 @@ systemParameters:
         dollar amounts (x-ratelimit-cost-limit-dollars, x-ratelimit-cost-remaining-dollars).
       minimum: 1
       default: 1000000000
-      "wso2/defaultValue": "${config.policy_configurations.llm_cost_ratelimit_v0.cost_scale_factor}"
+      "wso2/defaultValue": "${config.policy_configurations.llm_cost_ratelimit_v1.cost_scale_factor}"
 
     # Rate limiting algorithm and backend - inherited from advanced-ratelimit
     algorithm:
@@ -78,7 +78,7 @@ systemParameters:
           but can allow up to 2x burst at window boundaries.
       enum: ["gcra", "fixed-window"]
       default: "gcra"
-      "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.algorithm}"
+      "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.algorithm}"
 
     backend:
       type: string
@@ -87,7 +87,7 @@ systemParameters:
         'redis' for distributed rate limiting across multiple gateway instances.
       enum: ["memory", "redis"]
       default: "memory"
-      "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.backend}"
+      "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.backend}"
 
     redis:
       type: object
@@ -97,42 +97,42 @@ systemParameters:
         host:
           type: string
           default: "localhost"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.host}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.host}"
         port:
           type: integer
           default: 6379
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.port}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.port}"
         password:
           type: string
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.password}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.password}"
         username:
           type: string
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.username}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.username}"
         db:
           type: integer
           default: 0
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.db}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.db}"
         keyPrefix:
           type: string
           default: "ratelimit:v1:"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.key_prefix}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.key_prefix}"
         failureMode:
           type: string
           enum: ["open", "closed"]
           default: "open"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.failure_mode}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.failure_mode}"
         connectionTimeout:
           type: string
           default: "5s"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.connection_timeout}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.connection_timeout}"
         readTimeout:
           type: string
           default: "3s"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.read_timeout}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.read_timeout}"
         writeTimeout:
           type: string
           default: "3s"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.write_timeout}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.write_timeout}"
 
     memory:
       type: object
@@ -142,8 +142,8 @@ systemParameters:
         maxEntries:
           type: integer
           default: 10000
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.memory.max_entries}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.memory.max_entries}"
         cleanupInterval:
           type: string
           default: "5m"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.memory.cleanup_interval}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.memory.cleanup_interval}"

--- a/gateway/gateway-controller/default-policies/llm-cost.yaml
+++ b/gateway/gateway-controller/default-policies/llm-cost.yaml
@@ -31,4 +31,4 @@ systemParameters:
       description: >
         Path to the model pricing JSON file shipped with the gateway image.
         Can be overridden by the gateway admin via config.toml.
-      "wso2/defaultValue": "${config.policy_configurations.llm_cost_v0.pricing_file}"
+      "wso2/defaultValue": "${config.policy_configurations.llm_cost_v1.pricing_file}"

--- a/gateway/gateway-controller/default-policies/mcp-auth.yaml
+++ b/gateway/gateway-controller/default-policies/mcp-auth.yaml
@@ -174,51 +174,51 @@ systemParameters:
                   certificatePath:
                     type: string
                     description: Path to certificate or public key file (e.g., /etc/certs/public.pem).
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.keymanagers}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.keymanagers}"
 
     jwksCacheTtl:
       type: string
       description: Duration string for JWKS caching (e.g., "5m"). If omitted a default is used.
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.jwkscachettl}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.jwkscachettl}"
 
     jwksFetchTimeout:
       type: string
       description: Timeout for HTTP fetch of JWKS, e.g., "5s".
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.jwksfetchtimeout}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.jwksfetchtimeout}"
 
     jwksFetchRetryCount:
       type: integer
       description: Number of retries for JWKS fetch on transient failures.
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.jwksfetchretrycount}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.jwksfetchretrycount}"
 
     jwksFetchRetryInterval:
       type: string
       description: Interval between JWKS fetch retries, e.g., "2s".
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.jwksfetchretryinterval}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.jwksfetchretryinterval}"
 
     allowedAlgorithms:
       type: array
       description: Allowed JWT signing algorithms (e.g., ["RS256","ES256"]).
       items:
         type: string
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.allowedalgorithms}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.allowedalgorithms}"
 
     leeway:
       type: string
       description: Clock skew allowance for exp/nbf checks, e.g., "30s".
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.leeway}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.leeway}"
 
     authHeaderScheme:
       type: string
       description: Expected scheme prefix in the authorization header (e.g., "Bearer"). If set, runtime enforces the scheme; if omitted, runtime may accept raw header values or strip known schemes.
       default: Bearer
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.authheaderscheme}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.authheaderscheme}"
 
     headerName:
       type: string
       description: Header name to extract token from (default "Authorization").
       default: Authorization
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.headername}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.headername}"
 
     onFailureStatusCode:
       type: integer
@@ -227,7 +227,7 @@ systemParameters:
       enum:
         - 401
         - 403
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.onfailurestatuscode}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.onfailurestatuscode}"
 
     errorMessageFormat:
       type: string
@@ -237,24 +237,24 @@ systemParameters:
         - json
         - plain
         - minimal
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.errormessageformat}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.errormessageformat}"
     
     errorMessage:
       type: string
       description: Custom error message to include in the response body on authentication failure.
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.errormessage}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.errormessage}"
 
     validateIssuer:
       type: boolean
       description: Whether to validate the token's issuer claim against configured key managers.
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.validateissuer}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.validateissuer}"
     
     gatewayHost:
       type: string
       description: The host of the gateway to be included in the protected metadata URL and response.
       example: mcp1.api-platform.com
       default: localhost
-      "wso2/defaultValue": "${config.policy_configurations.mcpauth_v0.gatewayhost}"
+      "wso2/defaultValue": "${config.policy_configurations.mcpauth_v1.gatewayhost}"
 
 
   required: ["keyManagers"]

--- a/gateway/gateway-controller/default-policies/token-based-ratelimit.yaml
+++ b/gateway/gateway-controller/default-policies/token-based-ratelimit.yaml
@@ -114,7 +114,7 @@ systemParameters:
         - fixed-window: Simple fixed time window counter (default).
       enum: ["gcra", "fixed-window"]
       default: "fixed-window"
-      "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.algorithm}"
+      "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.algorithm}"
 
     backend:
       type: string
@@ -122,7 +122,7 @@ systemParameters:
         Rate limit storage backend. 'memory' or 'redis'.
       enum: ["memory", "redis"]
       default: "memory"
-      "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.backend}"
+      "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.backend}"
 
     redis:
       type: object
@@ -132,48 +132,48 @@ systemParameters:
         host:
           type: string
           default: "localhost"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.host}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.host}"
         port:
           type: integer
           default: 6379
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.port}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.port}"
         password:
           type: string
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.password}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.password}"
         username:
           type: string
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.username}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.username}"
         db:
           type: integer
           default: 0
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.db}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.db}"
         keyPrefix:
           type: string
           default: "ratelimit:v1:"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.keyprefix}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.keyprefix}"
         failureMode:
           type: string
           enum: ["open", "closed"]
           default: "open"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.failuremode}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.failuremode}"
         connectionTimeout:
           type: string
           description: Redis connection timeout as a Go duration string, for
             example "1s", "1m", "1h", or "24h".
           default: "5s"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.connectiontimeout}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.connectiontimeout}"
         readTimeout:
           type: string
           description: Redis read timeout as a Go duration string, for
             example "1s", "1m", "1h", or "24h".
           default: "3s"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.readtimeout}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.readtimeout}"
         writeTimeout:
           type: string
           description: Redis write timeout as a Go duration string, for
             example "1s", "1m", "1h", or "24h".
           default: "3s"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.writetimeout}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.writetimeout}"
 
     memory:
       type: object
@@ -183,11 +183,11 @@ systemParameters:
         maxEntries:
           type: integer
           default: 10000
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.memory.maxentries}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.memory.maxentries}"
         cleanupInterval:
           type: string
           description: Interval for cleaning up expired in-memory entries as a
             Go duration string, for example "1s", "1m", "1h", or "24h". Use
             "0" to disable cleanup.
           default: "5m"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.memory.cleanupinterval}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.memory.cleanupinterval}"

--- a/gateway/it/test-config.toml
+++ b/gateway/it/test-config.toml
@@ -215,21 +215,21 @@ port = 9003
 # =============================================================================
 
 
-[[policy_configurations.jwtauth_v0.keymanagers]]
+[[policy_configurations.jwtauth_v1.keymanagers]]
 name = "mock-jwks"
 issuer = "http://mock-jwks:8080/token"
 
-[policy_configurations.jwtauth_v0.keymanagers.jwks.remote]
+[policy_configurations.jwtauth_v1.keymanagers.jwks.remote]
 uri = "http://mock-jwks:8080/jwks"
 
-[[policy_configurations.jwtauth_v0.keymanagers]]
+[[policy_configurations.jwtauth_v1.keymanagers]]
 name = "wrong-issuer-km"
 issuer = "http://expected-issuer.com"
 
-[policy_configurations.jwtauth_v0.keymanagers.jwks.remote]
+[policy_configurations.jwtauth_v1.keymanagers.jwks.remote]
 uri = "http://mock-jwks:8080/jwks"
 
-[policy_configurations.ratelimit_v0]
+[policy_configurations.ratelimit_v1]
 algorithm = "fixed-window"
 
 
@@ -263,7 +263,7 @@ als_plain_text = true
 max_message_size = 1000000000
 max_header_limit = 8192
 
-[policy_configurations.llm_cost_v0]
+[policy_configurations.llm_cost_v1]
 pricing_file = "/home/wso2/conf/llm-pricing/model_prices.json"
 
 # =============================================================================

--- a/gateway/it/test-config.vhosts-multi.toml
+++ b/gateway/it/test-config.vhosts-multi.toml
@@ -212,21 +212,21 @@ port = 9003
 # =============================================================================
 
 
-[[policy_configurations.jwtauth_v0.keymanagers]]
+[[policy_configurations.jwtauth_v1.keymanagers]]
 name = "mock-jwks"
 issuer = "http://mock-jwks:8080/token"
 
-[policy_configurations.jwtauth_v0.keymanagers.jwks.remote]
+[policy_configurations.jwtauth_v1.keymanagers.jwks.remote]
 uri = "http://mock-jwks:8080/jwks"
 
-[[policy_configurations.jwtauth_v0.keymanagers]]
+[[policy_configurations.jwtauth_v1.keymanagers]]
 name = "wrong-issuer-km"
 issuer = "http://expected-issuer.com"
 
-[policy_configurations.jwtauth_v0.keymanagers.jwks.remote]
+[policy_configurations.jwtauth_v1.keymanagers.jwks.remote]
 uri = "http://mock-jwks:8080/jwks"
 
-[policy_configurations.ratelimit_v0]
+[policy_configurations.ratelimit_v1]
 algorithm = "fixed-window"
 
 

--- a/gateway/it/test-config.vhosts-single.toml
+++ b/gateway/it/test-config.vhosts-single.toml
@@ -212,21 +212,21 @@ port = 9003
 # =============================================================================
 
 
-[[policy_configurations.jwtauth_v0.keymanagers]]
+[[policy_configurations.jwtauth_v1.keymanagers]]
 name = "mock-jwks"
 issuer = "http://mock-jwks:8080/token"
 
-[policy_configurations.jwtauth_v0.keymanagers.jwks.remote]
+[policy_configurations.jwtauth_v1.keymanagers.jwks.remote]
 uri = "http://mock-jwks:8080/jwks"
 
-[[policy_configurations.jwtauth_v0.keymanagers]]
+[[policy_configurations.jwtauth_v1.keymanagers]]
 name = "wrong-issuer-km"
 issuer = "http://expected-issuer.com"
 
-[policy_configurations.jwtauth_v0.keymanagers.jwks.remote]
+[policy_configurations.jwtauth_v1.keymanagers.jwks.remote]
 uri = "http://mock-jwks:8080/jwks"
 
-[policy_configurations.ratelimit_v0]
+[policy_configurations.ratelimit_v1]
 algorithm = "fixed-window"
 
 

--- a/kubernetes/gateway-operator/config/samples/gateway-custom-config.yaml
+++ b/kubernetes/gateway-operator/config/samples/gateway-custom-config.yaml
@@ -301,7 +301,7 @@ data:
             format: json
 
         policy_configurations: 
-          jwtauth_v0:
+          jwtauth_v1:
             KeyManagers:
             - name: WSO2KeyManager1
               issuer: https://api.asgardeo.io/t/tharsanan1995/oauth2/token


### PR DESCRIPTION
## Purpose
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated policy configuration version identifiers from v0 to v1 across JWT authentication, rate limiting, and LLM cost policies. Configuration files referencing `jwtauth_v0`, `ratelimit_v0`, `llm_cost_v0`, and `mcpauth_v0` should be updated to their v1 equivalents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->