### PR TITLE
Platform api changes to support consumer based rl and cost based rl

### DIFF
--- a/platform-api/src/internal/service/llm_deployment.go
+++ b/platform-api/src/internal/service/llm_deployment.go
@@ -668,6 +668,41 @@ func generateLLMProviderDeploymentYAML(provider *model.LLMProvider, templateHand
 						},
 					})
 				}
+				if providerLevel.Global.Cost != nil && providerLevel.Global.Cost.Enabled {
+					costLimit := providerLevel.Global.Cost
+					duration, err := formatRateLimitDuration(costLimit.Reset.Duration, costLimit.Reset.Unit)
+					if err != nil {
+						return "", fmt.Errorf("invalid cost reset window: %w", err)
+					}
+					policies = append(policies, api.LLMPolicy{
+						Name:    llmCostBasedRateLimitPolicyName,
+						Version: "",
+						Paths: []api.LLMPolicyPath{
+							{
+								Path:    "/*",
+								Methods: []api.LLMPolicyPathMethods{"*"},
+								Params: map[string]interface{}{
+									"budgetLimits": []map[string]interface{}{
+										{"amount": costLimit.Amount, "duration": duration},
+									},
+								},
+							},
+						},
+					})
+					if !hasPolicy(policies, llmCostPolicyName) {
+						policies = append(policies, api.LLMPolicy{
+							Name:    llmCostPolicyName,
+							Version: "",
+							Paths: []api.LLMPolicyPath{
+								{
+									Path:    "/*",
+									Methods: []api.LLMPolicyPathMethods{"*"},
+									Params:  map[string]interface{}{},
+								},
+							},
+						})
+					}
+				}
 			} else if providerLevel.ResourceWise != nil {
 				// Step 2.2 Handle resource-wise rate limiting
 				defaultLimit := &providerLevel.ResourceWise.Default
@@ -731,6 +766,37 @@ func generateLLMProviderDeploymentYAML(provider *model.LLMProvider, templateHand
 						},
 					})
 				}
+				if defaultLimit.Cost != nil && defaultLimit.Cost.Enabled {
+					costLimit := defaultLimit.Cost
+					duration, err := formatRateLimitDuration(costLimit.Reset.Duration, costLimit.Reset.Unit)
+					if err != nil {
+						return "", fmt.Errorf("invalid cost reset window: %w", err)
+					}
+					policies = append(policies, api.LLMPolicy{
+						Name:    llmCostBasedRateLimitPolicyName,
+						Version: "",
+						Paths: []api.LLMPolicyPath{
+							{
+								Path:    "/*",
+								Methods: []api.LLMPolicyPathMethods{"*"},
+								Params: map[string]interface{}{
+									"budgetLimits": []map[string]interface{}{
+										{"amount": costLimit.Amount, "duration": duration},
+									},
+								},
+							},
+						},
+					})
+					if !hasPolicy(policies, llmCostPolicyName) {
+						policies = append(policies, api.LLMPolicy{
+							Name:    llmCostPolicyName,
+							Version: "",
+							Paths: []api.LLMPolicyPath{
+								{Path: "/*", Methods: []api.LLMPolicyPathMethods{"*"}, Params: map[string]interface{}{}},
+							},
+						})
+					}
+				}
 
 				// Step 2.2.2 Resource-wise rate limit
 				for _, r := range providerLevel.ResourceWise.Resources {
@@ -779,6 +845,35 @@ func generateLLMProviderDeploymentYAML(provider *model.LLMProvider, templateHand
 							},
 						})
 					}
+					if r.Limit.Cost != nil && r.Limit.Cost.Enabled {
+						costLimit := r.Limit.Cost
+						duration, err := formatRateLimitDuration(costLimit.Reset.Duration, costLimit.Reset.Unit)
+						if err != nil {
+							return "", fmt.Errorf("invalid cost reset window for resource %s: %w", r.Resource, err)
+						}
+						addOrAppendPolicyPath(&policies, llmCostBasedRateLimitPolicyName, "", api.LLMPolicyPath{
+							Path:    r.Resource,
+							Methods: []api.LLMPolicyPathMethods{"*"},
+							Params: map[string]interface{}{
+								"budgetLimits": []map[string]interface{}{
+									{"amount": costLimit.Amount, "duration": duration},
+								},
+							},
+						})
+						if !hasPolicy(policies, llmCostPolicyName) {
+							policies = append(policies, api.LLMPolicy{
+								Name:    llmCostPolicyName,
+								Version: "",
+								Paths: []api.LLMPolicyPath{
+									{
+										Path:    "/*",
+										Methods: []api.LLMPolicyPathMethods{"*"},
+										Params:  map[string]interface{}{},
+									},
+								},
+							})
+						}
+					}
 				}
 			}
 		}
