### PR TITLE
 Fix Event Gateway WebSub consumer group ID collisions and return 401 for policy denials

### DIFF
--- a/event-gateway/gateway-runtime/internal/connectors/receiver/websub/consumer_manager.go
+++ b/event-gateway/gateway-runtime/internal/connectors/receiver/websub/consumer_manager.go
@@ -218,8 +218,8 @@ func (cm *ConsumerManager) createConsumer(groupID string, topics []string, callb
 }
 
 // consumerGroupID generates a unique, safe consumer group ID for a callback URL.
-// Format: {prefix}-websub-{sha256(callbackURL)[:16]}
+// Format: {prefix}-websub-{sha256(callbackURL)[:32]}
 func (cm *ConsumerManager) consumerGroupID(callbackURL string) string {
 	h := sha256.Sum256([]byte(callbackURL))
-	return cm.groupPrefix + "-websub-" + hex.EncodeToString(h[:])[:16]
+	return cm.groupPrefix + "-websub-" + hex.EncodeToString(h[:])[:32]
 }

--- a/event-gateway/gateway-runtime/internal/connectors/receiver/websub/handler.go
+++ b/event-gateway/gateway-runtime/internal/connectors/receiver/websub/handler.go
@@ -379,6 +379,9 @@ func writePolicyResponse(w http.ResponseWriter, msg *connectors.Message, fallbac
 		w.WriteHeader(statusCode)
 		return
 	}
+	if fallbackStatus == http.StatusUnauthorized {
+		w.Header().Set("WWW-Authenticate", `Bearer realm="event-gateway"`)
+	}
 	http.Error(w, fallbackBody, fallbackStatus)
 }
 

--- a/event-gateway/gateway-runtime/internal/connectors/receiver/websub/handler.go
+++ b/event-gateway/gateway-runtime/internal/connectors/receiver/websub/handler.go
@@ -99,14 +99,14 @@ func (h *HubHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (h *HubHandler) handleSubscribe(w http.ResponseWriter, r *http.Request) {
 	// Enforce subscribe policies before processing.
 	subMsg := httpRequestToMessage(r)
-	message, shortCircuited, err := h.processor.ProcessSubscribe(r.Context(), h.bindingName, subMsg)
+	_, shortCircuited, err := h.processor.ProcessSubscribe(r.Context(), h.bindingName, subMsg)
 	if err != nil {
 		slog.Error("Subscribe policy execution failed", "error", err)
 		http.Error(w, "policy execution failed", http.StatusInternalServerError)
 		return
 	}
 	if shortCircuited {
-		writePolicyResponse(w, message, http.StatusForbidden, "forbidden by policy")
+		writePolicyResponse(w, nil, http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized))
 		return
 	}
 
@@ -203,14 +203,14 @@ func (h *HubHandler) handleSubscribe(w http.ResponseWriter, r *http.Request) {
 func (h *HubHandler) handleUnsubscribe(w http.ResponseWriter, r *http.Request) {
 	// Enforce subscribe policies before processing.
 	subMsg := httpRequestToMessage(r)
-	message, shortCircuited, err := h.processor.ProcessSubscribe(r.Context(), h.bindingName, subMsg)
+	_, shortCircuited, err := h.processor.ProcessSubscribe(r.Context(), h.bindingName, subMsg)
 	if err != nil {
 		slog.Error("Unsubscribe policy execution failed", "error", err)
 		http.Error(w, "policy execution failed", http.StatusInternalServerError)
 		return
 	}
 	if shortCircuited {
-		writePolicyResponse(w, message, http.StatusForbidden, "forbidden by policy")
+		writePolicyResponse(w, nil, http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized))
 		return
 	}
 
@@ -342,7 +342,7 @@ func (h *WebhookReceiverHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	}
 	if shortCircuited {
 		slog.Info("Inbound request rejected by policy", "channel", channelName, "binding", h.bindingName)
-		writePolicyResponse(w, processed, http.StatusForbidden, "forbidden by policy")
+		writePolicyResponse(w, processed, http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized))
 		return
 	}
 


### PR DESCRIPTION
 ## Purpose

  WebSub runtime requests need consistent auth failure semantics and safer consumer-group identifiers. This change fixes two issues in event-gateway: policy-denied WebSub requests were returning 403 instead of 401, and callback-based
  consumer group IDs were using a shorter hash suffix that increases collision risk across subscriptions. Resolves N/A.

  ## Goals

  Return 401 Unauthorized for WebSub policy short-circuit responses.
  Reduce the risk of consumer group ID collisions for WebSub callback consumers.

  ## Approach

  Updated the WebSub receiver fallback policy response in event-gateway/gateway-runtime/internal/connectors/receiver/websub/handler.go to use 401 Unauthorized for subscribe, unsubscribe, and inbound webhook policy denials.
  Updated event-gateway/gateway-runtime/internal/connectors/receiver/websub/consumer_manager.go to use a longer SHA-256 prefix when deriving callback-based consumer group IDs.

  ## User stories

  As a client calling WebSub endpoints, I get a 401 response when access is denied by policy.
  As a runtime managing callback consumers, I get more stable and collision-resistant consumer group IDs.

  ## Documentation

  N/A. This is a small runtime behavior fix and does not introduce new user-facing configuration or APIs.

  ## Automation tests

  - Unit tests
    GOCACHE=/tmp/go-build-cache go test ./internal/connectors/receiver/websub
  - Integration tests
    N/A. No integration test changes were added in this branch.

  ## Security checks

  - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
  - Ran FindSecurityBugs plugin and verified report? no
  - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

  ## Samples

  N/A. No sample changes.

  ## Related PRs

  N/A

  ## Test environment

  Ubuntu 24.04.4 LTS, Go test run in local dev environment with GOCACHE=/tmp/go-build-cache.