### PR TITLE
Implement inline execution of response body policies for bodyless responses

### DIFF
--- a/gateway/gateway-runtime/policy-engine/internal/kernel/execution_context.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/execution_context.go
@@ -363,6 +363,37 @@ func (ec *PolicyExecutionContext) processRequestBodyForEmptyRequest(
 	return TranslateRequestHeaderActionsWithBodyMerge(headerResult, bodyResult, ec)
 }
 
+// processResponseBodyForEmptyResponse executes body policies inline during the response-headers
+// phase for responses that carry no body. The body context is set to Present=false / EndOfStream=true
+// so policies can inspect headers-only state and still run on every response.
+func (ec *PolicyExecutionContext) processResponseBodyForEmptyResponse(
+	ctx context.Context,
+	headerResult *executor.ResponseHeaderExecutionResult,
+) (*extprocv3.ProcessingResponse, error) {
+	// Ensure the body context reflects a nil/absent body.
+	ec.responseBodyCtx.ResponseBody = &policy.Body{Content: nil, EndOfStream: true, Present: false}
+
+	slog.DebugContext(ctx, "[no-body] executing response body policies inline during response-headers phase",
+		"route", ec.routeKey,
+		"status", ec.responseHeaderCtx.ResponseStatus,
+	)
+
+	bodyResult, err := ec.server.executor.ExecuteResponsePolicies(
+		ctx,
+		ec.policyChain.Policies,
+		ec.responseBodyCtx,
+		ec.policyChain.PolicySpecs,
+		ec.sharedCtx.APIName,
+		ec.routeKey,
+		ec.policyChain.HasExecutionConditions,
+	)
+	if err != nil {
+		return ec.handlePolicyError(ctx, err, "response_body_no_body"), nil
+	}
+
+	return TranslateResponseHeaderActionsWithBodyMerge(headerResult, bodyResult, ec)
+}
+
 // processRequestBody processes request body phase
 func (ec *PolicyExecutionContext) processRequestBody(
 	ctx context.Context,
@@ -630,6 +661,12 @@ func (ec *PolicyExecutionContext) processResponseHeaders(
 	// Propagate header mutations into the shared in-memory context so that body-phase
 	// policies (OnResponseBody / OnResponseBodyChunk) observe the post-mutation headers.
 	applyResponseHeaderMutations(ec.responseHeaderCtx.ResponseHeaders, execResult.Results)
+
+	// For bodyless responses Envoy skips the ResponseBody ext_proc phase entirely.
+	// Execute body policies inline now so they run on every response, receiving a nil body.
+	if !execResult.ShortCircuited && ec.policyChain.RequiresResponseBody && ec.responseHasNoBody() {
+		return ec.processResponseBodyForEmptyResponse(ctx, execResult)
+	}
 
 	resp, err := TranslateResponseHeaderActions(execResult, ec)
 	if err != nil {

--- a/gateway/gateway-runtime/policy-engine/internal/kernel/translator.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/translator.go
@@ -814,6 +814,175 @@ func TranslateResponseHeaderActions(result *executor.ResponseHeaderExecutionResu
 	return response, nil
 }
 
+// TranslateResponseHeaderActionsWithBodyMerge merges the results of both response-headers
+// and response-body phase policy execution into a single ResponseHeaders ext_proc response.
+// This is called during the response-headers phase for bodyless responses where Envoy will not
+// deliver a separate ResponseBody phase.
+func TranslateResponseHeaderActionsWithBodyMerge(
+	headerResult *executor.ResponseHeaderExecutionResult,
+	bodyResult *executor.ResponseExecutionResult,
+	execCtx *PolicyExecutionContext,
+) (*extprocv3.ProcessingResponse, error) {
+	// Only body policies can short-circuit here: this function is called exclusively
+	// when header policies did NOT short-circuit (see processResponseBodyForEmptyResponse).
+	if bodyResult.ShortCircuited && bodyResult.FinalAction != nil {
+		if immResp, ok := bodyResult.FinalAction.(policy.ImmediateResponse); ok {
+			response := &extprocv3.ProcessingResponse{
+				Response: &extprocv3.ProcessingResponse_ImmediateResponse{
+					ImmediateResponse: &extprocv3.ImmediateResponse{
+						Status:  &typev3.HttpStatus{Code: typev3.StatusCode(immResp.StatusCode)},
+						Headers: buildHeaderValueOptions(immResp.Headers),
+						Body:    immResp.Body,
+					},
+				},
+			}
+			analyticsStruct, err := buildAnalyticsStruct(immResp.AnalyticsMetadata, execCtx)
+			if err != nil {
+				return nil, fmt.Errorf("failed to build analytics metadata for immediate response: %w", err)
+			}
+			response.DynamicMetadata = buildDynamicMetadata(analyticsStruct, nil, nil, immResp.DynamicMetadata)
+			return response, nil
+		}
+	}
+
+	headerOps := make(map[string][]*headerOp)
+	analyticsData := make(map[string]any)
+	dynamicMetadata := make(map[string]map[string]interface{})
+	headerMutation := &extprocv3.HeaderMutation{}
+	var bodyMutation *extprocv3.BodyMutation
+	var finalBodyLength int
+	bodyModified := false
+
+	// Seed with request-phase analytics and dynamic metadata.
+	for key, value := range execCtx.analyticsMetadata {
+		analyticsData[key] = value
+	}
+	mergeDynamicMetadata(dynamicMetadata, execCtx.dynamicMetadata)
+
+	// Collect mutations from header-phase policies (DownstreamResponseHeaderModifications).
+	for _, pr := range headerResult.Results {
+		if pr.Skipped || pr.Action == nil {
+			continue
+		}
+		mods, ok := pr.Action.(policy.DownstreamResponseHeaderModifications)
+		if !ok {
+			continue
+		}
+		for k, v := range mods.HeadersToSet {
+			headerOps[strings.ToLower(k)] = append(headerOps[strings.ToLower(k)], &headerOp{opType: "set", value: v})
+		}
+		for _, k := range mods.HeadersToRemove {
+			headerOps[strings.ToLower(k)] = append(headerOps[strings.ToLower(k)], &headerOp{opType: "remove", value: ""})
+		}
+		if mods.AnalyticsMetadata != nil {
+			for key, value := range mods.AnalyticsMetadata {
+				analyticsData[key] = value
+				execCtx.analyticsMetadata[key] = value
+			}
+		}
+		if mods.DynamicMetadata != nil {
+			mergeDynamicMetadata(dynamicMetadata, mods.DynamicMetadata)
+			mergeDynamicMetadata(execCtx.dynamicMetadata, mods.DynamicMetadata)
+		}
+		dropAction := mods.AnalyticsHeaderFilter
+		if dropAction.Action != "" || len(dropAction.Headers) > 0 {
+			originalHeaders := execCtx.responseBodyCtx.ResponseHeaders.GetAll()
+			finalizedHeaders := finalizeAnalyticsHeaders(dropAction, originalHeaders)
+			analyticsData["response_headers"] = finalizedHeaders
+			execCtx.analyticsMetadata["response_headers"] = finalizedHeaders
+		}
+	}
+
+	// Collect mutations from body-phase policies (DownstreamResponseModifications).
+	for _, pr := range bodyResult.Results {
+		if pr.Skipped || pr.Error != nil || pr.Action == nil {
+			continue
+		}
+		mods, ok := pr.Action.(policy.DownstreamResponseModifications)
+		if !ok {
+			continue
+		}
+		for k, v := range mods.HeadersToSet {
+			headerOps[strings.ToLower(k)] = append(headerOps[strings.ToLower(k)], &headerOp{opType: "set", value: v})
+		}
+		for _, k := range mods.HeadersToRemove {
+			headerOps[strings.ToLower(k)] = append(headerOps[strings.ToLower(k)], &headerOp{opType: "remove", value: ""})
+		}
+		if mods.Body != nil {
+			bodyMutation = &extprocv3.BodyMutation{
+				Mutation: &extprocv3.BodyMutation_Body{Body: mods.Body},
+			}
+			finalBodyLength = len(mods.Body)
+			bodyModified = true
+		}
+		if mods.StatusCode != nil {
+			headerOps[":status"] = append(headerOps[":status"], &headerOp{opType: "set", value: fmt.Sprintf("%d", *mods.StatusCode)})
+		}
+		if mods.AnalyticsMetadata != nil {
+			for key, value := range mods.AnalyticsMetadata {
+				analyticsData[key] = value
+				execCtx.analyticsMetadata[key] = value
+			}
+		}
+		if mods.DynamicMetadata != nil {
+			mergeDynamicMetadata(dynamicMetadata, mods.DynamicMetadata)
+			mergeDynamicMetadata(execCtx.dynamicMetadata, mods.DynamicMetadata)
+		}
+		dropAction := mods.AnalyticsHeaderFilter
+		if dropAction.Action != "" || len(dropAction.Headers) > 0 {
+			originalHeaders := execCtx.responseBodyCtx.ResponseHeaders.GetAll()
+			finalizedHeaders := finalizeAnalyticsHeaders(dropAction, originalHeaders)
+			analyticsData["response_headers"] = finalizedHeaders
+			execCtx.analyticsMetadata["response_headers"] = finalizedHeaders
+		}
+	}
+
+	// Re-compress body if a policy modified it and the original response was compressed.
+	if bodyModified && execCtx.responseContentEncoding != "" {
+		originalBody := bodyMutation.Mutation.(*extprocv3.BodyMutation_Body).Body
+		recompressed, err := recompressBody(originalBody, execCtx.responseContentEncoding)
+		if err != nil {
+			slog.Warn("Failed to re-compress response body, sending uncompressed",
+				"encoding", execCtx.responseContentEncoding,
+				"error", err,
+			)
+			headerOps["content-encoding"] = append(headerOps["content-encoding"], &headerOp{opType: "remove", value: ""})
+			finalBodyLength = len(originalBody)
+		} else {
+			bodyMutation.Mutation.(*extprocv3.BodyMutation_Body).Body = recompressed
+			finalBodyLength = len(recompressed)
+		}
+	}
+
+	if bodyModified {
+		delete(headerOps, "content-length")
+	}
+	mergeHeaderMutations(headerMutation, headerOps)
+	if bodyModified {
+		setContentLengthHeader(headerMutation, finalBodyLength)
+	}
+
+	response := &extprocv3.ProcessingResponse{
+		Response: &extprocv3.ProcessingResponse_ResponseHeaders{
+			ResponseHeaders: &extprocv3.HeadersResponse{
+				Response: &extprocv3.CommonResponse{
+					HeaderMutation: headerMutation,
+					BodyMutation:   bodyMutation,
+				},
+			},
+		},
+		ModeOverride: execCtx.getModeOverride(),
+	}
+
+	analyticsStruct, err := buildAnalyticsStruct(analyticsData, execCtx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build analytics metadata: %w", err)
+	}
+	response.DynamicMetadata = buildDynamicMetadata(analyticsStruct, nil, nil, dynamicMetadata)
+
+	return response, nil
+}
+
 // TranslateRequestHeadersActions converts request headers execution result to ext_proc response
 func TranslateRequestHeadersActions(result *executor.RequestExecutionResult, chain *registry.PolicyChain, execCtx *PolicyExecutionContext) (*extprocv3.ProcessingResponse, error) {
 	headerMutation, bodyMutation, analyticsData, dynamicMetadata, path, method, immediateResp, err := translateRequestActionsCore(result, execCtx)


### PR DESCRIPTION
$subject

https://github.com/wso2/api-platform/issues/1586

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Response body policies now execute for bodyless responses, ensuring consistent policy application across all response types.

* **Bug Fixes**
  * Improved handling of empty responses by properly merging response header and body policy effects during inline processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->