@@ -787,11 +882,183 @@ func generateLLMProviderDeploymentYAML(provider *model.LLMProvider, templateHand
 		consumerLevel := rateLimit.ConsumerLevel
 		if consumerLevel != nil {
 			if consumerLevel.Global != nil {
-				// Handle global rate limiting
-				// TODO: Convert global rate limit to policy format
+				if consumerLevel.Global.Token != nil && consumerLevel.Global.Token.Enabled {
+					tokenLimit := consumerLevel.Global.Token
+					duration, err := formatRateLimitDuration(tokenLimit.Reset.Duration, tokenLimit.Reset.Unit)
+					if err != nil {
+						return "", fmt.Errorf("invalid consumer token reset window: %w", err)
+					}
+					policies = append(policies, api.LLMPolicy{
+						Name:    tokenBasedRateLimitPolicyName,
+						Version: "",
+						Paths: []api.LLMPolicyPath{
+							{
+								Path:    "/*",
+								Methods: []api.LLMPolicyPathMethods{"*"},
+								Params: map[string]interface{}{
+									"totalTokenLimits": []map[string]interface{}{
+										{
+											"count":    tokenLimit.Count,
+											"duration": duration,
+										},
+									},
+									"consumerBased": true,
+								},
+							},
+						},
+					})
+				}
+				if consumerLevel.Global.Request != nil && consumerLevel.Global.Request.Enabled {
+					requestLimit := consumerLevel.Global.Request
+					duration, err := formatRateLimitDuration(requestLimit.Reset.Duration, requestLimit.Reset.Unit)
+					if err != nil {
+						return "", fmt.Errorf("invalid consumer request reset window: %w", err)
+					}
+					policies = append(policies, api.LLMPolicy{
+						Name:    advancedRateLimitPolicyName,
+						Version: "",
+						Paths: []api.LLMPolicyPath{
+							{
+								Path:    "/*",
+								Methods: []api.LLMPolicyPathMethods{"*"},
+								Params: map[string]interface{}{
+									"quotas": []map[string]interface{}{
+										{
+											"name": "consumer-request-limit",
+											"limits": []map[string]interface{}{
+												{
+													"limit":    requestLimit.Count,
+													"duration": duration,
+												},
+											},
+											"keyExtraction": []map[string]interface{}{
+												{"type": "routename"},
+												{"type": "metadata", "key": "x-wso2-application-id"},
+											},
+										},
+									},
+								},
+							},
+						},
+					})
+				}
+				if consumerLevel.Global.Cost != nil && consumerLevel.Global.Cost.Enabled {
+					costLimit := consumerLevel.Global.Cost
+					duration, err := formatRateLimitDuration(costLimit.Reset.Duration, costLimit.Reset.Unit)
+					if err != nil {
+						return "", fmt.Errorf("invalid consumer cost reset window: %w", err)
+					}
+					policies = append(policies, api.LLMPolicy{
+						Name:    llmCostBasedRateLimitPolicyName,
+						Version: "",
+						Paths: []api.LLMPolicyPath{
+							{
+								Path:    "/*",
+								Methods: []api.LLMPolicyPathMethods{"*"},
+								Params: map[string]interface{}{
+									"budgetLimits": []map[string]interface{}{
+										{"amount": costLimit.Amount, "duration": duration},
+									},
+									"consumerBased": true,
+								},
+							},
+						},
+					})
+					if !hasPolicy(policies, llmCostPolicyName) {
+						policies = append(policies, api.LLMPolicy{
+							Name:    llmCostPolicyName,
+							Version: "",
+							Paths: []api.LLMPolicyPath{
+								{
+									Path:    "/*",
+									Methods: []api.LLMPolicyPathMethods{"*"},
+									Params:  map[string]interface{}{},
+								},
+							},
+						})
+					}
+				}
 			} else if consumerLevel.ResourceWise != nil {
-				// Handle resource-wise rate limiting
-				// TODO: Convert resource-wise rate limit to policy format
+				for _, r := range consumerLevel.ResourceWise.Resources {
+					if r.Limit.Token != nil && r.Limit.Token.Enabled {
+						tokenLimit := r.Limit.Token
+						duration, err := formatRateLimitDuration(tokenLimit.Reset.Duration, tokenLimit.Reset.Unit)
+						if err != nil {
+							return "", fmt.Errorf("invalid consumer token reset window for resource %s: %w", r.Resource, err)
+						}
+						addOrAppendPolicyPath(&policies, tokenBasedRateLimitPolicyName, "", api.LLMPolicyPath{
+							Path:    r.Resource,
+							Methods: []api.LLMPolicyPathMethods{"*"},
+							Params: map[string]interface{}{
+								"totalTokenLimits": []map[string]interface{}{
+									{
+										"count":    tokenLimit.Count,
+										"duration": duration,
+									},
+								},
+								"consumerBased": true,
+							},
+						})
+					}
+					if r.Limit.Request != nil && r.Limit.Request.Enabled {
+						requestLimit := r.Limit.Request
+						duration, err := formatRateLimitDuration(requestLimit.Reset.Duration, requestLimit.Reset.Unit)
+						if err != nil {
+							return "", fmt.Errorf("invalid consumer request reset window for resource %s: %w", r.Resource, err)
+						}
+						addOrAppendPolicyPath(&policies, advancedRateLimitPolicyName, "", api.LLMPolicyPath{
+							Path:    r.Resource,
+							Methods: []api.LLMPolicyPathMethods{"*"},
+							Params: map[string]interface{}{
+								"quotas": []map[string]interface{}{
+									{
+										"name": "consumer-request-limit",
+										"limits": []map[string]interface{}{
+											{
+												"limit":    requestLimit.Count,
+												"duration": duration,
+											},
+										},
+										"keyExtraction": []map[string]interface{}{
+											{"type": "routename"},
+											{"type": "metadata", "key": "x-wso2-application-id"},
+										},
+									},
+								},
+							},
+						})
+					}
+					if r.Limit.Cost != nil && r.Limit.Cost.Enabled {
+						costLimit := r.Limit.Cost
+						duration, err := formatRateLimitDuration(costLimit.Reset.Duration, costLimit.Reset.Unit)
+						if err != nil {
+							return "", fmt.Errorf("invalid consumer cost reset window for resource %s: %w", r.Resource, err)
+						}
+						addOrAppendPolicyPath(&policies, llmCostBasedRateLimitPolicyName, "", api.LLMPolicyPath{
+							Path:    r.Resource,
+							Methods: []api.LLMPolicyPathMethods{"*"},
+							Params: map[string]interface{}{
+								"budgetLimits": []map[string]interface{}{
+									{"amount": costLimit.Amount, "duration": duration},
+								},
+								"consumerBased": true,
+							},
+						})
+						if !hasPolicy(policies, llmCostPolicyName) {
+							policies = append(policies, api.LLMPolicy{
+								Name:    llmCostPolicyName,
+								Version: "",
+								Paths: []api.LLMPolicyPath{
+									{
+										Path:    "/*",
+										Methods: []api.LLMPolicyPathMethods{"*"},
+										Params:  map[string]interface{}{},
+									},
+								},
+							})
+						}
+					}
+				}
 			}
 		}
 	}
