### PR TITLE
Gate policy phases by Mode() and add tests

### DIFF
--- a/gateway/gateway-runtime/policy-engine/internal/executor/chain.go
+++ b/gateway/gateway-runtime/policy-engine/internal/executor/chain.go
@@ -51,7 +51,7 @@ type RequestHeaderPolicyResult struct {
 type RequestHeaderExecutionResult struct {
 	Results            []RequestHeaderPolicyResult
 	ShortCircuited     bool                       // true if chain stopped early due to ImmediateResponse
-	FinalAction        policy.RequestHeaderAction  // Final action to apply
+	FinalAction        policy.RequestHeaderAction // Final action to apply
 	TotalExecutionTime time.Duration
 }
 
@@ -87,6 +87,10 @@ func (c *ChainExecutor) ExecuteRequestHeaderPolicies(
 
 		headerPol, ok := pol.(policy.RequestHeaderPolicy)
 		if !ok {
+			span.End()
+			continue
+		}
+		if pol.Mode().RequestHeaderMode != policy.HeaderModeProcess {
 			span.End()
 			continue
 		}
@@ -375,7 +379,7 @@ type ResponseHeaderPolicyResult struct {
 type ResponseHeaderExecutionResult struct {
 	Results            []ResponseHeaderPolicyResult
 	ShortCircuited     bool                        // true if chain stopped early due to ImmediateResponse
-	FinalAction        policy.ResponseHeaderAction  // Final action to apply
+	FinalAction        policy.ResponseHeaderAction // Final action to apply
 	TotalExecutionTime time.Duration
 }
 
@@ -411,6 +415,10 @@ func (c *ChainExecutor) ExecuteResponseHeaderPolicies(
 
 		headerPol, ok := pol.(policy.ResponseHeaderPolicy)
 		if !ok {
+			span.End()
+			continue
+		}
+		if pol.Mode().ResponseHeaderMode != policy.HeaderModeProcess {
 			span.End()
 			continue
 		}
@@ -731,8 +739,8 @@ func (c *ChainExecutor) ExecuteStreamingRequestPolicies(
 			continue
 		}
 
-		// Skip if the policy's mode says to skip request body processing
-		if pol.Mode().RequestBodyMode == policy.BodyModeSkip {
+		// Mode()-first: only execute streaming callbacks for policies that explicitly opt into STREAM.
+		if pol.Mode().RequestBodyMode != policy.BodyModeStream {
 			span.End()
 			continue
 		}
@@ -874,8 +882,8 @@ func (c *ChainExecutor) ExecuteStreamingResponsePolicies(
 			continue
 		}
 
-		// Skip if the policy's mode says to skip response body processing
-		if pol.Mode().ResponseBodyMode == policy.BodyModeSkip {
+		// Mode()-first: only execute streaming callbacks for policies that explicitly opt into STREAM.
+		if pol.Mode().ResponseBodyMode != policy.BodyModeStream {
 			span.End()
 			continue
 		}

--- a/gateway/gateway-runtime/policy-engine/internal/executor/chain_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/executor/chain_test.go
@@ -98,6 +98,78 @@ func newPolicySpec(name, version string, enabled bool, condition *string) policy
 	}
 }
 
+type countingRequestHeaderPolicy struct {
+	mode  policy.ProcessingMode
+	calls int
+}
+
+func (p *countingRequestHeaderPolicy) Mode() policy.ProcessingMode {
+	return p.mode
+}
+
+func (p *countingRequestHeaderPolicy) OnRequestHeaders(_ context.Context, _ *policy.RequestHeaderContext, _ map[string]interface{}) policy.RequestHeaderAction {
+	p.calls++
+	return policy.UpstreamRequestHeaderModifications{}
+}
+
+type countingResponseHeaderPolicy struct {
+	mode  policy.ProcessingMode
+	calls int
+}
+
+func (p *countingResponseHeaderPolicy) Mode() policy.ProcessingMode {
+	return p.mode
+}
+
+func (p *countingResponseHeaderPolicy) OnResponseHeaders(_ context.Context, _ *policy.ResponseHeaderContext, _ map[string]interface{}) policy.ResponseHeaderAction {
+	p.calls++
+	return policy.DownstreamResponseHeaderModifications{}
+}
+
+type countingStreamingRequestPolicy struct {
+	mode  policy.ProcessingMode
+	calls int
+}
+
+func (p *countingStreamingRequestPolicy) Mode() policy.ProcessingMode {
+	return p.mode
+}
+
+func (p *countingStreamingRequestPolicy) OnRequestBody(_ context.Context, _ *policy.RequestContext, _ map[string]interface{}) policy.RequestAction {
+	return policy.UpstreamRequestModifications{}
+}
+
+func (p *countingStreamingRequestPolicy) NeedsMoreRequestData(_ []byte) bool {
+	return false
+}
+
+func (p *countingStreamingRequestPolicy) OnRequestBodyChunk(_ context.Context, _ *policy.RequestStreamContext, _ *policy.StreamBody, _ map[string]interface{}) policy.StreamingRequestAction {
+	p.calls++
+	return policy.ForwardRequestChunk{}
+}
+
+type countingStreamingResponsePolicy struct {
+	mode  policy.ProcessingMode
+	calls int
+}
+
+func (p *countingStreamingResponsePolicy) Mode() policy.ProcessingMode {
+	return p.mode
+}
+
+func (p *countingStreamingResponsePolicy) OnResponseBody(_ context.Context, _ *policy.ResponseContext, _ map[string]interface{}) policy.ResponseAction {
+	return policy.DownstreamResponseModifications{}
+}
+
+func (p *countingStreamingResponsePolicy) NeedsMoreResponseData(_ []byte) bool {
+	return false
+}
+
+func (p *countingStreamingResponsePolicy) OnResponseBodyChunk(_ context.Context, _ *policy.ResponseStreamContext, _ *policy.StreamBody, _ map[string]interface{}) policy.StreamingResponseAction {
+	p.calls++
+	return policy.ForwardResponseChunk{}
+}
+
 // =============================================================================
 // Tests for NewChainExecutor
 // =============================================================================
@@ -759,4 +831,188 @@ func TestExecuteResponsePolicies_ImmediateResponseShortCircuit(t *testing.T) {
 	immResp, ok := result.FinalAction.(policy.ImmediateResponse)
 	require.True(t, ok)
 	assert.Equal(t, 503, immResp.StatusCode)
+}
+
+func TestExecuteRequestHeaderPolicies_ModeFirstGating(t *testing.T) {
+	tests := []struct {
+		name        string
+		mode        policy.HeaderProcessingMode
+		wantCalls   int
+		wantResults int
+	}{
+		{name: "process", mode: policy.HeaderModeProcess, wantCalls: 1, wantResults: 1},
+		{name: "skip", mode: policy.HeaderModeSkip, wantCalls: 0, wantResults: 0},
+		{name: "zero value", mode: "", wantCalls: 0, wantResults: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tracer := noop.NewTracerProvider().Tracer("test")
+			executor := NewChainExecutor(nil, nil, tracer)
+
+			pol := &countingRequestHeaderPolicy{
+				mode: policy.ProcessingMode{RequestHeaderMode: tt.mode},
+			}
+			reqCtx := &policy.RequestHeaderContext{
+				SharedContext: testutils.NewTestSharedContext(),
+				Headers:       policy.NewHeaders(map[string][]string{"content-type": {"application/json"}}),
+				Path:          "/test",
+				Method:        "GET",
+			}
+
+			result, err := executor.ExecuteRequestHeaderPolicies(
+				context.Background(),
+				[]policy.Policy{pol},
+				reqCtx,
+				[]policy.PolicySpec{newPolicySpec("header", "v1.0.0", true, nil)},
+				"api",
+				"route",
+				false,
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantCalls, pol.calls)
+			assert.Len(t, result.Results, tt.wantResults)
+		})
+	}
+}
+
+func TestExecuteResponseHeaderPolicies_ModeFirstGating(t *testing.T) {
+	tests := []struct {
+		name        string
+		mode        policy.HeaderProcessingMode
+		wantCalls   int
+		wantResults int
+	}{
+		{name: "process", mode: policy.HeaderModeProcess, wantCalls: 1, wantResults: 1},
+		{name: "skip", mode: policy.HeaderModeSkip, wantCalls: 0, wantResults: 0},
+		{name: "zero value", mode: "", wantCalls: 0, wantResults: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tracer := noop.NewTracerProvider().Tracer("test")
+			executor := NewChainExecutor(nil, nil, tracer)
+
+			pol := &countingResponseHeaderPolicy{
+				mode: policy.ProcessingMode{ResponseHeaderMode: tt.mode},
+			}
+			respCtx := &policy.ResponseHeaderContext{
+				SharedContext:   testutils.NewTestSharedContext(),
+				RequestHeaders:  policy.NewHeaders(map[string][]string{"content-type": {"application/json"}}),
+				RequestPath:     "/test",
+				RequestMethod:   "GET",
+				ResponseHeaders: policy.NewHeaders(map[string][]string{"content-type": {"application/json"}}),
+				ResponseStatus:  200,
+			}
+
+			result, err := executor.ExecuteResponseHeaderPolicies(
+				context.Background(),
+				[]policy.Policy{pol},
+				respCtx,
+				[]policy.PolicySpec{newPolicySpec("header", "v1.0.0", true, nil)},
+				"api",
+				"route",
+				false,
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantCalls, pol.calls)
+			assert.Len(t, result.Results, tt.wantResults)
+		})
+	}
+}
+
+func TestExecuteStreamingRequestPolicies_ModeFirstGating(t *testing.T) {
+	tests := []struct {
+		name        string
+		mode        policy.BodyProcessingMode
+		wantCalls   int
+		wantResults int
+	}{
+		{name: "stream", mode: policy.BodyModeStream, wantCalls: 1, wantResults: 1},
+		{name: "buffer", mode: policy.BodyModeBuffer, wantCalls: 0, wantResults: 0},
+		{name: "skip", mode: policy.BodyModeSkip, wantCalls: 0, wantResults: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tracer := noop.NewTracerProvider().Tracer("test")
+			executor := NewChainExecutor(nil, nil, tracer)
+
+			pol := &countingStreamingRequestPolicy{
+				mode: policy.ProcessingMode{RequestBodyMode: tt.mode},
+			}
+			reqCtx := &policy.RequestStreamContext{
+				SharedContext: testutils.NewTestSharedContext(),
+				Headers:       policy.NewHeaders(map[string][]string{"content-type": {"application/json"}}),
+				Path:          "/test",
+				Method:        "POST",
+			}
+			chunk := &policy.StreamBody{Chunk: []byte("hello"), EndOfStream: true}
+
+			result, err := executor.ExecuteStreamingRequestPolicies(
+				context.Background(),
+				[]policy.Policy{pol},
+				reqCtx,
+				chunk,
+				[]policy.PolicySpec{newPolicySpec("stream", "v1.0.0", true, nil)},
+				"api",
+				"route",
+				false,
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantCalls, pol.calls)
+			assert.Len(t, result.Results, tt.wantResults)
+		})
+	}
+}
+
+func TestExecuteStreamingResponsePolicies_ModeFirstGating(t *testing.T) {
+	tests := []struct {
+		name        string
+		mode        policy.BodyProcessingMode
+		wantCalls   int
+		wantResults int
+	}{
+		{name: "stream", mode: policy.BodyModeStream, wantCalls: 1, wantResults: 1},
+		{name: "buffer", mode: policy.BodyModeBuffer, wantCalls: 0, wantResults: 0},
+		{name: "skip", mode: policy.BodyModeSkip, wantCalls: 0, wantResults: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tracer := noop.NewTracerProvider().Tracer("test")
+			executor := NewChainExecutor(nil, nil, tracer)
+
+			pol := &countingStreamingResponsePolicy{
+				mode: policy.ProcessingMode{ResponseBodyMode: tt.mode},
+			}
+			respCtx := &policy.ResponseStreamContext{
+				SharedContext:   testutils.NewTestSharedContext(),
+				RequestHeaders:  policy.NewHeaders(map[string][]string{"content-type": {"application/json"}}),
+				RequestPath:     "/test",
+				RequestMethod:   "POST",
+				ResponseHeaders: policy.NewHeaders(map[string][]string{"content-type": {"application/json"}}),
+				ResponseStatus:  200,
+			}
+			chunk := &policy.StreamBody{Chunk: []byte("hello"), EndOfStream: true}
+
+			result, err := executor.ExecuteStreamingResponsePolicies(
+				context.Background(),
+				[]policy.Policy{pol},
+				respCtx,
+				chunk,
+				[]policy.PolicySpec{newPolicySpec("stream", "v1.0.0", true, nil)},
+				"api",
+				"route",
+				false,
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantCalls, pol.calls)
+			assert.Len(t, result.Results, tt.wantResults)
+		})
+	}
 }

