### PR TITLE
Handle WebSub delta updates without full undeploy/redeploy

### DIFF
--- a/event-gateway/gateway-runtime/internal/connectors/receiver/websub/delta.go
+++ b/event-gateway/gateway-runtime/internal/connectors/receiver/websub/delta.go
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package websub
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+)
+
+// ApplyBindingDelta mutates the live receiver for channel add/remove changes
+// without recreating the receiver or the subscription sync topic.
+func (e *WebSubReceiver) ApplyBindingDelta(ctx context.Context, removedChannels map[string]string, addedChannels map[string]string) error {
+	for channelName := range removedChannels {
+		subscriptions := e.store.GetByTopic(channelName)
+		for _, sub := range subscriptions {
+			if e.syncProducer != nil {
+				if err := e.syncProducer.PublishTombstone(ctx, channelName, sub.CallbackURL); err != nil {
+					return fmt.Errorf("failed to tombstone subscription for removed channel %q: %w", channelName, err)
+				}
+			}
+		}
+	}
+
+	for channelName, kafkaTopic := range removedChannels {
+		e.topics.Deregister(channelName)
+
+		subscriptions := e.store.GetByTopic(channelName)
+		for _, sub := range subscriptions {
+			if err := e.consumerMgr.RemoveSubscription(sub.CallbackURL, kafkaTopic); err != nil {
+				slog.Error("Failed to remove consumer for deleted WebSub channel",
+					"api", e.channel.Name,
+					"channel", channelName,
+					"callback", sub.CallbackURL,
+					"error", err)
+			}
+			if err := e.store.Remove(channelName, sub.CallbackURL); err != nil {
+				slog.Error("Failed to remove subscription for deleted WebSub channel",
+					"api", e.channel.Name,
+					"channel", channelName,
+					"callback", sub.CallbackURL,
+					"error", err)
+			}
+		}
+
+		delete(e.channel.Channels, channelName)
+	}
+
+	for channelName, kafkaTopic := range addedChannels {
+		e.channel.Channels[channelName] = kafkaTopic
+		e.topics.Register(channelName)
+	}
+
+	return nil
+}

--- a/event-gateway/gateway-runtime/internal/runtime/runtime.go
+++ b/event-gateway/gateway-runtime/internal/runtime/runtime.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"reflect"
 	"sync"
 	"time"
 
@@ -76,6 +77,11 @@ type managedServer struct {
 	tls      bool
 	certFile string
 	keyFile  string
+}
+
+type webSubBindingUpdater interface {
+	connectors.Receiver
+	ApplyBindingDelta(ctx context.Context, removedChannels map[string]string, addedChannels map[string]string) error
 }
 
 // New creates a new Runtime. After creation:
@@ -674,6 +680,119 @@ func (r *Runtime) unregisterBindingChains(b *hub.ChannelBinding) {
 	}
 }
 
