### PR TITLE
Make the compacted topic's partition/replication settings configurable

### DIFF
--- a/event-gateway/gateway-runtime/configs/config.toml
+++ b/event-gateway/gateway-runtime/configs/config.toml
@@ -26,6 +26,9 @@ metrics_port = 9003
 # Default Kafka brokers. Channels can override with broker-driver.config.brokers.
 brokers = ["localhost:9092"]
 consumer_group_prefix = "event-gateway"
+# Partitions and replication factor used for internal compacted topics.
+compact_topic_partitions = 1
+compact_topic_replication_factor = 1
 tls = false
 # Optional PEM CA file for self-signed or private Kafka CAs.
 # tls_ca_file = "/etc/event-gateway/kafka/ca.crt"
@@ -70,4 +73,3 @@ allow_payloads = false
 enabled = true
 xds_address = "localhost:18001"
 # node_id = ""
-

--- a/event-gateway/gateway-runtime/internal/config/config.go
+++ b/event-gateway/gateway-runtime/internal/config/config.go
@@ -57,16 +57,18 @@ type ServerConfig struct {
 
 // KafkaConfig holds Kafka connection settings.
 type KafkaConfig struct {
-	Brokers             []string `koanf:"brokers"`
-	ConsumerGroupPrefix string   `koanf:"consumer_group_prefix"`
-	TLS                 bool     `koanf:"tls"`
-	TLSCAFile           string   `koanf:"tls_ca_file"`
-	TLSCertFile         string   `koanf:"tls_cert_file"`
-	TLSKeyFile          string   `koanf:"tls_key_file"`
-	TLSServerName       string   `koanf:"tls_server_name"`
-	SASLMechanism       string   `koanf:"sasl_mechanism"`
-	SASLUsername        string   `koanf:"sasl_username"`
-	SASLPassword        string   `koanf:"sasl_password"`
+	Brokers                       []string `koanf:"brokers"`
+	ConsumerGroupPrefix           string   `koanf:"consumer_group_prefix"`
+	CompactTopicPartitions        int      `koanf:"compact_topic_partitions"`
+	CompactTopicReplicationFactor int      `koanf:"compact_topic_replication_factor"`
+	TLS                           bool     `koanf:"tls"`
+	TLSCAFile                     string   `koanf:"tls_ca_file"`
+	TLSCertFile                   string   `koanf:"tls_cert_file"`
+	TLSKeyFile                    string   `koanf:"tls_key_file"`
+	TLSServerName                 string   `koanf:"tls_server_name"`
+	SASLMechanism                 string   `koanf:"sasl_mechanism"`
+	SASLUsername                  string   `koanf:"sasl_username"`
+	SASLPassword                  string   `koanf:"sasl_password"`
 }
 
 // WebSubConfig holds WebSub-specific settings.
@@ -111,8 +113,10 @@ func DefaultConfig() *Config {
 			MetricsPort:     9003,
 		},
 		Kafka: KafkaConfig{
-			Brokers:             []string{"localhost:9092"},
-			ConsumerGroupPrefix: "event-gateway",
+			Brokers:                       []string{"localhost:9092"},
+			ConsumerGroupPrefix:           "event-gateway",
+			CompactTopicPartitions:        1,
+			CompactTopicReplicationFactor: 1,
 		},
 		WebSub: WebSubConfig{
 			VerificationTimeoutSeconds: 10,
@@ -223,6 +227,8 @@ func mapEnvValue(path, value string) interface{} {
 		"server.websocket_port",
 		"server.admin_port",
 		"server.metrics_port",
+		"kafka.compact_topic_partitions",
+		"kafka.compact_topic_replication_factor",
 		"websub.verification_timeout_seconds",
 		"websub.delivery_max_retries",
 		"websub.delivery_initial_delay_ms",
@@ -294,6 +300,12 @@ func validate(cfg *Config) error {
 func validateKafkaConfig(kafkaCfg KafkaConfig) error {
 	if len(kafkaCfg.Brokers) == 0 {
 		return fmt.Errorf("kafka.brokers must contain at least one broker")
+	}
+	if kafkaCfg.CompactTopicPartitions <= 0 {
+		return fmt.Errorf("kafka.compact_topic_partitions must be a positive integer, got %d", kafkaCfg.CompactTopicPartitions)
+	}
+	if kafkaCfg.CompactTopicReplicationFactor <= 0 {
+		return fmt.Errorf("kafka.compact_topic_replication_factor must be a positive integer, got %d", kafkaCfg.CompactTopicReplicationFactor)
 	}
 
 	if kafkaCfg.TLS {

--- a/event-gateway/gateway-runtime/internal/connectors/brokerdriver/kafka/config.go
+++ b/event-gateway/gateway-runtime/internal/connectors/brokerdriver/kafka/config.go
@@ -159,8 +159,14 @@ func validateConnectionConfig(cfg ConnectionConfig) error {
 	if cfg.CompactTopicPartitions <= 0 {
 		return fmt.Errorf("kafka.compact_topic_partitions must be a positive integer, got %d", cfg.CompactTopicPartitions)
 	}
+	if cfg.CompactTopicPartitions > math.MaxInt32 {
+		return fmt.Errorf("kafka.compact_topic_partitions must be <= %d, got %d", math.MaxInt32, cfg.CompactTopicPartitions)
+	}
 	if cfg.CompactTopicReplicationFactor <= 0 {
 		return fmt.Errorf("kafka.compact_topic_replication_factor must be a positive integer, got %d", cfg.CompactTopicReplicationFactor)
+	}
+	if cfg.CompactTopicReplicationFactor > math.MaxInt16 {
+		return fmt.Errorf("kafka.compact_topic_replication_factor must be <= %d, got %d", math.MaxInt16, cfg.CompactTopicReplicationFactor)
 	}
 
 	if !cfg.TLS {

--- a/event-gateway/gateway-runtime/internal/connectors/brokerdriver/kafka/config.go
+++ b/event-gateway/gateway-runtime/internal/connectors/brokerdriver/kafka/config.go
@@ -34,29 +34,39 @@ import (
 
 // ConnectionConfig holds the Kafka connection settings used by the driver.
 type ConnectionConfig struct {
-	Brokers       []string
-	TLS           bool
-	TLSCAFile     string
-	TLSCertFile   string
-	TLSKeyFile    string
-	TLSServerName string
-	SASLMechanism string
-	SASLUsername  string
-	SASLPassword  string
+	Brokers                       []string
+	CompactTopicPartitions        int
+	CompactTopicReplicationFactor int
+	TLS                           bool
+	TLSCAFile                     string
+	TLSCertFile                   string
+	TLSKeyFile                    string
+	TLSServerName                 string
+	SASLMechanism                 string
+	SASLUsername                  string
+	SASLPassword                  string
 }
 
 // ResolveConnectionConfig merges global runtime config with per-binding overrides.
 func ResolveConnectionConfig(global config.KafkaConfig, overrides map[string]interface{}) (ConnectionConfig, error) {
 	cfg := ConnectionConfig{
-		Brokers:       append([]string(nil), global.Brokers...),
-		TLS:           global.TLS,
-		TLSCAFile:     global.TLSCAFile,
-		TLSCertFile:   global.TLSCertFile,
-		TLSKeyFile:    global.TLSKeyFile,
-		TLSServerName: global.TLSServerName,
-		SASLMechanism: global.SASLMechanism,
-		SASLUsername:  global.SASLUsername,
-		SASLPassword:  global.SASLPassword,
+		Brokers:                       append([]string(nil), global.Brokers...),
+		CompactTopicPartitions:        global.CompactTopicPartitions,
+		CompactTopicReplicationFactor: global.CompactTopicReplicationFactor,
+		TLS:                           global.TLS,
+		TLSCAFile:                     global.TLSCAFile,
+		TLSCertFile:                   global.TLSCertFile,
+		TLSKeyFile:                    global.TLSKeyFile,
+		TLSServerName:                 global.TLSServerName,
+		SASLMechanism:                 global.SASLMechanism,
+		SASLUsername:                  global.SASLUsername,
+		SASLPassword:                  global.SASLPassword,
+	}
+	if cfg.CompactTopicPartitions <= 0 {
+		cfg.CompactTopicPartitions = 1
+	}
+	if cfg.CompactTopicReplicationFactor <= 0 {
+		cfg.CompactTopicReplicationFactor = 1
 	}
 
 	if overrides != nil {
@@ -64,6 +74,16 @@ func ResolveConnectionConfig(global config.KafkaConfig, overrides map[string]int
 			return ConnectionConfig{}, err
 		} else if ok {
 			cfg.Brokers = brokers
+		}
+		if v, ok, err := intOverride(overrides["compact_topic_partitions"]); err != nil {
+			return ConnectionConfig{}, err
+		} else if ok {
+			cfg.CompactTopicPartitions = v
+		}
+		if v, ok, err := intOverride(overrides["compact_topic_replication_factor"]); err != nil {
+			return ConnectionConfig{}, err
+		} else if ok {
+			cfg.CompactTopicReplicationFactor = v
 		}
 		if v, ok, err := boolOverride(overrides["tls"]); err != nil {
 			return ConnectionConfig{}, err
@@ -134,6 +154,12 @@ func normalizeConnectionConfig(cfg *ConnectionConfig) {
 func validateConnectionConfig(cfg ConnectionConfig) error {
 	if len(cfg.Brokers) == 0 {
 		return fmt.Errorf("kafka brokers must not be empty")
+	}
+	if cfg.CompactTopicPartitions <= 0 {
+		return fmt.Errorf("kafka.compact_topic_partitions must be a positive integer, got %d", cfg.CompactTopicPartitions)
+	}
+	if cfg.CompactTopicReplicationFactor <= 0 {
+		return fmt.Errorf("kafka.compact_topic_replication_factor must be a positive integer, got %d", cfg.CompactTopicReplicationFactor)
 	}
 
 	if !cfg.TLS {
@@ -260,6 +286,17 @@ func boolOverride(value interface{}) (bool, bool, error) {
 	v, ok := value.(bool)
 	if !ok {
 		return false, false, fmt.Errorf("expected boolean Kafka config override, got %T", value)
+	}
+	return v, true, nil
+}
+
+func intOverride(value interface{}) (int, bool, error) {
+	if value == nil {
+		return 0, false, nil
+	}
+	v, ok := value.(int)
+	if !ok {
+		return 0, false, fmt.Errorf("expected int override, got %T", value)
 	}
 	return v, true, nil
 }

--- a/event-gateway/gateway-runtime/internal/connectors/brokerdriver/kafka/config.go
+++ b/event-gateway/gateway-runtime/internal/connectors/brokerdriver/kafka/config.go
@@ -63,10 +63,10 @@ func ResolveConnectionConfig(global config.KafkaConfig, overrides map[string]int
 		SASLPassword:                  global.SASLPassword,
 	}
 	if cfg.CompactTopicPartitions <= 0 {
-		cfg.CompactTopicPartitions = 1
+		return ConnectionConfig{}, fmt.Errorf("kafka.compact_topic_partitions must be a positive integer, got %d", cfg.CompactTopicPartitions)
 	}
 	if cfg.CompactTopicReplicationFactor <= 0 {
-		cfg.CompactTopicReplicationFactor = 1
+		return ConnectionConfig{}, fmt.Errorf("kafka.compact_topic_replication_factor must be a positive integer, got %d", cfg.CompactTopicReplicationFactor)
 	}
 
 	if overrides != nil {

--- a/event-gateway/gateway-runtime/internal/connectors/brokerdriver/kafka/config.go
+++ b/event-gateway/gateway-runtime/internal/connectors/brokerdriver/kafka/config.go
@@ -22,6 +22,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"math"
 	"os"
 	"strings"
 
@@ -294,11 +295,23 @@ func intOverride(value interface{}) (int, bool, error) {
 	if value == nil {
 		return 0, false, nil
 	}
-	v, ok := value.(int)
-	if !ok {
+	switch v := value.(type) {
+	case int:
+		return v, true, nil
+	case float64:
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			return 0, false, fmt.Errorf("expected integer Kafka config override, got non-finite float64 %v", v)
+		}
+		if v != math.Trunc(v) {
+			return 0, false, fmt.Errorf("expected integer Kafka config override, got non-integer float64 %v", v)
+		}
+		if v < math.MinInt32 || v > math.MaxInt32 {
+			return 0, false, fmt.Errorf("expected integer Kafka config override within [%d, %d], got float64 %v", math.MinInt32, math.MaxInt32, v)
+		}
+		return int(v), true, nil
+	default:
 		return 0, false, fmt.Errorf("expected int override, got %T", value)
 	}
-	return v, true, nil
 }
 
 func stringOverride(value interface{}) (string, bool, error) {

--- a/event-gateway/gateway-runtime/internal/connectors/brokerdriver/kafka/config_test.go
+++ b/event-gateway/gateway-runtime/internal/connectors/brokerdriver/kafka/config_test.go
@@ -1,9 +1,11 @@
 package kafka
 
 import (
+	"math"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	runtimeconfig "github.com/wso2/api-platform/event-gateway/gateway-runtime/internal/config"
@@ -17,13 +19,15 @@ func TestResolveConnectionConfig_MergesGlobalAndOverrides(t *testing.T) {
 	}
 
 	global := runtimeconfig.KafkaConfig{
-		Brokers:       []string{"broker-1:9092"},
-		TLS:           true,
-		TLSCAFile:     caPath,
-		TLSServerName: "global-kafka",
-		SASLMechanism: "plain",
-		SASLUsername:  "global-user",
-		SASLPassword:  "global-pass",
+		Brokers:                       []string{"broker-1:9092"},
+		CompactTopicPartitions:        1,
+		CompactTopicReplicationFactor: 1,
+		TLS:                           true,
+		TLSCAFile:                     caPath,
+		TLSServerName:                 "global-kafka",
+		SASLMechanism:                 "plain",
+		SASLUsername:                  "global-user",
+		SASLPassword:                  "global-pass",
 	}
 
 	resolved, err := ResolveConnectionConfig(global, map[string]interface{}{
@@ -57,7 +61,10 @@ func TestResolveConnectionConfig_MergesGlobalAndOverrides(t *testing.T) {
 }
 
 func TestResolveConnectionConfig_PreservesOpaqueCredentials(t *testing.T) {
-	resolved, err := ResolveConnectionConfig(runtimeconfig.KafkaConfig{}, map[string]interface{}{
+	resolved, err := ResolveConnectionConfig(runtimeconfig.KafkaConfig{
+		CompactTopicPartitions:        1,
+		CompactTopicReplicationFactor: 1,
+	}, map[string]interface{}{
 		"brokers":        []interface{}{"broker:9092"},
 		"sasl_mechanism": "plain",
 		"sasl_username":  "  user-with-spaces  ",
@@ -77,8 +84,10 @@ func TestResolveConnectionConfig_PreservesOpaqueCredentials(t *testing.T) {
 
 func TestResolveConnectionConfig_RequiresTLSWhenTLSFilesAreConfigured(t *testing.T) {
 	_, err := ResolveConnectionConfig(runtimeconfig.KafkaConfig{
-		Brokers:   []string{"broker:9092"},
-		TLSCAFile: "/tmp/ca.crt",
+		Brokers:                       []string{"broker:9092"},
+		CompactTopicPartitions:        1,
+		CompactTopicReplicationFactor: 1,
+		TLSCAFile:                     "/tmp/ca.crt",
 	}, nil)
 	if err == nil {
 		t.Fatalf("expected error when TLS files are set with TLS disabled")
@@ -93,18 +102,22 @@ func TestResolveConnectionConfig_ValidatesReadableTLSFiles(t *testing.T) {
 	}
 
 	_, err := ResolveConnectionConfig(runtimeconfig.KafkaConfig{
-		Brokers:   []string{"broker:9092"},
-		TLS:       true,
-		TLSCAFile: caPath,
+		Brokers:                       []string{"broker:9092"},
+		CompactTopicPartitions:        1,
+		CompactTopicReplicationFactor: 1,
+		TLS:                           true,
+		TLSCAFile:                     caPath,
 	}, nil)
 	if err != nil {
 		t.Fatalf("expected readable CA file to validate, got %v", err)
 	}
 
 	_, err = ResolveConnectionConfig(runtimeconfig.KafkaConfig{
-		Brokers:   []string{"broker:9092"},
-		TLS:       true,
-		TLSCAFile: filepath.Join(tempDir, "missing.crt"),
+		Brokers:                       []string{"broker:9092"},
+		CompactTopicPartitions:        1,
+		CompactTopicReplicationFactor: 1,
+		TLS:                           true,
+		TLSCAFile:                     filepath.Join(tempDir, "missing.crt"),
 	}, nil)
 	if err == nil {
 		t.Fatalf("expected missing CA file to fail validation")
@@ -112,12 +125,67 @@ func TestResolveConnectionConfig_ValidatesReadableTLSFiles(t *testing.T) {
 }
 
 func TestResolveConnectionConfig_RequiresSASLCredentials(t *testing.T) {
-	_, err := ResolveConnectionConfig(runtimeconfig.KafkaConfig{}, map[string]interface{}{
+	_, err := ResolveConnectionConfig(runtimeconfig.KafkaConfig{
+		CompactTopicPartitions:        1,
+		CompactTopicReplicationFactor: 1,
+	}, map[string]interface{}{
 		"brokers":        []interface{}{"broker:9092"},
 		"sasl_mechanism": "scram-sha-512",
 		"sasl_username":  "user",
 	})
 	if err == nil {
 		t.Fatalf("expected missing SASL password to fail validation")
+	}
+}
+
+func TestIntOverride_AcceptsIntegerFloat64(t *testing.T) {
+	got, ok, err := intOverride(float64(3))
+	if err != nil {
+		t.Fatalf("expected integer float64 override to succeed, got %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected integer float64 override to be accepted")
+	}
+	if got != 3 {
+		t.Fatalf("expected integer float64 override to convert to 3, got %d", got)
+	}
+}
+
+func TestIntOverride_RejectsInvalidFloat64(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   float64
+		wantErr string
+	}{
+		{
+			name:    "non integer",
+			value:   3.5,
+			wantErr: "non-integer",
+		},
+		{
+			name:    "out of bounds",
+			value:   float64(math.MaxInt32) + 1,
+			wantErr: "within",
+		},
+		{
+			name:    "non finite",
+			value:   math.NaN(),
+			wantErr: "non-finite",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ok, err := intOverride(tt.value)
+			if err == nil {
+				t.Fatalf("expected float64 override %v to fail", tt.value)
+			}
+			if ok {
+				t.Fatalf("expected invalid float64 override %v to be rejected", tt.value)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error %q to contain %q", err.Error(), tt.wantErr)
+			}
+		})
 	}
 }

--- a/event-gateway/gateway-runtime/internal/connectors/brokerdriver/kafka/endpoint.go
+++ b/event-gateway/gateway-runtime/internal/connectors/brokerdriver/kafka/endpoint.go
@@ -123,9 +123,15 @@ func (e *KafkaBrokerDriver) EnsureTopics(ctx context.Context, topics []string) e
 
 // EnsureCompactedTopic creates a compacted topic if it does not already exist.
 func (e *KafkaBrokerDriver) EnsureCompactedTopic(ctx context.Context, topic string) error {
-	resp, err := e.admin.CreateTopics(ctx, 1, 1, map[string]*string{
-		"cleanup.policy": kadm.StringPtr("compact"),
-	}, topic)
+	resp, err := e.admin.CreateTopics(
+		ctx,
+		int32(e.cfg.CompactTopicPartitions),
+		int16(e.cfg.CompactTopicReplicationFactor),
+		map[string]*string{
+			"cleanup.policy": kadm.StringPtr("compact"),
+		},
+		topic,
+	)
 	if err != nil {
 		return fmt.Errorf("failed to create compacted topic %s: %w", topic, err)
 	}

--- a/event-gateway/gateway-runtime/internal/connectors/receiver/websub/consumer_manager.go
+++ b/event-gateway/gateway-runtime/internal/connectors/receiver/websub/consumer_manager.go
@@ -218,8 +218,8 @@ func (cm *ConsumerManager) createConsumer(groupID string, topics []string, callb
 }
 
 // consumerGroupID generates a unique, safe consumer group ID for a callback URL.
-// Format: {prefix}-websub-{sha256(callbackURL)[:16]}
+// Format: {prefix}-websub-{sha256(callbackURL)[:32]}
 func (cm *ConsumerManager) consumerGroupID(callbackURL string) string {
 	h := sha256.Sum256([]byte(callbackURL))
-	return cm.groupPrefix + "-websub-" + hex.EncodeToString(h[:])[:16]
+	return cm.groupPrefix + "-websub-" + hex.EncodeToString(h[:])[:32]
 }

--- a/event-gateway/gateway-runtime/internal/connectors/receiver/websub/handler.go
+++ b/event-gateway/gateway-runtime/internal/connectors/receiver/websub/handler.go
@@ -379,6 +379,9 @@ func writePolicyResponse(w http.ResponseWriter, msg *connectors.Message, fallbac
 		w.WriteHeader(statusCode)
 		return
 	}
+	if fallbackStatus == http.StatusUnauthorized {
+		w.Header().Set("WWW-Authenticate", `Bearer realm="event-gateway"`)
+	}
 	http.Error(w, fallbackBody, fallbackStatus)
 }
 

--- a/event-gateway/gateway-runtime/internal/connectors/receiver/websub/handler.go
+++ b/event-gateway/gateway-runtime/internal/connectors/receiver/websub/handler.go
@@ -99,14 +99,14 @@ func (h *HubHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (h *HubHandler) handleSubscribe(w http.ResponseWriter, r *http.Request) {
 	// Enforce subscribe policies before processing.
 	subMsg := httpRequestToMessage(r)
-	message, shortCircuited, err := h.processor.ProcessSubscribe(r.Context(), h.bindingName, subMsg)
+	_, shortCircuited, err := h.processor.ProcessSubscribe(r.Context(), h.bindingName, subMsg)
 	if err != nil {
 		slog.Error("Subscribe policy execution failed", "error", err)
 		http.Error(w, "policy execution failed", http.StatusInternalServerError)
 		return
 	}
 	if shortCircuited {
-		writePolicyResponse(w, message, http.StatusForbidden, "forbidden by policy")
+		writePolicyResponse(w, nil, http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized))
 		return
 	}
 
@@ -203,14 +203,14 @@ func (h *HubHandler) handleSubscribe(w http.ResponseWriter, r *http.Request) {
 func (h *HubHandler) handleUnsubscribe(w http.ResponseWriter, r *http.Request) {
 	// Enforce subscribe policies before processing.
 	subMsg := httpRequestToMessage(r)
-	message, shortCircuited, err := h.processor.ProcessSubscribe(r.Context(), h.bindingName, subMsg)
+	_, shortCircuited, err := h.processor.ProcessSubscribe(r.Context(), h.bindingName, subMsg)
 	if err != nil {
 		slog.Error("Unsubscribe policy execution failed", "error", err)
 		http.Error(w, "policy execution failed", http.StatusInternalServerError)
 		return
 	}
 	if shortCircuited {
-		writePolicyResponse(w, message, http.StatusForbidden, "forbidden by policy")
+		writePolicyResponse(w, nil, http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized))
 		return
 	}
 
@@ -342,7 +342,7 @@ func (h *WebhookReceiverHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	}
 	if shortCircuited {
 		slog.Info("Inbound request rejected by policy", "channel", channelName, "binding", h.bindingName)
-		writePolicyResponse(w, processed, http.StatusForbidden, "forbidden by policy")
+		writePolicyResponse(w, processed, http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized))
 		return
 	}
 

--- a/event-gateway/gateway-runtime/internal/connectors/receiver/websub/handler.go
+++ b/event-gateway/gateway-runtime/internal/connectors/receiver/websub/handler.go
@@ -99,14 +99,14 @@ func (h *HubHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (h *HubHandler) handleSubscribe(w http.ResponseWriter, r *http.Request) {
 	// Enforce subscribe policies before processing.
 	subMsg := httpRequestToMessage(r)
-	_, shortCircuited, err := h.processor.ProcessSubscribe(r.Context(), h.bindingName, subMsg)
+	message, shortCircuited, err := h.processor.ProcessSubscribe(r.Context(), h.bindingName, subMsg)
 	if err != nil {
 		slog.Error("Subscribe policy execution failed", "error", err)
 		http.Error(w, "policy execution failed", http.StatusInternalServerError)
 		return
 	}
 	if shortCircuited {
-		writePolicyResponse(w, nil, http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized))
+		writePolicyResponse(w, message, http.StatusForbidden, "forbidden by policy")
 		return
 	}
 
@@ -203,14 +203,14 @@ func (h *HubHandler) handleSubscribe(w http.ResponseWriter, r *http.Request) {
 func (h *HubHandler) handleUnsubscribe(w http.ResponseWriter, r *http.Request) {
 	// Enforce subscribe policies before processing.
 	subMsg := httpRequestToMessage(r)
-	_, shortCircuited, err := h.processor.ProcessSubscribe(r.Context(), h.bindingName, subMsg)
+	message, shortCircuited, err := h.processor.ProcessSubscribe(r.Context(), h.bindingName, subMsg)
 	if err != nil {
 		slog.Error("Unsubscribe policy execution failed", "error", err)
 		http.Error(w, "policy execution failed", http.StatusInternalServerError)
 		return
 	}
 	if shortCircuited {
-		writePolicyResponse(w, nil, http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized))
+		writePolicyResponse(w, message, http.StatusForbidden, "forbidden by policy")
 		return
 	}
 
@@ -342,7 +342,7 @@ func (h *WebhookReceiverHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	}
 	if shortCircuited {
 		slog.Info("Inbound request rejected by policy", "channel", channelName, "binding", h.bindingName)
-		writePolicyResponse(w, processed, http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized))
+		writePolicyResponse(w, processed, http.StatusForbidden, "forbidden by policy")
 		return
 	}
 
@@ -378,9 +378,6 @@ func writePolicyResponse(w http.ResponseWriter, msg *connectors.Message, fallbac
 		}
 		w.WriteHeader(statusCode)
 		return
-	}
-	if fallbackStatus == http.StatusUnauthorized {
-		w.Header().Set("WWW-Authenticate", `Bearer realm="event-gateway"`)
 	}
 	http.Error(w, fallbackBody, fallbackStatus)
 }

--- a/platform-api/src/config/config.go
+++ b/platform-api/src/config/config.go
@@ -55,6 +55,18 @@ type Server struct {
 
 	// API key configurations
 	APIKey APIKey `envconfig:"API_KEY"`
+
+	// Gateway configurations
+	Gateway Gateway `envconfig:"GATEWAY"`
+}
+
+// Gateway holds gateway-related configuration.
+type Gateway struct {
+	// EnableVersionVerification controls whether the platform API rejects gateway
+	// connections whose reported version does not match the registered version.
+	// When false (default), a mismatch is logged and the connection is allowed to proceed.
+	// Env: GATEWAY_ENABLE_VERSION_VERIFICATION (default: false)
+	EnableVersionVerification bool `envconfig:"ENABLE_VERSION_VERIFICATION" default:"false"`
 }
 
 // TLS holds TLS certificate configuration

--- a/platform-api/src/internal/server/server.go
+++ b/platform-api/src/internal/server/server.go
@@ -187,7 +187,7 @@ func StartPlatformAPIServer(cfg *config.Server, slogger *slog.Logger) (*Server, 
 	appService := service.NewApplicationService(appRepo, projectRepo, orgRepo, apiRepo, gatewayEventsService, slogger)
 	apiService := service.NewAPIService(apiRepo, projectRepo, orgRepo, gatewayRepo, deploymentRepo, devPortalRepo, publicationRepo,
 		subscriptionPlanRepo, customPolicyRepo, gatewayEventsService, devPortalService, apiUtil, slogger)
-	gatewayService := service.NewGatewayService(gatewayRepo, orgRepo, apiRepo, customPolicyRepo, gatewayEventsService, slogger)
+	gatewayService := service.NewGatewayService(gatewayRepo, orgRepo, apiRepo, customPolicyRepo, gatewayEventsService, slogger, cfg.Gateway.EnableVersionVerification)
 	subscriptionService := service.NewSubscriptionService(apiRepo, subscriptionRepo, gatewayEventsService, slogger)
 	subscriptionPlanService := service.NewSubscriptionPlanService(subscriptionPlanRepo, gatewayRepo, gatewayEventsService, slogger)
 	internalGatewayService := service.NewGatewayInternalAPIService(apiRepo, subscriptionRepo, subscriptionPlanRepo, llmProviderRepo, llmProxyRepo, mcpProxyRepo, websubAPIRepo, deploymentRepo, gatewayRepo, orgRepo, projectRepo, apiKeyRepo, artifactRepo, cfg, slogger)

--- a/platform-api/src/internal/service/gateway.go
+++ b/platform-api/src/internal/service/gateway.go
@@ -69,25 +69,28 @@ type Manifest struct {
 
 // GatewayService handles gateway business logic
 type GatewayService struct {
-	gatewayRepo          repository.GatewayRepository
-	orgRepo              repository.OrganizationRepository
-	apiRepo              repository.APIRepository
-	customPolicyRepo     repository.CustomPolicyRepository
-	gatewayEventsService *GatewayEventsService
-	slogger              *slog.Logger
+	gatewayRepo               repository.GatewayRepository
+	orgRepo                   repository.OrganizationRepository
+	apiRepo                   repository.APIRepository
+	customPolicyRepo          repository.CustomPolicyRepository
+	gatewayEventsService      *GatewayEventsService
+	slogger                   *slog.Logger
+	enableVersionVerification bool
 }
 
 // NewGatewayService creates a new gateway service
 func NewGatewayService(gatewayRepo repository.GatewayRepository, orgRepo repository.OrganizationRepository,
 	apiRepo repository.APIRepository, customPolicyRepo repository.CustomPolicyRepository,
-	gatewayEventsService *GatewayEventsService, slogger *slog.Logger) *GatewayService {
+	gatewayEventsService *GatewayEventsService, slogger *slog.Logger,
+	enableVersionVerification bool) *GatewayService {
 	return &GatewayService{
-		gatewayRepo:          gatewayRepo,
-		orgRepo:              orgRepo,
-		apiRepo:              apiRepo,
-		customPolicyRepo:     customPolicyRepo,
-		gatewayEventsService: gatewayEventsService,
-		slogger:              slogger,
+		gatewayRepo:               gatewayRepo,
+		orgRepo:                   orgRepo,
+		apiRepo:                   apiRepo,
+		customPolicyRepo:          customPolicyRepo,
+		gatewayEventsService:      gatewayEventsService,
+		slogger:                   slogger,
+		enableVersionVerification: enableVersionVerification,
 	}
 }
 
@@ -178,7 +181,15 @@ func (s *GatewayService) ReceiveGatewayManifest(orgID, gatewayID, gatewayVersion
 		registeredMinor = defaultGatewayVersion
 	}
 	if reportedMinor != registeredMinor {
-		return fmt.Errorf("%w: registered=%s, reported=%s", constants.ErrGatewayVersionMismatch, registeredMinor, reportedMinor)
+		if s.enableVersionVerification {
+			return fmt.Errorf("%w: registered=%s, reported=%s", constants.ErrGatewayVersionMismatch, registeredMinor, reportedMinor)
+		}
+		s.slogger.Warn("Gateway version mismatch ignored (verification disabled)",
+			slog.String("org_id", orgID),
+			slog.String("gateway_id", gatewayID),
+			slog.String("registered", registeredMinor),
+			slog.String("reported", reportedMinor),
+		)
 	}
 
 	reportedType := strings.TrimSpace(functionalityType)


### PR DESCRIPTION
 ## Purpose
  Internal compacted Kafka topics were always created with `1` partition and replication factor `1`, which ignores cluster policy and deployment-specific sizing needs.
  Resolves N/A.

  ## Goals
  - make internal compacted topic partition count configurable
  - make internal compacted topic replication factor configurable
  - keep sensible defaults and reject invalid values early

  ## Approach
  - added `kafka.compact_topic_partitions` and `kafka.compact_topic_replication_factor` to the existing runtime Kafka config path
  - threaded those values through Kafka connection resolution with defaulting and positive-value validation
  - replaced the hardcoded `CreateTopics(..., 1, 1, ...)` call in `EnsureCompactedTopic(...)` with the resolved config values

  ## User stories
  Operators can align internal compacted topic creation with cluster replication and partitioning requirements without patching code.

  ## Documentation
  N/A - config-only runtime behavior change; no product doc update included in this PR.

  ## Automation tests
  - Unit tests
    > Validated with existing package tests: `env GOCACHE=/tmp/go-build-cache go test ./event-gateway/gateway-runtime/internal/config ./event-gateway/gateway-runtime/
  internal/connectors/brokerdriver/kafka`
  - Integration tests
    > Not run in this turn

  ## Security checks
  - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
  - Ran FindSecurityBugs plugin and verified report? no
  - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

  ## Samples
  N/A

  ## Related PRs
  N/A

  ## Test environment
  Ubuntu 24.04.4 LTS, Go package tests run locally with `GOCACHE=/tmp/go-build-cache`