### PR TITLE
Support Python src-layout package policies

### DIFF
--- a/gateway/gateway-builder/internal/buildfile/generator.go
+++ b/gateway/gateway-builder/internal/buildfile/generator.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/wso2/api-platform/gateway/gateway-builder/internal/discovery"
 	"github.com/wso2/api-platform/gateway/gateway-builder/pkg/types"
 	"golang.org/x/mod/modfile"
 	"gopkg.in/yaml.v3"
@@ -206,7 +207,7 @@ func WriteBuildManifestWithVersions(buildFilePath string, discovered []*types.Di
 
 		entry.Version = found.Version
 		if found.IsPipPackage && found.PipSpec != "" {
-			entry.PipPackage = found.PipSpec
+			entry.PipPackage = discovery.SanitizePipSpec(found.PipSpec)
 		}
 		lock.Policies = append(lock.Policies, entry)
 	}

--- a/gateway/gateway-builder/internal/buildfile/generator_test.go
+++ b/gateway/gateway-builder/internal/buildfile/generator_test.go
@@ -583,6 +583,79 @@ policies:
 	assert.NotContains(t, lockContent, "version: v9.9.9")
 }
 
+func TestWriteBuildManifestWithVersions_PipPackageRedactsIndexCredentials(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	buildFileContent := `version: "1.0"
+policies:
+  - name: prompt-compressor
+    pipPackage: "prompt-compressor~=1.0"
+`
+	buildFilePath := filepath.Join(tmpDir, "build.yaml")
+	testutils.WriteFile(t, buildFilePath, buildFileContent)
+
+	discovered := []*types.DiscoveredPolicy{
+		{
+			Name:         "prompt-compressor",
+			Version:      "v1.2.3",
+			Runtime:      "python",
+			IsPipPackage: true,
+			PipSpec:      "prompt-compressor==1.2.3@https://deploy-token:secret123@private.pypi.org/simple/",
+		},
+	}
+
+	err := WriteBuildManifestWithVersions(buildFilePath, discovered)
+	require.NoError(t, err)
+
+	lockPath := filepath.Join(tmpDir, "build-manifest.yaml")
+	content, err := os.ReadFile(lockPath)
+	require.NoError(t, err)
+
+	lockContent := string(content)
+	assert.Contains(t, lockContent, "version: v1.2.3")
+	// Credentials must be redacted in the manifest
+	assert.NotContains(t, lockContent, "secret123")
+	assert.NotContains(t, lockContent, "deploy-token")
+	assert.Contains(t, lockContent, "<redacted-credentials>@private.pypi.org/simple/")
+}
+
+func TestWriteBuildManifestWithVersions_PipPackageRedactsVCSCredentials(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	buildFileContent := `version: "1.0"
+policies:
+  - name: prompt-compressor
+    pipPackage: "github.com/wso2/gateway-controllers/policies/prompt-compressor@v1"
+`
+	buildFilePath := filepath.Join(tmpDir, "build.yaml")
+	testutils.WriteFile(t, buildFilePath, buildFileContent)
+
+	discovered := []*types.DiscoveredPolicy{
+		{
+			Name:            "prompt-compressor",
+			Version:         "v1.0.0",
+			Runtime:         "python",
+			IsPipPackage:    true,
+			OriginalPipSpec: "github.com/wso2/gateway-controllers/policies/prompt-compressor@v1",
+			PipSpec:         "git+https://ghp_secrettoken@github.com/wso2/gateway-controllers.git@policies/prompt-compressor/v1.0.0#subdirectory=policies/prompt-compressor",
+		},
+	}
+
+	err := WriteBuildManifestWithVersions(buildFilePath, discovered)
+	require.NoError(t, err)
+
+	lockPath := filepath.Join(tmpDir, "build-manifest.yaml")
+	content, err := os.ReadFile(lockPath)
+	require.NoError(t, err)
+
+	lockContent := string(content)
+	assert.Contains(t, lockContent, "version: v1.0.0")
+	// VCS credentials must be redacted in the manifest
+	assert.NotContains(t, lockContent, "ghp_secrettoken")
+	assert.Contains(t, lockContent, "<redacted-credentials>@github.com/wso2/gateway-controllers.git")
+	assert.Contains(t, lockContent, "#subdirectory=policies/prompt-compressor")
+}
+
 func TestWriteBuildManifestWithVersions_InvalidBuildFileYAML(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/gateway/gateway-builder/internal/discovery/discovery_test.go
+++ b/gateway/gateway-builder/internal/discovery/discovery_test.go
@@ -867,6 +867,82 @@ func TestDetectRuntime_EmptyDirectory(t *testing.T) {
 	assert.Equal(t, "go", runtime)
 }
 
+func TestDetectRuntime_PythonSrcLayout(t *testing.T) {
+	tmpDir := t.TempDir()
+	// src layout: pyproject.toml at root, .py files under src/<pkg>/
+	testutils.WriteFile(t, filepath.Join(tmpDir, "pyproject.toml"), "[build-system]\nrequires = [\"hatchling\"]\n")
+	pkgDir := filepath.Join(tmpDir, "src", "my_policy")
+	testutils.CreateDir(t, pkgDir)
+	testutils.WriteFile(t, filepath.Join(pkgDir, "__init__.py"), "")
+	testutils.WriteFile(t, filepath.Join(pkgDir, "policy.py"), "class MyPolicy:\n    pass\n")
+
+	runtime, err := DetectRuntime(tmpDir)
+
+	require.NoError(t, err)
+	assert.Equal(t, "python", runtime)
+}
+
+func TestDiscoverPoliciesFromBuildFile_PythonPackagePolicy(t *testing.T) {
+	pipExe, _ := resolvePipExecutable()
+	if pipExe == "" {
+		t.Skip("pip not available")
+	}
+
+	tmpDir := t.TempDir()
+
+	// Create a src-layout Python package policy with pyproject.toml
+	policyDir := filepath.Join(tmpDir, "policies", "my-pkg-policy")
+	pkgDir := filepath.Join(policyDir, "src", "my_pkg_policy")
+	testutils.CreateDir(t, pkgDir)
+
+	testutils.WriteFile(t, filepath.Join(policyDir, "policy-definition.yaml"), "name: my-pkg-policy\nversion: v1.0.0\n")
+	testutils.WriteFile(t, filepath.Join(policyDir, "requirements.txt"), "")
+	testutils.WriteFile(t, filepath.Join(policyDir, "pyproject.toml"), `[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "my-pkg-policy"
+version = "1.0.0"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/my_pkg_policy"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"policy-definition.yaml" = "my_pkg_policy/policy-definition.yaml"
+`)
+	testutils.WriteFile(t, filepath.Join(pkgDir, "__init__.py"), "__version__ = \"1.0.0\"\n")
+	testutils.WriteFile(t, filepath.Join(pkgDir, "policy.py"), "def get_policy(metadata, params):\n    return None\n")
+
+	manifestContent := `version: v1
+policies:
+  - name: my-pkg-policy
+    filePath: ./policies/my-pkg-policy
+`
+	manifestPath := filepath.Join(tmpDir, "build-manifest.yaml")
+	testutils.WriteFile(t, manifestPath, manifestContent)
+
+	policies, err := DiscoverPoliciesFromBuildFile(manifestPath, "")
+
+	require.NoError(t, err)
+	require.Len(t, policies, 1)
+	assert.Equal(t, "my-pkg-policy", policies[0].Name)
+	assert.Equal(t, "python", policies[0].Runtime)
+	// PythonSourceDir should be the extracted wheel module dir, NOT the policy root
+	assert.NotEqual(t, policies[0].Path, policies[0].PythonSourceDir)
+	// Path should point to original project root (for requirements.txt)
+	assert.Equal(t, policyDir, policies[0].Path)
+	// Source files should be from the extracted module dir
+	assert.GreaterOrEqual(t, len(policies[0].SourceFiles), 1)
+	// TopLevelModule should be set
+	assert.Equal(t, "my_pkg_policy", policies[0].PythonTopLevelModule)
+
+	// Cleanup extracted dir
+	if policies[0].PythonSourceDir != "" {
+		os.RemoveAll(filepath.Dir(policies[0].PythonSourceDir))
+	}
+}
+
 func TestDetectRuntime_NonexistentDirectory(t *testing.T) {
 	runtime, err := DetectRuntime("/nonexistent/path")
 

--- a/gateway/gateway-builder/internal/discovery/manifest.go
+++ b/gateway/gateway-builder/internal/discovery/manifest.go
@@ -242,12 +242,15 @@ func DiscoverPoliciesFromBuildFile(buildFilePath string, baseDir string) ([]*typ
 
 // DetectRuntime auto-detects the policy runtime by examining the directory contents.
 // Presence of go.mod → "go"; presence of .py files (and no go.mod) → "python".
+// Also recognises the industry-standard src layout where pyproject.toml exists at
+// the root but .py files live under src/<package>/.
 func DetectRuntime(policyDir string) (string, error) {
 	goMod := filepath.Join(policyDir, "go.mod")
 	if _, err := os.Stat(goMod); err == nil {
 		return "go", nil
 	}
 
+	// Check for .py files directly in the policy root (flat layout)
 	entries, err := os.ReadDir(policyDir)
 	if err != nil {
 		return "", fmt.Errorf("failed to read policy directory %s: %w", policyDir, err)
@@ -256,6 +259,12 @@ func DetectRuntime(policyDir string) (string, error) {
 		if !e.IsDir() && filepath.Ext(e.Name()) == ".py" {
 			return "python", nil
 		}
+	}
+
+	// Check for pyproject.toml (src layout — .py files live under src/<pkg>/)
+	pyProject := filepath.Join(policyDir, "pyproject.toml")
+	if _, err := os.Stat(pyProject); err == nil {
+		return "python", nil
 	}
 
 	return "go", nil
@@ -281,7 +290,7 @@ func discoverPipPolicy(entry types.BuildEntry) (*types.DiscoveredPolicy, error) 
 		"resolvedPath", pkgInfo.Dir)
 
 	// Validate extracted source and parse definition
-	discovered, err := buildPythonDiscoveredPolicy(entry, pkgInfo.Dir, "pipPackage")
+	discovered, err := buildSimplePythonDiscoveredPolicy(entry, pkgInfo.Dir)
 	if err != nil {
 		return nil, err
 	}
@@ -296,7 +305,13 @@ func discoverPipPolicy(entry types.BuildEntry) (*types.DiscoveredPolicy, error) 
 	return discovered, nil
 }
 
-// discoverLocalPythonPolicy discovers a Python policy from a local filePath entry
+// discoverLocalPythonPolicy discovers a Python policy from a local filePath entry.
+// Python policies come in two forms:
+//   - Simple: policy.py + requirements.txt + policy-definition.yaml (no pyproject.toml)
+//   - Package: a proper Python package with pyproject.toml (any layout: flat, src, etc.)
+//
+// For packages, we build a wheel locally using pip and extract it — the same approach
+// used for remote pip packages. This is fully generic and works regardless of source layout.
 func discoverLocalPythonPolicy(entry types.BuildEntry, baseDir string) (*types.DiscoveredPolicy, error) {
 	policyPath := filepath.Join(baseDir, entry.FilePath)
 
@@ -305,11 +320,83 @@ func discoverLocalPythonPolicy(entry types.BuildEntry, baseDir string) (*types.D
 		"filePath", entry.FilePath,
 		"resolvedPath", policyPath)
 
-	return buildPythonDiscoveredPolicy(entry, policyPath, "filePath")
+	pyProject := filepath.Join(policyPath, "pyproject.toml")
+	if _, err := os.Stat(pyProject); err == nil {
+		return discoverLocalPythonPackagePolicy(entry, policyPath)
+	}
+
+	// Simple Python policy — flat directory with policy.py, requirements.txt, etc.
+	return buildSimplePythonDiscoveredPolicy(entry, policyPath)
 }
 
-// buildPythonDiscoveredPolicy is the shared logic for building a discovered Python policy
-func buildPythonDiscoveredPolicy(entry types.BuildEntry, policyPath string, source string) (*types.DiscoveredPolicy, error) {
+// discoverLocalPythonPackagePolicy discovers a Python policy that is a proper Python
+// package (has pyproject.toml). It builds a wheel from the local source — regardless
+// of source layout — extracts the module, and validates it.
+func discoverLocalPythonPackagePolicy(entry types.BuildEntry, policyPath string) (*types.DiscoveredPolicy, error) {
+	slog.Info("Building wheel for local Python package policy",
+		"name", entry.Name,
+		"path", policyPath,
+		"phase", "discovery")
+
+	wheelDir, err := os.MkdirTemp("", "pip-local-wheel-*")
+	if err != nil {
+		return nil, errors.NewDiscoveryError(
+			fmt.Sprintf("failed to create temp directory for %s", entry.Name), err)
+	}
+	defer os.RemoveAll(wheelDir)
+
+	args := []string{"wheel", "--no-deps", policyPath, "-w", wheelDir}
+	if err := runPipCommand(args, 2*time.Minute, policyPath, "", "wheel"); err != nil {
+		return nil, errors.NewDiscoveryError(
+			fmt.Sprintf("failed to build wheel for local Python package %s at %s", entry.Name, policyPath), err)
+	}
+
+	whlPath, err := findWheelFile(wheelDir)
+	if err != nil {
+		return nil, errors.NewDiscoveryError(
+			fmt.Sprintf("failed to find wheel for %s", entry.Name), err)
+	}
+
+	topLevelModule, err := readTopLevelFromWheel(whlPath)
+	if err != nil {
+		return nil, errors.NewDiscoveryError(
+			fmt.Sprintf("failed to read top-level module from wheel for %s", entry.Name), err)
+	}
+
+	extractDir, err := extractModuleFromWheel(whlPath, topLevelModule)
+	if err != nil {
+		return nil, errors.NewDiscoveryError(
+			fmt.Sprintf("failed to extract module from wheel for %s", entry.Name), err)
+	}
+
+	// Validate and build the discovered policy from the extracted module directory.
+	// The extracted dir is flat (policy.py, __init__.py, policy-definition.yaml, etc.)
+	// — the same structure as a simple policy or an extracted pip package.
+	discovered, err := buildSimplePythonDiscoveredPolicy(entry, extractDir)
+	if err != nil {
+		os.RemoveAll(extractDir)
+		return nil, err
+	}
+
+	// Override Path to the original project root so requirements.txt can be found there.
+	discovered.Path = policyPath
+	discovered.IsFilePathEntry = true
+	discovered.PythonTopLevelModule = topLevelModule
+
+	slog.Info("Discovered local Python package policy",
+		"name", discovered.Name,
+		"version", discovered.Version,
+		"topLevelModule", topLevelModule,
+		"extractDir", extractDir,
+		"phase", "discovery")
+
+	return discovered, nil
+}
+
+// buildSimplePythonDiscoveredPolicy builds a discovered policy from a flat directory
+// containing policy.py, policy-definition.yaml, and other Python source files.
+// Used for both simple (no pyproject.toml) policies and extracted wheel module directories.
+func buildSimplePythonDiscoveredPolicy(entry types.BuildEntry, policyPath string) (*types.DiscoveredPolicy, error) {
 	if err := fsutil.ValidatePathExists(policyPath, "policy path"); err != nil {
 		return nil, errors.NewDiscoveryError(
 			fmt.Sprintf("from build file entry %s: %v", entry.Name, err),
@@ -371,7 +458,6 @@ func buildPythonDiscoveredPolicy(entry types.BuildEntry, policyPath string, sour
 	slog.Info("Discovered Python policy",
 		"name", discovered.Name,
 		"version", discovered.Version,
-		"source", source,
 		"path", policyPath,
 		"phase", "discovery")
 

--- a/gateway/gateway-builder/internal/discovery/policy.go
+++ b/gateway/gateway-builder/internal/discovery/policy.go
@@ -122,7 +122,9 @@ func CollectSourceFiles(policyDir string) ([]string, error) {
 	return goFiles, nil
 }
 
-// ValidatePythonDirectoryStructure checks if a Python policy directory has required files
+// ValidatePythonDirectoryStructure checks if a Python policy directory has required files.
+// This validates a flat directory containing policy source files — either a simple policy
+// root or an extracted wheel module directory.
 func ValidatePythonDirectoryStructure(policyDir string) error {
 	slog.Debug("Validating Python directory structure", "dir", policyDir, "phase", "discovery")
 
@@ -162,7 +164,7 @@ func ValidatePythonDirectoryStructure(policyDir string) error {
 	return nil
 }
 
-// CollectPythonSourceFiles finds all .py files in a policy directory
+// CollectPythonSourceFiles finds all .py files in a flat policy directory.
 func CollectPythonSourceFiles(policyDir string) ([]string, error) {
 	var pyFiles []string
 

--- a/gateway/gateway-builder/internal/discovery/python_module.go
+++ b/gateway/gateway-builder/internal/discovery/python_module.go
@@ -59,8 +59,11 @@ func sanitizeURL(u string) string {
 	return u
 }
 
-// sanitizePipSpec removes credentials from any URL-like part of a pip spec.
-func sanitizePipSpec(spec string) string {
+// SanitizePipSpec removes credentials from any URL-like part of a pip spec.
+// It handles VCS URLs (git+https://user:pass@host/...) and private index URLs
+// (pkg==ver@https://user:pass@host/...) by replacing credentials with a
+// <redacted-credentials> placeholder.
+func SanitizePipSpec(spec string) string {
 	spec = strings.TrimSpace(spec)
 	if spec == "" {
 		return spec
@@ -186,7 +189,7 @@ func FetchPipPackage(pipPackage string) (*PipPackageInfo, error) {
 	if strings.Contains(pipPackage, " @ ") {
 		return nil, fmt.Errorf(
 			"unsupported pip direct reference: %q; only git+ VCS specs are supported for direct references",
-			sanitizePipSpec(pipPackage),
+			SanitizePipSpec(pipPackage),
 		)
 	}
 
@@ -202,7 +205,7 @@ func FetchPipPackage(pipPackage string) (*PipPackageInfo, error) {
 
 		slog.Info("Expanded short URL to VCS spec",
 			"input", pipPackage,
-			"expanded", sanitizePipSpec(expanded),
+			"expanded", SanitizePipSpec(expanded),
 			"phase", "discovery")
 
 		return fetchVCSPipPackage(expanded)
@@ -314,12 +317,12 @@ func fetchVCSPipPackage(pipPackage string) (*PipPackageInfo, error) {
 
 		resolvedSpec = rebuildVCSPipSpec(vcs, exactRef)
 		slog.Info("Resolved VCS ranged pip package",
-			"original", sanitizePipSpec(vcs.FullSpec),
-			"resolved", sanitizePipSpec(resolvedSpec),
+			"original", SanitizePipSpec(vcs.FullSpec),
+			"resolved", SanitizePipSpec(resolvedSpec),
 			"phase", "discovery")
 	}
 
-	sanitizedSpec := sanitizePipSpec(resolvedSpec)
+	sanitizedSpec := SanitizePipSpec(resolvedSpec)
 	slog.Info("Fetching VCS pip package",
 		"pipSpec", sanitizedSpec,
 		"phase", "discovery")
@@ -387,7 +390,7 @@ func runPipCommand(args []string, timeout time.Duration, spec string, indexURL s
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		sanitizedSpec := sanitizePipSpec(spec)
+		sanitizedSpec := SanitizePipSpec(spec)
 		sanitizedStderr := stderr.String()
 		if spec != sanitizedSpec {
 			sanitizedStderr = strings.ReplaceAll(sanitizedStderr, spec, sanitizedSpec)
@@ -448,7 +451,7 @@ func ParsePipPackageRef(ref string) (*PipPackageRef, error) {
 	if ref == "" {
 		return nil, fmt.Errorf(
 			"invalid pip spec: expected '<pkg>==<ver>', '<pkg>~=<major>.0', or '<pkg>~=<major>.<minor>.0', got %q",
-			sanitizePipSpec(ref),
+			SanitizePipSpec(ref),
 		)
 	}
 
@@ -461,7 +464,7 @@ func ParsePipPackageRef(ref string) (*PipPackageRef, error) {
 		if pkgName == "" || version == "" || (!isMajorOnly && !isMinorOnly) {
 			return nil, fmt.Errorf(
 				"invalid pip spec: expected '<pkg>==<ver>', '<pkg>~=<major>.0', or '<pkg>~=<major>.<minor>.0', got %q",
-				sanitizePipSpec(ref),
+				SanitizePipSpec(ref),
 			)
 		}
 
@@ -477,7 +480,7 @@ func ParsePipPackageRef(ref string) (*PipPackageRef, error) {
 	if len(parts) != 2 {
 		return nil, fmt.Errorf(
 			"invalid pip spec: expected '<pkg>==<ver>', '<pkg>~=<major>.0', or '<pkg>~=<major>.<minor>.0', got %q",
-			sanitizePipSpec(ref),
+			SanitizePipSpec(ref),
 		)
 	}
 
@@ -486,7 +489,7 @@ func ParsePipPackageRef(ref string) (*PipPackageRef, error) {
 	if pkgName == "" || version == "" {
 		return nil, fmt.Errorf(
 			"invalid pip spec: expected '<pkg>==<ver>', '<pkg>~=<major>.0', or '<pkg>~=<major>.<minor>.0', got %q",
-			sanitizePipSpec(ref),
+			SanitizePipSpec(ref),
 		)
 	}
 
@@ -530,7 +533,7 @@ func parseVCSPipSpec(spec string) (*VCSPipSpec, error) {
 	}
 
 	if !strings.HasPrefix(s, "git+") {
-		return nil, fmt.Errorf("only git+ VCS specs are supported, got %q", sanitizePipSpec(spec))
+		return nil, fmt.Errorf("only git+ VCS specs are supported, got %q", SanitizePipSpec(spec))
 	}
 
 	atIdx := strings.LastIndex(s, "@")

--- a/gateway/gateway-builder/internal/policyengine/generator.go
+++ b/gateway/gateway-builder/internal/policyengine/generator.go
@@ -307,9 +307,15 @@ func mergeRequirements(policies []*types.DiscoveredPolicy, baseRequirements stri
 			continue
 		}
 
-		// For local policies, read requirements.txt from the source directory
+		// For local policies, read requirements.txt from the source directory.
+		// For src-layout policies, PythonSourceDir points inside src/<pkg>/ so
+		// we also check the policy root (p.Path) where requirements.txt lives.
 		reqPath := filepath.Join(p.PythonSourceDir, "requirements.txt")
 		data, err := os.ReadFile(reqPath)
+		if err != nil && os.IsNotExist(err) && p.Path != p.PythonSourceDir {
+			reqPath = filepath.Join(p.Path, "requirements.txt")
+			data, err = os.ReadFile(reqPath)
+		}
 		if err != nil {
 			if os.IsNotExist(err) {
 				continue

--- a/gateway/gateway-builder/internal/validation/structure.go
+++ b/gateway/gateway-builder/internal/validation/structure.go
@@ -91,7 +91,7 @@ func ValidatePythonDirectoryStructure(policy *types.DiscoveredPolicy) []types.Va
 	}
 
 	// Check policy.py exists (recommended but optional)
-	policyPyPath := filepath.Join(policy.Path, "policy.py")
+	policyPyPath := filepath.Join(policy.PythonSourceDir, "policy.py")
 	if err := fsutil.ValidatePathExists(policyPyPath, "policy.py"); err != nil {
 		// This is a warning, not an error - policy.py is recommended but optional
 		// as long as there are other .py files


### PR DESCRIPTION
Add detection and discovery support for Python policies using the industry-standard src layout and pyproject.toml. DetectRuntime now recognizes pyproject.toml and treats such projects as Python. Local Python packages are built into wheels, extracted, and validated via a new discoverLocalPythonPackagePolicy flow; flat/extracted module directories are handled by buildSimplePythonDiscoveredPolicy. Adjust validation and source collection to use PythonSourceDir (and fall back to the project root for requirements.txt when needed). Added tests for runtime detection and discovering a src-layout package policy, and minor doc/comment tweaks.