### PR TITLE
Fix Coderabbit Suggestions : WebSub delta updates without full undeploy/redeploy

### DIFF
--- a/event-gateway/gateway-runtime/internal/connectors/receiver/websub/connector.go
+++ b/event-gateway/gateway-runtime/internal/connectors/receiver/websub/connector.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/wso2/api-platform/event-gateway/gateway-runtime/internal/binding"
@@ -55,6 +56,7 @@ type WebSubReceiver struct {
 	syncProducer   *subscription.SyncProducer
 	brokerDriver   connectors.BrokerDriver
 	channel        connectors.ChannelInfo
+	channelMu      sync.RWMutex
 	opts           Options
 }
 
@@ -98,17 +100,28 @@ func NewReceiver(cfg connectors.ReceiverConfig, opts Options) (connectors.Receiv
 
 	verificationTimeout := time.Duration(opts.VerificationTimeoutSeconds) * time.Second
 
+	receiver := &WebSubReceiver{
+		deliverer:    deliverer,
+		topics:       topics,
+		store:        store,
+		consumerMgr:  consumerMgr,
+		syncProducer: syncProducer,
+		brokerDriver: cfg.BrokerDriver,
+		channel:      cfg.Channel,
+		opts:         opts,
+	}
+
 	// Create HubHandler for subscribe/unsubscribe on {context}/{version}/hub.
 	hubHandler := NewHubHandler(
 		topics, store, verificationTimeout, opts.DefaultLeaseSeconds,
 		cfg.Processor, cfg.BrokerDriver, cfg.Channel.Name,
-		cfg.Channel.Channels, consumerMgr, syncProducer,
+		cfg.Channel.Channels, &receiver.channelMu, consumerMgr, syncProducer,
 	)
 
 	// Create WebhookReceiverHandler for ingress on {context}/{version}/webhook-receiver.
 	webhookHandler := NewWebhookReceiverHandler(
 		topics, cfg.Processor, cfg.BrokerDriver,
-		cfg.Channel.Name, cfg.Channel.Channels,
+		cfg.Channel.Name, cfg.Channel.Channels, &receiver.channelMu,
 	)
 
 	// Register handlers on shared mux.
@@ -116,18 +129,10 @@ func NewReceiver(cfg connectors.ReceiverConfig, opts Options) (connectors.Receiv
 	cfg.Mux.Handle(basePath+"/hub", hubHandler)
 	cfg.Mux.Handle(basePath+"/webhook-receiver", webhookHandler)
 
-	return &WebSubReceiver{
-		hubHandler:     hubHandler,
-		webhookHandler: webhookHandler,
-		deliverer:      deliverer,
-		topics:         topics,
-		store:          store,
-		consumerMgr:    consumerMgr,
-		syncProducer:   syncProducer,
-		brokerDriver:   cfg.BrokerDriver,
-		channel:        cfg.Channel,
-		opts:           opts,
-	}, nil
+	receiver.hubHandler = hubHandler
+	receiver.webhookHandler = webhookHandler
+
+	return receiver, nil
 }
 
 // Start ensures Kafka topics exist and sets up the consumer manager context.

--- a/event-gateway/gateway-runtime/internal/connectors/receiver/websub/delta.go
+++ b/event-gateway/gateway-runtime/internal/connectors/receiver/websub/delta.go
@@ -59,11 +59,15 @@ func (e *WebSubReceiver) ApplyBindingDelta(ctx context.Context, removedChannels 
 			}
 		}
 
+		e.channelMu.Lock()
 		delete(e.channel.Channels, channelName)
+		e.channelMu.Unlock()
 	}
 
 	for channelName, kafkaTopic := range addedChannels {
+		e.channelMu.Lock()
 		e.channel.Channels[channelName] = kafkaTopic
+		e.channelMu.Unlock()
 		e.topics.Register(channelName)
 	}
 

