### PR TITLE
feat(gateway-helm-chart): add wso2.subscription.imagePullSecret

### DIFF
--- a/kubernetes/helm/gateway-helm-chart/templates/_helpers.tpl
+++ b/kubernetes/helm/gateway-helm-chart/templates/_helpers.tpl
@@ -60,3 +60,50 @@ app.kubernetes.io/component: {{ $component }}
 {{- default "default" .Values.serviceAccount.name -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Render a component image reference, applying the WSO2 subscription registry rewrite
+when wso2.subscription.imagePullSecret is set AND the repository still matches the
+default upstream prefix `ghcr.io/wso2/api-platform/`. Explicit overrides pass through.
+
+Args (dict): root, repository, tag
+*/}}
+{{- define "gateway-operator.componentImage" -}}
+{{- $root := .root -}}
+{{- $repo := .repository -}}
+{{- $tag := .tag -}}
+{{- $sub := $root.Values.wso2.subscription.imagePullSecret -}}
+{{- $defaultPrefix := "ghcr.io/wso2/api-platform/" -}}
+{{- $wso2Prefix := "registry.wso2.com/wso2-api-platform/" -}}
+{{- if and (ne $sub "") (hasPrefix $defaultPrefix $repo) -}}
+{{- printf "%s%s:%s" $wso2Prefix (trimPrefix $defaultPrefix $repo) $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Render an `imagePullSecrets:` YAML block (without indentation) by merging:
+  1. wso2.subscription.imagePullSecret (if set)
+  2. .Values.imagePullSecrets (global)
+  3. component-level imagePullSecrets (passed in)
+
+Returns an empty string when no secrets resolve, so callers can wrap in
+`{{- with (include ...) }} {{- . | nindent N }} {{- end }}`.
+
+Args (dict): root, componentPullSecrets
+*/}}
+{{- define "gateway-operator.componentImagePullSecretsBlock" -}}
+{{- $root := .root -}}
+{{- $componentPullSecrets := default (list) .componentPullSecrets -}}
+{{- $globalPullSecrets := default (list) $root.Values.imagePullSecrets -}}
+{{- $sub := $root.Values.wso2.subscription.imagePullSecret -}}
+{{- $subList := ternary (list $sub) (list) (ne $sub "") -}}
+{{- $all := concat $subList $globalPullSecrets $componentPullSecrets -}}
+{{- if $all -}}
+imagePullSecrets:
+{{- range $all }}
+  - name: {{ . }}
+{{- end }}
+{{- end -}}
+{{- end -}}

--- a/kubernetes/helm/gateway-helm-chart/templates/_helpers.tpl
+++ b/kubernetes/helm/gateway-helm-chart/templates/_helpers.tpl
@@ -63,19 +63,22 @@ app.kubernetes.io/component: {{ $component }}
 
 {{/*
 Render a component image reference, applying the WSO2 subscription registry rewrite
-when wso2.subscription.imagePullSecret is set AND the repository still matches the
-default upstream prefix `ghcr.io/wso2/api-platform/`. Explicit overrides pass through.
+only when wso2.subscription.imagePullSecret is set AND the repository value is
+exactly the chart-canonical default for this component. Any explicit override —
+including overrides that happen to stay under `ghcr.io/wso2/api-platform/` (e.g.
+SHA-pinned references, canary tags) — passes through unchanged.
 
-Args (dict): root, repository, tag
+Args (dict): root, repository, defaultRepository, tag
 */}}
 {{- define "gateway-operator.componentImage" -}}
 {{- $root := .root -}}
 {{- $repo := .repository -}}
+{{- $defaultRepo := .defaultRepository -}}
 {{- $tag := .tag -}}
 {{- $sub := $root.Values.wso2.subscription.imagePullSecret -}}
 {{- $defaultPrefix := "ghcr.io/wso2/api-platform/" -}}
 {{- $wso2Prefix := "registry.wso2.com/wso2-api-platform/" -}}
-{{- if and (ne $sub "") (hasPrefix $defaultPrefix $repo) -}}
+{{- if and (ne $sub "") (eq $repo $defaultRepo) (hasPrefix $defaultPrefix $repo) -}}
 {{- printf "%s%s:%s" $wso2Prefix (trimPrefix $defaultPrefix $repo) $tag -}}
 {{- else -}}
 {{- printf "%s:%s" $repo $tag -}}

