### PR TITLE
build: include LICENSE in gateway and event-gateway images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,8 @@ platform-api/src/resources/openapi_with_binding.yaml
 
 # Gateway
 gateway/gateway-runtime/target
+gateway/gateway-controller/target/
+event-gateway/gateway-runtime/target/
 dev-policies/
 
 # Copilot Prompts

--- a/.gitignore
+++ b/.gitignore
@@ -142,6 +142,7 @@ platform-api/src/resources/openapi_with_binding.yaml
 # Gateway
 gateway/gateway-runtime/target
 gateway/gateway-controller/target/
+gateway/gateway-builder/target/
 event-gateway/gateway-runtime/target/
 dev-policies/
 

--- a/event-gateway/Makefile
+++ b/event-gateway/Makefile
@@ -73,6 +73,8 @@ build: build-event-gateway-controller build-gateway-runtime build-webhook-listen
 # once gateway-builder is integrated into the event-gateway build pipeline.
 build-event-gateway-controller: ## Build event-gateway-controller Docker image
 	@echo "Building event-gateway-controller Docker image ($(VERSION))..."
+	@mkdir -p ../gateway/gateway-controller/target
+	@cp ../LICENSE ../gateway/gateway-controller/target/
 	@cd ../gateway/gateway-controller && \
 		docker buildx build -f Dockerfile \
 			--build-context sdk=../../sdk \
@@ -80,6 +82,7 @@ build-event-gateway-controller: ## Build event-gateway-controller Docker image
 			--build-context common=../../common \
 			--build-context build-manifest=.. \
 			--build-context policies=../../event-gateway/default-policies \
+			--build-context target=target \
 			--build-arg VERSION=$(VERSION) \
 			--build-arg FUNCTIONALITY_TYPE=event \
 			--build-arg GIT_COMMIT=$$(git rev-parse --short HEAD 2>/dev/null || echo "unknown") \
@@ -87,6 +90,7 @@ build-event-gateway-controller: ## Build event-gateway-controller Docker image
 			-t $(EVENT_GATEWAY_CONTROLLER_IMAGE):$(VERSION) \
 			--load \
 			.
+	@rm -rf ../gateway/gateway-controller/target
 
 .PHONY: build-gateway-runtime
 build-gateway-runtime: ## Build event-gateway-runtime Docker image
@@ -107,6 +111,8 @@ build-and-push-multiarch: build-and-push-multiarch-event-gateway-controller buil
 # once gateway-builder is integrated into the event-gateway build pipeline.
 build-and-push-multiarch-event-gateway-controller: ## Build and push event-gateway-controller Docker image for multiple architectures
 	@echo "Building and pushing multi-arch event-gateway-controller Docker image ($(VERSION))..."
+	@mkdir -p ../gateway/gateway-controller/target
+	@cp ../LICENSE ../gateway/gateway-controller/target/
 	@cd ../gateway/gateway-controller && \
 		docker buildx build -f Dockerfile \
 			--build-context sdk=../../sdk \
@@ -114,6 +120,7 @@ build-and-push-multiarch-event-gateway-controller: ## Build and push event-gatew
 			--build-context common=../../common \
 			--build-context build-manifest=.. \
 			--build-context policies=../../event-gateway/default-policies \
+			--build-context target=target \
 			--platform linux/amd64,linux/arm64 \
 			--build-arg VERSION=$(VERSION) \
 			--build-arg FUNCTIONALITY_TYPE=event \
@@ -122,6 +129,7 @@ build-and-push-multiarch-event-gateway-controller: ## Build and push event-gatew
 			-t $(EVENT_GATEWAY_CONTROLLER_IMAGE):$(VERSION) \
 			--push \
 			.
+	@rm -rf ../gateway/gateway-controller/target
 
 .PHONY: build-and-push-multiarch-gateway-runtime
 build-and-push-multiarch-gateway-runtime: ## Build and push event-gateway-runtime Docker image for multiple architectures

--- a/event-gateway/gateway-runtime/Dockerfile
+++ b/event-gateway/gateway-runtime/Dockerfile
@@ -111,6 +111,7 @@ RUN apk add --no-cache ca-certificates bash tini && \
 WORKDIR /app
 
 COPY --from=policy-compiler /api-platform/output/event-gateway/event-gateway /app/event-gateway
