### PR TITLE
Set DisallowSystem to false to update :status from headers

### DIFF
--- a/gateway/gateway-controller/pkg/xds/translator.go
+++ b/gateway/gateway-controller/pkg/xds/translator.go
@@ -2983,7 +2983,7 @@ func (t *Translator) createExtProcFilter() (*hcm.HttpFilter, error) {
 		},
 		MessageTimeout: durationpb.New(time.Duration(policyEngine.MessageTimeoutMs) * time.Millisecond),
 		MutationRules: &mutationrules.HeaderMutationRules{
-			DisallowSystem:  wrapperspb.Bool(true),
+			DisallowSystem:  wrapperspb.Bool(false),
 			DisallowIsError: wrapperspb.Bool(true),
 		},
 		MetadataOptions: &extproc.MetadataOptions{


### PR DESCRIPTION
## Purpose
Without this, gateway returns 500 for `url-guardrail` when response path body sends an invalid url