### PR TITLE
build(gateway): add make dist target for standalone distribution zip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,5 @@ dev-policies/
 
 # Copilot Prompts
 .github/prompts
+
+gateway/target/

--- a/gateway/Makefile
+++ b/gateway/Makefile
@@ -73,6 +73,10 @@ help: ## Show this help message
 	@echo '  make version-bump-next-dev              - Bump to next minor dev version with SNAPSHOT'
 	@echo '  make version-get-release                - Get release version (strips SNAPSHOT suffix)'
 	@echo ''
+	@echo 'Distribution Targets:'
+	@echo '  make dist                      - Build standalone gateway distribution zip (target/wso2apip-api-gateway-<VERSION>.zip)'
+	@echo '  make clean-dist                - Remove distribution staging dir and zip'
+	@echo ''
 	@echo 'Clean Targets:'
 	@echo '  make clean                     - Clean all build artifacts'
 	@echo '  make clean-db                  - Remove local dev SQLite database files'
@@ -215,6 +219,46 @@ version-get-release: ## Get release version (strips SNAPSHOT suffix)
 	fi; \
 	echo "$$VERSION"
 
+# Distribution Targets
+DIST_VERSION := $(shell echo "$(VERSION)" | sed 's/-SNAPSHOT//')
+DIST_NAME    := wso2apip-api-gateway-$(DIST_VERSION)
+DIST_DIR     := target/$(DIST_NAME)
+DIST_ZIP     := target/$(DIST_NAME).zip
+AI_DIST_NAME := wso2apip-ai-gateway-$(DIST_VERSION)
+AI_DIST_DIR  := target/$(AI_DIST_NAME)
+AI_DIST_ZIP  := target/$(AI_DIST_NAME).zip
+
+.PHONY: dist
+dist: clean-dist ## Build standalone gateway distribution zip
+	@echo "Building distribution $(DIST_NAME)..."
+	@mkdir -p $(DIST_DIR)/configs $(DIST_DIR)/resources/certificates \
+	          $(DIST_DIR)/resources/listener-certs $(DIST_DIR)/resources/secure-backend
+	@cp build.yaml build-manifest.yaml $(DIST_DIR)/
+	@cp -R configs/. $(DIST_DIR)/configs/
+	@cp -R observability $(DIST_DIR)/
+	@cp gateway-controller/certificates/default-listener.crt   $(DIST_DIR)/resources/certificates/
+	@cp gateway-controller/listener-certs/default-listener.crt $(DIST_DIR)/resources/listener-certs/
+	@cp gateway-controller/listener-certs/default-listener.key $(DIST_DIR)/resources/listener-certs/
+	@cp -R resources/secure-backend/. $(DIST_DIR)/resources/secure-backend/
+	@cp distribution/docker-compose.yaml $(DIST_DIR)/docker-compose.yaml
+	@sed -i.bak \
+	    -e 's|/gateway-controller:[^[:space:]]*|/gateway-controller:$(DIST_VERSION)|g' \
+	    -e 's|/gateway-runtime:[^[:space:]]*|/gateway-runtime:$(DIST_VERSION)|g' \
+	    $(DIST_DIR)/docker-compose.yaml
+	@rm -f $(DIST_DIR)/docker-compose.yaml.bak
+	@sed -i.bak 's/^  version: .*/  version: $(DIST_VERSION)/' $(DIST_DIR)/build.yaml
+	@rm -f $(DIST_DIR)/build.yaml.bak
+	@cd target && zip -rq $(DIST_NAME).zip $(DIST_NAME)
+	@mv $(DIST_DIR) $(AI_DIST_DIR)
+	@cd target && zip -rq $(AI_DIST_NAME).zip $(AI_DIST_NAME)
+	@rm -rf $(AI_DIST_DIR)
+	@echo "✓ Built $(DIST_ZIP)"
+	@echo "✓ Built $(AI_DIST_ZIP)"
+
+.PHONY: clean-dist
+clean-dist: ## Remove distribution staging dir and zip
+	@rm -rf target/wso2apip-api-gateway-* target/wso2apip-ai-gateway-*
+
 # Clean Targets
 .PHONY: clean-db
 clean-db: ## Remove local dev SQLite database files
@@ -222,7 +266,7 @@ clean-db: ## Remove local dev SQLite database files
 	@echo "Cleaned local dev database files"
 
 .PHONY: clean
-clean: ## Clean all build artifacts
+clean: clean-dist ## Clean all build artifacts
 	$(MAKE) -C gateway-controller clean
 	$(MAKE) -C gateway-builder clean
 	$(MAKE) -C gateway-runtime clean

--- a/gateway/distribution/docker-compose.yaml
+++ b/gateway/distribution/docker-compose.yaml
@@ -16,12 +16,6 @@
 # under the License.
 # --------------------------------------------------------------------
 
