### PR TITLE
feat(platform-api)!: accept CalVer gateway version, drop preview format

### DIFF
--- a/platform-api/src/api/generated.go
+++ b/platform-api/src/api/generated.go
@@ -869,7 +869,7 @@ type CreateGatewayRequest struct {
 	// Properties Custom key-value properties for the gateway
 	Properties *map[string]interface{} `json:"properties,omitempty" yaml:"properties,omitempty"`
 
-	// Version Gateway version in `major.minor` format (e.g. `1.0`) or `major.minor.patch-preview-<build>` format (e.g. `1.1.0-preview-202603` or `1.1.0-preview-202603.1`). Defaults to `1.0` if not provided.
+	// Version Gateway version in `major.minor` format (e.g. `1.0`) or CalVer `YYYY.MM.DD` format (e.g. `2026.05.13`). Defaults to `1.0` if not provided.
 	Version *string `json:"version,omitempty" yaml:"version,omitempty"`
 
 	// Vhost Virtual host (domain name) for the gateway
@@ -1358,7 +1358,7 @@ type GatewayResponse struct {
 	// UpdatedAt Timestamp when gateway was last updated
 	UpdatedAt *time.Time `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
 
-	// Version Gateway version in `major.minor` format (e.g. `1.0`) or `major.minor.patch-preview-<build>` format (e.g. `1.1.0-preview-202603` or `1.1.0-preview-202603.1`)
+	// Version Gateway version in `major.minor` format (e.g. `1.0`) or CalVer `YYYY.MM.DD` format (e.g. `2026.05.13`)
 	Version *string `json:"version,omitempty" yaml:"version,omitempty"`
 
 	// Vhost Virtual host (domain name) for the gateway
@@ -2502,7 +2502,7 @@ type RESTAPIGatewayResponse struct {
 	// UpdatedAt Timestamp when gateway was last updated
 	UpdatedAt *time.Time `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
 
-	// Version Gateway version in `major.minor` format (e.g. `1.0`) or `major.minor.patch-preview-<build>` format (e.g. `1.1.0-preview-202603` or `1.1.0-preview-202603.1`)
+	// Version Gateway version in `major.minor` format (e.g. `1.0`) or CalVer `YYYY.MM.DD` format (e.g. `2026.05.13`)
 	Version *string `json:"version,omitempty" yaml:"version,omitempty"`
 
 	// Vhost Virtual host (domain name) for the gateway

--- a/platform-api/src/internal/handler/gateway.go
+++ b/platform-api/src/internal/handler/gateway.go
@@ -35,10 +35,11 @@ import (
 )
 
 // gatewayVersionPattern accepts two shapes for the registration version field:
-//   - `major.minor`                          (e.g. "1.0")
-//   - `major.minor.patch-preview-<numbers>`  (e.g. "1.1.0-preview-202603",
-//     "1.1.0-preview-202603.1")
-var gatewayVersionPattern = regexp.MustCompile(`^[0-9]{1,6}\.[0-9]{1,6}(\.[0-9]{1,6}-preview-[0-9]+(\.[0-9]+)*)?$`)
+//   - `major.minor`     (e.g. "1.0", "1.1") — LTS-style stable releases
+//   - `YYYY.MM.DD`      (e.g. "2026.05.13") — CalVer stable releases; the
+//     leading segment must be 4 digits to distinguish a calendar year from a
+//     `major.minor` value.
+var gatewayVersionPattern = regexp.MustCompile(`^([0-9]{1,6}\.[0-9]{1,6}|[0-9]{4}\.[0-9]{1,2}\.[0-9]{1,2})$`)
 
 // GatewayHandler handles HTTP requests for gateway operations
 type GatewayHandler struct {
@@ -100,7 +101,7 @@ func (h *GatewayHandler) CreateGateway(c *gin.Context) {
 	}
 	if version != "" && !gatewayVersionPattern.MatchString(version) {
 		c.JSON(http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request",
-			"version must be in 'major.minor' format (e.g. '1.0') or 'major.minor.patch-preview-<build>' format (e.g. '1.1.0-preview-202603' or '1.1.0-preview-202603.1')"))
+			"version must be in 'major.minor' format (e.g. '1.0') or CalVer 'YYYY.MM.DD' format (e.g. '2026.05.13')"))
 		return
 	}
 

