### PR TITLE
feat(gateway-builder): add Python in GW builder for Python policies

### DIFF
--- a/cli/src/utils/policy_utils.go
+++ b/cli/src/utils/policy_utils.go
@@ -367,10 +367,11 @@ func SetupTempGatewayWorkspace(buildFilePath string) (string, error) {
 	var buildFile struct {
 		Version  string `yaml:"version"`
 		Policies []struct {
-			Name     string `yaml:"name"`
-			Version  string `yaml:"version,omitempty"`
-			FilePath string `yaml:"filePath,omitempty"`
-			Gomodule string `yaml:"gomodule,omitempty"`
+			Name       string `yaml:"name"`
+			Version    string `yaml:"version,omitempty"`
+			FilePath   string `yaml:"filePath,omitempty"`
+			Gomodule   string `yaml:"gomodule,omitempty"`
+			PipPackage string `yaml:"pipPackage,omitempty"`
 		} `yaml:"policies"`
 	}
 	if err := yaml.Unmarshal(buildFileData, &buildFile); err != nil {

--- a/gateway/gateway-builder/Dockerfile
+++ b/gateway/gateway-builder/Dockerfile
@@ -82,16 +82,21 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update && apt-get install -y --no-install-recommends \
     git \
     make \
-    ca-certificates
+    ca-certificates \
+    python3 \
+    python3-pip \
+    python3-venv
 
 # Copy the compiled binary from builder stage
 COPY --from=builder /usr/local/bin/gateway-builder /usr/local/bin/gateway-builder
 
 # Copy Policy Engine framework source code
 COPY --from=policy-engine . /api-platform/gateway/gateway-runtime/policy-engine
+COPY --from=python-executor . /api-platform/gateway/gateway-runtime/python-executor
 COPY --from=system-policies . /api-platform/gateway/system-policies
 COPY --from=common . /api-platform/common
 COPY --from=sdk-core . /api-platform/sdk/core
+COPY --from=sdk-python . /api-platform/sdk-python
 
 # Set working directory
 WORKDIR /workspace

--- a/gateway/gateway-builder/Makefile
+++ b/gateway/gateway-builder/Makefile
@@ -58,9 +58,11 @@ build: ## Build Docker image using buildx
 	@echo "Building Docker image ($(IMAGE_NAME):$(VERSION))..."
 	@docker buildx build -f Dockerfile \
 		--build-context policy-engine=../gateway-runtime/policy-engine \
+		--build-context python-executor=../gateway-runtime/python-executor \
 		--build-context system-policies=../system-policies \
 		--build-context sdk=../../sdk \
 		--build-context sdk-core=../../sdk/core \
+		--build-context sdk-python=../../sdk-python \
 		--build-context common=../../common \
 		--build-arg VERSION=$(VERSION) \
 		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
@@ -81,9 +83,11 @@ build-and-push-multiarch: ## Build and push multi-architecture Docker image (lin
 	@echo "Building and pushing multi-arch Docker image: $(IMAGE_NAME):$(VERSION)"
 	docker buildx build -f Dockerfile \
 		--build-context policy-engine=../gateway-runtime/policy-engine \
+		--build-context python-executor=../gateway-runtime/python-executor \
 		--build-context system-policies=../system-policies \
 		--build-context sdk=../../sdk \
 		--build-context sdk-core=../../sdk/core \
+		--build-context sdk-python=../../sdk-python \
 		--build-context common=../../common \
 		--platform linux/amd64,linux/arm64 \
 		--build-arg VERSION=$(VERSION) \


### PR DESCRIPTION
## Purpose
- Install python3, python3-pip, python3-venv in the runtime stage of the gateway-builder image so it can compile and bundle Python policies
- Add python-executor and sdk-python build contexts to Dockerfile and Makefile (both build and build-and-push-multiarch targets)
- Add pipPackage field to policy struct in CLI's SetupTempGatewayWorkspace for parsing pip-based policy entries in build.yaml