### PR TITLE
Revert generate cert file permission

### DIFF
--- a/event-gateway/docker/kafka/generate-certs.sh
+++ b/event-gateway/docker/kafka/generate-certs.sh
@@ -92,5 +92,7 @@ keytool \
   -storepass "${password}" \
   -file "${cert_dir}/ca.crt"
 
+# Local dev: these files are shared read-only with the Kafka, Kafka UI, and runtime
+# containers via a Docker volume, so they must remain world-readable here.
 chmod 0644 "${cert_dir}/ca.crt"
-chmod 0600 "${cert_dir}/kafka.keystore.jks" "${cert_dir}/kafka.truststore.jks"
+chmod 0644 "${cert_dir}/kafka.keystore.jks" "${cert_dir}/kafka.truststore.jks"


### PR DESCRIPTION
 ## Purpose

  Enable local Event Gateway Kafka TLS/SASL development and harden a few related runtime paths. Resolves N/A.

  ## Goals

  Allow the dev Kafka stack to start reliably with generated certs, support Kafka TLS/SASL config in the runtime, and keep WebSub subscription sync and compacted-topic handling correct.

  ## Approach

  Added local Kafka cert generation and compose wiring, implemented Kafka TLS/SASL config support in the broker driver, verified existing compacted topics before accepting them, and removed Kafka-specific coupling from subscription
  sync code.

  ## User stories

  As a developer, I can run the local Event Gateway stack with secured Kafka and have WebSub state sync continue to work correctly.

  ## Documentation

  N/A - local dev and internal runtime behavior changes only.

  ## Automation tests

  - Unit tests
    Focused Kafka broker-driver tests added/updated; targeted package tests passed locally.
  - Integration tests
    Not run.

  ## Security checks

  - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
  - Ran FindSecurityBugs plugin and verified report? no
  - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

  ## Samples

  Local Docker Compose Kafka dev setup with generated TLS artifacts.

  ## Related PRs

  N/A

  ## Test environment

  Ubuntu 24.04 local dev environment.