--- a/platform-api/src/internal/service/gateway.go
+++ b/platform-api/src/internal/service/gateway.go
@@ -497,12 +497,12 @@ func (s *GatewayService) RegisterGateway(orgID, name, displayName, description, 
 	if version == "" {
 		version = defaultGatewayVersion
 	}
-	// Preview versions (e.g. "1.1.0-preview-202603") are persisted verbatim so
-	// the exact build is preserved. Stable versions are canonicalized to
-	// `major.minor` so equality checks against controller-reported versions
-	// (also normalized via extractMajorMinor) cannot diverge over leading
-	// zeros or other lexical variants.
-	if !strings.Contains(version, "-preview") {
+	// CalVer versions (e.g. "2026.05.13") are persisted verbatim so the exact
+	// build is preserved. Two-segment `major.minor` versions are canonicalized
+	// so equality checks against controller-reported versions (also normalized
+	// via extractMajorMinor) cannot diverge over leading zeros or other
+	// lexical variants.
+	if strings.Count(version, ".") == 1 {
 		if canonical := extractMajorMinor(version); canonical != "" {
 			version = canonical
 		}

--- a/platform-api/src/resources/openapi.yaml
+++ b/platform-api/src/resources/openapi.yaml
@@ -6654,8 +6654,8 @@ components:
           example: {"region": "us-west", "tier": "premium"}
         version:
           type: string
-          pattern: '^[0-9]{1,6}\.[0-9]{1,6}(\.[0-9]{1,6}-preview-[0-9]+(\.[0-9]+)*)?$'
-          description: Gateway version in `major.minor` format (e.g. `1.0`) or `major.minor.patch-preview-<build>` format (e.g. `1.1.0-preview-202603` or `1.1.0-preview-202603.1`). Defaults to `1.0` if not provided.
+          pattern: '^([0-9]{1,6}\.[0-9]{1,6}|[0-9]{4}\.[0-9]{1,2}\.[0-9]{1,2})$'
+          description: Gateway version in `major.minor` format (e.g. `1.0`) or CalVer `YYYY.MM.DD` format (e.g. `2026.05.13`). Defaults to `1.0` if not provided.
           default: "1.0"
           example: "1.0"
     CustomPolicyResponse:
@@ -6790,7 +6790,7 @@ components:
           example: "regular"
         version:
           type: string
-          description: Gateway version in `major.minor` format (e.g. `1.0`) or `major.minor.patch-preview-<build>` format (e.g. `1.1.0-preview-202603` or `1.1.0-preview-202603.1`)
+          description: Gateway version in `major.minor` format (e.g. `1.0`) or CalVer `YYYY.MM.DD` format (e.g. `2026.05.13`)
           example: "1.0"
         isActive:
           type: boolean


### PR DESCRIPTION
## Purpose

The gateway-registration version validator in Platform API previously accepted only `major.minor` (e.g. `1.0`) or the preview suffix `major.minor.patch-preview-<build>` (e.g. `1.1.0-preview-202603.1`). The preview format is no longer in use now that CalVer (`YYYY.MM.DD`, e.g. `2026.05.13`) is the stable release line. LTS releases continue to register as `major.minor`.

This PR drops the preview pattern and adds CalVer support so gateways on the new stable release can register successfully.

## Approach

- Replace `gatewayVersionPattern` with `^([0-9]{1,6}\.[0-9]{1,6}|[0-9]{4}\.[0-9]{1,2}\.[0-9]{1,2})$`; update the doc comment and the HTTP 400 error message to match.
- In `RegisterGateway`, canonicalize only two-segment versions (so `01.0` → `1.0`); persist 3-segment CalVer (`2026.05.13`) verbatim. Manifest-side comparison still goes through `extractMajorMinor` so equality continues to work after canonicalization.
- Update the OpenAPI spec (pattern + descriptions on `CreateGatewayRequest` and `GatewayResponse`) and regenerate `src/api/generated.go`.

## Related Issues

Related https://github.com/wso2-enterprise/apim-saas/issues/2540

## Remarks

BREAKING: gateways registering with the preview version format (`major.minor.patch-preview-<build>`) are now rejected with HTTP 400.

## Test plan

Validated end-to-end against `platform-api` running locally from source (`go run ./cmd`, SQLite, `JWT_SKIP_VALIDATION=true`). One JWT (HS256-signed dev token, `organization` claim = registered org `id`) was reused across every authenticated call.

| # | Call | Body | Expected | Got |
|---|---|---|---|---|
| 1 | `POST /api/v1/organizations` | `{id,handle,name,region}` | `201` | `201` ✓ |
| 2 | `GET  /api/v1/organizations` | — | `200`, `id` matches JWT claim | `200` ✓ |
| 3 | `POST /api/v1/projects` | `{name:"Validation Project"}` | `201`, `organizationId` matches | `201` ✓ |
| 4 | `POST /api/v1/gateways` | `version:"2026.05.13"` (CalVer) | `201`, `version` echoed **verbatim** | `201`, body had `"version":"2026.05.13"` ✓ |
| 5 | `POST /api/v1/gateways` | `version:"1.0"` (LTS major.minor) | `201`, `version:"1.0"` | `201`, `"version":"1.0"` ✓ |
| 6 | `POST /api/v1/gateways` | `version:"1.2.0-preview-202605"` (legacy preview) | `400` with the new error message | `400` `"version must be in 'major.minor' format (e.g. '1.0') or CalVer 'YYYY.MM.DD' format (e.g. '2026.05.13')"` ✓ |
| 7 | `GET  /api/v1/gateways` | — | `200`, list contains both happy-path gateways | `200`, `count=2` ✓ |
| 8 | `GET  /api/v1/gateways/{id}` | — | `200`, `version="2026.05.13"`, `organizationId` matches | `200` ✓ |
| 9 | `POST /api/v1/gateways/{id}/tokens` | — | `201`, plaintext `token` returned once | `201`, 43-char token ✓ |
| 10 | `GET  /api/v1/gateways/{id}/tokens` | — | `200`, token `status:"active"` | `200` ✓ |
| 11 | `DELETE /api/v1/gateways/{id}/tokens/{tokenId}` | — | `2xx`, idempotent | `200` `"Token revoked successfully"` ✓ |
| 12 | `DELETE /api/v1/gateways/{id}` (×2) + `DELETE /api/v1/projects/{id}` | — | `204` | `204` ×3 ✓ |

Direct evidence for the fix:

- **CalVer accepted, persisted verbatim**: `"version":"2026.05.13"` came back in both the create and get-by-id responses — confirming the new branch in `RegisterGateway` that only canonicalizes 2-segment versions.
- **LTS `1.0` still accepted**: the major.minor path is unchanged.
- **Preview rejected at the handler regex** with the new error string from `src/internal/handler/gateway.go:103`.

## Checklist
- [x] Tests added or updated (unit, integration, etc.) — manual end-to-end validation captured above; no new automated test added in this PR (the regex + service-layer code paths are exercised by the broader integration suite via the same `RegisterGateway` entry point).
- [ ] Samples updated (if applicable)
