### PR TITLE
build(platform-api): add common module to Docker build context

### DIFF
--- a/distribution/all-in-one/docker-compose.yaml
+++ b/distribution/all-in-one/docker-compose.yaml
@@ -53,6 +53,8 @@ services:
     build:
       context: ../../platform-api
       dockerfile: Dockerfile
+      additional_contexts:
+        common: ../../common
     ports:
       - "9243:9243"
     volumes:

--- a/platform-api/Dockerfile
+++ b/platform-api/Dockerfile
@@ -41,9 +41,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     fi \
     && rm -rf /var/lib/apt/lists/*
 
+# Copy go mod files for dependencies (needed for go.mod replace directive)
+COPY --from=common go.mod go.sum /common/
+
 COPY src/go.mod src/go.sum ./
 RUN go mod download
 
+COPY --from=common . /common
 COPY src/ ./
 
 # Build the binary with CGO enabled (required for mattn/go-sqlite3)

--- a/platform-api/Makefile
+++ b/platform-api/Makefile
@@ -43,6 +43,7 @@ test: ## Run tests
 build: ## Build Docker image
 	@echo "Building Docker image ($(IMAGE_NAME):$(VERSION))..."
 	docker buildx build -f Dockerfile \
+		--build-context common=../common \
 		--build-arg VERSION=$(VERSION) \
 		--build-arg PORT=$(PORT) \
 		-t $(IMAGE_NAME):$(VERSION) \
@@ -66,6 +67,7 @@ build-and-push-multiarch: ## Build and push multi-architecture Docker image (lin
 	@echo "Building and pushing multi-arch Docker image: $(IMAGE_NAME):$(VERSION)"
 	docker buildx build -f Dockerfile \
 		--platform linux/amd64,linux/arm64 \
+		--build-context common=../common \
 		--build-arg VERSION=$(VERSION) \
 		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
 		--build-arg PORT=$(PORT) \

--- a/platform-api/src/go.mod
+++ b/platform-api/src/go.mod
@@ -9,11 +9,12 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
-	github.com/jackc/pgx/v5 v5.8.0
+	github.com/jackc/pgx/v5 v5.9.1
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/mattn/go-sqlite3 v1.14.32
+	github.com/mattn/go-sqlite3 v1.14.41
 	github.com/oapi-codegen/runtime v1.1.2
 	github.com/pb33f/libopenapi v0.28.2
+	github.com/wso2/api-platform/common v0.0.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -60,3 +61,5 @@ require (
 	golang.org/x/text v0.33.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )
+
+replace github.com/wso2/api-platform/common => ../../common

--- a/platform-api/src/go.sum
+++ b/platform-api/src/go.sum
@@ -53,6 +53,8 @@ github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7Ulw
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
 github.com/jackc/pgx/v5 v5.8.0 h1:TYPDoleBBme0xGSAX3/+NujXXtpZn9HBONkQC7IEZSo=
 github.com/jackc/pgx/v5 v5.8.0/go.mod h1:QVeDInX2m9VyzvNeiCJVjCkNFqzsNb43204HshNSZKw=
+github.com/jackc/pgx/v5 v5.9.1 h1:uwrxJXBnx76nyISkhr33kQLlUqjv7et7b9FjCen/tdc=
+github.com/jackc/pgx/v5 v5.9.1/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/json-iterator/go v1.1.13-0.20220915233716-71ac16282d12 h1:9Nu54bhS/H/Kgo2/7xNSUuC5G28VR8ljfrLKU2G4IjU=
@@ -72,6 +74,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-sqlite3 v1.14.32 h1:JD12Ag3oLy1zQA+BNn74xRgaBbdhbNIDYvQUEuuErjs=
 github.com/mattn/go-sqlite3 v1.14.32/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+github.com/mattn/go-sqlite3 v1.14.41 h1:8p7Pwz5NHkEbWSqc/ygU4CBGubhFFkpgP9KwcdkAHNA=
+github.com/mattn/go-sqlite3 v1.14.41/go.mod h1:pjEuOr8IwzLJP2MfGeTb0A35jauH+C2kbHKBr7yXKVQ=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -113,6 +117,8 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.3.1 h1:waO7eEiFDwidsBN6agj1vJQ4AG7lh2yqXyOXqhgQuyY=
 github.com/ugorji/go/codec v1.3.1/go.mod h1:pRBVtBSKl77K30Bv8R2P+cLSGaTtex6fsA2Wjqmfxj4=
+github.com/wso2/api-platform/common v0.0.0-20260423105036-01673c84640c h1:RX0XFFlZMZf4/lS7OJkdF3OeHbL6WijCUa2I4xIcxqw=
+github.com/wso2/api-platform/common v0.0.0-20260423105036-01673c84640c/go.mod h1:x4ajDeXqwe9r809tCgsgVPxaGCKHTGbLey4zDs5tpYQ=
 go.uber.org/mock v0.6.0 h1:hyF9dfmbgIX5EfOdasqLsWD6xqpNZlXblLB/Dbnwv3Y=
 go.uber.org/mock v0.6.0/go.mod h1:KiVJ4BqZJaMj4svdfmHM0AUx4NJYO8ZNpPnZn1Z+BBU=
 go.yaml.in/yaml/v4 v4.0.0-rc.2 h1:/FrI8D64VSr4HtGIlUtlFMGsm7H7pWTbj6vOLVZcA6s=


### PR DESCRIPTION
## Purpose
The platform-api go.mod uses a replace directive pointing to the local common module, which isn't available inside the default Docker build context. This mirrors the pattern used by gateway-controller.

- Dockerfile: copy common go.mod/go.sum before go mod download, then copy full common source via --from=common
- Makefile: add --build-context common=../common to both build and build-and-push-multiarch targets
- all-in-one docker-compose: add additional_contexts for common
- go.mod/go.sum: add common dependency and replace directive