### PR TITLE
Add prompt-compressor to build yaml

### DIFF
--- a/gateway/build-manifest.yaml
+++ b/gateway/build-manifest.yaml
@@ -1,19 +1,19 @@
 version: v1
 policies:
     - name: advanced-ratelimit
-      version: v1.0.2
+      version: v1.0.3
       gomodule: github.com/wso2/gateway-controllers/policies/advanced-ratelimit@v1
     - name: analytics-header-filter
       version: v1.0.1
       gomodule: github.com/wso2/gateway-controllers/policies/analytics-header-filter@v1
     - name: api-key-auth
-      version: v1.0.1
+      version: v1.0.2
       gomodule: github.com/wso2/gateway-controllers/policies/api-key-auth@v1
     - name: aws-bedrock-guardrail
-      version: v1.0.1
+      version: v1.0.2
       gomodule: github.com/wso2/gateway-controllers/policies/aws-bedrock-guardrail@v1
     - name: azure-content-safety-content-moderation
-      version: v1.0.1
+      version: v1.0.2
       gomodule: github.com/wso2/gateway-controllers/policies/azure-content-safety-content-moderation@v1
     - name: basic-auth
       version: v1.0.1
@@ -37,25 +37,25 @@ policies:
       version: v1.0.1
       gomodule: github.com/wso2/gateway-controllers/policies/json-schema-guardrail@v1
     - name: json-xml-mediator
-      version: v1.0.1
+      version: v1.0.2
       gomodule: github.com/wso2/gateway-controllers/policies/json-xml-mediator@v1
     - name: jwt-auth
       version: v1.0.2
       gomodule: github.com/wso2/gateway-controllers/policies/jwt-auth@v1
     - name: llm-cost
-      version: v1.0.2
+      version: v1.0.3
       gomodule: github.com/wso2/gateway-controllers/policies/llm-cost@v1
     - name: llm-cost-based-ratelimit
-      version: v1.0.2
+      version: v1.0.3
       gomodule: github.com/wso2/gateway-controllers/policies/llm-cost-based-ratelimit@v1
     - name: log-message
-      version: v1.0.1
+      version: v1.0.2
       gomodule: github.com/wso2/gateway-controllers/policies/log-message@v1
     - name: mcp-acl-list
       version: v1.0.2
       gomodule: github.com/wso2/gateway-controllers/policies/mcp-acl-list@v1
     - name: mcp-auth
-      version: v1.0.2
+      version: v1.0.3
       gomodule: github.com/wso2/gateway-controllers/policies/mcp-auth@v1
     - name: mcp-authz
       version: v1.0.1
@@ -64,16 +64,19 @@ policies:
       version: v1.0.2
       gomodule: github.com/wso2/gateway-controllers/policies/mcp-rewrite@v1
     - name: model-round-robin
-      version: v1.0.2
+      version: v1.0.3
       gomodule: github.com/wso2/gateway-controllers/policies/model-round-robin@v1
     - name: model-weighted-round-robin
-      version: v1.0.2
+      version: v1.0.3
       gomodule: github.com/wso2/gateway-controllers/policies/model-weighted-round-robin@v1
     - name: pii-masking-regex
       version: v1.0.1
       gomodule: github.com/wso2/gateway-controllers/policies/pii-masking-regex@v1
+    - name: prompt-compressor
+      version: v0.1.0
+      pipPackage: git+https://github.com/wso2/gateway-controllers.git@policies/prompt-compressor/v0.1.0#subdirectory=policies/prompt-compressor
     - name: prompt-decorator
-      version: v1.0.1
+      version: v1.0.2
       gomodule: github.com/wso2/gateway-controllers/policies/prompt-decorator@v1
     - name: prompt-template
       version: v1.0.1
@@ -100,7 +103,7 @@ policies:
       version: v1.0.2
       gomodule: github.com/wso2/gateway-controllers/policies/semantic-tool-filtering@v1
     - name: sentence-count-guardrail
-      version: v1.0.1
+      version: v1.0.2
       gomodule: github.com/wso2/gateway-controllers/policies/sentence-count-guardrail@v1
     - name: set-headers
       version: v1.0.1
@@ -109,11 +112,11 @@ policies:
       version: v1.0.2
       gomodule: github.com/wso2/gateway-controllers/policies/subscription-validation@v1
     - name: token-based-ratelimit
-      version: v1.0.2
+      version: v1.0.3
       gomodule: github.com/wso2/gateway-controllers/policies/token-based-ratelimit@v1
     - name: url-guardrail
       version: v1.0.1
       gomodule: github.com/wso2/gateway-controllers/policies/url-guardrail@v1
     - name: word-count-guardrail
-      version: v1.0.1
+      version: v1.0.2
       gomodule: github.com/wso2/gateway-controllers/policies/word-count-guardrail@v1

--- a/gateway/build.yaml
+++ b/gateway/build.yaml
@@ -50,6 +50,8 @@ policies:
     gomodule: github.com/wso2/gateway-controllers/policies/model-weighted-round-robin@v1
   - name: pii-masking-regex
     gomodule: github.com/wso2/gateway-controllers/policies/pii-masking-regex@v1
+  - name: prompt-compressor
+    pipPackage: github.com/wso2/gateway-controllers/policies/prompt-compressor@v0
   - name: prompt-decorator
     gomodule: github.com/wso2/gateway-controllers/policies/prompt-decorator@v1
   - name: prompt-template


### PR DESCRIPTION
## Purpose
Add a new prompt-compressor policy. Updated gateway/build-manifest.yaml to include prompt-compressor with a pipPackage (git+https://github.com/wso2/gateway-controllers.git@policies/prompt-compressor/v0.1.0#subdirectory=policies/prompt-compressor). Added prompt-compressor to gateway/build.yaml with a pipPackage entry. No other functional changes.