### PR TITLE
feat(platform-api): add gateway version verification flag

### DIFF
--- a/platform-api/src/config/config.go
+++ b/platform-api/src/config/config.go
@@ -55,6 +55,18 @@ type Server struct {
 
 	// API key configurations
 	APIKey APIKey `envconfig:"API_KEY"`
+
+	// Gateway configurations
+	Gateway Gateway `envconfig:"GATEWAY"`
+}
+
+// Gateway holds gateway-related configuration.
+type Gateway struct {
+	// EnableVersionVerification controls whether the platform API rejects gateway
+	// connections whose reported version does not match the registered version.
+	// When false (default), a mismatch is logged and the connection is allowed to proceed.
+	// Env: GATEWAY_ENABLE_VERSION_VERIFICATION (default: false)
+	EnableVersionVerification bool `envconfig:"ENABLE_VERSION_VERIFICATION" default:"false"`
 }
 
 // TLS holds TLS certificate configuration

--- a/platform-api/src/internal/server/server.go
+++ b/platform-api/src/internal/server/server.go
@@ -187,7 +187,7 @@ func StartPlatformAPIServer(cfg *config.Server, slogger *slog.Logger) (*Server, 
 	appService := service.NewApplicationService(appRepo, projectRepo, orgRepo, apiRepo, gatewayEventsService, slogger)
 	apiService := service.NewAPIService(apiRepo, projectRepo, orgRepo, gatewayRepo, deploymentRepo, devPortalRepo, publicationRepo,
 		subscriptionPlanRepo, customPolicyRepo, gatewayEventsService, devPortalService, apiUtil, slogger)
-	gatewayService := service.NewGatewayService(gatewayRepo, orgRepo, apiRepo, customPolicyRepo, gatewayEventsService, slogger)
+	gatewayService := service.NewGatewayService(gatewayRepo, orgRepo, apiRepo, customPolicyRepo, gatewayEventsService, slogger, cfg.Gateway.EnableVersionVerification)
 	subscriptionService := service.NewSubscriptionService(apiRepo, subscriptionRepo, gatewayEventsService, slogger)
 	subscriptionPlanService := service.NewSubscriptionPlanService(subscriptionPlanRepo, gatewayRepo, gatewayEventsService, slogger)
 	internalGatewayService := service.NewGatewayInternalAPIService(apiRepo, subscriptionRepo, subscriptionPlanRepo, llmProviderRepo, llmProxyRepo, mcpProxyRepo, websubAPIRepo, deploymentRepo, gatewayRepo, orgRepo, projectRepo, apiKeyRepo, artifactRepo, cfg, slogger)

--- a/platform-api/src/internal/service/gateway.go
+++ b/platform-api/src/internal/service/gateway.go
@@ -69,25 +69,28 @@ type Manifest struct {
 
 // GatewayService handles gateway business logic
 type GatewayService struct {
-	gatewayRepo          repository.GatewayRepository
-	orgRepo              repository.OrganizationRepository
-	apiRepo              repository.APIRepository
-	customPolicyRepo     repository.CustomPolicyRepository
-	gatewayEventsService *GatewayEventsService
-	slogger              *slog.Logger
+	gatewayRepo               repository.GatewayRepository
+	orgRepo                   repository.OrganizationRepository
+	apiRepo                   repository.APIRepository
+	customPolicyRepo          repository.CustomPolicyRepository
+	gatewayEventsService      *GatewayEventsService
+	slogger                   *slog.Logger
+	enableVersionVerification bool
 }
 
 // NewGatewayService creates a new gateway service
 func NewGatewayService(gatewayRepo repository.GatewayRepository, orgRepo repository.OrganizationRepository,
 	apiRepo repository.APIRepository, customPolicyRepo repository.CustomPolicyRepository,
-	gatewayEventsService *GatewayEventsService, slogger *slog.Logger) *GatewayService {
+	gatewayEventsService *GatewayEventsService, slogger *slog.Logger,
+	enableVersionVerification bool) *GatewayService {
 	return &GatewayService{
-		gatewayRepo:          gatewayRepo,
-		orgRepo:              orgRepo,
-		apiRepo:              apiRepo,
-		customPolicyRepo:     customPolicyRepo,
-		gatewayEventsService: gatewayEventsService,
-		slogger:              slogger,
+		gatewayRepo:               gatewayRepo,
+		orgRepo:                   orgRepo,
+		apiRepo:                   apiRepo,
+		customPolicyRepo:          customPolicyRepo,
+		gatewayEventsService:      gatewayEventsService,
+		slogger:                   slogger,
+		enableVersionVerification: enableVersionVerification,
 	}
 }
 
@@ -178,7 +181,15 @@ func (s *GatewayService) ReceiveGatewayManifest(orgID, gatewayID, gatewayVersion
 		registeredMinor = defaultGatewayVersion
 	}
 	if reportedMinor != registeredMinor {
-		return fmt.Errorf("%w: registered=%s, reported=%s", constants.ErrGatewayVersionMismatch, registeredMinor, reportedMinor)
+		if s.enableVersionVerification {
+			return fmt.Errorf("%w: registered=%s, reported=%s", constants.ErrGatewayVersionMismatch, registeredMinor, reportedMinor)
+		}
+		s.slogger.Warn("Gateway version mismatch ignored (verification disabled)",
+			slog.String("org_id", orgID),
+			slog.String("gateway_id", gatewayID),
+			slog.String("registered", registeredMinor),
+			slog.String("reported", reportedMinor),
+		)
 	}
 
 	reportedType := strings.TrimSpace(functionalityType)


### PR DESCRIPTION
## Purpose
Introduce GATEWAY_ENABLE_VERSION_VERIFICATION env flag (default false). When enabled, the platform API rejects gateway connections whose reported version does not match the registered version. When disabled, the mismatch is logged as a warning and the connection is allowed to proceed, easing rolling upgrades.

Related Issue:
https://github.com/wso2/api-platform/issues/1897
