### PR TITLE
Add missing secret validation logic to llm flows

### DIFF
--- a/gateway/gateway-controller/pkg/utils/llm_deployment.go
+++ b/gateway/gateway-controller/pkg/utils/llm_deployment.go
@@ -297,6 +297,11 @@ func (s *LLMDeploymentService) DeployLLMProviderConfiguration(params LLMDeployme
 		return nil, err
 	}
 
+	err = s.validateSecretsWithPolicies(storedCfg)
+	if err != nil {
+		return nil, err
+	}
+
 	// Important: Do not persist the resolved configuration
 	// Save or update using timestamp-guarded upsert.
 	// affected=false means a newer version already exists (stale event — no-op).
@@ -452,6 +457,11 @@ func (s *LLMDeploymentService) DeployLLMProxyConfiguration(params LLMDeploymentP
 		return nil, err
 	}
 
+	err = s.validateSecretsWithPolicies(storedCfg)
+	if err != nil {
+		return nil, err
+	}
+
 	// Important: Do not persist the resolved configuration
 	// Save or update using timestamp-guarded upsert.
 	// Policy resolution happens in the EventListener after all replicas consume the
@@ -560,6 +570,31 @@ func (s *LLMDeploymentService) CreateLLMProviderTemplate(params LLMTemplateParam
 
 	s.publishLLMTemplateEvent("CREATE", stored.UUID, params.CorrelationID, params.Logger)
 	return stored, nil
+}
+
+// validateSecretsWithPolicies runs the stored configuration through policy resolution to validate referenced secrets against policy constraints.
+// Returns an error if any validation errors are found.
+func (s *LLMDeploymentService) validateSecretsWithPolicies(storedCfg *models.StoredConfig) error {
+	if s.deploymentService.policyResolver == nil {
+		return fmt.Errorf("policy resolver is not initialized")
+	}
+	_, validationErrors := s.deploymentService.policyResolver.ResolvePolicies(storedCfg)
+	if len(validationErrors) > 0 {
+		// Aggregate errors into a single error message
+		errMsgs := make([]string, 0, len(validationErrors))
+		for _, ve := range validationErrors {
+			errMsgs = append(errMsgs, ve.Message)
+		}
+		errMsg := strings.Join(errMsgs, "; ")
+
+		slog.Error("Policy resolution failed",
+			slog.String("config_handle", storedCfg.Handle),
+			slog.String("errors", errMsg),
+		)
+
+		return fmt.Errorf("policy resolution failed with %d errors: %s", len(validationErrors), errMsg)
+	}
+	return nil
 }
 
 // InitializeOOBTemplates persists OOB templates to database and memory store


### PR DESCRIPTION
## Purpose

Reintroduce the secret validation logic removed through https://github.com/wso2/api-platform/pull/1581


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a pre-deployment policy validation step for LLM configuration deployments. Deployments now abort if policy validation fails or if the validation component is unavailable, preventing invalid configurations from being saved. Failures are logged with the configuration handle and aggregated error details to aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->