### PR TITLE
feat(gateway-controller): enforce SQLite-only and fresh DB for immutable mode

### DIFF
--- a/gateway/gateway-controller/cmd/controller/main.go
+++ b/gateway/gateway-controller/cmd/controller/main.go
@@ -118,6 +118,17 @@ func main() {
 		log.Warn("No authentication configured: both basic auth and IDP are disabled. Gateway Controller API will allow all requests without authentication")
 	}
 
+	// In immutable mode, delete any stale SQLite files before opening the DB to
+	// guarantee a fresh, reproducible state on every boot.
+	if cfg.ImmutableGateway.Enabled {
+		log.Info("Immutable gateway mode enabled — removing existing SQLite files for fresh start",
+			slog.String("path", cfg.Controller.Storage.SQLite.Path))
+		if err := immutable.ResetSQLiteFiles(cfg.Controller.Storage.SQLite.Path, log); err != nil {
+			log.Error("Failed to reset SQLite files for immutable mode", slog.Any("error", err))
+			os.Exit(1)
+		}
+	}
+
 	// Initialize storage based on type
 	var db storage.Storage
 	db, err = storage.NewStorage(toBackendConfig(cfg), log)

--- a/gateway/gateway-controller/pkg/config/config.go
+++ b/gateway/gateway-controller/pkg/config/config.go
@@ -493,6 +493,8 @@ func LoadConfig(configPath string) (*Config, error) {
 			return "controller.controlplane.deployment_push_enabled"
 		case "controller_controlplane_sync_batch_size":
 			return "controller.controlplane.sync_batch_size"
+		case "immutable_gateway_enabled":
+			return "immutable_gateway.enabled"
 		default:
 			// For other env vars, use standard mapping (underscore to dot)
 			// Step 1: Convert double underscore "__" into a temporary placeholder
@@ -778,6 +780,14 @@ func defaultConfig() *Config {
 
 // Validate validates the configuration
 func (c *Config) Validate() error {
+	// Immutable mode requires SQLite — it starts with a fresh in-container DB on every boot,
+	// which is incompatible with external shared databases like Postgres.
+	if c.ImmutableGateway.Enabled && !strings.EqualFold(c.Controller.Storage.Type, "sqlite") {
+		return fmt.Errorf("immutable_gateway.enabled=true requires storage.type=sqlite; got %q. "+
+			"Immutable mode starts with a fresh in-container database on every boot and is incompatible with external databases",
+			c.Controller.Storage.Type)
+	}
+
 	// Validate storage type
 	validStorageTypes := []string{"sqlite", "postgres"}
 	isValidType := false

--- a/gateway/gateway-controller/pkg/immutable/reset.go
+++ b/gateway/gateway-controller/pkg/immutable/reset.go
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package immutable
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+)
+
+// ResetSQLiteFiles deletes the SQLite database file and its associated WAL/SHM/journal
+// files at the given path. Missing files are treated as success (idempotent).
+// Returns an error if any file exists but cannot be removed.
+func ResetSQLiteFiles(path string, log *slog.Logger) error {
+	suffixes := []string{"", "-wal", "-shm", "-journal"}
+	for _, suffix := range suffixes {
+		target := path + suffix
+		if err := os.Remove(target); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove %q: %w", target, err)
+		}
+		if suffix == "" {
+			log.Debug("Removed SQLite file for immutable mode reset", slog.String("file", target))
+		}
+	}
+	return nil
+}

--- a/gateway/gateway-controller/pkg/immutable/reset_test.go
+++ b/gateway/gateway-controller/pkg/immutable/reset_test.go
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package immutable
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResetSQLiteFiles_RemovesAllSuffixes(t *testing.T) {
+	dir := t.TempDir()
+	base := filepath.Join(dir, "gateway.db")
+
+	suffixes := []string{"", "-wal", "-shm", "-journal"}
+	for _, s := range suffixes {
+		if err := os.WriteFile(base+s, []byte("junk"), 0600); err != nil {
+			t.Fatalf("setup: write %s: %v", base+s, err)
+		}
+	}
+
+	if err := ResetSQLiteFiles(base, slog.Default()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, s := range suffixes {
+		if _, err := os.Stat(base + s); !os.IsNotExist(err) {
+			t.Errorf("expected %q to be removed, but it still exists", base+s)
+		}
+	}
+}
+
+func TestResetSQLiteFiles_MissingFilesSucceeds(t *testing.T) {
+	dir := t.TempDir()
+	base := filepath.Join(dir, "nonexistent.db")
+
+	if err := ResetSQLiteFiles(base, slog.Default()); err != nil {
+		t.Fatalf("expected success for missing files, got: %v", err)
+	}
+}
+
+func TestResetSQLiteFiles_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	base := filepath.Join(dir, "gateway.db")
+
+	if err := os.WriteFile(base, []byte("data"), 0600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	log := slog.Default()
+	if err := ResetSQLiteFiles(base, log); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if err := ResetSQLiteFiles(base, log); err != nil {
+		t.Fatalf("second call (idempotent): %v", err)
+	}
+}


### PR DESCRIPTION
## Purpose

- Reject startup if immutable_gateway.enabled=true with non-SQLite storage; Validate() now returns a clear error before any DB is touched
- Add APIP_GW_IMMUTABLE_GATEWAY_ENABLED env var mapping in config loader so the flag is settable without a config file
- Add ResetSQLiteFiles helper (pkg/immutable/reset.go) that removes .db, -wal, -shm, -journal files before storage init, guaranteeing a fresh state on every immutable-mode boot
- Wire reset call in main.go immediately before storage.NewStorage; fatal exit if removal fails to prevent booting on stale state
- Unit tests cover: all suffixes removed, missing files, idempotency