-# NOTE: gateway-controller and gateway-runtime are duplicated in docker-compose.debug.yaml — keep in sync.
-# NOTE: distribution/docker-compose.yaml ships the standalone variant (assembled by `make dist`) — keep
-#       gateway-controller/gateway-runtime services in sync there too. Documented differences that should
-#       diverge: cert mount paths under ./resources/, no sample-backend service, empty default for
-#       APIP_GW_CONTROLPLANE_HOST.
-
 services:
   gateway-controller:
     image: ghcr.io/wso2/api-platform/gateway-controller:1.1.0-SNAPSHOT
@@ -36,12 +30,12 @@ services:
     environment:
       - APIP_GW_DEVELOPMENT_MODE=true
       - APIP_GW_GATEWAY_REGISTRATION_TOKEN=${GATEWAY_REGISTRATION_TOKEN:-}
-      - APIP_GW_CONTROLPLANE_HOST=${GATEWAY_CONTROLPLANE_HOST:-host.docker.internal:9243}
+      - APIP_GW_CONTROLPLANE_HOST=${GATEWAY_CONTROLPLANE_HOST:-}
     volumes:
       - controller-data:/app/data
       - ./configs/config.toml:/etc/gateway-controller/config.toml:ro
-      - ./gateway-controller/certificates:/app/certificates  # Read-write for dynamic certificate management
-      - ./gateway-controller/listener-certs:/app/listener-certs:ro  # Read-only for HTTPS listener certificates
+      - ./resources/certificates:/app/certificates
+      - ./resources/listener-certs:/app/listener-certs:ro
     extra_hosts:
       - "host.docker.internal:host-gateway"
     networks:
@@ -68,15 +62,6 @@ services:
     volumes:
       - ./configs/config.toml:/etc/policy-engine/config.toml:ro
       - ./configs/llm-pricing/model_prices.json:/etc/policy-engine/llm-pricing/model_prices.json:ro
-    networks:
-      - gateway-network
-
-  sample-backend:
-    image: ghcr.io/wso2/api-platform/sample-service:latest
-    ports:
-      - "15000:5000"
-    command: ["-addr", ":5000", "-pretty"]
-    # command: ["-addr", ":5000", "-pretty", "-https", "-cert", "/app/certs/server.pem", "-key", "/app/certs/server.key"]
     networks:
       - gateway-network
 

--- a/scripts/update-docker-compose.sh
+++ b/scripts/update-docker-compose.sh
@@ -33,6 +33,7 @@ if [ -z "$COMPONENT" ] || [ -z "$VERSION" ]; then
 fi
 
 COMPOSE_FILE="gateway/docker-compose.yaml"
+DIST_COMPOSE_FILE="gateway/distribution/docker-compose.yaml"
 IT_COMPOSE_FILE="gateway/it/docker-compose.test.yaml"
 EVENT_GATEWAY_COMPOSE_FILE="event-gateway/docker-compose.yaml"
 
@@ -49,6 +50,15 @@ if [ "$COMPONENT" = "gateway" ]; then
         "$COMPOSE_FILE"
     rm -f "$COMPOSE_FILE.bak"
     echo "Updated $COMPOSE_FILE with gateway version $VERSION"
+    # Mirror the same image-tag rewrite in the distribution compose template
+    if [ -f "$DIST_COMPOSE_FILE" ]; then
+        sed -i.bak \
+            -e "s|image: .*/gateway-controller:.*|image: ${DOCKER_REGISTRY}/gateway-controller:$VERSION|" \
+            -e "s|image: .*/gateway-runtime:.*|image: ${DOCKER_REGISTRY}/gateway-runtime:$VERSION|" \
+            "$DIST_COMPOSE_FILE"
+        rm -f "$DIST_COMPOSE_FILE.bak"
+        echo "Updated $DIST_COMPOSE_FILE with gateway version $VERSION"
+    fi
 elif [ "$COMPONENT" = "event-gateway" ]; then
     # Update all event-gateway component images in event-gateway docker-compose.yaml
     if [ ! -f "$EVENT_GATEWAY_COMPOSE_FILE" ]; then


### PR DESCRIPTION
## Purpose
Fix https://github.com/wso2/api-platform/issues/524

- Add `make dist` to assemble configs, observability, certs and a standalone compose file into wso2apip-api-gateway-<VERSION>.zip plus a wso2apip-ai-gateway-<VERSION>.zip variant; build.yaml and image tags are rewritten to the release version.
- Add gateway/distribution/docker-compose.yaml as the shipped compose template (no sample-backend, certs under ./resources/, empty APIP_GW_CONTROLPLANE_HOST default).
- Trim default env vars (storage type/path, logging level, metrics port, LOG_LEVEL) and unpublished cross-container ports (18000/18001, 8082/8083) from the dev compose.
- Mirror gateway version bumps into the distribution compose via scripts/update-docker-compose.sh.
- Ignore gateway/target/ build artifacts.