### PR TITLE
Hash WebSub API topics

### DIFF
--- a/event-gateway/ARCHITECTURE.md
+++ b/event-gateway/ARCHITECTURE.md
@@ -1220,7 +1220,7 @@ type BrokerDriver interface {
     Publish(ctx context.Context, topic string, msg *Message) error
     Subscribe(groupID string, topics []string, handler MessageHandler) (Receiver, error)
     TopicExists(ctx context.Context, topic string) (bool, error)
-    EnsureTopics(ctx context.Context, topics []string) error
+    EnsureTopics(ctx context.Context, topics []string, metadata map[string]map[string]string) error
     DeleteTopics(ctx context.Context, topics []string) error
     Close() error
 }

--- a/event-gateway/gateway-runtime/internal/binding/types.go
+++ b/event-gateway/gateway-runtime/internal/binding/types.go
@@ -19,6 +19,7 @@
 package binding
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"path"
 	"strings"
@@ -146,18 +147,21 @@ type ChannelsConfig struct {
 	Channels []Binding `yaml:"channels"`
 }
 
-// JoinNormalizedTopic derives a Kafka topic name by normalizing each logical
-// segment and joining them with underscores.
+// JoinNormalizedTopic derives a Kafka topic name by hashing the parts joined with underscores.
+// Returns the SHA-256 hash of the joined string.
 func JoinNormalizedTopic(parts ...string) string {
 	if len(parts) == 0 {
 		return ""
 	}
 
-	normalizedParts := make([]string, 0, len(parts))
-	for _, part := range parts {
-		normalizedParts = append(normalizedParts, NormalizeTopicSegment(part))
-	}
-	return strings.Join(normalizedParts, "_")
+	// Join parts with underscore
+	joined := strings.Join(parts, "_")
+
+	// Calculate SHA-256 hash
+	hash := sha256.Sum256([]byte(joined))
+
+	// Return hex-encoded hash
+	return fmt.Sprintf("%x", hash)
 }
 
 // WebSubApiTopicName derives a Kafka topic name for a WebSubApi channel.

--- a/event-gateway/gateway-runtime/internal/binding/types.go
+++ b/event-gateway/gateway-runtime/internal/binding/types.go
@@ -148,18 +148,19 @@ type ChannelsConfig struct {
 }
 
 // JoinNormalizedTopic derives a Kafka topic name by hashing the parts joined with underscores.
+// Each part is written as `<length>:<value>|` to ensure uniqueness and prevent collisions.
+// eg: "my-api", "v1", "/orders" -> "6:my-api|2:v1|7:/orders|" -> SHA-256 hash of that string.
 // Returns the SHA-256 hash of the joined string.
 func JoinNormalizedTopic(parts ...string) string {
 	if len(parts) == 0 {
 		return ""
 	}
-
-	// Join parts with underscore
-	joined := strings.Join(parts, "_")
-
+	var joined strings.Builder
+	for _, part := range parts {
+		fmt.Fprintf(&joined, "%d:%s|", len(part), part)
+	}
 	// Calculate SHA-256 hash
-	hash := sha256.Sum256([]byte(joined))
-
+	hash := sha256.Sum256([]byte(joined.String()))
 	// Return hex-encoded hash
 	return fmt.Sprintf("%x", hash)
 }

--- a/event-gateway/gateway-runtime/internal/connectors/brokerdriver/kafka/endpoint.go
+++ b/event-gateway/gateway-runtime/internal/connectors/brokerdriver/kafka/endpoint.go
@@ -100,22 +100,36 @@ func (e *KafkaBrokerDriver) TopicExists(ctx context.Context, topic string) (bool
 }
 
 // EnsureTopics creates topics if they don't already exist (idempotent).
