### PR TITLE
feat(gateway-operator): support local helm chart via GATEWAY_HELM_CHART_PATH

### DIFF
--- a/kubernetes/gateway-operator/internal/config/config.go
+++ b/kubernetes/gateway-operator/internal/config/config.go
@@ -195,6 +195,8 @@ func LoadConfig(configPath string) (*OperatorConfig, error) {
 
 		// Map specific environment variables to config keys
 		switch s {
+		case "helm_chart_path":
+			return "gateway.helm_chart_path"
 		case "helm_chart_name":
 			return "gateway.helm_chart_name"
 		case "helm_chart_version":

--- a/kubernetes/gateway-operator/internal/helm/client.go
+++ b/kubernetes/gateway-operator/internal/helm/client.go
@@ -82,6 +82,10 @@ type InstallOrUpgradeOptions struct {
 	// Namespace is the Kubernetes namespace to install the chart into
 	Namespace string
 
+	// ChartPath is the path to a local chart directory or archive.
+	// When set, ChartName/Version/registry auth are ignored.
+	ChartPath string
+
 	// ChartName is the name of the remote chart (e.g., "bitnami/nginx" or "oci://registry/chart")
 	ChartName string
 
@@ -182,29 +186,35 @@ func (c *Client) install(ctx context.Context, actionConfig *action.Configuration
 		client.Timeout = time.Duration(opts.Timeout) * time.Second
 	}
 
-	// Handle registry authentication if provided
-	if opts.Username != "" && opts.Password != "" {
-		registryHost, err := extractRegistryHost(opts.ChartName)
+	var chartLoadPath string
+	if opts.ChartPath != "" {
+		chartLoadPath = opts.ChartPath
+	} else {
+		// Handle registry authentication if provided
+		if opts.Username != "" && opts.Password != "" {
+			registryHost, err := extractRegistryHost(opts.ChartName)
+			if err != nil {
+				return fmt.Errorf("failed to extract registry host: %w", err)
+			}
+
+			if err := c.registryClient.Login(
+				registryHost,
+				registry.LoginOptBasicAuth(opts.Username, opts.Password),
+				registry.LoginOptInsecure(opts.Insecure),
+			); err != nil {
+				return fmt.Errorf("failed to login to registry: %w", err)
+			}
+		}
+
+		// Locate and load chart from remote repository or OCI registry
+		located, err := client.ChartPathOptions.LocateChart(opts.ChartName, c.settings)
 		if err != nil {
-			return fmt.Errorf("failed to extract registry host: %w", err)
+			return fmt.Errorf("failed to locate chart %s: %w", opts.ChartName, err)
 		}
-
-		if err := c.registryClient.Login(
-			registryHost,
-			registry.LoginOptBasicAuth(opts.Username, opts.Password),
-			registry.LoginOptInsecure(opts.Insecure),
-		); err != nil {
-			return fmt.Errorf("failed to login to registry: %w", err)
-		}
+		chartLoadPath = located
 	}
 
-	// Locate and load chart from remote repository or OCI registry
-	chartPath, err := client.ChartPathOptions.LocateChart(opts.ChartName, c.settings)
-	if err != nil {
-		return fmt.Errorf("failed to locate chart %s: %w", opts.ChartName, err)
-	}
-
-	chart, err := loader.Load(chartPath)
+	chart, err := loader.Load(chartLoadPath)
 	if err != nil {
 		return fmt.Errorf("failed to load chart: %w", err)
 	}
@@ -242,29 +252,35 @@ func (c *Client) upgrade(ctx context.Context, actionConfig *action.Configuration
 		client.Timeout = time.Duration(opts.Timeout) * time.Second
 	}
 
-	// Handle registry authentication if provided
-	if opts.Username != "" && opts.Password != "" {
-		registryHost, err := extractRegistryHost(opts.ChartName)
+	var chartLoadPath string
+	if opts.ChartPath != "" {
+		chartLoadPath = opts.ChartPath
+	} else {
+		// Handle registry authentication if provided
+		if opts.Username != "" && opts.Password != "" {
+			registryHost, err := extractRegistryHost(opts.ChartName)
+			if err != nil {
+				return fmt.Errorf("failed to extract registry host: %w", err)
+			}
+
+			if err := c.registryClient.Login(
+				registryHost,
+				registry.LoginOptBasicAuth(opts.Username, opts.Password),
+				registry.LoginOptInsecure(opts.Insecure),
+			); err != nil {
+				return fmt.Errorf("failed to login to registry: %w", err)
+			}
+		}
+
+		// Locate and load chart from remote repository or OCI registry
+		located, err := client.ChartPathOptions.LocateChart(opts.ChartName, c.settings)
 		if err != nil {
-			return fmt.Errorf("failed to extract registry host: %w", err)
+			return fmt.Errorf("failed to locate chart %s: %w", opts.ChartName, err)
 		}
-
-		if err := c.registryClient.Login(
-			registryHost,
-			registry.LoginOptBasicAuth(opts.Username, opts.Password),
-			registry.LoginOptInsecure(opts.Insecure),
-		); err != nil {
-			return fmt.Errorf("failed to login to registry: %w", err)
-		}
+		chartLoadPath = located
 	}
 
-	// Locate and load chart from remote repository or OCI registry
-	chartPath, err := client.ChartPathOptions.LocateChart(opts.ChartName, c.settings)
-	if err != nil {
-		return fmt.Errorf("failed to locate chart %s: %w", opts.ChartName, err)
-	}
-
-	chart, err := loader.Load(chartPath)
+	chart, err := loader.Load(chartLoadPath)
 	if err != nil {
 		return fmt.Errorf("failed to load chart: %w", err)
 	}

--- a/kubernetes/gateway-operator/internal/helmgateway/deploy.go
+++ b/kubernetes/gateway-operator/internal/helmgateway/deploy.go
@@ -50,6 +50,7 @@ func InstallOrUpgrade(ctx context.Context, in DeployInput) error {
 	return helmClient.InstallOrUpgrade(ctx, helm.InstallOrUpgradeOptions{
 		ReleaseName:     releaseName,
 		Namespace:       in.Namespace,
+		ChartPath:       in.Config.Gateway.HelmChartPath,
 		ChartName:       in.Config.Gateway.HelmChartName,
 		ValuesYAML:      in.ValuesYAML,
 		ValuesFilePath:  in.ValuesFilePath,


### PR DESCRIPTION
## Purpose
Add support for deploying the gateway using a local Helm chart directory or archive instead of pulling from a remote registry.

- Map GATEWAY_HELM_CHART_PATH env var to gateway.helm_chart_path config
- Add ChartPath field to InstallOrUpgradeOptions; when set, skip LocateChart and registry auth and load the chart directly from disk
- Wire HelmChartPath through DeployInput into InstallOrUpgrade