+COPY --from=target LICENSE /app/LICENSE
 COPY configs/config.toml /etc/event-gateway/config.toml
 COPY configs/channels.yaml /etc/event-gateway/channels.yaml
 COPY docker-entrypoint.sh /app/docker-entrypoint.sh

--- a/event-gateway/gateway-runtime/Dockerfile.debug
+++ b/event-gateway/gateway-runtime/Dockerfile.debug
@@ -115,6 +115,7 @@ RUN go install github.com/go-delve/delve/cmd/dlv@latest
 WORKDIR /app
 
 COPY --from=policy-compiler /api-platform/output/event-gateway/event-gateway /app/event-gateway
+COPY --from=target LICENSE /app/LICENSE
 COPY configs/config.toml /etc/event-gateway/config.toml
 COPY configs/channels.yaml /etc/event-gateway/channels.yaml
 

--- a/event-gateway/gateway-runtime/Makefile
+++ b/event-gateway/gateway-runtime/Makefile
@@ -80,7 +80,9 @@ debug-local: generate ## Build locally with debug symbols and launch Delve on :2
 .PHONY: build-docker
 build-docker: ## Build Docker image
 	@echo "Building event-gateway-runtime Docker image ($(VERSION))..."
-	@mkdir -p target && cp ../build.yaml target/
+	@mkdir -p target
+	@cp ../build.yaml target/
+	@cp ../../LICENSE target/
 	docker buildx build \
 		--load \
 		--platform linux/$(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') \
@@ -100,7 +102,9 @@ build-docker: ## Build Docker image
 .PHONY: build-debug
 build-debug: ## Build Docker image with Delve remote debugger (port 2345)
 	@echo "Building event-gateway-runtime debug Docker image ($(VERSION))..."
-	@mkdir -p target && cp ../build.yaml target/
+	@mkdir -p target
+	@cp ../build.yaml target/
+	@cp ../../LICENSE target/
 	docker buildx build \
 		--load \
 		--platform linux/$(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') \
@@ -120,7 +124,9 @@ build-debug: ## Build Docker image with Delve remote debugger (port 2345)
 .PHONY: build-and-push-multiarch
 build-and-push-multiarch: ## Build and push Docker image for multiple architectures
 	@echo "Building and pushing multi-arch event-gateway-runtime Docker image ($(VERSION))..."
-	@mkdir -p target && cp ../build.yaml target/
+	@mkdir -p target
+	@cp ../build.yaml target/
+	@cp ../../LICENSE target/
 	docker buildx build \
 		--push \
 		--platform linux/amd64,linux/arm64 \

--- a/gateway/gateway-builder/Dockerfile
+++ b/gateway/gateway-builder/Dockerfile
@@ -97,6 +97,7 @@ COPY --from=system-policies . /api-platform/gateway/system-policies
 COPY --from=common . /api-platform/common
 COPY --from=sdk-core . /api-platform/sdk/core
 COPY --from=sdk-python . /api-platform/sdk-python
+COPY --from=target LICENSE /app/LICENSE
 
 # Set working directory
 WORKDIR /workspace

--- a/gateway/gateway-builder/Makefile
+++ b/gateway/gateway-builder/Makefile
@@ -56,6 +56,8 @@ help: ## Show this help message
 .PHONY: build
 build: ## Build Docker image using buildx
 	@echo "Building Docker image ($(IMAGE_NAME):$(VERSION))..."
+	@mkdir -p target
+	@cp ../../LICENSE target/
 	@docker buildx build -f Dockerfile \
 		--build-context policy-engine=../gateway-runtime/policy-engine \
 		--build-context python-executor=../gateway-runtime/python-executor \
@@ -64,6 +66,7 @@ build: ## Build Docker image using buildx
 		--build-context sdk-core=../../sdk/core \
 		--build-context sdk-python=../../sdk-python \
 		--build-context common=../../common \
+		--build-context target=target \
 		--build-arg VERSION=$(VERSION) \
 		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
 		-t $(IMAGE_NAME):$(VERSION) \
@@ -81,6 +84,8 @@ push: ## Push Docker image to registry
 .PHONY: build-and-push-multiarch
 build-and-push-multiarch: ## Build and push multi-architecture Docker image (linux/amd64, linux/arm64)
 	@echo "Building and pushing multi-arch Docker image: $(IMAGE_NAME):$(VERSION)"
+	@mkdir -p target
+	@cp ../../LICENSE target/
 	docker buildx build -f Dockerfile \
 		--build-context policy-engine=../gateway-runtime/policy-engine \
 		--build-context python-executor=../gateway-runtime/python-executor \
@@ -89,6 +94,7 @@ build-and-push-multiarch: ## Build and push multi-architecture Docker image (lin
 		--build-context sdk-core=../../sdk/core \
 		--build-context sdk-python=../../sdk-python \
 		--build-context common=../../common \
+		--build-context target=target \
 		--platform linux/amd64,linux/arm64 \
 		--build-arg VERSION=$(VERSION) \
 		--build-arg GIT_COMMIT=$(GIT_COMMIT) \

--- a/gateway/gateway-controller/Dockerfile
+++ b/gateway/gateway-controller/Dockerfile
@@ -88,6 +88,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 COPY --from=builder /build/controller .
 COPY --from=build-manifest build-manifest.yaml /app/build-manifest.yaml
 COPY --from=policies . /app/default-policies
+COPY --from=target LICENSE /app/LICENSE
 COPY lua /app/lua
 COPY default-llm-provider-templates /app/default-llm-provider-templates
 
@@ -117,11 +118,12 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
-# Copy build manifest 
+# Copy build manifest
 COPY --from=build-manifest build-manifest.yaml /app/build-manifest.yaml
 
 COPY --from=builder /build/controller .
 COPY --from=policies . /app/default-policies
+COPY --from=target LICENSE /app/LICENSE
 COPY lua /app/lua
 COPY default-llm-provider-templates /app/default-llm-provider-templates
 

--- a/gateway/gateway-controller/Makefile
+++ b/gateway/gateway-controller/Makefile
@@ -74,12 +74,15 @@ test: ## Run unit and integration tests
 
 build: generate-server-code test ## Build Docker image using buildx
 	@echo "Building Docker image ($(IMAGE_NAME):$(VERSION))..."
+	@mkdir -p target
+	@cp ../../LICENSE target/
 	docker buildx build -f Dockerfile \
 		--build-context sdk=../../sdk \
 		--build-context sdk-core=../../sdk/core \
 		--build-context common=../../common \
 		--build-context build-manifest=.. \
 		--build-context policies=$(POLICIES_BUILD_CONTEXT) \
+		--build-context target=target \
 		--build-arg VERSION=$(VERSION) \
 		--build-arg FUNCTIONALITY_TYPE=$(FUNCTIONALITY_TYPE) \
 		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
@@ -88,6 +91,7 @@ build: generate-server-code test ## Build Docker image using buildx
 		-t $(IMAGE_NAME):latest \
 		--load \
 		.
+	@rm -rf target
 	@echo "Docker image ($(IMAGE_NAME):$(VERSION)) built successfully."
 
 push: ## Push Docker image to registry
@@ -97,12 +101,15 @@ push: ## Push Docker image to registry
 
 build-and-push-multiarch: ## Build and push multi-architecture Docker image (linux/amd64, linux/arm64)
 	@echo "Building and pushing multi-arch Docker image: $(IMAGE_NAME):$(VERSION)"
+	@mkdir -p target
+	@cp ../../LICENSE target/
 	docker buildx build -f Dockerfile \
 		--build-context sdk=../../sdk \
 		--build-context sdk-core=../../sdk/core \
 		--build-context common=../../common \
 		--build-context build-manifest=.. \
 		--build-context policies=$(POLICIES_BUILD_CONTEXT) \
+		--build-context target=target \
 		--platform linux/amd64,linux/arm64 \
 		--build-arg VERSION=$(VERSION) \
 		--build-arg FUNCTIONALITY_TYPE=$(FUNCTIONALITY_TYPE) \
@@ -112,14 +119,18 @@ build-and-push-multiarch: ## Build and push multi-architecture Docker image (lin
 		-t $(IMAGE_NAME):latest \
 		--push \
 		.
+	@rm -rf target
 
 build-coverage-image: test ## Build coverage-instrumented gateway-controller image
+	@mkdir -p target
+	@cp ../../LICENSE target/
 	docker buildx build -f Dockerfile \
 		--build-context sdk=../../sdk \
 		--build-context sdk-core=../../sdk/core \
 		--build-context common=../../common \
 		--build-context build-manifest=.. \
 		--build-context policies=$(POLICIES_BUILD_CONTEXT) \
+		--build-context target=target \
 		--build-arg VERSION=$(VERSION) \
 		--build-arg FUNCTIONALITY_TYPE=$(FUNCTIONALITY_TYPE) \
 		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
@@ -128,14 +139,18 @@ build-coverage-image: test ## Build coverage-instrumented gateway-controller ima
 		-t $(IMAGE_NAME)-coverage:$(VERSION) \
 		--load \
 		.
+	@rm -rf target
 
 build-debug: ## Build debug image for remote debugging with dlv (VS Code attach on port 2345)
+	@mkdir -p target
+	@cp ../../LICENSE target/
 	docker buildx build -f Dockerfile \
 		--build-context sdk=../../sdk \
 		--build-context sdk-core=../../sdk/core \
 		--build-context common=../../common \
 		--build-context build-manifest=.. \
 		--build-context policies=$(POLICIES_BUILD_CONTEXT) \
+		--build-context target=target \
 		--build-arg VERSION=$(VERSION) \
 		--build-arg FUNCTIONALITY_TYPE=$(FUNCTIONALITY_TYPE) \
 		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
@@ -145,6 +160,7 @@ build-debug: ## Build debug image for remote debugging with dlv (VS Code attach 
 		-t $(IMAGE_NAME)-debug:latest \
 		--load \
 		.
+	@rm -rf target
 
 generate-listener-certs: ## Generate listener certificates
 	@echo "Generating listener certificates..."

--- a/gateway/gateway-runtime/Dockerfile
+++ b/gateway/gateway-runtime/Dockerfile
@@ -210,6 +210,7 @@ COPY router/config/config-override.yaml /etc/envoy/config-override.yaml
 COPY docker-entrypoint-debug.sh /usr/local/bin/docker-entrypoint.sh
 COPY health-check.sh /usr/local/bin/health-check.sh
 COPY --from=target configs/llm-pricing/ /home/wso2/conf/llm-pricing/
+COPY --from=target LICENSE /app/LICENSE
 
 RUN chmod +x /app/policy-engine /usr/local/bin/dlv /usr/local/bin/docker-entrypoint.sh /usr/local/bin/health-check.sh
 
@@ -263,6 +264,7 @@ COPY router/config/config-override.yaml /etc/envoy/config-override.yaml
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 COPY health-check.sh /usr/local/bin/health-check.sh
 COPY --from=target configs/llm-pricing/ /home/wso2/conf/llm-pricing/
+COPY --from=target LICENSE /app/LICENSE
 
 RUN chmod +x /app/policy-engine /usr/local/bin/docker-entrypoint.sh /usr/local/bin/health-check.sh
 

--- a/gateway/gateway-runtime/Makefile
+++ b/gateway/gateway-runtime/Makefile
@@ -56,7 +56,10 @@ help: ## Show this help message
 
 build: test ## Build Gateway Runtime Docker image using buildx
 	@echo "Building Gateway Runtime Docker image ($(IMAGE_NAME):$(VERSION))..."
-	@mkdir -p target/configs && cp ../build.yaml target/ && cp -r ../configs/llm-pricing target/configs/
+	@mkdir -p target/configs
+	@cp ../build.yaml target/
+	@cp ../../LICENSE target/
+	@cp -r ../configs/llm-pricing target/configs/
 	docker buildx build -f Dockerfile \
 		--build-context sdk=../../sdk \
 		--build-context sdk-python=../../sdk-python \
@@ -105,7 +108,10 @@ extract-policies: ## Extract controller policy YAMLs from the policy-compiler st
 
 build-debug: ## Build debug Gateway Runtime image for remote debugging with dlv (VS Code attach on port 2346)
 	@echo "Building Gateway Runtime debug image ($(IMAGE_NAME)-debug:$(VERSION))..."
-	@mkdir -p target/configs && cp ../build.yaml target/ && cp -r ../configs/llm-pricing target/configs/
+	@mkdir -p target/configs
+	@cp ../build.yaml target/
+	@cp ../../LICENSE target/
+	@cp -r ../configs/llm-pricing target/configs/
 	docker buildx build -f Dockerfile \
 		--build-context sdk=../../sdk \
 		--build-context sdk-python=../../sdk-python \
@@ -132,7 +138,10 @@ build-debug: ## Build debug Gateway Runtime image for remote debugging with dlv 
 
 build-coverage-image: test ## Build Gateway Runtime Docker image with coverage instrumentation
 	@echo "Building Gateway Runtime coverage image ($(IMAGE_NAME)-coverage:$(VERSION))..."
-	@mkdir -p target/configs && cp ../build.yaml target/ && cp -r ../configs/llm-pricing target/configs/
+	@mkdir -p target/configs
+	@cp ../build.yaml target/
+	@cp ../../LICENSE target/
+	@cp -r ../configs/llm-pricing target/configs/
 	DOCKER_BUILDKIT=1 docker build -f Dockerfile \
 		--build-context sdk=../../sdk \
 		--build-context sdk-python=../../sdk-python \
@@ -160,7 +169,10 @@ push: ## Push Docker image to registry
 
 build-and-push-multiarch: ## Build and push Gateway Runtime Docker image for multiple architectures (amd64, arm64)
 	@echo "Building and pushing multi-arch Gateway Runtime Docker image ($(VERSION))..."
-	@mkdir -p target/configs && cp ../build.yaml target/ && cp -r ../configs/llm-pricing target/configs/
+	@mkdir -p target/configs
+	@cp ../build.yaml target/
+	@cp ../../LICENSE target/
+	@cp -r ../configs/llm-pricing target/configs/
 	docker buildx build -f Dockerfile \
 		--build-context sdk=../../sdk \
 		--build-context sdk-python=../../sdk-python \


### PR DESCRIPTION
## Purpose

The gateway and event-gateway Docker images did not ship the Apache License 2.0 text, which is required for distribution compliance.

## Approach

- Stage the repo-root `LICENSE` into each image's `/app/LICENSE` via the existing `target/` build-context pattern.
- Cover both regular and multi-arch builds (plus the debug and coverage variants):
  - `gateway/gateway-runtime`, `gateway/gateway-controller`, `gateway/gateway-builder`
  - `event-gateway/gateway-runtime`, `event-gateway-controller`
- Add a `target/` build-context to `gateway-controller` and `gateway-builder` (which previously didn't use one) and clean it up after each build where appropriate.
- Gitignore the newly introduced `gateway/gateway-controller/target/`, `gateway/gateway-builder/target/`, and `event-gateway/gateway-runtime/target/` directories.
- Templated Dockerfiles (built from these base images by `gateway-builder`) inherit `/app/LICENSE` automatically, so no template changes were needed.

## Related Issues

Fixes wso2/api-platform#1968

## Test environment

Verified after building locally and running via `docker compose` / `docker run`:

### Gateway Controller

```
❯ docker compose exec -it gateway-controller bash
wso2@be61b38e43e2:/app$ ls
LICENSE  build-manifest.yaml  certificates  controller  data  default-llm-provider-templates  default-policies  listener-certs  lua
wso2@be61b38e43e2:/app$ head LICENSE
                                 Apache License
                           Version 2.0, January 2004
                        http://www.apache.org/licenses/

   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION

   1. Definitions.

      "License" shall mean the terms and conditions for use, reproduction,
      and distribution as defined by Sections 1 through 9 of this document.
```

### Gateway Runtime

```
❯ docker compose exec -it gateway-runtime bash
wso2@ca2aade32695:/$ cd app/
wso2@ca2aade32695:/app$ ls
LICENSE  build-manifest.yaml  policy-engine  python-executor  python-libs  python-requirements-lock.txt
wso2@ca2aade32695:/app$ head LICENSE
                                 Apache License
                           Version 2.0, January 2004
                        http://www.apache.org/licenses/

   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION

   1. Definitions.

      "License" shall mean the terms and conditions for use, reproduction,
      and distribution as defined by Sections 1 through 9 of this document.
```

### Gateway Builder

```
❯ docker run -it --rm --entrypoint  bash ghcr.io/wso2/api-platform/gateway-builder:1.2.0-SNAPSHOT
root@c2b39236c275:/workspace# cd /app
root@c2b39236c275:/app# ls
LICENSE
root@c2b39236c275:/app# head LICENSE
                                 Apache License
                           Version 2.0, January 2004
                        http://www.apache.org/licenses/

   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION

   1. Definitions.

      "License" shall mean the terms and conditions for use, reproduction,
      and distribution as defined by Sections 1 through 9 of this document.
```

## Documentation

N/A — no doc impact; this is a packaging change to embed the existing repo-root `LICENSE` in the published images.

## Automation tests

- Unit tests: N/A — build-system change only, no code paths affected.
- Integration tests: N/A — verified manually by inspecting the built images (see Test environment).

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — no Java code changed
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

N/A