@@ -897,9 +1164,17 @@ func normalizePolicyVersionToMajor(version string) string {
 }
 
 func addOrAppendPolicyPath(policies *[]api.LLMPolicy, name, version string, path api.LLMPolicyPath) {
+	newConsumerBased, _ := path.Params["consumerBased"].(bool)
+
 	for i := range *policies {
 		if (*policies)[i].Name == name && (*policies)[i].Version == version {
-			// TODO: Temporary
+			// Only merge entries that share the same scope (backend vs consumer)
+			if len((*policies)[i].Paths) > 0 {
+				existingConsumerBased, _ := (*policies)[i].Paths[0].Params["consumerBased"].(bool)
+				if existingConsumerBased != newConsumerBased {
+					continue // different scope — skip, look for another entry
+				}
+			}
 			for _, existingPath := range (*policies)[i].Paths {
 				if existingPath.Path == path.Path {
 					// Keep first occurrence and avoid duplicates.
@@ -916,6 +1191,15 @@ func addOrAppendPolicyPath(policies *[]api.LLMPolicy, name, version string, path
 		Version: version,
 		Paths:   []api.LLMPolicyPath{path},
 	})
+}
+
+func hasPolicy(policies []api.LLMPolicy, name string) bool {
+	for _, p := range policies {
+		if p.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 func isBoolTrue(v *bool) bool {

--- a/platform-api/src/internal/service/llm_deployment.go
+++ b/platform-api/src/internal/service/llm_deployment.go
@@ -1064,6 +1064,11 @@ func generateLLMProviderDeploymentYAML(provider *model.LLMProvider, templateHand
 	}
 
 	for _, p := range provider.Configuration.Policies {
+		// llm-cost is a parameterless tracker policy that the frontend attaches by default.
+		// Skip it here if the rate limiting block already added it to avoid duplication.
+		if p.Name == llmCostPolicyName && hasPolicy(policies, llmCostPolicyName) {
+			continue
+		}
 		paths := make([]api.LLMPolicyPath, 0, len(p.Paths))
 		for _, pp := range p.Paths {
 			methods := make([]api.LLMPolicyPathMethods, 0, len(pp.Methods))

--- a/platform-api/src/internal/service/llm_deployment_test.go
+++ b/platform-api/src/internal/service/llm_deployment_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"strings"
 	"testing"
 
 	"platform-api/src/internal/model"
@@ -16,4 +17,468 @@ func TestMapModelAuthToAPI_NormalizesApiKeyType(t *testing.T) {
 	if *out.Type != "api-key" {
 		t.Fatalf("expected auth type to be api-key, got %q", *out.Type)
 	}
+}
+
+func float32Ptr(f float32) *float32 { return &f }
+
+// providerWithConsumerLimits builds a minimal LLMProvider model with the given
+// consumer-level rate limiting config and no backend (provider-level) limits.
+func providerWithConsumerLimits(rl *model.LLMRateLimitingConfig) *model.LLMProvider {
+	return &model.LLMProvider{
+		ID:      "test-provider",
+		Name:    "Test Provider",
+		Version: "v1.0",
+		Configuration: model.LLMProviderConfig{
+			Context: strPtr("/test"),
+			Upstream: &model.UpstreamConfig{
+				Main: &model.UpstreamEndpoint{
+					URL: "https://api.anthropic.com",
+					Auth: &model.UpstreamAuth{
+						Type:   "api-key",
+						Header: "x-api-key",
+						Value:  "test-key",
+					},
+				},
+			},
+			AccessControl: &model.LLMAccessControl{Mode: "allow_all"},
+			RateLimiting:  rl,
+		},
+	}
+}
+
+// TestGenerateYAML_ConsumerRequestLimit verifies that a consumer-only request limit
+// generates a single advanced-ratelimit policy where the key extraction includes
+// x-wso2-application-id (making it consumer-scoped). Unlike token/cost limits,
+// the request limit does NOT use a consumerBased flag — it uses the application ID
+// directly in the key extraction.
+func TestGenerateYAML_ConsumerRequestLimit(t *testing.T) {
+	count := 100
+	rl := &model.LLMRateLimitingConfig{
+		ConsumerLevel: &model.RateLimitingScopeConfig{
+			Global: &model.RateLimitingLimitConfig{
+				Request: &model.RequestRateLimit{
+					Enabled: true,
+					Count:   count,
+					Reset:   model.RateLimitResetWindow{Duration: 2, Unit: "hour"},
+				},
+			},
+		},
+	}
+
+	yaml, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(yaml, "advanced-ratelimit") {
+		t.Error("expected advanced-ratelimit policy in generated YAML")
+	}
+	// Consumer-scoped: key extraction must include x-wso2-application-id
+	if !strings.Contains(yaml, "x-wso2-application-id") {
+		t.Error("expected x-wso2-application-id in key extraction for consumer request limit")
+	}
+	// Should NOT have a backend (non-consumer) advanced-ratelimit entry
+	if strings.Count(yaml, "advanced-ratelimit") > 1 {
+		t.Error("expected only one advanced-ratelimit policy (consumer), got more than one")
+	}
+
+	t.Logf("Generated YAML:\n%s", yaml)
+}
+
+// TestGenerateYAML_ConsumerTokenLimit verifies that a consumer token limit
+// generates a token-based-ratelimit policy with consumerBased: true.
+func TestGenerateYAML_ConsumerTokenLimit(t *testing.T) {
+	count := 100
+	rl := &model.LLMRateLimitingConfig{
+		ConsumerLevel: &model.RateLimitingScopeConfig{
+			Global: &model.RateLimitingLimitConfig{
+				Token: &model.TokenRateLimit{
+					Enabled: true,
+					Count:   count,
+					Reset:   model.RateLimitResetWindow{Duration: 2, Unit: "hour"},
+				},
+			},
+		},
+	}
+
+	yaml, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(yaml, "consumerBased: true") {
+		t.Error("expected consumerBased: true in generated YAML")
+	}
+	if !strings.Contains(yaml, "token-based-ratelimit") {
+		t.Error("expected token-based-ratelimit policy in generated YAML")
+	}
+
+	t.Logf("Generated YAML:\n%s", yaml)
+}
+
+// TestGenerateYAML_ConsumerCostLimit verifies that a consumer cost limit
+// generates a llm-cost-based-ratelimit policy with consumerBased: true.
+func TestGenerateYAML_ConsumerCostLimit(t *testing.T) {
+	rl := &model.LLMRateLimitingConfig{
+		ConsumerLevel: &model.RateLimitingScopeConfig{
+			Global: &model.RateLimitingLimitConfig{
+				Cost: &model.CostRateLimit{
+					Enabled: true,
+					Amount:  0.1,
+					Reset:   model.RateLimitResetWindow{Duration: 2, Unit: "hour"},
+				},
+			},
+		},
+	}
+
+	yaml, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(yaml, "consumerBased: true") {
+		t.Error("expected consumerBased: true in generated YAML")
+	}
+	if !strings.Contains(yaml, "llm-cost-based-ratelimit") {
+		t.Error("expected llm-cost-based-ratelimit policy in generated YAML")
+	}
+
+	t.Logf("Generated YAML:\n%s", yaml)
+}
+
+// TestGenerateYAML_BothBackendAndConsumerLimits verifies that when both a backend
+// and a consumer limit are configured, two separate policies are generated — one
+// without consumerBased and one with consumerBased: true.
+func TestGenerateYAML_BothBackendAndConsumerLimits(t *testing.T) {
+	count := 100
+	rl := &model.LLMRateLimitingConfig{
+		ProviderLevel: &model.RateLimitingScopeConfig{
+			Global: &model.RateLimitingLimitConfig{
+				Token: &model.TokenRateLimit{
+					Enabled: true,
+					Count:   count,
+					Reset:   model.RateLimitResetWindow{Duration: 1, Unit: "hour"},
+				},
+			},
+		},
+		ConsumerLevel: &model.RateLimitingScopeConfig{
+			Global: &model.RateLimitingLimitConfig{
+				Token: &model.TokenRateLimit{
+					Enabled: true,
+					Count:   count,
+					Reset:   model.RateLimitResetWindow{Duration: 1, Unit: "hour"},
+				},
+			},
+		},
+	}
+
+	yaml, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should have two token-based-ratelimit policies
+	if strings.Count(yaml, "token-based-ratelimit") < 2 {
+		t.Errorf("expected two token-based-ratelimit entries, got:\n%s", yaml)
+	}
+	// One must be consumer-based
+	if !strings.Contains(yaml, "consumerBased: true") {
+		t.Error("expected consumerBased: true in generated YAML")
+	}
+
+	t.Logf("Generated YAML:\n%s", yaml)
+}
+
+// ---------------------------------------------------------------------------
+// Regression: backend-only limits (no consumer)
+// ---------------------------------------------------------------------------
+
+// TestGenerateYAML_BackendOnlyTokenLimit verifies that a backend-only token limit
+// generates a token-based-ratelimit policy without consumerBased.
+func TestGenerateYAML_BackendOnlyTokenLimit(t *testing.T) {
+	count := 500
+	rl := &model.LLMRateLimitingConfig{
+		ProviderLevel: &model.RateLimitingScopeConfig{
+			Global: &model.RateLimitingLimitConfig{
+				Token: &model.TokenRateLimit{Enabled: true, Count: count, Reset: model.RateLimitResetWindow{Duration: 1, Unit: "hour"}},
+			},
+		},
+	}
+	yaml, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(yaml, "token-based-ratelimit") {
+		t.Error("expected token-based-ratelimit in generated YAML")
+	}
+	if strings.Contains(yaml, "consumerBased") {
+		t.Error("expected no consumerBased for backend-only limit")
+	}
+	t.Logf("Generated YAML:\n%s", yaml)
+}
+
+// TestGenerateYAML_BackendOnlyRequestLimit verifies that a backend-only request limit
+// generates an advanced-ratelimit policy with quota name "request-limit" (not "consumer-request-limit")
+// and without x-wso2-application-id in the key extraction.
+func TestGenerateYAML_BackendOnlyRequestLimit(t *testing.T) {
+	count := 500
+	rl := &model.LLMRateLimitingConfig{
+		ProviderLevel: &model.RateLimitingScopeConfig{
+			Global: &model.RateLimitingLimitConfig{
+				Request: &model.RequestRateLimit{Enabled: true, Count: count, Reset: model.RateLimitResetWindow{Duration: 1, Unit: "hour"}},
+			},
+		},
+	}
+	yaml, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(yaml, "advanced-ratelimit") {
+		t.Error("expected advanced-ratelimit in generated YAML")
+	}
+	if strings.Contains(yaml, "x-wso2-application-id") {
+		t.Error("expected no x-wso2-application-id for backend-only request limit")
+	}
+	if !strings.Contains(yaml, "request-limit") {
+		t.Error("expected quota name 'request-limit' in generated YAML")
+	}
+	if strings.Contains(yaml, "consumer-request-limit") {
+		t.Error("expected no 'consumer-request-limit' for backend-only request limit")
+	}
+	t.Logf("Generated YAML:\n%s", yaml)
+}
+
+// TestGenerateYAML_BackendOnlyCostLimit verifies that a backend-only cost limit
+// generates an llm-cost-based-ratelimit policy without consumerBased, plus one llm-cost policy.
+func TestGenerateYAML_BackendOnlyCostLimit(t *testing.T) {
+	rl := &model.LLMRateLimitingConfig{
+		ProviderLevel: &model.RateLimitingScopeConfig{
+			Global: &model.RateLimitingLimitConfig{
+				Cost: &model.CostRateLimit{Enabled: true, Amount: 1.0, Reset: model.RateLimitResetWindow{Duration: 1, Unit: "hour"}},
+			},
+		},
+	}
+	yaml, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(yaml, "llm-cost-based-ratelimit") {
+		t.Error("expected llm-cost-based-ratelimit in generated YAML")
+	}
+	if strings.Contains(yaml, "consumerBased") {
+		t.Error("expected no consumerBased for backend-only cost limit")
+	}
+	if strings.Count(yaml, "llm-cost") < 2 {
+		t.Error("expected llm-cost policy alongside llm-cost-based-ratelimit")
+	}
+	t.Logf("Generated YAML:\n%s", yaml)
+}
+
+func TestGenerateYAML_BackendResourceWiseDefaultCostLimit(t *testing.T) {
+	rl := &model.LLMRateLimitingConfig{
+		ProviderLevel: &model.RateLimitingScopeConfig{
+			ResourceWise: &model.ResourceWiseRateLimitingConfig{
+				Default: model.RateLimitingLimitConfig{
+					Cost: &model.CostRateLimit{Enabled: true, Amount: 0.10, Reset: model.RateLimitResetWindow{Duration: 24, Unit: "hour"}},
+				},
+			},
+		},
+	}
+	yaml, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(yaml, "llm-cost-based-ratelimit") {
+		t.Error("expected llm-cost-based-ratelimit in generated YAML")
+	}
+	if !strings.Contains(yaml, "budgetLimits") {
+		t.Error("expected budgetLimits in generated YAML")
+	}
+	if strings.Contains(yaml, "consumerBased") {
+		t.Error("expected no consumerBased for backend-only cost limit")
+	}
+	t.Logf("Generated YAML:\n%s", yaml)
+}
+
+func TestGenerateYAML_BackendPerResourceCostLimit(t *testing.T) {
+	rl := &model.LLMRateLimitingConfig{
+		ProviderLevel: &model.RateLimitingScopeConfig{
+			ResourceWise: &model.ResourceWiseRateLimitingConfig{
+				Default: model.RateLimitingLimitConfig{},
+				Resources: []model.RateLimitingResourceLimit{
+					{
+						Resource: "/v1/messages",
+						Limit: model.RateLimitingLimitConfig{
+							Cost: &model.CostRateLimit{Enabled: true, Amount: 0.02, Reset: model.RateLimitResetWindow{Duration: 1, Unit: "hour"}},
+						},
+					},
+				},
+			},
+		},
+	}
+	yaml, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(yaml, "llm-cost-based-ratelimit") {
+		t.Error("expected llm-cost-based-ratelimit in generated YAML")
+	}
+	if !strings.Contains(yaml, "budgetLimits") {
+		t.Error("expected budgetLimits in generated YAML")
+	}
+	if !strings.Contains(yaml, "/v1/messages") {
+		t.Error("expected resource path /v1/messages in generated YAML")
+	}
+	if strings.Contains(yaml, "consumerBased") {
+		t.Error("expected no consumerBased for backend-only cost limit")
+	}
+	t.Logf("Generated YAML:\n%s", yaml)
+}
+
+// ---------------------------------------------------------------------------
+// Backend + consumer for individual limit types
+// ---------------------------------------------------------------------------
+
+// TestGenerateYAML_BothBackendAndConsumerRequestLimits verifies that backend and consumer
+// request limits produce two advanced-ratelimit policies with distinct quota names:
+// "request-limit" (backend, no app-id key) and "consumer-request-limit" (consumer, with app-id key).
+func TestGenerateYAML_BothBackendAndConsumerRequestLimits(t *testing.T) {
+	count := 100
+	rl := &model.LLMRateLimitingConfig{
+		ProviderLevel: &model.RateLimitingScopeConfig{
+			Global: &model.RateLimitingLimitConfig{
+				Request: &model.RequestRateLimit{Enabled: true, Count: count, Reset: model.RateLimitResetWindow{Duration: 1, Unit: "hour"}},
+			},
+		},
+		ConsumerLevel: &model.RateLimitingScopeConfig{
+			Global: &model.RateLimitingLimitConfig{
+				Request: &model.RequestRateLimit{Enabled: true, Count: count, Reset: model.RateLimitResetWindow{Duration: 1, Unit: "hour"}},
+			},
+		},
+	}
+	yaml, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Count(yaml, "advanced-ratelimit") < 2 {
+		t.Error("expected two advanced-ratelimit policies (one backend, one consumer)")
+	}
+	if !strings.Contains(yaml, "consumer-request-limit") {
+		t.Error("expected 'consumer-request-limit' quota name for consumer policy")
+	}
+	if !strings.Contains(yaml, "x-wso2-application-id") {
+		t.Error("expected x-wso2-application-id in consumer policy key extraction")
+	}
+	t.Logf("Generated YAML:\n%s", yaml)
+}
+
+// TestGenerateYAML_BothBackendAndConsumerCostLimits verifies that backend and consumer
+// cost limits produce two llm-cost-based-ratelimit policies (one with consumerBased: true)
+// and exactly one llm-cost policy (not duplicated).
+func TestGenerateYAML_BothBackendAndConsumerCostLimits(t *testing.T) {
+	rl := &model.LLMRateLimitingConfig{
+		ProviderLevel: &model.RateLimitingScopeConfig{
+			Global: &model.RateLimitingLimitConfig{
+				Cost: &model.CostRateLimit{Enabled: true, Amount: 1.0, Reset: model.RateLimitResetWindow{Duration: 1, Unit: "hour"}},
+			},
+		},
+		ConsumerLevel: &model.RateLimitingScopeConfig{
+			Global: &model.RateLimitingLimitConfig{
+				Cost: &model.CostRateLimit{Enabled: true, Amount: 0.1, Reset: model.RateLimitResetWindow{Duration: 1, Unit: "hour"}},
+			},
+		},
+	}
+	yaml, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Count(yaml, "llm-cost-based-ratelimit") < 2 {
+		t.Error("expected two llm-cost-based-ratelimit policies (backend + consumer)")
+	}
+	if !strings.Contains(yaml, "consumerBased: true") {
+		t.Error("expected consumerBased: true on consumer cost policy")
+	}
+	// llm-cost must appear exactly once — hasPolicy check prevents duplication
+	if strings.Count(yaml, "name: llm-cost\n") != 1 {
+		t.Errorf("expected exactly one llm-cost policy, got:\n%s", yaml)
+	}
+	t.Logf("Generated YAML:\n%s", yaml)
+}
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+// TestGenerateYAML_DisabledLimitIsSkipped verifies that a limit with Enabled: false
+// produces no rate limiting policies.
+func TestGenerateYAML_DisabledLimitIsSkipped(t *testing.T) {
+	count := 100
+	rl := &model.LLMRateLimitingConfig{
+		ConsumerLevel: &model.RateLimitingScopeConfig{
+			Global: &model.RateLimitingLimitConfig{
+				Token: &model.TokenRateLimit{Enabled: false, Count: count, Reset: model.RateLimitResetWindow{Duration: 1, Unit: "hour"}},
+				Cost:  &model.CostRateLimit{Enabled: false, Amount: 0.5, Reset: model.RateLimitResetWindow{Duration: 1, Unit: "hour"}},
+			},
+		},
+	}
+	yaml, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(yaml, "token-based-ratelimit") {
+		t.Error("expected no token-based-ratelimit for disabled token limit")
+	}
+	if strings.Contains(yaml, "llm-cost-based-ratelimit") {
+		t.Error("expected no llm-cost-based-ratelimit for disabled cost limit")
+	}
+	t.Logf("Generated YAML:\n%s", yaml)
+}
+
+// TestGenerateYAML_AllThreeConsumerLimits verifies the full UI scenario from the
+// screenshot: consumer request + token + cost all enabled, no backend limits.
+func TestGenerateYAML_AllThreeConsumerLimits(t *testing.T) {
+	count := 100
+	rl := &model.LLMRateLimitingConfig{
+		ProviderLevel: &model.RateLimitingScopeConfig{
+			Global: &model.RateLimitingLimitConfig{},
+		},
+		ConsumerLevel: &model.RateLimitingScopeConfig{
+			Global: &model.RateLimitingLimitConfig{
+				Request: &model.RequestRateLimit{
+					Enabled: true,
+					Count:   count,
+					Reset:   model.RateLimitResetWindow{Duration: 2, Unit: "hour"},
+				},
+				Token: &model.TokenRateLimit{
+					Enabled: true,
+					Count:   count,
+					Reset:   model.RateLimitResetWindow{Duration: 2, Unit: "hour"},
+				},
+				Cost: &model.CostRateLimit{
+					Enabled: true,
+					Amount:  0.1,
+					Reset:   model.RateLimitResetWindow{Duration: 2, Unit: "hour"},
+				},
+			},
+		},
+	}
+
+	yaml, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	checks := []string{
+		"advanced-ratelimit",
+		"token-based-ratelimit",
+		"llm-cost-based-ratelimit",
+		"consumerBased: true",
+	}
+	for _, want := range checks {
+		if !strings.Contains(yaml, want) {
+			t.Errorf("expected %q in generated YAML", want)
+		}
+	}
+
+	t.Logf("Generated YAML:\n%s", yaml)
 }

--- a/platform-api/src/internal/service/llm_deployment_test.go
+++ b/platform-api/src/internal/service/llm_deployment_test.go
@@ -482,3 +482,144 @@ func TestGenerateYAML_AllThreeConsumerLimits(t *testing.T) {
 
 	t.Logf("Generated YAML:\n%s", yaml)
 }
+
+// ---------------------------------------------------------------------------
+// llm-cost deduplication
+// ---------------------------------------------------------------------------
+
+// providerWithCostRLAndDefaultPolicies builds a provider with a cost-based rate limit
+// configured AND llm-cost already in Configuration.Policies — which is exactly what
+// happens in production when the frontend attaches llm-cost by default at creation time
+// and the user later enables cost-based rate limiting via the rate limit tab.
+func providerWithCostRLAndDefaultPolicies(rl *model.LLMRateLimitingConfig) *model.LLMProvider {
+	p := providerWithConsumerLimits(rl)
+	p.Configuration.Policies = []model.LLMPolicy{
+		{
+			Name:    "llm-cost",
+			Version: "v1",
+			Paths:   []model.LLMPolicyPath{{Path: "/*", Methods: []string{"*"}, Params: map[string]interface{}{}}},
+		},
+	}
+	return p
+}
+
+// TestGenerateYAML_LLMCostNotDuplicatedWithProviderCostLimit verifies that when a
+// backend cost limit is configured (auto-adds llm-cost) and llm-cost is also present
+// in Configuration.Policies (added by the frontend by default), the final YAML
+// contains llm-cost exactly once.
+func TestGenerateYAML_LLMCostNotDuplicatedWithProviderCostLimit(t *testing.T) {
+	rl := &model.LLMRateLimitingConfig{
+		ProviderLevel: &model.RateLimitingScopeConfig{
+			Global: &model.RateLimitingLimitConfig{
+				Cost: &model.CostRateLimit{Enabled: true, Amount: 1.0, Reset: model.RateLimitResetWindow{Duration: 1, Unit: "hour"}},
+			},
+		},
+	}
+
+	yaml, err := generateLLMProviderDeploymentYAML(providerWithCostRLAndDefaultPolicies(rl), "anthropic")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if strings.Count(yaml, "name: llm-cost\n") != 1 {
+		t.Errorf("expected exactly one llm-cost policy, got:\n%s", yaml)
+	}
+	t.Logf("Generated YAML:\n%s", yaml)
+}
+
+// TestGenerateYAML_LLMCostNotDuplicatedWithConsumerCostLimit verifies the same
+// deduplication holds when the cost limit is on the consumer level.
+func TestGenerateYAML_LLMCostNotDuplicatedWithConsumerCostLimit(t *testing.T) {
+	rl := &model.LLMRateLimitingConfig{
+		ConsumerLevel: &model.RateLimitingScopeConfig{
+			Global: &model.RateLimitingLimitConfig{
+				Cost: &model.CostRateLimit{Enabled: true, Amount: 0.5, Reset: model.RateLimitResetWindow{Duration: 1, Unit: "hour"}},
+			},
+		},
+	}
+
+	yaml, err := generateLLMProviderDeploymentYAML(providerWithCostRLAndDefaultPolicies(rl), "anthropic")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if strings.Count(yaml, "name: llm-cost\n") != 1 {
+		t.Errorf("expected exactly one llm-cost policy, got:\n%s", yaml)
+	}
+	t.Logf("Generated YAML:\n%s", yaml)
+}
+
+// TestGenerateYAML_LLMCostNotDuplicatedWithBothProviderAndConsumerCostLimits verifies
+// that even when both backend and consumer cost limits are configured, llm-cost
+// still appears only once alongside two llm-cost-based-ratelimit entries.
+func TestGenerateYAML_LLMCostNotDuplicatedWithBothProviderAndConsumerCostLimits(t *testing.T) {
+	rl := &model.LLMRateLimitingConfig{
+		ProviderLevel: &model.RateLimitingScopeConfig{
+			Global: &model.RateLimitingLimitConfig{
+				Cost: &model.CostRateLimit{Enabled: true, Amount: 1.0, Reset: model.RateLimitResetWindow{Duration: 1, Unit: "hour"}},
+			},
+		},
+		ConsumerLevel: &model.RateLimitingScopeConfig{
+			Global: &model.RateLimitingLimitConfig{
+				Cost: &model.CostRateLimit{Enabled: true, Amount: 0.1, Reset: model.RateLimitResetWindow{Duration: 1, Unit: "hour"}},
+			},
+		},
+	}
+
+	yaml, err := generateLLMProviderDeploymentYAML(providerWithCostRLAndDefaultPolicies(rl), "anthropic")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if strings.Count(yaml, "name: llm-cost\n") != 1 {
+		t.Errorf("expected exactly one llm-cost policy, got:\n%s", yaml)
+	}
+	if strings.Count(yaml, "llm-cost-based-ratelimit") < 2 {
+		t.Errorf("expected two llm-cost-based-ratelimit policies (backend + consumer), got:\n%s", yaml)
+	}
+	t.Logf("Generated YAML:\n%s", yaml)
+}
+
+// TestGenerateYAML_LLMCostKeptWhenNoCostRLConfigured verifies that when no cost-based
+// rate limit is configured, the llm-cost policy from Configuration.Policies is still
+// included in the output (it should only be skipped if already added by the RL block).
+func TestGenerateYAML_LLMCostKeptWhenNoCostRLConfigured(t *testing.T) {
+	yaml, err := generateLLMProviderDeploymentYAML(providerWithCostRLAndDefaultPolicies(nil), "anthropic")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if strings.Count(yaml, "name: llm-cost\n") != 1 {
+		t.Errorf("expected exactly one llm-cost policy when no RL is configured, got:\n%s", yaml)
+	}
+	t.Logf("Generated YAML:\n%s", yaml)
+}
+
+// TestGenerateYAML_OtherCustomPoliciesNotDeduplicated verifies that the llm-cost
+// deduplication does not affect other guardrail policies — two entries with the same
+// name but different params must both be preserved.
+func TestGenerateYAML_OtherCustomPoliciesNotDeduplicated(t *testing.T) {
+	p := providerWithConsumerLimits(nil)
+	p.Configuration.Policies = []model.LLMPolicy{
+		{
+			Name:    "my-guardrail",
+			Version: "v1",
+			Paths:   []model.LLMPolicyPath{{Path: "/*", Methods: []string{"*"}, Params: map[string]interface{}{"threshold": 0.5}}},
+		},
+		{
+			Name:    "my-guardrail",
+			Version: "v1",
+			Paths:   []model.LLMPolicyPath{{Path: "/*", Methods: []string{"*"}, Params: map[string]interface{}{"threshold": 0.9}}},
+		},
+	}
+
+	yaml, err := generateLLMProviderDeploymentYAML(p, "anthropic")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if strings.Count(yaml, "name: my-guardrail") < 2 {
+		t.Errorf("expected both my-guardrail entries to be present, got:\n%s", yaml)
+	}
+	t.Logf("Generated YAML:\n%s", yaml)
+}


### PR DESCRIPTION
## Purpose
> Updated llm_deployment.go file in platform api to support  consumer based ratelimit 
- Consumer request limit: emits `advanced-ratelimit` with `x-wso2-application-id` in key extraction (`fallback: default`) and quota name `consumer-request-limit`
- Consumer token limit: emits `token-based-ratelimit` with `consumerBased: true`
- Consumer cost limit: emits `llm-cost-based-ratelimit` with `consumerBased: true`; `hasPolicy` guard prevents `llm-cost` appearing twice when both backend and consumer cost limits are configured
- Fixed `addOrAppendPolicyPath` to be scope-aware so backend and consumer entries with the same policy name are not merged

> Added unit tests to llm_deployment_test.go