### PR TITLE
refactor(gateway): simplify volume mount and volume handling in deployment.yaml

### DIFF
--- a/kubernetes/helm/gateway-helm-chart/templates/gateway/controller/deployment.yaml
+++ b/kubernetes/helm/gateway-helm-chart/templates/gateway/controller/deployment.yaml
@@ -170,8 +170,8 @@ spec:
               mountPath: {{ $controller.encryptionKeys.mountPath }}
               readOnly: true
             {{- end }}
-            {{- range $deployment.extraVolumeMounts }}
-            - {{- toYaml . | nindent 12 }}
+            {{- with $deployment.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
       volumes:
         - name: controller-data
@@ -217,7 +217,7 @@ spec:
           secret:
             secretName: {{ $controller.encryptionKeys.secretName }}
         {{- end }}
-        {{- range $deployment.extraVolumes }}
-        - {{- toYaml . | nindent 10 }}
+        {{- with $deployment.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
 {{- end }}


### PR DESCRIPTION
## Issue
Fix https://github.com/wso2/api-platform/issues/2004

## Purpose
Updated the deployment.yaml to use 'with' instead of 'range' for extraVolumeMounts and extraVolumes, improving readability and maintaining functionality.

- gateway.controller.deployment.extraVolumeMounts and extraVolumes failed Helm rendering with a YAML parse error whenever a non-empty list was provided
- Root cause: the controller template used {{- range . }} with - {{- toYaml . | nindent N }} — the {{- trim marker strips the newline after the, producing a bare - on its own line (invalid YAML)
- Fix: replaced both broken range blocks with the {{- with . }}{{- toYaml . | nindent N }}{{- end }} pattern already used correctly in the gateway-runtime deployment template

  **Test plan**

  All cases tested locally with helm template against the fixed chart (8/8 pass):

  - [x] Case 1 — Exact issue repro (secret volume + mount on controller)
```
  gateway:
    developmentMode: true
    controller:
      deployment:
        extraVolumeMounts:
          - name: extra-test
            mountPath: /etc/secrets/extra-test
            readOnly: true
        extraVolumes:
          - name: extra-test
            secret:
              secretName: gateway-extra-test
```
              
  - [x] Case 2 — Multiple volumes of different types (secret, configMap, emptyDir, hostPath)
```
  gateway:
    developmentMode: true
    controller:
      deployment:
        extraVolumeMounts:
          - name: secret-vol
            mountPath: /etc/secrets/my-secret
            readOnly: true
          - name: config-vol
            mountPath: /etc/config/my-config
            readOnly: true
          - name: empty-vol
            mountPath: /tmp/scratch
          - name: host-vol
            mountPath: /var/log/app
        extraVolumes:
          - name: secret-vol
            secret:
              secretName: my-secret
          - name: config-vol
            configMap:
              name: my-configmap
          - name: empty-vol
            emptyDir: {}
          - name: host-vol
            hostPath:
              path: /var/log/app
              type: DirectoryOrCreate
```
              
  - [x] Case 3 — Explicit empty lists ([] on both fields, chart renders cleanly)
```
  gateway:
    developmentMode: true
    controller:
      deployment:
        extraVolumeMounts: []
        extraVolumes: []
```

  - [x] Case 4 — Projected volume + PVC with subPath
```
  gateway:
    developmentMode: true
    controller:
      deployment:
        extraVolumeMounts:
          - name: projected-vol
            mountPath: /etc/combined
            readOnly: true
          - name: pvc-vol
            mountPath: /data/uploads
            subPath: uploads
        extraVolumes:
          - name: projected-vol
            projected:
              sources:
                - secret:
                    name: my-secret
                - configMap:
                    name: my-configmap
          - name: pvc-vol 
            persistentVolumeClaim:
              claimName: my-pvc
              
```
  - [x] Case 5 — extraVolumeMounts only, no extraVolumes
```
  gateway:
    developmentMode: true
    controller:
      deployment:
        extraVolumeMounts:
          - name: preexisting-vol
            mountPath: /etc/preexisting
            readOnly: true
```
            
  - [x] Case 6 — extraVolumes only, no extraVolumeMounts
```
  gateway:
    developmentMode: true
    controller:
      deployment:
        extraVolumes:
          - name: extra-secret
            secret:
              secretName: some-secret
```
  
  - [x] Case 7 — Both controller and gatewayRuntime extra fields simultaneously (regression: volumes stay isolated to their respective
  Deployments)
```
  gateway:
    developmentMode: true
    controller:
      deployment:
        extraVolumeMounts:
          - name: ctrl-secret
            mountPath: /etc/ctrl-secret
            readOnly: true
        extraVolumes:
          - name: ctrl-secret
            secret:
              secretName: ctrl-secret
    gatewayRuntime:
      deployment:
        extraVolumeMounts:
          - name: runtime-secret
            mountPath: /etc/runtime-secret
            readOnly: true
        extraVolumes:
          - name: runtime-secret
            secret:
              secretName: runtime-secret
```