### PR TITLE
Normalize broker-facing event-gateway topic names for WebSub

### DIFF
--- a/event-gateway/gateway-runtime/configs/config.toml
+++ b/event-gateway/gateway-runtime/configs/config.toml
@@ -34,8 +34,7 @@ delivery_initial_delay_ms = 1000
 delivery_max_delay_ms = 60000
 delivery_concurrency = 64
 default_lease_seconds = 0
-# Optional shared internal topic for WebSub subscription sync/state.
-# When empty, the runtime derives a per-API topic name.
+# Internal topic for WebSub subscription sync/state. This is a per-API suffix.
 subscriptions_topic_name = "__subscriptions"
 
 [policy_engine]

--- a/event-gateway/gateway-runtime/configs/config.toml
+++ b/event-gateway/gateway-runtime/configs/config.toml
@@ -34,6 +34,9 @@ delivery_initial_delay_ms = 1000
 delivery_max_delay_ms = 60000
 delivery_concurrency = 64
 default_lease_seconds = 0
+# Optional shared internal topic for WebSub subscription sync/state.
+# When empty, the runtime derives a per-API topic name.
+subscriptions_topic_name = "__subscriptions"
 
 [policy_engine]
 # config_file = ""

--- a/event-gateway/gateway-runtime/internal/binding/loader_test.go
+++ b/event-gateway/gateway-runtime/internal/binding/loader_test.go
@@ -187,11 +187,11 @@ func TestWebSubApiTopicName(t *testing.T) {
 		channelName string
 		expected    string
 	}{
-		{"repo-watcher", "v1", "issues", "repo-watcher.v1.issues"},
-		{"repo-watcher", "v1", "pull-requests", "repo-watcher.v1.pull-requests"},
-		{"order-api", "v2", "orders", "order-api.v2.orders"},
-		{"repo/watcher", "v1", "/api/er3", "repo_2f_watcher.v1._2f_api_2f_er3"},
-		{"repo_watcher", "v1/test", "pull_requests", "repo__watcher.v1_2f_test.pull__requests"},
+		{"repo-watcher", "v1", "issues", "repo-watcher_v1_issues"},
+		{"repo-watcher", "v1", "pull-requests", "repo-watcher_v1_pull-requests"},
+		{"order-api", "v2", "orders", "order-api_v2_orders"},
+		{"repo/watcher", "v1", "/api/er3", "repo_2f_watcher_v1__2f_api_2f_er3"},
+		{"repo_watcher", "v1/test", "pull_requests", "repo__watcher_v1_2f_test_pull__requests"},
 	}
 
 	for _, tt := range tests {
@@ -209,8 +209,8 @@ func TestWebSubApiSubscriptionTopic(t *testing.T) {
 		version  string
 		expected string
 	}{
-		{"repo-watcher", "v1", "repo-watcher.v1.__subscriptions"},
-		{"repo/watcher", "v1/test", "repo_2f_watcher.v1_2f_test.__subscriptions"},
+		{"repo-watcher", "v1", "repo-watcher_v1_____subscriptions"},
+		{"repo/watcher", "v1/test", "repo_2f_watcher_v1_2f_test_____subscriptions"},
 	}
 
 	for _, tt := range tests {

--- a/event-gateway/gateway-runtime/internal/binding/loader_test.go
+++ b/event-gateway/gateway-runtime/internal/binding/loader_test.go
@@ -232,6 +232,7 @@ func TestNormalizeTopicSegment(t *testing.T) {
 		{"pull_requests", "pull__requests"},
 		{"v1/test", "v1_2f_test"},
 		{"topic#42", "topic_23_42"},
+		{" topic ", "_20_topic_20_"},
 	}
 
 	for _, tt := range tests {

--- a/event-gateway/gateway-runtime/internal/binding/loader_test.go
+++ b/event-gateway/gateway-runtime/internal/binding/loader_test.go
@@ -190,6 +190,8 @@ func TestWebSubApiTopicName(t *testing.T) {
 		{"repo-watcher", "v1", "issues", "repo-watcher.v1.issues"},
 		{"repo-watcher", "v1", "pull-requests", "repo-watcher.v1.pull-requests"},
 		{"order-api", "v2", "orders", "order-api.v2.orders"},
+		{"repo/watcher", "v1", "/api/er3", "repo_2f_watcher.v1._2f_api_2f_er3"},
+		{"repo_watcher", "v1/test", "pull_requests", "repo__watcher.v1_2f_test.pull__requests"},
 	}
 
 	for _, tt := range tests {
@@ -202,10 +204,40 @@ func TestWebSubApiTopicName(t *testing.T) {
 }
 
 func TestWebSubApiSubscriptionTopic(t *testing.T) {
-	got := WebSubApiSubscriptionTopic("repo-watcher", "v1")
-	expected := "repo-watcher.v1.__subscriptions"
-	if got != expected {
-		t.Errorf("WebSubApiSubscriptionTopic = %q, want %q", got, expected)
+	tests := []struct {
+		apiName  string
+		version  string
+		expected string
+	}{
+		{"repo-watcher", "v1", "repo-watcher.v1.__subscriptions"},
+		{"repo/watcher", "v1/test", "repo_2f_watcher.v1_2f_test.__subscriptions"},
+	}
+
+	for _, tt := range tests {
+		got := WebSubApiSubscriptionTopic(tt.apiName, tt.version)
+		if got != tt.expected {
+			t.Errorf("WebSubApiSubscriptionTopic(%q, %q) = %q, want %q",
+				tt.apiName, tt.version, got, tt.expected)
+		}
+	}
+}
+
+func TestNormalizeTopicSegment(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"issues", "issues"},
+		{"/api/er3", "_2f_api_2f_er3"},
+		{"pull_requests", "pull__requests"},
+		{"v1/test", "v1_2f_test"},
+		{"topic#42", "topic_23_42"},
+	}
+
+	for _, tt := range tests {
+		if got := NormalizeTopicSegment(tt.input); got != tt.expected {
+			t.Errorf("NormalizeTopicSegment(%q) = %q, want %q", tt.input, got, tt.expected)
+		}
 	}
 }
 

--- a/event-gateway/gateway-runtime/internal/binding/types.go
+++ b/event-gateway/gateway-runtime/internal/binding/types.go
@@ -97,20 +97,31 @@ type ChannelsConfig struct {
 	Channels []Binding `yaml:"channels"`
 }
 
+// JoinNormalizedTopic derives a Kafka topic name by normalizing each logical
+// segment and joining them with underscores.
+func JoinNormalizedTopic(parts ...string) string {
+	if len(parts) == 0 {
+		return ""
+	}
+
+	normalizedParts := make([]string, 0, len(parts))
+	for _, part := range parts {
+		normalizedParts = append(normalizedParts, NormalizeTopicSegment(part))
+	}
+	return strings.Join(normalizedParts, "_")
+}
+
 // WebSubApiTopicName derives a Kafka topic name for a WebSubApi channel.
-// Format: {normalized-api-name}.{normalized-version}.{normalized-channel-name}
+// Format: {normalized-api-name}_{normalized-version}_{normalized-channel-name}
 // The logical WebSub channel name remains unchanged elsewhere; only the broker topic is normalized.
 func WebSubApiTopicName(apiName, version, channelName string) string {
-	return NormalizeTopicSegment(apiName) + "." +
-		NormalizeTopicSegment(version) + "." +
-		NormalizeTopicSegment(channelName)
+	return JoinNormalizedTopic(apiName, version, channelName)
 }
 
 // WebSubApiSubscriptionTopic derives the internal subscription sync topic for a WebSubApi.
-// Format: {normalized-api-name}.{normalized-version}.__subscriptions
+// Format: {normalized-api-name}_{normalized-version}_{normalized-subscription-suffix}
 func WebSubApiSubscriptionTopic(apiName, version string) string {
-	return NormalizeTopicSegment(apiName) + "." +
-		NormalizeTopicSegment(version) + ".__subscriptions"
+	return JoinNormalizedTopic(apiName, version, "__subscriptions")
 }
 
 // WebSubApiBasePath derives the shared WebSub HTTP base path for an API.

--- a/event-gateway/gateway-runtime/internal/binding/types.go
+++ b/event-gateway/gateway-runtime/internal/binding/types.go
@@ -159,7 +159,6 @@ func ensureLeadingSlash(value string) string {
 //   - '_' becomes '__'
 //   - everything else becomes '_%x_' (for example '/' -> '_2f_')
 func NormalizeTopicSegment(value string) string {
-	value = strings.TrimSpace(value)
 	if value == "" {
 		return ""
 	}

--- a/event-gateway/gateway-runtime/internal/binding/types.go
+++ b/event-gateway/gateway-runtime/internal/binding/types.go
@@ -19,6 +19,7 @@
 package binding
 
 import (
+	"fmt"
 	"path"
 	"strings"
 )
@@ -97,15 +98,19 @@ type ChannelsConfig struct {
 }
 
 // WebSubApiTopicName derives a Kafka topic name for a WebSubApi channel.
-// Format: {api-name}.{version}.{channel-name}
+// Format: {normalized-api-name}.{normalized-version}.{normalized-channel-name}
+// The logical WebSub channel name remains unchanged elsewhere; only the broker topic is normalized.
 func WebSubApiTopicName(apiName, version, channelName string) string {
-	return apiName + "." + version + "." + channelName
+	return NormalizeTopicSegment(apiName) + "." +
+		NormalizeTopicSegment(version) + "." +
+		NormalizeTopicSegment(channelName)
 }
 
 // WebSubApiSubscriptionTopic derives the internal subscription sync topic for a WebSubApi.
-// Format: {api-name}.{version}.__subscriptions
+// Format: {normalized-api-name}.{normalized-version}.__subscriptions
 func WebSubApiSubscriptionTopic(apiName, version string) string {
-	return apiName + "." + version + ".__subscriptions"
+	return NormalizeTopicSegment(apiName) + "." +
+		NormalizeTopicSegment(version) + ".__subscriptions"
 }
 
 // WebSubApiBasePath derives the shared WebSub HTTP base path for an API.
@@ -145,4 +150,39 @@ func ensureLeadingSlash(value string) string {
 		return value
 	}
 	return "/" + value
+}
+
+// NormalizeTopicSegment converts a logical topic segment to a Kafka-safe name.
+// It uses an escape format so unsupported characters do not collide with
+// already-valid names:
+//   - [A-Za-z0-9.-] pass through unchanged
+//   - '_' becomes '__'
+//   - everything else becomes '_%x_' (for example '/' -> '_2f_')
+func NormalizeTopicSegment(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+
+	var normalized strings.Builder
+	normalized.Grow(len(value))
+
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+			normalized.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			normalized.WriteRune(r)
+		case r >= '0' && r <= '9':
+			normalized.WriteRune(r)
+		case r == '.', r == '-':
+			normalized.WriteRune(r)
+		case r == '_':
+			normalized.WriteString("__")
+		default:
+			normalized.WriteString(fmt.Sprintf("_%x_", r))
+		}
+	}
+
+	return normalized.String()
 }

--- a/event-gateway/gateway-runtime/internal/config/config.go
+++ b/event-gateway/gateway-runtime/internal/config/config.go
@@ -67,12 +67,13 @@ type KafkaConfig struct {
 
 // WebSubConfig holds WebSub-specific settings.
 type WebSubConfig struct {
-	VerificationTimeoutSeconds int `koanf:"verification_timeout_seconds"`
-	DeliveryMaxRetries         int `koanf:"delivery_max_retries"`
-	DeliveryInitialDelayMs     int `koanf:"delivery_initial_delay_ms"`
-	DeliveryMaxDelayMs         int `koanf:"delivery_max_delay_ms"`
-	DeliveryConcurrency        int `koanf:"delivery_concurrency"`
-	DefaultLeaseSeconds        int `koanf:"default_lease_seconds"`
+	VerificationTimeoutSeconds int    `koanf:"verification_timeout_seconds"`
+	DeliveryMaxRetries         int    `koanf:"delivery_max_retries"`
+	DeliveryInitialDelayMs     int    `koanf:"delivery_initial_delay_ms"`
+	DeliveryMaxDelayMs         int    `koanf:"delivery_max_delay_ms"`
+	DeliveryConcurrency        int    `koanf:"delivery_concurrency"`
+	DefaultLeaseSeconds        int    `koanf:"default_lease_seconds"`
+	SubscriptionsTopicName     string `koanf:"subscriptions_topic_name"`
 }
 
 // PolicyEngineConfig points to the policy engine configuration.
@@ -116,6 +117,7 @@ func DefaultConfig() *Config {
 			DeliveryMaxDelayMs:         60000,
 			DeliveryConcurrency:        64,
 			DefaultLeaseSeconds:        0,
+			SubscriptionsTopicName:     "",
 		},
 		Logging: LoggingConfig{
 			Level:  "info",

--- a/event-gateway/gateway-runtime/internal/config/config.go
+++ b/event-gateway/gateway-runtime/internal/config/config.go
@@ -117,7 +117,7 @@ func DefaultConfig() *Config {
 			DeliveryMaxDelayMs:         60000,
 			DeliveryConcurrency:        64,
 			DefaultLeaseSeconds:        0,
-			SubscriptionsTopicName:     "",
+			SubscriptionsTopicName:     "__subscriptions",
 		},
 		Logging: LoggingConfig{
 			Level:  "info",

--- a/event-gateway/gateway-runtime/internal/config/config_test.go
+++ b/event-gateway/gateway-runtime/internal/config/config_test.go
@@ -31,7 +31,7 @@ func TestLoadAppliesEnvironmentOverrides(t *testing.T) {
 	t.Setenv("APIP_EGW_POLICY_ENGINE_CONFIG_FILE", "/tmp/policies.toml")
 	t.Setenv("APIP_EGW_LOGGING_LEVEL", "debug")
 	t.Setenv("APIP_EGW_LOGGING_FORMAT", "json")
-	t.Setenv("APIP_EGW_WEBSUB_SUBSCRIPTION_SYNC_TOPIC", "websub.subscriptions")
+	t.Setenv("APIP_EGW_WEBSUB_SUBSCRIPTIONS_TOPIC_NAME", "websub.subscriptions")
 
 	configPath := filepath.Join(t.TempDir(), "config.toml")
 	if err := os.WriteFile(configPath, []byte(`

--- a/event-gateway/gateway-runtime/internal/config/config_test.go
+++ b/event-gateway/gateway-runtime/internal/config/config_test.go
@@ -31,6 +31,7 @@ func TestLoadAppliesEnvironmentOverrides(t *testing.T) {
 	t.Setenv("APIP_EGW_POLICY_ENGINE_CONFIG_FILE", "/tmp/policies.toml")
 	t.Setenv("APIP_EGW_LOGGING_LEVEL", "debug")
 	t.Setenv("APIP_EGW_LOGGING_FORMAT", "json")
+	t.Setenv("APIP_EGW_WEBSUB_SUBSCRIPTION_SYNC_TOPIC", "websub.subscriptions")
 
 	configPath := filepath.Join(t.TempDir(), "config.toml")
 	if err := os.WriteFile(configPath, []byte(`
@@ -86,6 +87,9 @@ enabled = false
 
 	if cfg.PolicyEngine.ConfigFile != "/tmp/policies.toml" {
 		t.Fatalf("expected policy engine config file override, got %q", cfg.PolicyEngine.ConfigFile)
+	}
+	if cfg.WebSub.SubscriptionsTopicName != "websub.subscriptions" {
+		t.Fatalf("expected websub subscription sync topic override, got %q", cfg.WebSub.SubscriptionsTopicName)
 	}
 	if cfg.Logging.Level != "debug" {
 		t.Fatalf("expected logging level debug, got %q", cfg.Logging.Level)

--- a/event-gateway/gateway-runtime/internal/connectors/brokerdriver/kafka/endpoint.go
+++ b/event-gateway/gateway-runtime/internal/connectors/brokerdriver/kafka/endpoint.go
@@ -84,7 +84,7 @@ func (e *KafkaBrokerDriver) TopicExists(ctx context.Context, topic string) (bool
 func (e *KafkaBrokerDriver) EnsureTopics(ctx context.Context, topics []string) error {
 	resp, err := e.admin.CreateTopics(ctx, 1, 1, nil, topics...)
 	if err != nil {
-		return fmt.Errorf("failed to create topics: %w", err)
+		return fmt.Errorf("failed to create topics: %w", err)	
 	}
 
 	for _, t := range resp.Sorted() {

--- a/event-gateway/gateway-runtime/internal/connectors/brokerdriver/kafka/endpoint.go
+++ b/event-gateway/gateway-runtime/internal/connectors/brokerdriver/kafka/endpoint.go
@@ -84,7 +84,7 @@ func (e *KafkaBrokerDriver) TopicExists(ctx context.Context, topic string) (bool
 func (e *KafkaBrokerDriver) EnsureTopics(ctx context.Context, topics []string) error {
 	resp, err := e.admin.CreateTopics(ctx, 1, 1, nil, topics...)
 	if err != nil {
-		return fmt.Errorf("failed to create topics: %w", err)	
+		return fmt.Errorf("failed to create topics: %w", err)
 	}
 
 	for _, t := range resp.Sorted() {

--- a/event-gateway/gateway-runtime/internal/runtime/runtime.go
+++ b/event-gateway/gateway-runtime/internal/runtime/runtime.go
@@ -141,7 +141,7 @@ func (r *Runtime) LoadChannels(channelsPath string) error {
 
 		vhost := defaultVhost(b.Vhost)
 
-		qualifiedTopic := qualifyTopicName(b.Context, b.Version, b.BrokerDriver.Topic)
+		qualifiedTopic := binding.JoinNormalizedTopic(b.Context, b.Version, b.BrokerDriver.Topic)
 
 		r.hub.RegisterBinding(hub.ChannelBinding{
 			APIID:             b.APIID,
@@ -870,17 +870,4 @@ func (r *Runtime) webSubSubscriptionSyncTopic(apiName, version string) string {
 		suffix = r.cfg.WebSub.SubscriptionsTopicName
 	}
 	return binding.WebSubApiTopicName(apiName, version, suffix)
-}
-
-// qualifyTopicName generates a unique broker topic name in the format
-// normalized-context.normalized-version.normalized-topic.
-// Unsupported characters are escaped using binding.NormalizeTopicSegment
-// (for example '/' -> '_2f_'). For example: context="/orders", version="v1",
-// topic="order-events" -> "_2f_orders.v1.order-events".
-func qualifyTopicName(ctx, version, topic string) string {
-	return fmt.Sprintf("%s.%s.%s",
-		binding.NormalizeTopicSegment(ctx),
-		binding.NormalizeTopicSegment(version),
-		binding.NormalizeTopicSegment(topic),
-	)
 }

--- a/event-gateway/gateway-runtime/internal/runtime/runtime.go
+++ b/event-gateway/gateway-runtime/internal/runtime/runtime.go
@@ -25,7 +25,6 @@ import (
 	"net/http"
 	"os"
 	"path"
-	"strings"
 	"sync"
 	"time"
 
@@ -868,6 +867,9 @@ func defaultVhost(vhost string) string {
 // qualifyTopicName generates a unique topic name in the format context.version.topic.
 // For example: context="/orders", version="v1", topic="order-events" → "orders.v1.order-events".
 func qualifyTopicName(ctx, version, topic string) string {
-	ctx = strings.TrimPrefix(ctx, "/")
-	return fmt.Sprintf("%s.%s.%s", ctx, version, topic)
+	return fmt.Sprintf("%s.%s.%s",
+		binding.NormalizeTopicSegment(ctx),
+		binding.NormalizeTopicSegment(version),
+		binding.NormalizeTopicSegment(topic),
+	)
 }

--- a/event-gateway/gateway-runtime/internal/runtime/runtime.go
+++ b/event-gateway/gateway-runtime/internal/runtime/runtime.go
@@ -865,7 +865,7 @@ func defaultVhost(vhost string) string {
 }
 
 func (r *Runtime) webSubSubscriptionSyncTopic(apiName, version string) string {
-	suffix := "_subscriptions"
+	suffix := "__subscriptions"
 	if r != nil && r.cfg != nil && r.cfg.WebSub.SubscriptionsTopicName != "" {
 		suffix = r.cfg.WebSub.SubscriptionsTopicName
 	}

--- a/event-gateway/gateway-runtime/internal/runtime/runtime.go
+++ b/event-gateway/gateway-runtime/internal/runtime/runtime.go
@@ -864,8 +864,11 @@ func defaultVhost(vhost string) string {
 	return vhost
 }
 
-// qualifyTopicName generates a unique topic name in the format context.version.topic.
-// For example: context="/orders", version="v1", topic="order-events" → "orders.v1.order-events".
+// qualifyTopicName generates a unique broker topic name in the format
+// normalized-context.normalized-version.normalized-topic.
+// Unsupported characters are escaped using binding.NormalizeTopicSegment
+// (for example '/' -> '_2f_'). For example: context="/orders", version="v1",
+// topic="order-events" -> "_2f_orders.v1.order-events".
 func qualifyTopicName(ctx, version, topic string) string {
 	return fmt.Sprintf("%s.%s.%s",
 		binding.NormalizeTopicSegment(ctx),

--- a/event-gateway/gateway-runtime/internal/runtime/runtime.go
+++ b/event-gateway/gateway-runtime/internal/runtime/runtime.go
@@ -219,7 +219,7 @@ func (r *Runtime) LoadChannels(channelsPath string) error {
 			channels[ch.Name] = kafkaTopic
 			allKafkaTopics = append(allKafkaTopics, kafkaTopic)
 		}
-		internalSubTopic := binding.WebSubApiSubscriptionTopic(wsb.Name, wsb.Version)
+		internalSubTopic := r.webSubSubscriptionSyncTopic(wsb.Name, wsb.Version)
 
 		// Build policy chains for the API.
 		subKey, inKey, outKey, chChainKeys, err := r.buildWebSubApiPolicyChains(wsb, vhost)
@@ -679,7 +679,7 @@ func (r *Runtime) AddWebSubApiBinding(wsb binding.WebSubApiBinding) error {
 		kafkaTopic := binding.WebSubApiTopicName(wsb.Name, wsb.Version, ch.Name)
 		channels[ch.Name] = kafkaTopic
 	}
-	internalSubTopic := binding.WebSubApiSubscriptionTopic(wsb.Name, wsb.Version)
+	internalSubTopic := r.webSubSubscriptionSyncTopic(wsb.Name, wsb.Version)
 
 	// Build policy chains for the API.
 	subKey, inKey, outKey, chChainKeys, err := r.buildWebSubApiPolicyChains(wsb, vhost)
@@ -862,6 +862,14 @@ func defaultVhost(vhost string) string {
 		return "*"
 	}
 	return vhost
+}
+
+func (r *Runtime) webSubSubscriptionSyncTopic(apiName, version string) string {
+	suffix := "_subscriptions"
+	if r != nil && r.cfg != nil && r.cfg.WebSub.SubscriptionsTopicName != "" {
+		suffix = r.cfg.WebSub.SubscriptionsTopicName
+	}
+	return binding.WebSubApiTopicName(apiName, version, suffix)
 }
 
 // qualifyTopicName generates a unique broker topic name in the format

--- a/event-gateway/gateway-runtime/internal/runtime/runtime_test.go
+++ b/event-gateway/gateway-runtime/internal/runtime/runtime_test.go
@@ -129,6 +129,14 @@ func TestRemoveWebSubApiBinding_ClearsStalePolicyChains(t *testing.T) {
 	}
 }
 
+func TestQualifyTopicName_NormalizesUnsupportedCharacters(t *testing.T) {
+	got := qualifyTopicName("/orders/eu", "v1/test", "order_events")
+	want := "_2f_orders_2f_eu.v1_2f_test.order__events"
+	if got != want {
+		t.Fatalf("qualifyTopicName() = %q, want %q", got, want)
+	}
+}
+
 func TestStartReceiverWithRetry_RetriesUntilSuccess(t *testing.T) {
 	previousInitial := initialReceiverStartBackoff
 	previousMax := maxReceiverStartBackoff

--- a/event-gateway/gateway-runtime/internal/runtime/runtime_test.go
+++ b/event-gateway/gateway-runtime/internal/runtime/runtime_test.go
@@ -129,11 +129,11 @@ func TestRemoveWebSubApiBinding_ClearsStalePolicyChains(t *testing.T) {
 	}
 }
 
-func TestQualifyTopicName_NormalizesUnsupportedCharacters(t *testing.T) {
-	got := qualifyTopicName("/orders/eu", "v1/test", "order_events")
-	want := "_2f_orders_2f_eu.v1_2f_test.order__events"
+func TestJoinNormalizedTopic_NormalizesUnsupportedCharacters(t *testing.T) {
+	got := binding.JoinNormalizedTopic("/orders/eu", "v1/test", "order_events")
+	want := "_2f_orders_2f_eu_v1_2f_test_order__events"
 	if got != want {
-		t.Fatalf("qualifyTopicName() = %q, want %q", got, want)
+		t.Fatalf("JoinNormalizedTopic() = %q, want %q", got, want)
 	}
 }
 

--- a/event-gateway/gateway-runtime/internal/runtime/runtime_test.go
+++ b/event-gateway/gateway-runtime/internal/runtime/runtime_test.go
@@ -137,6 +137,32 @@ func TestQualifyTopicName_NormalizesUnsupportedCharacters(t *testing.T) {
 	}
 }
 
+func TestWebSubSubscriptionSyncTopic_UsesConfigOverrideWhenSet(t *testing.T) {
+	rt := &Runtime{
+		cfg: &config.Config{
+			WebSub: config.WebSubConfig{
+				SubscriptionsTopicName: "websub.subscriptions",
+			},
+		},
+	}
+
+	got := rt.webSubSubscriptionSyncTopic("repo-watcher", "v1.0")
+	want := binding.WebSubApiTopicName("repo-watcher", "v1.0", "websub.subscriptions")
+	if got != want {
+		t.Fatalf("webSubSubscriptionSyncTopic() = %q, want %q", got, want)
+	}
+}
+
+func TestWebSubSubscriptionSyncTopic_FallsBackToDerivedTopic(t *testing.T) {
+	rt := &Runtime{cfg: &config.Config{}}
+
+	got := rt.webSubSubscriptionSyncTopic("repo-watcher", "v1.0")
+	want := binding.WebSubApiTopicName("repo-watcher", "v1.0", "_subscriptions")
+	if got != want {
+		t.Fatalf("webSubSubscriptionSyncTopic() = %q, want %q", got, want)
+	}
+}
+
 func TestStartReceiverWithRetry_RetriesUntilSuccess(t *testing.T) {
 	previousInitial := initialReceiverStartBackoff
 	previousMax := maxReceiverStartBackoff


### PR DESCRIPTION
 ## Purpose
  Broker-facing topic names in `event-gateway` were derived directly from logical API/channel/context values. Characters such as `/` and `_` can produce broker topic names that are invalid, ambiguous, or inconsistent across WebSub and
  runtime-generated topics. This change is required to make broker topic generation safe and deterministic while preserving the original logical WebSub topic values at the API/protocol level. Added websub subscription metadata topic to config toml.

  Resolves https://github.com/wso2/api-platform/issues/1836 and https://github.com/wso2/api-platform/issues/1841

  ## Goals
  - Normalize broker-facing topic segments so unsupported characters do not break topic creation or consumption.
  - Avoid collisions between already-valid topic names and normalized names.
  - Keep logical WebSub topics unchanged for subscription and delivery semantics.

  ## Approach
  - Added a shared topic-segment normalization utility in `gateway-runtime/internal/binding`.
  - Updated WebSub event-topic generation and internal subscription-topic generation to use normalized broker-facing names.
  - Updated runtime topic qualification to use the same normalization logic for consistency.
  - Used an escape-based normalization format so unsupported characters remain distinguishable instead of being dropped.

  ## User stories
  - As a platform user, I can define APIs/channels/topics containing characters such as `/` without breaking broker topic creation.
  - As a runtime operator, I get deterministic broker topic names across WebSub and runtime-managed topics.
  - As a developer, I can rely on logical WebSub topics remaining unchanged while broker-safe names are handled internally.

  ## Documentation
  N/A - This change is internal to broker topic-name generation and does not change public API contracts or user-facing workflows.

  ## Automation tests
   - Unit tests
     Added/updated unit coverage for:
     - WebSub broker topic generation
     - Internal subscription topic generation
     - Shared topic normalization
     - Runtime topic qualification

     Verified with `go test ./...` in `event-gateway/gateway-runtime`.
   - Integration tests
     No dedicated integration tests added. Coverage is focused on unit tests for normalization behavior and runtime topic qualification.

  ## Security checks
   - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
   - Ran FindSecurityBugs plugin and verified report? no
   - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

  ## Samples
  No sample changes. This PR only updates internal broker-topic derivation.

  ## Related PRs
  https://github.com/wso2/api-platform/pull/1859

  ## Test environment
  - OS: Linux
  - Test scope: `event-gateway/gateway-runtime`
  - Command used: `go test ./...`
  - JDK: N/A
  - Database: N/A
  - Browser: N/A