### PR TITLE
Fix policy validation for LLM provider model deployments

### DIFF
--- a/gateway/gateway-controller/pkg/config/policy_validator.go
+++ b/gateway/gateway-controller/pkg/config/policy_validator.go
@@ -59,6 +59,45 @@ func BuildLatestVersionIndex(definitions map[string]models.PolicyDefinition) map
 	return index
 }
 
+// ValidateLLMPolicies validates all LLM policies by checking that
+// each referenced policy name and version exists in the loaded definitions,
+// and that per-path parameters conform to the policy's JSON schema.
+func (pv *PolicyValidator) ValidateLLMPolicies(policies *[]api.LLMPolicy) []ValidationError {
+	var errors []ValidationError
+
+	if policies == nil {
+		return errors
+	}
+
+	for i, llmPolicy := range *policies {
+		fieldPath := fmt.Sprintf("spec.policies[%d]", i)
+
+		// Convert each path entry to an api.Policy to reuse validatePolicy
+		for j, pathEntry := range llmPolicy.Paths {
+			pathFieldPath := fmt.Sprintf("%s.paths[%d]", fieldPath, j)
+			policy := api.Policy{
+				Name:    llmPolicy.Name,
+				Version: llmPolicy.Version,
+				Params:  &pathEntry.Params,
+			}
+			errs := pv.validatePolicy(policy, pathFieldPath)
+			errors = append(errors, errs...)
+		}
+
+		// If no paths, still validate name and version
+		if len(llmPolicy.Paths) == 0 {
+			policy := api.Policy{
+				Name:    llmPolicy.Name,
+				Version: llmPolicy.Version,
+			}
+			errs := pv.validatePolicy(policy, fieldPath)
+			errors = append(errors, errs...)
+		}
+	}
+
+	return errors
+}
+
 // ValidateMCPProxyPolicies validates all policies in an MCP proxy configuration
 func (pv *PolicyValidator) ValidateMCPProxyPolicies(mcpConfig *api.MCPProxyConfiguration) []ValidationError {
 	var errors []ValidationError

--- a/gateway/gateway-controller/pkg/config/policy_validator_test.go
+++ b/gateway/gateway-controller/pkg/config/policy_validator_test.go
@@ -867,6 +867,299 @@ func boolPtr(b bool) *bool {
 	return &b
 }
 
+// ========================================
+// ValidateLLMPolicies tests
+// ========================================
+
+func TestValidateLLMPolicies_NilPolicies(t *testing.T) {
+	validator := NewPolicyValidator(map[string]models.PolicyDefinition{})
+	errors := validator.ValidateLLMPolicies(nil)
+	if len(errors) != 0 {
+		t.Errorf("Expected no errors for nil policies, got %d", len(errors))
+	}
+}
+
+func TestValidateLLMPolicies_EmptyPolicies(t *testing.T) {
+	validator := NewPolicyValidator(map[string]models.PolicyDefinition{})
+	policies := &[]api.LLMPolicy{}
+	errors := validator.ValidateLLMPolicies(policies)
+	if len(errors) != 0 {
+		t.Errorf("Expected no errors for empty policies, got %d", len(errors))
+	}
+}
+
+func TestValidateLLMPolicies_NonExistentPolicyName(t *testing.T) {
+	policyDefs := map[string]models.PolicyDefinition{
+		"set-headers|v1.0.0": {
+			Name:    "set-headers",
+			Version: "v1.0.0",
+		},
+	}
+	validator := NewPolicyValidator(policyDefs)
+
+	policies := &[]api.LLMPolicy{
+		{
+			Name:    "set-headerssss",
+			Version: "v1",
+			Paths: []api.LLMPolicyPath{
+				{
+					Path:    "/chat/completions",
+					Methods: []api.LLMPolicyPathMethods{"POST"},
+					Params:  map[string]interface{}{},
+				},
+			},
+		},
+	}
+
+	errors := validator.ValidateLLMPolicies(policies)
+	if len(errors) == 0 {
+		t.Fatal("Expected validation errors for non-existent policy name, got none")
+	}
+	if !strings.Contains(errors[0].Message, "not found") {
+		t.Errorf("Expected 'not found' in error message, got: %s", errors[0].Message)
+	}
+}
+
+func TestValidateLLMPolicies_ValidPolicyName(t *testing.T) {
+	policyDefs := map[string]models.PolicyDefinition{
+		"set-headers|v1.0.0": {
+			Name:    "set-headers",
+			Version: "v1.0.0",
+		},
+	}
+	validator := NewPolicyValidator(policyDefs)
+
+	policies := &[]api.LLMPolicy{
+		{
+			Name:    "set-headers",
+			Version: "v1",
+			Paths: []api.LLMPolicyPath{
+				{
+					Path:    "/chat/completions",
+					Methods: []api.LLMPolicyPathMethods{"POST"},
+					Params:  map[string]interface{}{},
+				},
+			},
+		},
+	}
+
+	errors := validator.ValidateLLMPolicies(policies)
+	if len(errors) != 0 {
+		t.Errorf("Expected no errors for valid policy, got %d: %v", len(errors), errors)
+	}
+}
+
+func TestValidateLLMPolicies_PolicyExistsButVersionNotFound(t *testing.T) {
+	policyDefs := map[string]models.PolicyDefinition{
+		"set-headers|v1.0.0": {
+			Name:    "set-headers",
+			Version: "v1.0.0",
+		},
+	}
+	validator := NewPolicyValidator(policyDefs)
+
+	policies := &[]api.LLMPolicy{
+		{
+			Name:    "set-headers",
+			Version: "v99",
+			Paths: []api.LLMPolicyPath{
+				{
+					Path:    "/chat/completions",
+					Methods: []api.LLMPolicyPathMethods{"POST"},
+					Params:  map[string]interface{}{},
+				},
+			},
+		},
+	}
+
+	errors := validator.ValidateLLMPolicies(policies)
+	if len(errors) == 0 {
+		t.Fatal("Expected validation errors for non-existent version, got none")
+	}
+	if !strings.Contains(errors[0].Message, "not found") {
+		t.Errorf("Expected 'not found' in error message, got: %s", errors[0].Message)
+	}
+}
+
+func TestValidateLLMPolicies_InvalidPolicyParameters(t *testing.T) {
+	policyDefs := map[string]models.PolicyDefinition{
+		"set-headers|v1.0.0": {
+			Name:    "set-headers",
+			Version: "v1.0.0",
+			Parameters: &map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"request": map[string]interface{}{
+						"type": "object",
+					},
+				},
+				"required":             []interface{}{"request"},
+				"additionalProperties": false,
+			},
+		},
+	}
+	validator := NewPolicyValidator(policyDefs)
+
+	policies := &[]api.LLMPolicy{
+		{
+			Name:    "set-headers",
+			Version: "v1",
+			Paths: []api.LLMPolicyPath{
+				{
+					Path:    "/chat/completions",
+					Methods: []api.LLMPolicyPathMethods{"POST"},
+					Params: map[string]interface{}{
+						"invalidField": "invalidValue",
+					},
+				},
+			},
+		},
+	}
+
+	errors := validator.ValidateLLMPolicies(policies)
+	if len(errors) == 0 {
+		t.Fatal("Expected validation errors for invalid params, got none")
+	}
+}
+
+func TestValidateLLMPolicies_MultiplePoliciesOneInvalid(t *testing.T) {
+	policyDefs := map[string]models.PolicyDefinition{
+		"set-headers|v1.0.0": {
+			Name:    "set-headers",
+			Version: "v1.0.0",
+		},
+	}
+	validator := NewPolicyValidator(policyDefs)
+
+	policies := &[]api.LLMPolicy{
+		{
+			Name:    "set-headers",
+			Version: "v1",
+			Paths: []api.LLMPolicyPath{
+				{
+					Path:    "/chat/completions",
+					Methods: []api.LLMPolicyPathMethods{"POST"},
+					Params:  map[string]interface{}{},
+				},
+			},
+		},
+		{
+			Name:    "non-existent-policy",
+			Version: "v1",
+			Paths: []api.LLMPolicyPath{
+				{
+					Path:    "/chat/completions",
+					Methods: []api.LLMPolicyPathMethods{"POST"},
+					Params:  map[string]interface{}{},
+				},
+			},
+		},
+	}
+
+	errors := validator.ValidateLLMPolicies(policies)
+	if len(errors) == 0 {
+		t.Fatal("Expected validation errors when one policy is invalid, got none")
+	}
+	// The valid policy should pass, the invalid one should fail
+	foundNotFound := false
+	for _, e := range errors {
+		if strings.Contains(e.Message, "not found") {
+			foundNotFound = true
+		}
+	}
+	if !foundNotFound {
+		t.Errorf("Expected a 'not found' error for invalid policy, got: %v", errors)
+	}
+}
+
+func TestValidateLLMPolicies_PolicyWithNoPaths(t *testing.T) {
+	// Empty policy definitions — no policies loaded
+	policyDefs := map[string]models.PolicyDefinition{}
+	validator := NewPolicyValidator(policyDefs)
+
+	policies := &[]api.LLMPolicy{
+		{
+			Name:    "non-existent-policy",
+			Version: "v1",
+			Paths:   []api.LLMPolicyPath{},
+		},
+	}
+
+	errors := validator.ValidateLLMPolicies(policies)
+	if len(errors) == 0 {
+		t.Fatal("Expected validation errors for non-existent policy with no paths, got none")
+	}
+	if !strings.Contains(errors[0].Message, "not found") {
+		t.Errorf("Expected 'not found' in error message, got: %s", errors[0].Message)
+	}
+}
+
+func TestValidateLLMPolicies_MultiplePathsSamePolicy(t *testing.T) {
+	policyDefs := map[string]models.PolicyDefinition{
+		"set-headers|v1.0.0": {
+			Name:    "set-headers",
+			Version: "v1.0.0",
+		},
+	}
+	validator := NewPolicyValidator(policyDefs)
+
+	policies := &[]api.LLMPolicy{
+		{
+			Name:    "set-headers",
+			Version: "v1",
+			Paths: []api.LLMPolicyPath{
+				{
+					Path:    "/chat/completions",
+					Methods: []api.LLMPolicyPathMethods{"POST"},
+					Params:  map[string]interface{}{},
+				},
+				{
+					Path:    "/embeddings",
+					Methods: []api.LLMPolicyPathMethods{"POST"},
+					Params:  map[string]interface{}{},
+				},
+			},
+		},
+	}
+
+	errors := validator.ValidateLLMPolicies(policies)
+	if len(errors) != 0 {
+		t.Errorf("Expected no errors for valid policy with multiple paths, got %d: %v", len(errors), errors)
+	}
+}
+
+func TestValidateLLMPolicies_FullSemverRejected(t *testing.T) {
+	policyDefs := map[string]models.PolicyDefinition{
+		"set-headers|v1.0.0": {
+			Name:    "set-headers",
+			Version: "v1.0.0",
+		},
+	}
+	validator := NewPolicyValidator(policyDefs)
+
+	policies := &[]api.LLMPolicy{
+		{
+			Name:    "set-headers",
+			Version: "v1.0.0",
+			Paths: []api.LLMPolicyPath{
+				{
+					Path:    "/chat/completions",
+					Methods: []api.LLMPolicyPathMethods{"POST"},
+					Params:  map[string]interface{}{},
+				},
+			},
+		},
+	}
+
+	errors := validator.ValidateLLMPolicies(policies)
+	if len(errors) == 0 {
+		t.Fatal("Expected validation errors for full semver version, got none")
+	}
+	if !strings.Contains(errors[0].Message, "major-only") {
+		t.Errorf("Expected 'major-only' in error message, got: %s", errors[0].Message)
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) > 0 && len(substr) > 0 && (s == substr || len(s) >= len(substr) && s[:len(substr)] == substr || stringContains(s, substr))
 }

