### PR TITLE
Fix the dependency validation workflow to properly support pull requests from forks

### DIFF
--- a/.github/workflows/dependency-validation.yml
+++ b/.github/workflows/dependency-validation.yml
@@ -1,7 +1,7 @@
 name: Dependency Validation
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
     paths:
       - '**/go.mod'
@@ -9,6 +9,7 @@ on:
 
 permissions:
   pull-requests: write
+  issues: write
   contents: read
 
 env: 
@@ -23,6 +24,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Detect modified go.mod files
         id: detect-changes


### PR DESCRIPTION
## Changes

  - Switch trigger from `pull_request` to `pull_request_target` to allow workflow execution on fork PRs
  - Add `issues: write` permission to enable workflow to comment on PRs from forks
  - Add explicit `ref: ${{ github.event.pull_request.head.sha }}` to checkout step to ensure correct commit
  is validated

  ## Why These Changes?

  The previous configuration using `pull_request` trigger didn't have sufficient permissions to:

-   Post validation results as comments on the PR

  With `pull_request_target`, the workflow runs with write permissions while still validating the fork's
  code.