### PR TITLE
Add monetized subscription data to xds

### DIFF
--- a/sdk/core/policyengine/subscription_store.go
+++ b/sdk/core/policyengine/subscription_store.go
@@ -15,10 +15,13 @@ func HashSubscriptionToken(token string) string {
 
 // SubscriptionEntry holds the subscription state and rate limit info from the plan.
 type SubscriptionEntry struct {
-	Status             string
-	ThrottleLimitCount int
-	ThrottleLimitUnit  string
-	StopOnQuotaReach   bool
+	Status                string
+	ThrottleLimitCount    int
+	ThrottleLimitUnit     string
+	StopOnQuotaReach      bool
+	PlanName              string
+	BillingCustomerID     *string
+	BillingSubscriptionID *string
 }
 
 // SubscriptionStore stores subscription state in memory for fast lookups by policies.
@@ -65,10 +68,13 @@ func (s *SubscriptionStore) ReplaceAll(subs []SubscriptionData) {
 		}
 
 		entry := &SubscriptionEntry{
-			Status:             sub.Status,
-			ThrottleLimitCount: sub.ThrottleLimitCount,
-			ThrottleLimitUnit:  sub.ThrottleLimitUnit,
-			StopOnQuotaReach:   sub.StopOnQuotaReach,
+			Status:                sub.Status,
+			ThrottleLimitCount:    sub.ThrottleLimitCount,
+			ThrottleLimitUnit:     sub.ThrottleLimitUnit,
+			StopOnQuotaReach:      sub.StopOnQuotaReach,
+			PlanName:              sub.PlanName,
+			BillingCustomerID:     sub.BillingCustomerId,
+			BillingSubscriptionID: sub.BillingSubscriptionId,
 		}
 
 		// Build token-based index

--- a/sdk/core/policyengine/subscription_xds.go
+++ b/sdk/core/policyengine/subscription_xds.go
@@ -25,6 +25,15 @@ type SubscriptionData struct {
 
 	// StopOnQuotaReach indicates whether to block requests when quota is exhausted.
 	StopOnQuotaReach bool `json:"stopOnQuotaReach,omitempty" yaml:"stopOnQuotaReach,omitempty"`
+
+	// PlanName is the name of the subscription plan
+	PlanName string `json:"planName,omitempty" yaml:"planName,omitempty"`
+
+	// BillingCustomerId is the billing customer identifier
+	BillingCustomerId *string `json:"billingCustomerId,omitempty" yaml:"billingCustomerId,omitempty"`
+
+	// BillingSubscriptionId is the billing subscription identifier
+	BillingSubscriptionId *string `json:"billingSubscriptionId,omitempty" yaml:"billingSubscriptionId,omitempty"`
 }
 
 // SubscriptionStateResource represents the complete state of subscriptions


### PR DESCRIPTION
## Purpose

This pull request adds support for storing and tracking additional billing and plan information in subscription data structures. The changes ensure that each subscription now includes plan name and billing identifiers, making it easier to associate subscriptions with billing records and plans.

## Approach

Enhancements to subscription data structures:

* Added `PlanName`, `BillingCustomerId`, and `BillingSubscriptionId` fields to the `SubscriptionData` struct in `subscription_xds.go` to store plan and billing information.
* Added corresponding `PlanName`, `BillingCustomerID`, and `BillingSubscriptionID` fields to the `SubscriptionEntry` struct in `subscription_store.go` to mirror the new data.

Synchronization of new fields:

* Updated the `ReplaceAll` method in `SubscriptionStore` (`subscription_store.go`) to copy the new plan and billing fields from `SubscriptionData` into `SubscriptionEntry`.