### PR TITLE
Enhance gateway configuration by conditionally including OAuth2 client ID and secret in the Helm chart template

### DIFF
--- a/kubernetes/helm/gateway-helm-chart/templates/gateway/gateway-config.yaml
+++ b/kubernetes/helm/gateway-helm-chart/templates/gateway/gateway-config.yaml
@@ -69,8 +69,12 @@ data:
     deployment_push_enabled = {{ $gc.controlplane.deployment_push_enabled }}
     sync_batch_size = {{ $gc.controlplane.sync_batch_size }}
     gateway_name = {{ $gc.controlplane.gateway_name | quote }}
+    {{- if $gc.controlplane.apim_oauth2_client_id }}
     apim_oauth2_client_id = {{ $gc.controlplane.apim_oauth2_client_id | quote }}
+    {{- end }}
+    {{- if $gc.controlplane.apim_oauth2_client_secret }}
     apim_oauth2_client_secret = {{ $gc.controlplane.apim_oauth2_client_secret | quote }}
+    {{- end }}
     apim_oauth2_username = {{ $gc.controlplane.apim_oauth2_username | quote }}
     apim_oauth2_password = {{ $gc.controlplane.apim_oauth2_password | quote }}
 


### PR DESCRIPTION
## Purpose

This is not a mandatory fix - as we can ommit these values without adding even empty values to the values.yaml

https://github.com/wso2/api-platform/issues/1987

Without the conditionals, the template would render:

  apim_oauth2_client_id = ""
  apim_oauth2_client_secret = ""

An explicit empty string is a value — it gets written to the ConfigMap and the controller reads it from the TOML file. Most Go config frameworks (Viper, etc.) won't fall back to an env var when the key is present in the config file, even if the value is empty. The env var would be silently ignored.

By making the fields conditional, those lines are omitted entirely from config.toml. Only then — when the key is absent from the file — does the controller fall back to its env var override (APIP_GW_CONTROLPLANE_APIM_OAUTH2_CLIENT_ID).

So the conditionals are load-bearing. Without them: controller auth fails with an empty client ID. With them: the TOML is silent on those fields, env vars win.