--- a/gateway/gateway-controller/pkg/utils/llm_deployment.go
+++ b/gateway/gateway-controller/pkg/utils/llm_deployment.go
@@ -210,26 +210,27 @@ func (s *LLMDeploymentService) DeployLLMProviderConfiguration(params LLMDeployme
 		return nil, fmt.Errorf("provider validation failed with %d error(s): %s", len(validationErrors), strings.Join(errs, "; "))
 	}
 
+	// Validate policies against loaded policy definitions (before transformation,
+	// which injects template parameters that would fail schema validation)
+	if s.policyValidator != nil {
+		policyErrors := s.policyValidator.ValidateLLMPolicies(providerConfig.Spec.Policies)
+		if len(policyErrors) > 0 {
+			errs := make([]string, 0, len(policyErrors))
+			for i, e := range policyErrors {
+				if params.Logger != nil {
+					params.Logger.Warn("Policy validation error", slog.String("field", e.Field), slog.String("message", e.Message))
+				}
+				errs = append(errs, fmt.Sprintf("%d. %s: %s", i+1, e.Field, e.Message))
+			}
+			return nil, fmt.Errorf("policy validation failed with %d error(s): %s", len(policyErrors), strings.Join(errs, "; "))
+		}
+	}
+
 	// Transform to RestAPI configuration
 	_, err := s.transformer.Transform(&providerConfig, &apiConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to transform LLM provider to API configuration: %w", err)
 	}
