### PR TITLE
cost based ratelimit policy generation

### DIFF
--- a/platform-api/src/internal/service/llm_deployment.go
+++ b/platform-api/src/internal/service/llm_deployment.go
@@ -668,6 +668,35 @@ func generateLLMProviderDeploymentYAML(provider *model.LLMProvider, templateHand
 						},
 					})
 				}
+				if providerLevel.Global.Cost != nil && providerLevel.Global.Cost.Enabled {
+					costLimit := providerLevel.Global.Cost
+					duration, err := formatRateLimitDuration(costLimit.Reset.Duration, costLimit.Reset.Unit)
+					if err != nil {
+						return "", fmt.Errorf("invalid cost reset window: %w", err)
+					}
+					policies = append(policies, api.LLMPolicy{
+						Name:    llmCostBasedRateLimitPolicyName,
+						Version: "",
+						Paths: []api.LLMPolicyPath{
+							{
+								Path:    "/*",
+								Methods: []api.LLMPolicyPathMethods{"*"},
+								Params: map[string]interface{}{
+									"budgetLimits": []map[string]interface{}{
+										{
+											"amount":   costLimit.Amount,
+											"duration": duration,
+										},
+									},
+								},
+							},
+						},
+					})
+					addOrAppendPolicyPath(&policies, llmCostPolicyName, "", api.LLMPolicyPath{
+						Path:    "/*",
+						Methods: []api.LLMPolicyPathMethods{"*"},
+					})
+				}
 			} else if providerLevel.ResourceWise != nil {
 				// Step 2.2 Handle resource-wise rate limiting
 				defaultLimit := &providerLevel.ResourceWise.Default
@@ -731,6 +760,35 @@ func generateLLMProviderDeploymentYAML(provider *model.LLMProvider, templateHand
 						},
 					})
 				}
+				if defaultLimit.Cost != nil && defaultLimit.Cost.Enabled {
+					costLimit := defaultLimit.Cost
+					duration, err := formatRateLimitDuration(costLimit.Reset.Duration, costLimit.Reset.Unit)
+					if err != nil {
+						return "", fmt.Errorf("invalid cost reset window: %w", err)
+					}
+					policies = append(policies, api.LLMPolicy{
+						Name:    llmCostBasedRateLimitPolicyName,
+						Version: "",
+						Paths: []api.LLMPolicyPath{
+							{
+								Path:    "/*",
+								Methods: []api.LLMPolicyPathMethods{"*"},
+								Params: map[string]interface{}{
+									"budgetLimits": []map[string]interface{}{
+										{
+											"amount":   costLimit.Amount,
+											"duration": duration,
+										},
+									},
+								},
+							},
+						},
+					})
+					addOrAppendPolicyPath(&policies, llmCostPolicyName, "", api.LLMPolicyPath{
+						Path:    "/*",
+						Methods: []api.LLMPolicyPathMethods{"*"},
+					})
+				}
 
 				// Step 2.2.2 Resource-wise rate limit
 				for _, r := range providerLevel.ResourceWise.Resources {
@@ -777,6 +835,29 @@ func generateLLMProviderDeploymentYAML(provider *model.LLMProvider, templateHand
 									},
 								},
 							},
+						})
+					}
+					if r.Limit.Cost != nil && r.Limit.Cost.Enabled {
+						costLimit := r.Limit.Cost
+						duration, err := formatRateLimitDuration(costLimit.Reset.Duration, costLimit.Reset.Unit)
+						if err != nil {
+							return "", fmt.Errorf("invalid cost reset window for resource %s: %w", r.Resource, err)
+						}
+						addOrAppendPolicyPath(&policies, llmCostBasedRateLimitPolicyName, "", api.LLMPolicyPath{
+							Path:    r.Resource,
+							Methods: []api.LLMPolicyPathMethods{"*"},
+							Params: map[string]interface{}{
+								"budgetLimits": []map[string]interface{}{
+									{
+										"amount":   costLimit.Amount,
+										"duration": duration,
+									},
+								},
+							},
+						})
+						addOrAppendPolicyPath(&policies, llmCostPolicyName, "", api.LLMPolicyPath{
+							Path:    "/*",
+							Methods: []api.LLMPolicyPathMethods{"*"},
 						})
 					}
 				}

--- a/platform-api/src/internal/service/llm_deployment_test.go
+++ b/platform-api/src/internal/service/llm_deployment_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"strings"
 	"testing"
 
 	"platform-api/src/internal/model"