+func webSubChannelTopicMap(wsb binding.WebSubApiBinding) map[string]string {
+	channels := make(map[string]string, len(wsb.Channels))
+	for _, ch := range wsb.Channels {
+		channels[ch.Name] = binding.WebSubApiTopicName(wsb.Name, wsb.Version, ch.Name)
+	}
+	return channels
+}
+
+func webSubTopicList(channels map[string]string, subscriptionTopic string) []string {
+	topics := make([]string, 0, len(channels)+1)
+	for _, kafkaTopic := range channels {
+		topics = append(topics, kafkaTopic)
+	}
+	if subscriptionTopic != "" {
+		topics = append(topics, subscriptionTopic)
+	}
+	return topics
+}
+
+func diffChannelTopics(oldChannels, newChannels map[string]string) (map[string]string, map[string]string) {
+	removed := make(map[string]string)
+	added := make(map[string]string)
+
+	for channelName, kafkaTopic := range oldChannels {
+		if _, exists := newChannels[channelName]; !exists {
+			removed[channelName] = kafkaTopic
+		}
+	}
+	for channelName, kafkaTopic := range newChannels {
+		if _, exists := oldChannels[channelName]; !exists {
+			added[channelName] = kafkaTopic
+		}
+	}
+
+	return removed, added
+}
+
+func webSubActiveChainKeys(wsb binding.WebSubApiBinding, vhost string) map[string]bool {
+	active := make(map[string]bool)
+	basePath := binding.WebSubApiBasePath(wsb.Context, wsb.Version)
+	hubPath := basePath + "/hub"
+
+	if len(wsb.Policies.Subscribe) > 0 {
+		active[binding.GenerateRouteKey("SUBSCRIBE", hubPath, vhost)] = true
+	}
+	if len(wsb.Policies.Inbound) > 0 {
+		active[binding.GenerateRouteKey("SUB", basePath+"/webhook-receiver", vhost)] = true
+	}
+	if len(wsb.Policies.Outbound) > 0 {
+		active[binding.GenerateRouteKey("DELIVER", hubPath, vhost)] = true
+	}
+
+	for _, ch := range wsb.Channels {
+		chPath := hubPath + "/" + ch.Name
+		if len(ch.Policies.Subscribe) > 0 {
+			active[binding.GenerateRouteKey("SUBSCRIBE", chPath, vhost)] = true
+		}
+		if len(ch.Policies.Inbound) > 0 {
+			active[binding.GenerateRouteKey("SUB", chPath, vhost)] = true
+		}
+		if len(ch.Policies.Outbound) > 0 {
+			active[binding.GenerateRouteKey("DELIVER", chPath, vhost)] = true
+		}
+	}
+
+	return active
+}
+
+func (r *Runtime) unregisterStaleBindingChains(b *hub.ChannelBinding, activeKeys map[string]bool) {
+	if b == nil {
+		return
+	}
+	keys := []string{b.SubscribeChainKey, b.InboundChainKey, b.OutboundChainKey}
+	for _, key := range keys {
+		if key == "" {
+			continue
+		}
+		if !activeKeys[key] {
+			r.engine.UnregisterChain(key)
+		}
+	}
+	for _, chKeys := range b.ChannelChainKeys {
+		channelKeys := []string{chKeys.SubscribeChainKey, chKeys.InboundChainKey, chKeys.OutboundChainKey}
+		for _, key := range channelKeys {
+			if key == "" {
+				continue
+			}
+			if !activeKeys[key] {
+				r.engine.UnregisterChain(key)
+			}
+		}
+	}
+}
+
+func canDeltaUpdateWebSubBinding(oldWSB, newWSB binding.WebSubApiBinding) bool {
+	if oldWSB.Name != newWSB.Name {
+		return false
+	}
+	if oldWSB.Context != newWSB.Context {
+		return false
+	}
+	if oldWSB.Version != newWSB.Version {
+		return false
+	}
+	if !reflect.DeepEqual(oldWSB.Receiver, newWSB.Receiver) {
+		return false
+	}
+	if !reflect.DeepEqual(oldWSB.BrokerDriver, newWSB.BrokerDriver) {
+		return false
+	}
+	return true
+}
+
 // AddWebSubApiBinding dynamically adds a WebSubApi binding at runtime (xDS mode).
 func (r *Runtime) AddWebSubApiBinding(wsb binding.WebSubApiBinding) error {
 	r.mu.Lock()
@@ -726,12 +845,7 @@ func (r *Runtime) AddWebSubApiBinding(wsb binding.WebSubApiBinding) error {
 	r.bindingPaths[wsb.Name] = []string{basePath + "/hub", basePath + "/webhook-receiver"}
 
 	// Track all Kafka topics for cleanup on removal.
-	allTopics := make([]string, 0, len(channels)+1)
-	for _, kafkaTopic := range channels {
-		allTopics = append(allTopics, kafkaTopic)
-	}
-	allTopics = append(allTopics, internalSubTopic)
-	r.bindingTopics[wsb.Name] = allTopics
+	r.bindingTopics[wsb.Name] = webSubTopicList(channels, internalSubTopic)
 
 	ch := connectors.ChannelInfo{
 		Name:             wsb.Name,
@@ -775,6 +889,102 @@ func (r *Runtime) AddWebSubApiBinding(wsb binding.WebSubApiBinding) error {
 		"context", wsb.Context,
 		"version", wsb.Version,
 		"channels", len(wsb.Channels),
+	)
+
+	return nil
+}
+
+// UpdateWebSubApiBinding dynamically updates an existing WebSubApi binding at runtime (xDS mode).
+func (r *Runtime) UpdateWebSubApiBinding(oldWSB, newWSB binding.WebSubApiBinding) error {
+	if !canDeltaUpdateWebSubBinding(oldWSB, newWSB) {
+		if err := r.RemoveWebSubApiBinding(oldWSB.Name); err != nil {
+			return err
+		}
+		return r.AddWebSubApiBinding(newWSB)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	receiver, ok := r.activeReceivers[oldWSB.Name]
+	if !ok {
+		return fmt.Errorf("active receiver not found for WebSubApi %q", oldWSB.Name)
+	}
+	updater, ok := receiver.(webSubBindingUpdater)
+	if !ok {
+		return fmt.Errorf("receiver for WebSubApi %q does not support delta updates", oldWSB.Name)
+	}
+
+	brokerDriver, ok := r.activeBrokerDrivers[oldWSB.Name]
+	if !ok {
+		return fmt.Errorf("active broker-driver not found for WebSubApi %q", oldWSB.Name)
+	}
+
+	oldChannels := webSubChannelTopicMap(oldWSB)
+	newChannels := webSubChannelTopicMap(newWSB)
+	removedChannels, addedChannels := diffChannelTopics(oldChannels, newChannels)
+	oldBinding := r.hub.GetBinding(oldWSB.Name)
+
+	if len(addedChannels) > 0 {
+		topicsToEnsure := make([]string, 0, len(addedChannels))
+		for _, kafkaTopic := range addedChannels {
+			topicsToEnsure = append(topicsToEnsure, kafkaTopic)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		if err := brokerDriver.EnsureTopics(ctx, topicsToEnsure); err != nil {
+			cancel()
+			return fmt.Errorf("failed to ensure broker-driver topics during update for WebSubApi %q: %w", newWSB.Name, err)
+		}
+		cancel()
+	}
+
+	if err := updater.ApplyBindingDelta(context.Background(), removedChannels, addedChannels); err != nil {
+		return fmt.Errorf("failed to apply WebSub delta update for %q: %w", newWSB.Name, err)
+	}
+
+	if len(removedChannels) > 0 {
+		topicsToDelete := make([]string, 0, len(removedChannels))
+		for _, kafkaTopic := range removedChannels {
+			topicsToDelete = append(topicsToDelete, kafkaTopic)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		if err := brokerDriver.DeleteTopics(ctx, topicsToDelete); err != nil {
+			slog.Error("Failed to delete broker-driver topics during delta update",
+				"name", newWSB.Name,
+				"error", err)
+		}
+		cancel()
+	}
+
+	vhost := defaultVhost(newWSB.Vhost)
+	subKey, inKey, outKey, chChainKeys, err := r.buildWebSubApiPolicyChains(newWSB, vhost)
+	if err != nil {
+		return fmt.Errorf("failed to build chains for updated WebSubApi %q: %w", newWSB.Name, err)
+	}
+
+	r.unregisterStaleBindingChains(oldBinding, webSubActiveChainKeys(newWSB, vhost))
+	r.hub.RegisterBinding(hub.ChannelBinding{
+		APIID:             newWSB.APIID,
+		Name:              newWSB.Name,
+		Mode:              "websub",
+		Context:           newWSB.Context,
+		Version:           newWSB.Version,
+		Vhost:             vhost,
+		SubscribeChainKey: subKey,
+		InboundChainKey:   inKey,
+		OutboundChainKey:  outKey,
+		Channels:          newChannels,
+		ChannelChainKeys:  chChainKeys,
+	})
+
+	internalSubTopic := binding.WebSubApiSubscriptionTopic(newWSB.Name, newWSB.Version)
+	r.bindingTopics[newWSB.Name] = webSubTopicList(newChannels, internalSubTopic)
+
+	slog.Info("Dynamically updated WebSubApi binding",
+		"name", newWSB.Name,
+		"added_channels", len(addedChannels),
+		"removed_channels", len(removedChannels),
+		"channels", len(newWSB.Channels),
 	)
 
 	return nil

--- a/event-gateway/gateway-runtime/internal/xdsclient/handler.go
+++ b/event-gateway/gateway-runtime/internal/xdsclient/handler.go
@@ -38,6 +38,7 @@ import (
 type BindingManager interface {
 	AddWebSubApiBinding(wsb binding.WebSubApiBinding) error
 	RemoveWebSubApiBinding(name string) error
+	UpdateWebSubApiBinding(oldWSB, newWSB binding.WebSubApiBinding) error
 }
 
 // KafkaConfig holds local Kafka broker settings used as defaults.
@@ -187,15 +188,14 @@ func (h *Handler) HandleResources(ctx context.Context, resources []*discoveryv3.
 			if reflect.DeepEqual(old, ecr) {
 				continue
 			}
-			// Update: remove then re-add
 			slog.Info("Updating binding via xDS", "name", ecr.Name, "uuid", uuid)
-			if err := h.manager.RemoveWebSubApiBinding(old.Name); err != nil {
-				slog.Error("Failed to remove binding for update", "name", old.Name, "error", err)
+			if err := h.manager.UpdateWebSubApiBinding(h.toWebSubApiBinding(old), h.toWebSubApiBinding(ecr)); err != nil {
+				return fmt.Errorf("failed to update binding %q: %w", ecr.Name, err)
 			}
-		} else {
-			slog.Info("Adding binding via xDS", "name", ecr.Name, "uuid", uuid)
+			continue
 		}
 
+		slog.Info("Adding binding via xDS", "name", ecr.Name, "uuid", uuid)
 		wsb := h.toWebSubApiBinding(ecr)
 		if err := h.manager.AddWebSubApiBinding(wsb); err != nil {
 			return fmt.Errorf("failed to add binding %q: %w", ecr.Name, err)

--- a/event-gateway/gateway-runtime/internal/xdsclient/handler_test.go
+++ b/event-gateway/gateway-runtime/internal/xdsclient/handler_test.go
@@ -141,11 +141,17 @@ func TestHandlerHandleResources_UpdatesOnlyChangedBinding(t *testing.T) {
 		t.Fatalf("updated HandleResources returned error: %v", err)
 	}
 
-	if got := manager.removedNames(); len(got) != 1 || got[0] != "githubser" {
-		t.Fatalf("expected only githubser to be removed on change, got %#v", got)
+	if got := len(manager.updated); got != 1 {
+		t.Fatalf("expected exactly one update call, got %d", got)
 	}
-	if got := manager.addedCount("githubser"); got != 2 {
-		t.Fatalf("expected githubser to be added twice, got %d", got)
+	if manager.updated[0].old.Name != "githubser" || manager.updated[0].new.Name != "githubser" {
+		t.Fatalf("unexpected update binding names: %#v", manager.updated[0])
+	}
+	if got := manager.removedNames(); len(got) != 0 {
+		t.Fatalf("expected no removals on delta update, got %#v", got)
+	}
+	if got := manager.addedCount("githubser"); got != 1 {
+		t.Fatalf("expected githubser to be added once, got %d", got)
 	}
 	if got := manager.addedCount("gitlabser"); got != 1 {
 		t.Fatalf("expected gitlabser to be added once, got %d", got)
@@ -155,6 +161,12 @@ func TestHandlerHandleResources_UpdatesOnlyChangedBinding(t *testing.T) {
 type recordingBindingManager struct {
 	added   []string
 	removed []string
+	updated []updatedBindingCall
+}
+
+type updatedBindingCall struct {
+	old binding.WebSubApiBinding
+	new binding.WebSubApiBinding
 }
 
 func (m *recordingBindingManager) AddWebSubApiBinding(wsb binding.WebSubApiBinding) error {
@@ -164,6 +176,11 @@ func (m *recordingBindingManager) AddWebSubApiBinding(wsb binding.WebSubApiBindi
 
 func (m *recordingBindingManager) RemoveWebSubApiBinding(name string) error {
 	m.removed = append(m.removed, name)
+	return nil
+}
+
+func (m *recordingBindingManager) UpdateWebSubApiBinding(oldWSB, newWSB binding.WebSubApiBinding) error {
+	m.updated = append(m.updated, updatedBindingCall{old: oldWSB, new: newWSB})
 	return nil
 }
 

--- a/gateway/gateway-controller/pkg/api/handlers/handlers.go
+++ b/gateway/gateway-controller/pkg/api/handlers/handlers.go
@@ -46,6 +46,7 @@ import (
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/policyxds"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/secrets"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/service/restapi"
+	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/service/websubapi"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/storage"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/utils"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/xds"
@@ -56,6 +57,7 @@ type APIServer struct {
 	*RestAPIHandler // embedded — promotes CreateRestAPI, ListRestAPIs, GetRestAPIById, UpdateRestAPI, DeleteRestAPI
 
 	restAPIService              *restapi.RestAPIService
+	webSubAPIService            *websubapi.WebSubAPIService
 	store                       *storage.ConfigStore
 	db                          storage.Storage
 	snapshotManager             *xds.SnapshotManager
@@ -151,6 +153,17 @@ func NewAPIServer(
 		subscriptionResourceService: subscriptionResourceService,
 	}
 	server.restAPIService = restAPIService
+	server.webSubAPIService = websubapi.NewWebSubAPIService(
+		db,
+		deploymentService,
+		controlPlaneClient,
+		systemConfig,
+		parser,
+		validator,
+		logger,
+		eventHub,
+		secretService,
+	)
 	server.RestAPIHandler = NewRestAPIHandler(restAPIService, logger)
 
 	// Register status update callback

--- a/gateway/gateway-controller/pkg/api/handlers/handlers_test.go
+++ b/gateway/gateway-controller/pkg/api/handlers/handlers_test.go
@@ -49,6 +49,7 @@ import (
 	policybuilder "github.com/wso2/api-platform/gateway/gateway-controller/pkg/policy"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/policyxds"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/service/restapi"
+	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/service/websubapi"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/storage"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/utils"
 )
@@ -1019,6 +1020,17 @@ func createTestAPIServerWithDB(db storage.Storage) *APIServer {
 		httpClient, parser, validator, logger, hub, nil,
 	)
 	server.restAPIService = restAPIService
+	server.webSubAPIService = websubapi.NewWebSubAPIService(
+		db,
+		deploymentService,
+		nil,
+		systemCfg,
+		parser,
+		validator,
+		logger,
+		hub,
+		nil,
+	)
 	server.RestAPIHandler = NewRestAPIHandler(restAPIService, logger)
 
 	return server
@@ -1238,6 +1250,17 @@ func attachTestEventHub(server *APIServer, hub eventhub.EventHub, gatewayID stri
 		server.restAPIService = restAPIService
 		server.RestAPIHandler = NewRestAPIHandler(restAPIService, server.logger)
 	}
+	server.webSubAPIService = websubapi.NewWebSubAPIService(
+		server.db,
+		server.deploymentService,
+		nil,
+		server.systemConfig,
+		server.parser,
+		server.validator,
+		server.logger,
+		hub,
+		nil,
+	)
 }
 
 func seedAPIForAPIKeyHandlerTests(t *testing.T, server *APIServer, handle string) *models.StoredConfig {
@@ -2997,6 +3020,69 @@ func TestGetLLMProxyByIdWithDeployedAt(t *testing.T) {
 	server.GetLLMProxyById(c, "test-llm-proxy-handle")
 
 	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestUpdateWebSubAPIUndeployUsesDedicatedServicePath(t *testing.T) {
+	server := createTestAPIServer()
+	mockDB := server.db.(*MockStorage)
+	mockHub := &mockEventHub{}
+	attachTestEventHub(server, mockHub, "test-gateway")
+
+	cfg := &models.StoredConfig{
+		UUID:        "0000-websub-id-0000-000000000000",
+		Kind:        string(api.WebSubAPIKindWebSubApi),
+		Handle:      "repo-watcher-v1-0",
+		DisplayName: "repo-watcher",
+		Version:     "v1.0",
+		SourceConfiguration: api.WebSubAPI{
+			ApiVersion: api.WebSubAPIApiVersionGatewayApiPlatformWso2Comv1alpha1,
+			Kind:       api.WebSubAPIKindWebSubApi,
+			Metadata: api.Metadata{
+				Name: "repo-watcher-v1-0",
+			},
+			Spec: api.WebhookAPIData{
+				DisplayName: "repo-watcher",
+				Version:     "v1.0",
+				Context:     "/repos",
+				Hub: api.WebSubHub{
+					Channels: []api.HubChannel{{Name: "issues"}},
+				},
+			},
+		},
+		DesiredState: models.StateDeployed,
+		Origin:       models.OriginGatewayAPI,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	require.NoError(t, mockDB.SaveConfig(cfg))
+
+	body := []byte(`{
+		"apiVersion":"gateway.api-platform.wso2.com/v1alpha1",
+		"kind":"WebSubApi",
+		"metadata":{"name":"repo-watcher-v1-0"},
+		"spec":{
+			"displayName":"repo-watcher",
+			"version":"v1.0",
+			"context":"/repos",
+			"deploymentState":"undeployed",
+			"hub":{"channels":[{"name":"issues"}]}
+		}
+	}`)
+
+	c, w := createTestContext("PUT", "/websub-apis/repo-watcher-v1-0", body)
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	server.UpdateWebSubAPI(c, "repo-watcher-v1-0")
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	updatedCfg, err := mockDB.GetConfig("0000-websub-id-0000-000000000000")
+	require.NoError(t, err)
+	assert.Equal(t, models.StateUndeployed, updatedCfg.DesiredState)
+	require.Len(t, mockHub.publishedEvents, 1)
+	assert.Equal(t, "UPDATE", mockHub.publishedEvents[0].event.Action)
+	assert.Equal(t, eventhub.EventTypeAPI, mockHub.publishedEvents[0].event.EventType)
+	assert.Equal(t, "0000-websub-id-0000-000000000000", mockHub.publishedEvents[0].event.EntityID)
 }
 
 // TestHandleStatusUpdateStoreError tests handleStatusUpdate with store error

--- a/gateway/gateway-controller/pkg/api/handlers/websub_api_handler.go
+++ b/gateway/gateway-controller/pkg/api/handlers/websub_api_handler.go
@@ -20,6 +20,7 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -32,9 +33,12 @@ import (
 	api "github.com/wso2/api-platform/gateway/gateway-controller/pkg/api/management"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/api/middleware"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/models"
+	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/service/websubapi"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/storage"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/utils"
 )
+
+//TODO: Refactor to move business logic to service layer and keep handlers thin, focusing on request parsing, response formatting, and error handling.
 
 // CreateWebSubAPI implements ServerInterface.CreateWebSubAPI
 // (POST /websub-apis)
@@ -182,31 +186,23 @@ func (s *APIServer) UpdateWebSubAPI(c *gin.Context, id string) {
 		return
 	}
 
-	existing, err := s.db.GetConfigByKindAndHandle(models.KindWebSubApi, handle)
-	if err != nil {
-		log.Warn("WebSub API configuration not found",
-			slog.String("handle", handle))
-		c.JSON(http.StatusNotFound, api.ErrorResponse{
-			Status:  "error",
-			Message: fmt.Sprintf("WebSub API configuration with handle '%s' not found", handle),
-		})
-		return
-	}
-
 	correlationID := middleware.GetCorrelationID(c)
 
-	result, err := s.deploymentService.DeployAPIConfiguration(utils.APIDeploymentParams{
-		Data:          body,
+	result, err := s.webSubAPIService.Update(websubapi.UpdateParams{
+		Handle:        handle,
+		Body:          body,
 		ContentType:   c.GetHeader("Content-Type"),
-		Kind:          "WebSubApi",
-		APIID:         existing.UUID,
-		Origin:        models.OriginGatewayAPI,
 		CorrelationID: correlationID,
 		Logger:        log,
 	})
 	if err != nil {
 		log.Error("Failed to update WebSub API configuration", slog.Any("error", err))
-		if storage.IsConflictError(err) {
+		if errors.Is(err, websubapi.ErrNotFound) {
+			c.JSON(http.StatusNotFound, api.ErrorResponse{
+				Status:  "error",
+				Message: fmt.Sprintf("WebSub API configuration with handle '%s' not found", handle),
+			})
+		} else if storage.IsConflictError(err) {
 			c.JSON(http.StatusConflict, api.ErrorResponse{
 				Status:  "error",
 				Message: err.Error(),
@@ -223,7 +219,7 @@ func (s *APIServer) UpdateWebSubAPI(c *gin.Context, id string) {
 		return
 	}
 
-	updated := result.StoredConfig
+	updated := result.Config
 
 	log.Info("WebSub API configuration updated",
 		slog.String("id", updated.UUID),

--- a/gateway/gateway-controller/pkg/service/websubapi/errors.go
+++ b/gateway/gateway-controller/pkg/service/websubapi/errors.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package websubapi
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/config"
+)
+
+var (
+	// ErrNotFound is returned when a WebSub API is not found.
+	ErrNotFound = errors.New("websub api not found")
+)
+
+// ValidationError wraps configuration validation errors.
+type ValidationError struct {
+	Errors []config.ValidationError
+}
+
+func (e *ValidationError) Error() string {
+	return fmt.Sprintf("configuration validation failed (%d errors)", len(e.Errors))
+}
+
+// ParseError wraps a configuration parse failure.
+type ParseError struct {
+	Cause error
+}
+
+func (e *ParseError) Error() string {
+	return fmt.Sprintf("failed to parse configuration: %v", e.Cause)
+}
+
+func (e *ParseError) Unwrap() error {
+	return e.Cause
+}
+
+// HandleMismatchError is returned when the path handle doesn't match metadata.name.
+type HandleMismatchError struct {
+	PathHandle string
+	YAMLHandle string
+}
+
+func (e *HandleMismatchError) Error() string {
+	return fmt.Sprintf("handle mismatch: path has '%s' but YAML metadata.name has '%s'", e.PathHandle, e.YAMLHandle)
+}

--- a/gateway/gateway-controller/pkg/service/websubapi/service.go
+++ b/gateway/gateway-controller/pkg/service/websubapi/service.go
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package websubapi
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/wso2/api-platform/common/eventhub"
+	api "github.com/wso2/api-platform/gateway/gateway-controller/pkg/api/management"
+	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/config"
+	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/controlplane"
+	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/models"
+	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/storage"
+	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/templateengine"
+	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/templateengine/funcs"
+	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/utils"
+)
+
+// UpdateParams holds parameters for the Update operation.
+type UpdateParams struct {
+	Handle        string
+	Body          []byte
+	ContentType   string
+	CorrelationID string
+	Logger        *slog.Logger
+}
+
+// UpdateResult holds the result of an Update operation.
+type UpdateResult struct {
+	Config *models.StoredConfig
+}
+
+// WebSubAPIService encapsulates WebSub API update behavior.
+type WebSubAPIService struct {
+	db                 storage.Storage
+	deploymentService  *utils.APIDeploymentService
+	controlPlaneClient controlplane.ControlPlaneClient
+	systemConfig       *config.Config
+	parser             *config.Parser
+	validator          config.Validator
+	logger             *slog.Logger
+	eventHub           eventhub.EventHub
+	secretResolver     funcs.SecretResolver
+}
+
+// NewWebSubAPIService creates a new WebSubAPIService.
+func NewWebSubAPIService(
+	db storage.Storage,
+	deploymentService *utils.APIDeploymentService,
+	controlPlaneClient controlplane.ControlPlaneClient,
+	systemConfig *config.Config,
+	parser *config.Parser,
+	validator config.Validator,
+	logger *slog.Logger,
+	eventHub eventhub.EventHub,
+	secretResolver funcs.SecretResolver,
+) *WebSubAPIService {
+	if db == nil {
+		panic("WebSubAPIService requires non-nil storage")
+	}
+	if deploymentService == nil {
+		panic("WebSubAPIService requires APIDeploymentService")
+	}
+	if eventHub == nil {
+		panic("WebSubAPIService requires non-nil EventHub")
+	}
+	if systemConfig == nil {
+		panic("WebSubAPIService requires non-nil system config")
+	}
+	if strings.TrimSpace(systemConfig.Controller.Server.GatewayID) == "" {
+		panic("WebSubAPIService requires non-empty gateway ID")
+	}
+
+	return &WebSubAPIService{
+		db:                 db,
+		deploymentService:  deploymentService,
+		controlPlaneClient: controlPlaneClient,
+		systemConfig:       systemConfig,
+		parser:             parser,
+		validator:          validator,
+		logger:             logger,
+		eventHub:           eventHub,
+		secretResolver:     secretResolver,
+	}
+}
+
+// Update modifies an existing WebSub API configuration.
+func (s *WebSubAPIService) Update(params UpdateParams) (*UpdateResult, error) {
+	log := params.Logger
+
+	var apiConfig api.WebSubAPI
+	if err := s.parser.Parse(params.Body, params.ContentType, &apiConfig); err != nil {
+		return nil, &ParseError{Cause: err}
+	}
+
+	if apiConfig.Metadata.Name != "" && apiConfig.Metadata.Name != params.Handle {
+		return nil, &HandleMismatchError{
+			PathHandle: params.Handle,
+			YAMLHandle: apiConfig.Metadata.Name,
+		}
+	}
+
+	existing, err := s.db.GetConfigByKindAndHandle(models.KindWebSubApi, params.Handle)
+	if err != nil {
+		if storage.IsNotFoundError(err) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("failed to retrieve existing websub api: %w", err)
+	}
+
+	desiredState := models.StateDeployed
+	if apiConfig.Spec.DeploymentState != nil &&
+		*apiConfig.Spec.DeploymentState == api.WebhookAPIDataDeploymentStateUndeployed {
+		desiredState = models.StateUndeployed
+	}
+
+	if desiredState != models.StateUndeployed {
+		result, err := s.deploymentService.DeployAPIConfiguration(utils.APIDeploymentParams{
+			Data:          params.Body,
+			ContentType:   params.ContentType,
+			Kind:          "WebSubApi",
+			APIID:         existing.UUID,
+			Origin:        models.OriginGatewayAPI,
+			CorrelationID: params.CorrelationID,
+			Logger:        log,
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &UpdateResult{Config: result.StoredConfig}, nil
+	}
+
+	existing.Configuration = apiConfig
+	existing.SourceConfiguration = apiConfig
+
+	if err := templateengine.RenderSpec(existing, s.secretResolver, log); err != nil {
+		return nil, err
+	}
+
+	renderedConfig, ok := existing.Configuration.(api.WebSubAPI)
+	if !ok {
+		return nil, fmt.Errorf("failed to render websub api configuration")
+	}
+
+	validationErrors := s.validator.Validate(&renderedConfig)
+	if len(validationErrors) > 0 {
+		return nil, &ValidationError{Errors: validationErrors}
+	}
+
+	if err := s.validateArtifactConflicts(existing.UUID, renderedConfig.Spec.DisplayName, renderedConfig.Spec.Version, existing.Handle); err != nil {
+		return nil, err
+	}
+
+	now := time.Now()
+	existing.DisplayName = renderedConfig.Spec.DisplayName
+	existing.Version = renderedConfig.Spec.Version
+	existing.DesiredState = desiredState
+	existing.UpdatedAt = now
+
+	truncatedNow := now.Truncate(time.Millisecond)
+	existing.DeployedAt = &truncatedNow
+
+	if existing.Origin == models.OriginGatewayAPI {
+		existing.CPSyncStatus = models.CPSyncStatusPending
+	}
+
+	if err := s.db.UpdateConfig(existing); err != nil {
+		log.Error("Failed to update WebSub API config in database", slog.Any("error", err))
+		return nil, fmt.Errorf("failed to persist configuration update: %w", err)
+	}
+
+	s.publishEvent(eventhub.EventTypeAPI, "UPDATE", existing.UUID, params.CorrelationID, log)
+
+	if existing.Origin == models.OriginGatewayAPI && s.controlPlaneClient != nil && s.controlPlaneClient.IsConnected() && s.controlPlaneClient.IsOnPrem() {
+		go func() {
+			if err := s.controlPlaneClient.SyncArtifactsToOnPremAPIM(s.controlPlaneClient.GetAPIMConfig()); err != nil {
+				log.Error("Failed to sync WebSub API to on-prem APIM", slog.Any("error", err))
+			}
+		}()
+	}
+
+	log.Info("WebSub API configuration updated",
+		slog.String("id", existing.UUID),
+		slog.String("handle", params.Handle),
+		slog.String("desired_state", string(desiredState)))
+
+	return &UpdateResult{Config: existing}, nil
+}
+
+func (s *WebSubAPIService) validateArtifactConflicts(currentID, displayName, version, handle string) error {
+	existingByNameVersion, err := s.db.GetConfigByKindNameAndVersion(models.KindWebSubApi, displayName, version)
+	if err == nil {
+		if existingByNameVersion != nil && existingByNameVersion.UUID != currentID {
+			return fmt.Errorf("%w: configuration with name '%s' and version '%s' already exists",
+				storage.ErrConflict, displayName, version)
+		}
+	} else if !storage.IsNotFoundError(err) {
+		return fmt.Errorf("failed to check existing WebSubApi name/version conflict: %w", err)
+	}
+
+	existingByHandle, err := s.db.GetConfigByKindAndHandle(models.KindWebSubApi, handle)
+	if err == nil {
+		if existingByHandle != nil && existingByHandle.UUID != currentID {
+			return fmt.Errorf("%w: configuration with handle '%s' already exists",
+				storage.ErrConflict, handle)
+		}
+	} else if !storage.IsNotFoundError(err) {
+		return fmt.Errorf("failed to check existing WebSubApi handle conflict: %w", err)
+	}
+
+	return nil
+}
+
+func (s *WebSubAPIService) publishEvent(eventType eventhub.EventType, action, entityID, correlationID string, logger *slog.Logger) {
+	gatewayID := strings.TrimSpace(s.systemConfig.Controller.Server.GatewayID)
+	event := eventhub.Event{
+		GatewayID:           gatewayID,
+		OriginatedTimestamp: time.Now(),
+		EventType:           eventType,
+		Action:              action,
+		EntityID:            entityID,
+		EventID:             correlationID,
+		EventData:           eventhub.EmptyEventData,
+	}
+
+	if err := s.eventHub.PublishEvent(gatewayID, event); err != nil {
+		logger.Warn("Failed to publish event to event hub",
+			slog.String("gateway_id", gatewayID),
+			slog.String("event_type", string(eventType)),
+			slog.String("action", action),
+			slog.String("entity_id", entityID),
+			slog.Any("error", err))
+		return
+	}
+
+	logger.Debug("Published event to event hub",
+		slog.String("gateway_id", gatewayID),
+		slog.String("event_type", string(eventType)),
+		slog.String("action", action),
+		slog.String("entity_id", entityID))
+}

--- a/platform-api/src/config/config.go
+++ b/platform-api/src/config/config.go
@@ -55,6 +55,18 @@ type Server struct {
 
 	// API key configurations
 	APIKey APIKey `envconfig:"API_KEY"`
+
+	// Gateway configurations
+	Gateway Gateway `envconfig:"GATEWAY"`
+}
+
+// Gateway holds gateway-related configuration.
+type Gateway struct {
+	// EnableVersionVerification controls whether the platform API rejects gateway
+	// connections whose reported version does not match the registered version.
+	// When false (default), a mismatch is logged and the connection is allowed to proceed.
+	// Env: GATEWAY_ENABLE_VERSION_VERIFICATION (default: false)
+	EnableVersionVerification bool `envconfig:"ENABLE_VERSION_VERIFICATION" default:"false"`
 }
 
 // TLS holds TLS certificate configuration

--- a/platform-api/src/internal/server/server.go
+++ b/platform-api/src/internal/server/server.go
@@ -187,7 +187,7 @@ func StartPlatformAPIServer(cfg *config.Server, slogger *slog.Logger) (*Server, 
 	appService := service.NewApplicationService(appRepo, projectRepo, orgRepo, apiRepo, gatewayEventsService, slogger)
 	apiService := service.NewAPIService(apiRepo, projectRepo, orgRepo, gatewayRepo, deploymentRepo, devPortalRepo, publicationRepo,
 		subscriptionPlanRepo, customPolicyRepo, gatewayEventsService, devPortalService, apiUtil, slogger)
-	gatewayService := service.NewGatewayService(gatewayRepo, orgRepo, apiRepo, customPolicyRepo, gatewayEventsService, slogger)
+	gatewayService := service.NewGatewayService(gatewayRepo, orgRepo, apiRepo, customPolicyRepo, gatewayEventsService, slogger, cfg.Gateway.EnableVersionVerification)
 	subscriptionService := service.NewSubscriptionService(apiRepo, subscriptionRepo, gatewayEventsService, slogger)
 	subscriptionPlanService := service.NewSubscriptionPlanService(subscriptionPlanRepo, gatewayRepo, gatewayEventsService, slogger)
 	internalGatewayService := service.NewGatewayInternalAPIService(apiRepo, subscriptionRepo, subscriptionPlanRepo, llmProviderRepo, llmProxyRepo, mcpProxyRepo, websubAPIRepo, deploymentRepo, gatewayRepo, orgRepo, projectRepo, apiKeyRepo, artifactRepo, cfg, slogger)

--- a/platform-api/src/internal/service/gateway.go
+++ b/platform-api/src/internal/service/gateway.go
@@ -69,25 +69,28 @@ type Manifest struct {
 
 // GatewayService handles gateway business logic
 type GatewayService struct {
-	gatewayRepo          repository.GatewayRepository
-	orgRepo              repository.OrganizationRepository
-	apiRepo              repository.APIRepository
-	customPolicyRepo     repository.CustomPolicyRepository
-	gatewayEventsService *GatewayEventsService
-	slogger              *slog.Logger
+	gatewayRepo               repository.GatewayRepository
+	orgRepo                   repository.OrganizationRepository
+	apiRepo                   repository.APIRepository
+	customPolicyRepo          repository.CustomPolicyRepository
+	gatewayEventsService      *GatewayEventsService
+	slogger                   *slog.Logger
+	enableVersionVerification bool
 }
 
 // NewGatewayService creates a new gateway service
 func NewGatewayService(gatewayRepo repository.GatewayRepository, orgRepo repository.OrganizationRepository,
 	apiRepo repository.APIRepository, customPolicyRepo repository.CustomPolicyRepository,
-	gatewayEventsService *GatewayEventsService, slogger *slog.Logger) *GatewayService {
+	gatewayEventsService *GatewayEventsService, slogger *slog.Logger,
+	enableVersionVerification bool) *GatewayService {
 	return &GatewayService{
-		gatewayRepo:          gatewayRepo,
-		orgRepo:              orgRepo,
-		apiRepo:              apiRepo,
-		customPolicyRepo:     customPolicyRepo,
-		gatewayEventsService: gatewayEventsService,
-		slogger:              slogger,
+		gatewayRepo:               gatewayRepo,
+		orgRepo:                   orgRepo,
+		apiRepo:                   apiRepo,
+		customPolicyRepo:          customPolicyRepo,
+		gatewayEventsService:      gatewayEventsService,
+		slogger:                   slogger,
+		enableVersionVerification: enableVersionVerification,
 	}
 }
 
@@ -178,7 +181,15 @@ func (s *GatewayService) ReceiveGatewayManifest(orgID, gatewayID, gatewayVersion
 		registeredMinor = defaultGatewayVersion
 	}
 	if reportedMinor != registeredMinor {
-		return fmt.Errorf("%w: registered=%s, reported=%s", constants.ErrGatewayVersionMismatch, registeredMinor, reportedMinor)
+		if s.enableVersionVerification {
+			return fmt.Errorf("%w: registered=%s, reported=%s", constants.ErrGatewayVersionMismatch, registeredMinor, reportedMinor)
+		}
+		s.slogger.Warn("Gateway version mismatch ignored (verification disabled)",
+			slog.String("org_id", orgID),
+			slog.String("gateway_id", gatewayID),
+			slog.String("registered", registeredMinor),
+			slog.String("reported", reportedMinor),
+		)
 	}
 
 	reportedType := strings.TrimSpace(functionalityType)


### PR DESCRIPTION
 ## Purpose
  WebSub binding updates were going through full remove-and-readd flows, which caused unnecessary undeploy behavior, dropped live receiver state, and made channel-only
  updates heavier than needed. Resolves N/A.

  ## Goals
  - apply WebSub channel-only updates in place
  - keep subscription sync topics and live receiver state intact during delta updates
  - fall back to full rebind only for structural changes

  ## Approach
  - added a WebSub receiver delta-update path that can add/remove channels without recreating the whole binding
  - updated runtime WebSub binding handling to diff channel topics, update hub chains, ensure new topics, and delete removed channel topics while preserving the internal
  subscription topic
  - changed the xDS handler to call `UpdateWebSubApiBinding(...)` instead of remove-then-add for changed bindings
  - added controller/service-side undeploy handling improvements included in this branch’s diff

  ## User stories
  WebSub API updates with channel-only changes are applied without unnecessary undeploys, while real structural changes still rebind safely.

  ## Documentation
  N/A - runtime/controller behavior fix only; no product documentation update included in this PR.

  ## Automation tests
  - Unit tests
    > Branch includes focused handler/runtime/service test coverage for delta update and undeploy paths
  - Integration tests
    > Not run in this turn

  ## Security checks
  - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
  - Ran FindSecurityBugs plugin and verified report? no
  - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

  ## Samples
  N/A

  ## Related PRs
  N/A

  ## Test environment
  Local diff review on Ubuntu 24.04.4 LTS