### PR TITLE
Fix duplicate LLM provider/proxy creation returning 201 instead of 409

### DIFF
--- a/gateway/gateway-controller/pkg/api/handlers/handlers.go
+++ b/gateway/gateway-controller/pkg/api/handlers/handlers.go
@@ -721,6 +721,13 @@ func (s *APIServer) CreateLLMProvider(c *gin.Context) {
 	})
 	if err != nil {
 		log.Error("Failed to create LLM provider", slog.Any("error", err))
+		if storage.IsConflictError(err) {
+			c.JSON(http.StatusConflict, api.ErrorResponse{
+				Status:  "error",
+				Message: err.Error(),
+			})
+			return
+		}
 		if utils.IsPolicyDefinitionMissingError(err) {
 			c.JSON(http.StatusInternalServerError, api.ErrorResponse{
 				Status:  "error",
@@ -947,6 +954,13 @@ func (s *APIServer) CreateLLMProxy(c *gin.Context) {
 	})
 	if err != nil {
 		log.Error("Failed to create LLM proxy", slog.Any("error", err))
+		if storage.IsConflictError(err) {
+			c.JSON(http.StatusConflict, api.ErrorResponse{
+				Status:  "error",
+				Message: err.Error(),
+			})
+			return
+		}
 		if utils.IsPolicyDefinitionMissingError(err) {
 			c.JSON(http.StatusInternalServerError, api.ErrorResponse{
 				Status:  "error",

--- a/gateway/gateway-controller/pkg/utils/llm_deployment.go
+++ b/gateway/gateway-controller/pkg/utils/llm_deployment.go
@@ -241,6 +241,26 @@ func (s *LLMDeploymentService) DeployLLMProviderConfiguration(params LLMDeployme
 		}
 	}
 
+	// Check for duplicate LLM provider configurations
+	handle := providerConfig.Metadata.Name
+	existingConfigs, err := s.db.GetAllConfigsByKind(string(api.LlmProvider))
+	if err != nil {
+		return nil, fmt.Errorf("failed to list LLM provider configurations from database: %w", err)
+	}
+	for _, cfg := range existingConfigs {
+		if cfg.UUID == apiID {
+			continue
+		}
+		if cfg.DisplayName == providerConfig.Spec.DisplayName && cfg.Version == providerConfig.Spec.Version {
+			return nil, fmt.Errorf("%w: configuration with name '%s' and version '%s' already exists",
+				storage.ErrConflict, providerConfig.Spec.DisplayName, providerConfig.Spec.Version)
+		}
+		if handle != "" && cfg.Handle == handle {
+			return nil, fmt.Errorf("%w: configuration with handle '%s' already exists",
+				storage.ErrConflict, handle)
+		}
+	}
+
 	// Create stored configuration
 	now := time.Now()
 	deployedAt := params.DeployedAt
@@ -393,6 +413,26 @@ func (s *LLMDeploymentService) DeployLLMProxyConfiguration(params LLMDeploymentP
 		apiID, err = GenerateUUID()
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate API ID: %w", err)
+		}
+	}
+
+	// Check for duplicate LLM proxy configurations
+	proxyHandle := proxyConfig.Metadata.Name
+	existingProxyConfigs, err := s.db.GetAllConfigsByKind(string(api.LlmProxy))
+	if err != nil {
+		return nil, fmt.Errorf("failed to list LLM proxy configurations from database: %w", err)
+	}
+	for _, cfg := range existingProxyConfigs {
+		if cfg.UUID == apiID {
+			continue
+		}
+		if cfg.DisplayName == proxyConfig.Spec.DisplayName && cfg.Version == proxyConfig.Spec.Version {
+			return nil, fmt.Errorf("%w: configuration with name '%s' and version '%s' already exists",
+				storage.ErrConflict, proxyConfig.Spec.DisplayName, proxyConfig.Spec.Version)
+		}
+		if proxyHandle != "" && cfg.Handle == proxyHandle {
+			return nil, fmt.Errorf("%w: configuration with handle '%s' already exists",
+				storage.ErrConflict, proxyHandle)
 		}
 	}
 

--- a/gateway/gateway-controller/pkg/utils/llm_deployment_test.go
+++ b/gateway/gateway-controller/pkg/utils/llm_deployment_test.go
@@ -1082,3 +1082,146 @@ func TestLLMDeploymentService_InitializeOOBTemplates_UpdateExisting(t *testing.T
 	assert.NoError(t, err)
 	assert.Equal(t, "Updated Template", found.Configuration.Spec.DisplayName)
 }
+
+func testLLMProviderYAML(handle, displayName, version string) []byte {
+	return []byte(fmt.Sprintf(`
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: %s
+spec:
+  displayName: %s
+  version: %s
+  template: openai
+  upstream:
+    url: https://api.openai.com
+  accessControl:
+    mode: allow_all
+`, handle, displayName, version))
+}
+
+func testLLMProxyYAML(handle, displayName, version, providerHandle string) []byte {
+	return []byte(fmt.Sprintf(`
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProxy
+metadata:
+  name: %s
+spec:
+  displayName: %s
+  version: %s
+  provider: %s
+  accessControl:
+    mode: allow_all
+`, handle, displayName, version, providerHandle))
+}
+
+func setupLLMDeploymentServiceWithTemplate(t *testing.T) (*LLMDeploymentService, *testMockDB) {
+	t.Helper()
+	store := storage.NewConfigStore()
+	db := newTestMockDB()
+	routerConfig := &config.RouterConfig{ListenerPort: 8080}
+	mockHub := &mockLLMEventHub{}
+	apiDeploymentService := newTestAPIDeploymentServiceWithHub(store, db, nil, nil, routerConfig, nil, mockHub, "test-gateway")
+	service := NewLLMDeploymentService(store, db, nil, nil, nil, apiDeploymentService, routerConfig, nil, nil)
+
+	// Save a template so the transformer can find it
+	template := testStoredLLMTemplate("template-uuid", "openai", "OpenAI")
+	require.NoError(t, db.SaveLLMProviderTemplate(template))
+
+	return service, db
+}
+
+func TestLLMDeploymentService_DeployLLMProviderConfiguration_DuplicateHandle(t *testing.T) {
+	service, _ := setupLLMDeploymentServiceWithTemplate(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	params := LLMDeploymentParams{
+		Data:          testLLMProviderYAML("my-provider", "My Provider", "v1.0"),
+		ContentType:   "application/yaml",
+		CorrelationID: "corr-1",
+		Logger:        logger,
+		Origin:        models.OriginGatewayAPI,
+	}
+
+	// First deploy should succeed
+	result, err := service.DeployLLMProviderConfiguration(params)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Second deploy with same handle should return conflict
+	params2 := LLMDeploymentParams{
+		Data:          testLLMProviderYAML("my-provider", "Different Name", "v2.0"),
+		ContentType:   "application/yaml",
+		CorrelationID: "corr-2",
+		Logger:        logger,
+		Origin:        models.OriginGatewayAPI,
+	}
+
+	_, err = service.DeployLLMProviderConfiguration(params2)
+	require.Error(t, err)
+	assert.True(t, storage.IsConflictError(err), "expected conflict error, got: %v", err)
+	assert.Contains(t, err.Error(), "my-provider")
+}
+
+func TestLLMDeploymentService_DeployLLMProviderConfiguration_DuplicateDisplayNameAndVersion(t *testing.T) {
+	service, _ := setupLLMDeploymentServiceWithTemplate(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	params := LLMDeploymentParams{
+		Data:          testLLMProviderYAML("provider-one", "My Provider", "v1.0"),
+		ContentType:   "application/yaml",
+		CorrelationID: "corr-1",
+		Logger:        logger,
+		Origin:        models.OriginGatewayAPI,
+	}
+
+	// First deploy should succeed
+	result, err := service.DeployLLMProviderConfiguration(params)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Second deploy with different handle but same displayName+version should conflict
+	params2 := LLMDeploymentParams{
+		Data:          testLLMProviderYAML("provider-two", "My Provider", "v1.0"),
+		ContentType:   "application/yaml",
+		CorrelationID: "corr-2",
+		Logger:        logger,
+		Origin:        models.OriginGatewayAPI,
+	}
+
+	_, err = service.DeployLLMProviderConfiguration(params2)
+	require.Error(t, err)
+	assert.True(t, storage.IsConflictError(err), "expected conflict error, got: %v", err)
+	assert.Contains(t, err.Error(), "My Provider")
+	assert.Contains(t, err.Error(), "v1.0")
+}
+
+func TestLLMDeploymentService_DeployLLMProviderConfiguration_DifferentNameAndVersion_Succeeds(t *testing.T) {
+	service, _ := setupLLMDeploymentServiceWithTemplate(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	params := LLMDeploymentParams{
+		Data:          testLLMProviderYAML("provider-one", "Provider One", "v1.0"),
+		ContentType:   "application/yaml",
+		CorrelationID: "corr-1",
+		Logger:        logger,
+		Origin:        models.OriginGatewayAPI,
+	}
+
+	result, err := service.DeployLLMProviderConfiguration(params)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Different handle and different displayName+version should succeed
+	params2 := LLMDeploymentParams{
+		Data:          testLLMProviderYAML("provider-two", "Provider Two", "v1.0"),
+		ContentType:   "application/yaml",
+		CorrelationID: "corr-2",
+		Logger:        logger,
+		Origin:        models.OriginGatewayAPI,
+	}
+
+	result2, err := service.DeployLLMProviderConfiguration(params2)
+	require.NoError(t, err)
+	require.NotNil(t, result2)
+}


### PR DESCRIPTION
## Summary
- Add conflict detection in `DeployLLMProviderConfiguration` and `DeployLLMProxyConfiguration` to check for existing configs with the same handle or displayName+version before persisting, returning `storage.ErrConflict` on duplicates
- Map `storage.ErrConflict` to HTTP 409 in `CreateLLMProvider` and `CreateLLMProxy` handlers
- Add unit tests for duplicate handle, duplicate displayName+version, and positive (different name) scenarios

Fixes #1545

## Test plan
- [x] Unit tests pass: `TestDeployLLMProviderConfiguration_DuplicateHandle`, `TestDeployLLMProviderConfiguration_DuplicateDisplayNameAndVersion`, `TestDeployLLMProviderConfiguration_DifferentNameAndVersion_Succeeds`
- [x] Full `make test-controller` passes
- [ ] Manual verification: POST same LLM provider twice → first returns 201, second returns 409
- [ ] Integration test with Docker Compose

🤖 Generated with [Claude Code](https://claude.ai/claude-code)