### PR TITLE
Add SSL Support for WebBroker API WebSockets

### DIFF
--- a/event-gateway/docker-compose.yaml
+++ b/event-gateway/docker-compose.yaml
@@ -50,6 +50,7 @@ services:
       - "8080:8080"   # WebSub HTTP
       - "8443:8443"   # WebSub HTTPS
       - "8081:8081"   # WebSocket
+      - "8444:8444"   # WebSocket HTTPS (WSS)
       - "9002:9002"   # Admin API
       - "9003:9003"   # Metrics
     environment:
@@ -61,6 +62,10 @@ services:
       - APIP_EGW_SERVER_WEBSUB_TLS_CERT_FILE=/etc/event-gateway/tls/default-listener.crt
       - APIP_EGW_SERVER_WEBSUB_TLS_KEY_FILE=/etc/event-gateway/tls/default-listener.key
       - APIP_EGW_SERVER_WEBSOCKET_PORT=8081
+      - APIP_EGW_SERVER_WEBSOCKET_HTTPS_PORT=8444
+      - APIP_EGW_SERVER_WEBSOCKET_TLS_ENABLED=true
+      - APIP_EGW_SERVER_WEBSOCKET_TLS_CERT_FILE=/etc/event-gateway/tls/default-listener.crt
+      - APIP_EGW_SERVER_WEBSOCKET_TLS_KEY_FILE=/etc/event-gateway/tls/default-listener.key
       - APIP_EGW_CONTROLPLANE_ENABLED=true
       - APIP_EGW_LOGGING_LEVEL=debug
       - APIP_EGW_CONTROLPLANE_XDS_ADDRESS=gateway-controller:18001

--- a/event-gateway/gateway-runtime/configs/config.toml
+++ b/event-gateway/gateway-runtime/configs/config.toml
@@ -19,6 +19,12 @@ websub_tls_enabled = true
 websub_tls_cert_file = "/etc/event-gateway/tls/default-listener.crt"
 websub_tls_key_file = "/etc/event-gateway/tls/default-listener.key"
 websocket_port = 8081
+# HTTPS port for WebSocket server (used when TLS is enabled for WebBrokerApi)
+websocket_https_port = 8444
+# Set to true to serve WebBrokerApi WebSocket connections over WSS (TLS).
+websocket_tls_enabled = true
+websocket_tls_cert_file = "/etc/event-gateway/tls/default-listener.crt"
+websocket_tls_key_file = "/etc/event-gateway/tls/default-listener.key"
 admin_port = 9002
 metrics_port = 9003
 

