### PR TITLE
Implement atomic api key replacement (xDS Update)

### DIFF
--- a/common/apikey/store.go
+++ b/common/apikey/store.go
@@ -329,6 +329,49 @@ func (aks *APIkeyStore) ClearAll() error {
 	return nil
 }
 
+// ReplaceAll atomically replaces all API keys in the store with the provided snapshot.
+func (aks *APIkeyStore) ReplaceAll(newMap map[string]map[string]*APIKey) error {
+	replacement := make(map[string]map[string]*APIKey, len(newMap))
+	for apiId, apiKeys := range newMap {
+		if len(apiKeys) == 0 {
+			continue
+		}
+
+		clonedKeys := make(map[string]*APIKey, len(apiKeys))
+		for hash, apiKey := range apiKeys {
+			if apiKey == nil {
+				return fmt.Errorf("API key cannot be nil")
+			}
+
+			normalizedHash := strings.TrimSpace(hash)
+			clonedAPIKey := cloneAPIKey(apiKey)
+			clonedAPIKey.APIKey = strings.TrimSpace(clonedAPIKey.APIKey)
+			if clonedAPIKey.APIKey == "" {
+				return fmt.Errorf("%w: API key hash cannot be empty", ErrInvalidInput)
+			}
+			if normalizedHash == "" {
+				normalizedHash = clonedAPIKey.APIKey
+			}
+			if normalizedHash != clonedAPIKey.APIKey {
+				return fmt.Errorf("%w: API key map hash does not match API key hash", ErrInvalidInput)
+			}
+			if _, exists := clonedKeys[normalizedHash]; exists {
+				return ErrConflict
+			}
+
+			clonedKeys[normalizedHash] = clonedAPIKey
+		}
+
+		replacement[apiId] = clonedKeys
+	}
+
+	aks.mu.Lock()
+	defer aks.mu.Unlock()
+	aks.apiKeysByAPI = replacement
+
+	return nil
+}
+
 // ComputeAPIKeyHash computes a SHA-256 hash of the plain-text API key for storage and lookup
 // Returns the hash as hex-encoded string (64 characters)
 // Normalizes the key by trimming whitespace before hashing for consistency

--- a/event-gateway/gateway-runtime/internal/xdsclient/api_key_handler.go
+++ b/event-gateway/gateway-runtime/internal/xdsclient/api_key_handler.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	discoveryv3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
@@ -58,10 +59,7 @@ func (h *APIKeyStateHandler) HandleResources(ctx context.Context, resources []*d
 		allKeys = append(allKeys, state.APIKeys...)
 	}
 