-
-	// Validate policies against loaded policy definitions
-	// if s.policyValidator != nil {
-	// 	policyErrors := s.policyValidator.ValidatePolicies(&apiConfig)
-	// 	if len(policyErrors) > 0 {
-	// 		errs := make([]string, 0, len(policyErrors))
-	// 		for i, e := range policyErrors {
-	// 			if params.Logger != nil {
-	// 				params.Logger.Warn("Policy validation error", slog.String("field", e.Field), slog.String("message", e.Message))
-	// 			}
-	// 			errs = append(errs, fmt.Sprintf("%d. %s: %s", i+1, e.Field, e.Message))
-	// 		}
-	// 		return nil, fmt.Errorf("policy validation failed with %d error(s): %s", len(policyErrors), strings.Join(errs, "; "))
-	// 	}
-	// }
 
 	// Generate API ID if not provided
 	apiID := params.ID
@@ -365,26 +366,27 @@ func (s *LLMDeploymentService) DeployLLMProxyConfiguration(params LLMDeploymentP
 		return nil, fmt.Errorf("proxy validation failed with %d error(s): %s", len(validationErrors), strings.Join(errs, "; "))
 	}
 
+	// Validate policies against loaded policy definitions (before transformation,
+	// which injects template parameters that would fail schema validation)
+	if s.policyValidator != nil {
+		policyErrors := s.policyValidator.ValidateLLMPolicies(proxyConfig.Spec.Policies)
+		if len(policyErrors) > 0 {
+			errs := make([]string, 0, len(policyErrors))
+			for i, e := range policyErrors {
+				if params.Logger != nil {
+					params.Logger.Warn("Policy validation error", slog.String("field", e.Field), slog.String("message", e.Message))
+				}
+				errs = append(errs, fmt.Sprintf("%d. %s: %s", i+1, e.Field, e.Message))
+			}
+			return nil, fmt.Errorf("policy validation failed with %d error(s): %s", len(policyErrors), strings.Join(errs, "; "))
+		}
+	}
+
 	// Transform to RestAPI configuration
 	_, err := s.transformer.Transform(&proxyConfig, &apiConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to transform LLM proxy to API configuration: %w", err)
 	}
