### PR TITLE
fix(llm-transformer): remove unwanted template params from guardrail policies

### DIFF
--- a/gateway/gateway-controller/pkg/utils/llm_transformer.go
+++ b/gateway/gateway-controller/pkg/utils/llm_transformer.go
@@ -269,14 +269,10 @@ func (t *LLMProviderTransformer) transformProxy(proxy *api.LLMProxyConfiguration
 									operationRegistry[targetKey] = targetOp
 								}
 
-								templateParams, err := buildTemplateParams(tmpl, targetPath)
-								if err != nil {
-									return nil, fmt.Errorf("failed to build template params: %w", err)
-								}
 								pol := api.Policy{
 									Name:    llmPol.Name,
 									Version: llmPol.Version,
-									Params:  mergeParams(pathEntry.Params, templateParams),
+									Params:  copyParams(pathEntry.Params),
 								}
 								appendOperationPolicy(targetOp, pol)
 								attachedPolicyPaths[targetPath] = true
@@ -510,14 +506,10 @@ func (t *LLMProviderTransformer) transformProvider(provider *api.LLMProviderConf
 										continue
 									}
 
-									templateParams, err := buildTemplateParams(tmpl, targetPath)
-									if err != nil {
-										return nil, fmt.Errorf("failed to build template params: %w", err)
-									}
 									pol := api.Policy{
 										Name:    llmPol.Name,
 										Version: llmPol.Version,
-										Params:  mergeParams(pathEntry.Params, templateParams),
+										Params:  copyParams(pathEntry.Params),
 									}
 									appendOperationPolicy(targetOp, pol)
 									attachedPolicyPaths[targetPath] = true
@@ -615,14 +607,10 @@ func (t *LLMProviderTransformer) transformProvider(provider *api.LLMProviderConf
 										operationRegistry[targetKey] = targetOp
 									}
 
-									templateParams, err := buildTemplateParams(tmpl, targetPath)
-									if err != nil {
-										return nil, fmt.Errorf("failed to build template params: %w", err)
-									}
 									pol := api.Policy{
 										Name:    llmPol.Name,
 										Version: llmPol.Version,
-										Params:  mergeParams(pathEntry.Params, templateParams),
+										Params:  copyParams(pathEntry.Params),
 									}
 									appendOperationPolicy(targetOp, pol)
 									attachedPolicyPaths[targetPath] = true
@@ -791,6 +779,19 @@ func mergeParams(base map[string]interface{}, extra map[string]interface{}) *map
 		merged[k] = v
 	}
 	return &merged
+}
+
+// copyParams creates a shallow copy of the parameters map and returns a pointer to it.
+// Returns nil if the input map is nil or empty.
+func copyParams(params map[string]interface{}) *map[string]interface{} {
+	if len(params) == 0 {
+		return nil
+	}
+	copied := make(map[string]interface{}, len(params))
+	for k, v := range params {
+		copied[k] = v
+	}
+	return &copied
 }
 
 func appendOperationPolicy(op *api.Operation, pol api.Policy) {

--- a/gateway/gateway-controller/pkg/utils/llm_transformer_test.go
+++ b/gateway/gateway-controller/pkg/utils/llm_transformer_test.go
@@ -981,9 +981,9 @@ func TestTransformProvider_ExpandsWildcardPolicyPathWithTemplateMappings(t *test
 	require.NotNil(t, responsesPolicy)
 	require.NotNil(t, responsesPolicy.Params)
 
-	reqModel, ok := (*responsesPolicy.Params)["requestModel"].(map[string]interface{})
-	require.True(t, ok)
-	assert.Equal(t, responsesModel, reqModel["identifier"])
+	// User-defined policies should only contain user params, not template params
+	_, hasRequestModel := (*responsesPolicy.Params)["requestModel"]
+	assert.False(t, hasRequestModel, "template params should not be merged into user-defined policies")
 	assert.Equal(t, "value", (*responsesPolicy.Params)["userParam"])
 
 	require.NotNil(t, wildcardPostOp)
@@ -1000,9 +1000,9 @@ func TestTransformProvider_ExpandsWildcardPolicyPathWithTemplateMappings(t *test
 	require.NotNil(t, wildcardPolicy)
 	require.NotNil(t, wildcardPolicy.Params)
 
-	wildcardReqModel, ok := (*wildcardPolicy.Params)["requestModel"].(map[string]interface{})
-	require.True(t, ok)
-	assert.Equal(t, defaultModel, wildcardReqModel["identifier"])
+	// User-defined policies should only contain user params, not template params
+	_, hasWildcardRequestModel := (*wildcardPolicy.Params)["requestModel"]
+	assert.False(t, hasWildcardRequestModel, "template params should not be merged into user-defined policies")
 	assert.Equal(t, "value", (*wildcardPolicy.Params)["userParam"])
 }
 


### PR DESCRIPTION
## Purpose
  Fixes unwanted LLM template extraction parameters being attached to guardrail policies when deployed with LLM providers. When policies like `word-count-guardrail` are attached to an LLM provider, the policy
  engine config dump shows extraneous parameters (`promptTokens`, `completionTokens`, `totalTokens`, `remainingTokens`, `requestModel`, `responseModel`) that are not defined in the policy schema
  and should not be present.

  ## Approach
  - Replace `mergeParams(pathEntry.Params, templateParams)` with `copyParams(pathEntry.Params)` in three locations within `llm_transformer.go` (transformProxy and transformProvider methods for both AllowAll
  and DenyAll modes)
  - Add new `copyParams()` helper function that creates a shallow copy of user-provided parameters without merging LLM template extraction fields
  - Template extraction fields (`buildTemplateParams()`) are preserved for other uses but no longer injected into user policy parameters

  ## Testing
  - Deployed LLM provider with `word-count-guardrail` attached
  - Verified via `/config_dump` endpoint that only user-provided params (`request`, `response`) appear
  - Before fix: 8 parameters including unwanted template fields
  - After fix: Only user-configured parameters

  Fixes #1592