### PR TITLE
feat(platform-api): persist preview gateway versions verbatim

### DIFF
--- a/platform-api/src/internal/service/gateway.go
+++ b/platform-api/src/internal/service/gateway.go
@@ -455,14 +455,19 @@ func (s *GatewayService) RegisterGateway(orgID, name, displayName, description, 
 		return nil, err
 	}
 
-	if strings.TrimSpace(version) == "" {
+	version = strings.TrimSpace(version)
+	if version == "" {
 		version = defaultGatewayVersion
 	}
-	// Canonicalize so equality checks against controller-reported versions
+	// Preview versions (e.g. "1.1.0-preview-202603") are persisted verbatim so
+	// the exact build is preserved. Stable versions are canonicalized to
+	// `major.minor` so equality checks against controller-reported versions
 	// (also normalized via extractMajorMinor) cannot diverge over leading
 	// zeros or other lexical variants.
-	if canonical := extractMajorMinor(version); canonical != "" {
-		version = canonical
+	if !strings.Contains(version, "-preview") {
+		if canonical := extractMajorMinor(version); canonical != "" {
+			version = canonical
+		}
 	}
 
 	// 2. Validate organization exists


### PR DESCRIPTION
## Purpose
Preview versions (e.g. "1.1.0-preview-202603") sent during gateway registration are now stored as-is, preserving the exact build identifier. Stable versions continue to be canonicalized to `major.minor` form. Manifest version comparison is unaffected since extractMajorMinor strips the preview suffix.

Related Issue:
https://github.com/wso2/api-platform/issues/1897