-
-	// Validate policies against loaded policy definitions
-	// if s.policyValidator != nil {
-	// 	policyErrors := s.policyValidator.ValidatePolicies(&apiConfig)
-	// 	if len(policyErrors) > 0 {
-	// 		errs := make([]string, 0, len(policyErrors))
-	// 		for i, e := range policyErrors {
-	// 			if params.Logger != nil {
-	// 				params.Logger.Warn("Policy validation error", slog.String("field", e.Field), slog.String("message", e.Message))
-	// 			}
-	// 			errs = append(errs, fmt.Sprintf("%d. %s: %s", i+1, e.Field, e.Message))
-	// 		}
-	// 		return nil, fmt.Errorf("policy validation failed with %d error(s): %s", len(policyErrors), strings.Join(errs, "; "))
-	// 	}
-	// }
 
 	// Generate API ID if not provided
 	apiID := params.ID

--- a/gateway/gateway-controller/pkg/utils/llm_deployment_test.go
+++ b/gateway/gateway-controller/pkg/utils/llm_deployment_test.go
@@ -143,6 +143,236 @@ func testStoredLLMTemplate(uuid, handle, displayName string) *models.StoredLLMPr
 	}
 }
 
+// ========================================
+// Policy validation tests for LLM providers
+// ========================================
+
+func TestLLMDeploymentService_CreateLLMProvider_InvalidPolicyName(t *testing.T) {
+	store := storage.NewConfigStore()
+	routerConfig := &config.RouterConfig{ListenerPort: 8080}
+	db := newTestMockDB()
+	apiDeploymentService := newTestAPIDeploymentService(store, db, nil, nil, routerConfig, nil)
+
+	// Create validator with known policy definitions
+	policyDefs := map[string]models.PolicyDefinition{
+		"set-headers|v1.0.0": {
+			Name:    "set-headers",
+			Version: "v1.0.0",
+		},
+	}
+	policyValidator := config.NewPolicyValidator(policyDefs)
+
+	service := NewLLMDeploymentService(store, db, nil, nil, nil, apiDeploymentService, routerConfig, nil, policyValidator)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// LLM provider YAML with invalid policy name "set-headerssss"
+	yamlData := `
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: invalid-policy-provider
+spec:
+  displayName: Provider With Invalid Policy
+  version: v1.0
+  template: openai
+  upstream:
+    url: "https://api.openai.com/v1"
+  accessControl:
+    mode: allow_all
+  policies:
+    - name: set-headerssss
+      version: v1
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params: {}
+`
+	params := LLMDeploymentParams{
+		Data:        []byte(yamlData),
+		ContentType: "application/yaml",
+		Logger:      logger,
+		Origin:      models.OriginGatewayAPI,
+	}
+
+	_, err := service.CreateLLMProvider(params)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "policy validation failed")
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestLLMDeploymentService_CreateLLMProvider_ValidPolicyPassesValidation(t *testing.T) {
+	// Test that a valid policy name passes the policy validation step.
+	// We directly call ValidateLLMPolicies to isolate the validation from the
+	// deeper deployment flow (which requires PolicyResolver, DB, etc.)
+	policyDefs := map[string]models.PolicyDefinition{
+		"set-headers|v1.0.0": {
+			Name:    "set-headers",
+			Version: "v1.0.0",
+		},
+	}
+	policyValidator := config.NewPolicyValidator(policyDefs)
+
+	policies := &[]api.LLMPolicy{
+		{
+			Name:    "set-headers",
+			Version: "v1",
+			Paths: []api.LLMPolicyPath{
+				{
+					Path:    "/chat/completions",
+					Methods: []api.LLMPolicyPathMethods{"POST"},
+					Params:  map[string]interface{}{},
+				},
+			},
+		},
+	}
+
+	errors := policyValidator.ValidateLLMPolicies(policies)
+	assert.Empty(t, errors, "Valid policy should not produce validation errors")
+}
+
+func TestLLMDeploymentService_CreateLLMProvider_PolicyVersionNotFound(t *testing.T) {
+	store := storage.NewConfigStore()
+	routerConfig := &config.RouterConfig{ListenerPort: 8080}
+	db := newTestMockDB()
+	apiDeploymentService := newTestAPIDeploymentService(store, db, nil, nil, routerConfig, nil)
+
+	policyDefs := map[string]models.PolicyDefinition{
+		"set-headers|v1.0.0": {
+			Name:    "set-headers",
+			Version: "v1.0.0",
+		},
+	}
+	policyValidator := config.NewPolicyValidator(policyDefs)
+	service := NewLLMDeploymentService(store, db, nil, nil, nil, apiDeploymentService, routerConfig, nil, policyValidator)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// Valid policy name but non-existent version v99
+	yamlData := `
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: bad-version-provider
+spec:
+  displayName: Provider With Bad Version
+  version: v1.0
+  template: openai
+  upstream:
+    url: "https://api.openai.com/v1"
+  accessControl:
+    mode: allow_all
+  policies:
+    - name: set-headers
+      version: v99
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params: {}
+`
+	params := LLMDeploymentParams{
+		Data:        []byte(yamlData),
+		ContentType: "application/yaml",
+		Logger:      logger,
+		Origin:      models.OriginGatewayAPI,
+	}
+
+	_, err := service.CreateLLMProvider(params)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "policy validation failed")
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestLLMDeploymentService_CreateLLMProvider_NilPolicyValidatorSkipsValidation(t *testing.T) {
+	store := storage.NewConfigStore()
+	routerConfig := &config.RouterConfig{ListenerPort: 8080}
+	db := newTestMockDB()
+	apiDeploymentService := newTestAPIDeploymentService(store, db, nil, nil, routerConfig, nil)
+
+	// Pass nil policy validator — should skip policy validation
+	service := NewLLMDeploymentService(store, db, nil, nil, nil, apiDeploymentService, routerConfig, nil, nil)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	yamlData := `
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: no-validator-provider
+spec:
+  displayName: Provider Without Validator
+  version: v1.0
+  template: openai
+  upstream:
+    url: "https://api.openai.com/v1"
+  accessControl:
+    mode: allow_all
+  policies:
+    - name: totally-fake-policy
+      version: v1
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params: {}
+`
+	params := LLMDeploymentParams{
+		Data:        []byte(yamlData),
+		ContentType: "application/yaml",
+		Logger:      logger,
+		Origin:      models.OriginGatewayAPI,
+	}
+
+	_, err := service.CreateLLMProvider(params)
+	// Should NOT fail with policy validation error (nil validator is skipped)
+	if err != nil {
+		assert.NotContains(t, err.Error(), "policy validation failed")
+	}
+}
+
+func TestLLMDeploymentService_CreateLLMProxy_InvalidPolicyName(t *testing.T) {
+	store := storage.NewConfigStore()
+	routerConfig := &config.RouterConfig{ListenerPort: 8080}
+	db := newTestMockDB()
+	apiDeploymentService := newTestAPIDeploymentService(store, db, nil, nil, routerConfig, nil)
+
+	policyDefs := map[string]models.PolicyDefinition{
+		"set-headers|v1.0.0": {
+			Name:    "set-headers",
+			Version: "v1.0.0",
+		},
+	}
+	policyValidator := config.NewPolicyValidator(policyDefs)
+	service := NewLLMDeploymentService(store, db, nil, nil, nil, apiDeploymentService, routerConfig, nil, policyValidator)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	yamlData := `
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProxy
+metadata:
+  name: invalid-policy-proxy
+spec:
+  displayName: Proxy With Invalid Policy
+  version: v1.0
+  provider:
+    id: some-provider-id
+  policies:
+    - name: non-existent-policy
+      version: v1
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params: {}
+`
+	params := LLMDeploymentParams{
+		Data:        []byte(yamlData),
+		ContentType: "application/yaml",
+		Logger:      logger,
+		Origin:      models.OriginGatewayAPI,
+	}
+
+	_, err := service.CreateLLMProxy(params)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "policy validation failed")
+	assert.Contains(t, err.Error(), "not found")
+}
+
 func TestLLMDeploymentService_ListLLMProviders(t *testing.T) {
 	t.Run("Empty store returns empty list", func(t *testing.T) {
 		store := storage.NewConfigStore()

--- a/gateway/it/features/llm-provider.feature
+++ b/gateway/it/features/llm-provider.feature
@@ -387,6 +387,37 @@ Feature: LLM Provider Management
     When I delete the LLM provider "policy-provider"
     Then the response status code should be 200
 
+  Scenario: LLM provider with non-existing policy should fail
+    Given I authenticate using basic auth as "admin"
+    When I create this LLM provider:
+        """
+        apiVersion: gateway.api-platform.wso2.com/v1alpha1
+        kind: LlmProvider
+        metadata:
+          name: invalid-policy-provider
+        spec:
+          displayName: Provider With Invalid Policy
+          version: v1.0
+          template: openai
+          upstream:
+            url: https://mock-openapi-https:9443/openai/v1
+            auth:
+              type: api-key
+              header: Authorization
+              value: Bearer sk-test
+          accessControl:
+            mode: allow_all
+          policies:
+            - name: non-existing-policy
+              version: v1
+              paths:
+                - path: /chat/completions
+                  methods: [POST]
+                  params: {}
+        """
+    Then the response status code should be 400
+    And the response should be valid JSON
+
   # ========================================
   # Scenario Group 8: Error Scenarios
   # ========================================


### PR DESCRIPTION
## Summary
- Add validation to ensure policy names referenced in model deployment configurations exist in the LLM provider's policy list
- Previously, invalid policy references in model deployments were silently accepted, leading to runtime errors
- Added unit tests for the new validation logic and integration test scenarios

## Related Issue
Fixes #1547

## Test plan
- [ ] Unit tests pass for policy validator (`policy_validator_test.go`)
- [ ] Unit tests pass for LLM deployment utils (`llm_deployment_test.go`)
- [ ] Integration test scenarios for invalid policy references in LLM providers
- [ ] Existing integration tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)