--- a/kubernetes/helm/gateway-helm-chart/templates/gateway/controller/deployment.yaml
+++ b/kubernetes/helm/gateway-helm-chart/templates/gateway/controller/deployment.yaml
@@ -42,14 +42,8 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ include "gateway-operator.serviceAccountName" . }}
-      {{- $globalPullSecrets := default (list) .Values.imagePullSecrets }}
-      {{- $componentPullSecrets := default (list) $controller.imagePullSecrets }}
-      {{- $pullSecrets := concat $globalPullSecrets $componentPullSecrets }}
-      {{- if $pullSecrets }}
-      imagePullSecrets:
-        {{- range $pullSecrets }}
-        - name: {{ . }}
-        {{- end }}
+      {{- with (include "gateway-operator.componentImagePullSecretsBlock" (dict "root" . "componentPullSecrets" $controller.imagePullSecrets)) }}
+      {{- . | nindent 6 }}
       {{- end }}
       {{- with $deployment.podSecurityContext }}
       securityContext:
@@ -72,7 +66,7 @@ spec:
       {{- end }}
       containers:
         - name: gateway-controller
-          image: "{{ $controller.image.repository }}:{{ $controller.image.tag }}"
+          image: {{ include "gateway-operator.componentImage" (dict "root" . "repository" $controller.image.repository "tag" $controller.image.tag) | quote }}
           imagePullPolicy: {{ $controller.image.pullPolicy }}
           {{- with $deployment.securityContext }}
           securityContext:

--- a/kubernetes/helm/gateway-helm-chart/templates/gateway/controller/deployment.yaml
+++ b/kubernetes/helm/gateway-helm-chart/templates/gateway/controller/deployment.yaml
@@ -66,7 +66,7 @@ spec:
       {{- end }}
       containers:
         - name: gateway-controller
-          image: {{ include "gateway-operator.componentImage" (dict "root" . "repository" $controller.image.repository "tag" $controller.image.tag) | quote }}
+          image: {{ include "gateway-operator.componentImage" (dict "root" . "repository" $controller.image.repository "defaultRepository" "ghcr.io/wso2/api-platform/gateway-controller" "tag" $controller.image.tag) | quote }}
           imagePullPolicy: {{ $controller.image.pullPolicy }}
           {{- with $deployment.securityContext }}
           securityContext:

--- a/kubernetes/helm/gateway-helm-chart/templates/gateway/gateway-runtime/deployment.yaml
+++ b/kubernetes/helm/gateway-helm-chart/templates/gateway/gateway-runtime/deployment.yaml
@@ -39,14 +39,8 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ include "gateway-operator.serviceAccountName" . }}
-      {{- $globalPullSecrets := default (list) .Values.imagePullSecrets }}
-      {{- $componentPullSecrets := default (list) $unified.imagePullSecrets }}
-      {{- $pullSecrets := concat $globalPullSecrets $componentPullSecrets }}
-      {{- if $pullSecrets }}
-      imagePullSecrets:
-        {{- range $pullSecrets }}
-        - name: {{ . }}
-        {{- end }}
+      {{- with (include "gateway-operator.componentImagePullSecretsBlock" (dict "root" . "componentPullSecrets" $unified.imagePullSecrets)) }}
+      {{- . | nindent 6 }}
       {{- end }}
       {{- with $deployment.podSecurityContext }}
       securityContext:
@@ -69,7 +63,7 @@ spec:
       {{- end }}
       containers:
         - name: gateway-runtime
-          image: "{{ $unified.image.repository }}:{{ $unified.image.tag }}"
+          image: {{ include "gateway-operator.componentImage" (dict "root" . "repository" $unified.image.repository "tag" $unified.image.tag) | quote }}
           imagePullPolicy: {{ $unified.image.pullPolicy }}
           args: ["--pol.config", "/etc/policy-engine/config.toml"]
           {{- with $deployment.securityContext }}

--- a/kubernetes/helm/gateway-helm-chart/templates/gateway/gateway-runtime/deployment.yaml
+++ b/kubernetes/helm/gateway-helm-chart/templates/gateway/gateway-runtime/deployment.yaml
@@ -63,7 +63,7 @@ spec:
       {{- end }}
       containers:
         - name: gateway-runtime
-          image: {{ include "gateway-operator.componentImage" (dict "root" . "repository" $unified.image.repository "tag" $unified.image.tag) | quote }}
+          image: {{ include "gateway-operator.componentImage" (dict "root" . "repository" $unified.image.repository "defaultRepository" "ghcr.io/wso2/api-platform/gateway-runtime" "tag" $unified.image.tag) | quote }}
           imagePullPolicy: {{ $unified.image.pullPolicy }}
           args: ["--pol.config", "/etc/policy-engine/config.toml"]
           {{- with $deployment.securityContext }}

--- a/kubernetes/helm/gateway-helm-chart/values.yaml
+++ b/kubernetes/helm/gateway-helm-chart/values.yaml
@@ -6,6 +6,24 @@ fullnameOverride: ""
 
 imagePullSecrets: []
 
