### PR TITLE
Remove subscriptions during API deletion

### DIFF
--- a/gateway/gateway-controller/pkg/controlplane/client.go
+++ b/gateway/gateway-controller/pkg/controlplane/client.go
@@ -1687,6 +1687,21 @@ func (c *Client) performFullAPIDeletion(apiID string, apiConfig *models.StoredCo
 		)
 	}
 
+	// 3. Delete all subscriptions from database (no FK cascade)
+	if err := c.db.DeleteSubscriptionsForAPINotIn(apiID, nil); err != nil {
+		c.logger.Warn("Failed to delete subscriptions from database",
+			slog.String("api_id", apiID),
+			slog.Any("error", err),
+		)
+	} else {
+		c.logger.Info("Successfully deleted subscriptions from database",
+			slog.String("api_id", apiID),
+		)
+	}
+
+	// Refresh subscription xDS so policy engine drops tokens immediately.
+	c.refreshSubscriptionSnapshot()
+
 	evt := eventhub.Event{
 		EventType: eventhub.EventTypeAPI,
 		Action:    "DELETE",

--- a/gateway/gateway-controller/pkg/eventlistener/api_processor.go
+++ b/gateway/gateway-controller/pkg/eventlistener/api_processor.go
@@ -150,6 +150,26 @@ func (l *EventListener) handleAPIDelete(event eventhub.Event) {
 			slog.Any("error", err))
 	}
 
+	// Remove subscriptions for this API from the DB (subscriptions.api_id is not a FK).
+	// Guard nil to keep unit tests (that construct EventListener without NewEventListener) from panicking.
+	if l.db != nil {
+		if err := l.db.DeleteSubscriptionsForAPINotIn(entityID, nil); err != nil {
+			l.logger.Warn("Failed to delete subscriptions from database after API deletion",
+				slog.String("api_id", entityID),
+				slog.Any("error", err))
+		} else if l.subscriptionManager != nil {
+			// Refresh subscription xDS so policy engine drops tokens immediately.
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			if err := l.subscriptionManager.UpdateSnapshot(ctx); err != nil {
+				l.logger.Warn("Failed to refresh subscription snapshot after API deletion",
+					slog.String("api_id", entityID),
+					slog.String("event_id", event.EventID),
+					slog.Any("error", err))
+			}
+		}
+	}
+
 	if existingConfig != nil && l.apiKeyXDSManager != nil {
 		apiName, apiVersion := extractAPINameVersion(existingConfig)
 		if apiName != "" {


### PR DESCRIPTION
## Purpose
Remove subscriptions during API deletion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API deletion now explicitly removes all associated subscriptions from the system
  * Subscription snapshots are immediately refreshed after API deletion to ensure policies and tokens reflect changes without delay
  * Added improved error handling and logging for subscription cleanup operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->