### PR TITLE
Event gateway TLS Config

### DIFF
--- a/common/apikey/store.go
+++ b/common/apikey/store.go
@@ -329,6 +329,49 @@ func (aks *APIkeyStore) ClearAll() error {
 	return nil
 }
 
+// ReplaceAll atomically replaces all API keys in the store with the provided snapshot.
+func (aks *APIkeyStore) ReplaceAll(newMap map[string]map[string]*APIKey) error {
+	replacement := make(map[string]map[string]*APIKey, len(newMap))
+	for apiId, apiKeys := range newMap {
+		if len(apiKeys) == 0 {
+			continue
+		}
+
+		clonedKeys := make(map[string]*APIKey, len(apiKeys))
+		for hash, apiKey := range apiKeys {
+			if apiKey == nil {
+				return fmt.Errorf("API key cannot be nil")
+			}
+
+			normalizedHash := strings.TrimSpace(hash)
+			clonedAPIKey := cloneAPIKey(apiKey)
+			clonedAPIKey.APIKey = strings.TrimSpace(clonedAPIKey.APIKey)
+			if clonedAPIKey.APIKey == "" {
+				return fmt.Errorf("%w: API key hash cannot be empty", ErrInvalidInput)
+			}
+			if normalizedHash == "" {
+				normalizedHash = clonedAPIKey.APIKey
+			}
+			if normalizedHash != clonedAPIKey.APIKey {
+				return fmt.Errorf("%w: API key map hash does not match API key hash", ErrInvalidInput)
+			}
+			if _, exists := clonedKeys[normalizedHash]; exists {
+				return ErrConflict
+			}
+
+			clonedKeys[normalizedHash] = clonedAPIKey
+		}
+
+		replacement[apiId] = clonedKeys
+	}
+
+	aks.mu.Lock()
+	defer aks.mu.Unlock()
+	aks.apiKeysByAPI = replacement
+
+	return nil
+}
+
 // ComputeAPIKeyHash computes a SHA-256 hash of the plain-text API key for storage and lookup
 // Returns the hash as hex-encoded string (64 characters)
 // Normalizes the key by trimming whitespace before hashing for consistency