--- a/event-gateway/gateway-runtime/internal/connectors/receiver/websub/handler.go
+++ b/event-gateway/gateway-runtime/internal/connectors/receiver/websub/handler.go
@@ -25,6 +25,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/wso2/api-platform/event-gateway/gateway-runtime/internal/connectors"
@@ -41,6 +42,7 @@ type HubHandler struct {
 	brokerDriver connectors.BrokerDriver
 	bindingName  string
 	channels     map[string]string // channel-name → Kafka topic
+	channelMu    *sync.RWMutex
 	consumerMgr  *ConsumerManager
 	syncProducer *subscription.SyncProducer
 	defaultLease int
@@ -56,6 +58,7 @@ func NewHubHandler(
 	brokerDriver connectors.BrokerDriver,
 	bindingName string,
 	channels map[string]string,
+	channelMu *sync.RWMutex,
 	consumerMgr *ConsumerManager,
 	syncProducer *subscription.SyncProducer,
 ) *HubHandler {
@@ -67,6 +70,7 @@ func NewHubHandler(
 		brokerDriver: brokerDriver,
 		bindingName:  bindingName,
 		channels:     channels,
+		channelMu:    channelMu,
 		consumerMgr:  consumerMgr,
 		syncProducer: syncProducer,
 		defaultLease: defaultLease,
@@ -131,7 +135,9 @@ func (h *HubHandler) handleSubscribe(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Resolve the Kafka topic for this channel.
+	h.channelMu.RLock()
 	kafkaTopic, ok := h.channels[topic]
+	h.channelMu.RUnlock()
 	if !ok {
 		http.Error(w, fmt.Sprintf("no kafka topic for channel: %s", topic), http.StatusNotFound)
 		return
@@ -239,7 +245,9 @@ func (h *HubHandler) handleUnsubscribe(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Stop/update per-callback consumer.
+	h.channelMu.RLock()
 	kafkaTopic := h.channels[topic]
+	h.channelMu.RUnlock()
 	if kafkaTopic != "" {
 		if err := h.consumerMgr.RemoveSubscription(callback, kafkaTopic); err != nil {
 			slog.Error("Failed to update consumer on unsubscribe", "callback", callback, "error", err)
@@ -271,6 +279,7 @@ type WebhookReceiverHandler struct {
 	brokerDriver connectors.BrokerDriver
 	bindingName  string
 	channels     map[string]string // channel-name → Kafka topic
+	channelMu    *sync.RWMutex
 }
 
 // NewWebhookReceiverHandler creates a new webhook receiver handler.
@@ -280,6 +289,7 @@ func NewWebhookReceiverHandler(
 	brokerDriver connectors.BrokerDriver,
 	bindingName string,
 	channels map[string]string,
+	channelMu *sync.RWMutex,
 ) *WebhookReceiverHandler {
 	return &WebhookReceiverHandler{
 		topics:       topics,
@@ -287,6 +297,7 @@ func NewWebhookReceiverHandler(
 		brokerDriver: brokerDriver,
 		bindingName:  bindingName,
 		channels:     channels,
+		channelMu:    channelMu,
 	}
 }
 
@@ -309,7 +320,9 @@ func (h *WebhookReceiverHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	h.channelMu.RLock()
 	kafkaTopic, ok := h.channels[channelName]
+	h.channelMu.RUnlock()
 	if !ok {
 		http.Error(w, fmt.Sprintf("no kafka topic for channel: %s", channelName), http.StatusNotFound)
 		return

--- a/event-gateway/gateway-runtime/internal/runtime/runtime.go
+++ b/event-gateway/gateway-runtime/internal/runtime/runtime.go
@@ -995,7 +995,7 @@ func (r *Runtime) UpdateWebSubApiBinding(oldWSB, newWSB binding.WebSubApiBinding
 		ChannelChainKeys:  chChainKeys,
 	})
 
-	internalSubTopic := binding.WebSubApiSubscriptionTopic(newWSB.Name, newWSB.Version)
+	internalSubTopic := r.webSubSubscriptionSyncTopic(newWSB.Name, newWSB.Version)
 	r.bindingTopics[newWSB.Name] = webSubTopicList(newChannels, internalSubTopic)
 
 	slog.Info("Dynamically updated WebSubApi binding",

--- a/event-gateway/gateway-runtime/internal/runtime/runtime.go
+++ b/event-gateway/gateway-runtime/internal/runtime/runtime.go
@@ -904,19 +904,21 @@ func (r *Runtime) UpdateWebSubApiBinding(oldWSB, newWSB binding.WebSubApiBinding
 	}
 
 	r.mu.Lock()
-	defer r.mu.Unlock()
 
 	receiver, ok := r.activeReceivers[oldWSB.Name]
 	if !ok {
+		r.mu.Unlock()
 		return fmt.Errorf("active receiver not found for WebSubApi %q", oldWSB.Name)
 	}
 	updater, ok := receiver.(webSubBindingUpdater)
 	if !ok {
+		r.mu.Unlock()
 		return fmt.Errorf("receiver for WebSubApi %q does not support delta updates", oldWSB.Name)
 	}
 
 	brokerDriver, ok := r.activeBrokerDrivers[oldWSB.Name]
 	if !ok {
+		r.mu.Unlock()
 		return fmt.Errorf("active broker-driver not found for WebSubApi %q", oldWSB.Name)
 	}
 
@@ -924,6 +926,7 @@ func (r *Runtime) UpdateWebSubApiBinding(oldWSB, newWSB binding.WebSubApiBinding
 	newChannels := webSubChannelTopicMap(newWSB)
 	removedChannels, addedChannels := diffChannelTopics(oldChannels, newChannels)
 	oldBinding := r.hub.GetBinding(oldWSB.Name)
+	r.mu.Unlock()
 
 	if len(addedChannels) > 0 {
 		topicsToEnsure := make([]string, 0, len(addedChannels))
@@ -960,6 +963,21 @@ func (r *Runtime) UpdateWebSubApiBinding(oldWSB, newWSB binding.WebSubApiBinding
 	subKey, inKey, outKey, chChainKeys, err := r.buildWebSubApiPolicyChains(newWSB, vhost)
 	if err != nil {
 		return fmt.Errorf("failed to build chains for updated WebSubApi %q: %w", newWSB.Name, err)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	currentReceiver, ok := r.activeReceivers[oldWSB.Name]
+	if !ok || currentReceiver != receiver {
+		return fmt.Errorf("active receiver changed during WebSubApi update for %q", newWSB.Name)
+	}
+	currentBrokerDriver, ok := r.activeBrokerDrivers[oldWSB.Name]
+	if !ok || currentBrokerDriver != brokerDriver {
+		return fmt.Errorf("active broker-driver changed during WebSubApi update for %q", newWSB.Name)
+	}
+	if r.hub.GetBinding(oldWSB.Name) != oldBinding {
+		return fmt.Errorf("hub binding changed during WebSubApi update for %q", newWSB.Name)
 	}
 
 	r.unregisterStaleBindingChains(oldBinding, webSubActiveChainKeys(newWSB, vhost))

--- a/event-gateway/gateway-runtime/internal/runtime/runtime.go
+++ b/event-gateway/gateway-runtime/internal/runtime/runtime.go
@@ -928,6 +928,12 @@ func (r *Runtime) UpdateWebSubApiBinding(oldWSB, newWSB binding.WebSubApiBinding
 	oldBinding := r.hub.GetBinding(oldWSB.Name)
 	r.mu.Unlock()
 
+	vhost := defaultVhost(newWSB.Vhost)
+	subKey, inKey, outKey, chChainKeys, err := r.buildWebSubApiPolicyChains(newWSB, vhost)
+	if err != nil {
+		return fmt.Errorf("failed to build chains for updated WebSubApi %q: %w", newWSB.Name, err)
+	}
+
 	if len(addedChannels) > 0 {
 		topicsToEnsure := make([]string, 0, len(addedChannels))
 		for _, kafkaTopic := range addedChannels {
@@ -957,12 +963,6 @@ func (r *Runtime) UpdateWebSubApiBinding(oldWSB, newWSB binding.WebSubApiBinding
 				"error", err)
 		}
 		cancel()
-	}
-
-	vhost := defaultVhost(newWSB.Vhost)
-	subKey, inKey, outKey, chChainKeys, err := r.buildWebSubApiPolicyChains(newWSB, vhost)
-	if err != nil {
-		return fmt.Errorf("failed to build chains for updated WebSubApi %q: %w", newWSB.Name, err)
 	}
 
 	r.mu.Lock()

--- a/gateway/gateway-controller/pkg/api/handlers/websub_api_handler.go
+++ b/gateway/gateway-controller/pkg/api/handlers/websub_api_handler.go
@@ -202,6 +202,7 @@ func (s *APIServer) UpdateWebSubAPI(c *gin.Context, id string) {
 				Status:  "error",
 				Message: fmt.Sprintf("WebSub API configuration with handle '%s' not found", handle),
 			})
+			return
 		} else if storage.IsConflictError(err) {
 			c.JSON(http.StatusConflict, api.ErrorResponse{
 				Status:  "error",

--- a/gateway/gateway-controller/pkg/service/websubapi/service.go
+++ b/gateway/gateway-controller/pkg/service/websubapi/service.go
@@ -149,6 +149,10 @@ func (s *WebSubAPIService) Update(params UpdateParams) (*UpdateResult, error) {
 		return &UpdateResult{Config: result.StoredConfig}, nil
 	}
 
+	if apiConfig.Metadata.Name == "" {
+		apiConfig.Metadata.Name = params.Handle
+	}
+
 	existing.Configuration = apiConfig
 	existing.SourceConfiguration = apiConfig
 

--- a/gateway/gateway-controller/pkg/service/websubapi/service.go
+++ b/gateway/gateway-controller/pkg/service/websubapi/service.go
@@ -156,11 +156,12 @@ func (s *WebSubAPIService) Update(params UpdateParams) (*UpdateResult, error) {
 	existing.Configuration = apiConfig
 	existing.SourceConfiguration = apiConfig
 
-	if err := templateengine.RenderSpec(existing, s.secretResolver, log); err != nil {
+	renderedExisting := *existing
+	if err := templateengine.RenderSpec(&renderedExisting, s.secretResolver, log); err != nil {
 		return nil, err
 	}
 
-	renderedConfig, ok := existing.Configuration.(api.WebSubAPI)
+	renderedConfig, ok := renderedExisting.Configuration.(api.WebSubAPI)
 	if !ok {
 		return nil, fmt.Errorf("failed to render websub api configuration")
 	}


### PR DESCRIPTION
 ## Purpose
  WebSub binding updates were going through full remove-and-readd flows, which caused unnecessary undeploy behavior, dropped live receiver state, and made channel-only
  updates heavier than needed. Resolves N/A.

  ## Goals
  - apply WebSub channel-only updates in place
  - keep subscription sync topics and live receiver state intact during delta updates
  - fall back to full rebind only for structural changes

  ## Approach
  - added a WebSub receiver delta-update path that can add/remove channels without recreating the whole binding
  - updated runtime WebSub binding handling to diff channel topics, update hub chains, ensure new topics, and delete removed channel topics while preserving the internal
  subscription topic
  - changed the xDS handler to call `UpdateWebSubApiBinding(...)` instead of remove-then-add for changed bindings
  - added controller/service-side undeploy handling improvements included in this branch’s diff

  ## User stories
  WebSub API updates with channel-only changes are applied without unnecessary undeploys, while real structural changes still rebind safely.

  ## Documentation
  N/A - runtime/controller behavior fix only; no product documentation update included in this PR.

  ## Automation tests
  - Unit tests
    > Branch includes focused handler/runtime/service test coverage for delta update and undeploy paths
  - Integration tests
    > Not run in this turn

  ## Security checks
  - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
  - Ran FindSecurityBugs plugin and verified report? no
  - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

  ## Samples
  N/A

  ## Related PRs
  N/A

  ## Test environment
  Local diff review on Ubuntu 24.04.4 LTS