-	if err := h.store.ClearAll(); err != nil {
-		return fmt.Errorf("failed to clear API key store: %w", err)
-	}
-
+	newMap := make(map[string]map[string]*apikey.APIKey)
 	for _, key := range allKeys {
 		issuer := key.Issuer
 		ak := &apikey.APIKey{
@@ -81,9 +79,13 @@ func (h *APIKeyStateHandler) HandleResources(ctx context.Context, resources []*d
 			Issuer:          issuer,
 		}
 
-		if err := h.store.StoreAPIKey(key.APIId, ak); err != nil {
-			return fmt.Errorf("failed to store API key %q for API %q: %w", key.ID, key.APIId, err)
+		if err := addAPIKeyToSnapshot(newMap, key.APIId, ak); err != nil {
+			return fmt.Errorf("failed to build API key snapshot for API key %q and API %q: %w", key.ID, key.APIId, err)
 		}
+	}
+
+	if err := h.store.ReplaceAll(newMap); err != nil {
+		return fmt.Errorf("failed to replace API key store: %w", err)
 	}
 
 	slog.InfoContext(ctx, "Updated event-gateway API key state",
@@ -116,6 +118,41 @@ func decodeAPIKeyStateResource(resource *anypb.Any) (*APIKeyStateResource, error
 	}
 
 	return &state, nil
+}
+
+func addAPIKeyToSnapshot(snapshot map[string]map[string]*apikey.APIKey, apiId string, apiKey *apikey.APIKey) error {
+	if apiKey == nil {
+		return fmt.Errorf("API key cannot be nil")
+	}
+
+	apiKey.APIKey = strings.TrimSpace(apiKey.APIKey)
+	if apiKey.APIKey == "" {
+		return fmt.Errorf("%w: API key hash cannot be empty", apikey.ErrInvalidInput)
+	}
+
+	apiKeys, apiIdExists := snapshot[apiId]
+	var existingHash string
+	if apiIdExists {
+		for hash, existingKey := range apiKeys {
+			if existingKey.Name == apiKey.Name {
+				existingHash = hash
+				break
+			}
+		}
+	}
+	if existingHash != "" {
+		delete(apiKeys, existingHash)
+	}
+
+	if snapshot[apiId] == nil {
+		snapshot[apiId] = make(map[string]*apikey.APIKey)
+	}
+	if _, exists := snapshot[apiId][apiKey.APIKey]; exists {
+		return apikey.ErrConflict
+	}
+
+	snapshot[apiId][apiKey.APIKey] = apiKey
+	return nil
 }
 
 // APIKeyStateResource represents the complete API key snapshot distributed over xDS.

--- a/event-gateway/gateway-runtime/internal/xdsclient/api_key_handler_test.go
+++ b/event-gateway/gateway-runtime/internal/xdsclient/api_key_handler_test.go
@@ -21,6 +21,7 @@ package xdsclient
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -103,6 +104,60 @@ func TestAPIKeyStateHandlerHandleResources_EmptySnapshotClearsStore(t *testing.T
 	resolved, err := store.ResolveValidatedAPIKey("api-1", "/repos/v1/hub", "POST", "plain-test-key", "")
 	if err == nil || resolved != nil {
 		t.Fatalf("expected API key store to be cleared, got resolved=%v err=%v", resolved, err)
+	}
+}
+
+func TestAPIKeyStateHandlerHandleResources_KeepsExistingStoreOnInvalidSnapshot(t *testing.T) {
+	store := apikey.NewAPIkeyStore()
+	if err := store.StoreAPIKey("api-1", &apikey.APIKey{
+		ID:         "existing-key",
+		Name:       "existing-key",
+		APIKey:     apikey.ComputeAPIKeyHash("plain-test-key"),
+		APIId:      "api-1",
+		Operations: "*",
+		Status:     apikey.Active,
+		CreatedAt:  time.Now(),
+		CreatedBy:  "tester",
+		UpdatedAt:  time.Now(),
+		Source:     "external",
+	}); err != nil {
+		t.Fatalf("failed to seed API key store: %v", err)
+	}
+
+	handler := NewAPIKeyStateHandler(store)
+	resources := []*discoveryv3.Resource{
+		{
+			Resource: mustBuildAPIKeyStateAny(t, APIKeyStateResource{
+				Version: 2,
+				APIKeys: []APIKeyData{
+					{
+						ID:         "invalid-key",
+						Name:       "invalid-key",
+						APIKey:     "",
+						APIId:      "api-1",
+						Operations: "*",
+						Status:     "active",
+						CreatedAt:  time.Now(),
+						CreatedBy:  "tester",
+						UpdatedAt:  time.Now(),
+						Source:     "external",
+					},
+				},
+			}),
+		},
+	}
+
+	err := handler.HandleResources(context.Background(), resources, "44")
+	if !errors.Is(err, apikey.ErrInvalidInput) {
+		t.Fatalf("expected ErrInvalidInput, got %v", err)
+	}
+
+	resolved, err := store.ResolveValidatedAPIKey("api-1", "/repos/v1/hub", "POST", "plain-test-key", "")
+	if err != nil {
+		t.Fatalf("expected existing key to remain after failed update, got error: %v", err)
+	}
+	if resolved == nil || resolved.ID != "existing-key" {
+		t.Fatalf("expected existing key to remain, got %#v", resolved)
 	}
 }
 


### PR DESCRIPTION
## Purpose
Fix event gateway runtime xDS Updates around API key state atomic updates. Resolves N/A.

## Goals
Avoid API key authentication gaps during xDS API key snapshot updates.

## Approach
Add atomic APIkeyStore.ReplaceAll() and update xDS API key handling to build/validate snapshots before replacing active state.

## User stories
Event gateway operators get stable API key auth during xDS updates.

## Documentation


## Automation tests
Unit tests: Updated tests for API key snapshot replacement.
Integration tests: N/A.

## Security checks
Followed secure coding standards: yes
Ran FindSecurityBugs plugin and verified report: no, Go-only change
Confirmed no keys/passwords/tokens/secrets are committed: yes

## Samples
> N/A

## Related PRs
> N/A

## Test environment
Go 1.26.1 on Linux amd64. Verified with:
go test ./internal/runtime ./internal/xdsclient