@@ -15,5 +16,141 @@ func TestMapModelAuthToAPI_NormalizesApiKeyType(t *testing.T) {
 	}
 	if *out.Type != "api-key" {
 		t.Fatalf("expected auth type to be api-key, got %q", *out.Type)
+	}
+}
+
+func TestGenerateLLMProviderDeploymentYAML_CostRateLimitGlobal(t *testing.T) {
+	context := "/test"
+	enabled := true
+	amount := 0.05
+	provider := &model.LLMProvider{
+		ID:   "test-provider",
+		Name: "Test Provider",
+		Configuration: model.LLMProviderConfig{
+			Context: &context,
+			Upstream: &model.UpstreamConfig{
+				Main: &model.UpstreamEndpoint{URL: "https://api.anthropic.com"},
+			},
+			RateLimiting: &model.LLMRateLimitingConfig{
+				ProviderLevel: &model.RateLimitingScopeConfig{
+					Global: &model.RateLimitingLimitConfig{
+						Cost: &model.CostRateLimit{
+							Enabled: enabled,
+							Amount:  amount,
+							Reset:   model.RateLimitResetWindow{Duration: 1, Unit: "hour"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	yaml, err := generateLLMProviderDeploymentYAML(provider, "anthropic")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(yaml, llmCostBasedRateLimitPolicyName) {
+		t.Errorf("expected YAML to contain %q, got:\n%s", llmCostBasedRateLimitPolicyName, yaml)
+	}
+	if !strings.Contains(yaml, "budgetLimits") {
+		t.Errorf("expected YAML to contain budgetLimits, got:\n%s", yaml)
+	}
+	if !strings.Contains(yaml, llmCostPolicyName) {
+		t.Errorf("expected YAML to contain %q, got:\n%s", llmCostPolicyName, yaml)
+	}
+}
+
+func TestGenerateLLMProviderDeploymentYAML_CostRateLimitResourceWiseDefault(t *testing.T) {
+	context := "/test"
+	enabled := true
+	amount := 0.10
+	provider := &model.LLMProvider{
+		ID:   "test-provider",
+		Name: "Test Provider",
+		Configuration: model.LLMProviderConfig{
+			Context: &context,
+			Upstream: &model.UpstreamConfig{
+				Main: &model.UpstreamEndpoint{URL: "https://api.anthropic.com"},
+			},
+			RateLimiting: &model.LLMRateLimitingConfig{
+				ProviderLevel: &model.RateLimitingScopeConfig{
+					ResourceWise: &model.ResourceWiseRateLimitingConfig{
+						Default: model.RateLimitingLimitConfig{
+							Cost: &model.CostRateLimit{
+								Enabled: enabled,
+								Amount:  amount,
+								Reset:   model.RateLimitResetWindow{Duration: 24, Unit: "hour"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	yaml, err := generateLLMProviderDeploymentYAML(provider, "anthropic")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(yaml, llmCostBasedRateLimitPolicyName) {
+		t.Errorf("expected YAML to contain %q, got:\n%s", llmCostBasedRateLimitPolicyName, yaml)
+	}
+	if !strings.Contains(yaml, "budgetLimits") {
+		t.Errorf("expected YAML to contain budgetLimits, got:\n%s", yaml)
+	}
+	if !strings.Contains(yaml, llmCostPolicyName) {
+		t.Errorf("expected YAML to contain %q, got:\n%s", llmCostPolicyName, yaml)
+	}
+}
+
+func TestGenerateLLMProviderDeploymentYAML_CostRateLimitPerResource(t *testing.T) {
+	context := "/test"
+	enabled := true
+	amount := 0.02
+	provider := &model.LLMProvider{
+		ID:   "test-provider",
+		Name: "Test Provider",
+		Configuration: model.LLMProviderConfig{
+			Context: &context,
+			Upstream: &model.UpstreamConfig{
+				Main: &model.UpstreamEndpoint{URL: "https://api.anthropic.com"},
+			},
+			RateLimiting: &model.LLMRateLimitingConfig{
+				ProviderLevel: &model.RateLimitingScopeConfig{
+					ResourceWise: &model.ResourceWiseRateLimitingConfig{
+						Default: model.RateLimitingLimitConfig{},
+						Resources: []model.RateLimitingResourceLimit{
+							{
+								Resource: "/v1/messages",
+								Limit: model.RateLimitingLimitConfig{
+									Cost: &model.CostRateLimit{
+										Enabled: enabled,
+										Amount:  amount,
+										Reset:   model.RateLimitResetWindow{Duration: 1, Unit: "hour"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	yaml, err := generateLLMProviderDeploymentYAML(provider, "anthropic")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(yaml, llmCostBasedRateLimitPolicyName) {
+		t.Errorf("expected YAML to contain %q, got:\n%s", llmCostBasedRateLimitPolicyName, yaml)
+	}
+	if !strings.Contains(yaml, "budgetLimits") {
+		t.Errorf("expected YAML to contain budgetLimits, got:\n%s", yaml)
+	}
+	if !strings.Contains(yaml, llmCostPolicyName) {
+		t.Errorf("expected YAML to contain %q, got:\n%s", llmCostPolicyName, yaml)
+	}
+	if !strings.Contains(yaml, "/v1/messages") {
+		t.Errorf("expected YAML to contain resource path /v1/messages, got:\n%s", yaml)
 	}
 }


### PR DESCRIPTION
## Description
Added cost rate limit policy translation in llm_deployment.go. When a provider has a cost rate limit configured, the generated deployment YAML now includes llm-cost-based-ratelimit (with budgetLimits) and llm-cost policies                                                                                                 
                                                                                                                                                                     
## Test Plan                                                                                                                                                        
                                                                                                                                                                   
  - Unit tests added in llm_deployment_test.go covering all three cost rate limit cases: global, resource-wise default, and per-resource.             
  - Verified end-to-end locally: ran platform-api with go run, connected a local gateway, deployed an LLM provider with cost config via REST API, and confirmed the gateway controller received the correct YAML with llm-cost-based-ratelimit and llm-cost policies.           
                                                                                                                                                                   
Fixes #2331    


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cost-based rate limiting for LLM deployments, configurable at provider global, provider default, and per-resource levels.
  * Support for customizable reset windows with validation for invalid configurations.

* **Tests**
  * Added test coverage for cost-based rate limiting across all configuration levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->