### PR TITLE
feat(platform-api): allow x.x.x-preview gateway version on registration

### DIFF
--- a/platform-api/src/internal/handler/gateway.go
+++ b/platform-api/src/internal/handler/gateway.go
@@ -34,8 +34,11 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// gatewayVersionPattern enforces `major.minor` (1–6 digits each) for the registration version field.
-var gatewayVersionPattern = regexp.MustCompile(`^[0-9]{1,6}\.[0-9]{1,6}$`)
+// gatewayVersionPattern accepts two shapes for the registration version field:
+//   - `major.minor`                          (e.g. "1.0")
+//   - `major.minor.patch-preview-<numbers>`  (e.g. "1.1.0-preview-202603",
+//     "1.1.0-preview-202603.1")
+var gatewayVersionPattern = regexp.MustCompile(`^[0-9]{1,6}\.[0-9]{1,6}(\.[0-9]{1,6}-preview-[0-9]+(\.[0-9]+)*)?$`)
 
 // GatewayHandler handles HTTP requests for gateway operations
 type GatewayHandler struct {
@@ -97,7 +100,7 @@ func (h *GatewayHandler) CreateGateway(c *gin.Context) {
 	}
 	if version != "" && !gatewayVersionPattern.MatchString(version) {
 		c.JSON(http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request",
-			"version must be in 'major.minor' format (e.g. '1.0')"))
+			"version must be in 'major.minor' format (e.g. '1.0') or 'major.minor.patch-preview-<build>' format (e.g. '1.1.0-preview-202603' or '1.1.0-preview-202603.1')"))
 		return
 	}
 

--- a/platform-api/src/resources/openapi.yaml
+++ b/platform-api/src/resources/openapi.yaml
@@ -5914,8 +5914,8 @@ components:
           example: {"region": "us-west", "tier": "premium"}
         version:
           type: string
-          pattern: '^[0-9]{1,6}\.[0-9]{1,6}$'
-          description: Gateway version in `major.minor` format. Defaults to `1.0` if not provided.
+          pattern: '^[0-9]{1,6}\.[0-9]{1,6}(\.[0-9]{1,6}-preview-[0-9]+(\.[0-9]+)*)?$'
+          description: Gateway version in `major.minor` format (e.g. `1.0`) or `major.minor.patch-preview-<build>` format (e.g. `1.1.0-preview-202603` or `1.1.0-preview-202603.1`). Defaults to `1.0` if not provided.
           default: "1.0"
           example: "1.0"
     CustomPolicyResponse:
@@ -6050,7 +6050,7 @@ components:
           example: "regular"
         version:
           type: string
-          description: Gateway version in `major.minor` format
+          description: Gateway version in `major.minor` format (e.g. `1.0`) or `major.minor.patch-preview-<build>` format (e.g. `1.1.0-preview-202603` or `1.1.0-preview-202603.1`)
           example: "1.0"
         isActive:
           type: boolean


### PR DESCRIPTION
## Purpose
Relax the gateway-registration version regex to accept either `major.minor` (e.g. `1.0`) or `major.minor.patch-preview` (e.g. `1.2.0-preview`). The manifest comparator already strips the `-preview` suffix via extractMajorMinor, so a registered `1.2.0-preview` matches a controller reporting any of `1.2.0-preview`, `1.2.0`, or `1.2`.

- update gatewayVersionPattern and the 400 error message
- update CreateGatewayRequest.version pattern, description, and GatewayResponse.version description in openapi.yaml

Related Issue:
https://github.com/wso2/api-platform/issues/1897