### PR TITLE
docs(gateway): add immutable gateway and artifact templating docs

### DIFF
--- a/docs/gateway/README.md
+++ b/docs/gateway/README.md
@@ -70,3 +70,4 @@ You can extend the gateway with your own policies or include specific policies f
 | [Analytics](analytics/) | Analytics integrations (Moesif) |
 | [REST APIs](../rest-apis/gateway/) | REST API authentication and usage |
 | [Policies and Guardrails](https://github.com/wso2/gateway-controllers/blob/main/docs/README.md) | Gateway policies and guardrails for API traffic control |
+| [Immutable Gateway](immutable-gateway.md) | File-based, GitOps-native gateway configuration |

--- a/docs/gateway/artifact-templating.md
+++ b/docs/gateway/artifact-templating.md
@@ -1,0 +1,89 @@
+# Gateway Artifact Templating
+
+Gateway artifact files (YAML/JSON) support Go `text/template` expressions for injecting dynamic values at startup. Templates are rendered on the raw artifact string before YAML/JSON parsing, so expressions work in any string field across the entire artifact — `upstream`, `auth`, policy `params`, metadata, etc.
+
+## Available functions
+
+### `env`
+
+Reads a value from an environment variable.
+
+```
+{{ env "KEY" }}
+```
+
+Returns an empty string if the variable is not set. Use `| default` to provide a fallback:
+
+```
+{{ env "BACKEND_URL" | default "http://localhost:8080" }}
+```
+
+### `required`
+
+Like `env`, but fails at startup if the variable is not set or empty. Use this to enforce that a value must be provided:
+
+```
+{{ required "BACKEND_URL" }}
+```
+
+If the variable is missing, the gateway will not start and will log which variable is required.
+
+### `redact`
+
+Marks a resolved value for redaction in config dumps. Any field rendered with `| redact` will appear as `***REDACTED***` in the gateway's config dump output instead of its actual value.
+
+```
+{{ env "API_KEY" | redact }}
+```
+
+Use `| redact` for any sensitive value injected from an environment variable (API keys, tokens, passwords).
+
+### `default`
+
+Provides a fallback value when the input is empty:
+
+```
+{{ env "LOG_LEVEL" | default "info" }}
+```
+
+Can be combined with any other function in a pipeline.
+
+## Combining functions
+
+Functions compose as pipelines:
+
+```
+{{ env "KEY" | default "fallback" }}
+{{ env "KEY" | redact }}
+{{ required "KEY" | redact }}
+```
+
+## Example
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: orders-api-v1
+spec:
+  context: /orders/v1
+  upstream:
+    main:
+      url: '{{ env "ORDERS_BACKEND_URL" | default "http://orders-svc:8080" }}'
+    auth:
+      apiKey: '{{ required "ORDERS_API_KEY" | redact }}'
+  policies:
+    - name: set-headers
+      version: v1
+      params:
+        request:
+          headers:
+            - name: X-Env
+              value: '{{ env "DEPLOYMENT_ENV" | default "production" }}'
+```
+
+In this example:
+
+- `ORDERS_BACKEND_URL` is optional — falls back to the default URL if not set.
+- `ORDERS_API_KEY` is required — the gateway will not start if it is missing, and the value is redacted in config dumps.
+- `DEPLOYMENT_ENV` is optional with a default of `production`.

--- a/docs/gateway/immutable-gateway.md
+++ b/docs/gateway/immutable-gateway.md
@@ -1,0 +1,144 @@
+# Immutable Gateway
+
+This guide explains how to run the API Platform Gateway in **immutable mode**, where API configurations are loaded from files at startup instead of being managed through the REST API.
+
+## Overview
+
+In immutable mode, the gateway controller reads API artifacts from a local directory at startup and applies them automatically. The management REST API remains available for read operations but rejects any mutating requests (`POST`, `PUT`, `PATCH`, `DELETE`) with `405 Method Not Allowed`.
+
+This is the recommended approach for:
+
+- **GitOps workflows** — store artifacts in a Git repository and bake them into a custom gateway image via CI/CD.
+- **Immutable infrastructure** — ship a self-contained gateway image that requires no runtime configuration.
+- **Kubernetes deployments** — mount a ConfigMap or Secret as a volume at the artifacts path.
+
+## Configuration
+
+Enable immutable mode in `config.toml` or via environment variable:
+
+```toml
+[immutable_gateway]
+enabled = true
+```
+
+```bash
+APIP_GW_IMMUTABLE_GATEWAY_ENABLED=true
+```
+
+By default, the gateway controller loads artifacts from `/etc/api-platform-gateway/immutable_gateway/artifacts`. You only need to set `artifacts_dir` if you want to use a different path.
+
+> **Note:** Full configuration reference with all options:
+>
+> ```toml
+> [immutable_gateway]
+> enabled = true
+> artifacts_dir = "/etc/api-platform-gateway/immutable_gateway/artifacts"
+> ```
+>
+> The equivalent environment variable overrides follow the standard `APIP_GW_` prefix convention:
+>
+> ```bash
+> APIP_GW_IMMUTABLE_GATEWAY_ENABLED=true
+> APIP_GW_IMMUTABLE_GATEWAY_ARTIFACTS_DIR=/etc/api-platform-gateway/immutable_gateway/artifacts
+> ```
+
+## Artifact format
+
+Artifacts use the same Kubernetes-style resource format supported by the gateway. Each file must include `apiVersion`, `kind`, `metadata`, and `spec`.
+
+### Injecting environment variables
+
+Artifact files support Go template expressions for injecting dynamic values. Templates are rendered on the raw artifact string before YAML parsing, so expressions work in any string field — `upstream`, `auth`, policy `params`, etc.
+
+| Function | Redacted in config dumps | Use for |
+|---|---|---|
+| `{{ env "KEY" }}` | No | Non-sensitive env vars (URLs, policy param values) |
+| `{{ env "KEY" \| redact }}` | Yes | Sensitive env vars (tokens, API keys) |
+
+Use `| redact` for sensitive values to hide them from config dumps. A `| default "value"` pipe is available for fallback values. See [Gateway Artifact Templating](artifact-templating.md) for the full function reference.
+
+### Sample: Reading List API
+
+Save the following as `artifacts/reading-list-v1.yaml`:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: reading-list-api-v1
+spec:
+  displayName: Reading List API
+  version: v1.0
+  context: /reading-list/$version
+  upstream:
+    main:
+      # read from env, falls back to the public sample backend if not set
+      url: '{{ env "BACKEND_URL" | default "https://apis.bijira.dev/samples/reading-list-api-service/v1.0" }}'
+  operations:
+    - method: GET
+      path: /books
+    - method: POST
+      path: /books
+    - method: GET
+      path: /books/{id}
+    - method: PUT
+      path: /books/{id}
+    - method: DELETE
+      path: /books/{id}
+```
+
+### Directory structure
+
+The controller walks all subdirectories, so you can organize artifacts however you like:
+
+```
+artifacts/
+├── rest-apis/
+│   ├── petstore-v1.yaml
+│   └── orders-v2.yaml
+├── llm-providers/
+│   └── openai.yaml
+├── llm-proxies/
+│   └── chat-proxy.yaml
+└── mcp-proxies/
+    └── tools-proxy.yaml
+```
+
+## Deployment
+
+### Baking artifacts into a custom image
+
+The recommended GitOps approach is to build a custom gateway-controller image with artifacts copied in at build time:
+
+```dockerfile
+FROM ghcr.io/wso2/api-platform/gateway-controller:1.0.0
+
+COPY ./artifacts /etc/api-platform-gateway/immutable_gateway/artifacts
+
+ENV APIP_GW_IMMUTABLE_GATEWAY_ENABLED=true
+```
+
+### Kubernetes — mounting a ConfigMap volume
+
+You can also mount artifacts as a volume from a ConfigMap or Secret without building a custom image:
+
+```yaml
+volumes:
+  - name: gateway-artifacts
+    configMap:
+      name: gateway-artifacts
+volumeMounts:
+  - name: gateway-artifacts
+    mountPath: /etc/api-platform-gateway/immutable_gateway/artifacts
+    readOnly: true
+```
+
+Set `APIP_GW_IMMUTABLE_GATEWAY_ENABLED=true` in the container's environment variables.
+
+## Invoking the API
+
+Once the gateway is running with the sample artifact, invoke the Reading List API:
+
+```bash
+curl -i http://localhost:8080/reading-list/v1.0/books
+```

--- a/kubernetes/gateway-operator/tryout.md
+++ b/kubernetes/gateway-operator/tryout.md
@@ -1,4 +1,3 @@
-
 # API Platform – Local Setup Guide
 
 This document explains how to install Cert-Manager, configure Docker Hub credentials, deploy the Gateway Operator, apply Gateway/API configurations, and test APIs locally.


### PR DESCRIPTION
## Purpose
Fix https://github.com/wso2/api-platform/issues/1724
- Add docs/gateway/immutable-gateway.md covering immutable mode configuration, artifact format with env/redact templating, deployment patterns (custom image, Kubernetes ConfigMap), and a sample Reading List API artifact with curl invocation
- Add docs/gateway/artifact-templating.md with full reference for env, required, redact, and default template functions
- Link both docs from docs/gateway/README.md