--- a/gateway/gateway-runtime/policy-engine/internal/kernel/body_mode.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/body_mode.go
@@ -20,6 +20,7 @@ package kernel
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/wso2/api-platform/gateway/gateway-runtime/policy-engine/internal/registry"
 	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
@@ -43,14 +44,15 @@ const (
 )
 
 // BuildPolicyChain creates a PolicyChain from PolicySpecs with body requirement computation.
-// Capabilities are discovered at chain-build time using type assertions — once, at startup,
-// with zero per-request overhead.
+// Phase participation is determined by Mode() — the authoritative source for all six phases.
+// Type assertions are used only for streaming capability checks and method dispatch validation.
+// Chain flags are computed once at startup, with zero per-request overhead.
 func (k *Kernel) BuildPolicyChain(routeKey string, policySpecs []policy.PolicySpec, reg *registry.PolicyRegistry, apiMetadata policy.PolicyMetadata) (*registry.PolicyChain, error) {
 	chain := &registry.PolicyChain{
-		Policies:             make([]policy.Policy, 0),
-		PolicySpecs:          make([]policy.PolicySpec, 0),
-		RequiresRequestBody:  false,
-		RequiresResponseBody: false,
+		Policies:               make([]policy.Policy, 0),
+		PolicySpecs:            make([]policy.PolicySpec, 0),
+		RequiresRequestBody:    false,
+		RequiresResponseBody:   false,
 		HasExecutionConditions: false,
 		// Optimistically assume full streaming support; flipped to false if any
 		// body-processing policy does not implement the streaming interface.
@@ -63,7 +65,7 @@ func (k *Kernel) BuildPolicyChain(routeKey string, policySpecs []policy.PolicySp
 	hasRequestBodyPolicy := false
 	hasResponseBodyPolicy := false
 
-	// Build policy list and compute body requirements via type assertions
+	// Build policy list and compute phase requirements via Mode()
 	for _, spec := range policySpecs {
 		metadata := policy.PolicyMetadata{
 			RouteName:  routeKey,
@@ -87,34 +89,63 @@ func (k *Kernel) BuildPolicyChain(routeKey string, policySpecs []policy.PolicySp
 		chain.Policies = append(chain.Policies, impl)
 		chain.PolicySpecs = append(chain.PolicySpecs, spec)
 
-		// Get policy mode and update body requirements
+		// Get policy mode and update phase requirements
 		mode := impl.Mode()
 		if mode.RequestBodyMode == policy.BodyModeBuffer || mode.RequestBodyMode == policy.BodyModeStream {
 			chain.RequiresRequestBody = true
 			hasRequestBodyPolicy = true
-			// A buffered-only policy (no StreamingRequestPolicy) forces the
-			// entire chain to BUFFERED mode.
-			if _, streaming := impl.(policy.StreamingRequestPolicy); !streaming {
+			if mode.RequestBodyMode == policy.BodyModeStream {
+				if _, streaming := impl.(policy.StreamingRequestPolicy); !streaming {
+					chain.SupportsRequestStreaming = false
+					slog.Warn("[chain-build] policy declares RequestBodyMode=STREAM but does not implement StreamingRequestPolicy",
+						"policy", spec.Name, "route", routeKey)
+				}
+			} else {
 				chain.SupportsRequestStreaming = false
 			}
 		}
 		if mode.ResponseBodyMode == policy.BodyModeBuffer || mode.ResponseBodyMode == policy.BodyModeStream {
 			chain.RequiresResponseBody = true
 			hasResponseBodyPolicy = true
-			// A buffered-only policy forces the entire chain to BUFFERED mode,
-			// preserving the ability to return ImmediateResponse before the
-			// client sees any bytes.
-			if _, streaming := impl.(policy.StreamingResponsePolicy); !streaming {
+			if mode.ResponseBodyMode == policy.BodyModeStream {
+				if _, streaming := impl.(policy.StreamingResponsePolicy); !streaming {
+					chain.SupportsResponseStreaming = false
+					slog.Warn("[chain-build] policy declares ResponseBodyMode=STREAM but does not implement StreamingResponsePolicy",
+						"policy", spec.Name, "route", routeKey)
+				}
+			} else {
 				chain.SupportsResponseStreaming = false
 			}
 		}
 
-		// Discover header capabilities via type assertions.
-		if _, ok := impl.(policy.RequestHeaderPolicy); ok {
-			chain.RequiresRequestHeader = true
+		if mode.RequestHeaderMode == policy.HeaderModeProcess {
+			if _, ok := impl.(policy.RequestHeaderPolicy); ok {
+				chain.RequiresRequestHeader = true
+			} else {
+				slog.Warn("[chain-build] policy declares RequestHeaderMode=PROCESS but does not implement RequestHeaderPolicy",
+					"policy", spec.Name, "route", routeKey)
+			}
 		}
-		if _, ok := impl.(policy.ResponseHeaderPolicy); ok {
-			chain.RequiresResponseHeader = true
+		if mode.ResponseHeaderMode == policy.HeaderModeProcess {
+			if _, ok := impl.(policy.ResponseHeaderPolicy); ok {
+				chain.RequiresResponseHeader = true
+			} else {
+				slog.Warn("[chain-build] policy declares ResponseHeaderMode=PROCESS but does not implement ResponseHeaderPolicy",
+					"policy", spec.Name, "route", routeKey)
+			}
+		}
+
+		if mode.RequestBodyMode != policy.BodyModeSkip {
+			if _, ok := impl.(policy.RequestPolicy); !ok {
+				slog.Debug("[chain-build] policy declares non-SKIP RequestBodyMode but does not implement RequestPolicy (may be cross-phase body access)",
+					"policy", spec.Name, "mode", mode.RequestBodyMode, "route", routeKey)
+			}
+		}
+		if mode.ResponseBodyMode != policy.BodyModeSkip {
+			if _, ok := impl.(policy.ResponsePolicy); !ok {
+				slog.Warn("[chain-build] policy declares non-SKIP ResponseBodyMode but does not implement ResponsePolicy",
+					"policy", spec.Name, "mode", mode.ResponseBodyMode, "route", routeKey)
+			}
 		}
 	}
 

--- a/gateway/gateway-runtime/policy-engine/internal/kernel/body_mode.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/body_mode.go
@@ -137,7 +137,7 @@ func (k *Kernel) BuildPolicyChain(routeKey string, policySpecs []policy.PolicySp
 
 		if mode.RequestBodyMode != policy.BodyModeSkip {
 			if _, ok := impl.(policy.RequestPolicy); !ok {
-				slog.Debug("[chain-build] policy declares non-SKIP RequestBodyMode but does not implement RequestPolicy (may be cross-phase body access)",
+				slog.Warn("[chain-build] policy declares non-SKIP RequestBodyMode but does not implement RequestPolicy (may be cross-phase body access)",
 					"policy", spec.Name, "mode", mode.RequestBodyMode, "route", routeKey)
 			}
 		}

--- a/gateway/gateway-runtime/policy-engine/internal/kernel/body_mode_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/body_mode_test.go
@@ -19,6 +19,7 @@
 package kernel
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -203,4 +204,313 @@ func TestGetResponseBodyMode_WithChainNotRequiringBody(t *testing.T) {
 	mode := kernel.GetResponseBodyMode("test-route")
 
 	assert.Equal(t, BodyModeSkip, mode)
+}
+
+type modeOnlyPolicy struct {
+	mode policy.ProcessingMode
+}
+
+func (p *modeOnlyPolicy) Mode() policy.ProcessingMode {
+	return p.mode
+}
+
+type requestHeaderModePolicy struct {
+	mode policy.ProcessingMode
+}
+
+func (p *requestHeaderModePolicy) Mode() policy.ProcessingMode {
+	return p.mode
+}
+
+func (p *requestHeaderModePolicy) OnRequestHeaders(_ context.Context, _ *policy.RequestHeaderContext, _ map[string]interface{}) policy.RequestHeaderAction {
+	return policy.UpstreamRequestHeaderModifications{}
+}
+
+type responseHeaderModePolicy struct {
+	mode policy.ProcessingMode
+}
+
+func (p *responseHeaderModePolicy) Mode() policy.ProcessingMode {
+	return p.mode
+}
+
+func (p *responseHeaderModePolicy) OnResponseHeaders(_ context.Context, _ *policy.ResponseHeaderContext, _ map[string]interface{}) policy.ResponseHeaderAction {
+	return policy.DownstreamResponseHeaderModifications{}
+}
+
+type bufferedRequestModePolicy struct {
+	mode policy.ProcessingMode
+}
+
+func (p *bufferedRequestModePolicy) Mode() policy.ProcessingMode {
+	return p.mode
+}
+
+func (p *bufferedRequestModePolicy) OnRequestBody(_ context.Context, _ *policy.RequestContext, _ map[string]interface{}) policy.RequestAction {
+	return policy.UpstreamRequestModifications{}
+}
+
+type streamingRequestModePolicy struct {
+	mode policy.ProcessingMode
+}
+
+func (p *streamingRequestModePolicy) Mode() policy.ProcessingMode {
+	return p.mode
+}
+
+func (p *streamingRequestModePolicy) OnRequestBody(_ context.Context, _ *policy.RequestContext, _ map[string]interface{}) policy.RequestAction {
+	return policy.UpstreamRequestModifications{}
+}
+
+func (p *streamingRequestModePolicy) NeedsMoreRequestData(_ []byte) bool {
+	return false
+}
+
+func (p *streamingRequestModePolicy) OnRequestBodyChunk(_ context.Context, _ *policy.RequestStreamContext, _ *policy.StreamBody, _ map[string]interface{}) policy.StreamingRequestAction {
+	return policy.ForwardRequestChunk{}
+}
+
+type bufferedResponseModePolicy struct {
+	mode policy.ProcessingMode
+}
+
+func (p *bufferedResponseModePolicy) Mode() policy.ProcessingMode {
+	return p.mode
+}
+
+func (p *bufferedResponseModePolicy) OnResponseBody(_ context.Context, _ *policy.ResponseContext, _ map[string]interface{}) policy.ResponseAction {
+	return policy.DownstreamResponseModifications{}
+}
+
+type streamingResponseModePolicy struct {
+	mode policy.ProcessingMode
+}
+
+func (p *streamingResponseModePolicy) Mode() policy.ProcessingMode {
+	return p.mode
+}
+
+func (p *streamingResponseModePolicy) OnResponseBody(_ context.Context, _ *policy.ResponseContext, _ map[string]interface{}) policy.ResponseAction {
+	return policy.DownstreamResponseModifications{}
+}
+
+func (p *streamingResponseModePolicy) NeedsMoreResponseData(_ []byte) bool {
+	return false
+}
+
+func (p *streamingResponseModePolicy) OnResponseBodyChunk(_ context.Context, _ *policy.ResponseStreamContext, _ *policy.StreamBody, _ map[string]interface{}) policy.StreamingResponseAction {
+	return policy.ForwardResponseChunk{}
+}
+
+func buildSinglePolicyChainForTest(t *testing.T, name string, impl policy.Policy) *registry.PolicyChain {
+	t.Helper()
+
+	reg := &registry.PolicyRegistry{
+		Policies: make(map[string]*registry.PolicyEntry),
+	}
+	require.NoError(t, reg.SetConfig(map[string]interface{}{}))
+	require.NoError(t, reg.Register(&policy.PolicyDefinition{
+		Name:    name,
+		Version: "v1.0.0",
+	}, func(metadata policy.PolicyMetadata, params map[string]interface{}) (policy.Policy, error) {
+		return impl, nil
+	}))
+
+	specs := []policy.PolicySpec{
+		{
+			Name:       name,
+			Version:    "v1",
+			Enabled:    true,
+			Parameters: policy.PolicyParameters{Raw: map[string]interface{}{}},
+		},
+	}
+
+	k := NewKernel()
+	chain, err := k.BuildPolicyChain("test-route", specs, reg, policy.PolicyMetadata{})
+	require.NoError(t, err)
+	return chain
+}
+
+func TestBuildPolicyChain_RequestHeaderParticipationFollowsMode(t *testing.T) {
+	tests := []struct {
+		name         string
+		impl         policy.Policy
+		wantRequired bool
+	}{
+		{
+			name: "process with interface",
+			impl: &requestHeaderModePolicy{mode: policy.ProcessingMode{
+				RequestHeaderMode: policy.HeaderModeProcess,
+			}},
+			wantRequired: true,
+		},
+		{
+			name: "skip with interface",
+			impl: &requestHeaderModePolicy{mode: policy.ProcessingMode{
+				RequestHeaderMode: policy.HeaderModeSkip,
+			}},
+			wantRequired: false,
+		},
+		{
+			name: "process without interface",
+			impl: &modeOnlyPolicy{mode: policy.ProcessingMode{
+				RequestHeaderMode: policy.HeaderModeProcess,
+			}},
+			wantRequired: false,
+		},
+		{
+			name:         "zero value with interface",
+			impl:         &requestHeaderModePolicy{mode: policy.ProcessingMode{}},
+			wantRequired: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chain := buildSinglePolicyChainForTest(t, "request-header-test", tt.impl)
+			assert.Equal(t, tt.wantRequired, chain.RequiresRequestHeader)
+		})
+	}
+}
+
+func TestBuildPolicyChain_ResponseHeaderParticipationFollowsMode(t *testing.T) {
+	tests := []struct {
+		name         string
+		impl         policy.Policy
+		wantRequired bool
+	}{
+		{
+			name: "process with interface",
+			impl: &responseHeaderModePolicy{mode: policy.ProcessingMode{
+				ResponseHeaderMode: policy.HeaderModeProcess,
+			}},
+			wantRequired: true,
+		},
+		{
+			name: "skip with interface",
+			impl: &responseHeaderModePolicy{mode: policy.ProcessingMode{
+				ResponseHeaderMode: policy.HeaderModeSkip,
+			}},
+			wantRequired: false,
+		},
+		{
+			name: "process without interface",
+			impl: &modeOnlyPolicy{mode: policy.ProcessingMode{
+				ResponseHeaderMode: policy.HeaderModeProcess,
+			}},
+			wantRequired: false,
+		},
+		{
+			name:         "zero value with interface",
+			impl:         &responseHeaderModePolicy{mode: policy.ProcessingMode{}},
+			wantRequired: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chain := buildSinglePolicyChainForTest(t, "response-header-test", tt.impl)
+			assert.Equal(t, tt.wantRequired, chain.RequiresResponseHeader)
+		})
+	}
+}
+
+func TestBuildPolicyChain_RequestStreamingFollowsMode(t *testing.T) {
+	tests := []struct {
+		name         string
+		impl         policy.Policy
+		wantRequired bool
+		wantStream   bool
+	}{
+		{
+			name: "stream with streaming interface",
+			impl: &streamingRequestModePolicy{mode: policy.ProcessingMode{
+				RequestBodyMode: policy.BodyModeStream,
+			}},
+			wantRequired: true,
+			wantStream:   true,
+		},
+		{
+			name: "stream without streaming interface",
+			impl: &bufferedRequestModePolicy{mode: policy.ProcessingMode{
+				RequestBodyMode: policy.BodyModeStream,
+			}},
+			wantRequired: true,
+			wantStream:   false,
+		},
+		{
+			name: "buffer with streaming interface",
+			impl: &streamingRequestModePolicy{mode: policy.ProcessingMode{
+				RequestBodyMode: policy.BodyModeBuffer,
+			}},
+			wantRequired: true,
+			wantStream:   false,
+		},
+		{
+			name: "buffer without streaming interface",
+			impl: &bufferedRequestModePolicy{mode: policy.ProcessingMode{
+				RequestBodyMode: policy.BodyModeBuffer,
+			}},
+			wantRequired: true,
+			wantStream:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chain := buildSinglePolicyChainForTest(t, "request-stream-test", tt.impl)
+			assert.Equal(t, tt.wantRequired, chain.RequiresRequestBody)
+			assert.Equal(t, tt.wantStream, chain.SupportsRequestStreaming)
+		})
+	}
+}
+
+func TestBuildPolicyChain_ResponseStreamingFollowsMode(t *testing.T) {
+	tests := []struct {
+		name         string
+		impl         policy.Policy
+		wantRequired bool
+		wantStream   bool
+	}{
+		{
+			name: "stream with streaming interface",
+			impl: &streamingResponseModePolicy{mode: policy.ProcessingMode{
+				ResponseBodyMode: policy.BodyModeStream,
+			}},
+			wantRequired: true,
+			wantStream:   true,
+		},
+		{
+			name: "stream without streaming interface",
+			impl: &bufferedResponseModePolicy{mode: policy.ProcessingMode{
+				ResponseBodyMode: policy.BodyModeStream,
+			}},
+			wantRequired: true,
+			wantStream:   false,
+		},
+		{
+			name: "buffer with streaming interface",
+			impl: &streamingResponseModePolicy{mode: policy.ProcessingMode{
+				ResponseBodyMode: policy.BodyModeBuffer,
+			}},
+			wantRequired: true,
+			wantStream:   false,
+		},
+		{
+			name: "buffer without streaming interface",
+			impl: &bufferedResponseModePolicy{mode: policy.ProcessingMode{
+				ResponseBodyMode: policy.BodyModeBuffer,
+			}},
+			wantRequired: true,
+			wantStream:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chain := buildSinglePolicyChainForTest(t, "response-stream-test", tt.impl)
+			assert.Equal(t, tt.wantRequired, chain.RequiresResponseBody)
+			assert.Equal(t, tt.wantStream, chain.SupportsResponseStreaming)
+		})
+	}
 }

--- a/gateway/gateway-runtime/policy-engine/internal/kernel/xds.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/xds.go
@@ -215,7 +215,7 @@ func (cl *ConfigLoader) buildPolicyChain(routeKey string, config *policyenginev1
 
 		if mode.RequestBodyMode != policy.BodyModeSkip {
 			if _, ok := impl.(policy.RequestPolicy); !ok {
-				slog.Debug("[chain-build] policy declares non-SKIP RequestBodyMode but does not implement RequestPolicy (may be cross-phase body access)",
+				slog.Warn("[chain-build] policy declares non-SKIP RequestBodyMode but does not implement RequestPolicy (may be cross-phase body access)",
 					"policy", policyConfig.Name, "mode", mode.RequestBodyMode, "route", routeKey)
 			}
 		}

--- a/gateway/gateway-runtime/policy-engine/internal/kernel/xds.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/xds.go
@@ -172,23 +172,58 @@ func (cl *ConfigLoader) buildPolicyChain(routeKey string, config *policyenginev1
 		if mode.RequestBodyMode == policy.BodyModeBuffer || mode.RequestBodyMode == policy.BodyModeStream {
 			requiresRequestBody = true
 			hasRequestBodyPolicy = true
-			if _, streaming := impl.(policy.StreamingRequestPolicy); !streaming {
+			if mode.RequestBodyMode == policy.BodyModeStream {
+				if _, streaming := impl.(policy.StreamingRequestPolicy); !streaming {
+					supportsRequestStreaming = false
+					slog.Warn("[chain-build] policy declares RequestBodyMode=STREAM but does not implement StreamingRequestPolicy",
+						"policy", policyConfig.Name, "route", routeKey)
+				}
+			} else {
 				supportsRequestStreaming = false
 			}
 		}
 		if mode.ResponseBodyMode == policy.BodyModeBuffer || mode.ResponseBodyMode == policy.BodyModeStream {
 			requiresResponseBody = true
 			hasResponseBodyPolicy = true
-			if _, streaming := impl.(policy.StreamingResponsePolicy); !streaming {
+			if mode.ResponseBodyMode == policy.BodyModeStream {
+				if _, streaming := impl.(policy.StreamingResponsePolicy); !streaming {
+					supportsResponseStreaming = false
+					slog.Warn("[chain-build] policy declares ResponseBodyMode=STREAM but does not implement StreamingResponsePolicy",
+						"policy", policyConfig.Name, "route", routeKey)
+				}
+			} else {
 				supportsResponseStreaming = false
 			}
 		}
 
-		if _, ok := impl.(policy.RequestHeaderPolicy); ok {
-			requiresRequestHeader = true
+		if mode.RequestHeaderMode == policy.HeaderModeProcess {
+			if _, ok := impl.(policy.RequestHeaderPolicy); ok {
+				requiresRequestHeader = true
+			} else {
+				slog.Warn("[chain-build] policy declares RequestHeaderMode=PROCESS but does not implement RequestHeaderPolicy",
+					"policy", policyConfig.Name, "route", routeKey)
+			}
 		}
-		if _, ok := impl.(policy.ResponseHeaderPolicy); ok {
-			requiresResponseHeader = true
+		if mode.ResponseHeaderMode == policy.HeaderModeProcess {
+			if _, ok := impl.(policy.ResponseHeaderPolicy); ok {
+				requiresResponseHeader = true
+			} else {
+				slog.Warn("[chain-build] policy declares ResponseHeaderMode=PROCESS but does not implement ResponseHeaderPolicy",
+					"policy", policyConfig.Name, "route", routeKey)
+			}
+		}
+
+		if mode.RequestBodyMode != policy.BodyModeSkip {
+			if _, ok := impl.(policy.RequestPolicy); !ok {
+				slog.Debug("[chain-build] policy declares non-SKIP RequestBodyMode but does not implement RequestPolicy (may be cross-phase body access)",
+					"policy", policyConfig.Name, "mode", mode.RequestBodyMode, "route", routeKey)
+			}
+		}
+		if mode.ResponseBodyMode != policy.BodyModeSkip {
+			if _, ok := impl.(policy.ResponsePolicy); !ok {
+				slog.Warn("[chain-build] policy declares non-SKIP ResponseBodyMode but does not implement ResponsePolicy",
+					"policy", policyConfig.Name, "mode", mode.ResponseBodyMode, "route", routeKey)
+			}
 		}
 	}
 
@@ -200,13 +235,13 @@ func (cl *ConfigLoader) buildPolicyChain(routeKey string, config *policyenginev1
 	}
 
 	chain := &registry.PolicyChain{
-		Policies:                 policyList,
-		PolicySpecs:              policySpecs,
-		RequiresRequestBody:      requiresRequestBody,
-		RequiresResponseBody:     requiresResponseBody,
-		HasExecutionConditions:   hasExecutionConditions,
-		RequiresRequestHeader:    requiresRequestHeader,
-		RequiresResponseHeader:   requiresResponseHeader,
+		Policies:                  policyList,
+		PolicySpecs:               policySpecs,
+		RequiresRequestBody:       requiresRequestBody,
+		RequiresResponseBody:      requiresResponseBody,
+		HasExecutionConditions:    hasExecutionConditions,
+		RequiresRequestHeader:     requiresRequestHeader,
+		RequiresResponseHeader:    requiresResponseHeader,
 		SupportsRequestStreaming:  supportsRequestStreaming,
 		SupportsResponseStreaming: supportsResponseStreaming,
 	}

--- a/gateway/gateway-runtime/policy-engine/internal/registry/chain.go
+++ b/gateway/gateway-runtime/policy-engine/internal/registry/chain.go
@@ -54,11 +54,15 @@ type PolicyChain struct {
 	// When false, CEL evaluation is skipped entirely during execution.
 	HasExecutionConditions bool
 
-	// Computed flag: true if any policy in the chain implements RequestHeaderPolicy.
-	// Used to determine whether request headers need to be sent to ext_proc.
+	// Computed flag: true if any policy declares RequestHeaderMode=PROCESS in Mode()
+	// AND implements the RequestHeaderPolicy interface. Note: this flag does NOT
+	// control Envoy header transport (headers always flow for lifecycle reasons).
+	// It reflects callback participation intent.
 	RequiresRequestHeader bool
 
-	// Computed flag: true if any policy in the chain implements ResponseHeaderPolicy.
-	// Used to determine whether response headers need to be sent to ext_proc.
+	// Computed flag: true if any policy declares ResponseHeaderMode=PROCESS in Mode()
+	// AND implements the ResponseHeaderPolicy interface. Note: this flag does NOT
+	// control Envoy header transport (headers always flow for lifecycle reasons).
+	// It reflects callback participation intent.
 	RequiresResponseHeader bool
 }

--- a/gateway/gateway-runtime/policy-engine/internal/xdsclient/handler.go
+++ b/gateway/gateway-runtime/policy-engine/internal/xdsclient/handler.go
@@ -405,23 +405,58 @@ func (h *ResourceHandler) buildPolicyChain(routeKey string, config *policyengine
 		if mode.RequestBodyMode == policy.BodyModeBuffer || mode.RequestBodyMode == policy.BodyModeStream {
 			requiresRequestBody = true
 			hasRequestBodyPolicy = true
-			if _, streaming := impl.(policy.StreamingRequestPolicy); !streaming {
+			if mode.RequestBodyMode == policy.BodyModeStream {
+				if _, streaming := impl.(policy.StreamingRequestPolicy); !streaming {
+					supportsRequestStreaming = false
+					slog.Warn("[chain-build] policy declares RequestBodyMode=STREAM but does not implement StreamingRequestPolicy",
+						"policy", policyConfig.Name, "route", routeKey)
+				}
+			} else {
 				supportsRequestStreaming = false
 			}
 		}
 		if mode.ResponseBodyMode == policy.BodyModeBuffer || mode.ResponseBodyMode == policy.BodyModeStream {
 			requiresResponseBody = true
 			hasResponseBodyPolicy = true
-			if _, streaming := impl.(policy.StreamingResponsePolicy); !streaming {
+			if mode.ResponseBodyMode == policy.BodyModeStream {
+				if _, streaming := impl.(policy.StreamingResponsePolicy); !streaming {
+					supportsResponseStreaming = false
+					slog.Warn("[chain-build] policy declares ResponseBodyMode=STREAM but does not implement StreamingResponsePolicy",
+						"policy", policyConfig.Name, "route", routeKey)
+				}
+			} else {
 				supportsResponseStreaming = false
 			}
 		}
 
-		if _, ok := impl.(policy.RequestHeaderPolicy); ok {
-			requiresRequestHeader = true
+		if mode.RequestHeaderMode == policy.HeaderModeProcess {
+			if _, ok := impl.(policy.RequestHeaderPolicy); ok {
+				requiresRequestHeader = true
+			} else {
+				slog.Warn("[chain-build] policy declares RequestHeaderMode=PROCESS but does not implement RequestHeaderPolicy",
+					"policy", policyConfig.Name, "route", routeKey)
+			}
 		}
-		if _, ok := impl.(policy.ResponseHeaderPolicy); ok {
-			requiresResponseHeader = true
+		if mode.ResponseHeaderMode == policy.HeaderModeProcess {
+			if _, ok := impl.(policy.ResponseHeaderPolicy); ok {
+				requiresResponseHeader = true
+			} else {
+				slog.Warn("[chain-build] policy declares ResponseHeaderMode=PROCESS but does not implement ResponseHeaderPolicy",
+					"policy", policyConfig.Name, "route", routeKey)
+			}
+		}
+
+		if mode.RequestBodyMode != policy.BodyModeSkip {
+			if _, ok := impl.(policy.RequestPolicy); !ok {
+				slog.Debug("[chain-build] policy declares non-SKIP RequestBodyMode but does not implement RequestPolicy (may be cross-phase body access)",
+					"policy", policyConfig.Name, "mode", mode.RequestBodyMode, "route", routeKey)
+			}
+		}
+		if mode.ResponseBodyMode != policy.BodyModeSkip {
+			if _, ok := impl.(policy.ResponsePolicy); !ok {
+				slog.Warn("[chain-build] policy declares non-SKIP ResponseBodyMode but does not implement ResponsePolicy",
+					"policy", policyConfig.Name, "mode", mode.ResponseBodyMode, "route", routeKey)
+			}
 		}
 	}
 
@@ -433,13 +468,13 @@ func (h *ResourceHandler) buildPolicyChain(routeKey string, config *policyengine
 	}
 
 	chain := &registry.PolicyChain{
-		Policies:                 policyList,
-		PolicySpecs:              policySpecs,
-		RequiresRequestBody:      requiresRequestBody,
-		RequiresResponseBody:     requiresResponseBody,
-		RequiresRequestHeader:    requiresRequestHeader,
-		RequiresResponseHeader:   requiresResponseHeader,
-		HasExecutionConditions:   hasExecutionConditions,
+		Policies:                  policyList,
+		PolicySpecs:               policySpecs,
+		RequiresRequestBody:       requiresRequestBody,
+		RequiresResponseBody:      requiresResponseBody,
+		RequiresRequestHeader:     requiresRequestHeader,
+		RequiresResponseHeader:    requiresResponseHeader,
+		HasExecutionConditions:    hasExecutionConditions,
 		SupportsRequestStreaming:  supportsRequestStreaming,
 		SupportsResponseStreaming: supportsResponseStreaming,
 	}

--- a/gateway/it/features/llm-cost-based-ratelimit.feature
+++ b/gateway/it/features/llm-cost-based-ratelimit.feature
@@ -78,6 +78,7 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
+    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -166,6 +167,7 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
+    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -250,6 +252,7 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
+    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -334,6 +337,7 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
+    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -453,6 +457,7 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
+    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -549,6 +554,7 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
+    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -644,6 +650,7 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
+    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -736,6 +743,7 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
+    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -824,6 +832,7 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
+    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -907,6 +916,7 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
+    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -989,6 +999,7 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
+    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -1072,6 +1083,7 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
+    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -1155,6 +1167,7 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
+    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -1238,6 +1251,7 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
+    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -1321,6 +1335,7 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
+    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -1403,6 +1418,7 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
+    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -1485,6 +1501,7 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
+    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -1567,6 +1584,7 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
+    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -1649,6 +1667,7 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
+    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -1731,6 +1750,7 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
+    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -1812,6 +1832,7 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
+    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -1892,6 +1913,7 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
+    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"

--- a/gateway/it/features/llm-cost-based-ratelimit.feature
+++ b/gateway/it/features/llm-cost-based-ratelimit.feature
@@ -78,7 +78,6 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
-    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -167,7 +166,6 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
-    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -252,7 +250,6 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
-    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -337,7 +334,6 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
-    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -457,7 +453,6 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
-    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -554,7 +549,6 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
-    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -650,7 +644,6 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
-    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -743,7 +736,6 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
-    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -832,7 +824,6 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
-    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -916,7 +907,6 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
-    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -999,7 +989,6 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
-    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -1083,7 +1072,6 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
-    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -1167,7 +1155,6 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
-    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -1251,7 +1238,6 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
-    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -1335,7 +1321,6 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
-    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -1418,7 +1403,6 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
-    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -1501,7 +1485,6 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
-    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -1584,7 +1567,6 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
-    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -1667,7 +1649,6 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
-    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -1750,7 +1731,6 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
-    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -1832,7 +1812,6 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
-    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"
@@ -1913,7 +1892,6 @@ Feature: LLM Cost-Based Rate Limiting
                   - '*'
       """
     Then the response status code should be 201
-    And I wait for 2 seconds
     And I wait for policy snapshot sync
 
     Given I set header "Content-Type" to "application/json"

--- a/gateway/it/steps_health.go
+++ b/gateway/it/steps_health.go
@@ -277,48 +277,31 @@ func (h *HealthSteps) waitForPolicySnapshotSync() error {
 
 	controllerURL := fmt.Sprintf("%s/xds_sync_status", h.state.Config.GatewayControllerAdminURL)
 	policyEngineURL := fmt.Sprintf("%s/xds_sync_status", h.state.Config.PolicyEngineURL)
+	lastControllerVersion := ""
+	lastRuntimeVersion := ""
+	var lastControllerErr error
+	var lastRuntimeErr error
 
-	// First read the current version
-	initialVersion, _ := h.getControllerPolicyVersion(controllerURL)
-	var targetVersion string
-	var lastErr error
-
-	// Poll until it observes a different version from the controller
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		currentVersion, err := h.getControllerPolicyVersion(controllerURL)
-		if err == nil && currentVersion != "" && currentVersion != initialVersion {
-			targetVersion = currentVersion
-			break
-		}
-		lastErr = err
-		if attempt < maxAttempts {
-			time.Sleep(attemptInterval)
-		}
-	}
+		controllerVersion, controllerErr := h.getControllerPolicyVersion(controllerURL)
+		runtimeVersion, runtimeErr := h.getPolicyEnginePolicyVersion(policyEngineURL)
+		lastControllerVersion = controllerVersion
+		lastRuntimeVersion = runtimeVersion
+		lastControllerErr = controllerErr
+		lastRuntimeErr = runtimeErr
 
-	if targetVersion == "" {
-		if lastErr != nil {
-			return fmt.Errorf("failed to get new controller policy version (last error: %v)", lastErr)
-		}
-		return fmt.Errorf("controller policy version did not change from %q after %d attempts", initialVersion, maxAttempts)
-	}
-
-	// Continue polling until the policy-engine reported version equals the target version
-	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		runtimeVersion, err := h.getPolicyEnginePolicyVersion(policyEngineURL)
-		if err == nil && runtimeVersion == targetVersion {
+		if controllerErr == nil && runtimeErr == nil &&
+			controllerVersion == runtimeVersion && controllerVersion != "" {
 			return nil
 		}
-		lastErr = err
+
 		if attempt < maxAttempts {
 			time.Sleep(attemptInterval)
 		}
 	}
 
-	if lastErr != nil {
-		return fmt.Errorf("policy engine failed to sync to target version %q (last error: %v)", targetVersion, lastErr)
-	}
-	return fmt.Errorf("policy engine did not sync to target version %q after %d attempts", targetVersion, maxAttempts)
+	return fmt.Errorf("policy snapshot versions did not sync in time between controller and policy engine: controller_version=%q runtime_version=%q controller_err=%v runtime_err=%v",
+		lastControllerVersion, lastRuntimeVersion, lastControllerErr, lastRuntimeErr)
 }
 
 func (h *HealthSteps) getControllerPolicyVersion(url string) (string, error) {

--- a/gateway/it/steps_health.go
+++ b/gateway/it/steps_health.go
@@ -277,31 +277,48 @@ func (h *HealthSteps) waitForPolicySnapshotSync() error {
 
 	controllerURL := fmt.Sprintf("%s/xds_sync_status", h.state.Config.GatewayControllerAdminURL)
 	policyEngineURL := fmt.Sprintf("%s/xds_sync_status", h.state.Config.PolicyEngineURL)
-	lastControllerVersion := ""
-	lastRuntimeVersion := ""
-	var lastControllerErr error
-	var lastRuntimeErr error
 
+	// First read the current version
+	initialVersion, _ := h.getControllerPolicyVersion(controllerURL)
+	var targetVersion string
+	var lastErr error
+
+	// Poll until it observes a different version from the controller
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		controllerVersion, controllerErr := h.getControllerPolicyVersion(controllerURL)
-		runtimeVersion, runtimeErr := h.getPolicyEnginePolicyVersion(policyEngineURL)
-		lastControllerVersion = controllerVersion
-		lastRuntimeVersion = runtimeVersion
-		lastControllerErr = controllerErr
-		lastRuntimeErr = runtimeErr
-
-		if controllerErr == nil && runtimeErr == nil &&
-			controllerVersion == runtimeVersion && controllerVersion != "" {
-			return nil
+		currentVersion, err := h.getControllerPolicyVersion(controllerURL)
+		if err == nil && currentVersion != "" && currentVersion != initialVersion {
+			targetVersion = currentVersion
+			break
 		}
-
+		lastErr = err
 		if attempt < maxAttempts {
 			time.Sleep(attemptInterval)
 		}
 	}
 
-	return fmt.Errorf("policy snapshot versions did not sync in time between controller and policy engine: controller_version=%q runtime_version=%q controller_err=%v runtime_err=%v",
-		lastControllerVersion, lastRuntimeVersion, lastControllerErr, lastRuntimeErr)
+	if targetVersion == "" {
+		if lastErr != nil {
+			return fmt.Errorf("failed to get new controller policy version (last error: %v)", lastErr)
+		}
+		return fmt.Errorf("controller policy version did not change from %q after %d attempts", initialVersion, maxAttempts)
+	}
+
+	// Continue polling until the policy-engine reported version equals the target version
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		runtimeVersion, err := h.getPolicyEnginePolicyVersion(policyEngineURL)
+		if err == nil && runtimeVersion == targetVersion {
+			return nil
+		}
+		lastErr = err
+		if attempt < maxAttempts {
+			time.Sleep(attemptInterval)
+		}
+	}
+
+	if lastErr != nil {
+		return fmt.Errorf("policy engine failed to sync to target version %q (last error: %v)", targetVersion, lastErr)
+	}
+	return fmt.Errorf("policy engine did not sync to target version %q after %d attempts", targetVersion, maxAttempts)
 }
 
 func (h *HealthSteps) getControllerPolicyVersion(url string) (string, error) {

--- a/sdk/core/policy/v1alpha2/interface.go
+++ b/sdk/core/policy/v1alpha2/interface.go
@@ -1,8 +1,9 @@
 // Package policyv1alpha2 provides the policy interface for the WSO2 API Gateway.
 //
-// Policies declare capabilities by implementing phase-specific sub-interfaces.
-// The kernel discovers which phases a policy participates in via type assertions
-// at chain-build time — once at startup, with zero per-request overhead.
+// Policies declare phase participation via Mode(), which is the authoritative
+// source for all six processing phases. Phase-specific sub-interfaces provide
+// the method implementations; the kernel uses type assertions only for method
+// dispatch and streaming capability validation at chain-build time.
 package policyv1alpha2
 
 import "context"


### PR DESCRIPTION
## Related Discussion

- Refers to *#1680*

## Purpose
The primary motivation for this change is the upcoming **Python Policy Runtime**. To support Python policies, the engine requires a single unified Go `PythonBridge` struct that implements all six policy interfaces. This bridge will dynamically delegate execution to the Python environment based on the specific policy's configuration.

Previously, the policy engine relied on an inconsistent mix of `Mode()` declarations and Go type assertions to determine phase participation. Because the unified `PythonBridge` implements *every* interface, the engine's legacy type-assertion gating was incorrectly routing buffered Python policies into the streaming executors. 

To fix this, we are refactoring the engine to establish `Mode()` as the strict, sole source of truth for phase participation, explicitly removing arbitrary type assertion fallbacks.

## Goals
Establish `Mode()` as the single, authoritative source of truth for all policy chain building and runtime execution gating. This ensures safe dynamic multi-interface dispatch and resolves the bug where streaming executors dispatched non-streaming traffic simply because a policy returned `!= BodyModeSkip`.

## Approach
- **Chain-Build Refactoring:** Updated `kernel/body_mode.go`, `kernel/xds.go`, and `xdsclient/handler.go` to dynamically compute boolean flags (e.g., `RequiresRequestBody`, `RequiresRequestHeader`) explicitly from `Mode()` configuration prior to interface validation.
- **Execution Gating:** Refactored `ChainExecutor` in `executor/chain.go` to explicitly gate header executions against `pol.Mode().RequestHeaderMode == HeaderModeProcess`. 
- **Tightened Streaming:** Modified streaming executor routing in `ChainExecutor` to strictly gate on `== BodyModeStream` rather than the legacy `!= BodyModeSkip`, safely enabling the Python bridge to operate under buffered logic execution without accidental routing into streaming paths.
- **Documentation:** Modernized struct documentation in `registry/chain.go` accurately separating Envoy lifecycle obligations from phase execution intent.

## User stories
As a gateway developer, I need the policy engine to cleanly decouple phase participation from interface existence, allowing dynamic environments (like the new Python bridge) to execute policy callbacks precisely according to their explicit `Mode()` without impacting or hijacking streaming traffic.

## Documentation
N/A. Engine-internal architectural changes; SDK structural impacts and execution intent nuances were documented directly via inline codebase comments (`registry/chain.go` and `interface.go`).

## Automation tests
 - Unit tests 
   > Updated `ChainExecutor` unit tests verifying streaming callbacks are immediately bypassed for any policy returning `BodyModeBuffer`, maintaining strict parity with mode configuration. 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
- https://github.com/wso2/api-platform/pull/1343

## Test environment
- macOS / Linux