--- a/event-gateway/README.md
+++ b/event-gateway/README.md
@@ -241,9 +241,9 @@ The event gateway is configured via [`gateway-runtime/configs/config.toml`](gate
 | Section | Key | Default | Description |
 |---------|-----|---------|-------------|
 | `server` | `websub_port` | `8080` | WebSub listener port |
-| `server` | `websub_tls_enabled` | `false` | Serve the WebSub listener with HTTPS |
-| `server` | `websub_tls_cert_file` | `""` | PEM certificate path for the WebSub HTTPS listener |
-| `server` | `websub_tls_key_file` | `""` | PEM private key path for the WebSub HTTPS listener |
+| `server` | `websub_tls_enabled` | `true` | Serve the WebSub listener with HTTPS |
+| `server` | `websub_tls_cert_file` | `/etc/event-gateway/tls/default-listener.crt` | PEM certificate path for the WebSub HTTPS listener |
+| `server` | `websub_tls_key_file` | `/etc/event-gateway/tls/default-listener.key` | PEM private key path for the WebSub HTTPS listener |
 | `server` | `websocket_port` | `8081` | WebSocket listener port |
 | `server` | `admin_port` | `9002` | Admin/health endpoint port |
 | `server` | `metrics_port` | `9003` | Metrics endpoint port |

--- a/event-gateway/gateway-runtime/go.mod
+++ b/event-gateway/gateway-runtime/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/twmb/franz-go/pkg/kadm v1.14.0
 	github.com/wso2/api-platform/common v0.0.0
 	github.com/wso2/api-platform/gateway/gateway-runtime/policy-engine v0.0.0
-	github.com/wso2/api-platform/sdk/core v0.2.9
+	github.com/wso2/api-platform/sdk/core v0.2.12
 	github.com/wso2/gateway-controllers/policies/api-key-auth v1.0.1
 	github.com/wso2/gateway-controllers/policies/basic-auth v1.0.1
 	github.com/wso2/gateway-controllers/policies/set-headers v1.0.1

--- a/event-gateway/gateway-runtime/internal/runtime/runtime.go
+++ b/event-gateway/gateway-runtime/internal/runtime/runtime.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os"
 	"path"
 	"strings"
 	"sync"
@@ -413,12 +414,37 @@ func (r *Runtime) newManagedServer(name string, port int, handler http.Handler, 
 	}
 
 	if allowTLS && r.cfg.Server.WebSubTLSEnabled {
+		certFile := strings.TrimSpace(r.cfg.Server.WebSubTLSCertFile)
+		keyFile := strings.TrimSpace(r.cfg.Server.WebSubTLSKeyFile)
+		if err := validateTLSFile("certificate", certFile); err != nil {
+			slog.Error("WebSub TLS is disabled because the TLS certificate file is invalid", "name", name, "error", err)
+			return server
+		}
+		if err := validateTLSFile("private key", keyFile); err != nil {
+			slog.Error("WebSub TLS is disabled because the TLS private key file is invalid", "name", name, "error", err)
+			return server
+		}
+
 		server.tls = true
-		server.certFile = r.cfg.Server.WebSubTLSCertFile
-		server.keyFile = r.cfg.Server.WebSubTLSKeyFile
+		server.certFile = certFile
+		server.keyFile = keyFile
 	}
 
 	return server
+}
+
+func validateTLSFile(label, filePath string) error {
+	if filePath == "" {
+		return fmt.Errorf("%s file path is empty", label)
+	}
+	info, err := os.Stat(filePath)
+	if err != nil {
+		return fmt.Errorf("%s file %q is not accessible: %w", label, filePath, err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("%s file %q is a directory", label, filePath)
+	}
+	return nil
 }
 
 func (r *Runtime) runServer(srv *managedServer) {

--- a/event-gateway/gateway-runtime/internal/runtime/runtime_test.go
+++ b/event-gateway/gateway-runtime/internal/runtime/runtime_test.go
@@ -21,11 +21,14 @@ package runtime
 import (
 	"context"
 	"errors"
+	"net/http"
+	"os"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/wso2/api-platform/event-gateway/gateway-runtime/internal/binding"
+	"github.com/wso2/api-platform/event-gateway/gateway-runtime/internal/config"
 	"github.com/wso2/api-platform/event-gateway/gateway-runtime/internal/connectors"
 	"github.com/wso2/api-platform/event-gateway/gateway-runtime/internal/hub"
 	enginepkg "github.com/wso2/api-platform/gateway/gateway-runtime/policy-engine/pkg/engine"
@@ -172,6 +175,82 @@ func TestStartReceiverWithRetry_StopsWhenContextIsCanceled(t *testing.T) {
 	}
 }
 
+func TestNewManagedServerEnablesTLSWhenFilesExist(t *testing.T) {
+	certFile := writeTestTLSFile(t, "tls.crt")
+	keyFile := writeTestTLSFile(t, "tls.key")
+
+	rt := &Runtime{
+		cfg: &config.Config{
+			Server: config.ServerConfig{
+				WebSubTLSEnabled:  true,
+				WebSubTLSCertFile: certFile,
+				WebSubTLSKeyFile:  keyFile,
+			},
+		},
+	}
+
+	server := rt.newManagedServer("WebSub", 8080, http.NewServeMux(), true)
+	if !server.tls {
+		t.Fatal("expected TLS to be enabled when certificate and key files exist")
+	}
+	if server.certFile != certFile {
+		t.Fatalf("expected cert file %q, got %q", certFile, server.certFile)
+	}
+	if server.keyFile != keyFile {
+		t.Fatalf("expected key file %q, got %q", keyFile, server.keyFile)
+	}
+}
+
+func TestNewManagedServerDoesNotEnableTLSForInvalidTLSFiles(t *testing.T) {
+	existingKey := writeTestTLSFile(t, "tls.key")
+
+	tests := []struct {
+		name     string
+		certFile string
+		keyFile  string
+	}{
+		{
+			name:     "empty certificate path",
+			certFile: "",
+			keyFile:  existingKey,
+		},
+		{
+			name:     "missing certificate file",
+			certFile: t.TempDir() + "/missing.crt",
+			keyFile:  existingKey,
+		},
+		{
+			name:     "empty key path",
+			certFile: writeTestTLSFile(t, "tls.crt"),
+			keyFile:  "",
+		},
+		{
+			name:     "missing key file",
+			certFile: writeTestTLSFile(t, "second-tls.crt"),
+			keyFile:  t.TempDir() + "/missing.key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rt := &Runtime{
+				cfg: &config.Config{
+					Server: config.ServerConfig{
+						WebSubTLSEnabled:  true,
+						WebSubTLSCertFile: tt.certFile,
+						WebSubTLSKeyFile:  tt.keyFile,
+					},
+				},
+			}
+
+			server := rt.newManagedServer("WebSub", 8080, http.NewServeMux(), true)
+			if server.tls {
+				t.Fatal("expected TLS to remain disabled when certificate or key validation fails")
+			}
+		})
+	}
+}
+
 type testNoopPolicy struct{}
 
 type flakyReceiver struct {
@@ -204,6 +283,16 @@ func (r *flakyReceiver) Attempts() int {
 
 func newTestNoopPolicy(policy.PolicyMetadata, map[string]interface{}) (policy.Policy, error) {
 	return testNoopPolicy{}, nil
+}
+
+func writeTestTLSFile(t *testing.T, name string) string {
+	t.Helper()
+
+	filePath := t.TempDir() + "/" + name
+	if err := os.WriteFile(filePath, []byte("test"), 0600); err != nil {
+		t.Fatalf("failed to write test TLS file: %v", err)
+	}
+	return filePath
 }
 
 func (testNoopPolicy) Mode() policy.ProcessingMode {

--- a/event-gateway/gateway-runtime/internal/xdsclient/api_key_handler.go
+++ b/event-gateway/gateway-runtime/internal/xdsclient/api_key_handler.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	discoveryv3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
@@ -58,10 +59,7 @@ func (h *APIKeyStateHandler) HandleResources(ctx context.Context, resources []*d
 		allKeys = append(allKeys, state.APIKeys...)
 	}
 
-	if err := h.store.ClearAll(); err != nil {
-		return fmt.Errorf("failed to clear API key store: %w", err)
-	}
-
+	newMap := make(map[string]map[string]*apikey.APIKey)
 	for _, key := range allKeys {
 		issuer := key.Issuer
 		ak := &apikey.APIKey{
@@ -81,9 +79,13 @@ func (h *APIKeyStateHandler) HandleResources(ctx context.Context, resources []*d
 			Issuer:          issuer,
 		}
 
-		if err := h.store.StoreAPIKey(key.APIId, ak); err != nil {
-			return fmt.Errorf("failed to store API key %q for API %q: %w", key.ID, key.APIId, err)
+		if err := addAPIKeyToSnapshot(newMap, key.APIId, ak); err != nil {
+			return fmt.Errorf("failed to build API key snapshot for API key %q and API %q: %w", key.ID, key.APIId, err)
 		}
+	}
+
+	if err := h.store.ReplaceAll(newMap); err != nil {
+		return fmt.Errorf("failed to replace API key store: %w", err)
 	}
 
 	slog.InfoContext(ctx, "Updated event-gateway API key state",
@@ -116,6 +118,41 @@ func decodeAPIKeyStateResource(resource *anypb.Any) (*APIKeyStateResource, error
 	}
 
 	return &state, nil
+}
+
+func addAPIKeyToSnapshot(snapshot map[string]map[string]*apikey.APIKey, apiId string, apiKey *apikey.APIKey) error {
+	if apiKey == nil {
+		return fmt.Errorf("API key cannot be nil")
+	}
+
+	apiKey.APIKey = strings.TrimSpace(apiKey.APIKey)
+	if apiKey.APIKey == "" {
+		return fmt.Errorf("%w: API key hash cannot be empty", apikey.ErrInvalidInput)
+	}
+
+	apiKeys, apiIdExists := snapshot[apiId]
+	var existingHash string
+	if apiIdExists {
+		for hash, existingKey := range apiKeys {
+			if existingKey.Name == apiKey.Name {
+				existingHash = hash
+				break
+			}
+		}
+	}
+	if existingHash != "" {
+		delete(apiKeys, existingHash)
+	}
+
+	if snapshot[apiId] == nil {
+		snapshot[apiId] = make(map[string]*apikey.APIKey)
+	}
+	if _, exists := snapshot[apiId][apiKey.APIKey]; exists {
+		return apikey.ErrConflict
+	}
+
+	snapshot[apiId][apiKey.APIKey] = apiKey
+	return nil
 }
 
 // APIKeyStateResource represents the complete API key snapshot distributed over xDS.

--- a/event-gateway/gateway-runtime/internal/xdsclient/api_key_handler_test.go
+++ b/event-gateway/gateway-runtime/internal/xdsclient/api_key_handler_test.go
@@ -21,6 +21,7 @@ package xdsclient
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -103,6 +104,60 @@ func TestAPIKeyStateHandlerHandleResources_EmptySnapshotClearsStore(t *testing.T
 	resolved, err := store.ResolveValidatedAPIKey("api-1", "/repos/v1/hub", "POST", "plain-test-key", "")
 	if err == nil || resolved != nil {
 		t.Fatalf("expected API key store to be cleared, got resolved=%v err=%v", resolved, err)
+	}
+}
+
+func TestAPIKeyStateHandlerHandleResources_KeepsExistingStoreOnInvalidSnapshot(t *testing.T) {
+	store := apikey.NewAPIkeyStore()
+	if err := store.StoreAPIKey("api-1", &apikey.APIKey{
+		ID:         "existing-key",
+		Name:       "existing-key",
+		APIKey:     apikey.ComputeAPIKeyHash("plain-test-key"),
+		APIId:      "api-1",
+		Operations: "*",
+		Status:     apikey.Active,
+		CreatedAt:  time.Now(),
+		CreatedBy:  "tester",
+		UpdatedAt:  time.Now(),
+		Source:     "external",
+	}); err != nil {
+		t.Fatalf("failed to seed API key store: %v", err)
+	}
+
+	handler := NewAPIKeyStateHandler(store)
+	resources := []*discoveryv3.Resource{
+		{
+			Resource: mustBuildAPIKeyStateAny(t, APIKeyStateResource{
+				Version: 2,
+				APIKeys: []APIKeyData{
+					{
+						ID:         "invalid-key",
+						Name:       "invalid-key",
+						APIKey:     "",
+						APIId:      "api-1",
+						Operations: "*",
+						Status:     "active",
+						CreatedAt:  time.Now(),
+						CreatedBy:  "tester",
+						UpdatedAt:  time.Now(),
+						Source:     "external",
+					},
+				},
+			}),
+		},
+	}
+
+	err := handler.HandleResources(context.Background(), resources, "44")
+	if !errors.Is(err, apikey.ErrInvalidInput) {
+		t.Fatalf("expected ErrInvalidInput, got %v", err)
+	}
+
+	resolved, err := store.ResolveValidatedAPIKey("api-1", "/repos/v1/hub", "POST", "plain-test-key", "")
+	if err != nil {
+		t.Fatalf("expected existing key to remain after failed update, got error: %v", err)
+	}
+	if resolved == nil || resolved.ID != "existing-key" {
+		t.Fatalf("expected existing key to remain, got %#v", resolved)
 	}
 }
 


### PR DESCRIPTION
## Purpose
Fix event gateway runtime reliability gaps around WebSub TLS startup and API key state updates. Resolves N/A.

## Goals
- Prevent invalid WebSub TLS config from failing only at listener startup.
- Avoid API key authentication gaps during xDS API key snapshot updates.
- Align README defaults and SDK dependency version.

## Approach
- Validate WebSub TLS cert/key files before enabling HTTPS.
- Add atomic `APIkeyStore.ReplaceAll()` and update xDS API key handling to build/validate snapshots before replacing active state.
- Add focused unit tests for TLS validation and API key snapshot failure behavior.
- Update `websub_tls_enabled` defaults in docs and bump `sdk/core` to `0.2.12`.

## User stories
Event gateway operators get safer TLS startup behavior and stable API key auth during xDS updates.

## Documentation
Updated `event-gateway/README.md` for WebSub TLS defaults.

## Automation tests
- Unit tests: Added/updated tests for TLS file validation and API key snapshot replacement.
- Integration tests: N/A.

## Security checks
- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin and verified report: no, Go-only change
- Confirmed no keys/passwords/tokens/secrets are committed: yes

## Samples
N/A.

## Related PRs
N/A.

## Test environment
Go 1.26.1 on Linux amd64. Verified with:
`go test ./internal/runtime ./internal/xdsclient`