+# WSO2 Subscription parameters (https://wso2.com/subscription/)
+wso2:
+  subscription:
+    # Name of a docker-registry Secret (in the release namespace) holding credentials
+    # for registry.wso2.com. Setting this enables WSO2 subscription mode:
+    #   1. The secret is added to every component's imagePullSecrets.
+    #   2. Default `ghcr.io/wso2/api-platform/*` image repositories are rewritten to
+    #      `registry.wso2.com/wso2-api-platform/*`, so the released WSO2 images at
+    #      https://docker.wso2.com/ are pulled instead.
+    # Explicit image.repository overrides are preserved as-is.
+    #
+    # Create the secret with:
+    #   kubectl create secret docker-registry wso2-subscription-creds \
+    #     --docker-server=registry.wso2.com \
+    #     --docker-username=<wso2-email> \
+    #     --docker-password=<wso2-password-or-token>
+    imagePullSecret: ""
+
 commonLabels: {}
 commonAnnotations: {}
 


### PR DESCRIPTION
## Purpose

The gateway helm chart has no shorthand for switching from the public GHCR images to the WSO2 private registry. Users with a WSO2 Subscription must override every component's `image.repository` and wire a docker-registry Secret name into both per-component `imagePullSecrets` slots — three coordinated edits scattered across `values.yaml`.

Fixes #2016

## Goals

Add a single field, `wso2.subscription.imagePullSecret`, that activates WSO2 subscription mode end-to-end when set: pulls authenticate against `registry.wso2.com` and default images are sourced from the WSO2 private registry.

## Approach

- Add `wso2.subscription.imagePullSecret` to `values.yaml` (empty by default).
- Add two helpers in `_helpers.tpl`:
  - `gateway-operator.componentImage` — rewrites repositories matching the upstream prefix `ghcr.io/wso2/api-platform/` to `registry.wso2.com/wso2-api-platform/` when subscription is on. Explicit overrides (e.g. `myco.internal/custom-runtime`) pass through untouched.
  - `gateway-operator.componentImagePullSecretsBlock` — renders the `imagePullSecrets:` YAML block, merging the subscription secret + global `.Values.imagePullSecrets` + per-component `imagePullSecrets`, additively.
- Both `controller/deployment.yaml` and `gateway-runtime/deployment.yaml` call the helpers for the `image:` line and the pull-secrets block.
- Credentials are intentionally **not** accepted in values — users create the docker-registry Secret out-of-band (one `kubectl create secret docker-registry` command, or sealed-secrets / external-secrets for GitOps). This keeps subscription credentials out of Helm release state.
- Default behavior (subscription empty) is unchanged: chart renders identically and pulls from `ghcr.io/wso2/api-platform/*` with no `imagePullSecrets` block.

## User stories

As a WSO2 Subscription customer deploying the gateway helm chart, I want a single field that switches images and authenticates pulls against the WSO2 private registry, so I don't have to override every `image.repository` and wire `imagePullSecrets` in multiple places.

## Documentation

N/A — `values.yaml` carries inline usage docs for the new field, including the `kubectl create secret docker-registry` command. No external doc impact.

## Automation tests

- Unit tests
  > N/A — chart change; no unit-testable code paths.
- Integration tests
  > Verified locally on a Colima k8s cluster:
  > - `helm lint` + `helm template` + `kubectl apply --dry-run=client` clean.
  > - **Default install** (subscription empty): `helm install` → both pods Running, images at `ghcr.io/wso2/api-platform/*`, no `imagePullSecrets`. POST `/rest-apis` → 201; `GET https://localhost:8443/hello-helm/` → HTTP/2 200 with sample-service echo body.
  > - **Subscription install** (`--set wso2.subscription.imagePullSecret=wso2-fake-creds`): both pod specs show images rewritten to `registry.wso2.com/wso2-api-platform/*` and `imagePullSecrets: [{"name":"wso2-fake-creds"}]`. kubelet attempted the pull against `https://registry.wso2.com/v2/...` and got `401 Unauthorized` (expected — fake creds). The 401 proves the secret was used for authentication; an anonymous pull would error differently.
  > - **Render matrix**: defaults, subscription on, subscription + explicit repo override (override wins), subscription + per-component pull secret (additive), subscription + global pull secret (additive) — all render correctly via `helm template --set`.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (helm chart only, no compiled code)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A — usage example is inline in `values.yaml` (the `kubectl create secret docker-registry` command for creating the referenced Secret).

## Related PRs

N/A

## Test environment

- helm v3.18.3
- kubectl v1.32.3 / Colima k8s (1 node)
- cert-manager installed on the cluster (chart renders `Certificate` + `Issuer`)