### PR TITLE
Fix to avoid avoid sending system policies with gateway manifest

### DIFF
--- a/gateway/gateway-controller/pkg/controlplane/client.go
+++ b/gateway/gateway-controller/pkg/controlplane/client.go
@@ -3653,6 +3653,9 @@ func (c *Client) pushGatewayManifestOnConnect(gatewayID string) {
 
 	policies := make([]models.PolicyDefinition, 0, len(c.policyDefinitions))
 	for _, def := range c.policyDefinitions {
+		if strings.HasPrefix(def.Name, "wso2_apip_sys_") {
+			continue
+		}
 		policies = append(policies, def)
 	}
 


### PR DESCRIPTION
## Purpose
$subject

Relates with: https://github.com/wso2/api-platform/issues/1456

## Goals
> Describe **what solutions** this feature or fix introduces to address the problems outlined above.

## Approach
> Describe **how** you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Gateway manifest push now properly filters internal system policy definitions during synchronization, resulting in more focused manifest payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->