### PR TITLE
[Immutable GW] Bottom Up Sync Rest API Artifacts

### DIFF
--- a/gateway/gateway-controller/cmd/controller/main.go
+++ b/gateway/gateway-controller/cmd/controller/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/policyxds"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/storage"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/immutable"
+	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/service/restapi"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/transform"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/utils"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/xds"
@@ -467,14 +468,10 @@ func main() {
 	policyValidator := config.NewPolicyValidator(policyDefinitions)
 	validator.SetPolicyValidator(policyValidator)
 
-	// Construct shared deployment services for ImmutableGW and APIServer.
-	// Services are stateless method dispatchers over shared resources, so two
-	// instances pointing at the same store/db/snapshotManager are safe.
 	apiSvc := utils.NewAPIDeploymentService(configStore, db, snapshotManager, validator, &cfg.Router, eventHubInstance, gatewayID, secretsService)
 	mcpSvc := utils.NewMCPDeploymentService(configStore, db, snapshotManager, policyManager, policyValidator, eventHubInstance, gatewayID)
 	llmSvc := utils.NewLLMDeploymentService(configStore, db, snapshotManager, lazyResourceXDSManager, templateDefinitions,
 		apiSvc, &cfg.Router, policyVersionResolver, policyValidator)
-	igw := immutable.NewImmutableGW(cfg.ImmutableGateway, apiSvc, llmSvc, mcpSvc)
 
 	// Initialize and start control plane client with dependencies for API creation and API key management
 	cpClient := controlplane.NewClient(
@@ -497,6 +494,15 @@ func main() {
 		log.Error("Failed to start control plane client", slog.Any("error", err))
 		// Don't fail startup - gateway can run in degraded mode without control plane
 	}
+
+	restAPIService := restapi.NewRestAPIService(
+		configStore, db, snapshotManager, policyManager,
+		apiSvc, apiKeyXDSManager,
+		cpClient, &cfg.Router, cfg,
+		&http.Client{Timeout: 10 * time.Second}, config.NewParser(), validator, log,
+		eventHubInstance, secretsService,
+	)
+	igw := immutable.NewImmutableGW(cfg.ImmutableGateway, restAPIService, llmSvc, mcpSvc)
 
 	// Initialize Gin router
 	if os.Getenv("GIN_MODE") == "" {
@@ -564,6 +570,7 @@ func main() {
 		eventHubInstance,
 		subscriptionSnapshotManager,
 		secretsService,
+		restAPIService,
 	)
 
 	// Load immutable gateway artifacts from the filesystem (no-op when immutable mode is disabled).

--- a/gateway/gateway-controller/pkg/api/handlers/handlers.go
+++ b/gateway/gateway-controller/pkg/api/handlers/handlers.go
@@ -55,6 +55,7 @@ import (
 type APIServer struct {
 	*RestAPIHandler // embedded — promotes CreateRestAPI, ListRestAPIs, GetRestAPIById, UpdateRestAPI, DeleteRestAPI
 
+	restAPIService              *restapi.RestAPIService
 	store                       *storage.ConfigStore
 	db                          storage.Storage
 	snapshotManager             *xds.SnapshotManager
@@ -97,6 +98,7 @@ func NewAPIServer(
 	eventHub eventhub.EventHub,
 	subscriptionSnapshotUpdater utils.SubscriptionSnapshotUpdater,
 	secretService *secrets.SecretService,
+	restAPIService *restapi.RestAPIService,
 ) *APIServer {
 	if db == nil {
 		panic("APIServer requires non-nil storage")
@@ -148,15 +150,7 @@ func NewAPIServer(
 		subscriptionSnapshotUpdater: subscriptionSnapshotUpdater,
 		subscriptionResourceService: subscriptionResourceService,
 	}
-	// Create RestAPI service and handler
-	restAPIService := restapi.NewRestAPIService(
-		store, db, snapshotManager, policyManager,
-		policyDefinitions, &server.policyDefMu,
-		deploymentService, apiKeyXDSManager,
-		controlPlaneClient, routerConfig, systemConfig,
-		httpClient, parser, validator, logger,
-		eventHub, secretService,
-	)
+	server.restAPIService = restAPIService
 	server.RestAPIHandler = NewRestAPIHandler(restAPIService, logger)
 
 	// Register status update callback

--- a/gateway/gateway-controller/pkg/api/handlers/handlers_test.go
+++ b/gateway/gateway-controller/pkg/api/handlers/handlers_test.go
@@ -956,11 +956,11 @@ func createTestAPIServerWithDB(db storage.Storage) *APIServer {
 	// Initialize RestAPI service and handler
 	restAPIService := restapi.NewRestAPIService(
 		store, db, nil, nil,
-		policyDefs, &server.policyDefMu,
 		deploymentService, nil, nil,
 		routerCfg, systemCfg,
 		httpClient, parser, validator, logger, hub, nil,
 	)
+	server.restAPIService = restAPIService
 	server.RestAPIHandler = NewRestAPIHandler(restAPIService, logger)
 
 	return server
@@ -1173,11 +1173,11 @@ func attachTestEventHub(server *APIServer, hub eventhub.EventHub, gatewayID stri
 	if server.RestAPIHandler != nil {
 		restAPIService := restapi.NewRestAPIService(
 			server.store, server.db, nil, nil,
-			server.policyDefinitions, &server.policyDefMu,
 			server.deploymentService, server.apiKeyXDSManager, nil,
 			server.routerConfig, server.systemConfig,
 			server.httpClient, server.parser, server.validator, server.logger, hub, nil,
 		)
+		server.restAPIService = restAPIService
 		server.RestAPIHandler = NewRestAPIHandler(restAPIService, server.logger)
 	}
 }

--- a/gateway/gateway-controller/pkg/immutable/loader.go
+++ b/gateway/gateway-controller/pkg/immutable/loader.go
@@ -32,6 +32,7 @@ import (
 	api "github.com/wso2/api-platform/gateway/gateway-controller/pkg/api/management"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/config"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/models"
+	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/service/restapi"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/utils"
 )
 
@@ -39,26 +40,26 @@ import (
 // read-only enforcement on the management API at runtime.
 // When cfg.Enabled is false, all methods are no-ops.
 type ImmutableGW struct {
-	cfg               config.ImmutableGatewayConfig
-	deploymentService *utils.APIDeploymentService
-	llmService        *utils.LLMDeploymentService
-	mcpService        *utils.MCPDeploymentService
-	parser            *config.Parser
+	cfg            config.ImmutableGatewayConfig
+	restAPIService *restapi.RestAPIService
+	llmService     *utils.LLMDeploymentService
+	mcpService     *utils.MCPDeploymentService
+	parser         *config.Parser
 }
 
 // NewImmutableGW creates an ImmutableGW. All methods are no-ops when cfg.Enabled is false.
 func NewImmutableGW(
 	cfg config.ImmutableGatewayConfig,
-	deploymentService *utils.APIDeploymentService,
+	restAPIService *restapi.RestAPIService,
 	llmService *utils.LLMDeploymentService,
 	mcpService *utils.MCPDeploymentService,
 ) *ImmutableGW {
 	return &ImmutableGW{
-		cfg:               cfg,
-		deploymentService: deploymentService,
-		llmService:        llmService,
-		mcpService:        mcpService,
-		parser:            config.NewParser(),
+		cfg:            cfg,
+		restAPIService: restAPIService,
+		llmService:     llmService,
+		mcpService:     mcpService,
+		parser:         config.NewParser(),
 	}
 }
 
@@ -166,10 +167,10 @@ func (g *ImmutableGW) applyArtifact(path, kind, contentType string, data []byte,
 			return fmt.Errorf("failed to apply %s %s: %w", kind, path, err)
 		}
 	case models.KindRestApi, models.KindWebSubApi:
-		if _, err := g.deploymentService.DeployAPIConfiguration(utils.APIDeploymentParams{
-			Data:        data,
+		if _, err := g.restAPIService.Create(restapi.CreateParams{
+			Body:        data,
 			ContentType: contentType,
-			Origin:      models.OriginGatewayAPI,
+			Kind:        kind,
 			Logger:      log,
 		}); err != nil {
 			return fmt.Errorf("failed to apply %s %s: %w", kind, path, err)

--- a/gateway/gateway-controller/pkg/immutable/loader.go
+++ b/gateway/gateway-controller/pkg/immutable/loader.go
@@ -54,6 +54,9 @@ func NewImmutableGW(
 	llmService *utils.LLMDeploymentService,
 	mcpService *utils.MCPDeploymentService,
 ) *ImmutableGW {
+	if cfg.Enabled && restAPIService == nil {
+		panic("ImmutableGW requires non-nil RestAPIService when immutable mode is enabled")
+	}
 	return &ImmutableGW{
 		cfg:            cfg,
 		restAPIService: restAPIService,

--- a/gateway/gateway-controller/pkg/service/restapi/service.go
+++ b/gateway/gateway-controller/pkg/service/restapi/service.go
@@ -74,8 +74,6 @@ type RestAPIService struct {
 	db                 storage.Storage
 	snapshotManager    *xds.SnapshotManager
 	policyManager      *policyxds.PolicyManager
-	policyDefinitions  map[string]models.PolicyDefinition
-	policyDefMu        *sync.RWMutex
 	deploymentService  *utils.APIDeploymentService
 	apiKeyXDSManager   *apikeyxds.APIKeyStateManager
 	controlPlaneClient controlplane.ControlPlaneClient
@@ -95,8 +93,6 @@ func NewRestAPIService(
 	db storage.Storage,
 	snapshotManager *xds.SnapshotManager,
 	policyManager *policyxds.PolicyManager,
-	policyDefinitions map[string]models.PolicyDefinition,
-	policyDefMu *sync.RWMutex,
 	deploymentService *utils.APIDeploymentService,
 	apiKeyXDSManager *apikeyxds.APIKeyStateManager,
 	controlPlaneClient controlplane.ControlPlaneClient,
@@ -130,8 +126,6 @@ func NewRestAPIService(
 		db:                 db,
 		snapshotManager:    snapshotManager,
 		policyManager:      policyManager,
-		policyDefinitions:  policyDefinitions,
-		policyDefMu:        policyDefMu,
 		deploymentService:  deploymentService,
 		apiKeyXDSManager:   apiKeyXDSManager,
 		controlPlaneClient: controlPlaneClient,
@@ -151,6 +145,7 @@ type CreateParams struct {
 	Body          []byte
 	ContentType   string
 	CorrelationID string
+	Kind          string
 	Logger        *slog.Logger
 }
 
@@ -158,10 +153,15 @@ type CreateParams struct {
 func (s *RestAPIService) Create(params CreateParams) (*CreateResult, error) {
 	log := params.Logger
 
+	kind := params.Kind
+	if kind == "" {
+		kind = "RestApi"
+	}
+
 	result, err := s.deploymentService.DeployAPIConfiguration(utils.APIDeploymentParams{
 		Data:          params.Body,
 		ContentType:   params.ContentType,
-		Kind:          "RestApi",
+		Kind:          kind,
 		APIID:         "",
 		Origin:        models.OriginGatewayAPI,
 		CorrelationID: params.CorrelationID,


### PR DESCRIPTION
## Purpose
use RestAPIService.Create for RestApi/Web…SubApi artifacts

Previously, ImmutableGW.applyArtifact called
APIDeploymentService.DeployAPIConfiguration directly, bypassing RestAPIService.Create and its two side effects: bottom-up sync to on-prem APIM (SyncBottomUpAPIs) and async control-plane push (waitForDeploymentAndPush). Artifacts loaded on startup now follow the same code path as the REST handler.

- Remove unused policyDefinitions and policyDefMu from RestAPIService
- Add Kind field to CreateParams (defaults to "RestApi" when empty)
- Pass RestAPIService into NewAPIServer and NewImmutableGW from main, constructed after cpClient so the CP client is available
- ImmutableGW.applyArtifact calls restAPIService.Create for RestApi/WebSubApi, passing Kind through for correct routing
