### PR TITLE
fix(platform-api): allow regular gateway to connect as ai type

### DIFF
--- a/platform-api/src/config/config.go
+++ b/platform-api/src/config/config.go
@@ -67,6 +67,13 @@ type Gateway struct {
 	// When false (default), a mismatch is logged and the connection is allowed to proceed.
 	// Env: GATEWAY_ENABLE_VERSION_VERIFICATION (default: false)
 	EnableVersionVerification bool `envconfig:"ENABLE_VERSION_VERIFICATION" default:"false"`
+
+	// EnableFunctionalityTypeVerification controls whether the platform API rejects
+	// gateway connections whose reported functionality type is incompatible with the
+	// registered type. When false (default), a mismatch is logged and the connection
+	// is allowed to proceed.
+	// Env: GATEWAY_ENABLE_FUNCTIONALITY_TYPE_VERIFICATION (default: false)
+	EnableFunctionalityTypeVerification bool `envconfig:"ENABLE_FUNCTIONALITY_TYPE_VERIFICATION" default:"false"`
 }
 
 // TLS holds TLS certificate configuration

--- a/platform-api/src/internal/server/server.go
+++ b/platform-api/src/internal/server/server.go
@@ -187,7 +187,7 @@ func StartPlatformAPIServer(cfg *config.Server, slogger *slog.Logger) (*Server, 
 	appService := service.NewApplicationService(appRepo, projectRepo, orgRepo, apiRepo, gatewayEventsService, slogger)
 	apiService := service.NewAPIService(apiRepo, projectRepo, orgRepo, gatewayRepo, deploymentRepo, devPortalRepo, publicationRepo,
 		subscriptionPlanRepo, customPolicyRepo, gatewayEventsService, devPortalService, apiUtil, slogger)
-	gatewayService := service.NewGatewayService(gatewayRepo, orgRepo, apiRepo, customPolicyRepo, gatewayEventsService, slogger, cfg.Gateway.EnableVersionVerification)
+	gatewayService := service.NewGatewayService(gatewayRepo, orgRepo, apiRepo, customPolicyRepo, gatewayEventsService, slogger, cfg.Gateway.EnableVersionVerification, cfg.Gateway.EnableFunctionalityTypeVerification)
 	subscriptionService := service.NewSubscriptionService(apiRepo, subscriptionRepo, gatewayEventsService, slogger)
 	subscriptionPlanService := service.NewSubscriptionPlanService(subscriptionPlanRepo, gatewayRepo, gatewayEventsService, slogger)
 	internalGatewayService := service.NewGatewayInternalAPIService(apiRepo, subscriptionRepo, subscriptionPlanRepo, llmProviderRepo, llmProxyRepo, mcpProxyRepo, websubAPIRepo, deploymentRepo, gatewayRepo, orgRepo, projectRepo, apiKeyRepo, artifactRepo, cfg, slogger)

--- a/platform-api/src/internal/service/gateway.go
+++ b/platform-api/src/internal/service/gateway.go
@@ -156,6 +156,23 @@ func extractMajorMinor(raw string) string {
 // "functionalityType" field in the manifest payload (pre-1.1.0 builds).
 const legacyFunctionalityType = "regular"
 
+// functionalityTypeCompatible reports whether a controller-reported functionality
+// type is acceptable for the registered gateway type.
+//
+// AI and regular gateways are compiled into the same binary, which reports
+// itself as "regular". A gateway registered as either "ai" or "regular"
+// therefore accepts a controller reporting "regular". The event gateway has
+// its own binary and must match exactly.
+func functionalityTypeCompatible(registered, reported string) bool {
+	if registered == reported {
+		return true
+	}
+	if registered == constants.GatewayFunctionalityTypeAI && reported == constants.GatewayFunctionalityTypeRegular {
+		return true
+	}
+	return false
+}
+
 // ReceiveGatewayManifest stores the manifest posted by the gateway controller on connect.
 // All policies are stored with name and version; customer-managed policies include policy_definition.
 // gatewayVersion is the controller's reported build version; an empty string means the controller
@@ -196,7 +213,7 @@ func (s *GatewayService) ReceiveGatewayManifest(orgID, gatewayID, gatewayVersion
 	if reportedType == "" {
 		reportedType = legacyFunctionalityType
 	}
-	if reportedType != gateway.FunctionalityType {
+	if !functionalityTypeCompatible(gateway.FunctionalityType, reportedType) {
 		return fmt.Errorf("%w: registered=%s, reported=%s", constants.ErrGatewayFunctionalityTypeMismatch, gateway.FunctionalityType, reportedType)
 	}
 

--- a/platform-api/src/internal/service/gateway.go
+++ b/platform-api/src/internal/service/gateway.go
@@ -69,28 +69,30 @@ type Manifest struct {
 
 // GatewayService handles gateway business logic
 type GatewayService struct {
-	gatewayRepo               repository.GatewayRepository
-	orgRepo                   repository.OrganizationRepository
-	apiRepo                   repository.APIRepository
-	customPolicyRepo          repository.CustomPolicyRepository
-	gatewayEventsService      *GatewayEventsService
-	slogger                   *slog.Logger
-	enableVersionVerification bool
+	gatewayRepo                         repository.GatewayRepository
+	orgRepo                             repository.OrganizationRepository
+	apiRepo                             repository.APIRepository
+	customPolicyRepo                    repository.CustomPolicyRepository
+	gatewayEventsService                *GatewayEventsService
+	slogger                             *slog.Logger
+	enableVersionVerification           bool
+	enableFunctionalityTypeVerification bool
 }
 
 // NewGatewayService creates a new gateway service
 func NewGatewayService(gatewayRepo repository.GatewayRepository, orgRepo repository.OrganizationRepository,
 	apiRepo repository.APIRepository, customPolicyRepo repository.CustomPolicyRepository,
 	gatewayEventsService *GatewayEventsService, slogger *slog.Logger,
-	enableVersionVerification bool) *GatewayService {
+	enableVersionVerification bool, enableFunctionalityTypeVerification bool) *GatewayService {
 	return &GatewayService{
-		gatewayRepo:               gatewayRepo,
-		orgRepo:                   orgRepo,
-		apiRepo:                   apiRepo,
-		customPolicyRepo:          customPolicyRepo,
-		gatewayEventsService:      gatewayEventsService,
-		slogger:                   slogger,
-		enableVersionVerification: enableVersionVerification,
+		gatewayRepo:                         gatewayRepo,
+		orgRepo:                             orgRepo,
+		apiRepo:                             apiRepo,
+		customPolicyRepo:                    customPolicyRepo,
+		gatewayEventsService:                gatewayEventsService,
+		slogger:                             slogger,
+		enableVersionVerification:           enableVersionVerification,
+		enableFunctionalityTypeVerification: enableFunctionalityTypeVerification,
 	}
 }
 
@@ -214,7 +216,15 @@ func (s *GatewayService) ReceiveGatewayManifest(orgID, gatewayID, gatewayVersion
 		reportedType = legacyFunctionalityType
 	}
 	if !functionalityTypeCompatible(gateway.FunctionalityType, reportedType) {
-		return fmt.Errorf("%w: registered=%s, reported=%s", constants.ErrGatewayFunctionalityTypeMismatch, gateway.FunctionalityType, reportedType)
+		if s.enableFunctionalityTypeVerification {
+			return fmt.Errorf("%w: registered=%s, reported=%s", constants.ErrGatewayFunctionalityTypeMismatch, gateway.FunctionalityType, reportedType)
+		}
+		s.slogger.Warn("Gateway functionality type mismatch ignored (verification disabled)",
+			slog.String("org_id", orgID),
+			slog.String("gateway_id", gatewayID),
+			slog.String("registered", gateway.FunctionalityType),
+			slog.String("reported", reportedType),
+		)
 	}
 
 	entries := make([]GatewayPolicyDefinition, 0, len(policies))


### PR DESCRIPTION
## Purpose
AI and regular gateways share the same binary, which always reports its functionality type as "regular". Introduce  functionalityTypeCompatible to allow a controller reporting "regular" to match a gateway registered as either "ai" or "regular". Event gateways use a distinct binary and continue to require an exact match.

Related Issue:
https://github.com/wso2/api-platform/issues/1897