--- a/event-gateway/gateway-runtime/internal/config/config.go
+++ b/event-gateway/gateway-runtime/internal/config/config.go
@@ -44,15 +44,19 @@ type Config struct {
 
 // ServerConfig holds HTTP/WS server settings.
 type ServerConfig struct {
-	WebSubEnabled     bool   `koanf:"websub_enabled"`
-	WebSubHTTPPort    int    `koanf:"websub_http_port"`
-	WebSubHTTPSPort   int    `koanf:"websub_https_port"`
-	WebSubTLSEnabled  bool   `koanf:"websub_tls_enabled"`
-	WebSubTLSCertFile string `koanf:"websub_tls_cert_file"`
-	WebSubTLSKeyFile  string `koanf:"websub_tls_key_file"`
-	WebSocketPort     int    `koanf:"websocket_port"`
-	AdminPort         int    `koanf:"admin_port"`
-	MetricsPort       int    `koanf:"metrics_port"`
+	WebSubEnabled        bool   `koanf:"websub_enabled"`
+	WebSubHTTPPort       int    `koanf:"websub_http_port"`
+	WebSubHTTPSPort      int    `koanf:"websub_https_port"`
+	WebSubTLSEnabled     bool   `koanf:"websub_tls_enabled"`
+	WebSubTLSCertFile    string `koanf:"websub_tls_cert_file"`
+	WebSubTLSKeyFile     string `koanf:"websub_tls_key_file"`
+	WebSocketPort        int    `koanf:"websocket_port"`
+	WebSocketHTTPSPort   int    `koanf:"websocket_https_port"`
+	WebSocketTLSEnabled  bool   `koanf:"websocket_tls_enabled"`
+	WebSocketTLSCertFile string `koanf:"websocket_tls_cert_file"`
+	WebSocketTLSKeyFile  string `koanf:"websocket_tls_key_file"`
+	AdminPort            int    `koanf:"admin_port"`
+	MetricsPort          int    `koanf:"metrics_port"`
 }
 
 // KafkaConfig holds Kafka connection settings.
@@ -103,12 +107,13 @@ type LoggingConfig struct {
 func DefaultConfig() *Config {
 	return &Config{
 		Server: ServerConfig{
-			WebSubEnabled:   true,
-			WebSubHTTPPort:  8080,
-			WebSubHTTPSPort: 8443,
-			WebSocketPort:   8081,
-			AdminPort:       9002,
-			MetricsPort:     9003,
+			WebSubEnabled:      true,
+			WebSubHTTPPort:     8080,
+			WebSubHTTPSPort:    8443,
+			WebSocketPort:      8081,
+			WebSocketHTTPSPort: 8444,
+			AdminPort:          9002,
+			MetricsPort:        9003,
 		},
 		Kafka: KafkaConfig{
 			Brokers:             []string{"localhost:9092"},
@@ -176,6 +181,7 @@ func Load(path string) (*Config, map[string]interface{}, error) {
 		"websub_https_port", cfg.Server.WebSubHTTPSPort,
 		"websub_tls_enabled", cfg.Server.WebSubTLSEnabled,
 		"websocket_port", cfg.Server.WebSocketPort,
+		"websocket_tls_enabled", cfg.Server.WebSocketTLSEnabled,
 		"admin_port", cfg.Server.AdminPort,
 		"kafka_brokers", cfg.Kafka.Brokers,
 		"log_level", cfg.Logging.Level,
@@ -221,6 +227,7 @@ func mapEnvValue(path, value string) interface{} {
 	case "server.websub_http_port",
 		"server.websub_https_port",
 		"server.websocket_port",
+		"server.websocket_https_port",
 		"server.admin_port",
 		"server.metrics_port",
 		"websub.verification_timeout_seconds",
@@ -232,7 +239,7 @@ func mapEnvValue(path, value string) interface{} {
 		if n, err := strconv.Atoi(value); err == nil {
 			return n
 		}
-	case "kafka.tls", "controlplane.enabled", "server.websub_enabled", "server.websub_tls_enabled":
+	case "kafka.tls", "controlplane.enabled", "server.websub_enabled", "server.websub_tls_enabled", "server.websocket_tls_enabled":
 		if b, err := strconv.ParseBool(value); err == nil {
 			return b
 		}
@@ -264,10 +271,19 @@ func validate(cfg *Config) error {
 	}
 
 	if cfg.Server.WebSubTLSEnabled {
-		if err := validateReadableFile(cfg.Server.WebSubTLSCertFile, "server.websub_tls_cert_file"); err != nil {
+		if err := validateReadableFile(cfg.Server.WebSubTLSCertFile, "server.websub_tls_cert_file", "server.websub_tls_enabled"); err != nil {
 			return err
 		}
-		if err := validateReadableFile(cfg.Server.WebSubTLSKeyFile, "server.websub_tls_key_file"); err != nil {
+		if err := validateReadableFile(cfg.Server.WebSubTLSKeyFile, "server.websub_tls_key_file", "server.websub_tls_enabled"); err != nil {
+			return err
+		}
+	}
+
+	if cfg.Server.WebSocketTLSEnabled {
+		if err := validateReadableFile(cfg.Server.WebSocketTLSCertFile, "server.websocket_tls_cert_file", "server.websocket_tls_enabled"); err != nil {
+			return err
+		}
+		if err := validateReadableFile(cfg.Server.WebSocketTLSKeyFile, "server.websocket_tls_key_file", "server.websocket_tls_enabled"); err != nil {
 			return err
 		}
 	}
@@ -298,7 +314,7 @@ func validateKafkaConfig(kafkaCfg KafkaConfig) error {
 
 	if kafkaCfg.TLS {
 		if strings.TrimSpace(kafkaCfg.TLSCAFile) != "" {
-			if err := validateReadableFile(kafkaCfg.TLSCAFile, "kafka.tls_ca_file"); err != nil {
+			if err := validateReadableFile(kafkaCfg.TLSCAFile, "kafka.tls_ca_file", "kafka.tls"); err != nil {
 				return err
 			}
 		}
@@ -308,10 +324,10 @@ func validateKafkaConfig(kafkaCfg KafkaConfig) error {
 			if certFile == "" || keyFile == "" {
 				return fmt.Errorf("kafka.tls_cert_file and kafka.tls_key_file must be configured together")
 			}
-			if err := validateReadableFile(certFile, "kafka.tls_cert_file"); err != nil {
+			if err := validateReadableFile(certFile, "kafka.tls_cert_file", "kafka.tls"); err != nil {
 				return err
 			}
-			if err := validateReadableFile(keyFile, "kafka.tls_key_file"); err != nil {
+			if err := validateReadableFile(keyFile, "kafka.tls_key_file", "kafka.tls"); err != nil {
 				return err
 			}
 		}
@@ -346,6 +362,7 @@ func validateServerPorts(serverCfg ServerConfig) error {
 		{name: "server.websub_http_port", value: serverCfg.WebSubHTTPPort},
 		{name: "server.websub_https_port", value: serverCfg.WebSubHTTPSPort},
 		{name: "server.websocket_port", value: serverCfg.WebSocketPort},
+		{name: "server.websocket_https_port", value: serverCfg.WebSocketHTTPSPort},
 		{name: "server.admin_port", value: serverCfg.AdminPort},
 		{name: "server.metrics_port", value: serverCfg.MetricsPort},
 	}
@@ -364,10 +381,10 @@ func validateServerPorts(serverCfg ServerConfig) error {
 	return nil
 }
 
-func validateReadableFile(filePath, fieldName string) error {
+func validateReadableFile(filePath, fieldName, enabledFieldName string) error {
 	trimmedPath := strings.TrimSpace(filePath)
 	if trimmedPath == "" {
-		return fmt.Errorf("%s is required when server.websub_tls_enabled is true", fieldName)
+		return fmt.Errorf("%s is required when %s is true", fieldName, enabledFieldName)
 	}
 
 	info, err := os.Stat(trimmedPath)

--- a/event-gateway/gateway-runtime/internal/config/config_test.go
+++ b/event-gateway/gateway-runtime/internal/config/config_test.go
@@ -228,6 +228,134 @@ websub_tls_key_file = "`+keyPath+`"
 	}
 }
 
+func TestLoadAppliesWebSocketTLSEnvironmentOverrides(t *testing.T) {
+	tempDir := t.TempDir()
+	certPath := filepath.Join(tempDir, "tls.crt")
+	keyPath := filepath.Join(tempDir, "tls.key")
+	if err := os.WriteFile(certPath, []byte("cert"), 0o644); err != nil {
+		t.Fatalf("write cert: %v", err)
+	}
+	if err := os.WriteFile(keyPath, []byte("key"), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+
+	t.Setenv("APIP_EGW_SERVER_WEBSOCKET_HTTPS_PORT", "9444")
+	t.Setenv("APIP_EGW_SERVER_WEBSOCKET_TLS_ENABLED", "true")
+	t.Setenv("APIP_EGW_SERVER_WEBSOCKET_TLS_CERT_FILE", certPath)
+	t.Setenv("APIP_EGW_SERVER_WEBSOCKET_TLS_KEY_FILE", keyPath)
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(configPath, []byte(`
+[kafka]
+brokers = ["localhost:9092"]
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, _, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	if cfg.Server.WebSocketHTTPSPort != 9444 {
+		t.Fatalf("expected websocket https port 9444, got %d", cfg.Server.WebSocketHTTPSPort)
+	}
+	if !cfg.Server.WebSocketTLSEnabled {
+		t.Fatalf("expected websocket TLS to be enabled")
+	}
+	if cfg.Server.WebSocketTLSCertFile != certPath {
+		t.Fatalf("expected websocket TLS cert file override, got %q", cfg.Server.WebSocketTLSCertFile)
+	}
+	if cfg.Server.WebSocketTLSKeyFile != keyPath {
+		t.Fatalf("expected websocket TLS key file override, got %q", cfg.Server.WebSocketTLSKeyFile)
+	}
+}
+
+func TestLoadRequiresWebSocketTLSFilesWhenEnabled(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(configPath, []byte(`
+[server]
+websocket_tls_enabled = true
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, _, err := Load(configPath)
+	if err == nil {
+		t.Fatalf("expected load to fail when TLS files are missing")
+	}
+
+	want := "server.websocket_tls_cert_file is required when server.websocket_tls_enabled is true"
+	if err.Error() != want {
+		t.Fatalf("expected error %q, got %q", want, err.Error())
+	}
+}
+
+func TestLoadRejectsMissingWebSocketTLSFilesWhenEnabled(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	missingCert := filepath.Join(t.TempDir(), "missing.crt")
+	missingKey := filepath.Join(t.TempDir(), "missing.key")
+	if err := os.WriteFile(configPath, []byte(`
+[server]
+websocket_tls_enabled = true
+websocket_tls_cert_file = "`+missingCert+`"
+websocket_tls_key_file = "`+missingKey+`"
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, _, err := Load(configPath)
+	if err == nil {
+		t.Fatalf("expected load to fail when TLS cert file is missing")
+	}
+
+	if !strings.Contains(err.Error(), `server.websocket_tls_cert_file file "`) || !strings.Contains(err.Error(), `does not exist`) {
+		t.Fatalf("expected missing cert file error, got %q", err.Error())
+	}
+}
+
+func TestLoadRejectsUnreadableWebSocketTLSKeyFileWhenEnabled(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission-based readability checks are unreliable when running as root")
+	}
+
+	tempDir := t.TempDir()
+	certPath := filepath.Join(tempDir, "tls.crt")
+	keyPath := filepath.Join(tempDir, "tls.key")
+	configPath := filepath.Join(tempDir, "config.toml")
+
+	if err := os.WriteFile(certPath, []byte("cert"), 0o644); err != nil {
+		t.Fatalf("write cert: %v", err)
+	}
+	if err := os.WriteFile(keyPath, []byte("key"), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	if err := os.Chmod(keyPath, 0o000); err != nil {
+		t.Fatalf("chmod key unreadable: %v", err)
+	}
+	defer func() {
+		_ = os.Chmod(keyPath, 0o600)
+	}()
+
+	if err := os.WriteFile(configPath, []byte(`
+[server]
+websocket_tls_enabled = true
+websocket_tls_cert_file = "`+certPath+`"
+websocket_tls_key_file = "`+keyPath+`"
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, _, err := Load(configPath)
+	if err == nil {
+		t.Fatalf("expected load to fail when TLS key file is unreadable")
+	}
+
+	if !strings.Contains(err.Error(), `server.websocket_tls_key_file file "`) || !strings.Contains(err.Error(), `is not readable`) {
+		t.Fatalf("expected unreadable key file error, got %q", err.Error())
+	}
+}
+
 func TestLoadRejectsNonPositiveServerPorts(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.toml")
 	if err := os.WriteFile(configPath, []byte(`

--- a/event-gateway/gateway-runtime/internal/connectors/registry.go
+++ b/event-gateway/gateway-runtime/internal/connectors/registry.go
@@ -20,6 +20,7 @@ package connectors
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 )
 
@@ -63,6 +64,7 @@ func (r *Registry) RegisterBrokerDriver(name string, factory BrokerDriverFactory
 
 // CreateReceiver creates a receiver using the registered factory.
 func (r *Registry) CreateReceiver(name string, cfg ReceiverConfig) (Receiver, error) {
+	name = strings.ToLower(name)
 	r.mu.RLock()
 	factory, ok := r.receivers[name]
 	r.mu.RUnlock()
@@ -74,6 +76,7 @@ func (r *Registry) CreateReceiver(name string, cfg ReceiverConfig) (Receiver, er
 
 // CreateBrokerDriver creates a broker-driver using the registered factory.
 func (r *Registry) CreateBrokerDriver(name string, cfg map[string]interface{}) (BrokerDriver, error) {
+	name = strings.ToLower(name)
 	r.mu.RLock()
 	factory, ok := r.brokerDrivers[name]
 	r.mu.RUnlock()

--- a/event-gateway/gateway-runtime/internal/runtime/runtime.go
+++ b/event-gateway/gateway-runtime/internal/runtime/runtime.go
@@ -403,22 +403,30 @@ func (r *Runtime) LoadChannels(channelsPath string) error {
 
 	// Create shared HTTP servers.
 	if hasWS {
-		wsServer, err := r.newManagedServer("WebSocket", r.cfg.Server.WebSocketPort, wsMux, false)
+		wsServer, err := r.newManagedServer("WebSocket", r.cfg.Server.WebSocketPort, wsMux, "", "")
 		if err != nil {
 			return fmt.Errorf("failed to create WebSocket server: %w", err)
 		}
 		r.servers = append(r.servers, wsServer)
+		// Create WSS server if TLS is enabled
+		if r.cfg.Server.WebSocketTLSEnabled {
+			wssServer, err := r.newManagedServer("WebSocket-HTTPS", r.cfg.Server.WebSocketHTTPSPort, wsMux, r.cfg.Server.WebSocketTLSCertFile, r.cfg.Server.WebSocketTLSKeyFile)
+			if err != nil {
+				return fmt.Errorf("failed to create WebSocket HTTPS server: %w", err)
+			}
+			r.servers = append(r.servers, wssServer)
+		}
 	}
 	if hasWebSub && r.cfg.Server.WebSubEnabled {
 		// Create HTTP server
-		websubHTTPServer, err := r.newManagedServer("WebSub-HTTP", r.cfg.Server.WebSubHTTPPort, websubMux, false)
+		websubHTTPServer, err := r.newManagedServer("WebSub-HTTP", r.cfg.Server.WebSubHTTPPort, websubMux, "", "")
 		if err != nil {
 			return fmt.Errorf("failed to create WebSub HTTP server: %w", err)
 		}
 		r.servers = append(r.servers, websubHTTPServer)
 		// Create HTTPS server if TLS is enabled
 		if r.cfg.Server.WebSubTLSEnabled {
-			websubHTTPSServer, err := r.newManagedServer("WebSub-HTTPS", r.cfg.Server.WebSubHTTPSPort, websubMux, true)
+			websubHTTPSServer, err := r.newManagedServer("WebSub-HTTPS", r.cfg.Server.WebSubHTTPSPort, websubMux, r.cfg.Server.WebSubTLSCertFile, r.cfg.Server.WebSubTLSKeyFile)
 			if err != nil {
 				return fmt.Errorf("failed to create WebSub HTTPS server: %w", err)
 			}
@@ -446,7 +454,7 @@ func (r *Runtime) Run(ctx context.Context) error {
 	if r.cfg.ControlPlane.Enabled {
 		// Create WebSocket server for dynamic WebBrokerApi bindings
 		slog.Info("Creating WebSocket server for dynamic WebBrokerApi bindings", "port", r.cfg.Server.WebSocketPort)
-		wsServer, err := r.newManagedServer("WebSocket", r.cfg.Server.WebSocketPort, r.wsMux, false)
+		wsServer, err := r.newManagedServer("WebSocket", r.cfg.Server.WebSocketPort, r.wsMux, "", "")
 		if err != nil {
 			r.mu.Unlock()
 			return fmt.Errorf("failed to create WebSocket server: %w", err)
@@ -456,10 +464,24 @@ func (r *Runtime) Run(ctx context.Context) error {
 			r.runServer(wsServer)
 		}()
 
+		// Create WSS server if TLS is enabled
+		if r.cfg.Server.WebSocketTLSEnabled {
+			slog.Info("Creating WebSocket HTTPS server for dynamic WebBrokerApi bindings", "port", r.cfg.Server.WebSocketHTTPSPort)
+			wssServer, err := r.newManagedServer("WebSocket-HTTPS", r.cfg.Server.WebSocketHTTPSPort, r.wsMux, r.cfg.Server.WebSocketTLSCertFile, r.cfg.Server.WebSocketTLSKeyFile)
+			if err != nil {
+				r.mu.Unlock()
+				return fmt.Errorf("failed to create WebSocket HTTPS server: %w", err)
+			}
+			r.servers = append(r.servers, wssServer)
+			go func() {
+				r.runServer(wssServer)
+			}()
+		}
+
 		// Create WebSub servers for dynamic WebSubApi bindings
 		if r.cfg.Server.WebSubEnabled {
 			slog.Info("Creating WebSub HTTP server for dynamic WebSubApi bindings", "port", r.cfg.Server.WebSubHTTPPort)
-			websubHTTPServer, err := r.newManagedServer("WebSub-HTTP", r.cfg.Server.WebSubHTTPPort, r.websubMux, false)
+			websubHTTPServer, err := r.newManagedServer("WebSub-HTTP", r.cfg.Server.WebSubHTTPPort, r.websubMux, "", "")
 			if err != nil {
 				r.mu.Unlock()
 				return fmt.Errorf("failed to create WebSub HTTP server: %w", err)
@@ -472,7 +494,7 @@ func (r *Runtime) Run(ctx context.Context) error {
 			// Create HTTPS server if TLS is enabled
 			if r.cfg.Server.WebSubTLSEnabled {
 				slog.Info("Creating WebSub HTTPS server for dynamic WebSubApi bindings", "port", r.cfg.Server.WebSubHTTPSPort)
-				websubHTTPSServer, err := r.newManagedServer("WebSub-HTTPS", r.cfg.Server.WebSubHTTPSPort, r.websubMux, true)
+				websubHTTPSServer, err := r.newManagedServer("WebSub-HTTPS", r.cfg.Server.WebSubHTTPSPort, r.websubMux, r.cfg.Server.WebSubTLSCertFile, r.cfg.Server.WebSubTLSKeyFile)
 				if err != nil {
 					r.mu.Unlock()
 					return fmt.Errorf("failed to create WebSub HTTPS server: %w", err)
@@ -562,7 +584,7 @@ func (r *Runtime) Run(ctx context.Context) error {
 	return nil
 }
 
-func (r *Runtime) newManagedServer(name string, port int, handler http.Handler, allowTLS bool) (*managedServer, error) {
+func (r *Runtime) newManagedServer(name string, port int, handler http.Handler, certFile, keyFile string) (*managedServer, error) {
 	server := &managedServer{
 		name: name,
 		server: &http.Server{
@@ -571,16 +593,16 @@ func (r *Runtime) newManagedServer(name string, port int, handler http.Handler, 
 		},
 	}
 
-	if allowTLS && r.cfg.Server.WebSubTLSEnabled {
-		if err := ensureReadableTLSAsset(r.cfg.Server.WebSubTLSCertFile, "server.websub_tls_cert_file"); err != nil {
+	if certFile != "" {
+		if err := ensureReadableTLSAsset(certFile, name+" TLS cert file"); err != nil {
 			return nil, fmt.Errorf("invalid TLS configuration for %s server: %w", name, err)
 		}
-		if err := ensureReadableTLSAsset(r.cfg.Server.WebSubTLSKeyFile, "server.websub_tls_key_file"); err != nil {
+		if err := ensureReadableTLSAsset(keyFile, name+" TLS key file"); err != nil {
 			return nil, fmt.Errorf("invalid TLS configuration for %s server: %w", name, err)
 		}
 		server.tls = true
-		server.certFile = r.cfg.Server.WebSubTLSCertFile
-		server.keyFile = r.cfg.Server.WebSubTLSKeyFile
+		server.certFile = certFile
+		server.keyFile = keyFile
 	}
 
 	return server, nil

--- a/event-gateway/gateway-runtime/internal/runtime/runtime_test.go
+++ b/event-gateway/gateway-runtime/internal/runtime/runtime_test.go
@@ -224,7 +224,7 @@ func TestNewManagedServerRejectsMissingTLSFiles(t *testing.T) {
 		},
 	}
 
-	_, err := rt.newManagedServer("WebSub-HTTPS", 8443, http.NewServeMux(), true)
+	_, err := rt.newManagedServer("WebSub-HTTPS", 8443, http.NewServeMux(), rt.cfg.Server.WebSubTLSCertFile, rt.cfg.Server.WebSubTLSKeyFile)
 	if err == nil {
 		t.Fatal("expected newManagedServer to fail when TLS files are missing")
 	}
@@ -254,7 +254,63 @@ func TestNewManagedServerAcceptsReadableTLSFiles(t *testing.T) {
 		},
 	}
 
-	server, err := rt.newManagedServer("WebSub-HTTPS", 8443, http.NewServeMux(), true)
+	server, err := rt.newManagedServer("WebSub-HTTPS", 8443, http.NewServeMux(), certPath, keyPath)
+	if err != nil {
+		t.Fatalf("expected newManagedServer to succeed, got %v", err)
+	}
+	if !server.tls {
+		t.Fatal("expected TLS to be enabled on the managed server")
+	}
+	if server.certFile != certPath {
+		t.Fatalf("expected cert path %q, got %q", certPath, server.certFile)
+	}
+	if server.keyFile != keyPath {
+		t.Fatalf("expected key path %q, got %q", keyPath, server.keyFile)
+	}
+}
+
+func TestNewManagedServerWebSocketRejectsMissingTLSFiles(t *testing.T) {
+	rt := &Runtime{
+		cfg: &config.Config{
+			Server: config.ServerConfig{
+				WebSocketTLSEnabled:  true,
+				WebSocketTLSCertFile: filepath.Join(t.TempDir(), "missing.crt"),
+				WebSocketTLSKeyFile:  filepath.Join(t.TempDir(), "missing.key"),
+			},
+		},
+	}
+
+	_, err := rt.newManagedServer("WebSocket-HTTPS", 8444, http.NewServeMux(), rt.cfg.Server.WebSocketTLSCertFile, rt.cfg.Server.WebSocketTLSKeyFile)
+	if err == nil {
+		t.Fatal("expected newManagedServer to fail when TLS files are missing")
+	}
+	if !strings.Contains(err.Error(), "invalid TLS configuration for WebSocket-HTTPS server") {
+		t.Fatalf("expected wrapped TLS configuration error, got %q", err.Error())
+	}
+}
+
+func TestNewManagedServerWebSocketAcceptsReadableTLSFiles(t *testing.T) {
+	tempDir := t.TempDir()
+	certPath := filepath.Join(tempDir, "tls.crt")
+	keyPath := filepath.Join(tempDir, "tls.key")
+	if err := os.WriteFile(certPath, []byte("cert"), 0o644); err != nil {
+		t.Fatalf("write cert: %v", err)
+	}
+	if err := os.WriteFile(keyPath, []byte("key"), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+
+	rt := &Runtime{
+		cfg: &config.Config{
+			Server: config.ServerConfig{
+				WebSocketTLSEnabled:  true,
+				WebSocketTLSCertFile: certPath,
+				WebSocketTLSKeyFile:  keyPath,
+			},
+		},
+	}
+
+	server, err := rt.newManagedServer("WebSocket-HTTPS", 8444, http.NewServeMux(), certPath, keyPath)
 	if err != nil {
 		t.Fatalf("expected newManagedServer to succeed, got %v", err)
 	}


### PR DESCRIPTION
### Add SSL Support for WebBroker API WebSockets
Resolves https://github.com/wso2/api-platform/issues/1978

Testing WebBrokerAPI WSS (SSL) support

- Ensure certs exist in `event-gateway/tls/` (generate with openssl if not present)
- Start the stack: `docker compose up`
- Verify WSS server started in logs: `Starting server name=WebSocket-HTTPS protocol=HTTPS addr=:8444`
- Connect via wscat:
```
NODE_EXTRA_CA_CERTS=event-gateway/tls/default-listener.crt \
  wscat -c "wss://localhost:8444/<api-context>/<version>" -H "X-channel: <channel>"
```

### Convert WebBroker API Receiver & Broker driver names to lower case. 
Resolves https://github.com/wso2/api-platform/issues/2028