-func (e *KafkaBrokerDriver) EnsureTopics(ctx context.Context, topics []string) error {
-	resp, err := e.admin.CreateTopics(ctx, 1, 1, nil, topics...)
-	if err != nil {
-		return fmt.Errorf("failed to create topics: %w", err)
-	}
-
-	for _, t := range resp.Sorted() {
-		if t.Err != nil {
-			// "TOPIC_ALREADY_EXISTS" is not a real failure for idempotent creates.
-			if isTopicAlreadyExistsErr(t.Err) {
-				slog.Debug("Topic already exists", "topic", t.Topic)
-				continue
-			}
-			return fmt.Errorf("failed to create topic %s: %w", t.Topic, t.Err)
+// metadata is an optional map of topic name -> key-value pairs for logging/tracking purposes.
+// For WebSubAPI topics, metadata typically includes: apiName, apiVersion, channelName.
+// Note: metadata is logged but not stored in Kafka (Kafka only accepts specific configuration keys).
+func (e *KafkaBrokerDriver) EnsureTopics(ctx context.Context, topics []string, metadata map[string]map[string]string) error {
+	// Create topics one by one to allow logging metadata per topic
+	for _, topic := range topics {
+		resp, err := e.admin.CreateTopics(ctx, 1, 1, nil, topic)
+		if err != nil {
+			return fmt.Errorf("failed to create topic %s: %w", topic, err)
 		}
-		slog.Info("Created topic", "topic", t.Topic)
+
+		for _, t := range resp.Sorted() {
+			if t.Err != nil {
+				// "TOPIC_ALREADY_EXISTS" is not a real failure for idempotent creates.
+				if isTopicAlreadyExistsErr(t.Err) {
+					slog.Debug("Topic already exists", "topic", t.Topic)
+					continue
+				}
+				return fmt.Errorf("failed to create topic %s: %w", t.Topic, t.Err)
+			}
+			slog.Info("Created topic", "topic", t.Topic)
+			// Log metadata for debugging/tracking purposes
+			if metadata != nil && metadata[t.Topic] != nil {
+				slog.Info("Topic metadata",
+					"topic_hash", t.Topic,
+					"apiName", metadata[t.Topic]["apiName"],
+					"apiVersion", metadata[t.Topic]["apiVersion"],
+					"channelName", metadata[t.Topic]["channelName"])
+			}
+		}
 	}
 
 	return nil

--- a/event-gateway/gateway-runtime/internal/connectors/receiver/websocket/broker_api_connector.go
+++ b/event-gateway/gateway-runtime/internal/connectors/receiver/websocket/broker_api_connector.go
@@ -102,7 +102,7 @@ func (e *WebBrokerApiReceiver) Start(ctx context.Context) error {
 		slog.Info("Ensuring Kafka topics exist",
 			"channel", e.channel.Name,
 			"topics", e.opts.Topics)
-		if err := e.brokerDriver.EnsureTopics(ctx, e.opts.Topics); err != nil {
+		if err := e.brokerDriver.EnsureTopics(ctx, e.opts.Topics, nil); err != nil {
 			return fmt.Errorf("failed to ensure kafka topics: %w", err)
 		}
 		slog.Info("Kafka topics verified",

--- a/event-gateway/gateway-runtime/internal/connectors/receiver/websub/connector.go
+++ b/event-gateway/gateway-runtime/internal/connectors/receiver/websub/connector.go
@@ -133,14 +133,22 @@ func NewReceiver(cfg connectors.ReceiverConfig, opts Options) (connectors.Receiv
 // Start ensures Kafka topics exist and sets up the consumer manager context.
 // The HTTP server is managed by the runtime.
 func (e *WebSubReceiver) Start(ctx context.Context) error {
-	// Collect all Kafka topics to ensure.
+	// Collect all Kafka topics to ensure and build metadata for WebSubAPI topics.
 	var topicsToEnsure []string
-	for _, kafkaTopic := range e.channel.Channels {
+	topicMetadata := make(map[string]map[string]string)
+
+	for channelName, kafkaTopic := range e.channel.Channels {
 		topicsToEnsure = append(topicsToEnsure, kafkaTopic)
+		// Add metadata for WebSubAPI topics
+		topicMetadata[kafkaTopic] = map[string]string{
+			"apiName":     e.channel.Name,
+			"apiVersion":  e.channel.Version,
+			"channelName": channelName,
+		}
 	}
 
 	if len(topicsToEnsure) > 0 {
-		if err := e.brokerDriver.EnsureTopics(ctx, topicsToEnsure); err != nil {
+		if err := e.brokerDriver.EnsureTopics(ctx, topicsToEnsure, topicMetadata); err != nil {
 			return fmt.Errorf("failed to ensure kafka topics: %w", err)
 		}
 	}

--- a/event-gateway/gateway-runtime/internal/connectors/types.go
+++ b/event-gateway/gateway-runtime/internal/connectors/types.go
@@ -66,7 +66,7 @@ type BrokerDriver interface {
 	SubscribeManual(groupID string, topics []string, handler MessageHandler) (Receiver, error)
 	Replay(ctx context.Context, topic string, handler MessageHandler) error
 	TopicExists(ctx context.Context, topic string) (bool, error)
-	EnsureTopics(ctx context.Context, topics []string) error
+	EnsureTopics(ctx context.Context, topics []string, metadata map[string]map[string]string) error
 	EnsureCompactedTopic(ctx context.Context, topic string) error
 	DeleteTopics(ctx context.Context, topics []string) error
 	Close() error

--- a/event-gateway/gateway-runtime/internal/runtime/runtime_test.go
+++ b/event-gateway/gateway-runtime/internal/runtime/runtime_test.go
@@ -132,7 +132,8 @@ func TestRemoveWebSubApiBinding_ClearsStalePolicyChains(t *testing.T) {
 
 func TestJoinNormalizedTopic_NormalizesUnsupportedCharacters(t *testing.T) {
 	got := binding.JoinNormalizedTopic("/orders/eu", "v1/test", "order_events")
-	want := "ecc4531260bf8164380296afed77e0b7d4e24e29ff148327f841f0ae4776d81e"
+	// SHA-256 hash of "10:/orders/eu|7:v1/test|12:order_events|"
+	want := "2836e285c333e251f0929fbbbe31dec3bb7d61423761103d790bcef2429b194b"
 	if got != want {
 		t.Fatalf("JoinNormalizedTopic() = %q, want %q", got, want)
 	}

--- a/event-gateway/gateway-runtime/internal/runtime/runtime_test.go
+++ b/event-gateway/gateway-runtime/internal/runtime/runtime_test.go
@@ -132,7 +132,7 @@ func TestRemoveWebSubApiBinding_ClearsStalePolicyChains(t *testing.T) {
 
 func TestJoinNormalizedTopic_NormalizesUnsupportedCharacters(t *testing.T) {
 	got := binding.JoinNormalizedTopic("/orders/eu", "v1/test", "order_events")
-	want := "_2f_orders_2f_eu_v1_2f_test_order__events"
+	want := "ecc4531260bf8164380296afed77e0b7d4e24e29ff148327f841f0ae4776d81e"
 	if got != want {
 		t.Fatalf("JoinNormalizedTopic() = %q, want %q", got, want)
 	}


### PR DESCRIPTION
## Purpose
> Hash WebSub API topics, which are stored in Kafka. Resolves https://github.com/wso2/api-platform/issues/1981

The fix encodes each part with its **length** as a prefix, making part boundaries unambiguous:

```go
fmt.Fprintf(&joined, "%d:%s|", len(part), part)
```

Each segment is written as `<length>:<value>|`. Now the same two inputs produce **different** preimages:

| Input | Encoded string |
|---|---|
| `["a_b", "c"]` | `3:a_b|1:c|` |
| `["a", "b_c"]` | `1:a|3:b_c|` |

Since the preimages differ, SHA-256 produces **different hashes** — no collision.

---

### Concrete end-to-end example

Suppose two WebSub APIs:
- API 1: `apiName="myapi_v1"`, `version="latest"`, `channel="events"` → raw join: `myapi_v1_latest_events`
- API 2: `apiName="myapi"`, `version="v1_latest"`, `channel="events"` → raw join: `myapi_v1_latest_events`

**Current code:** Both hash to the same Kafka topic — a silent collision.  
**Fixed code:** API 1 encodes to `8:myapi_v1|6:latest|6:events|` and API 2 encodes to `5:myapi|8:v1_latest|6:events|` — distinct preimages, distinct hashes.



Sample Gateway logs during WebSub API creation:
```
time=2026-05-21T10:25:03.190Z level=INFO msg="Adding binding via xDS" name=6a0edd710d284c4933f9d33a uuid=019e4a11-0458-772a-b35f-df44cb0a05de kind=WebSubApi
time=2026-05-21T10:25:03.336Z level=INFO msg="Created topic" topic=d595967d603284cbcec3833081ab084634f59f1c9d01a967ce9596a94acb2fe4
time=2026-05-21T10:25:03.336Z level=INFO msg="Topic metadata" topic_hash=d595967d603284cbcec3833081ab084634f59f1c9d01a967ce9596a94acb2fe4 apiName=6a0edd710d284c4933f9d33a apiVersion=v1.0 channelName=/issues
time=2026-05-21T10:25:03.364Z level=INFO msg="Created topic" topic=8dcbca9b1a5785512b0f0b06fde842ee2bd4b7a83421d3374e8eaca7f11a08a1
time=2026-05-21T10:25:03.365Z level=INFO msg="Topic metadata" topic_hash=8dcbca9b1a5785512b0f0b06fde842ee2bd4b7a83421d3374e8eaca7f11a08a1 apiName=6a0edd710d284c4933f9d33a apiVersion=v1.0 channelName=/pull-requests
time=2026-05-21T10:25:03.397Z level=INFO msg="Starting subscription reconciliation from Kafka"
time=2026-05-21T10:25:03.424Z level=INFO msg="Subscription reconciliation complete" replayed=0 active_subscriptions=0
time=2026-05-21T10:25:03.425Z level=INFO msg="WebSub receiver started" api=6a0edd710d284c4933f9d33a channels=2 subscribe_url=/default/websub-21may-354pm/v1.0/hub data_ingress_url=/default/websub-21may-354pm/v1.0/webhook-receiver
time=2026-05-21T10:25:03.425Z level=INFO msg="Dynamically added WebSubApi binding" name=6a0edd710d284c4933f9d33a context=/default/websub-21may-354pm/v1.0 version=v1.0 channels=2
time=2026-05-21T10:25:03.425Z level=INFO msg="Processed xDS update" type_url=api-platform.wso2.org/v1.EventChannelConfig version=2 resources=1
```

## Goals
> Describe **what solutions** this feature or fix introduces to address the problems outlined above.

## Approach
> Describe **how** you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
