### PR TITLE
Add devportal REST API documentation

### DIFF
--- a/docs/rest-apis/devportal/README.md
+++ b/docs/rest-apis/devportal/README.md
@@ -1,0 +1,188 @@
+
+<h1 id="wso2-api-developer-portal-core-devportal-routes">WSO2 API Developer Portal Core - Devportal Routes v1.0.0</h1>
+
+Fine-grained Developer Portal API for managing organizations, identity providers, providers,
+API metadata and content, applications, subscriptions, application credentials, billing, invoices, usage, and API flows.
+
+All paths are served under the `/devportal` base path. Operations declare the least-privilege
+OAuth2 scopes required for each resource action, and selected billing-related endpoints also
+support API key authentication where configured.
+
+Base URLs:
+* <a href="http://localhost:3000/devportal">http://localhost:3000/devportal</a>
+* <a href="https://localhost:{port}/devportal">https://localhost:{port}/devportal</a>
+    * **port** -  Default: 9443
+
+## Table of Contents
+
+### [Authentication](authentication.md)
+
+### [Organizations](organizations.md)
+
+- [Create an organization](organizations.md#create-an-organization)
+- [List organizations](organizations.md#list-organizations)
+- [Update an organization](organizations.md#update-an-organization)
+- [Get an organization](organizations.md#get-an-organization)
+- [Delete an organization](organizations.md#delete-an-organization)
+
+### [Identity Providers](identity-providers.md)
+
+- [Create an identity provider](identity-providers.md#create-an-identity-provider)
+- [Update an identity provider](identity-providers.md#update-an-identity-provider)
+- [Get an identity provider](identity-providers.md#get-an-identity-provider)
+- [Delete an identity provider](identity-providers.md#delete-an-identity-provider)
+
+### [Organization Content](organization-content.md)
+
+- [Upload organization layout content](organization-content.md#upload-organization-layout-content)
+- [Replace organization layout content](organization-content.md#replace-organization-layout-content)
+- [Get a single organization layout asset](organization-content.md#get-a-single-organization-layout-asset)
+- [Delete organization layout content](organization-content.md#delete-organization-layout-content)
+- [List organization layout assets by file type](organization-content.md#list-organization-layout-assets-by-file-type)
+
+### [Providers](providers.md)
+
+- [Create a provider](providers.md#create-a-provider)
+- [Update a provider](providers.md#update-a-provider)
+- [Get providers](providers.md#get-providers)
+- [Delete a provider](providers.md#delete-a-provider)
+
+### [APIs](apis.md)
+
+- [Create API metadata](apis.md#create-api-metadata)
+- [List API metadata](apis.md#list-api-metadata)
+- [Get API metadata](apis.md#get-api-metadata)
+- [Update API metadata](apis.md#update-api-metadata)
+- [Delete API metadata](apis.md#delete-api-metadata)
+
+### [API Content](api-content.md)
+
+- [Upload API content](api-content.md#upload-api-content)
+- [Replace API content](api-content.md#replace-api-content)
+- [Get an API content file](api-content.md#get-an-api-content-file)
+- [Delete API content files](api-content.md#delete-api-content-files)
+
+### [Subscription Policies](subscription-policies.md)
+
+- [Create subscription policies](subscription-policies.md#create-subscription-policies)
+- [Upsert subscription policies](subscription-policies.md#upsert-subscription-policies)
+- [Get a subscription policy](subscription-policies.md#get-a-subscription-policy)
+- [Delete a subscription policy](subscription-policies.md#delete-a-subscription-policy)
+
+### [Labels](labels.md)
+
+- [Create labels](labels.md#create-labels)
+- [Upsert labels](labels.md#upsert-labels)
+- [List labels](labels.md#list-labels)
+- [Delete labels](labels.md#delete-labels)
+
+### [Applications](applications.md)
+
+- [Create an application](applications.md#create-an-application)
+- [List applications](applications.md#list-applications)
+- [Update an application](applications.md#update-an-application)
+- [Get application details](applications.md#get-application-details)
+- [Delete an application](applications.md#delete-an-application)
+- [Import an application](applications.md#import-an-application)
+- [Create an application for the authenticated user's organization](applications.md#create-an-application-for-the-authenticated-users-organization)
+- [Update an application for the authenticated user](applications.md#update-an-application-for-the-authenticated-user)
+- [Delete an application for the authenticated user](applications.md#delete-an-application-for-the-authenticated-user)
+- [Reset application throttle policy](applications.md#reset-application-throttle-policy)
+
+### [Subscriptions](subscriptions.md)
+
+- [Create a subscription](subscriptions.md#create-a-subscription)
+- [List subscriptions](subscriptions.md#list-subscriptions)
+- [Get a subscription](subscriptions.md#get-a-subscription)
+- [Update a subscription](subscriptions.md#update-a-subscription)
+- [Delete a subscription](subscriptions.md#delete-a-subscription)
+
+### [API Keys](api-keys.md)
+
+- [Generate an API key](api-keys.md#generate-an-api-key)
+- [List API keys](api-keys.md#list-api-keys)
+- [Regenerate an API key](api-keys.md#regenerate-an-api-key)
+- [Revoke an API key](api-keys.md#revoke-an-api-key)
+
+### [App Key Mapping](app-key-mapping.md)
+
+- [Create application key mapping](app-key-mapping.md#create-application-key-mapping)
+- [Get application key mappings](app-key-mapping.md#get-application-key-mappings)
+
+### [Views](views.md)
+
+- [Create a view](views.md#create-a-view)
+- [List views](views.md#list-views)
+- [Update a view](views.md#update-a-view)
+- [Get a view](views.md#get-a-view)
+- [Delete a view](views.md#delete-a-view)
+
+### [Application Keys](application-keys.md)
+
+- [Generate OAuth keys for a control-plane application](application-keys.md#generate-oauth-keys-for-a-control-plane-application)
+- [Generate an OAuth access token](application-keys.md#generate-an-oauth-access-token)
+- [Revoke OAuth keys](application-keys.md#revoke-oauth-keys)
+- [Update OAuth keys](application-keys.md#update-oauth-keys)
+- [Clean up OAuth key artifacts](application-keys.md#clean-up-oauth-key-artifacts)
+
+### [Billing](billing.md)
+
+- [Get billing usage data](billing.md#get-billing-usage-data)
+- [List payment methods](billing.md#list-payment-methods)
+- [Add billing engine keys](billing.md#add-billing-engine-keys)
+- [Update billing engine keys](billing.md#update-billing-engine-keys)
+- [Delete billing engine keys](billing.md#delete-billing-engine-keys)
+- [Get billing engine keys](billing.md#get-billing-engine-keys)
+- [Get billing profile information](billing.md#get-billing-profile-information)
+- [List subscriptions for billing](billing.md#list-subscriptions-for-billing)
+- [Create a checkout session](billing.md#create-a-checkout-session)
+- [Register a Stripe checkout session](billing.md#register-a-stripe-checkout-session)
+- [Cancel a paid subscription](billing.md#cancel-a-paid-subscription)
+- [Get subscription billing status](billing.md#get-subscription-billing-status)
+- [Create an organization billing portal session](billing.md#create-an-organization-billing-portal-session)
+- [Create a subscription billing portal session](billing.md#create-a-subscription-billing-portal-session)
+
+### [Usage](usage.md)
+
+- [Get subscription usage](usage.md#get-subscription-usage)
+
+### [Invoices](invoices.md)
+
+- [List invoices](invoices.md#list-invoices)
+- [Get an invoice](invoices.md#get-an-invoice)
+- [List invoices by subscription](invoices.md#list-invoices-by-subscription)
+- [Get invoice PDF link](invoices.md#get-invoice-pdf-link)
+- [redirectHostedInvoice](invoices.md#redirecthostedinvoice)
+
+### [API Flows](api-flows.md)
+
+- [Create an API flow](api-flows.md#create-an-api-flow)
+- [List API flows](api-flows.md#list-api-flows)
+- [Get an API flow](api-flows.md#get-an-api-flow)
+- [Update an API flow](api-flows.md#update-an-api-flow)
+- [Delete an API flow](api-flows.md#delete-an-api-flow)
+- [Generate an API flow agent prompt](api-flows.md#generate-an-api-flow-agent-prompt)
+
+### [Utilities](utilities.md)
+
+- [Create a temporary Arazzo file](utilities.md#create-a-temporary-arazzo-file)
+
+### [Authentication](authentication.md)
+
+### [Key Managers](key-managers.md)
+
+- [Create a key manager](key-managers.md#create-a-key-manager)
+- [List key managers](key-managers.md#list-key-managers)
+- [List available key managers for developers](key-managers.md#list-available-key-managers-for-developers)
+- [Get a key manager](key-managers.md#get-a-key-manager)
+- [Update a key manager](key-managers.md#update-a-key-manager)
+- [Delete a key manager](key-managers.md#delete-a-key-manager)
+
+### [Webhook Events](webhook-events.md)
+
+- [List webhook events](webhook-events.md#list-webhook-events)
+- [Get a webhook event](webhook-events.md#get-a-webhook-event)
+- [Retry a failed webhook delivery](webhook-events.md#retry-a-failed-webhook-delivery)
+
+### [Schemas](schemas.md)
+

--- a/docs/rest-apis/devportal/api-content.md
+++ b/docs/rest-apis/devportal/api-content.md
@@ -1,0 +1,469 @@
+<h1 id="wso2-api-developer-portal-core-devportal-routes-api-content">API Content</h1>
+
+## Upload API content
+
+<a id="opIdcreateAPIContent"></a>
+
+`POST /organizations/{orgId}/apis/{apiId}/content`
+
+> Code samples
+
+```shell
+
+curl -X POST http://localhost:3000/devportal/organizations/{orgId}/apis/{apiId}/content \
+  -u {username}:{password} \
+  -H 'Content-Type: multipart/form-data' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Uploads the static content package for an API.
+
+The `apiContent` ZIP must contain at least one of these root directories:
+- `web/` for API landing-page assets such as markdown, HTML, CSS, JavaScript, and images.
+- `docs/` for downloadable API documents.
+
+Use `docMetadata` to add external document links that are stored alongside uploaded documents.
+Use `imageMetadata` to map uploaded images to API image roles such as the API icon.
+
+> Payload
+
+```yaml
+apiContent: string
+docMetadata: '[{"name":"External
+  guide","url":"https://example.com/docs/guide","type":"LINK"}]'
+imageMetadata: '{"api-icon":"icon.png"}'
+
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="upload-api-content-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|object|true|API content ZIP upload.|
+|» apiContent|body|string(binary)|true|ZIP upload field named `apiContent`.|
+|» docMetadata|body|string|false|Optional JSON string containing API document link metadata.|
+|» imageMetadata|body|string|false|Optional JSON string containing API image metadata.|
+|orgId|path|string|true|none|
+|apiId|path|string|true|none|
+
+#### Detailed descriptions
+
+**body**: API content ZIP upload.
+
+Expected ZIP structure:
+- `web/`: optional API landing-page files and images.
+- `docs/`: optional downloadable documents.
+
+At least one of `web/` or `docs/` must exist at the ZIP root.
+`docMetadata` and `imageMetadata` are JSON strings because they are submitted as multipart form fields.
+
+> Example responses
+
+> 201 Response
+
+```json
+{
+  "message": "string"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 409 Response
+
+```json
+{
+  "code": "409",
+  "message": "Conflict",
+  "description": "Organization already exists"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="upload-api-content-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|JSON message response.|[MessageResponse](schemas.md#schemamessageresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Duplicate organization data conflicts with an existing record.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="upload-api-content-responseschema">Response Schema</h3>
+
+## Replace API content
+
+<a id="opIdupdateAPIContent"></a>
+
+`PUT /organizations/{orgId}/apis/{apiId}/content`
+
+> Code samples
+
+```shell
+
+curl -X PUT http://localhost:3000/devportal/organizations/{orgId}/apis/{apiId}/content \
+  -u {username}:{password} \
+  -H 'Content-Type: multipart/form-data' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Replaces or adds static content files for an existing API.
+
+The upload format is the same as `POST /organizations/{orgId}/apis/{apiId}/content`.
+Existing files with the same stored `type` and `fileName` are updated; new files are created.
+Image metadata is updated only when image metadata can be resolved from the upload or request body.
+
+> Payload
+
+```yaml
+apiContent: string
+docMetadata: '[{"name":"External
+  guide","url":"https://example.com/docs/guide","type":"LINK"}]'
+imageMetadata: '{"api-icon":"icon.png"}'
+
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="replace-api-content-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|object|true|API content ZIP upload.|
+|» apiContent|body|string(binary)|true|ZIP upload field named `apiContent`.|
+|» docMetadata|body|string|false|Optional JSON string containing API document link metadata.|
+|» imageMetadata|body|string|false|Optional JSON string containing API image metadata.|
+|orgId|path|string|true|none|
+|apiId|path|string|true|none|
+
+#### Detailed descriptions
+
+**body**: API content ZIP upload.
+
+Expected ZIP structure:
+- `web/`: optional API landing-page files and images.
+- `docs/`: optional downloadable documents.
+
+At least one of `web/` or `docs/` must exist at the ZIP root.
+`docMetadata` and `imageMetadata` are JSON strings because they are submitted as multipart form fields.
+
+> Example responses
+
+> 201 Response
+
+```json
+{
+  "message": "string"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 409 Response
+
+```json
+{
+  "code": "409",
+  "message": "Conflict",
+  "description": "Organization already exists"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="replace-api-content-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|JSON message response.|[MessageResponse](schemas.md#schemamessageresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Duplicate organization data conflicts with an existing record.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="replace-api-content-responseschema">Response Schema</h3>
+
+## Get an API content file
+
+<a id="opIdgetAPIContentFile"></a>
+
+`GET /organizations/{orgId}/apis/{apiId}/content`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId}/apis/{apiId}/content?type=document&fileName=getting-started.md \
+  -u {username}:{password} \
+  -H 'Accept: text/css' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Retrieves a single stored API content file.
+
+The `type` query parameter selects the stored content category and `fileName` selects the file
+within that category. Text files and external document links are returned as text. Image files are
+returned as binary content with a media type derived from the file extension.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="get-an-api-content-file-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|type|query|string|true|Stored API content type selector. Common values are `web`, `document`, `image`, and `link`, depending on how the uploaded ZIP content was classified.|
+|fileName|query|string|true|Stored API content file name to retrieve.|
+|orgId|path|string|true|none|
+|apiId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```
+"<section>API overview</section>"
+```
+
+```
+"https://example.com/docs/guide"
+```
+
+```json
+{
+  "title": "API overview"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```
+"string"
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="get-an-api-content-file-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Stored API content asset. The concrete media type depends on the stored file extension or whether the content is an external document link.|string|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Plain text success response.|string|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="get-an-api-content-file-responseschema">Response Schema</h3>
+
+## Delete API content files
+
+<a id="opIddeleteAPIContentFile"></a>
+
+`DELETE /organizations/{orgId}/apis/{apiId}/content`
+
+> Code samples
+
+```shell
+
+curl -X DELETE http://localhost:3000/devportal/organizations/{orgId}/apis/{apiId}/content?type=document \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Deletes stored API content.
+
+Send both `type` and `fileName` to delete one file. Send only `type` to delete all stored content
+files matching that content category for the API.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="delete-api-content-files-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|type|query|string|true|Stored API content type selector. Common values are `web`, `document`, `image`, and `link`, depending on how the uploaded ZIP content was classified.|
+|fileName|query|string|false|File name selector used by file retrieval and organization content deletion.|
+|orgId|path|string|true|none|
+|apiId|path|string|true|none|
+
+> Example responses
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```
+"string"
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="delete-api-content-files-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|API content deleted successfully.|None|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Plain text success response.|string|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="delete-api-content-files-responseschema">Response Schema</h3>

--- a/docs/rest-apis/devportal/api-flows.md
+++ b/docs/rest-apis/devportal/api-flows.md
@@ -1,0 +1,451 @@
+<h1 id="wso2-api-developer-portal-core-devportal-routes-api-flows">API Flows</h1>
+
+## Create an API flow
+
+<a id="opIdcreateAPIFlow"></a>
+
+`POST /organizations/{orgId}/views/{viewName}/api-flows`
+
+> Code samples
+
+```shell
+
+curl -X POST http://localhost:3000/devportal/organizations/{orgId}/views/{viewName}/api-flows \
+  -u {username}:{password} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Creates an API flow in the selected view. If `handle` is omitted, the service generates one from the name. `ARAZZO` content is parsed from JSON or YAML; invalid Arazzo content returns a bad request.
+
+> Payload
+
+```json
+{
+  "name": "Weather onboarding",
+  "handle": "weather-onboarding",
+  "description": "Guides users through the Weather API onboarding workflow.",
+  "contentType": "ARAZZO",
+  "apiFlowDefinition": {
+    "arazzo": "1.0.1",
+    "info": {
+      "title": "Weather onboarding",
+      "version": "1.0.0"
+    },
+    "workflows": []
+  }
+}
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="create-an-api-flow-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[APIFlowCreateRequest](schemas.md#schemaapiflowcreaterequest)|true|API flow creation payload. Use `contentType` `ARAZZO` for JSON/YAML workflow content or `MD` for Markdown flow content.|
+|orgId|path|string|true|none|
+|viewName|path|string|true|none|
+
+> Example responses
+
+> 201 Response
+
+```json
+{
+  "apiFlowId": "flow-12345",
+  "name": "Weather onboarding",
+  "status": "PUBLISHED"
+}
+```
+
+> 400 Response
+
+```json
+{
+  "message": "string"
+}
+```
+
+<h3 id="create-an-api-flow-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Created API flow summary.|[APIFlowCreateResponse](schemas.md#schemaapiflowcreateresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|JSON message response.|[MessageResponse](schemas.md#schemamessageresponse)|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|JSON message response.|[MessageResponse](schemas.md#schemamessageresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|JSON message response.|[MessageResponse](schemas.md#schemamessageresponse)|
+
+## List API flows
+
+<a id="opIdgetAllAPIFlows"></a>
+
+`GET /organizations/{orgId}/views/{viewName}/api-flows`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId}/views/{viewName}/api-flows \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Lists all API flows for the selected organization view.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="list-api-flows-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+|viewName|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+[
+  {
+    "apiFlowId": "flow-12345",
+    "name": "Weather onboarding",
+    "handle": "weather-onboarding",
+    "description": "string",
+    "agentPrompt": "string",
+    "status": "PUBLISHED",
+    "visibility": "PUBLIC",
+    "agentVisibility": "VISIBLE",
+    "contentType": "ARAZZO",
+    "apiFlowDefinition": "string",
+    "markdownContent": "string",
+    "createdAt": "May 7, 2026",
+    "updatedAt": "string"
+  }
+]
+```
+
+<h3 id="list-api-flows-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|List of API flow DTOs.|Inline|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|JSON message response.|[MessageResponse](schemas.md#schemamessageresponse)|
+
+<h3 id="list-api-flows-responseschema">Response Schema</h3>
+
+Status Code **200**
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|*anonymous*|[[APIFlowResponse](schemas.md#schemaapiflowresponse)]|false|none|none|
+|» apiFlowId|string|false|none|none|
+|» name|string|false|none|none|
+|» handle|string|false|none|none|
+|» description|string|false|none|none|
+|» agentPrompt|string|false|none|none|
+|» status|string|false|none|none|
+|» visibility|string|false|none|none|
+|» agentVisibility|string|false|none|none|
+|» contentType|string|false|none|none|
+|» apiFlowDefinition|string¦null|false|none|none|
+|» markdownContent|string¦null|false|none|none|
+|» createdAt|string|false|none|none|
+|» updatedAt|string¦null|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|contentType|ARAZZO|
+|contentType|MD|
+
+## Get an API flow
+
+<a id="opIdgetAPIFlow"></a>
+
+`GET /organizations/{orgId}/views/{viewName}/api-flows/{apiFlowId}`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId}/views/{viewName}/api-flows/{apiFlowId} \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Retrieves a single API flow by ID from the selected view.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="get-an-api-flow-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+|viewName|path|string|true|none|
+|apiFlowId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "apiFlowId": "flow-12345",
+  "name": "Weather onboarding",
+  "handle": "weather-onboarding",
+  "description": "Guides users through the Weather API onboarding workflow.",
+  "agentPrompt": "Follow this workflow to onboard a Weather API user.",
+  "status": "PUBLISHED",
+  "visibility": "PUBLIC",
+  "agentVisibility": "VISIBLE",
+  "contentType": "ARAZZO",
+  "apiFlowDefinition": "{\"arazzo\":\"1.0.1\",\"info\":{\"title\":\"Weather onboarding\",\"version\":\"1.0.0\"},\"workflows\":[]}",
+  "markdownContent": null,
+  "createdAt": "May 7, 2026",
+  "updatedAt": "2026-05-07T08:30:00Z"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "message": "string"
+}
+```
+
+<h3 id="get-an-api-flow-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|API flow DTO.|[APIFlowResponse](schemas.md#schemaapiflowresponse)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|JSON message response.|[MessageResponse](schemas.md#schemamessageresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|JSON message response.|[MessageResponse](schemas.md#schemamessageresponse)|
+
+## Update an API flow
+
+<a id="opIdupdateAPIFlow"></a>
+
+`PUT /organizations/{orgId}/views/{viewName}/api-flows/{apiFlowId}`
+
+> Code samples
+
+```shell
+
+curl -X PUT http://localhost:3000/devportal/organizations/{orgId}/views/{viewName}/api-flows/{apiFlowId} \
+  -u {username}:{password} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Updates API flow metadata and content for the selected view. Duplicate handles return a conflict.
+
+> Payload
+
+```json
+{
+  "name": "Weather onboarding v2",
+  "handle": "weather-onboarding-v2",
+  "description": "Updated Weather API onboarding workflow.",
+  "agentPrompt": "string",
+  "status": "PUBLISHED",
+  "visibility": "PUBLIC",
+  "agentVisibility": "VISIBLE",
+  "contentType": "ARAZZO",
+  "apiFlowDefinition": {},
+  "markdownContent": "string"
+}
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="update-an-api-flow-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[APIFlowUpdateRequest](schemas.md#schemaapiflowupdaterequest)|true|API flow update payload. Include only the fields that should change.|
+|orgId|path|string|true|none|
+|viewName|path|string|true|none|
+|apiFlowId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "message": "string"
+}
+```
+
+<h3 id="update-an-api-flow-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|JSON message response.|[MessageResponse](schemas.md#schemamessageresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|JSON message response.|[MessageResponse](schemas.md#schemamessageresponse)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|JSON message response.|[MessageResponse](schemas.md#schemamessageresponse)|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|JSON message response.|[MessageResponse](schemas.md#schemamessageresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|JSON message response.|[MessageResponse](schemas.md#schemamessageresponse)|
+
+## Delete an API flow
+
+<a id="opIddeleteAPIFlow"></a>
+
+`DELETE /organizations/{orgId}/views/{viewName}/api-flows/{apiFlowId}`
+
+> Code samples
+
+```shell
+
+curl -X DELETE http://localhost:3000/devportal/organizations/{orgId}/views/{viewName}/api-flows/{apiFlowId} \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Deletes an API flow from the selected view.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="delete-an-api-flow-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+|viewName|path|string|true|none|
+|apiFlowId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "message": "string"
+}
+```
+
+<h3 id="delete-an-api-flow-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|JSON message response.|[MessageResponse](schemas.md#schemamessageresponse)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|JSON message response.|[MessageResponse](schemas.md#schemamessageresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|JSON message response.|[MessageResponse](schemas.md#schemamessageresponse)|
+
+## Generate an API flow agent prompt
+
+<a id="opIdgeneratePrompt"></a>
+
+`POST /organizations/{orgId}/views/{viewName}/api-flows/generate-prompt`
+
+> Code samples
+
+```shell
+
+curl -X POST http://localhost:3000/devportal/organizations/{orgId}/views/{viewName}/api-flows/generate-prompt \
+  -u {username}:{password} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Generates the default agent prompt text for a proposed API flow using the supplied name, description, APIs, and view context.
+
+> Payload
+
+```json
+{
+  "name": "Weather onboarding",
+  "description": "Guides users through the Weather API onboarding workflow.",
+  "apis": [
+    {}
+  ],
+  "orgHandle": "acme",
+  "viewName": "default",
+  "handle": "weather-onboarding"
+}
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="generate-an-api-flow-agent-prompt-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[APIFlowPromptRequest](schemas.md#schemaapiflowpromptrequest)|true|API flow prompt-generation payload.|
+|orgId|path|string|true|none|
+|viewName|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "agentPrompt": "You are an API workflow assistant. Help the user complete Weather onboarding."
+}
+```
+
+> 500 Response
+
+```json
+{
+  "message": "string"
+}
+```
+
+<h3 id="generate-an-api-flow-agent-prompt-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Generated API flow agent prompt.|[APIFlowPromptResponse](schemas.md#schemaapiflowpromptresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|JSON message response.|[MessageResponse](schemas.md#schemamessageresponse)|

--- a/docs/rest-apis/devportal/api-keys.md
+++ b/docs/rest-apis/devportal/api-keys.md
@@ -1,0 +1,476 @@
+<h1 id="wso2-api-developer-portal-core-devportal-routes-api-keys">API Keys</h1>
+
+## Generate an API key
+
+<a id="opIdgenerateApiKey"></a>
+
+`POST /organizations/{orgId}/api-keys/generate`
+
+> Code samples
+
+```shell
+
+curl -X POST http://localhost:3000/devportal/organizations/{orgId}/api-keys/generate \
+  -u {username}:{password} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Generates an API key stored in the Developer Portal (devportal is source of truth). The plaintext secret is returned once in the response and never persisted. A `apikey.generated` webhook event is published so gateways can register the key. Key names must match `^[a-z0-9][a-z0-9_-]{0,127}$`, and `expiresAt` must include a timezone when sent as an ISO-8601 string.
+
+> Payload
+
+```json
+{
+  "apiId": "api-7f4c2a6b",
+  "name": "weather_prod_key",
+  "expiresAt": "2026-12-31T23:59:59Z"
+}
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="generate-an-api-key-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[ApiKeyRequest](schemas.md#schemaapikeyrequest)|true|API key payload. `apiId` is the Developer Portal API ID. `name` must be lowercase and may contain numbers, underscores, and hyphens. `expiresAt` can be an ISO-8601 datetime with timezone, epoch seconds, or epoch milliseconds.|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 201 Response
+
+```json
+{
+  "keyId": "key-12345",
+  "name": "weather_prod_key",
+  "apiId": "api-7f4c2a6b",
+  "key": "ak_dGhpcyBpcyBub3QgYSByZWFsIGtleQ",
+  "expiresAt": "2026-12-31T23:59:59Z",
+  "status": "ACTIVE"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 403 Response
+
+```json
+{
+  "code": "403",
+  "message": "Forbidden",
+  "description": "Write operations are disabled in read-only mode"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="generate-an-api-key-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Generated or regenerated API key. The plaintext `key` is returned exactly once.|[ApiKeyResponse](schemas.md#schemaapikeyresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|403|[Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)|Request is forbidden for the current runtime mode or caller permissions.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="generate-an-api-key-responseschema">Response Schema</h3>
+
+## List API keys
+
+<a id="opIdlistApiKeys"></a>
+
+`GET /organizations/{orgId}/api-keys`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId}/api-keys?apiId=api-7f4c2a6b \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Lists API keys for an API. The `apiId` query parameter is required and is resolved from the Developer Portal API ID to the control-plane API reference.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="list-api-keys-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|apiId|query|string|true|Developer Portal API ID used to resolve the control-plane API reference.|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+[
+  {
+    "keyId": "key-12345",
+    "name": "weather_prod_key",
+    "apiId": "api-7f4c2a6b",
+    "status": "ACTIVE",
+    "expiresAt": "2026-12-31T23:59:59Z",
+    "createdAt": "2019-08-24T14:15:22Z",
+    "revokedAt": "2019-08-24T14:15:22Z"
+  }
+]
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="list-api-keys-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|List of API key metadata records.|Inline|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="list-api-keys-responseschema">Response Schema</h3>
+
+Status Code **200**
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|*anonymous*|[[ApiKeyMetadataResponse](schemas.md#schemaapikeymetadataresponse)]|false|none|[API key metadata returned by list operations. Secret material is omitted.]|
+|» keyId|string|false|none|Developer Portal key identifier.|
+|» name|string|false|none|none|
+|» apiId|string|false|none|Developer Portal API ID the key belongs to.|
+|» status|string|false|none|none|
+|» expiresAt|string(date-time)¦null|false|none|none|
+|» createdAt|string(date-time)|false|none|none|
+|» revokedAt|string(date-time)¦null|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|status|ACTIVE|
+|status|REVOKED|
+
+## Regenerate an API key
+
+<a id="opIdregenerateApiKey"></a>
+
+`POST /organizations/{orgId}/api-keys/{apiKeyId}/regenerate`
+
+> Code samples
+
+```shell
+
+curl -X POST http://localhost:3000/devportal/organizations/{orgId}/api-keys/{apiKeyId}/regenerate \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Regenerates the secret for an existing API key identified by `apiKeyId`. The old secret is invalidated at connected gateways via an `apikey.regenerated` webhook event. The new plaintext secret is returned once and never persisted.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="regenerate-an-api-key-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+|apiKeyId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "keyId": "key-12345",
+  "name": "weather_prod_key",
+  "apiId": "api-7f4c2a6b",
+  "key": "ak_dGhpcyBpcyBub3QgYSByZWFsIGtleQ",
+  "expiresAt": "2026-12-31T23:59:59Z",
+  "status": "ACTIVE"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 403 Response
+
+```json
+{
+  "code": "403",
+  "message": "Forbidden",
+  "description": "Write operations are disabled in read-only mode"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="regenerate-an-api-key-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Generated or regenerated API key. The plaintext `key` is returned exactly once.|[ApiKeyResponse](schemas.md#schemaapikeyresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|403|[Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)|Request is forbidden for the current runtime mode or caller permissions.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="regenerate-an-api-key-responseschema">Response Schema</h3>
+
+## Revoke an API key
+
+<a id="opIdrevokeApiKey"></a>
+
+`POST /organizations/{orgId}/api-keys/{apiKeyId}/revoke`
+
+> Code samples
+
+```shell
+
+curl -X POST http://localhost:3000/devportal/organizations/{orgId}/api-keys/{apiKeyId}/revoke \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Revokes an existing API key. An `apikey.revoked` webhook event is published so connected gateways can immediately reject requests carrying the key.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="revoke-an-api-key-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+|apiKeyId|path|string|true|none|
+
+> Example responses
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 403 Response
+
+```json
+{
+  "code": "403",
+  "message": "Forbidden",
+  "description": "Write operations are disabled in read-only mode"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="revoke-an-api-key-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|API key revoked successfully.|None|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|403|[Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)|Request is forbidden for the current runtime mode or caller permissions.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="revoke-an-api-key-responseschema">Response Schema</h3>

--- a/docs/rest-apis/devportal/apis.md
+++ b/docs/rest-apis/devportal/apis.md
@@ -1,0 +1,776 @@
+<h1 id="wso2-api-developer-portal-core-devportal-routes-apis">APIs</h1>
+
+## Create API metadata
+
+<a id="opIdcreateAPIMetadata"></a>
+
+`POST /organizations/{orgId}/apis`
+
+> Code samples
+
+```shell
+
+curl -X POST http://localhost:3000/devportal/organizations/{orgId}/apis \
+  -u {username}:{password} \
+  -H 'Content-Type: multipart/form-data' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Creates Developer Portal API metadata from either a full API artifact ZIP, an API metadata YAML file, or an `apiMetadata` JSON string. An API definition file is required unless supplied by the artifact ZIP. The service also stores labels, subscription policy mappings, image metadata, and schema definitions for MCP or GraphQL APIs when provided.
+
+> Payload
+
+```yaml
+api: string
+apiDefinition: string
+artifact: string
+schemaDefinition: string
+apiMetadata: '{"apiInfo":{"apiName":"Weather
+  API","apiVersion":"v1","apiDescription":"Weather forecast
+  API","apiType":"REST","visibility":"PUBLIC","provider":"WSO2","apiStatus":"PUBLISHED","tags":["weather"],
+  "labels":["default"]},"endPoints":{"productionURL":"https://api.example.com/weather",
+  "sandboxURL":"https://sandbox.example.com/weather"},"subscriptionPolicies":[{"policyName":"Gold"}]}'
+
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="create-api-metadata-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|object|true|API metadata upload. Send either `artifact`, or `api` with `apiDefinition`, or `apiMetadata` with `apiDefinition`. `schemaDefinition` is used for MCP APIs and GraphQL schema updates.|
+|» api|body|string(binary)|false|API metadata YAML file.|
+|» apiDefinition|body|string(binary)|false|API definition file.|
+|» artifact|body|string(binary)|false|Full API ZIP artifact containing metadata and definition files.|
+|» schemaDefinition|body|string(binary)|false|Schema definition file, used by MCP APIs.|
+|» apiMetadata|body|string|false|JSON string accepted by the service when the `api` YAML file is not supplied.|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 201 Response
+
+```json
+{
+  "apiID": "api-7f4c2a6b",
+  "apiReferenceID": "cp-api-12345",
+  "apiHandle": "weather-api-v1",
+  "provider": "WSO2",
+  "dataSource": "DEVPORTAL",
+  "apiInfo": {
+    "apiName": "Weather API",
+    "apiTitle": "Weather Forecast API",
+    "apiVersion": "v1",
+    "apiDescription": "Weather forecast API.",
+    "apiType": "REST",
+    "visibility": "PUBLIC",
+    "agentVisibility": "VISIBLE",
+    "gatewayVendor": "wso2",
+    "tokenBasedSubscriptionEnabled": false,
+    "gatewayType": null,
+    "tags": [
+      "weather"
+    ],
+    "labels": [
+      "default"
+    ]
+  },
+  "endPoints": {
+    "productionURL": "https://api.example.com/weather",
+    "sandboxURL": "https://sandbox.example.com/weather"
+  },
+  "monetizationInfo": {
+    "enabled": false
+  },
+  "subscriptionPolicies": [
+    {
+      "policyID": "policy-gold",
+      "policyName": "Gold",
+      "displayName": "Gold",
+      "billingPlan": "FREE",
+      "requestCount": 10000
+    }
+  ]
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 409 Response
+
+```json
+{
+  "code": "409",
+  "message": "Conflict",
+  "description": "Organization already exists"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="create-api-metadata-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Created API metadata payload returned by the service.|[ApiMetadataCreateResponse](schemas.md#schemaapimetadatacreateresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Duplicate organization data conflicts with an existing record.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="create-api-metadata-responseschema">Response Schema</h3>
+
+## List API metadata
+
+<a id="opIdgetAllAPIMetadataForOrganization"></a>
+
+`GET /organizations/{orgId}/apis`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId}/apis \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Lists API metadata for an organization. The service supports exact filters by API name, version, and tags, free-text search with `query`, group filtering, and view filtering. Unknown query parameters are rejected.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="list-api-metadata-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|query|query|string|false|Free-text API metadata search term.|
+|apiName|query|string|false|Exact API name filter.|
+|version|query|string|false|Exact API version filter.|
+|tags|query|string|false|Exact API tags filter used by the metadata DAO.|
+|groups|query|string|false|Space-separated visible groups used for API visibility filtering.|
+|view|query|string|false|Developer Portal view name used to filter visible APIs.|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+[
+  {
+    "apiID": "api-7f4c2a6b",
+    "apiReferenceID": "cp-api-12345",
+    "apiHandle": "weather-api-v1",
+    "provider": "WSO2",
+    "dataSource": "DEVPORTAL",
+    "apiInfo": {
+      "apiName": "Weather API",
+      "apiVersion": "v1",
+      "apiDescription": "Weather forecast API.",
+      "apiType": "REST",
+      "visibility": "PUBLIC",
+      "agentVisibility": "VISIBLE",
+      "gatewayVendor": "wso2",
+      "tokenBasedSubscriptionEnabled": false,
+      "gatewayType": null,
+      "labels": [
+        "default"
+      ]
+    },
+    "endPoints": {
+      "sandboxURL": "https://sandbox.example.com/weather",
+      "productionURL": "https://api.example.com/weather"
+    },
+    "monetizationInfo": {
+      "enabled": false
+    }
+  }
+]
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="list-api-metadata-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|List of API metadata DTOs.|Inline|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="list-api-metadata-responseschema">Response Schema</h3>
+
+Status Code **200**
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|*anonymous*|[[ApiMetadataResponse](schemas.md#schemaapimetadataresponse)]|false|none|none|
+|» apiID|string|false|none|none|
+|» apiReferenceID|string|false|none|none|
+|» apiHandle|string|false|none|none|
+|» provider|string|false|none|none|
+|» dataSource|string|false|none|none|
+|» policyID|string|false|none|none|
+|» apiInfo|[ApiInfoResponse](schemas.md#schemaapiinforesponse)|false|none|none|
+|»» apiName|string|false|none|none|
+|»» apiTitle|string¦null|false|none|none|
+|»» remotes|[object]|false|none|none|
+|»» apiVersion|string|false|none|none|
+|»» apiDescription|string|false|none|none|
+|»» apiType|string|false|none|none|
+|»» visibility|string|false|none|none|
+|»» agentVisibility|string|false|none|none|
+|»» gatewayVendor|string|false|none|none|
+|»» tokenBasedSubscriptionEnabled|boolean|false|none|none|
+|»» gatewayType|string¦null|false|none|none|
+|»» addedLabels|[string]|false|none|none|
+|»» removedLabels|[string]|false|none|none|
+|»» visibleGroups|[string]|false|none|none|
+|»» owners|[ApiOwnersResponse](schemas.md#schemaapiownersresponse)|false|none|none|
+|»»» technicalOwner|string|false|none|none|
+|»»» businessOwner|string|false|none|none|
+|»»» businessOwnerEmail|string|false|none|none|
+|»»» technicalOwnerEmail|string|false|none|none|
+|»» apiImageMetadata|[ApiImageMetadataResponse](schemas.md#schemaapiimagemetadataresponse)|false|none|none|
+|»»» **additionalProperties**|string|false|none|none|
+|»» tags|[string]|false|none|none|
+|»» labels|[string]|false|none|none|
+|» endPoints|[ApiEndpointsResponse](schemas.md#schemaapiendpointsresponse)|false|none|none|
+|»» sandboxURL|string|false|none|none|
+|»» productionURL|string|false|none|none|
+|» monetizationInfo|[ApiMonetizationInfoResponse](schemas.md#schemaapimonetizationinforesponse)|false|none|none|
+|»» enabled|boolean|false|none|none|
+|» subscriptionPolicies|[[SubscriptionPolicyResponse](schemas.md#schemasubscriptionpolicyresponse)]|false|none|none|
+|»» policyID|string|false|none|none|
+|»» policyName|string|false|none|none|
+|»» displayName|string|false|none|none|
+|»» billingPlan|string|false|none|none|
+|»» description|string|false|none|none|
+|»» requestCount|any|false|none|none|
+
+*oneOf*
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|»»» *anonymous*|integer|false|none|none|
+
+*xor*
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|»»» *anonymous*|string|false|none|none|
+
+*continued*
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|»» orgID|string|false|none|none|
+|»» pricingModel|string|false|none|none|
+|»» currency|string|false|none|none|
+|»» billingPeriod|string|false|none|none|
+|»» flatAmount|number|false|none|none|
+|»» unitAmount|number|false|none|none|
+|»» pricingMetadata|object|false|none|none|
+
+## Get API metadata
+
+<a id="opIdgetAPIMetadata"></a>
+
+`GET /organizations/{orgId}/apis/{apiId}`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId}/apis/{apiId} \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Retrieves a single API metadata record by Developer Portal API ID.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="get-api-metadata-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+|apiId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "apiID": "api-7f4c2a6b",
+  "apiReferenceID": "cp-api-12345",
+  "apiHandle": "weather-api-v1",
+  "provider": "WSO2",
+  "dataSource": "DEVPORTAL",
+  "apiInfo": {
+    "apiName": "Weather API",
+    "apiTitle": "Weather Forecast API",
+    "remotes": [],
+    "apiVersion": "v1",
+    "apiDescription": "Weather forecast API.",
+    "apiType": "REST",
+    "visibility": "PUBLIC",
+    "agentVisibility": "VISIBLE",
+    "gatewayVendor": "wso2",
+    "tokenBasedSubscriptionEnabled": false,
+    "gatewayType": null,
+    "labels": [
+      "default"
+    ]
+  },
+  "endPoints": {
+    "sandboxURL": "https://sandbox.example.com/weather",
+    "productionURL": "https://api.example.com/weather"
+  },
+  "monetizationInfo": {
+    "enabled": false
+  },
+  "subscriptionPolicies": [
+    {
+      "policyID": "policy-gold",
+      "policyName": "Gold",
+      "displayName": "Gold",
+      "billingPlan": "FREE",
+      "requestCount": 10000
+    }
+  ]
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```
+"string"
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="get-api-metadata-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|API metadata DTO returned by the service.|[ApiMetadataResponse](schemas.md#schemaapimetadataresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Plain text success response.|string|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="get-api-metadata-responseschema">Response Schema</h3>
+
+## Update API metadata
+
+<a id="opIdupdateAPIMetadata"></a>
+
+`PUT /organizations/{orgId}/apis/{apiId}`
+
+> Code samples
+
+```shell
+
+curl -X PUT http://localhost:3000/devportal/organizations/{orgId}/apis/{apiId} \
+  -u {username}:{password} \
+  -H 'Content-Type: multipart/form-data' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Updates Developer Portal API metadata and its stored definition. The update flow can also adjust label mappings, subscription policy mappings, schema definitions, and image metadata. Status changes to unpublished are rejected when active subscriptions exist.
+
+> Payload
+
+```yaml
+api: string
+apiDefinition: string
+artifact: string
+schemaDefinition: string
+apiMetadata: '{"apiInfo":{"apiName":"Weather
+  API","apiVersion":"v1","apiDescription":"Weather forecast
+  API","apiType":"REST","visibility":"PUBLIC","provider":"WSO2","apiStatus":"PUBLISHED","tags":["weather"],
+  "labels":["default"]},"endPoints":{"productionURL":"https://api.example.com/weather",
+  "sandboxURL":"https://sandbox.example.com/weather"},"subscriptionPolicies":[{"policyName":"Gold"}]}'
+
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="update-api-metadata-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|object|true|API metadata upload. Send either `artifact`, or `api` with `apiDefinition`, or `apiMetadata` with `apiDefinition`. `schemaDefinition` is used for MCP APIs and GraphQL schema updates.|
+|» api|body|string(binary)|false|API metadata YAML file.|
+|» apiDefinition|body|string(binary)|false|API definition file.|
+|» artifact|body|string(binary)|false|Full API ZIP artifact containing metadata and definition files.|
+|» schemaDefinition|body|string(binary)|false|Schema definition file, used by MCP APIs.|
+|» apiMetadata|body|string|false|JSON string accepted by the service when the `api` YAML file is not supplied.|
+|orgId|path|string|true|none|
+|apiId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "apiID": "api-7f4c2a6b",
+  "apiReferenceID": "cp-api-12345",
+  "apiHandle": "weather-api-v1",
+  "provider": "WSO2",
+  "dataSource": "DEVPORTAL",
+  "apiInfo": {
+    "apiName": "Weather API",
+    "apiTitle": "Weather Forecast API",
+    "remotes": [],
+    "apiVersion": "v1",
+    "apiDescription": "Weather forecast API.",
+    "apiType": "REST",
+    "visibility": "PUBLIC",
+    "agentVisibility": "VISIBLE",
+    "gatewayVendor": "wso2",
+    "tokenBasedSubscriptionEnabled": false,
+    "gatewayType": null,
+    "labels": [
+      "default"
+    ]
+  },
+  "endPoints": {
+    "sandboxURL": "https://sandbox.example.com/weather",
+    "productionURL": "https://api.example.com/weather"
+  },
+  "monetizationInfo": {
+    "enabled": false
+  },
+  "subscriptionPolicies": [
+    {
+      "policyID": "policy-gold",
+      "policyName": "Gold",
+      "displayName": "Gold",
+      "billingPlan": "FREE",
+      "requestCount": 10000
+    }
+  ]
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 409 Response
+
+```json
+{
+  "code": "409",
+  "message": "Conflict",
+  "description": "Organization already exists"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="update-api-metadata-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|API metadata DTO returned by the service.|[ApiMetadataResponse](schemas.md#schemaapimetadataresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Duplicate organization data conflicts with an existing record.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="update-api-metadata-responseschema">Response Schema</h3>
+
+## Delete API metadata
+
+<a id="opIddeleteAPIMetadata"></a>
+
+`DELETE /organizations/{orgId}/apis/{apiId}`
+
+> Code samples
+
+```shell
+
+curl -X DELETE http://localhost:3000/devportal/organizations/{orgId}/apis/{apiId} \
+  -u {username}:{password} \
+  -H 'Accept: text/plain' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Deletes API metadata when the API has no active subscriptions.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="delete-api-metadata-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+|apiId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```
+"string"
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 409 Response
+
+```json
+{
+  "code": "409",
+  "message": "Conflict",
+  "description": "Organization already exists"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="delete-api-metadata-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Plain text success response.|string|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Duplicate organization data conflicts with an existing record.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="delete-api-metadata-responseschema">Response Schema</h3>

--- a/docs/rest-apis/devportal/app-key-mapping.md
+++ b/docs/rest-apis/devportal/app-key-mapping.md
@@ -1,0 +1,237 @@
+<h1 id="wso2-api-developer-portal-core-devportal-routes-app-key-mapping">App Key Mapping</h1>
+
+## Create application key mapping
+
+<a id="opIdcreateAppKeyMapping"></a>
+
+`POST /organizations/{orgId}/app-key-mapping`
+
+> Code samples
+
+```shell
+
+curl -X POST http://localhost:3000/devportal/organizations/{orgId}/app-key-mapping \
+  -u {username}:{password} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Creates or reuses an application and generates or maps OAuth credentials through the selected key manager. In control-plane mode the portal creates a CP application and synchronizes subscriptions. In decoupled mode the portal calls the Authorization Server DCR endpoint directly using the configured key manager adapter. Supply `clientID` to map an existing AS client instead of creating one; `tokenDetails.keyType` is required in both cases.
+
+> Payload
+
+```json
+{
+  "applicationName": "Weather App",
+  "tokenType": "OAUTH",
+  "tokenDetails": {
+    "keyManager": "Resident Key Manager",
+    "keyType": "PRODUCTION",
+    "grantTypesToBeSupported": [
+      "client_credentials",
+      "refresh_token"
+    ],
+    "callbackUrl": "https://app.example.com/callback",
+    "additionalProperties": {
+      "application_access_token_expiry_time": "3600",
+      "user_access_token_expiry_time": "3600"
+    }
+  }
+}
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="create-application-key-mapping-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[AppKeyMappingRequest](schemas.md#schemaappkeymappingrequest)|true|Application key mapping payload. Use internal, resident, or STS key managers to generate OAuth keys. For external key managers, provide `clientID` and `tokenDetails.keyType` to map an existing client.|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "keyMappingId": "km-12345",
+  "keyManager": "Resident Key Manager",
+  "keyType": "PRODUCTION",
+  "consumerKey": "consumer-key-123",
+  "consumerSecret": "consumer-secret-abc",
+  "supportedGrantTypes": [
+    "client_credentials",
+    "refresh_token"
+  ],
+  "appRefId": "cp-app-98765",
+  "subscriptionScopes": [
+    "weather.read",
+    "weather.write"
+  ]
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 409 Response
+
+```json
+{
+  "code": "409",
+  "message": "Conflict",
+  "description": "Organization already exists"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="create-application-key-mapping-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Control-plane key generation or key mapping response, enriched with the control-plane application reference and subscription scope keys.|[AppKeyMappingCreateResponse](schemas.md#schemaappkeymappingcreateresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Duplicate organization data conflicts with an existing record.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="create-application-key-mapping-responseschema">Response Schema</h3>
+
+## Get application key mappings
+
+<a id="opIdretrieveAppKeyMappings"></a>
+
+`GET /organizations/{orgId}/app-key-mapping/{appId}`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId}/app-key-mapping/{appId} \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Retrieves the Developer Portal application and its stored control-plane key mapping rows. The request is scoped to the authenticated user, and returns `404` when the application is not visible to that user.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="get-application-key-mappings-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+|appId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "APP_ID": "app-12345",
+  "ORG_ID": "org-12345",
+  "CREATED_BY": "user-12345",
+  "NAME": "Weather App",
+  "DESCRIPTION": "Application used to call Weather APIs.",
+  "TYPE": "WEB",
+  "DP_APP_KEY_MAPPINGs": [
+    {
+      "MAPPING_ID": "map-12345",
+      "APP_ID": "app-12345",
+      "CP_APP_REF": "cp-app-98765",
+      "API_REF_ID": "cp-api-12345",
+      "ORG_ID": "org-12345",
+      "SUBSCRIPTION_REF_ID": "cp-sub-12345",
+      "SHARED_TOKEN": true,
+      "TOKEN_TYPE": "OAUTH"
+    }
+  ]
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="get-application-key-mappings-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Application row with stored control-plane key mapping entries.|[AppKeyMappingListResponse](schemas.md#schemaappkeymappinglistresponse)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|

--- a/docs/rest-apis/devportal/application-keys.md
+++ b/docs/rest-apis/devportal/application-keys.md
@@ -1,0 +1,566 @@
+<h1 id="wso2-api-developer-portal-core-devportal-routes-application-keys">Application Keys</h1>
+
+## Generate OAuth keys for a control-plane application
+
+<a id="opIdgenerateApplicationKeys"></a>
+
+`POST /applications/{applicationId}/generate-keys`
+
+> Code samples
+
+```shell
+
+curl -X POST http://localhost:3000/devportal/applications/{applicationId}/generate-keys \
+  -u {username}:{password} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Proxies key generation to the control-plane application key endpoint. Use this when the caller already has the control-plane application ID and wants to create OAuth credentials for a key manager.
+
+> Payload
+
+```json
+{
+  "keyType": "PRODUCTION",
+  "keyManager": "Resident Key Manager",
+  "grantTypesToBeSupported": [
+    "client_credentials",
+    "refresh_token"
+  ],
+  "callbackUrl": "https://app.example.com/callback",
+  "additionalProperties": {}
+}
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="generate-oauth-keys-for-a-control-plane-application-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[ApplicationKeysGenerateRequest](schemas.md#schemaapplicationkeysgeneraterequest)|false|OAuth key generation payload passed through to the configured control-plane application key endpoint.|
+|applicationId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "keyMappingId": "km-12345",
+  "keyManager": "Resident Key Manager",
+  "keyType": "PRODUCTION",
+  "consumerKey": "consumer-key-123",
+  "consumerSecret": "consumer-secret-abc",
+  "supportedGrantTypes": [
+    "client_credentials",
+    "refresh_token"
+  ],
+  "callbackUrl": "https://app.example.com/callback"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 409 Response
+
+```json
+{
+  "code": "409",
+  "message": "Conflict",
+  "description": "Organization already exists"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="generate-oauth-keys-for-a-control-plane-application-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Application OAuth key response returned by the control plane.|[ApplicationOAuthKeyResponse](schemas.md#schemaapplicationoauthkeyresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Duplicate organization data conflicts with an existing record.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="generate-oauth-keys-for-a-control-plane-application-responseschema">Response Schema</h3>
+
+## Generate an OAuth access token
+
+<a id="opIdgenerateOAuthKeys"></a>
+
+`POST /applications/{applicationId}/oauth-keys/{keyMappingId}/generate-token`
+
+> Code samples
+
+```shell
+
+curl -X POST http://localhost:3000/devportal/applications/{applicationId}/oauth-keys/{keyMappingId}/generate-token \
+  -u {username}:{password} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Generates an access token for an existing application OAuth key mapping. In control-plane mode the request is proxied to the control plane. In decoupled mode the portal calls the Authorization Server token endpoint directly using the client credentials supplied in `consumerSecret`.
+
+> Payload
+
+```json
+{
+  "consumerSecret": "my-consumer-secret",
+  "scopes": [
+    "weather.read"
+  ],
+  "validityPeriod": 3600
+}
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="generate-an-oauth-access-token-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[OAuthGenerateTokenRequest](schemas.md#schemaoauthgeneratetokenrequest)|false|Passed through to the configured control-plane OAuth token generation endpoint.|
+|applicationId|path|string|true|none|
+|keyMappingId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.example",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "scope": "weather.read"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="generate-an-oauth-access-token-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OAuth access token response returned by the control plane.|[OAuthTokenResponse](schemas.md#schemaoauthtokenresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="generate-an-oauth-access-token-responseschema">Response Schema</h3>
+
+## Revoke OAuth keys
+
+<a id="opIdrevokeOAuthKeys"></a>
+
+`DELETE /applications/{applicationId}/oauth-keys/{keyMappingId}`
+
+> Code samples
+
+```shell
+
+curl -X DELETE http://localhost:3000/devportal/applications/{applicationId}/oauth-keys/{keyMappingId} \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Revokes an application OAuth key mapping in the control plane.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="revoke-oauth-keys-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|applicationId|path|string|true|none|
+|keyMappingId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "message": "Operation completed successfully"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="revoke-oauth-keys-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Message or control-plane response payload.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="revoke-oauth-keys-responseschema">Response Schema</h3>
+
+## Update OAuth keys
+
+<a id="opIdupdateOAuthKeys"></a>
+
+`PUT /applications/{applicationId}/oauth-keys/{keyMappingId}`
+
+> Code samples
+
+```shell
+
+curl -X PUT http://localhost:3000/devportal/applications/{applicationId}/oauth-keys/{keyMappingId} \
+  -u {username}:{password} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Updates an application OAuth key mapping in the control plane.
+
+> Payload
+
+```json
+{
+  "supportedGrantTypes": [
+    "client_credentials",
+    "refresh_token"
+  ],
+  "callbackUrl": "https://app.example.com/new-callback",
+  "additionalProperties": {}
+}
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="update-oauth-keys-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[OAuthKeyUpdateRequest](schemas.md#schemaoauthkeyupdaterequest)|false|Passed through to the configured control-plane OAuth key update endpoint.|
+|applicationId|path|string|true|none|
+|keyMappingId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "keyMappingId": "km-12345",
+  "keyManager": "Resident Key Manager",
+  "keyType": "PRODUCTION",
+  "consumerKey": "consumer-key-123",
+  "consumerSecret": "consumer-secret-abc",
+  "supportedGrantTypes": [
+    "client_credentials",
+    "refresh_token"
+  ],
+  "callbackUrl": "https://app.example.com/callback"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="update-oauth-keys-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Application OAuth key response returned by the control plane.|[ApplicationOAuthKeyResponse](schemas.md#schemaapplicationoauthkeyresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="update-oauth-keys-responseschema">Response Schema</h3>
+
+## Clean up OAuth key artifacts
+
+<a id="opIdcleanUpOAuthKeys"></a>
+
+`POST /applications/{applicationId}/oauth-keys/{keyMappingId}/clean-up`
+
+> Code samples
+
+```shell
+
+curl -X POST http://localhost:3000/devportal/applications/{applicationId}/oauth-keys/{keyMappingId}/clean-up \
+  -u {username}:{password} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Proxies an OAuth key cleanup request to the control plane for a specific application key mapping. This is used to remove pending or partially-created OAuth key artifacts.
+
+> Payload
+
+```json
+{
+  "keyType": "PRODUCTION",
+  "keyManager": "Resident Key Manager"
+}
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="clean-up-oauth-key-artifacts-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[OAuthKeyCleanUpRequest](schemas.md#schemaoauthkeycleanuprequest)|false|Passed through to the configured control-plane OAuth cleanup endpoint.|
+|applicationId|path|string|true|none|
+|keyMappingId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "message": "Operation completed successfully"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="clean-up-oauth-key-artifacts-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Message or control-plane response payload.|Inline|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="clean-up-oauth-key-artifacts-responseschema">Response Schema</h3>

--- a/docs/rest-apis/devportal/applications.md
+++ b/docs/rest-apis/devportal/applications.md
@@ -1,0 +1,1046 @@
+<h1 id="wso2-api-developer-portal-core-devportal-routes-applications">Applications</h1>
+
+## Create an application
+
+<a id="opIdcreateDevPortalApplication"></a>
+
+`POST /organizations/{orgId}/applications`
+
+> Code samples
+
+```shell
+
+curl -X POST http://localhost:3000/devportal/organizations/{orgId}/applications \
+  -u {username}:{password} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Creates a Developer Portal application in the specified organization for the authenticated user. The request may be JSON, multipart form fields, or an application YAML file in the `application` multipart field.
+
+> Payload
+
+```json
+{
+  "name": "Weather App",
+  "description": "Application used to call Weather APIs.",
+  "type": "WEB"
+}
+```
+
+```yaml
+name: Weather App
+description: Application used to call Weather APIs.
+type: WEB
+
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="create-an-application-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[ApplicationRequest](schemas.md#schemaapplicationrequest)|true|Application payload. Send JSON, multipart form fields, or an application YAML file in the `application` field. When YAML is used, the service reads `spec.displayName` or `metadata.name` as the application name and `spec.description` as the description.|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 201 Response
+
+```json
+{
+  "id": "app-12345",
+  "name": "Weather App",
+  "description": "Application used to call Weather APIs.",
+  "type": "WEB"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 409 Response
+
+```json
+{
+  "code": "409",
+  "message": "Conflict",
+  "description": "Organization already exists"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="create-an-application-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Application DTO.|[ApplicationResponse](schemas.md#schemaapplicationresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Duplicate organization data conflicts with an existing record.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="create-an-application-responseschema">Response Schema</h3>
+
+## List applications
+
+<a id="opIdgetDevPortalApplications"></a>
+
+`GET /organizations/{orgId}/applications`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId}/applications \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Returns applications in the organization that belong to the authenticated user.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="list-applications-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+[
+  {
+    "id": "app-12345",
+    "name": "Weather App",
+    "description": "Application used to call Weather APIs.",
+    "type": "WEB",
+    "appMap": [
+      {
+        "appRefID": "cp-app-98765",
+        "token": "OAUTH",
+        "shared": true
+      }
+    ]
+  }
+]
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="list-applications-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|List of application DTOs.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="list-applications-responseschema">Response Schema</h3>
+
+Status Code **200**
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|*anonymous*|[[ApplicationResponse](schemas.md#schemaapplicationresponse)]|false|none|none|
+|» id|string|false|none|none|
+|» name|string|false|none|none|
+|» description|string|false|none|none|
+|» type|string|false|none|none|
+|» appMap|[[ApplicationKeyMappingSummary](schemas.md#schemaapplicationkeymappingsummary)]|false|none|none|
+|»» appRefID|string|false|none|none|
+|»» token|string|false|none|none|
+|»» shared|boolean|false|none|none|
+
+## Update an application
+
+<a id="opIdupdateDevPortalApplication"></a>
+
+`PUT /organizations/{orgId}/applications/{appId}`
+
+> Code samples
+
+```shell
+
+curl -X PUT http://localhost:3000/devportal/organizations/{orgId}/applications/{appId} \
+  -u {username}:{password} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Updates an existing Developer Portal application owned by the authenticated user.
+
+> Payload
+
+```json
+{
+  "name": "Weather App",
+  "description": "Application used to call Weather APIs.",
+  "type": "WEB"
+}
+```
+
+```yaml
+name: Weather App
+description: Application used to call Weather APIs.
+type: WEB
+
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="update-an-application-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[ApplicationRequest](schemas.md#schemaapplicationrequest)|true|Application payload. Send JSON, multipart form fields, or an application YAML file in the `application` field. When YAML is used, the service reads `spec.displayName` or `metadata.name` as the application name and `spec.description` as the description.|
+|orgId|path|string|true|none|
+|appId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "id": "app-12345",
+  "name": "Weather App",
+  "description": "Application used to call Weather APIs.",
+  "type": "WEB"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 409 Response
+
+```json
+{
+  "code": "409",
+  "message": "Conflict",
+  "description": "Organization already exists"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="update-an-application-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Application DTO.|[ApplicationResponse](schemas.md#schemaapplicationresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Duplicate organization data conflicts with an existing record.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="update-an-application-responseschema">Response Schema</h3>
+
+## Get application details
+
+<a id="opIdgetDevPortalApplicationDetails"></a>
+
+`GET /organizations/{orgId}/applications/{appId}`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId}/applications/{appId} \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Retrieves one Developer Portal application by ID for the authenticated user.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="get-application-details-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+|appId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "id": "app-12345",
+  "name": "Weather App",
+  "description": "Application used to call Weather APIs.",
+  "type": "WEB"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="get-application-details-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Application DTO.|[ApplicationResponse](schemas.md#schemaapplicationresponse)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+## Delete an application
+
+<a id="opIddeleteDevPortalApplication"></a>
+
+`DELETE /organizations/{orgId}/applications/{appId}`
+
+> Code samples
+
+```shell
+
+curl -X DELETE http://localhost:3000/devportal/organizations/{orgId}/applications/{appId} \
+  -u {username}:{password} \
+  -H 'Accept: text/plain' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Deletes a Developer Portal application owned by the authenticated user.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="delete-an-application-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+|appId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```
+"string"
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="delete-an-application-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Plain text success response.|string|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+## Import an application
+
+<a id="opIdimportApplications"></a>
+
+`POST /organizations/{orgId}/applications/import`
+
+> Code samples
+
+```shell
+
+curl -X POST http://localhost:3000/devportal/organizations/{orgId}/applications/import \
+  -u {username}:{password} \
+  -H 'Content-Type: multipart/form-data' \
+  -H 'Accept: application/json' \
+  -H 'pat-token: string' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Imports an application from an application YAML file. This route is registered only when `config.features.importApplication.enabled` is true. When `withKeys` is true, `keyManager` is required and matching keys from the YAML are imported.
+
+> Payload
+
+```yaml
+file: application.yaml
+withKeys: false
+
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="import-an-application-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|pat-token|header|string|true|Personal access token used by the application import flow.|
+|body|body|object|true|Application import payload. The uploaded YAML describes the application, subscriptions, and optionally application keys. Set `withKeys` to true only when importing keys for a specific `keyManager`.|
+|» file|body|string(binary)|true|Imported application YAML file.|
+|» withKeys|body|boolean|false|Whether to import application keys from the YAML.|
+|» keyManager|body|string|false|Required when `withKeys` is true.|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> Application import result.
+
+```json
+{
+  "status": "Success"
+}
+```
+
+```json
+{
+  "status": "Incomplete",
+  "failedSubscriptions": [
+    {
+      "apiName": "Weather API",
+      "reason": "Subscription policy not found"
+    }
+  ]
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="import-an-application-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Application import result.|[ApplicationImportResponse](schemas.md#schemaapplicationimportresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="import-an-application-responseschema">Response Schema</h3>
+
+## Create an application for the authenticated user's organization
+
+<a id="opIdsaveApplication"></a>
+
+`POST /applications`
+
+> Code samples
+
+```shell
+
+curl -X POST http://localhost:3000/devportal/applications \
+  -u {username}:{password} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Creates a Developer Portal application in the organization resolved from the authenticated user's organization identifier. The request may be JSON, multipart form fields, or an application YAML file in the `application` multipart field.
+
+> Payload
+
+```json
+{
+  "name": "Weather App",
+  "description": "Application used to call Weather APIs.",
+  "type": "WEB"
+}
+```
+
+```yaml
+name: Weather App
+description: Application used to call Weather APIs.
+type: WEB
+
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="create-an-application-for-the-authenticated-user's-organization-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[ApplicationRequest](schemas.md#schemaapplicationrequest)|true|Application payload. Send JSON, multipart form fields, or an application YAML file in the `application` field. When YAML is used, the service reads `spec.displayName` or `metadata.name` as the application name and `spec.description` as the description.|
+
+> Example responses
+
+> 201 Response
+
+```json
+{
+  "id": "app-12345",
+  "name": "Weather App",
+  "description": "Application used to call Weather APIs.",
+  "type": "WEB"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 409 Response
+
+```json
+{
+  "code": "409",
+  "message": "Conflict",
+  "description": "Organization already exists"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="create-an-application-for-the-authenticated-user's-organization-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Application DTO.|[ApplicationResponse](schemas.md#schemaapplicationresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Duplicate organization data conflicts with an existing record.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="create-an-application-for-the-authenticated-user's-organization-responseschema">Response Schema</h3>
+
+## Update an application for the authenticated user
+
+<a id="opIdupdateApplication"></a>
+
+`PUT /applications/{applicationId}`
+
+> Code samples
+
+```shell
+
+curl -X PUT http://localhost:3000/devportal/applications/{applicationId} \
+  -u {username}:{password} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Updates an application owned by the authenticated user in the organization resolved from the authenticated user's organization identifier. The request may be JSON, multipart form fields, or an application YAML file in the `application` multipart field.
+
+> Payload
+
+```json
+{
+  "name": "Weather App",
+  "description": "Application used to call Weather APIs.",
+  "type": "WEB"
+}
+```
+
+```yaml
+name: Weather App
+description: Application used to call Weather APIs.
+type: WEB
+
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="update-an-application-for-the-authenticated-user-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[ApplicationRequest](schemas.md#schemaapplicationrequest)|true|Application payload. Send JSON, multipart form fields, or an application YAML file in the `application` field. When YAML is used, the service reads `spec.displayName` or `metadata.name` as the application name and `spec.description` as the description.|
+|applicationId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "id": "app-12345",
+  "name": "Weather App",
+  "description": "Application used to call Weather APIs.",
+  "type": "WEB"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 409 Response
+
+```json
+{
+  "code": "409",
+  "message": "Conflict",
+  "description": "Organization already exists"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="update-an-application-for-the-authenticated-user-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Application DTO.|[ApplicationResponse](schemas.md#schemaapplicationresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Duplicate organization data conflicts with an existing record.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="update-an-application-for-the-authenticated-user-responseschema">Response Schema</h3>
+
+## Delete an application for the authenticated user
+
+<a id="opIddeleteApplication"></a>
+
+`DELETE /applications/{applicationId}`
+
+> Code samples
+
+```shell
+
+curl -X DELETE http://localhost:3000/devportal/applications/{applicationId} \
+  -u {username}:{password} \
+  -H 'Accept: text/plain' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Deletes an application owned by the authenticated user. If the application has billed Stripe subscriptions, the service cancels them before deleting the local application. If a control-plane application mapping exists, the corresponding control-plane application is deleted as well.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="delete-an-application-for-the-authenticated-user-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|applicationId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```
+"string"
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="delete-an-application-for-the-authenticated-user-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Plain text success response.|string|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+## Reset application throttle policy
+
+<a id="opIdresetThrottlingPolicy"></a>
+
+`POST /applications/{applicationId}/reset-throttle-policy`
+
+> Code samples
+
+```shell
+
+curl -X POST http://localhost:3000/devportal/applications/{applicationId}/reset-throttle-policy \
+  -u {username}:{password} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Resets throttling policy state for a control-plane application. The request is proxied to the control plane using the supplied user name.
+
+> Payload
+
+```json
+{
+  "userName": "alice@example.com"
+}
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="reset-application-throttle-policy-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[ResetThrottlePolicyRequest](schemas.md#schemaresetthrottlepolicyrequest)|true|User throttle policy reset payload.|
+|applicationId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "message": "string"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="reset-application-throttle-policy-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|JSON message response.|[MessageResponse](schemas.md#schemamessageresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="reset-application-throttle-policy-responseschema">Response Schema</h3>

--- a/docs/rest-apis/devportal/authentication.md
+++ b/docs/rest-apis/devportal/authentication.md
@@ -1,0 +1,91 @@
+# Authentication
+
+- oAuth2 authentication. OAuth2/OIDC access token with fine-grained Developer Portal scopes. Each operation declares the exact resource/action scope it requires.
+
+    - Flow: authorizationCode
+    - Authorization URL = [https://localhost:9443/oauth2/authorize](https://localhost:9443/oauth2/authorize)
+    - Token URL = [https://localhost:9443/oauth2/token](https://localhost:9443/oauth2/token)
+
+|Scope|Scope Description|
+|---|---|
+|dp:org_read|Read organizations.|
+|dp:org_write|Create or update organizations.|
+|dp:org_delete|Delete organizations.|
+|dp:org_manage|Manage organizations (including creating, updating, and deleting).|
+|dp:idp_read|Read organization identity provider configuration.|
+|dp:idp_write|Create or update identity provider configuration.|
+|dp:idp_delete|Delete identity provider configuration.|
+|dp:idp_manage|Manage organization identity provider configuration.|
+|dp:provider_read|Read providers.|
+|dp:provider_write|Create or update providers.|
+|dp:provider_delete|Delete providers.|
+|dp:provider_manage|Manage providers (including creating, updating, and deleting).|
+|dp:org_content_read|Read organization layout or content.|
+|dp:org_content_write|Create or update organization layout or content.|
+|dp:org_content_delete|Delete organization layout or content.|
+|dp:org_content_manage|Manage organization layout or content.|
+|dp:api_read|Read API metadata.|
+|dp:api_write|Create or update API metadata.|
+|dp:api_delete|Delete API metadata.|
+|dp:api_manage|Manage API metadata.|
+|dp:api_content_read|Read API content.|
+|dp:api_content_write|Create or update API content.|
+|dp:api_content_delete|Delete API content.|
+|dp:api_content_manage|Manage API content.|
+|dp:sub_policy_read|Read subscription policies.|
+|dp:sub_policy_write|Create or update subscription policies.|
+|dp:sub_policy_delete|Delete subscription policies.|
+|dp:sub_policy_manage|Manage subscription policies.|
+|dp:label_read|Read labels.|
+|dp:label_write|Create or update labels.|
+|dp:label_delete|Delete labels.|
+|dp:label_manage|Manage labels.|
+|dp:app_read|Read applications.|
+|dp:app_write|Create or update applications.|
+|dp:app_delete|Delete applications.|
+|dp:app_import|Import applications.|
+|dp:app_manage|Manage applications.|
+|dp:subscription_read|Read subscriptions.|
+|dp:subscription_write|Create or update subscriptions.|
+|dp:subscription_delete|Delete subscriptions.|
+|dp:subscription_manage|Manage subscriptions.|
+|dp:api_key_read|Read API keys.|
+|dp:api_key_write|Generate or regenerate API keys.|
+|dp:api_key_revoke|Revoke API keys.|
+|dp:api_key_manage|Manage API keys.|
+|dp:app_key_mapping_read|Read application key mappings.|
+|dp:app_key_mapping_write|Create application key mappings.|
+|dp:app_key_mapping_manage|Manage application key mappings.|
+|dp:view_read|Read views.|
+|dp:view_write|Create or update views.|
+|dp:view_delete|Delete views.|
+|dp:view_manage|Manage views.|
+|dp:app_key_write|Generate, update, regenerate, or clean up application keys.|
+|dp:app_key_revoke|Revoke application keys.|
+|dp:app_key_manage|Manage application keys.|
+|dp:billing_read|Read billing information, usage data, payment methods, and subscription billing status.|
+|dp:billing_write|Create checkout sessions, register checkout sessions, create billing portal sessions, or cancel paid subscriptions.|
+|dp:billing_manage|Manage billing information, checkout, portal, and subscription billing actions.|
+|dp:billing_config_read|Read billing engine key configuration.|
+|dp:billing_config_write|Create or update billing engine key configuration.|
+|dp:billing_config_delete|Delete billing engine key configuration.|
+|dp:billing_config_manage|Manage billing engine key configuration.|
+|dp:usage_read|Read subscription usage.|
+|dp:usage_manage|Manage subscription usage access.|
+|dp:invoice_read|Read invoices and invoice links.|
+|dp:invoice_manage|Manage invoice access.|
+|dp:api_flow_read|Read API flows.|
+|dp:api_flow_write|Create, update, or generate API flows.|
+|dp:api_flow_delete|Delete API flows.|
+|dp:api_flow_manage|Manage API flows.|
+|dp:event_read|Read webhook events and delivery details.|
+|dp:delivery_manage|Retry failed webhook deliveries.|
+|dp:utility_write|Create temporary utility files.|
+|dp:utility_manage|Manage utility operations.|
+|dp:km_read|Read key manager configurations.|
+|dp:km_write|Create or update key manager configurations.|
+|dp:km_delete|Delete key manager configurations.|
+|dp:km_manage|Manage key manager configurations (including creating, updating, and deleting).|
+
+* API Key (apiKeyAuth)
+    - Parameter Name: **x-api-key**, in: header. API key authentication. Server-side authorization should bind each key to the same fine-grained permissions used by OAuth2 scopes.

--- a/docs/rest-apis/devportal/billing.md
+++ b/docs/rest-apis/devportal/billing.md
@@ -1,0 +1,1462 @@
+<h1 id="wso2-api-developer-portal-core-devportal-routes-billing">Billing</h1>
+
+## Get billing usage data
+
+<a id="opIdgetUsageData"></a>
+
+`GET /organizations/{orgId}/billing/usage-data`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId}/billing/usage-data \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Returns billing usage totals for the authenticated user in the organization. The optional period can be `current`, `last30`, or `last90`; `from` and `to` can be used for a custom date range.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="get-billing-usage-data-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|period|query|string|false|Usage period used when `from` and `to` are not supplied.|
+|from|query|string(date)|false|Custom usage start date. The service expands this to the beginning of the day in UTC.|
+|to|query|string(date)|false|Custom usage end date. The service expands this to the end of the day in UTC.|
+|orgId|path|string|true|none|
+
+#### Enumerated Values
+
+|Parameter|Value|
+|---|---|
+|period|current|
+|period|last30|
+|period|last90|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "totalRequests": 12450,
+  "activeSubscriptions": 2,
+  "estimatedCost": 29.99,
+  "currency": "USD",
+  "avgResponseTime": 142,
+  "subscriptions": [
+    {
+      "apiName": "Weather API",
+      "applicationName": "Weather App",
+      "planName": "Pro",
+      "requests": 12000,
+      "pricingModel": "METERED",
+      "cost": 24.99,
+      "currency": "USD",
+      "avgResponseTime": 145
+    }
+  ]
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="get-billing-usage-data-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Billing usage summary for the authenticated user.|[BillingUsageDataResponse](schemas.md#schemabillingusagedataresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="get-billing-usage-data-responseschema">Response Schema</h3>
+
+## List payment methods
+
+<a id="opIdgetPaymentMethods"></a>
+
+`GET /organizations/{orgId}/billing/payment-methods`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId}/billing/payment-methods \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Lists Stripe payment methods for the authenticated billing user. If no Stripe customer exists yet, the service can create or locate one by user email before listing methods.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="list-payment-methods-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "paymentMethods": [
+    {
+      "id": "pm_12345",
+      "brand": "visa",
+      "last4": "4242",
+      "expMonth": 12,
+      "expYear": 2030,
+      "isDefault": true
+    }
+  ]
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="list-payment-methods-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Stripe payment methods for the authenticated billing user.|[PaymentMethodsResponse](schemas.md#schemapaymentmethodsresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="list-payment-methods-responseschema">Response Schema</h3>
+
+## Add billing engine keys
+
+<a id="opIdaddBillingEngineKeys"></a>
+
+`POST /organizations/{orgId}/billing-engine-keys`
+
+> Code samples
+
+```shell
+
+curl -X POST http://localhost:3000/devportal/organizations/{orgId}/billing-engine-keys \
+  -u {username}:{password} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Stores encrypted billing engine credentials for the organization. Currently used for Stripe secret, publishable, and webhook keys.
+
+> Payload
+
+```json
+{
+  "billingEngine": "STRIPE",
+  "secretKey": "sk_test_123",
+  "publishableKey": "pk_test_123",
+  "webhookSecret": "whsec_123"
+}
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="add-billing-engine-keys-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[BillingEngineKeysRequest](schemas.md#schemabillingenginekeysrequest)|true|Billing engine credentials to encrypt and store for the organization.|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 201 Response
+
+```json
+{
+  "message": "string"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="add-billing-engine-keys-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|JSON message response.|[MessageResponse](schemas.md#schemamessageresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="add-billing-engine-keys-responseschema">Response Schema</h3>
+
+## Update billing engine keys
+
+<a id="opIdupdateBillingEngineKeys"></a>
+
+`PUT /organizations/{orgId}/billing-engine-keys`
+
+> Code samples
+
+```shell
+
+curl -X PUT http://localhost:3000/devportal/organizations/{orgId}/billing-engine-keys \
+  -u {username}:{password} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Updates the encrypted billing engine credentials for an existing organization billing configuration.
+
+> Payload
+
+```json
+{
+  "billingEngine": "STRIPE",
+  "secretKey": "sk_test_123",
+  "publishableKey": "pk_test_123",
+  "webhookSecret": "whsec_123"
+}
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="update-billing-engine-keys-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[BillingEngineKeysRequest](schemas.md#schemabillingenginekeysrequest)|true|Billing engine credentials to encrypt and store for the organization.|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "message": "string"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="update-billing-engine-keys-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|JSON message response.|[MessageResponse](schemas.md#schemamessageresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|JSON message response.|[MessageResponse](schemas.md#schemamessageresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="update-billing-engine-keys-responseschema">Response Schema</h3>
+
+## Delete billing engine keys
+
+<a id="opIddeleteBillingEngineKeys"></a>
+
+`DELETE /organizations/{orgId}/billing-engine-keys`
+
+> Code samples
+
+```shell
+
+curl -X DELETE http://localhost:3000/devportal/organizations/{orgId}/billing-engine-keys \
+  -u {username}:{password} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Deletes billing engine credentials for the organization. `billingEngine` may be supplied in the request body or as a query parameter.
+
+> Payload
+
+```json
+{
+  "billingEngine": "STRIPE"
+}
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="delete-billing-engine-keys-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|billingEngine|query|string|false|Alternative to sending `billingEngine` in the delete request body.|
+|body|body|[BillingEngineDeleteRequest](schemas.md#schemabillingenginedeleterequest)|false|Optional billing engine selector. The same value can also be supplied with the `billingEngine` query parameter.|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "message": "string"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="delete-billing-engine-keys-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|JSON message response.|[MessageResponse](schemas.md#schemamessageresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|JSON message response.|[MessageResponse](schemas.md#schemamessageresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="delete-billing-engine-keys-responseschema">Response Schema</h3>
+
+## Get billing engine keys
+
+<a id="opIdgetBillingEngineKeys"></a>
+
+`GET /organizations/{orgId}/billing-engine-keys`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId}/billing-engine-keys \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Returns masked billing engine key metadata. Secret values are never returned; configured values are represented as `****`.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="get-billing-engine-keys-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|billingEngine|query|string|false|Alternative to sending `billingEngine` in the delete request body.|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "billingEngine": "STRIPE",
+  "secretKey": "****",
+  "publishableKey": "****",
+  "webhookSecret": "****"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "message": "string"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="get-billing-engine-keys-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Masked billing engine credentials.|[BillingEngineKeysResponse](schemas.md#schemabillingenginekeysresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|JSON message response.|[MessageResponse](schemas.md#schemamessageresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="get-billing-engine-keys-responseschema">Response Schema</h3>
+
+## Get billing profile information
+
+<a id="opIdgetBillingInfo"></a>
+
+`GET /organizations/{orgId}/billing/info`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId}/billing/info \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Returns billing profile information for the authenticated user and organization. When a Stripe customer exists, the response includes customer address and tax ID information from Stripe.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="get-billing-profile-information-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "organizationName": "Acme Inc",
+  "email": "dev@example.com",
+  "address": {
+    "line1": "100 Market Street",
+    "city": "San Francisco",
+    "country": "US"
+  },
+  "taxId": "123456789"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="get-billing-profile-information-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Billing profile information for the authenticated user.|[BillingInfoResponse](schemas.md#schemabillinginforesponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="get-billing-profile-information-responseschema">Response Schema</h3>
+
+## List subscriptions for billing
+
+<a id="opIdgetActiveSubscriptions"></a>
+
+`GET /organizations/{orgId}/billing/subscriptions`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId}/billing/subscriptions \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Returns the authenticated user's subscriptions formatted for the billing page, including plan, billing cycle, amount, currency, next billing date, and payment status.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="list-subscriptions-for-billing-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "subscriptions": [
+    {
+      "id": "sub-12345",
+      "apiName": "Weather API",
+      "applicationName": "Weather App",
+      "planName": "Pro",
+      "billingCycle": "Month",
+      "amount": 2999,
+      "currency": "usd",
+      "nextBillingDate": 1775088000000,
+      "status": "active"
+    }
+  ]
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="list-subscriptions-for-billing-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Subscriptions formatted for billing page display.|[BillingSubscriptionsResponse](schemas.md#schemabillingsubscriptionsresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+## Create a checkout session
+
+<a id="opIdcreateCheckoutSessionForSubscription"></a>
+
+`POST /organizations/{orgId}/monetization/checkout`
+
+> Code samples
+
+```shell
+
+curl -X POST http://localhost:3000/devportal/organizations/{orgId}/monetization/checkout \
+  -u {username}:{password} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Creates a pending Developer Portal subscription row and a Stripe embedded checkout session for a paid subscription policy.
+
+> Payload
+
+```json
+{
+  "applicationID": "app-12345",
+  "apiId": "api-7f4c2a6b",
+  "apiReferenceID": "cp-api-12345",
+  "policyId": "policy-pro",
+  "policyName": "Pro",
+  "sourcePage": "/devportal/apis/weather-api-v1"
+}
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="create-a-checkout-session-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[CheckoutSessionRequest](schemas.md#schemacheckoutsessionrequest)|true|Paid subscription checkout payload.|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "subId": "sub-12345",
+  "checkoutSessionId": "cs_test_12345",
+  "clientSecret": "cs_test_12345_secret_abc",
+  "publishableKey": "pk_test_123",
+  "billingCustomerId": "cus_12345",
+  "paymentProvider": "STRIPE",
+  "paymentStatus": "PENDING"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 409 Response
+
+```json
+{
+  "message": "string"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="create-a-checkout-session-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Stripe checkout session details for a pending paid subscription.|[CheckoutSessionResponse](schemas.md#schemacheckoutsessionresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|JSON message response.|[MessageResponse](schemas.md#schemamessageresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|502|[Bad Gateway](https://tools.ietf.org/html/rfc7231#section-6.6.3)|JSON message response.|[MessageResponse](schemas.md#schemamessageresponse)|
+
+<h3 id="create-a-checkout-session-responseschema">Response Schema</h3>
+
+## Register a Stripe checkout session
+
+<a id="opIdregisterStripeCheckoutSession"></a>
+
+`POST /organizations/{orgId}/monetization/stripe/register/{checkoutSessionId}`
+
+> Code samples
+
+```shell
+
+curl -X POST http://localhost:3000/devportal/organizations/{orgId}/monetization/stripe/register/{checkoutSessionId} \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Verifies the Stripe checkout session, activates the Developer Portal subscription, and synchronizes the subscription into the control plane when application key mappings already exist.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="register-a-stripe-checkout-session-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+|checkoutSessionId|path|string|true|none|
+
+> Example responses
+
+> 201 Response
+
+```json
+{
+  "subId": "sub-12345",
+  "billingCustomerId": "cus_12345",
+  "billingSubscriptionId": "sub_stripe_12345",
+  "paymentStatus": "ACTIVE",
+  "paymentProvider": "STRIPE"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 409 Response
+
+```json
+{
+  "message": "string"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="register-a-stripe-checkout-session-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Registered checkout session and activated subscription details.|[CheckoutRegistrationResponse](schemas.md#schemacheckoutregistrationresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|JSON message response.|[MessageResponse](schemas.md#schemamessageresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|502|[Bad Gateway](https://tools.ietf.org/html/rfc7231#section-6.6.3)|JSON message response.|[MessageResponse](schemas.md#schemamessageresponse)|
+
+<h3 id="register-a-stripe-checkout-session-responseschema">Response Schema</h3>
+
+## Cancel a paid subscription
+
+<a id="opIdcancelSubscription"></a>
+
+`POST /organizations/{orgId}/subscriptions/{subId}/cancel`
+
+> Code samples
+
+```shell
+
+curl -X POST http://localhost:3000/devportal/organizations/{orgId}/subscriptions/{subId}/cancel \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Cancels a paid Stripe subscription, marks the Developer Portal subscription as canceled, and schedules non-fatal Moesif billing cleanup.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="cancel-a-paid-subscription-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+|subId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "subId": "sub-12345",
+  "paymentStatus": "CANCELED"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+> 502 Response
+
+```json
+{
+  "message": "string"
+}
+```
+
+<h3 id="cancel-a-paid-subscription-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Paid subscription cancellation result.|[BillingCancelResponse](schemas.md#schemabillingcancelresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|502|[Bad Gateway](https://tools.ietf.org/html/rfc7231#section-6.6.3)|JSON message response.|[MessageResponse](schemas.md#schemamessageresponse)|
+
+<h3 id="cancel-a-paid-subscription-responseschema">Response Schema</h3>
+
+## Get subscription billing status
+
+<a id="opIdgetSubscriptionBillingStatus"></a>
+
+`GET /organizations/{orgId}/subscriptions/{subId}/billing-status`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId}/subscriptions/{subId}/billing-status \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Returns billing status and Stripe billing identifiers for a Developer Portal subscription.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="get-subscription-billing-status-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+|subId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "subId": "sub-12345",
+  "paymentProvider": "STRIPE",
+  "paymentStatus": "ACTIVE",
+  "billingCustomerId": "cus_12345",
+  "billingSubscriptionId": "sub_stripe_12345"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="get-subscription-billing-status-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Billing status for a Developer Portal subscription.|[SubscriptionBillingStatusResponse](schemas.md#schemasubscriptionbillingstatusresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="get-subscription-billing-status-responseschema">Response Schema</h3>
+
+## Create an organization billing portal session
+
+<a id="opIdcreateBillingPortalByOrg"></a>
+
+`POST /organizations/{orgId}/billing-portal`
+
+> Code samples
+
+```shell
+
+curl -X POST http://localhost:3000/devportal/organizations/{orgId}/billing-portal \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Creates a Stripe customer portal session for the authenticated user's organization. If no billed subscription exists yet, the service can create or locate a Stripe customer by user email.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="create-an-organization-billing-portal-session-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "url": "https://billing.stripe.com/p/session/test_123"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+> 502 Response
+
+```json
+{
+  "message": "string"
+}
+```
+
+<h3 id="create-an-organization-billing-portal-session-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Stripe billing portal session URL.|[BillingPortalResponse](schemas.md#schemabillingportalresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|502|[Bad Gateway](https://tools.ietf.org/html/rfc7231#section-6.6.3)|JSON message response.|[MessageResponse](schemas.md#schemamessageresponse)|
+
+<h3 id="create-an-organization-billing-portal-session-responseschema">Response Schema</h3>
+
+## Create a subscription billing portal session
+
+<a id="opIdcreateBillingPortal"></a>
+
+`POST /organizations/{orgId}/subscriptions/{subId}/billing-portal`
+
+> Code samples
+
+```shell
+
+curl -X POST http://localhost:3000/devportal/organizations/{orgId}/subscriptions/{subId}/billing-portal \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Creates a Stripe customer portal session for a specific paid subscription.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="create-a-subscription-billing-portal-session-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+|subId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "url": "https://billing.stripe.com/p/session/test_123"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+> 502 Response
+
+```json
+{
+  "message": "string"
+}
+```
+
+<h3 id="create-a-subscription-billing-portal-session-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Stripe billing portal session URL.|[BillingPortalResponse](schemas.md#schemabillingportalresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|502|[Bad Gateway](https://tools.ietf.org/html/rfc7231#section-6.6.3)|JSON message response.|[MessageResponse](schemas.md#schemamessageresponse)|
+
+<h3 id="create-a-subscription-billing-portal-session-responseschema">Response Schema</h3>

--- a/docs/rest-apis/devportal/identity-providers.md
+++ b/docs/rest-apis/devportal/identity-providers.md
@@ -1,0 +1,512 @@
+<h1 id="wso2-api-developer-portal-core-devportal-routes-identity-providers">Identity Providers</h1>
+
+## Create an identity provider
+
+<a id="opIdcreateIdentityProvider"></a>
+
+`POST /organizations/{orgId}/identityProvider`
+
+> Code samples
+
+```shell
+
+curl -X POST http://localhost:3000/devportal/organizations/{orgId}/identityProvider \
+  -u {username}:{password} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Creates the organization-level OIDC identity provider configuration.
+
+> Payload
+
+```json
+{
+  "issuer": "string",
+  "name": "string",
+  "authorizationURL": "http://example.com",
+  "tokenURL": "http://example.com",
+  "userInfoURL": "http://example.com",
+  "clientId": "string",
+  "callbackURL": "http://example.com",
+  "signUpURL": "http://example.com",
+  "logoutURL": "http://example.com",
+  "logoutRedirectURI": "http://example.com",
+  "scope": "string",
+  "jwksURL": "http://example.com",
+  "certificate": "string"
+}
+```
+
+```yaml
+issuer: string
+name: string
+authorizationURL: http://example.com
+tokenURL: http://example.com
+userInfoURL: http://example.com
+clientId: string
+callbackURL: http://example.com
+signUpURL: http://example.com
+logoutURL: http://example.com
+logoutRedirectURI: http://example.com
+scope: string
+jwksURL: http://example.com
+certificate: string
+
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="create-an-identity-provider-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[IdentityProviderRequest](schemas.md#schemaidentityproviderrequest)|true|Identity provider payload. Send JSON or an identity provider YAML file in the `identityProvider` multipart field. When YAML is used, the service reads `metadata.name` as the provider name and all other fields from `spec`.|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 201 Response
+
+```json
+{
+  "name": "string",
+  "issuer": "string",
+  "authorizationURL": "http://example.com",
+  "tokenURL": "http://example.com",
+  "clientId": "string",
+  "callbackURL": "http://example.com",
+  "scope": "string",
+  "logoutURL": "http://example.com",
+  "logoutRedirectURI": "http://example.com",
+  "userInfoURL": "http://example.com",
+  "signUpURL": "http://example.com",
+  "jwksURL": "http://example.com",
+  "certificate": "string"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 409 Response
+
+```json
+{
+  "code": "409",
+  "message": "Conflict",
+  "description": "Organization already exists"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="create-an-identity-provider-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Identity provider DTO returned by create, update, and lookup operations.|[IdentityProviderResponse](schemas.md#schemaidentityproviderresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Duplicate organization data conflicts with an existing record.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="create-an-identity-provider-responseschema">Response Schema</h3>
+
+## Update an identity provider
+
+<a id="opIdupdateIdentityProvider"></a>
+
+`PUT /organizations/{orgId}/identityProvider`
+
+> Code samples
+
+```shell
+
+curl -X PUT http://localhost:3000/devportal/organizations/{orgId}/identityProvider \
+  -u {username}:{password} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Updates the organization-level OIDC identity provider configuration.
+
+> Payload
+
+```json
+{
+  "issuer": "string",
+  "name": "string",
+  "authorizationURL": "http://example.com",
+  "tokenURL": "http://example.com",
+  "userInfoURL": "http://example.com",
+  "clientId": "string",
+  "callbackURL": "http://example.com",
+  "signUpURL": "http://example.com",
+  "logoutURL": "http://example.com",
+  "logoutRedirectURI": "http://example.com",
+  "scope": "string",
+  "jwksURL": "http://example.com",
+  "certificate": "string"
+}
+```
+
+```yaml
+issuer: string
+name: string
+authorizationURL: http://example.com
+tokenURL: http://example.com
+userInfoURL: http://example.com
+clientId: string
+callbackURL: http://example.com
+signUpURL: http://example.com
+logoutURL: http://example.com
+logoutRedirectURI: http://example.com
+scope: string
+jwksURL: http://example.com
+certificate: string
+
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="update-an-identity-provider-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[IdentityProviderRequest](schemas.md#schemaidentityproviderrequest)|true|Identity provider payload. Send JSON or an identity provider YAML file in the `identityProvider` multipart field. When YAML is used, the service reads `metadata.name` as the provider name and all other fields from `spec`.|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "name": "string",
+  "issuer": "string",
+  "authorizationURL": "http://example.com",
+  "tokenURL": "http://example.com",
+  "clientId": "string",
+  "callbackURL": "http://example.com",
+  "scope": "string",
+  "logoutURL": "http://example.com",
+  "logoutRedirectURI": "http://example.com",
+  "userInfoURL": "http://example.com",
+  "signUpURL": "http://example.com",
+  "jwksURL": "http://example.com",
+  "certificate": "string"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 409 Response
+
+```json
+{
+  "code": "409",
+  "message": "Conflict",
+  "description": "Organization already exists"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="update-an-identity-provider-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Identity provider DTO returned by create, update, and lookup operations.|[IdentityProviderResponse](schemas.md#schemaidentityproviderresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Duplicate organization data conflicts with an existing record.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="update-an-identity-provider-responseschema">Response Schema</h3>
+
+## Get an identity provider
+
+<a id="opIdgetIdentityProvider"></a>
+
+`GET /organizations/{orgId}/identityProvider`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId}/identityProvider \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Retrieves the organization-level OIDC identity provider configuration.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="get-an-identity-provider-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "name": "string",
+  "issuer": "string",
+  "authorizationURL": "http://example.com",
+  "tokenURL": "http://example.com",
+  "clientId": "string",
+  "callbackURL": "http://example.com",
+  "scope": "string",
+  "logoutURL": "http://example.com",
+  "logoutRedirectURI": "http://example.com",
+  "userInfoURL": "http://example.com",
+  "signUpURL": "http://example.com",
+  "jwksURL": "http://example.com",
+  "certificate": "string"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="get-an-identity-provider-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Identity provider DTO returned by create, update, and lookup operations.|[IdentityProviderResponse](schemas.md#schemaidentityproviderresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Identity provider configuration not found.|None|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="get-an-identity-provider-responseschema">Response Schema</h3>
+
+## Delete an identity provider
+
+<a id="opIddeleteIdentityProvider"></a>
+
+`DELETE /organizations/{orgId}/identityProvider`
+
+> Code samples
+
+```shell
+
+curl -X DELETE http://localhost:3000/devportal/organizations/{orgId}/identityProvider \
+  -u {username}:{password} \
+  -H 'Accept: text/plain' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Deletes the organization-level OIDC identity provider configuration.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="delete-an-identity-provider-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```
+"string"
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="delete-an-identity-provider-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Plain text success response.|string|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="delete-an-identity-provider-responseschema">Response Schema</h3>

--- a/docs/rest-apis/devportal/invoices.md
+++ b/docs/rest-apis/devportal/invoices.md
@@ -1,0 +1,469 @@
+<h1 id="wso2-api-developer-portal-core-devportal-routes-invoices">Invoices</h1>
+
+## List invoices
+
+<a id="opIdlistInvoices"></a>
+
+`GET /organizations/{orgId}/invoices`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId}/invoices \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Lists invoices for the authenticated billing user. The `period` query controls the Stripe invoice created-date window.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="list-invoices-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|period|query|string|false|Invoice created-date window.|
+|orgId|path|string|true|none|
+
+#### Enumerated Values
+
+|Parameter|Value|
+|---|---|
+|period|last3months|
+|period|last6months|
+|period|last12months|
+|period|all|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "invoices": [
+    {
+      "id": "in_12345",
+      "number": "INV-001",
+      "created": 1775088000,
+      "amount": 2999,
+      "currency": "usd",
+      "status": "paid",
+      "hostedInvoiceUrl": "https://invoice.stripe.com/i/acct/test",
+      "invoicePdf": "https://pay.stripe.com/invoice/acct/test/pdf"
+    }
+  ]
+}
+```
+
+> 400 Response
+
+```json
+{
+  "error": "InternalServerError",
+  "message": "An unexpected error occurred"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "error": "InternalServerError",
+  "message": "An unexpected error occurred"
+}
+```
+
+> 502 Response
+
+```json
+{
+  "error": "InternalServerError",
+  "message": "An unexpected error occurred"
+}
+```
+
+<h3 id="list-invoices-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Compact invoice list for the authenticated billing user.|[InvoiceListResponse](schemas.md#schemainvoicelistresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Invoice lookup error.|[ControllerErrorResponse](schemas.md#schemacontrollererrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Invoice lookup error.|[ControllerErrorResponse](schemas.md#schemacontrollererrorresponse)|
+|502|[Bad Gateway](https://tools.ietf.org/html/rfc7231#section-6.6.3)|Invoice lookup error.|[ControllerErrorResponse](schemas.md#schemacontrollererrorresponse)|
+
+## Get an invoice
+
+<a id="opIdgetInvoice"></a>
+
+`GET /organizations/{orgId}/invoices/{invoiceId}`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId}/invoices/{invoiceId} \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Retrieves a Stripe invoice after verifying that the invoice customer belongs to the authenticated user.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="get-an-invoice-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+|invoiceId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "id": "in_12345",
+  "object": "invoice",
+  "status": "paid",
+  "customer": "cus_12345",
+  "hosted_invoice_url": "https://invoice.stripe.com/i/acct/test",
+  "invoice_pdf": "https://pay.stripe.com/invoice/acct/test/pdf"
+}
+```
+
+> 400 Response
+
+```json
+{
+  "error": "InternalServerError",
+  "message": "An unexpected error occurred"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "error": "InternalServerError",
+  "message": "An unexpected error occurred"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "error": "InternalServerError",
+  "message": "An unexpected error occurred"
+}
+```
+
+> 502 Response
+
+```json
+{
+  "error": "InternalServerError",
+  "message": "An unexpected error occurred"
+}
+```
+
+<h3 id="get-an-invoice-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Stripe invoice object.|[StripeInvoiceResponse](schemas.md#schemastripeinvoiceresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Invoice lookup error.|[ControllerErrorResponse](schemas.md#schemacontrollererrorresponse)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Invoice lookup error.|[ControllerErrorResponse](schemas.md#schemacontrollererrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Invoice lookup error.|[ControllerErrorResponse](schemas.md#schemacontrollererrorresponse)|
+|502|[Bad Gateway](https://tools.ietf.org/html/rfc7231#section-6.6.3)|Invoice lookup error.|[ControllerErrorResponse](schemas.md#schemacontrollererrorresponse)|
+
+## List invoices by subscription
+
+<a id="opIdlistInvoicesBySubscription"></a>
+
+`GET /organizations/{orgId}/subscriptions/{subId}/invoices`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId}/subscriptions/{subId}/invoices \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Lists Stripe invoices for a specific Developer Portal subscription after verifying subscription ownership. The response preserves Stripe's invoice list shape and filters it to the Stripe subscription linked to the Developer Portal subscription.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="list-invoices-by-subscription-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+|subId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "object": "list",
+  "data": [
+    {
+      "id": "in_12345",
+      "object": "invoice",
+      "status": "paid",
+      "hosted_invoice_url": "https://invoice.stripe.com/i/acct/test",
+      "invoice_pdf": "https://pay.stripe.com/invoice/acct/test/pdf"
+    }
+  ],
+  "has_more": false
+}
+```
+
+> 400 Response
+
+```json
+{
+  "error": "InternalServerError",
+  "message": "An unexpected error occurred"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "error": "InternalServerError",
+  "message": "An unexpected error occurred"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "error": "InternalServerError",
+  "message": "An unexpected error occurred"
+}
+```
+
+> 502 Response
+
+```json
+{
+  "error": "InternalServerError",
+  "message": "An unexpected error occurred"
+}
+```
+
+<h3 id="list-invoices-by-subscription-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Stripe invoice list response filtered by subscription.|[StripeInvoiceListResponse](schemas.md#schemastripeinvoicelistresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Invoice lookup error.|[ControllerErrorResponse](schemas.md#schemacontrollererrorresponse)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Invoice lookup error.|[ControllerErrorResponse](schemas.md#schemacontrollererrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Invoice lookup error.|[ControllerErrorResponse](schemas.md#schemacontrollererrorresponse)|
+|502|[Bad Gateway](https://tools.ietf.org/html/rfc7231#section-6.6.3)|Invoice lookup error.|[ControllerErrorResponse](schemas.md#schemacontrollererrorresponse)|
+
+## Get invoice PDF link
+
+<a id="opIdgetInvoicePdfLink"></a>
+
+`GET /organizations/{orgId}/invoices/{invoiceId}/pdf`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId}/invoices/{invoiceId}/pdf \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Returns hosted invoice and PDF links for an invoice. A non-finalized invoice may not have a PDF link yet.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="get-invoice-pdf-link-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+|invoiceId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "invoiceId": "in_12345",
+  "hosted_invoice_url": "https://invoice.stripe.com/i/acct/test",
+  "invoice_pdf": "https://pay.stripe.com/invoice/acct/test/pdf"
+}
+```
+
+> 400 Response
+
+```json
+{
+  "error": "InternalServerError",
+  "message": "An unexpected error occurred"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "error": "InvoicePdfNotAvailable",
+  "message": "Invoice PDF is not available for this invoice. It may not be finalized or paid yet.",
+  "hosted_invoice_url": "https://invoice.stripe.com/i/acct/test"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "error": "InternalServerError",
+  "message": "An unexpected error occurred"
+}
+```
+
+> 502 Response
+
+```json
+{
+  "error": "InternalServerError",
+  "message": "An unexpected error occurred"
+}
+```
+
+<h3 id="get-invoice-pdf-link-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Hosted invoice and PDF links.|[InvoicePdfLinkResponse](schemas.md#schemainvoicepdflinkresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Invoice lookup error.|[ControllerErrorResponse](schemas.md#schemacontrollererrorresponse)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Invoice PDF is not available yet.|[InvoicePdfNotAvailableResponse](schemas.md#schemainvoicepdfnotavailableresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Invoice lookup error.|[ControllerErrorResponse](schemas.md#schemacontrollererrorresponse)|
+|502|[Bad Gateway](https://tools.ietf.org/html/rfc7231#section-6.6.3)|Invoice lookup error.|[ControllerErrorResponse](schemas.md#schemacontrollererrorresponse)|
+
+## redirectHostedInvoice
+
+<a id="opIdredirectHostedInvoice"></a>
+
+`GET /organizations/{orgId}/invoices/{invoiceId}/hosted`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId}/invoices/{invoiceId}/hosted \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="redirecthostedinvoice-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+|invoiceId|path|string|true|none|
+
+> Example responses
+
+> 400 Response
+
+```json
+{
+  "error": "InternalServerError",
+  "message": "An unexpected error occurred"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "message": "string"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "error": "InternalServerError",
+  "message": "An unexpected error occurred"
+}
+```
+
+> 502 Response
+
+```json
+{
+  "error": "InternalServerError",
+  "message": "An unexpected error occurred"
+}
+```
+
+<h3 id="redirecthostedinvoice-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|302|[Found](https://tools.ietf.org/html/rfc7231#section-6.4.3)|Redirects to the hosted invoice URL.|None|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Invoice lookup error.|[ControllerErrorResponse](schemas.md#schemacontrollererrorresponse)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|JSON message response.|[MessageResponse](schemas.md#schemamessageresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Invoice lookup error.|[ControllerErrorResponse](schemas.md#schemacontrollererrorresponse)|
+|502|[Bad Gateway](https://tools.ietf.org/html/rfc7231#section-6.6.3)|Invoice lookup error.|[ControllerErrorResponse](schemas.md#schemacontrollererrorresponse)|
+
+### Response Headers
+
+|Status|Header|Type|Format|Description|
+|---|---|---|---|---|
+|302|Location|string|uri|Hosted Stripe invoice URL.|

--- a/docs/rest-apis/devportal/key-managers.md
+++ b/docs/rest-apis/devportal/key-managers.md
@@ -1,0 +1,732 @@
+<h1 id="wso2-api-developer-portal-core-devportal-routes-key-managers">Key Managers</h1>
+
+## Create a key manager
+
+<a id="opIdcreateKeyManager"></a>
+
+`POST /organizations/{orgId}/key-managers`
+
+> Code samples
+
+```shell
+
+curl -X POST http://localhost:3000/devportal/organizations/{orgId}/key-managers \
+  -u {username}:{password} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Creates a key manager configuration for the organization. Accepts either a `application/json` body or a `multipart/form-data` upload with a `keymanager` field containing the KeyManager YAML file. The `adminClientId` and `adminClientSecret` are encrypted at rest using AES-256-GCM.
+
+> Payload
+
+```json
+{
+  "name": "Asgardeo",
+  "type": "ASGARDEO",
+  "enabled": true,
+  "tokenEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/token",
+  "clientRegistrationEndpoint": "https://api.asgardeo.io/t/myorg/api/identity/oauth2/dcr/v1.1/register",
+  "issuer": "https://api.asgardeo.io/t/myorg/oauth2/token",
+  "jwksURL": "https://api.asgardeo.io/t/myorg/oauth2/jwks",
+  "adminClientId": "<client-id>",
+  "adminClientSecret": "<client-secret>",
+  "supportedGrantTypes": [
+    "client_credentials",
+    "authorization_code",
+    "refresh_token"
+  ],
+  "supportedScopes": [
+    "openid",
+    "profile"
+  ],
+  "additionalProperties": {
+    "authorizeEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/authorize",
+    "revokeEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/revoke",
+    "logoutEndpoint": "https://api.asgardeo.io/t/myorg/oidc/logout"
+  }
+}
+```
+
+```yaml
+name: Asgardeo
+type: ASGARDEO
+enabled: true
+tokenEndpoint: https://api.asgardeo.io/t/myorg/oauth2/token
+clientRegistrationEndpoint: https://api.asgardeo.io/t/myorg/api/identity/oauth2/dcr/v1.1/register
+issuer: https://api.asgardeo.io/t/myorg/oauth2/token
+jwksURL: https://api.asgardeo.io/t/myorg/oauth2/jwks
+adminClientId: <client-id>
+adminClientSecret: <client-secret>
+supportedGrantTypes:
+  - client_credentials
+  - authorization_code
+  - refresh_token
+supportedScopes:
+  - openid
+  - profile
+additionalProperties:
+  authorizeEndpoint: https://api.asgardeo.io/t/myorg/oauth2/authorize
+  revokeEndpoint: https://api.asgardeo.io/t/myorg/oauth2/revoke
+  logoutEndpoint: https://api.asgardeo.io/t/myorg/oidc/logout
+
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="create-a-key-manager-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[KeyManagerRequest](schemas.md#schemakeymanagerrequest)|false|Key manager configuration payload. Submit as `application/json` or as `multipart/form-data` with a `keymanager` field containing a KeyManager YAML file.|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 201 Response
+
+```json
+{
+  "id": "km-uuid-12345",
+  "orgId": "org-12345",
+  "name": "Asgardeo",
+  "type": "ASGARDEO",
+  "enabled": true,
+  "tokenEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/token",
+  "clientRegistrationEndpoint": "https://api.asgardeo.io/t/myorg/api/identity/oauth2/dcr/v1.1/register",
+  "issuer": "https://api.asgardeo.io/t/myorg/oauth2/token",
+  "jwksURL": "https://api.asgardeo.io/t/myorg/oauth2/jwks",
+  "supportedGrantTypes": [
+    "client_credentials",
+    "authorization_code",
+    "refresh_token"
+  ],
+  "supportedScopes": [
+    "openid",
+    "profile"
+  ],
+  "additionalProperties": {
+    "authorizeEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/authorize",
+    "revokeEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/revoke",
+    "logoutEndpoint": "https://api.asgardeo.io/t/myorg/oidc/logout"
+  }
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 409 Response
+
+```json
+{
+  "code": "409",
+  "message": "Conflict",
+  "description": "Organization already exists"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="create-a-key-manager-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Key manager configuration response.|[KeyManagerResponseSchema](schemas.md#schemakeymanagerresponseschema)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Duplicate organization data conflicts with an existing record.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="create-a-key-manager-responseschema">Response Schema</h3>
+
+## List key managers
+
+<a id="opIdgetKeyManagers"></a>
+
+`GET /organizations/{orgId}/key-managers`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId}/key-managers \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Returns all key manager configurations for the organization. Admin credentials are never included in the response.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="list-key-managers-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+[
+  {
+    "id": "km-uuid-12345",
+    "orgId": "org-12345",
+    "name": "Asgardeo",
+    "type": "ASGARDEO",
+    "enabled": true,
+    "tokenEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/token",
+    "clientRegistrationEndpoint": "https://api.asgardeo.io/t/myorg/api/identity/oauth2/dcr/v1.1/register",
+    "issuer": "https://api.asgardeo.io/t/myorg/oauth2/token",
+    "jwksURL": "https://api.asgardeo.io/t/myorg/oauth2/jwks",
+    "supportedGrantTypes": [
+      "client_credentials",
+      "authorization_code",
+      "refresh_token"
+    ],
+    "supportedScopes": [
+      "openid",
+      "profile"
+    ],
+    "additionalProperties": {
+      "authorizeEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/authorize",
+      "revokeEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/revoke",
+      "logoutEndpoint": "https://api.asgardeo.io/t/myorg/oidc/logout"
+    }
+  }
+]
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="list-key-managers-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|List of key manager configurations.|Inline|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="list-key-managers-responseschema">Response Schema</h3>
+
+Status Code **200**
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|*anonymous*|[[KeyManagerResponseSchema](schemas.md#schemakeymanagerresponseschema)]|false|none|[Key manager configuration. Admin credentials are never included.]|
+|» id|string|false|none|Key manager UUID.|
+|» orgId|string|false|none|none|
+|» name|string|false|none|none|
+|» type|string|false|none|none|
+|» enabled|boolean|false|none|none|
+|» tokenEndpoint|string(uri)|false|none|none|
+|» clientRegistrationEndpoint|string(uri)|false|none|none|
+|» issuer|string(uri)¦null|false|none|none|
+|» jwksURL|string(uri)¦null|false|none|none|
+|» supportedGrantTypes|[string]|false|none|none|
+|» supportedScopes|[string]|false|none|none|
+|» additionalProperties|object|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|type|ASGARDEO|
+|type|WSO2IS|
+|type|KEYCLOAK|
+|type|GENERIC_OIDC|
+
+## List available key managers for developers
+
+<a id="opIdgetAvailableKeyManagers"></a>
+
+`GET /organizations/{orgId}/key-managers/discover`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId}/key-managers/discover \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Returns the minimal public view of enabled key managers. This is the developer-facing endpoint used when generating application keys — no admin credentials or internal endpoints are exposed.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="list-available-key-managers-for-developers-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+[
+  {
+    "id": "km-uuid-12345",
+    "name": "Asgardeo",
+    "type": "ASGARDEO",
+    "tokenEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/token",
+    "supportedGrantTypes": [
+      "client_credentials",
+      "authorization_code"
+    ],
+    "supportedScopes": [
+      "openid",
+      "profile"
+    ]
+  }
+]
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="list-available-key-managers-for-developers-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|List of enabled key managers (developer-facing, minimal view).|Inline|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="list-available-key-managers-for-developers-responseschema">Response Schema</h3>
+
+Status Code **200**
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|*anonymous*|[[KeyManagerPublicResponseSchema](schemas.md#schemakeymanagerpublicresponseschema)]|false|none|[Minimal developer-facing key manager view. No admin credentials or DCR endpoints.]|
+|» id|string|false|none|none|
+|» name|string|false|none|none|
+|» type|string|false|none|none|
+|» tokenEndpoint|string(uri)|false|none|none|
+|» supportedGrantTypes|[string]|false|none|none|
+|» supportedScopes|[string]|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|type|ASGARDEO|
+|type|WSO2IS|
+|type|KEYCLOAK|
+|type|GENERIC_OIDC|
+
+## Get a key manager
+
+<a id="opIdgetKeyManager"></a>
+
+`GET /organizations/{orgId}/key-managers/{kmId}`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId}/key-managers/{kmId} \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Retrieves a single key manager configuration by ID.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="get-a-key-manager-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+|kmId|path|string|true|Key manager ID (UUID).|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "id": "km-uuid-12345",
+  "orgId": "org-12345",
+  "name": "Asgardeo",
+  "type": "ASGARDEO",
+  "enabled": true,
+  "tokenEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/token",
+  "clientRegistrationEndpoint": "https://api.asgardeo.io/t/myorg/api/identity/oauth2/dcr/v1.1/register",
+  "issuer": "https://api.asgardeo.io/t/myorg/oauth2/token",
+  "jwksURL": "https://api.asgardeo.io/t/myorg/oauth2/jwks",
+  "supportedGrantTypes": [
+    "client_credentials",
+    "authorization_code",
+    "refresh_token"
+  ],
+  "supportedScopes": [
+    "openid",
+    "profile"
+  ],
+  "additionalProperties": {
+    "authorizeEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/authorize",
+    "revokeEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/revoke",
+    "logoutEndpoint": "https://api.asgardeo.io/t/myorg/oidc/logout"
+  }
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="get-a-key-manager-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Key manager configuration response.|[KeyManagerResponseSchema](schemas.md#schemakeymanagerresponseschema)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+## Update a key manager
+
+<a id="opIdupdateKeyManager"></a>
+
+`PUT /organizations/{orgId}/key-managers/{kmId}`
+
+> Code samples
+
+```shell
+
+curl -X PUT http://localhost:3000/devportal/organizations/{orgId}/key-managers/{kmId} \
+  -u {username}:{password} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Updates an existing key manager configuration. Accepts either a `application/json` body or a `multipart/form-data` upload with a `keymanager` YAML file. Only supplied fields are updated; omitted fields retain their stored values.
+
+> Payload
+
+```json
+{
+  "name": "Asgardeo",
+  "type": "ASGARDEO",
+  "enabled": true,
+  "tokenEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/token",
+  "clientRegistrationEndpoint": "https://api.asgardeo.io/t/myorg/api/identity/oauth2/dcr/v1.1/register",
+  "issuer": "https://api.asgardeo.io/t/myorg/oauth2/token",
+  "jwksURL": "https://api.asgardeo.io/t/myorg/oauth2/jwks",
+  "adminClientId": "<client-id>",
+  "adminClientSecret": "<client-secret>",
+  "supportedGrantTypes": [
+    "client_credentials",
+    "authorization_code",
+    "refresh_token"
+  ],
+  "supportedScopes": [
+    "openid",
+    "profile"
+  ],
+  "additionalProperties": {
+    "authorizeEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/authorize",
+    "revokeEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/revoke",
+    "logoutEndpoint": "https://api.asgardeo.io/t/myorg/oidc/logout"
+  }
+}
+```
+
+```yaml
+name: Asgardeo
+type: ASGARDEO
+enabled: true
+tokenEndpoint: https://api.asgardeo.io/t/myorg/oauth2/token
+clientRegistrationEndpoint: https://api.asgardeo.io/t/myorg/api/identity/oauth2/dcr/v1.1/register
+issuer: https://api.asgardeo.io/t/myorg/oauth2/token
+jwksURL: https://api.asgardeo.io/t/myorg/oauth2/jwks
+adminClientId: <client-id>
+adminClientSecret: <client-secret>
+supportedGrantTypes:
+  - client_credentials
+  - authorization_code
+  - refresh_token
+supportedScopes:
+  - openid
+  - profile
+additionalProperties:
+  authorizeEndpoint: https://api.asgardeo.io/t/myorg/oauth2/authorize
+  revokeEndpoint: https://api.asgardeo.io/t/myorg/oauth2/revoke
+  logoutEndpoint: https://api.asgardeo.io/t/myorg/oidc/logout
+
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="update-a-key-manager-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[KeyManagerUpdateRequest](schemas.md#schemakeymanagerupdaterequest)|false|Key manager update payload. All fields are optional; only supplied fields are updated. Submit as `application/json` or as `multipart/form-data` with a `keymanager` field containing a KeyManager YAML file.|
+|orgId|path|string|true|none|
+|kmId|path|string|true|Key manager ID (UUID).|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "id": "km-uuid-12345",
+  "orgId": "org-12345",
+  "name": "Asgardeo",
+  "type": "ASGARDEO",
+  "enabled": true,
+  "tokenEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/token",
+  "clientRegistrationEndpoint": "https://api.asgardeo.io/t/myorg/api/identity/oauth2/dcr/v1.1/register",
+  "issuer": "https://api.asgardeo.io/t/myorg/oauth2/token",
+  "jwksURL": "https://api.asgardeo.io/t/myorg/oauth2/jwks",
+  "supportedGrantTypes": [
+    "client_credentials",
+    "authorization_code",
+    "refresh_token"
+  ],
+  "supportedScopes": [
+    "openid",
+    "profile"
+  ],
+  "additionalProperties": {
+    "authorizeEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/authorize",
+    "revokeEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/revoke",
+    "logoutEndpoint": "https://api.asgardeo.io/t/myorg/oidc/logout"
+  }
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 409 Response
+
+```json
+{
+  "code": "409",
+  "message": "Conflict",
+  "description": "Organization already exists"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="update-a-key-manager-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Key manager configuration response.|[KeyManagerResponseSchema](schemas.md#schemakeymanagerresponseschema)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Duplicate organization data conflicts with an existing record.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="update-a-key-manager-responseschema">Response Schema</h3>
+
+## Delete a key manager
+
+<a id="opIddeleteKeyManager"></a>
+
+`DELETE /organizations/{orgId}/key-managers/{kmId}`
+
+> Code samples
+
+```shell
+
+curl -X DELETE http://localhost:3000/devportal/organizations/{orgId}/key-managers/{kmId} \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Deletes a key manager configuration by ID.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="delete-a-key-manager-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+|kmId|path|string|true|Key manager ID (UUID).|
+
+> Example responses
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="delete-a-key-manager-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Key manager deleted successfully.|None|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|

--- a/docs/rest-apis/devportal/labels.md
+++ b/docs/rest-apis/devportal/labels.md
@@ -1,0 +1,441 @@
+<h1 id="wso2-api-developer-portal-core-devportal-routes-labels">Labels</h1>
+
+## Create labels
+
+<a id="opIdcreateLabels"></a>
+
+`POST /organizations/{orgId}/labels`
+
+> Code samples
+
+```shell
+
+curl -X POST http://localhost:3000/devportal/organizations/{orgId}/labels \
+  -u {username}:{password} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Creates one or more labels for the organization. The response echoes the accepted label array.
+
+> Payload
+
+```json
+[
+  {
+    "name": "premium",
+    "displayName": "Premium APIs"
+  }
+]
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="create-labels-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[LabelRequest](schemas.md#schemalabelrequest)|true|Label array to create or upsert.|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 201 Response
+
+```json
+[
+  {
+    "name": "default",
+    "displayName": "default"
+  },
+  {
+    "name": "premium",
+    "displayName": "Premium APIs"
+  }
+]
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 409 Response
+
+```json
+{
+  "code": "409",
+  "message": "Conflict",
+  "description": "Organization already exists"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="create-labels-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|List of label DTOs.|Inline|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Duplicate organization data conflicts with an existing record.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="create-labels-responseschema">Response Schema</h3>
+
+Status Code **201**
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|*anonymous*|[[LabelResponse](schemas.md#schemalabelresponse)]|false|none|none|
+|» name|string|false|none|none|
+|» displayName|string|false|none|none|
+
+## Upsert labels
+
+<a id="opIdupdateLabel"></a>
+
+`PUT /organizations/{orgId}/labels`
+
+> Code samples
+
+```shell
+
+curl -X PUT http://localhost:3000/devportal/organizations/{orgId}/labels \
+  -u {username}:{password} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Updates existing labels by name or creates them when they do not already exist. The response echoes the accepted label array.
+
+> Payload
+
+```json
+[
+  {
+    "name": "premium",
+    "displayName": "Premium APIs"
+  }
+]
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="upsert-labels-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[LabelRequest](schemas.md#schemalabelrequest)|true|Label array to create or upsert.|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 201 Response
+
+```json
+[
+  {
+    "name": "default",
+    "displayName": "default"
+  },
+  {
+    "name": "premium",
+    "displayName": "Premium APIs"
+  }
+]
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 409 Response
+
+```json
+{
+  "code": "409",
+  "message": "Conflict",
+  "description": "Organization already exists"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="upsert-labels-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|List of label DTOs.|Inline|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Duplicate organization data conflicts with an existing record.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="upsert-labels-responseschema">Response Schema</h3>
+
+Status Code **201**
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|*anonymous*|[[LabelResponse](schemas.md#schemalabelresponse)]|false|none|none|
+|» name|string|false|none|none|
+|» displayName|string|false|none|none|
+
+## List labels
+
+<a id="opIdretrieveLabels"></a>
+
+`GET /organizations/{orgId}/labels`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId}/labels \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Returns all labels configured for the organization.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="list-labels-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+[
+  {
+    "name": "default",
+    "displayName": "default"
+  },
+  {
+    "name": "premium",
+    "displayName": "Premium APIs"
+  }
+]
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="list-labels-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|List of label DTOs.|Inline|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="list-labels-responseschema">Response Schema</h3>
+
+Status Code **200**
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|*anonymous*|[[LabelResponse](schemas.md#schemalabelresponse)]|false|none|none|
+|» name|string|false|none|none|
+|» displayName|string|false|none|none|
+
+## Delete labels
+
+<a id="opIddeleteLabels"></a>
+
+`DELETE /organizations/{orgId}/labels`
+
+> Code samples
+
+```shell
+
+curl -X DELETE http://localhost:3000/devportal/organizations/{orgId}/labels?names=default%2Cpremium \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Deletes one or more labels by comma-separated label names.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="delete-labels-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|names|query|string|true|Comma-separated label names to delete.|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="delete-labels-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Labels deleted successfully.|None|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="delete-labels-responseschema">Response Schema</h3>

--- a/docs/rest-apis/devportal/organization-content.md
+++ b/docs/rest-apis/devportal/organization-content.md
@@ -1,0 +1,475 @@
+<h1 id="wso2-api-developer-portal-core-devportal-routes-organization-content">Organization Content</h1>
+
+## Upload organization layout content
+
+<a id="opIdcreateOrgContent"></a>
+
+`POST /organizations/{orgId}/views/{name}/layout`
+
+> Code samples
+
+```shell
+
+curl -X POST http://localhost:3000/devportal/organizations/{orgId}/views/{name}/layout \
+  -u {username}:{password} \
+  -H 'Content-Type: multipart/form-data' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Uploads a ZIP file containing organization layout assets for the selected view. The service extracts the archive, reads supported files, and stores each content item under the view.
+
+> Payload
+
+```yaml
+file: string
+
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="upload-organization-layout-content-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|object|true|ZIP file upload. Organization content uploads are limited to 50 MB.|
+|» file|body|string(binary)|true|ZIP file containing organization layout assets.|
+|orgId|path|string|true|none|
+|name|path|string|true|none|
+
+> Example responses
+
+> 201 Response
+
+```json
+{
+  "orgId": "string",
+  "fileName": "string"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 409 Response
+
+```json
+{
+  "code": "409",
+  "message": "Conflict",
+  "description": "Organization already exists"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="upload-organization-layout-content-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Organization content upload accepted and stored successfully.|[OrganizationContentUploadResponse](schemas.md#schemaorganizationcontentuploadresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Duplicate organization data conflicts with an existing record.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="upload-organization-layout-content-responseschema">Response Schema</h3>
+
+## Replace organization layout content
+
+<a id="opIdupdateOrgContent"></a>
+
+`PUT /organizations/{orgId}/views/{name}/layout`
+
+> Code samples
+
+```shell
+
+curl -X PUT http://localhost:3000/devportal/organizations/{orgId}/views/{name}/layout \
+  -u {username}:{password} \
+  -H 'Content-Type: multipart/form-data' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Uploads a ZIP file and upserts the extracted organization layout assets for the selected view. Existing content records are updated and missing content records are created.
+
+> Payload
+
+```yaml
+file: string
+
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="replace-organization-layout-content-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|object|true|ZIP file upload. Organization content uploads are limited to 50 MB.|
+|» file|body|string(binary)|true|ZIP file containing organization layout assets.|
+|orgId|path|string|true|none|
+|name|path|string|true|none|
+
+> Example responses
+
+> 201 Response
+
+```json
+{
+  "orgId": "string",
+  "fileName": "string"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 409 Response
+
+```json
+{
+  "code": "409",
+  "message": "Conflict",
+  "description": "Organization already exists"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="replace-organization-layout-content-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Organization content upload accepted and stored successfully.|[OrganizationContentUploadResponse](schemas.md#schemaorganizationcontentuploadresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Duplicate organization data conflicts with an existing record.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="replace-organization-layout-content-responseschema">Response Schema</h3>
+
+## Get a single organization layout asset
+
+<a id="opIdgetOrgLayoutContent"></a>
+
+`GET /organizations/{orgId}/views/{name}/layout`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId}/views/{name}/layout?fileType=string&fileName=string \
+  -u {username}:{password} \
+  -H 'Accept: text/css'
+
+```
+
+Retrieves one organization layout asset when `fileType` and `fileName` are supplied as query parameters. The response content type is derived from the stored file type and extension.
+
+<h3 id="get-a-single-organization-layout-asset-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|fileType|query|string|true|Organization content file type, such as style, image, text, template, or partial.|
+|fileName|query|string|true|Stored organization content file name.|
+|filePath|query|string|false|Optional relative content path used together with `fileType` and `fileName`.|
+|orgId|path|string|true|none|
+|name|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```
+"string"
+```
+
+<h3 id="get-a-single-organization-layout-asset-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Stored organization content asset.|string|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Plain text success response.|string|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Plain text success response.|string|
+
+## Delete organization layout content
+
+<a id="opIddeleteOrgContent"></a>
+
+`DELETE /organizations/{orgId}/views/{name}/layout`
+
+> Code samples
+
+```shell
+
+curl -X DELETE http://localhost:3000/devportal/organizations/{orgId}/views/{name}/layout \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Deletes all organization layout content for the selected view, or deletes one content item when `fileName` is supplied as a query parameter.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="delete-organization-layout-content-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|fileName|query|string|false|File name selector used by file retrieval and organization content deletion.|
+|orgId|path|string|true|none|
+|name|path|string|true|none|
+
+> Example responses
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="delete-organization-layout-content-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Organization content deleted successfully.|None|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="delete-organization-layout-content-responseschema">Response Schema</h3>
+
+## List organization layout assets by file type
+
+<a id="opIdgetOrgLayoutContentByFileType"></a>
+
+`GET /organizations/{orgId}/views/{name}/layout/{fileType}`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId}/views/{name}/layout/{fileType} \
+  -u {username}:{password} \
+  -H 'Accept: application/json'
+
+```
+
+Returns all stored organization layout content records for the selected file type and view.
+
+<h3 id="list-organization-layout-assets-by-file-type-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+|name|path|string|true|none|
+|fileType|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+[
+  {
+    "orgId": "string",
+    "fileName": "string",
+    "fileContent": "string"
+  }
+]
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```
+"string"
+```
+
+<h3 id="list-organization-layout-assets-by-file-type-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|List of organization content records for the requested file type.|Inline|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Plain text success response.|string|
+
+<h3 id="list-organization-layout-assets-by-file-type-responseschema">Response Schema</h3>
+
+Status Code **200**
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|*anonymous*|[[OrganizationContentListItemResponse](schemas.md#schemaorganizationcontentlistitemresponse)]|false|none|none|
+|» orgId|string|false|none|none|
+|» fileName|string|false|none|none|
+|» fileContent|string¦null|false|none|UTF-8 content string returned for stored organization content records.|

--- a/docs/rest-apis/devportal/organizations.md
+++ b/docs/rest-apis/devportal/organizations.md
@@ -1,0 +1,602 @@
+<h1 id="wso2-api-developer-portal-core-devportal-routes-organizations">Organizations</h1>
+
+## Create an organization
+
+<a id="opIdcreateOrganization"></a>
+
+`POST /organizations`
+
+> Code samples
+
+```shell
+
+curl -X POST http://localhost:3000/devportal/organizations \
+  -u {username}:{password} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Creates a Developer Portal organization and initializes its default portal configuration, default label, default view, default WSO2 provider, and default subscription policies when configured.
+
+> Payload
+
+```json
+{
+  "orgName": "string",
+  "businessOwner": "string",
+  "businessOwnerContact": "string",
+  "businessOwnerEmail": "user@example.com",
+  "orgHandle": "string",
+  "roleClaimName": "string",
+  "groupsClaimName": "string",
+  "organizationClaimName": "string",
+  "organizationIdentifier": "string",
+  "adminRole": "string",
+  "subscriberRole": "string",
+  "superAdminRole": "string"
+}
+```
+
+```yaml
+orgName: string
+businessOwner: string
+businessOwnerContact: string
+businessOwnerEmail: user@example.com
+orgHandle: string
+roleClaimName: string
+groupsClaimName: string
+organizationClaimName: string
+organizationIdentifier: string
+adminRole: string
+subscriberRole: string
+superAdminRole: string
+
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="create-an-organization-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[OrganizationCreateRequest](schemas.md#schemaorganizationcreaterequest)|true|Organization creation payload. Send JSON or an organization YAML file in the `organization` multipart field. When YAML is used, the service reads `metadata.name` as `orgHandle` and `spec.displayName` as `orgName`; all other fields are read from `spec`.|
+
+> Example responses
+
+> 201 Response
+
+```json
+{
+  "orgId": "string",
+  "orgName": "string",
+  "businessOwner": "string",
+  "businessOwnerContact": "string",
+  "businessOwnerEmail": "user@example.com",
+  "orgHandle": "string",
+  "roleClaimName": "string",
+  "groupsClaimName": "string",
+  "organizationClaimName": "string",
+  "organizationIdentifier": "string",
+  "adminRole": "string",
+  "subscriberRole": "string",
+  "superAdminRole": "string",
+  "groupClaimName": "string",
+  "orgConfiguration": {}
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 409 Response
+
+```json
+{
+  "code": "409",
+  "message": "Conflict",
+  "description": "Organization already exists"
+}
+```
+
+> 415 Response
+
+```json
+{
+  "code": "415",
+  "message": "Unsupported Media Type",
+  "description": "Content-Type must be application/json"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="create-an-organization-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Organization created successfully.|[OrganizationResponse](schemas.md#schemaorganizationresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Duplicate organization data conflicts with an existing record.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|415|[Unsupported Media Type](https://tools.ietf.org/html/rfc7231#section-6.5.13)|Unsupported request media type.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="create-an-organization-responseschema">Response Schema</h3>
+
+## List organizations
+
+<a id="opIdgetOrganizations"></a>
+
+`GET /organizations`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Returns all Developer Portal organizations visible to the admin context.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+> Example responses
+
+> 200 Response
+
+```json
+[
+  {
+    "orgID": "string",
+    "orgName": "string",
+    "businessOwner": "string",
+    "businessOwnerContact": "string",
+    "businessOwnerEmail": "user@example.com",
+    "orgHandle": "string",
+    "roleClaimName": "string",
+    "groupsClaimName": "string",
+    "organizationClaimName": "string",
+    "organizationIdentifier": "string",
+    "adminRole": "string",
+    "subscriberRole": "string",
+    "superAdminRole": "string",
+    "orgConfiguration": {}
+  }
+]
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="list-organizations-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|List of organization DTOs.|Inline|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="list-organizations-responseschema">Response Schema</h3>
+
+Status Code **200**
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|*anonymous*|[[OrganizationListItemResponse](schemas.md#schemaorganizationlistitemresponse)]|false|none|none|
+|» orgID|string|false|none|none|
+|» orgName|string|false|none|none|
+|» businessOwner|string¦null|false|none|none|
+|» businessOwnerContact|string¦null|false|none|none|
+|» businessOwnerEmail|string(email)¦null|false|none|none|
+|» orgHandle|string|false|none|none|
+|» roleClaimName|string|false|none|none|
+|» groupsClaimName|string|false|none|none|
+|» organizationClaimName|string|false|none|none|
+|» organizationIdentifier|string|false|none|none|
+|» adminRole|string|false|none|none|
+|» subscriberRole|string|false|none|none|
+|» superAdminRole|string¦null|false|none|none|
+|» orgConfiguration|[GenericObject](schemas.md#schemagenericobject)|false|none|none|
+
+## Update an organization
+
+<a id="opIdupdateOrganization"></a>
+
+`PUT /organizations/{orgId}`
+
+> Code samples
+
+```shell
+
+curl -X PUT http://localhost:3000/devportal/organizations/{orgId} \
+  -u {username}:{password} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Updates organization metadata, claim mappings, role mappings, and portal configuration.
+
+> Payload
+
+```json
+{
+  "orgName": "string",
+  "businessOwner": "string",
+  "businessOwnerContact": "string",
+  "businessOwnerEmail": "user@example.com",
+  "orgHandle": "string",
+  "roleClaimName": "string",
+  "groupsClaimName": "string",
+  "organizationClaimName": "string",
+  "organizationIdentifier": "string",
+  "adminRole": "string",
+  "subscriberRole": "string",
+  "superAdminRole": "string",
+  "orgConfiguration": {}
+}
+```
+
+```yaml
+orgName: string
+businessOwner: string
+businessOwnerContact: string
+businessOwnerEmail: user@example.com
+orgHandle: string
+roleClaimName: string
+groupsClaimName: string
+organizationClaimName: string
+organizationIdentifier: string
+adminRole: string
+subscriberRole: string
+superAdminRole: string
+orgConfiguration: {}
+
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="update-an-organization-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[OrganizationUpdateRequest](schemas.md#schemaorganizationupdaterequest)|true|Organization update payload. Send JSON or an organization YAML file in the `organization` multipart field. When YAML is used, the service reads `metadata.name` as `orgHandle` and `spec.displayName` as `orgName`; all other fields are read from `spec`.|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "orgId": "string",
+  "orgName": "string",
+  "businessOwner": "string",
+  "businessOwnerContact": "string",
+  "businessOwnerEmail": "user@example.com",
+  "orgHandle": "string",
+  "roleClaimName": "string",
+  "groupsClaimName": "string",
+  "organizationClaimName": "string",
+  "organizationIdentifier": "string",
+  "adminRole": "string",
+  "subscriberRole": "string",
+  "superAdminRole": "string",
+  "groupClaimName": "string",
+  "orgConfiguration": {}
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 409 Response
+
+```json
+{
+  "code": "409",
+  "message": "Conflict",
+  "description": "Organization already exists"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="update-an-organization-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Organization DTO returned by create, update, and lookup operations.|[OrganizationResponse](schemas.md#schemaorganizationresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Duplicate organization data conflicts with an existing record.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="update-an-organization-responseschema">Response Schema</h3>
+
+## Get an organization
+
+<a id="opIdgetOrganization"></a>
+
+`GET /organizations/{orgId}`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId} \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Retrieves a single organization by organization ID, organization name, organization handle, or organization identifier.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="get-an-organization-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "orgId": "string",
+  "orgName": "string",
+  "businessOwner": "string",
+  "businessOwnerContact": "string",
+  "businessOwnerEmail": "user@example.com",
+  "orgHandle": "string",
+  "roleClaimName": "string",
+  "groupsClaimName": "string",
+  "organizationClaimName": "string",
+  "organizationIdentifier": "string",
+  "adminRole": "string",
+  "subscriberRole": "string",
+  "superAdminRole": "string",
+  "groupClaimName": "string",
+  "orgConfiguration": {}
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="get-an-organization-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Organization DTO returned by create, update, and lookup operations.|[OrganizationResponse](schemas.md#schemaorganizationresponse)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+## Delete an organization
+
+<a id="opIddeleteOrganization"></a>
+
+`DELETE /organizations/{orgId}`
+
+> Code samples
+
+```shell
+
+curl -X DELETE http://localhost:3000/devportal/organizations/{orgId} \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Deletes an organization and returns no response body when deletion succeeds.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="delete-an-organization-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="delete-an-organization-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Organization deleted successfully.|None|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="delete-an-organization-responseschema">Response Schema</h3>

--- a/docs/rest-apis/devportal/providers.md
+++ b/docs/rest-apis/devportal/providers.md
@@ -1,0 +1,405 @@
+<h1 id="wso2-api-developer-portal-core-devportal-routes-providers">Providers</h1>
+
+## Create a provider
+
+<a id="opIdcreateProvider"></a>
+
+`POST /organizations/{orgId}/provider`
+
+> Code samples
+
+```shell
+
+curl -X POST http://localhost:3000/devportal/organizations/{orgId}/provider \
+  -u {username}:{password} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Creates an API provider configuration for the organization. The current service contract accepts a provider `name` and `providerURL`, rejects unexpected properties, and stores the provider URL as a provider property.
+
+> Payload
+
+```json
+{
+  "name": "string",
+  "providerURL": "http://example.com"
+}
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="create-a-provider-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[ProviderRequest](schemas.md#schemaproviderrequest)|true|none|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 201 Response
+
+```json
+{
+  "orgId": "string",
+  "name": "string",
+  "providerURL": "http://example.com"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 409 Response
+
+```json
+{
+  "code": "409",
+  "message": "Conflict",
+  "description": "Organization already exists"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="create-a-provider-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Provider DTO returned by create and update operations.|[ProviderResponse](schemas.md#schemaproviderresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Duplicate organization data conflicts with an existing record.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="create-a-provider-responseschema">Response Schema</h3>
+
+## Update a provider
+
+<a id="opIdupdateProvider"></a>
+
+`PUT /organizations/{orgId}/provider`
+
+> Code samples
+
+```shell
+
+curl -X PUT http://localhost:3000/devportal/organizations/{orgId}/provider \
+  -u {username}:{password} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Updates the provider URL for an existing organization provider.
+
+> Payload
+
+```json
+{
+  "name": "string",
+  "providerURL": "http://example.com"
+}
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="update-a-provider-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[ProviderRequest](schemas.md#schemaproviderrequest)|true|none|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "orgId": "string",
+  "name": "string",
+  "providerURL": "http://example.com"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 409 Response
+
+```json
+{
+  "code": "409",
+  "message": "Conflict",
+  "description": "Organization already exists"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="update-a-provider-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Provider DTO returned by create and update operations.|[ProviderResponse](schemas.md#schemaproviderresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Duplicate organization data conflicts with an existing record.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="update-a-provider-responseschema">Response Schema</h3>
+
+## Get providers
+
+<a id="opIdgetProviders"></a>
+
+`GET /organizations/{orgId}/provider`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId}/provider \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Returns all providers for the organization. When `name` is supplied, returns the matching provider configuration.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="get-providers-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|name|query|string|false|Optional provider name selector. When omitted, all providers are returned.|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "name": "string",
+  "providerURL": "http://example.com"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="get-providers-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Provider DTO or list of provider DTOs.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="get-providers-responseschema">Response Schema</h3>
+
+## Delete a provider
+
+<a id="opIddeleteProvider"></a>
+
+`DELETE /organizations/{orgId}/provider`
+
+> Code samples
+
+```shell
+
+curl -X DELETE http://localhost:3000/devportal/organizations/{orgId}/provider?name=string \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Deletes an organization provider by `name`. When `property` is supplied, deletes only that provider property.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="delete-a-provider-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|name|query|string|true|Provider name.|
+|property|query|string|false|Optional provider property name to delete instead of deleting the whole provider.|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="delete-a-provider-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Provider or provider property deleted successfully.|None|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="delete-a-provider-responseschema">Response Schema</h3>

--- a/docs/rest-apis/devportal/schemas.md
+++ b/docs/rest-apis/devportal/schemas.md
@@ -1,0 +1,3488 @@
+# Schemas
+
+<h2 id="tocS_MessageResponse">MessageResponse</h2>
+
+<a id="schemamessageresponse"></a>
+<a id="schema_MessageResponse"></a>
+<a id="tocSmessageresponse"></a>
+<a id="tocsmessageresponse"></a>
+
+```json
+{
+  "message": "string"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|message|string|true|none|none|
+
+<h2 id="tocS_GenericValue">GenericValue</h2>
+
+<a id="schemagenericvalue"></a>
+<a id="schema_GenericValue"></a>
+<a id="tocSgenericvalue"></a>
+<a id="tocsgenericvalue"></a>
+
+```json
+{}
+
+```
+
+### Properties
+
+oneOf
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|*anonymous*|object|false|none|none|
+
+xor
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|*anonymous*|[any]|false|none|none|
+
+xor
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|*anonymous*|string|false|none|none|
+
+xor
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|*anonymous*|number|false|none|none|
+
+xor
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|*anonymous*|boolean|false|none|none|
+
+<h2 id="tocS_GenericObject">GenericObject</h2>
+
+<a id="schemagenericobject"></a>
+<a id="schema_GenericObject"></a>
+<a id="tocSgenericobject"></a>
+<a id="tocsgenericobject"></a>
+
+```json
+{}
+
+```
+
+### Properties
+
+*None*
+
+<h2 id="tocS_ErrorResponse">ErrorResponse</h2>
+
+<a id="schemaerrorresponse"></a>
+<a id="schema_ErrorResponse"></a>
+<a id="tocSerrorresponse"></a>
+<a id="tocserrorresponse"></a>
+
+```json
+{
+  "code": "string",
+  "message": "string",
+  "description": "string"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|code|any|true|none|HTTP status code returned by the error handler.|
+
+oneOf
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|string|false|none|none|
+
+xor
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|integer|false|none|none|
+
+continued
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|message|string|true|none|none|
+|description|string|true|none|none|
+
+<h2 id="tocS_ValidationErrorList">ValidationErrorList</h2>
+
+<a id="schemavalidationerrorlist"></a>
+<a id="schema_ValidationErrorList"></a>
+<a id="tocSvalidationerrorlist"></a>
+<a id="tocsvalidationerrorlist"></a>
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "string"
+  }
+]
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|*anonymous*|[[ValidationError](#schemavalidationerror)]|false|none|none|
+
+<h2 id="tocS_ValidationError">ValidationError</h2>
+
+<a id="schemavalidationerror"></a>
+<a id="schema_ValidationError"></a>
+<a id="tocSvalidationerror"></a>
+<a id="tocsvalidationerror"></a>
+
+```json
+{
+  "code": "400",
+  "message": "input validation failed",
+  "description": "string"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|code|string|true|none|none|
+|message|string|true|none|none|
+|description|string|true|none|none|
+
+<h2 id="tocS_OrganizationResponse">OrganizationResponse</h2>
+
+<a id="schemaorganizationresponse"></a>
+<a id="schema_OrganizationResponse"></a>
+<a id="tocSorganizationresponse"></a>
+<a id="tocsorganizationresponse"></a>
+
+```json
+{
+  "orgId": "string",
+  "orgName": "string",
+  "businessOwner": "string",
+  "businessOwnerContact": "string",
+  "businessOwnerEmail": "user@example.com",
+  "orgHandle": "string",
+  "roleClaimName": "string",
+  "groupsClaimName": "string",
+  "organizationClaimName": "string",
+  "organizationIdentifier": "string",
+  "adminRole": "string",
+  "subscriberRole": "string",
+  "superAdminRole": "string",
+  "groupClaimName": "string",
+  "orgConfiguration": {}
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|orgId|string|false|none|none|
+|orgName|string|false|none|none|
+|businessOwner|string¦null|false|none|none|
+|businessOwnerContact|string¦null|false|none|none|
+|businessOwnerEmail|string(email)¦null|false|none|none|
+|orgHandle|string|false|none|none|
+|roleClaimName|string|false|none|none|
+|groupsClaimName|string|false|none|none|
+|organizationClaimName|string|false|none|none|
+|organizationIdentifier|string|false|none|none|
+|adminRole|string|false|none|none|
+|subscriberRole|string|false|none|none|
+|superAdminRole|string¦null|false|none|none|
+|groupClaimName|string¦null|false|none|none|
+|orgConfiguration|[GenericObject](#schemagenericobject)|false|none|none|
+
+<h2 id="tocS_OrganizationListItemResponse">OrganizationListItemResponse</h2>
+
+<a id="schemaorganizationlistitemresponse"></a>
+<a id="schema_OrganizationListItemResponse"></a>
+<a id="tocSorganizationlistitemresponse"></a>
+<a id="tocsorganizationlistitemresponse"></a>
+
+```json
+{
+  "orgID": "string",
+  "orgName": "string",
+  "businessOwner": "string",
+  "businessOwnerContact": "string",
+  "businessOwnerEmail": "user@example.com",
+  "orgHandle": "string",
+  "roleClaimName": "string",
+  "groupsClaimName": "string",
+  "organizationClaimName": "string",
+  "organizationIdentifier": "string",
+  "adminRole": "string",
+  "subscriberRole": "string",
+  "superAdminRole": "string",
+  "orgConfiguration": {}
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|orgID|string|false|none|none|
+|orgName|string|false|none|none|
+|businessOwner|string¦null|false|none|none|
+|businessOwnerContact|string¦null|false|none|none|
+|businessOwnerEmail|string(email)¦null|false|none|none|
+|orgHandle|string|false|none|none|
+|roleClaimName|string|false|none|none|
+|groupsClaimName|string|false|none|none|
+|organizationClaimName|string|false|none|none|
+|organizationIdentifier|string|false|none|none|
+|adminRole|string|false|none|none|
+|subscriberRole|string|false|none|none|
+|superAdminRole|string¦null|false|none|none|
+|orgConfiguration|[GenericObject](#schemagenericobject)|false|none|none|
+
+<h2 id="tocS_IdentityProviderResponse">IdentityProviderResponse</h2>
+
+<a id="schemaidentityproviderresponse"></a>
+<a id="schema_IdentityProviderResponse"></a>
+<a id="tocSidentityproviderresponse"></a>
+<a id="tocsidentityproviderresponse"></a>
+
+```json
+{
+  "name": "string",
+  "issuer": "string",
+  "authorizationURL": "http://example.com",
+  "tokenURL": "http://example.com",
+  "clientId": "string",
+  "callbackURL": "http://example.com",
+  "scope": "string",
+  "logoutURL": "http://example.com",
+  "logoutRedirectURI": "http://example.com",
+  "userInfoURL": "http://example.com",
+  "signUpURL": "http://example.com",
+  "jwksURL": "http://example.com",
+  "certificate": "string"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|name|string|false|none|none|
+|issuer|string|false|none|none|
+|authorizationURL|string(uri)|false|none|none|
+|tokenURL|string(uri)|false|none|none|
+|clientId|string|false|none|none|
+|callbackURL|string(uri)|false|none|none|
+|scope|string¦null|false|none|none|
+|logoutURL|string(uri)|false|none|none|
+|logoutRedirectURI|string(uri)|false|none|none|
+|userInfoURL|string(uri)|false|none|none|
+|signUpURL|string(uri)|false|none|none|
+|jwksURL|string(uri)|false|none|none|
+|certificate|string|false|none|none|
+
+<h2 id="tocS_OrganizationContentUploadResponse">OrganizationContentUploadResponse</h2>
+
+<a id="schemaorganizationcontentuploadresponse"></a>
+<a id="schema_OrganizationContentUploadResponse"></a>
+<a id="tocSorganizationcontentuploadresponse"></a>
+<a id="tocsorganizationcontentuploadresponse"></a>
+
+```json
+{
+  "orgId": "string",
+  "fileName": "string"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|orgId|string|true|none|none|
+|fileName|string|true|none|Original ZIP file name uploaded in the `file` multipart field.|
+
+<h2 id="tocS_OrganizationContentListItemResponse">OrganizationContentListItemResponse</h2>
+
+<a id="schemaorganizationcontentlistitemresponse"></a>
+<a id="schema_OrganizationContentListItemResponse"></a>
+<a id="tocSorganizationcontentlistitemresponse"></a>
+<a id="tocsorganizationcontentlistitemresponse"></a>
+
+```json
+{
+  "orgId": "string",
+  "fileName": "string",
+  "fileContent": "string"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|orgId|string|false|none|none|
+|fileName|string|false|none|none|
+|fileContent|string¦null|false|none|UTF-8 content string returned for stored organization content records.|
+
+<h2 id="tocS_ProviderResponse">ProviderResponse</h2>
+
+<a id="schemaproviderresponse"></a>
+<a id="schema_ProviderResponse"></a>
+<a id="tocSproviderresponse"></a>
+<a id="tocsproviderresponse"></a>
+
+```json
+{
+  "orgId": "string",
+  "name": "string",
+  "providerURL": "http://example.com"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|orgId|string|true|none|none|
+|name|string|true|none|none|
+|providerURL|string(uri)|true|none|none|
+
+<h2 id="tocS_ProviderLookupItemResponse">ProviderLookupItemResponse</h2>
+
+<a id="schemaproviderlookupitemresponse"></a>
+<a id="schema_ProviderLookupItemResponse"></a>
+<a id="tocSproviderlookupitemresponse"></a>
+<a id="tocsproviderlookupitemresponse"></a>
+
+```json
+{
+  "name": "string",
+  "providerURL": "http://example.com"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|name|string|true|none|none|
+|providerURL|string(uri)|true|none|none|
+
+<h2 id="tocS_ApiMetadataCreateResponse">ApiMetadataCreateResponse</h2>
+
+<a id="schemaapimetadatacreateresponse"></a>
+<a id="schema_ApiMetadataCreateResponse"></a>
+<a id="tocSapimetadatacreateresponse"></a>
+<a id="tocsapimetadatacreateresponse"></a>
+
+```json
+{
+  "apiID": "string",
+  "apiReferenceID": "string",
+  "apiHandle": "string",
+  "provider": "string",
+  "dataSource": "string",
+  "apiInfo": {
+    "apiName": "string",
+    "apiTitle": "string",
+    "remotes": [
+      {}
+    ],
+    "apiVersion": "string",
+    "apiDescription": "string",
+    "apiType": "string",
+    "visibility": "string",
+    "agentVisibility": "string",
+    "gatewayVendor": "string",
+    "tokenBasedSubscriptionEnabled": true,
+    "gatewayType": "string",
+    "addedLabels": [
+      "string"
+    ],
+    "removedLabels": [
+      "string"
+    ],
+    "visibleGroups": [
+      "string"
+    ],
+    "owners": {
+      "technicalOwner": "string",
+      "businessOwner": "string",
+      "businessOwnerEmail": "string",
+      "technicalOwnerEmail": "string"
+    },
+    "apiImageMetadata": {
+      "property1": "string",
+      "property2": "string"
+    },
+    "tags": [
+      "string"
+    ],
+    "labels": [
+      "string"
+    ]
+  },
+  "endPoints": {
+    "sandboxURL": "string",
+    "productionURL": "string"
+  },
+  "monetizationInfo": {
+    "enabled": true
+  },
+  "subscriptionPolicies": [
+    {
+      "policyID": "string",
+      "policyName": "string",
+      "displayName": "string",
+      "billingPlan": "string",
+      "description": "string",
+      "requestCount": 0,
+      "orgID": "string",
+      "pricingModel": "string",
+      "currency": "string",
+      "billingPeriod": "string",
+      "flatAmount": 0,
+      "unitAmount": 0,
+      "pricingMetadata": {}
+    }
+  ]
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|apiID|string|false|none|none|
+|apiReferenceID|string|false|none|none|
+|apiHandle|string|false|none|none|
+|provider|string|false|none|none|
+|dataSource|string|false|none|none|
+|apiInfo|[ApiInfoResponse](#schemaapiinforesponse)|false|none|none|
+|endPoints|[ApiEndpointsResponse](#schemaapiendpointsresponse)|false|none|none|
+|monetizationInfo|[ApiMonetizationInfoResponse](#schemaapimonetizationinforesponse)|false|none|none|
+|subscriptionPolicies|[[SubscriptionPolicyResponse](#schemasubscriptionpolicyresponse)]|false|none|none|
+
+<h2 id="tocS_ApiMetadataResponse">ApiMetadataResponse</h2>
+
+<a id="schemaapimetadataresponse"></a>
+<a id="schema_ApiMetadataResponse"></a>
+<a id="tocSapimetadataresponse"></a>
+<a id="tocsapimetadataresponse"></a>
+
+```json
+{
+  "apiID": "string",
+  "apiReferenceID": "string",
+  "apiHandle": "string",
+  "provider": "string",
+  "dataSource": "string",
+  "policyID": "string",
+  "apiInfo": {
+    "apiName": "string",
+    "apiTitle": "string",
+    "remotes": [
+      {}
+    ],
+    "apiVersion": "string",
+    "apiDescription": "string",
+    "apiType": "string",
+    "visibility": "string",
+    "agentVisibility": "string",
+    "gatewayVendor": "string",
+    "tokenBasedSubscriptionEnabled": true,
+    "gatewayType": "string",
+    "addedLabels": [
+      "string"
+    ],
+    "removedLabels": [
+      "string"
+    ],
+    "visibleGroups": [
+      "string"
+    ],
+    "owners": {
+      "technicalOwner": "string",
+      "businessOwner": "string",
+      "businessOwnerEmail": "string",
+      "technicalOwnerEmail": "string"
+    },
+    "apiImageMetadata": {
+      "property1": "string",
+      "property2": "string"
+    },
+    "tags": [
+      "string"
+    ],
+    "labels": [
+      "string"
+    ]
+  },
+  "endPoints": {
+    "sandboxURL": "string",
+    "productionURL": "string"
+  },
+  "monetizationInfo": {
+    "enabled": true
+  },
+  "subscriptionPolicies": [
+    {
+      "policyID": "string",
+      "policyName": "string",
+      "displayName": "string",
+      "billingPlan": "string",
+      "description": "string",
+      "requestCount": 0,
+      "orgID": "string",
+      "pricingModel": "string",
+      "currency": "string",
+      "billingPeriod": "string",
+      "flatAmount": 0,
+      "unitAmount": 0,
+      "pricingMetadata": {}
+    }
+  ]
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|apiID|string|false|none|none|
+|apiReferenceID|string|false|none|none|
+|apiHandle|string|false|none|none|
+|provider|string|false|none|none|
+|dataSource|string|false|none|none|
+|policyID|string|false|none|none|
+|apiInfo|[ApiInfoResponse](#schemaapiinforesponse)|false|none|none|
+|endPoints|[ApiEndpointsResponse](#schemaapiendpointsresponse)|false|none|none|
+|monetizationInfo|[ApiMonetizationInfoResponse](#schemaapimonetizationinforesponse)|false|none|none|
+|subscriptionPolicies|[[SubscriptionPolicyResponse](#schemasubscriptionpolicyresponse)]|false|none|none|
+
+<h2 id="tocS_ApiInfoResponse">ApiInfoResponse</h2>
+
+<a id="schemaapiinforesponse"></a>
+<a id="schema_ApiInfoResponse"></a>
+<a id="tocSapiinforesponse"></a>
+<a id="tocsapiinforesponse"></a>
+
+```json
+{
+  "apiName": "string",
+  "apiTitle": "string",
+  "remotes": [
+    {}
+  ],
+  "apiVersion": "string",
+  "apiDescription": "string",
+  "apiType": "string",
+  "visibility": "string",
+  "agentVisibility": "string",
+  "gatewayVendor": "string",
+  "tokenBasedSubscriptionEnabled": true,
+  "gatewayType": "string",
+  "addedLabels": [
+    "string"
+  ],
+  "removedLabels": [
+    "string"
+  ],
+  "visibleGroups": [
+    "string"
+  ],
+  "owners": {
+    "technicalOwner": "string",
+    "businessOwner": "string",
+    "businessOwnerEmail": "string",
+    "technicalOwnerEmail": "string"
+  },
+  "apiImageMetadata": {
+    "property1": "string",
+    "property2": "string"
+  },
+  "tags": [
+    "string"
+  ],
+  "labels": [
+    "string"
+  ]
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|apiName|string|false|none|none|
+|apiTitle|string¦null|false|none|none|
+|remotes|[object]|false|none|none|
+|apiVersion|string|false|none|none|
+|apiDescription|string|false|none|none|
+|apiType|string|false|none|none|
+|visibility|string|false|none|none|
+|agentVisibility|string|false|none|none|
+|gatewayVendor|string|false|none|none|
+|tokenBasedSubscriptionEnabled|boolean|false|none|none|
+|gatewayType|string¦null|false|none|none|
+|addedLabels|[string]|false|none|none|
+|removedLabels|[string]|false|none|none|
+|visibleGroups|[string]|false|none|none|
+|owners|[ApiOwnersResponse](#schemaapiownersresponse)|false|none|none|
+|apiImageMetadata|[ApiImageMetadataResponse](#schemaapiimagemetadataresponse)|false|none|none|
+|tags|[string]|false|none|none|
+|labels|[string]|false|none|none|
+
+<h2 id="tocS_ApiOwnersResponse">ApiOwnersResponse</h2>
+
+<a id="schemaapiownersresponse"></a>
+<a id="schema_ApiOwnersResponse"></a>
+<a id="tocSapiownersresponse"></a>
+<a id="tocsapiownersresponse"></a>
+
+```json
+{
+  "technicalOwner": "string",
+  "businessOwner": "string",
+  "businessOwnerEmail": "string",
+  "technicalOwnerEmail": "string"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|technicalOwner|string|false|none|none|
+|businessOwner|string|false|none|none|
+|businessOwnerEmail|string|false|none|none|
+|technicalOwnerEmail|string|false|none|none|
+
+<h2 id="tocS_ApiEndpointsResponse">ApiEndpointsResponse</h2>
+
+<a id="schemaapiendpointsresponse"></a>
+<a id="schema_ApiEndpointsResponse"></a>
+<a id="tocSapiendpointsresponse"></a>
+<a id="tocsapiendpointsresponse"></a>
+
+```json
+{
+  "sandboxURL": "string",
+  "productionURL": "string"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|sandboxURL|string|false|none|none|
+|productionURL|string|false|none|none|
+
+<h2 id="tocS_ApiImageMetadataResponse">ApiImageMetadataResponse</h2>
+
+<a id="schemaapiimagemetadataresponse"></a>
+<a id="schema_ApiImageMetadataResponse"></a>
+<a id="tocSapiimagemetadataresponse"></a>
+<a id="tocsapiimagemetadataresponse"></a>
+
+```json
+{
+  "property1": "string",
+  "property2": "string"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|**additionalProperties**|string|false|none|none|
+
+<h2 id="tocS_ApiMonetizationInfoResponse">ApiMonetizationInfoResponse</h2>
+
+<a id="schemaapimonetizationinforesponse"></a>
+<a id="schema_ApiMonetizationInfoResponse"></a>
+<a id="tocSapimonetizationinforesponse"></a>
+<a id="tocsapimonetizationinforesponse"></a>
+
+```json
+{
+  "enabled": true
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|enabled|boolean|false|none|none|
+
+<h2 id="tocS_SubscriptionPolicyResponse">SubscriptionPolicyResponse</h2>
+
+<a id="schemasubscriptionpolicyresponse"></a>
+<a id="schema_SubscriptionPolicyResponse"></a>
+<a id="tocSsubscriptionpolicyresponse"></a>
+<a id="tocssubscriptionpolicyresponse"></a>
+
+```json
+{
+  "policyID": "string",
+  "policyName": "string",
+  "displayName": "string",
+  "billingPlan": "string",
+  "description": "string",
+  "requestCount": 0,
+  "orgID": "string",
+  "pricingModel": "string",
+  "currency": "string",
+  "billingPeriod": "string",
+  "flatAmount": 0,
+  "unitAmount": 0,
+  "pricingMetadata": {}
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|policyID|string|false|none|none|
+|policyName|string|false|none|none|
+|displayName|string|false|none|none|
+|billingPlan|string|false|none|none|
+|description|string|false|none|none|
+|requestCount|any|false|none|none|
+
+oneOf
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|integer|false|none|none|
+
+xor
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|string|false|none|none|
+
+continued
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|orgID|string|false|none|none|
+|pricingModel|string|false|none|none|
+|currency|string|false|none|none|
+|billingPeriod|string|false|none|none|
+|flatAmount|number|false|none|none|
+|unitAmount|number|false|none|none|
+|pricingMetadata|object|false|none|none|
+
+<h2 id="tocS_LabelResponse">LabelResponse</h2>
+
+<a id="schemalabelresponse"></a>
+<a id="schema_LabelResponse"></a>
+<a id="tocSlabelresponse"></a>
+<a id="tocslabelresponse"></a>
+
+```json
+{
+  "name": "premium",
+  "displayName": "Premium APIs"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|name|string|false|none|none|
+|displayName|string|false|none|none|
+
+<h2 id="tocS_ApplicationResponse">ApplicationResponse</h2>
+
+<a id="schemaapplicationresponse"></a>
+<a id="schema_ApplicationResponse"></a>
+<a id="tocSapplicationresponse"></a>
+<a id="tocsapplicationresponse"></a>
+
+```json
+{
+  "id": "app-12345",
+  "name": "Weather App",
+  "description": "Application used to call Weather APIs.",
+  "type": "WEB",
+  "appMap": [
+    {
+      "appRefID": "cp-app-98765",
+      "token": "OAUTH",
+      "shared": true
+    }
+  ]
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|id|string|false|none|none|
+|name|string|false|none|none|
+|description|string|false|none|none|
+|type|string|false|none|none|
+|appMap|[[ApplicationKeyMappingSummary](#schemaapplicationkeymappingsummary)]|false|none|none|
+
+<h2 id="tocS_ApplicationKeyMappingSummary">ApplicationKeyMappingSummary</h2>
+
+<a id="schemaapplicationkeymappingsummary"></a>
+<a id="schema_ApplicationKeyMappingSummary"></a>
+<a id="tocSapplicationkeymappingsummary"></a>
+<a id="tocsapplicationkeymappingsummary"></a>
+
+```json
+{
+  "appRefID": "cp-app-98765",
+  "token": "OAUTH",
+  "shared": true
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|appRefID|string|false|none|none|
+|token|string|false|none|none|
+|shared|boolean|false|none|none|
+
+<h2 id="tocS_ApplicationImportResponse">ApplicationImportResponse</h2>
+
+<a id="schemaapplicationimportresponse"></a>
+<a id="schema_ApplicationImportResponse"></a>
+<a id="tocSapplicationimportresponse"></a>
+<a id="tocsapplicationimportresponse"></a>
+
+```json
+{
+  "status": "Success",
+  "failedSubscriptions": [
+    {}
+  ]
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|status|string|true|none|none|
+|failedSubscriptions|[object]|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|status|Success|
+|status|Incomplete|
+
+<h2 id="tocS_ViewResponse">ViewResponse</h2>
+
+<a id="schemaviewresponse"></a>
+<a id="schema_ViewResponse"></a>
+<a id="tocSviewresponse"></a>
+<a id="tocsviewresponse"></a>
+
+```json
+{
+  "name": "partner-apis",
+  "displayName": "Partner APIs",
+  "labels": [
+    "partner",
+    "public"
+  ]
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|name|string|true|none|none|
+|displayName|string|true|none|none|
+|labels|[string]|true|none|none|
+
+<h2 id="tocS_OrganizationCreateRequest">OrganizationCreateRequest</h2>
+
+<a id="schemaorganizationcreaterequest"></a>
+<a id="schema_OrganizationCreateRequest"></a>
+<a id="tocSorganizationcreaterequest"></a>
+<a id="tocsorganizationcreaterequest"></a>
+
+```json
+{
+  "orgName": "string",
+  "businessOwner": "string",
+  "businessOwnerContact": "string",
+  "businessOwnerEmail": "user@example.com",
+  "orgHandle": "string",
+  "roleClaimName": "string",
+  "groupsClaimName": "string",
+  "organizationClaimName": "string",
+  "organizationIdentifier": "string",
+  "adminRole": "string",
+  "subscriberRole": "string",
+  "superAdminRole": "string"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|orgName|string|true|none|none|
+|businessOwner|string|false|none|none|
+|businessOwnerContact|string|false|none|none|
+|businessOwnerEmail|string(email)|false|none|none|
+|orgHandle|string|true|none|Public organization handle used in portal URLs.|
+|roleClaimName|string|true|none|none|
+|groupsClaimName|string|true|none|none|
+|organizationClaimName|string|true|none|none|
+|organizationIdentifier|string|true|none|none|
+|adminRole|string|true|none|none|
+|subscriberRole|string|true|none|none|
+|superAdminRole|string|true|none|none|
+
+<h2 id="tocS_OrganizationUpdateRequest">OrganizationUpdateRequest</h2>
+
+<a id="schemaorganizationupdaterequest"></a>
+<a id="schema_OrganizationUpdateRequest"></a>
+<a id="tocSorganizationupdaterequest"></a>
+<a id="tocsorganizationupdaterequest"></a>
+
+```json
+{
+  "orgName": "string",
+  "businessOwner": "string",
+  "businessOwnerContact": "string",
+  "businessOwnerEmail": "user@example.com",
+  "orgHandle": "string",
+  "roleClaimName": "string",
+  "groupsClaimName": "string",
+  "organizationClaimName": "string",
+  "organizationIdentifier": "string",
+  "adminRole": "string",
+  "subscriberRole": "string",
+  "superAdminRole": "string",
+  "orgConfiguration": {}
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|orgName|string|true|none|none|
+|businessOwner|string|false|none|none|
+|businessOwnerContact|string|false|none|none|
+|businessOwnerEmail|string(email)|false|none|none|
+|orgHandle|string|true|none|none|
+|roleClaimName|string|true|none|none|
+|groupsClaimName|string|true|none|none|
+|organizationClaimName|string|true|none|none|
+|organizationIdentifier|string|true|none|none|
+|adminRole|string|true|none|none|
+|subscriberRole|string|true|none|none|
+|superAdminRole|string|true|none|none|
+|orgConfiguration|[GenericObject](#schemagenericobject)|false|none|none|
+
+<h2 id="tocS_IdentityProviderRequest">IdentityProviderRequest</h2>
+
+<a id="schemaidentityproviderrequest"></a>
+<a id="schema_IdentityProviderRequest"></a>
+<a id="tocSidentityproviderrequest"></a>
+<a id="tocsidentityproviderrequest"></a>
+
+```json
+{
+  "issuer": "string",
+  "name": "string",
+  "authorizationURL": "http://example.com",
+  "tokenURL": "http://example.com",
+  "userInfoURL": "http://example.com",
+  "clientId": "string",
+  "callbackURL": "http://example.com",
+  "signUpURL": "http://example.com",
+  "logoutURL": "http://example.com",
+  "logoutRedirectURI": "http://example.com",
+  "scope": "string",
+  "jwksURL": "http://example.com",
+  "certificate": "string"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|issuer|string|true|none|none|
+|name|string|true|none|none|
+|authorizationURL|string(uri)|true|none|none|
+|tokenURL|string(uri)|true|none|none|
+|userInfoURL|string(uri)|false|none|none|
+|clientId|string|true|none|none|
+|callbackURL|string(uri)|true|none|none|
+|signUpURL|string(uri)|false|none|none|
+|logoutURL|string(uri)|true|none|none|
+|logoutRedirectURI|string(uri)|true|none|none|
+|scope|string|false|none|none|
+|jwksURL|string(uri)|false|none|none|
+|certificate|string|false|none|none|
+
+<h2 id="tocS_ProviderRequest">ProviderRequest</h2>
+
+<a id="schemaproviderrequest"></a>
+<a id="schema_ProviderRequest"></a>
+<a id="tocSproviderrequest"></a>
+<a id="tocsproviderrequest"></a>
+
+```json
+{
+  "name": "string",
+  "providerURL": "http://example.com"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|name|string|true|none|none|
+|providerURL|string(uri)|true|none|none|
+
+<h2 id="tocS_SubscriptionPolicyRequest">SubscriptionPolicyRequest</h2>
+
+<a id="schemasubscriptionpolicyrequest"></a>
+<a id="schema_SubscriptionPolicyRequest"></a>
+<a id="tocSsubscriptionpolicyrequest"></a>
+<a id="tocssubscriptionpolicyrequest"></a>
+
+```json
+{
+  "policyId": "string",
+  "policyID": "string",
+  "policyName": "string",
+  "displayName": "string",
+  "billingPlan": "FREE",
+  "description": "string",
+  "type": "requestcount",
+  "requestCount": 0,
+  "eventCount": 0,
+  "pricingModel": "FREE",
+  "currency": "USD",
+  "billingPeriod": "month",
+  "flatAmount": 0,
+  "unitAmount": 0,
+  "externalProductId": "string",
+  "externalPriceId": "string",
+  "tiers": [
+    {
+      "tierIndex": 0,
+      "startUnit": 0,
+      "endUnit": 0,
+      "unitPrice": 0,
+      "flatPrice": 0
+    }
+  ],
+  "pricingTiers": [
+    {
+      "tierIndex": 0,
+      "startUnit": 0,
+      "endUnit": 0,
+      "unitPrice": 0,
+      "flatPrice": 0
+    }
+  ],
+  "billingMeterData": [
+    {
+      "apiId": "string",
+      "meterId": "string"
+    }
+  ]
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|policyId|string|false|none|Optional external/APIM policy UUID.|
+|policyID|string|false|none|Alternative casing accepted by the DAO.|
+|policyName|string|true|none|none|
+|displayName|string|true|none|none|
+|billingPlan|string|false|none|none|
+|description|string|false|none|none|
+|type|string|true|none|Service accepts case-insensitive `requestcount` or `eventcount`.|
+|requestCount|any|false|none|Required for request-count policies. Use -1 for unlimited.|
+
+oneOf
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|integer|false|none|none|
+
+xor
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|string|false|none|none|
+
+continued
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|eventCount|any|false|none|Required for event-count policies. Use -1 for unlimited.|
+
+oneOf
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|integer|false|none|none|
+
+xor
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|string|false|none|none|
+
+continued
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|pricingModel|string|false|none|none|
+|currency|string|false|none|none|
+|billingPeriod|string|false|none|none|
+|flatAmount|number|false|none|none|
+|unitAmount|number|false|none|none|
+|externalProductId|string|false|none|none|
+|externalPriceId|string|false|none|none|
+|tiers|[[PricingTier](#schemapricingtier)]|false|none|none|
+|pricingTiers|[[PricingTier](#schemapricingtier)]|false|none|none|
+|billingMeterData|[object]|false|none|none|
+|» apiId|string|false|none|none|
+|» meterId|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|type|requestcount|
+|type|eventcount|
+|pricingModel|FREE|
+|pricingModel|FLAT|
+|pricingModel|PER_UNIT|
+|pricingModel|VOLUME_TIERS|
+|pricingModel|GRADUATED_TIERS|
+
+<h2 id="tocS_PricingTier">PricingTier</h2>
+
+<a id="schemapricingtier"></a>
+<a id="schema_PricingTier"></a>
+<a id="tocSpricingtier"></a>
+<a id="tocspricingtier"></a>
+
+```json
+{
+  "tierIndex": 0,
+  "startUnit": 0,
+  "endUnit": 0,
+  "unitPrice": 0,
+  "flatPrice": 0
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|tierIndex|integer|false|none|none|
+|startUnit|integer|false|none|none|
+|endUnit|integer¦null|false|none|none|
+|unitPrice|number¦null|false|none|none|
+|flatPrice|number¦null|false|none|none|
+
+<h2 id="tocS_LabelRequest">LabelRequest</h2>
+
+<a id="schemalabelrequest"></a>
+<a id="schema_LabelRequest"></a>
+<a id="tocSlabelrequest"></a>
+<a id="tocslabelrequest"></a>
+
+```json
+{
+  "name": "premium",
+  "displayName": "Premium APIs"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|name|string|true|none|none|
+|displayName|string|true|none|none|
+
+<h2 id="tocS_ApplicationRequest">ApplicationRequest</h2>
+
+<a id="schemaapplicationrequest"></a>
+<a id="schema_ApplicationRequest"></a>
+<a id="tocSapplicationrequest"></a>
+<a id="tocsapplicationrequest"></a>
+
+```json
+{
+  "name": "Weather App",
+  "description": "Application used to call Weather APIs.",
+  "type": "WEB"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|name|string|true|none|none|
+|description|string|true|none|none|
+|type|string|false|none|none|
+
+<h2 id="tocS_ResetThrottlePolicyRequest">ResetThrottlePolicyRequest</h2>
+
+<a id="schemaresetthrottlepolicyrequest"></a>
+<a id="schema_ResetThrottlePolicyRequest"></a>
+<a id="tocSresetthrottlepolicyrequest"></a>
+<a id="tocsresetthrottlepolicyrequest"></a>
+
+```json
+{
+  "userName": "alice@example.com"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|userName|string|true|none|User name whose application throttle policy should be reset in the control plane.|
+
+<h2 id="tocS_SubscriptionCreateRequest">SubscriptionCreateRequest</h2>
+
+<a id="schemasubscriptioncreaterequest"></a>
+<a id="schema_SubscriptionCreateRequest"></a>
+<a id="tocSsubscriptioncreaterequest"></a>
+<a id="tocssubscriptioncreaterequest"></a>
+
+```json
+{
+  "apiId": "api-7f4c2a6b",
+  "subscriptionPlanName": "Gold",
+  "applicationId": "cp-app-98765"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|apiId|string|true|none|Developer Portal API ID.|
+|subscriptionPlanName|string|false|none|Optional subscription plan name to use in the control plane.|
+|applicationId|string|false|none|Optional control-plane application ID.|
+
+<h2 id="tocS_SubscriptionUpdateRequest">SubscriptionUpdateRequest</h2>
+
+<a id="schemasubscriptionupdaterequest"></a>
+<a id="schema_SubscriptionUpdateRequest"></a>
+<a id="tocSsubscriptionupdaterequest"></a>
+<a id="tocssubscriptionupdaterequest"></a>
+
+```json
+{
+  "status": "ACTIVE"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|status|string|true|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|status|ACTIVE|
+|status|INACTIVE|
+
+<h2 id="tocS_SubscriptionResponse">SubscriptionResponse</h2>
+
+<a id="schemasubscriptionresponse"></a>
+<a id="schema_SubscriptionResponse"></a>
+<a id="tocSsubscriptionresponse"></a>
+<a id="tocssubscriptionresponse"></a>
+
+```json
+{
+  "subscriptionId": "sub-12345",
+  "id": "sub-12345",
+  "apiId": "cp-api-12345",
+  "apiName": "Weather API",
+  "applicationId": "cp-app-98765",
+  "applicationName": "Weather App",
+  "subscriptionPlanName": "Gold",
+  "status": "ACTIVE",
+  "createdTime": "2019-08-24T14:15:22Z",
+  "updatedTime": "2019-08-24T14:15:22Z"
+}
+
+```
+
+Subscription payload returned by the control plane.
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|subscriptionId|string|false|none|none|
+|id|string|false|none|Alternative subscription identifier used by some control-plane responses.|
+|apiId|string|false|none|Control-plane API reference ID.|
+|apiName|string|false|none|none|
+|applicationId|string|false|none|none|
+|applicationName|string|false|none|none|
+|subscriptionPlanName|string|false|none|none|
+|status|string|false|none|none|
+|createdTime|string(date-time)|false|none|none|
+|updatedTime|string(date-time)|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|status|ACTIVE|
+|status|INACTIVE|
+|status|ON_HOLD|
+|status|REJECTED|
+|status|TIER_UPDATE_PENDING|
+
+<h2 id="tocS_ApiKeyRequest">ApiKeyRequest</h2>
+
+<a id="schemaapikeyrequest"></a>
+<a id="schema_ApiKeyRequest"></a>
+<a id="tocSapikeyrequest"></a>
+<a id="tocsapikeyrequest"></a>
+
+```json
+{
+  "apiId": "api-7f4c2a6b",
+  "name": "weather_prod_key",
+  "subscriptionId": "sub-abc123",
+  "expiresAt": "2026-12-31T23:59:59Z"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|apiId|string|true|none|Developer Portal API ID.|
+|name|string|true|none|none|
+|subscriptionId|string|false|none|Optional subscription ID to associate the key with.|
+|expiresAt|any|false|none|Optional ISO-8601 datetime with timezone, epoch seconds, or epoch milliseconds.|
+
+oneOf
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|string(date-time)|false|none|none|
+
+xor
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|number|false|none|none|
+
+<h2 id="tocS_ApiKeyMetadataResponse">ApiKeyMetadataResponse</h2>
+
+<a id="schemaapikeymetadataresponse"></a>
+<a id="schema_ApiKeyMetadataResponse"></a>
+<a id="tocSapikeymetadataresponse"></a>
+<a id="tocsapikeymetadataresponse"></a>
+
+```json
+{
+  "keyId": "key-12345",
+  "name": "weather_prod_key",
+  "apiId": "api-7f4c2a6b",
+  "status": "ACTIVE",
+  "expiresAt": "2026-12-31T23:59:59Z",
+  "createdAt": "2019-08-24T14:15:22Z",
+  "revokedAt": "2019-08-24T14:15:22Z"
+}
+
+```
+
+API key metadata returned by list operations. Secret material is omitted.
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|keyId|string|false|none|Developer Portal key identifier.|
+|name|string|false|none|none|
+|apiId|string|false|none|Developer Portal API ID the key belongs to.|
+|status|string|false|none|none|
+|expiresAt|string(date-time)¦null|false|none|none|
+|createdAt|string(date-time)|false|none|none|
+|revokedAt|string(date-time)¦null|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|status|ACTIVE|
+|status|REVOKED|
+
+<h2 id="tocS_ApiKeyResponse">ApiKeyResponse</h2>
+
+<a id="schemaapikeyresponse"></a>
+<a id="schema_ApiKeyResponse"></a>
+<a id="tocSapikeyresponse"></a>
+<a id="tocsapikeyresponse"></a>
+
+```json
+{
+  "keyId": "key-12345",
+  "name": "weather_prod_key",
+  "apiId": "api-7f4c2a6b",
+  "status": "ACTIVE",
+  "expiresAt": "2026-12-31T23:59:59Z",
+  "createdAt": "2019-08-24T14:15:22Z",
+  "revokedAt": "2019-08-24T14:15:22Z",
+  "key": "ak_dGhpcyBpcyBub3QgYSByZWFsIGtleQ"
+}
+
+```
+
+### Properties
+
+allOf
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|*anonymous*|[ApiKeyMetadataResponse](#schemaapikeymetadataresponse)|false|none|API key metadata returned by list operations. Secret material is omitted.|
+
+and
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|*anonymous*|object|false|none|API key response returned by generate/regenerate. The plaintext secret is returned exactly once and never persisted — store it securely.|
+|» key|string|false|none|One-time plaintext API key secret.|
+
+<h2 id="tocS_SubscriptionRequest">SubscriptionRequest</h2>
+
+<a id="schemasubscriptionrequest"></a>
+<a id="schema_SubscriptionRequest"></a>
+<a id="tocSsubscriptionrequest"></a>
+<a id="tocssubscriptionrequest"></a>
+
+```json
+{
+  "applicationID": "app-12345",
+  "apiId": "api-7f4c2a6b",
+  "apiReferenceID": "cp-api-12345",
+  "policyId": "policy-gold",
+  "policyName": "Gold"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|applicationID|string|true|none|Developer Portal application ID.|
+|apiId|string|true|none|Developer Portal API ID.|
+|apiReferenceID|string|false|none|Control-plane API reference ID, used when a CP subscription is created or updated.|
+|policyId|string|true|none|Developer Portal subscription policy ID.|
+|policyName|string|false|none|Subscription policy name used as throttling policy in the control plane.|
+
+<h2 id="tocS_KeyManagerRequest">KeyManagerRequest</h2>
+
+<a id="schemakeymanagerrequest"></a>
+<a id="schema_KeyManagerRequest"></a>
+<a id="tocSkeymanagerrequest"></a>
+<a id="tocskeymanagerrequest"></a>
+
+```json
+{
+  "name": "Asgardeo",
+  "type": "ASGARDEO",
+  "enabled": true,
+  "tokenEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/token",
+  "clientRegistrationEndpoint": "https://api.asgardeo.io/t/myorg/api/identity/oauth2/dcr/v1.1/register",
+  "issuer": "https://api.asgardeo.io/t/myorg/oauth2/token",
+  "jwksURL": "https://api.asgardeo.io/t/myorg/oauth2/jwks",
+  "adminClientId": "<client-id>",
+  "adminClientSecret": "<client-secret>",
+  "supportedGrantTypes": [
+    "client_credentials",
+    "authorization_code",
+    "refresh_token"
+  ],
+  "supportedScopes": [
+    "openid",
+    "profile"
+  ],
+  "additionalProperties": {
+    "authorizeEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/authorize",
+    "revokeEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/revoke",
+    "logoutEndpoint": "https://api.asgardeo.io/t/myorg/oidc/logout"
+  }
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|name|string|true|none|Unique name within the organization.|
+|type|string|true|none|none|
+|enabled|boolean|false|none|none|
+|tokenEndpoint|string(uri)|true|none|OAuth2 token endpoint. Used to obtain admin tokens and proxy developer token requests.|
+|clientRegistrationEndpoint|string(uri)|true|none|DCR endpoint used to create, update, and delete OAuth clients on behalf of developers.|
+|issuer|string(uri)|false|none|Issuer identifier. Used as a string to validate the `iss` claim in tokens issued by this KM. For Asgardeo and WSO2 IS this is the same URL as `tokenEndpoint`.|
+|jwksURL|string(uri)|false|none|JWKS endpoint. Consumers and gateways fetch public keys from here to verify token signatures.|
+|adminClientId|string|true|none|Client ID of the admin application used for DCR operations. Stored encrypted.|
+|adminClientSecret|string|true|none|Client secret of the admin application. Stored encrypted; never returned in responses.|
+|supportedGrantTypes|[string]|false|none|none|
+|supportedScopes|[string]|false|none|none|
+|additionalProperties|object|false|none|AS-specific extra configuration. For Asgardeo: `authorizeEndpoint`, `revokeEndpoint`, `logoutEndpoint`. For Keycloak: `realm`, `revokeEndpoint`, `logoutEndpoint`.|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|type|ASGARDEO|
+|type|WSO2IS|
+|type|KEYCLOAK|
+|type|GENERIC_OIDC|
+
+<h2 id="tocS_KeyManagerUpdateRequest">KeyManagerUpdateRequest</h2>
+
+<a id="schemakeymanagerupdaterequest"></a>
+<a id="schema_KeyManagerUpdateRequest"></a>
+<a id="tocSkeymanagerupdaterequest"></a>
+<a id="tocskeymanagerupdaterequest"></a>
+
+```json
+{
+  "name": "Asgardeo",
+  "type": "ASGARDEO",
+  "enabled": true,
+  "tokenEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/token",
+  "clientRegistrationEndpoint": "https://api.asgardeo.io/t/myorg/api/identity/oauth2/dcr/v1.1/register",
+  "issuer": "https://api.asgardeo.io/t/myorg/oauth2/token",
+  "jwksURL": "https://api.asgardeo.io/t/myorg/oauth2/jwks",
+  "adminClientId": "<client-id>",
+  "adminClientSecret": "<client-secret>",
+  "supportedGrantTypes": [
+    "client_credentials",
+    "authorization_code",
+    "refresh_token"
+  ],
+  "supportedScopes": [
+    "openid",
+    "profile"
+  ],
+  "additionalProperties": {
+    "authorizeEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/authorize",
+    "revokeEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/revoke",
+    "logoutEndpoint": "https://api.asgardeo.io/t/myorg/oidc/logout"
+  }
+}
+
+```
+
+Partial update payload for a key manager. All fields are optional; only supplied fields are applied. Omitted fields retain their stored values.
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|name|string|false|none|Unique name within the organization.|
+|type|string|false|none|none|
+|enabled|boolean|false|none|none|
+|tokenEndpoint|string(uri)|false|none|OAuth2 token endpoint. Used to obtain admin tokens and proxy developer token requests.|
+|clientRegistrationEndpoint|string(uri)|false|none|DCR endpoint used to create, update, and delete OAuth clients on behalf of developers.|
+|issuer|string(uri)|false|none|Issuer identifier. Used as a string to validate the `iss` claim in tokens issued by this KM. For Asgardeo and WSO2 IS this is the same URL as `tokenEndpoint`.|
+|jwksURL|string(uri)|false|none|JWKS endpoint. Consumers and gateways fetch public keys from here to verify token signatures.|
+|adminClientId|string|false|none|Client ID of the admin application used for DCR operations. Stored encrypted.|
+|adminClientSecret|string|false|none|Client secret of the admin application. Stored encrypted; never returned in responses.|
+|supportedGrantTypes|[string]|false|none|none|
+|supportedScopes|[string]|false|none|none|
+|additionalProperties|object|false|none|AS-specific extra configuration. For Asgardeo: `authorizeEndpoint`, `revokeEndpoint`, `logoutEndpoint`. For Keycloak: `realm`, `revokeEndpoint`, `logoutEndpoint`.|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|type|ASGARDEO|
+|type|WSO2IS|
+|type|KEYCLOAK|
+|type|GENERIC_OIDC|
+
+<h2 id="tocS_KeyManagerResponseSchema">KeyManagerResponseSchema</h2>
+
+<a id="schemakeymanagerresponseschema"></a>
+<a id="schema_KeyManagerResponseSchema"></a>
+<a id="tocSkeymanagerresponseschema"></a>
+<a id="tocskeymanagerresponseschema"></a>
+
+```json
+{
+  "id": "km-uuid-12345",
+  "orgId": "org-12345",
+  "name": "Asgardeo",
+  "type": "ASGARDEO",
+  "enabled": true,
+  "tokenEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/token",
+  "clientRegistrationEndpoint": "https://api.asgardeo.io/t/myorg/api/identity/oauth2/dcr/v1.1/register",
+  "issuer": "https://api.asgardeo.io/t/myorg/oauth2/token",
+  "jwksURL": "https://api.asgardeo.io/t/myorg/oauth2/jwks",
+  "supportedGrantTypes": [
+    "client_credentials",
+    "authorization_code",
+    "refresh_token"
+  ],
+  "supportedScopes": [
+    "openid",
+    "profile"
+  ],
+  "additionalProperties": {
+    "authorizeEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/authorize",
+    "revokeEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/revoke",
+    "logoutEndpoint": "https://api.asgardeo.io/t/myorg/oidc/logout"
+  }
+}
+
+```
+
+Key manager configuration. Admin credentials are never included.
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|id|string|false|none|Key manager UUID.|
+|orgId|string|false|none|none|
+|name|string|false|none|none|
+|type|string|false|none|none|
+|enabled|boolean|false|none|none|
+|tokenEndpoint|string(uri)|false|none|none|
+|clientRegistrationEndpoint|string(uri)|false|none|none|
+|issuer|string(uri)¦null|false|none|none|
+|jwksURL|string(uri)¦null|false|none|none|
+|supportedGrantTypes|[string]|false|none|none|
+|supportedScopes|[string]|false|none|none|
+|additionalProperties|object|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|type|ASGARDEO|
+|type|WSO2IS|
+|type|KEYCLOAK|
+|type|GENERIC_OIDC|
+
+<h2 id="tocS_KeyManagerPublicResponseSchema">KeyManagerPublicResponseSchema</h2>
+
+<a id="schemakeymanagerpublicresponseschema"></a>
+<a id="schema_KeyManagerPublicResponseSchema"></a>
+<a id="tocSkeymanagerpublicresponseschema"></a>
+<a id="tocskeymanagerpublicresponseschema"></a>
+
+```json
+{
+  "id": "km-uuid-12345",
+  "name": "Asgardeo",
+  "type": "ASGARDEO",
+  "tokenEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/token",
+  "supportedGrantTypes": [
+    "client_credentials",
+    "authorization_code"
+  ],
+  "supportedScopes": [
+    "openid",
+    "profile"
+  ]
+}
+
+```
+
+Minimal developer-facing key manager view. No admin credentials or DCR endpoints.
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|id|string|false|none|none|
+|name|string|false|none|none|
+|type|string|false|none|none|
+|tokenEndpoint|string(uri)|false|none|none|
+|supportedGrantTypes|[string]|false|none|none|
+|supportedScopes|[string]|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|type|ASGARDEO|
+|type|WSO2IS|
+|type|KEYCLOAK|
+|type|GENERIC_OIDC|
+
+<h2 id="tocS_AppKeyMappingRequest">AppKeyMappingRequest</h2>
+
+<a id="schemaappkeymappingrequest"></a>
+<a id="schema_AppKeyMappingRequest"></a>
+<a id="tocSappkeymappingrequest"></a>
+<a id="tocsappkeymappingrequest"></a>
+
+```json
+{
+  "applicationName": "Weather App",
+  "apis": [
+    {
+      "apiName": "Weather API",
+      "apiRefId": "214te6382jjq9274eg332190",
+      "policyID": "24341d98-90f7-4530-95ef-0709609eea1a"
+    }
+  ],
+  "tokenType": "OAUTH",
+  "provider": "WSO2",
+  "clientID": "external-client-123",
+  "tokenDetails": {
+    "keyManager": "Resident Key Manager",
+    "keyType": "PRODUCTION",
+    "grantTypesToBeSupported": [
+      "client_credentials",
+      "refresh_token"
+    ],
+    "callbackUrl": "https://app.example.com/callback",
+    "additionalProperties": {
+      "application_access_token_expiry_time": "3600",
+      "user_access_token_expiry_time": "3600"
+    }
+  }
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|applicationName|string|true|none|none|
+|apis|[object]|false|none|Optional list of API identifiers. Existing service logic synchronizes subscribed APIs for the application.|
+|tokenType|string|false|none|none|
+|provider|string|false|none|none|
+|clientID|string|false|none|Existing consumer key used when mapping external keys.|
+|tokenDetails|object|true|none|none|
+|» keyManager|string|true|none|none|
+|» keyType|string|false|none|none|
+|» grantTypesToBeSupported|[string]|false|none|none|
+|» callbackUrl|string(uri)|false|none|none|
+|» additionalProperties|object|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|tokenType|API_KEY|
+|tokenType|OAUTH|
+|tokenType|BASIC|
+|keyType|PRODUCTION|
+|keyType|SANDBOX|
+
+<h2 id="tocS_AppKeyMappingCreateResponse">AppKeyMappingCreateResponse</h2>
+
+<a id="schemaappkeymappingcreateresponse"></a>
+<a id="schema_AppKeyMappingCreateResponse"></a>
+<a id="tocSappkeymappingcreateresponse"></a>
+<a id="tocsappkeymappingcreateresponse"></a>
+
+```json
+{
+  "keyMappingId": "km-12345",
+  "keyManager": "Resident Key Manager",
+  "keyType": "PRODUCTION",
+  "consumerKey": "consumer-key-123",
+  "consumerSecret": "consumer-secret-abc",
+  "supportedGrantTypes": [
+    "client_credentials",
+    "refresh_token"
+  ],
+  "tokenEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/token",
+  "appRefId": "cp-app-98765",
+  "subscriptionScopes": [
+    "weather.read",
+    "weather.write"
+  ]
+}
+
+```
+
+Control-plane OAuth key generation or mapped-key response. Exact fields can vary by key manager; the Developer Portal always adds `appRefId` and normalized `subscriptionScopes`.
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|keyMappingId|string|false|none|none|
+|keyManager|string|false|none|none|
+|keyType|string|false|none|none|
+|consumerKey|string|false|none|none|
+|consumerSecret|string|false|none|none|
+|supportedGrantTypes|[string]|false|none|none|
+|tokenEndpoint|string(uri)|false|none|Token endpoint of the key manager. Populated in decoupled mode.|
+|appRefId|string|false|none|Control-plane application reference ID.|
+|subscriptionScopes|[string]|false|none|Scope keys available through the application's subscriptions.|
+
+<h2 id="tocS_AppKeyMappingListResponse">AppKeyMappingListResponse</h2>
+
+<a id="schemaappkeymappinglistresponse"></a>
+<a id="schema_AppKeyMappingListResponse"></a>
+<a id="tocSappkeymappinglistresponse"></a>
+<a id="tocsappkeymappinglistresponse"></a>
+
+```json
+{
+  "APP_ID": "app-12345",
+  "ORG_ID": "org-12345",
+  "CREATED_BY": "user-12345",
+  "NAME": "Weather App",
+  "DESCRIPTION": "Application used to call Weather APIs.",
+  "TYPE": "WEB",
+  "DP_APP_KEY_MAPPINGs": [
+    {
+      "MAPPING_ID": "map-12345",
+      "APP_ID": "app-12345",
+      "ORG_ID": "org-12345",
+      "KM_ID": "3f6c1b2a-4d5e-4f7a-8b9c-0d1e2f3a4b5c",
+      "AS_CLIENT_ID": "asgardeo-client-abc123",
+      "KEY_TYPE": "PRODUCTION",
+      "ADDITIONAL_PROPERTIES": {
+        "client_name": "my-app",
+        "grant_types": [
+          "client_credentials"
+        ]
+      }
+    }
+  ]
+}
+
+```
+
+Application row with included key mapping rows as returned by Sequelize.
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|APP_ID|string|false|none|none|
+|ORG_ID|string|false|none|none|
+|CREATED_BY|string|false|none|none|
+|NAME|string|false|none|none|
+|DESCRIPTION|string|false|none|none|
+|TYPE|string|false|none|none|
+|DP_APP_KEY_MAPPINGs|[[AppKeyMappingRowResponse](#schemaappkeymappingrowresponse)]|false|none|none|
+
+<h2 id="tocS_AppKeyMappingRowResponse">AppKeyMappingRowResponse</h2>
+
+<a id="schemaappkeymappingrowresponse"></a>
+<a id="schema_AppKeyMappingRowResponse"></a>
+<a id="tocSappkeymappingrowresponse"></a>
+<a id="tocsappkeymappingrowresponse"></a>
+
+```json
+{
+  "MAPPING_ID": "map-12345",
+  "APP_ID": "app-12345",
+  "ORG_ID": "org-12345",
+  "KM_ID": "3f6c1b2a-4d5e-4f7a-8b9c-0d1e2f3a4b5c",
+  "AS_CLIENT_ID": "asgardeo-client-abc123",
+  "KEY_TYPE": "PRODUCTION",
+  "ADDITIONAL_PROPERTIES": {
+    "client_name": "my-app",
+    "grant_types": [
+      "client_credentials"
+    ]
+  }
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|MAPPING_ID|string|false|none|none|
+|APP_ID|string|false|none|none|
+|ORG_ID|string|false|none|none|
+|KM_ID|string(uuid)¦null|false|none|UUID of the key manager that issued credentials for this mapping.|
+|AS_CLIENT_ID|string¦null|false|none|Authorization Server client ID registered via DCR.|
+|KEY_TYPE|string|false|none|Key type for this mapping. Used to separate production and sandbox keys in the UI.|
+|ADDITIONAL_PROPERTIES|object¦null|false|none|AS-specific extra properties returned during DCR (e.g. token endpoint, grant types).|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|KEY_TYPE|PRODUCTION|
+|KEY_TYPE|SANDBOX|
+
+<h2 id="tocS_ViewCreateRequest">ViewCreateRequest</h2>
+
+<a id="schemaviewcreaterequest"></a>
+<a id="schema_ViewCreateRequest"></a>
+<a id="tocSviewcreaterequest"></a>
+<a id="tocsviewcreaterequest"></a>
+
+```json
+{
+  "name": "partner-apis",
+  "displayName": "Partner APIs",
+  "labels": [
+    "partner",
+    "public"
+  ]
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|name|string|true|none|none|
+|displayName|string|false|none|Optional display name. Defaults to `name` when omitted.|
+|labels|[string]|true|none|Label names to attach to the view.|
+
+<h2 id="tocS_ViewUpdateRequest">ViewUpdateRequest</h2>
+
+<a id="schemaviewupdaterequest"></a>
+<a id="schema_ViewUpdateRequest"></a>
+<a id="tocSviewupdaterequest"></a>
+<a id="tocsviewupdaterequest"></a>
+
+```json
+{
+  "displayName": "Partner and Public APIs",
+  "addedLabels": [
+    "premium"
+  ],
+  "removedLabels": [
+    "internal"
+  ]
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|displayName|string|false|none|none|
+|addedLabels|[string]|false|none|Label names to attach to the view.|
+|removedLabels|[string]|false|none|Label names to detach from the view.|
+
+<h2 id="tocS_ApiKeyGenerateRequest">ApiKeyGenerateRequest</h2>
+
+<a id="schemaapikeygeneraterequest"></a>
+<a id="schema_ApiKeyGenerateRequest"></a>
+<a id="tocSapikeygeneraterequest"></a>
+<a id="tocsapikeygeneraterequest"></a>
+
+```json
+{
+  "apiId": "cp-api-12345",
+  "applicationId": "cp-app-98765",
+  "devportalAppId": "app-12345",
+  "projectID": "project-12345",
+  "keyType": "PRODUCTION",
+  "name": "weather-prod-key",
+  "subscriptionPlan": "string"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|apiId|string|true|none|Control-plane API reference ID.|
+|applicationId|string|false|none|Existing control-plane application ID, if one already exists.|
+|devportalAppId|string|true|none|Developer Portal application ID.|
+|projectID|string|true|none|Project ID used to resolve environment templates.|
+|keyType|string|true|none|none|
+|name|string|false|none|Optional API key name. When omitted, the service generates a name from API handle, application reference, and key type.|
+|subscriptionPlan|any|false|none|Subscription plan or policy details forwarded when a control-plane subscription must be created.|
+
+oneOf
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|string|false|none|none|
+
+xor
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[GenericObject](#schemagenericobject)|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|keyType|PRODUCTION|
+|keyType|SANDBOX|
+
+<h2 id="tocS_ApplicationKeysGenerateRequest">ApplicationKeysGenerateRequest</h2>
+
+<a id="schemaapplicationkeysgeneraterequest"></a>
+<a id="schema_ApplicationKeysGenerateRequest"></a>
+<a id="tocSapplicationkeysgeneraterequest"></a>
+<a id="tocsapplicationkeysgeneraterequest"></a>
+
+```json
+{
+  "keyType": "PRODUCTION",
+  "keyManager": "Resident Key Manager",
+  "grantTypesToBeSupported": [
+    "client_credentials",
+    "refresh_token"
+  ],
+  "callbackUrl": "https://app.example.com/callback",
+  "additionalProperties": {}
+}
+
+```
+
+OAuth key generation payload accepted by the control-plane application key endpoint.
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|keyType|string|false|none|none|
+|keyManager|string|false|none|none|
+|grantTypesToBeSupported|[string]|false|none|none|
+|callbackUrl|string(uri)|false|none|none|
+|additionalProperties|object|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|keyType|PRODUCTION|
+|keyType|SANDBOX|
+
+<h2 id="tocS_OAuthGenerateTokenRequest">OAuthGenerateTokenRequest</h2>
+
+<a id="schemaoauthgeneratetokenrequest"></a>
+<a id="schema_OAuthGenerateTokenRequest"></a>
+<a id="tocSoauthgeneratetokenrequest"></a>
+<a id="tocsoauthgeneratetokenrequest"></a>
+
+```json
+{
+  "consumerSecret": "my-consumer-secret",
+  "scopes": [
+    "weather.read"
+  ],
+  "validityPeriod": 3600
+}
+
+```
+
+OAuth access token generation payload. In decoupled mode `consumerSecret` is required — the portal uses it to call the AS token endpoint directly. In control-plane mode the body is proxied as-is.
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|consumerSecret|string|false|none|Client secret for the OAuth application. Required in decoupled (non-control-plane) mode. Not stored by the portal — the caller must supply it on each token generation request.|
+|scopes|[string]|false|none|none|
+|validityPeriod|integer|false|none|none|
+
+<h2 id="tocS_OAuthKeyUpdateRequest">OAuthKeyUpdateRequest</h2>
+
+<a id="schemaoauthkeyupdaterequest"></a>
+<a id="schema_OAuthKeyUpdateRequest"></a>
+<a id="tocSoauthkeyupdaterequest"></a>
+<a id="tocsoauthkeyupdaterequest"></a>
+
+```json
+{
+  "supportedGrantTypes": [
+    "client_credentials",
+    "refresh_token"
+  ],
+  "callbackUrl": "https://app.example.com/new-callback",
+  "additionalProperties": {}
+}
+
+```
+
+OAuth key update payload accepted by the control plane.
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|supportedGrantTypes|[string]|false|none|none|
+|callbackUrl|string(uri)|false|none|none|
+|additionalProperties|object|false|none|none|
+
+<h2 id="tocS_OAuthKeyCleanUpRequest">OAuthKeyCleanUpRequest</h2>
+
+<a id="schemaoauthkeycleanuprequest"></a>
+<a id="schema_OAuthKeyCleanUpRequest"></a>
+<a id="tocSoauthkeycleanuprequest"></a>
+<a id="tocsoauthkeycleanuprequest"></a>
+
+```json
+{
+  "keyType": "PRODUCTION",
+  "keyManager": "Resident Key Manager"
+}
+
+```
+
+OAuth cleanup payload accepted by the control plane.
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|keyType|string|false|none|none|
+|keyManager|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|keyType|PRODUCTION|
+|keyType|SANDBOX|
+
+<h2 id="tocS_ApplicationApiKeyResponse">ApplicationApiKeyResponse</h2>
+
+<a id="schemaapplicationapikeyresponse"></a>
+<a id="schema_ApplicationApiKeyResponse"></a>
+<a id="tocSapplicationapikeyresponse"></a>
+<a id="tocsapplicationapikeyresponse"></a>
+
+```json
+{
+  "id": "api-key-12345",
+  "apiKeyId": "api-key-12345",
+  "name": "weather-prod-key",
+  "keyType": "PRODUCTION",
+  "apiId": "cp-api-12345",
+  "applicationId": "cp-app-98765",
+  "apiKey": "generated-api-key-value",
+  "token": "generated-api-key-value",
+  "appRefId": "cp-app-98765"
+}
+
+```
+
+API key payload returned by the control plane. The Developer Portal adds `appRefId` for generation responses.
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|id|string|false|none|none|
+|apiKeyId|string|false|none|none|
+|name|string|false|none|none|
+|keyType|string|false|none|none|
+|apiId|string|false|none|none|
+|applicationId|string|false|none|none|
+|apiKey|string|false|none|Generated API key secret.|
+|token|string|false|none|Alternative generated key field used by some control-plane responses.|
+|appRefId|string|false|none|Control-plane application reference ID added by Developer Portal generation flow.|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|keyType|PRODUCTION|
+|keyType|SANDBOX|
+
+<h2 id="tocS_ApplicationOAuthKeyResponse">ApplicationOAuthKeyResponse</h2>
+
+<a id="schemaapplicationoauthkeyresponse"></a>
+<a id="schema_ApplicationOAuthKeyResponse"></a>
+<a id="tocSapplicationoauthkeyresponse"></a>
+<a id="tocsapplicationoauthkeyresponse"></a>
+
+```json
+{
+  "keyMappingId": "km-12345",
+  "keyManager": "Resident Key Manager",
+  "keyType": "PRODUCTION",
+  "consumerKey": "consumer-key-123",
+  "consumerSecret": "consumer-secret-abc",
+  "supportedGrantTypes": [
+    "client_credentials",
+    "refresh_token"
+  ],
+  "callbackUrl": "https://app.example.com/callback"
+}
+
+```
+
+OAuth key payload returned by the control plane.
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|keyMappingId|string|false|none|none|
+|keyManager|string|false|none|none|
+|keyType|string|false|none|none|
+|consumerKey|string|false|none|none|
+|consumerSecret|string|false|none|none|
+|supportedGrantTypes|[string]|false|none|none|
+|callbackUrl|string(uri)|false|none|none|
+
+<h2 id="tocS_OAuthTokenResponse">OAuthTokenResponse</h2>
+
+<a id="schemaoauthtokenresponse"></a>
+<a id="schema_OAuthTokenResponse"></a>
+<a id="tocSoauthtokenresponse"></a>
+<a id="tocsoauthtokenresponse"></a>
+
+```json
+{
+  "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.example",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "scope": "weather.read"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|access_token|string|false|none|none|
+|token_type|string|false|none|none|
+|expires_in|integer|false|none|none|
+|scope|string|false|none|none|
+
+<h2 id="tocS_BillingEngineKeysRequest">BillingEngineKeysRequest</h2>
+
+<a id="schemabillingenginekeysrequest"></a>
+<a id="schema_BillingEngineKeysRequest"></a>
+<a id="tocSbillingenginekeysrequest"></a>
+<a id="tocsbillingenginekeysrequest"></a>
+
+```json
+{
+  "billingEngine": "STRIPE",
+  "secretKey": "sk_test_123",
+  "publishableKey": "pk_test_123",
+  "webhookSecret": "whsec_123"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|billingEngine|string|true|none|none|
+|secretKey|string|true|none|Billing engine secret key. Stored encrypted and never returned in clear text.|
+|publishableKey|string|true|none|none|
+|webhookSecret|string|true|none|none|
+
+<h2 id="tocS_BillingEngineDeleteRequest">BillingEngineDeleteRequest</h2>
+
+<a id="schemabillingenginedeleterequest"></a>
+<a id="schema_BillingEngineDeleteRequest"></a>
+<a id="tocSbillingenginedeleterequest"></a>
+<a id="tocsbillingenginedeleterequest"></a>
+
+```json
+{
+  "billingEngine": "STRIPE"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|billingEngine|string|false|none|none|
+
+<h2 id="tocS_BillingEngineKeysResponse">BillingEngineKeysResponse</h2>
+
+<a id="schemabillingenginekeysresponse"></a>
+<a id="schema_BillingEngineKeysResponse"></a>
+<a id="tocSbillingenginekeysresponse"></a>
+<a id="tocsbillingenginekeysresponse"></a>
+
+```json
+{
+  "billingEngine": "STRIPE",
+  "secretKey": "****",
+  "publishableKey": "****",
+  "webhookSecret": "****"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|billingEngine|string|true|none|none|
+|secretKey|string¦null|false|none|Masked secret key marker when configured.|
+|publishableKey|string¦null|false|none|Masked publishable key marker when configured.|
+|webhookSecret|string¦null|false|none|Masked webhook secret marker when configured.|
+
+<h2 id="tocS_CheckoutSessionRequest">CheckoutSessionRequest</h2>
+
+<a id="schemacheckoutsessionrequest"></a>
+<a id="schema_CheckoutSessionRequest"></a>
+<a id="tocScheckoutsessionrequest"></a>
+<a id="tocscheckoutsessionrequest"></a>
+
+```json
+{
+  "applicationID": "app-12345",
+  "apiId": "api-7f4c2a6b",
+  "apiReferenceID": "cp-api-12345",
+  "policyId": "policy-pro",
+  "policyName": "Pro",
+  "sourcePage": "/devportal/apis/weather-api-v1"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|applicationID|string|true|none|Developer Portal application ID.|
+|apiId|string|true|none|Developer Portal API ID.|
+|apiReferenceID|string|true|none|Control-plane API reference ID.|
+|policyId|string|true|none|Developer Portal subscription policy ID.|
+|policyName|string|true|none|Subscription policy name.|
+|sourcePage|string|false|none|Portal page to return to after checkout.|
+
+<h2 id="tocS_BillingUsageDataResponse">BillingUsageDataResponse</h2>
+
+<a id="schemabillingusagedataresponse"></a>
+<a id="schema_BillingUsageDataResponse"></a>
+<a id="tocSbillingusagedataresponse"></a>
+<a id="tocsbillingusagedataresponse"></a>
+
+```json
+{
+  "totalRequests": 12450,
+  "activeSubscriptions": 2,
+  "estimatedCost": 29.99,
+  "currency": "USD",
+  "avgResponseTime": 142,
+  "subscriptions": [
+    {
+      "apiName": "Weather API",
+      "applicationName": "Weather App",
+      "planName": "Pro",
+      "requests": 12000,
+      "pricingModel": "METERED",
+      "cost": 24.99,
+      "currency": "USD",
+      "avgResponseTime": 145
+    }
+  ]
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|totalRequests|integer|false|none|none|
+|activeSubscriptions|integer|false|none|none|
+|estimatedCost|number|false|none|none|
+|currency|string|false|none|none|
+|avgResponseTime|integer|false|none|Average response time in milliseconds.|
+|subscriptions|[[BillingUsageSubscription](#schemabillingusagesubscription)]|false|none|none|
+
+<h2 id="tocS_BillingUsageSubscription">BillingUsageSubscription</h2>
+
+<a id="schemabillingusagesubscription"></a>
+<a id="schema_BillingUsageSubscription"></a>
+<a id="tocSbillingusagesubscription"></a>
+<a id="tocsbillingusagesubscription"></a>
+
+```json
+{
+  "apiName": "Weather API",
+  "applicationName": "Weather App",
+  "planName": "Pro",
+  "requests": 12000,
+  "pricingModel": "METERED",
+  "cost": 24.99,
+  "currency": "USD",
+  "avgResponseTime": 145
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|apiName|string|false|none|none|
+|applicationName|string|false|none|none|
+|planName|string|false|none|none|
+|requests|integer|false|none|none|
+|pricingModel|string|false|none|none|
+|cost|number|false|none|none|
+|currency|string|false|none|none|
+|avgResponseTime|integer|false|none|none|
+
+<h2 id="tocS_PaymentMethodsResponse">PaymentMethodsResponse</h2>
+
+<a id="schemapaymentmethodsresponse"></a>
+<a id="schema_PaymentMethodsResponse"></a>
+<a id="tocSpaymentmethodsresponse"></a>
+<a id="tocspaymentmethodsresponse"></a>
+
+```json
+{
+  "paymentMethods": [
+    {
+      "id": "pm_12345",
+      "brand": "visa",
+      "last4": "4242",
+      "expMonth": 12,
+      "expYear": 2030,
+      "isDefault": true
+    }
+  ]
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|paymentMethods|[[PaymentMethodResponse](#schemapaymentmethodresponse)]|false|none|none|
+
+<h2 id="tocS_PaymentMethodResponse">PaymentMethodResponse</h2>
+
+<a id="schemapaymentmethodresponse"></a>
+<a id="schema_PaymentMethodResponse"></a>
+<a id="tocSpaymentmethodresponse"></a>
+<a id="tocspaymentmethodresponse"></a>
+
+```json
+{
+  "id": "pm_12345",
+  "brand": "visa",
+  "last4": "4242",
+  "expMonth": 12,
+  "expYear": 2030,
+  "isDefault": true
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|id|string|false|none|none|
+|brand|string|false|none|none|
+|last4|string|false|none|none|
+|expMonth|integer|false|none|none|
+|expYear|integer|false|none|none|
+|isDefault|boolean|false|none|none|
+
+<h2 id="tocS_BillingInfoResponse">BillingInfoResponse</h2>
+
+<a id="schemabillinginforesponse"></a>
+<a id="schema_BillingInfoResponse"></a>
+<a id="tocSbillinginforesponse"></a>
+<a id="tocsbillinginforesponse"></a>
+
+```json
+{
+  "organizationName": "Acme Inc",
+  "email": "dev@example.com",
+  "address": {},
+  "taxId": "123456789"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|organizationName|string|false|none|none|
+|email|string(email)|false|none|none|
+|address|object¦null|false|none|none|
+|taxId|string¦null|false|none|none|
+
+<h2 id="tocS_BillingSubscriptionsResponse">BillingSubscriptionsResponse</h2>
+
+<a id="schemabillingsubscriptionsresponse"></a>
+<a id="schema_BillingSubscriptionsResponse"></a>
+<a id="tocSbillingsubscriptionsresponse"></a>
+<a id="tocsbillingsubscriptionsresponse"></a>
+
+```json
+{
+  "subscriptions": [
+    {
+      "id": "sub-12345",
+      "apiName": "Weather API",
+      "applicationName": "Weather App",
+      "planName": "Pro",
+      "billingCycle": "Month",
+      "amount": 2999,
+      "currency": "usd",
+      "nextBillingDate": 1775088000000,
+      "status": "active"
+    }
+  ]
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|subscriptions|[[BillingSubscriptionResponse](#schemabillingsubscriptionresponse)]|false|none|none|
+
+<h2 id="tocS_BillingSubscriptionResponse">BillingSubscriptionResponse</h2>
+
+<a id="schemabillingsubscriptionresponse"></a>
+<a id="schema_BillingSubscriptionResponse"></a>
+<a id="tocSbillingsubscriptionresponse"></a>
+<a id="tocsbillingsubscriptionresponse"></a>
+
+```json
+{
+  "id": "sub-12345",
+  "apiName": "Weather API",
+  "applicationName": "Weather App",
+  "planName": "Pro",
+  "billingCycle": "Month",
+  "amount": 2999,
+  "currency": "usd",
+  "nextBillingDate": 1775088000000,
+  "status": "active"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|id|string|false|none|none|
+|apiName|string|false|none|none|
+|applicationName|string|false|none|none|
+|planName|string|false|none|none|
+|billingCycle|string|false|none|none|
+|amount|number|false|none|Amount in the smallest Stripe currency unit when sourced from Stripe.|
+|currency|string|false|none|none|
+|nextBillingDate|integer¦null|false|none|Next billing timestamp in milliseconds since epoch.|
+|status|string|false|none|none|
+
+<h2 id="tocS_CheckoutSessionResponse">CheckoutSessionResponse</h2>
+
+<a id="schemacheckoutsessionresponse"></a>
+<a id="schema_CheckoutSessionResponse"></a>
+<a id="tocScheckoutsessionresponse"></a>
+<a id="tocscheckoutsessionresponse"></a>
+
+```json
+{
+  "subId": "sub-12345",
+  "checkoutSessionId": "cs_test_12345",
+  "clientSecret": "cs_test_12345_secret_abc",
+  "publishableKey": "pk_test_123",
+  "billingCustomerId": "cus_12345",
+  "paymentProvider": "STRIPE",
+  "paymentStatus": "PENDING"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|subId|string|false|none|none|
+|checkoutSessionId|string|false|none|none|
+|clientSecret|string|false|none|none|
+|publishableKey|string|false|none|none|
+|billingCustomerId|string|false|none|none|
+|paymentProvider|string|false|none|none|
+|paymentStatus|string|false|none|none|
+
+<h2 id="tocS_CheckoutRegistrationResponse">CheckoutRegistrationResponse</h2>
+
+<a id="schemacheckoutregistrationresponse"></a>
+<a id="schema_CheckoutRegistrationResponse"></a>
+<a id="tocScheckoutregistrationresponse"></a>
+<a id="tocscheckoutregistrationresponse"></a>
+
+```json
+{
+  "subId": "sub-12345",
+  "billingCustomerId": "cus_12345",
+  "billingSubscriptionId": "sub_stripe_12345",
+  "paymentStatus": "ACTIVE",
+  "paymentProvider": "STRIPE"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|subId|string|false|none|none|
+|billingCustomerId|string|false|none|none|
+|billingSubscriptionId|string|false|none|none|
+|paymentStatus|string|false|none|none|
+|paymentProvider|string|false|none|none|
+
+<h2 id="tocS_BillingCancelResponse">BillingCancelResponse</h2>
+
+<a id="schemabillingcancelresponse"></a>
+<a id="schema_BillingCancelResponse"></a>
+<a id="tocSbillingcancelresponse"></a>
+<a id="tocsbillingcancelresponse"></a>
+
+```json
+{
+  "subId": "sub-12345",
+  "paymentStatus": "CANCELED"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|subId|string|false|none|none|
+|paymentStatus|string|false|none|none|
+
+<h2 id="tocS_SubscriptionBillingStatusResponse">SubscriptionBillingStatusResponse</h2>
+
+<a id="schemasubscriptionbillingstatusresponse"></a>
+<a id="schema_SubscriptionBillingStatusResponse"></a>
+<a id="tocSsubscriptionbillingstatusresponse"></a>
+<a id="tocssubscriptionbillingstatusresponse"></a>
+
+```json
+{
+  "subId": "sub-12345",
+  "paymentProvider": "STRIPE",
+  "paymentStatus": "ACTIVE",
+  "billingCustomerId": "cus_12345",
+  "billingSubscriptionId": "sub_stripe_12345"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|subId|string|false|none|none|
+|paymentProvider|string¦null|false|none|none|
+|paymentStatus|string¦null|false|none|none|
+|billingCustomerId|string¦null|false|none|none|
+|billingSubscriptionId|string¦null|false|none|none|
+
+<h2 id="tocS_BillingPortalResponse">BillingPortalResponse</h2>
+
+<a id="schemabillingportalresponse"></a>
+<a id="schema_BillingPortalResponse"></a>
+<a id="tocSbillingportalresponse"></a>
+<a id="tocsbillingportalresponse"></a>
+
+```json
+{
+  "url": "https://billing.stripe.com/p/session/test_123"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|url|string(uri)|false|none|none|
+
+<h2 id="tocS_ControllerErrorResponse">ControllerErrorResponse</h2>
+
+<a id="schemacontrollererrorresponse"></a>
+<a id="schema_ControllerErrorResponse"></a>
+<a id="tocScontrollererrorresponse"></a>
+<a id="tocscontrollererrorresponse"></a>
+
+```json
+{
+  "error": "InternalServerError",
+  "message": "An unexpected error occurred",
+  "description": "string"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|error|string|false|none|none|
+|message|string|false|none|none|
+|description|string|false|none|none|
+
+<h2 id="tocS_SubscriptionUsageResponse">SubscriptionUsageResponse</h2>
+
+<a id="schemasubscriptionusageresponse"></a>
+<a id="schema_SubscriptionUsageResponse"></a>
+<a id="tocSsubscriptionusageresponse"></a>
+<a id="tocssubscriptionusageresponse"></a>
+
+```json
+{
+  "subscriptionId": "cp-sub-12345",
+  "from": "2019-08-24T14:15:22Z",
+  "to": "2019-08-24T14:15:22Z",
+  "total_requests": 12000,
+  "usage": 12000,
+  "avg_response_time": 145,
+  "currency": "USD"
+}
+
+```
+
+Usage response returned by the monetization service or Moesif proxy.
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|subscriptionId|string|false|none|none|
+|from|string(date-time)|false|none|none|
+|to|string(date-time)|false|none|none|
+|total_requests|integer|false|none|none|
+|usage|integer|false|none|none|
+|avg_response_time|number|false|none|none|
+|currency|string|false|none|none|
+
+<h2 id="tocS_InvoiceListResponse">InvoiceListResponse</h2>
+
+<a id="schemainvoicelistresponse"></a>
+<a id="schema_InvoiceListResponse"></a>
+<a id="tocSinvoicelistresponse"></a>
+<a id="tocsinvoicelistresponse"></a>
+
+```json
+{
+  "invoices": [
+    {
+      "id": "in_12345",
+      "number": "INV-001",
+      "created": 1775088000,
+      "amount": 2999,
+      "currency": "usd",
+      "status": "paid",
+      "hostedInvoiceUrl": "http://example.com",
+      "invoicePdf": "http://example.com"
+    }
+  ]
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|invoices|[[InvoiceSummaryResponse](#schemainvoicesummaryresponse)]|false|none|none|
+
+<h2 id="tocS_InvoiceSummaryResponse">InvoiceSummaryResponse</h2>
+
+<a id="schemainvoicesummaryresponse"></a>
+<a id="schema_InvoiceSummaryResponse"></a>
+<a id="tocSinvoicesummaryresponse"></a>
+<a id="tocsinvoicesummaryresponse"></a>
+
+```json
+{
+  "id": "in_12345",
+  "number": "INV-001",
+  "created": 1775088000,
+  "amount": 2999,
+  "currency": "usd",
+  "status": "paid",
+  "hostedInvoiceUrl": "http://example.com",
+  "invoicePdf": "http://example.com"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|id|string|false|none|none|
+|number|string¦null|false|none|none|
+|created|integer|false|none|Stripe-created timestamp in seconds.|
+|amount|number|false|none|none|
+|currency|string|false|none|none|
+|status|string|false|none|none|
+|hostedInvoiceUrl|string(uri)¦null|false|none|none|
+|invoicePdf|string(uri)¦null|false|none|none|
+
+<h2 id="tocS_StripeInvoiceListResponse">StripeInvoiceListResponse</h2>
+
+<a id="schemastripeinvoicelistresponse"></a>
+<a id="schema_StripeInvoiceListResponse"></a>
+<a id="tocSstripeinvoicelistresponse"></a>
+<a id="tocsstripeinvoicelistresponse"></a>
+
+```json
+{
+  "object": "list",
+  "data": [
+    {
+      "id": "in_12345",
+      "object": "invoice",
+      "status": "paid",
+      "customer": "string",
+      "subscription": "sub_stripe_12345",
+      "hosted_invoice_url": "http://example.com",
+      "invoice_pdf": "http://example.com"
+    }
+  ],
+  "has_more": false,
+  "url": "string"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|object|string|false|none|none|
+|data|[[StripeInvoiceResponse](#schemastripeinvoiceresponse)]|false|none|none|
+|has_more|boolean|false|none|none|
+|url|string|false|none|none|
+
+<h2 id="tocS_StripeInvoiceResponse">StripeInvoiceResponse</h2>
+
+<a id="schemastripeinvoiceresponse"></a>
+<a id="schema_StripeInvoiceResponse"></a>
+<a id="tocSstripeinvoiceresponse"></a>
+<a id="tocsstripeinvoiceresponse"></a>
+
+```json
+{
+  "id": "in_12345",
+  "object": "invoice",
+  "status": "paid",
+  "customer": "string",
+  "subscription": "sub_stripe_12345",
+  "hosted_invoice_url": "http://example.com",
+  "invoice_pdf": "http://example.com"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|id|string|false|none|none|
+|object|string|false|none|none|
+|status|string|false|none|none|
+|customer|any|false|none|none|
+
+oneOf
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|string|false|none|none|
+
+xor
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|object|false|none|none|
+
+continued
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|subscription|string¦null|false|none|none|
+|hosted_invoice_url|string(uri)¦null|false|none|none|
+|invoice_pdf|string(uri)¦null|false|none|none|
+
+<h2 id="tocS_InvoicePdfLinkResponse">InvoicePdfLinkResponse</h2>
+
+<a id="schemainvoicepdflinkresponse"></a>
+<a id="schema_InvoicePdfLinkResponse"></a>
+<a id="tocSinvoicepdflinkresponse"></a>
+<a id="tocsinvoicepdflinkresponse"></a>
+
+```json
+{
+  "invoiceId": "in_12345",
+  "hosted_invoice_url": "http://example.com",
+  "invoice_pdf": "http://example.com"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|invoiceId|string|false|none|none|
+|hosted_invoice_url|string(uri)¦null|false|none|none|
+|invoice_pdf|string(uri)|false|none|none|
+
+<h2 id="tocS_InvoicePdfNotAvailableResponse">InvoicePdfNotAvailableResponse</h2>
+
+<a id="schemainvoicepdfnotavailableresponse"></a>
+<a id="schema_InvoicePdfNotAvailableResponse"></a>
+<a id="tocSinvoicepdfnotavailableresponse"></a>
+<a id="tocsinvoicepdfnotavailableresponse"></a>
+
+```json
+{
+  "error": "InvoicePdfNotAvailable",
+  "message": "string",
+  "hosted_invoice_url": "http://example.com"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|error|string|false|none|none|
+|message|string|false|none|none|
+|hosted_invoice_url|string(uri)¦null|false|none|none|
+
+<h2 id="tocS_APIFlowCreateResponse">APIFlowCreateResponse</h2>
+
+<a id="schemaapiflowcreateresponse"></a>
+<a id="schema_APIFlowCreateResponse"></a>
+<a id="tocSapiflowcreateresponse"></a>
+<a id="tocsapiflowcreateresponse"></a>
+
+```json
+{
+  "apiFlowId": "flow-12345",
+  "name": "Weather onboarding",
+  "status": "PUBLISHED"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|apiFlowId|string|false|none|none|
+|name|string|false|none|none|
+|status|string|false|none|none|
+
+<h2 id="tocS_APIFlowResponse">APIFlowResponse</h2>
+
+<a id="schemaapiflowresponse"></a>
+<a id="schema_APIFlowResponse"></a>
+<a id="tocSapiflowresponse"></a>
+<a id="tocsapiflowresponse"></a>
+
+```json
+{
+  "apiFlowId": "flow-12345",
+  "name": "Weather onboarding",
+  "handle": "weather-onboarding",
+  "description": "string",
+  "agentPrompt": "string",
+  "status": "PUBLISHED",
+  "visibility": "PUBLIC",
+  "agentVisibility": "VISIBLE",
+  "contentType": "ARAZZO",
+  "apiFlowDefinition": "string",
+  "markdownContent": "string",
+  "createdAt": "May 7, 2026",
+  "updatedAt": "string"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|apiFlowId|string|false|none|none|
+|name|string|false|none|none|
+|handle|string|false|none|none|
+|description|string|false|none|none|
+|agentPrompt|string|false|none|none|
+|status|string|false|none|none|
+|visibility|string|false|none|none|
+|agentVisibility|string|false|none|none|
+|contentType|string|false|none|none|
+|apiFlowDefinition|string¦null|false|none|none|
+|markdownContent|string¦null|false|none|none|
+|createdAt|string|false|none|none|
+|updatedAt|string¦null|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|contentType|ARAZZO|
+|contentType|MD|
+
+<h2 id="tocS_APIFlowPromptResponse">APIFlowPromptResponse</h2>
+
+<a id="schemaapiflowpromptresponse"></a>
+<a id="schema_APIFlowPromptResponse"></a>
+<a id="tocSapiflowpromptresponse"></a>
+<a id="tocsapiflowpromptresponse"></a>
+
+```json
+{
+  "agentPrompt": "string"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|agentPrompt|string|false|none|none|
+
+<h2 id="tocS_TempArazzoFileResponse">TempArazzoFileResponse</h2>
+
+<a id="schematemparazzofileresponse"></a>
+<a id="schema_TempArazzoFileResponse"></a>
+<a id="tocStemparazzofileresponse"></a>
+<a id="tocstemparazzofileresponse"></a>
+
+```json
+{
+  "path": "/tmp/arazzo-abc123/workflow.arazzo.yaml"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|path|string|false|none|none|
+
+<h2 id="tocS_APIFlowCreateRequest">APIFlowCreateRequest</h2>
+
+<a id="schemaapiflowcreaterequest"></a>
+<a id="schema_APIFlowCreateRequest"></a>
+<a id="tocSapiflowcreaterequest"></a>
+<a id="tocsapiflowcreaterequest"></a>
+
+```json
+{
+  "name": "Weather onboarding",
+  "handle": "weather-onboarding",
+  "description": "Guides users through the Weather API onboarding workflow.",
+  "agentPrompt": "Follow this workflow to onboard a Weather API user.",
+  "status": "PUBLISHED",
+  "visibility": "PUBLIC",
+  "agentVisibility": "VISIBLE",
+  "contentType": "ARAZZO",
+  "apiFlowDefinition": {},
+  "markdownContent": "string"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|name|string|true|none|none|
+|handle|string|false|none|none|
+|description|string|true|none|none|
+|agentPrompt|string|false|none|none|
+|status|string|false|none|none|
+|visibility|string|false|none|none|
+|agentVisibility|string|false|none|none|
+|contentType|string|false|none|none|
+|apiFlowDefinition|any|false|none|JSON/YAML Arazzo content when `contentType` is `ARAZZO`.|
+
+oneOf
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|object|false|none|none|
+
+xor
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|string|false|none|none|
+
+continued
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|markdownContent|string|false|none|Markdown content when `contentType` is `MD`.|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|contentType|ARAZZO|
+|contentType|MD|
+
+<h2 id="tocS_APIFlowUpdateRequest">APIFlowUpdateRequest</h2>
+
+<a id="schemaapiflowupdaterequest"></a>
+<a id="schema_APIFlowUpdateRequest"></a>
+<a id="tocSapiflowupdaterequest"></a>
+<a id="tocsapiflowupdaterequest"></a>
+
+```json
+{
+  "name": "Weather onboarding v2",
+  "handle": "weather-onboarding-v2",
+  "description": "Updated Weather API onboarding workflow.",
+  "agentPrompt": "string",
+  "status": "PUBLISHED",
+  "visibility": "PUBLIC",
+  "agentVisibility": "VISIBLE",
+  "contentType": "ARAZZO",
+  "apiFlowDefinition": {},
+  "markdownContent": "string"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|name|string|false|none|none|
+|handle|string|false|none|none|
+|description|string|false|none|none|
+|agentPrompt|string|false|none|none|
+|status|string|false|none|none|
+|visibility|string|false|none|none|
+|agentVisibility|string|false|none|none|
+|contentType|string|false|none|none|
+|apiFlowDefinition|any|false|none|none|
+
+oneOf
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|object|false|none|none|
+
+xor
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|string|false|none|none|
+
+continued
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|markdownContent|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|contentType|ARAZZO|
+|contentType|MD|
+
+<h2 id="tocS_APIFlowPromptRequest">APIFlowPromptRequest</h2>
+
+<a id="schemaapiflowpromptrequest"></a>
+<a id="schema_APIFlowPromptRequest"></a>
+<a id="tocSapiflowpromptrequest"></a>
+<a id="tocsapiflowpromptrequest"></a>
+
+```json
+{
+  "name": "Weather onboarding",
+  "description": "Guides users through the Weather API onboarding workflow.",
+  "apis": [
+    {}
+  ],
+  "orgHandle": "acme",
+  "viewName": "default",
+  "handle": "weather-onboarding"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|name|string|true|none|none|
+|description|string|true|none|none|
+|apis|[object]|false|none|none|
+|orgHandle|string|false|none|none|
+|viewName|string|false|none|none|
+|handle|string|false|none|none|
+
+<h2 id="tocS_LoginRequest">LoginRequest</h2>
+
+<a id="schemaloginrequest"></a>
+<a id="schema_LoginRequest"></a>
+<a id="tocSloginrequest"></a>
+<a id="tocsloginrequest"></a>
+
+```json
+{
+  "username": "string",
+  "password": "pa$$word"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|username|string|true|none|none|
+|password|string(password)|true|none|none|
+
+<h2 id="tocS_TempArazzoFileRequest">TempArazzoFileRequest</h2>
+
+<a id="schematemparazzofilerequest"></a>
+<a id="schema_TempArazzoFileRequest"></a>
+<a id="tocStemparazzofilerequest"></a>
+<a id="tocstemparazzofilerequest"></a>
+
+```json
+{
+  "content": "arazzo: 1.0.1\ninfo:\n  title: Weather onboarding\n  version: 1.0.0\nworkflows: []\n",
+  "filename": "workflow.arazzo.yaml"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|content|string|true|none|Arazzo YAML content to write to a temporary file.|
+|filename|string|false|none|none|
+
+<h2 id="tocS_WebhookEventDelivery">WebhookEventDelivery</h2>
+
+<a id="schemawebhookeventdelivery"></a>
+<a id="schema_WebhookEventDelivery"></a>
+<a id="tocSwebhookeventdelivery"></a>
+<a id="tocswebhookeventdelivery"></a>
+
+```json
+{
+  "deliveryId": "del-abc123",
+  "subscriberId": "sub-xyz789",
+  "targetUrl": "https://example.com/webhook",
+  "status": "DELIVERED",
+  "attemptCount": 1,
+  "lastHttpStatus": 200,
+  "lastError": "string",
+  "lastAttemptAt": "2019-08-24T14:15:22Z",
+  "deliveredAt": "2019-08-24T14:15:22Z"
+}
+
+```
+
+A single webhook delivery attempt.
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|deliveryId|string|false|none|none|
+|subscriberId|string|false|none|none|
+|targetUrl|string¦null|false|none|none|
+|status|string|false|none|none|
+|attemptCount|integer|false|none|none|
+|lastHttpStatus|integer¦null|false|none|none|
+|lastError|string¦null|false|none|none|
+|lastAttemptAt|string(date-time)¦null|false|none|none|
+|deliveredAt|string(date-time)¦null|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|status|PENDING|
+|status|IN_FLIGHT|
+|status|DELIVERED|
+|status|FAILED|
+|status|DEAD_LETTERED|
+
+<h2 id="tocS_WebhookEvent">WebhookEvent</h2>
+
+<a id="schemawebhookevent"></a>
+<a id="schema_WebhookEvent"></a>
+<a id="tocSwebhookevent"></a>
+<a id="tocswebhookevent"></a>
+
+```json
+{
+  "eventId": "evt-abc123",
+  "eventType": "apikey.generated",
+  "orgId": "org-default",
+  "gatewayType": "default",
+  "aggregateType": "apikey",
+  "aggregateId": "key-12345",
+  "status": "ALL_DELIVERED",
+  "occurredAt": "2019-08-24T14:15:22Z",
+  "deliveries": [
+    {
+      "deliveryId": "del-abc123",
+      "subscriberId": "sub-xyz789",
+      "targetUrl": "https://example.com/webhook",
+      "status": "DELIVERED",
+      "attemptCount": 1,
+      "lastHttpStatus": 200,
+      "lastError": "string",
+      "lastAttemptAt": "2019-08-24T14:15:22Z",
+      "deliveredAt": "2019-08-24T14:15:22Z"
+    }
+  ]
+}
+
+```
+
+A webhook event with its delivery rows.
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|eventId|string|false|none|none|
+|eventType|string|false|none|none|
+|orgId|string|false|none|none|
+|gatewayType|string¦null|false|none|none|
+|aggregateType|string|false|none|none|
+|aggregateId|string|false|none|none|
+|status|string|false|none|none|
+|occurredAt|string(date-time)|false|none|none|
+|deliveries|[[WebhookEventDelivery](#schemawebhookeventdelivery)]|false|none|[A single webhook delivery attempt.]|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|status|PENDING|
+|status|DISPATCHED|
+|status|ALL_DELIVERED|
+|status|FAILED|

--- a/docs/rest-apis/devportal/subscription-policies.md
+++ b/docs/rest-apis/devportal/subscription-policies.md
@@ -1,0 +1,598 @@
+<h1 id="wso2-api-developer-portal-core-devportal-routes-subscription-policies">Subscription Policies</h1>
+
+## Create subscription policies
+
+<a id="opIdaddSubscriptionPolicies"></a>
+
+`POST /organizations/{orgId}/subscription-policies`
+
+> Code samples
+
+```shell
+
+curl -X POST http://localhost:3000/devportal/organizations/{orgId}/subscription-policies \
+  -u {username}:{password} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Creates one subscription policy when the request body is an object, or multiple subscription policies when the body is an array. Bulk creation returns a message instead of creating policies when `generateDefaultSubPolicies` is enabled.
+
+> Payload
+
+```json
+{
+  "policyId": "string",
+  "policyID": "string",
+  "policyName": "string",
+  "displayName": "string",
+  "billingPlan": "FREE",
+  "description": "string",
+  "type": "requestcount",
+  "requestCount": 0,
+  "eventCount": 0,
+  "pricingModel": "FREE",
+  "currency": "USD",
+  "billingPeriod": "month",
+  "flatAmount": 0,
+  "unitAmount": 0,
+  "externalProductId": "string",
+  "externalPriceId": "string",
+  "tiers": [
+    {
+      "tierIndex": 0,
+      "startUnit": 0,
+      "endUnit": 0,
+      "unitPrice": 0,
+      "flatPrice": 0
+    }
+  ],
+  "pricingTiers": [
+    {
+      "tierIndex": 0,
+      "startUnit": 0,
+      "endUnit": 0,
+      "unitPrice": 0,
+      "flatPrice": 0
+    }
+  ],
+  "billingMeterData": [
+    {
+      "apiId": "string",
+      "meterId": "string"
+    }
+  ]
+}
+```
+
+```yaml
+policyId: string
+policyID: string
+policyName: string
+displayName: string
+billingPlan: FREE
+description: string
+type: requestcount
+requestCount: 0
+eventCount: 0
+pricingModel: FREE
+currency: USD
+billingPeriod: month
+flatAmount: 0
+unitAmount: 0
+externalProductId: string
+externalPriceId: string
+tiers:
+  - tierIndex: 0
+    startUnit: 0
+    endUnit: 0
+    unitPrice: 0
+    flatPrice: 0
+pricingTiers:
+  - tierIndex: 0
+    startUnit: 0
+    endUnit: 0
+    unitPrice: 0
+    flatPrice: 0
+billingMeterData:
+  - apiId: string
+    meterId: string
+
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="create-subscription-policies-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|any|true|Subscription policy payload. Send a single object for single create/upsert, or a non-empty array for bulk create/upsert. The service currently processes policies with `type` set to `requestcount` or `eventcount`. Alternatively, upload a YAML file in the `subscriptionPolicy` multipart field; use `kind: SubscriptionPolicy` for a single policy or `kind: SubscriptionPolicyList` with an `items` array for bulk operations.|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "message": "string"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 409 Response
+
+```json
+{
+  "code": "409",
+  "message": "Conflict",
+  "description": "Organization already exists"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="create-subscription-policies-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|JSON message response.|[MessageResponse](schemas.md#schemamessageresponse)|
+|201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Subscription policy create/update response for single or bulk operations.|Inline|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Duplicate organization data conflicts with an existing record.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="create-subscription-policies-responseschema">Response Schema</h3>
+
+## Upsert subscription policies
+
+<a id="opIdputSubscriptionPolicies"></a>
+
+`PUT /organizations/{orgId}/subscription-policies`
+
+> Code samples
+
+```shell
+
+curl -X PUT http://localhost:3000/devportal/organizations/{orgId}/subscription-policies \
+  -u {username}:{password} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Upserts one subscription policy when the request body is an object, or multiple policies when the body is an array. A single policy update returns `200` when an existing policy is updated and `201` when a new policy is created. Bulk updates return a message when `generateDefaultSubPolicies` is enabled.
+
+> Payload
+
+```json
+{
+  "policyId": "string",
+  "policyID": "string",
+  "policyName": "string",
+  "displayName": "string",
+  "billingPlan": "FREE",
+  "description": "string",
+  "type": "requestcount",
+  "requestCount": 0,
+  "eventCount": 0,
+  "pricingModel": "FREE",
+  "currency": "USD",
+  "billingPeriod": "month",
+  "flatAmount": 0,
+  "unitAmount": 0,
+  "externalProductId": "string",
+  "externalPriceId": "string",
+  "tiers": [
+    {
+      "tierIndex": 0,
+      "startUnit": 0,
+      "endUnit": 0,
+      "unitPrice": 0,
+      "flatPrice": 0
+    }
+  ],
+  "pricingTiers": [
+    {
+      "tierIndex": 0,
+      "startUnit": 0,
+      "endUnit": 0,
+      "unitPrice": 0,
+      "flatPrice": 0
+    }
+  ],
+  "billingMeterData": [
+    {
+      "apiId": "string",
+      "meterId": "string"
+    }
+  ]
+}
+```
+
+```yaml
+policyId: string
+policyID: string
+policyName: string
+displayName: string
+billingPlan: FREE
+description: string
+type: requestcount
+requestCount: 0
+eventCount: 0
+pricingModel: FREE
+currency: USD
+billingPeriod: month
+flatAmount: 0
+unitAmount: 0
+externalProductId: string
+externalPriceId: string
+tiers:
+  - tierIndex: 0
+    startUnit: 0
+    endUnit: 0
+    unitPrice: 0
+    flatPrice: 0
+pricingTiers:
+  - tierIndex: 0
+    startUnit: 0
+    endUnit: 0
+    unitPrice: 0
+    flatPrice: 0
+billingMeterData:
+  - apiId: string
+    meterId: string
+
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="upsert-subscription-policies-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|any|true|Subscription policy payload. Send a single object for single create/upsert, or a non-empty array for bulk create/upsert. The service currently processes policies with `type` set to `requestcount` or `eventcount`. Alternatively, upload a YAML file in the `subscriptionPolicy` multipart field; use `kind: SubscriptionPolicy` for a single policy or `kind: SubscriptionPolicyList` with an `items` array for bulk operations.|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "policyID": "string",
+  "policyName": "string",
+  "displayName": "string",
+  "billingPlan": "string",
+  "description": "string",
+  "requestCount": 0,
+  "orgID": "string",
+  "pricingModel": "string",
+  "currency": "string",
+  "billingPeriod": "string",
+  "flatAmount": 0,
+  "unitAmount": 0,
+  "pricingMetadata": {}
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 409 Response
+
+```json
+{
+  "code": "409",
+  "message": "Conflict",
+  "description": "Organization already exists"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="upsert-subscription-policies-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Subscription policy update response. Bulk updates may return a list, and some configurations return a message.|Inline|
+|201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Subscription policy create/update response for single or bulk operations.|Inline|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Duplicate organization data conflicts with an existing record.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="upsert-subscription-policies-responseschema">Response Schema</h3>
+
+## Get a subscription policy
+
+<a id="opIdgetSubscriptionPolicy"></a>
+
+`GET /organizations/{orgId}/subscription-policies/{policyIdOrName}`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId}/subscription-policies/{policyIdOrName} \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Uses the route value as `policyID`.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="get-a-subscription-policy-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+|policyIdOrName|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "policyID": "string",
+  "policyName": "string",
+  "displayName": "string",
+  "billingPlan": "string",
+  "description": "string",
+  "requestCount": 0,
+  "orgID": "string",
+  "pricingModel": "string",
+  "currency": "string",
+  "billingPeriod": "string",
+  "flatAmount": 0,
+  "unitAmount": 0,
+  "pricingMetadata": {}
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="get-a-subscription-policy-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Subscription policy DTO.|[SubscriptionPolicyResponse](schemas.md#schemasubscriptionpolicyresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="get-a-subscription-policy-responseschema">Response Schema</h3>
+
+## Delete a subscription policy
+
+<a id="opIddeleteSubscriptionPolicy"></a>
+
+`DELETE /organizations/{orgId}/subscription-policies/{policyIdOrName}`
+
+> Code samples
+
+```shell
+
+curl -X DELETE http://localhost:3000/devportal/organizations/{orgId}/subscription-policies/{policyIdOrName} \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Uses the route value as `policyName`.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="delete-a-subscription-policy-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+|policyIdOrName|path|string|true|none|
+
+> Example responses
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="delete-a-subscription-policy-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Subscription policy deleted successfully.|None|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="delete-a-subscription-policy-responseschema">Response Schema</h3>

--- a/docs/rest-apis/devportal/subscriptions.md
+++ b/docs/rest-apis/devportal/subscriptions.md
@@ -1,0 +1,502 @@
+<h1 id="wso2-api-developer-portal-core-devportal-routes-subscriptions">Subscriptions</h1>
+
+## Create a subscription
+
+<a id="opIdcreateSubscription"></a>
+
+`POST /organizations/{orgId}/subscriptions`
+
+> Code samples
+
+```shell
+
+curl -X POST http://localhost:3000/devportal/organizations/{orgId}/subscriptions \
+  -u {username}:{password} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Creates a token-based subscription for an API. The Developer Portal API ID is resolved to the control-plane API reference before the subscription is created. The API must exist, have token-based subscriptions enabled, and contain a control-plane reference ID.
+
+> Payload
+
+```json
+{
+  "apiId": "api-7f4c2a6b"
+}
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="create-a-subscription-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[SubscriptionCreateRequest](schemas.md#schemasubscriptioncreaterequest)|true|Subscription creation payload. `apiId` is the Developer Portal API ID; the service resolves it to the control-plane API reference before forwarding the request.|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 201 Response
+
+```json
+{
+  "subscriptionId": "sub-12345",
+  "apiId": "cp-api-12345",
+  "apiName": "Weather API",
+  "applicationId": "cp-app-98765",
+  "subscriptionPlanName": "Gold",
+  "status": "ACTIVE",
+  "createdTime": "2026-05-07T08:30:00Z"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="create-a-subscription-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Subscription DTO returned by the control plane.|[SubscriptionResponse](schemas.md#schemasubscriptionresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="create-a-subscription-responseschema">Response Schema</h3>
+
+## List subscriptions
+
+<a id="opIdlistSubscriptions"></a>
+
+`GET /organizations/{orgId}/subscriptions`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId}/subscriptions \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Lists subscriptions from the control plane. When `apiId` is provided, the Developer Portal API ID is validated locally and translated to the control-plane API reference.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="list-subscriptions-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|apiId|query|string|false|Optional Developer Portal API ID used to filter by the resolved control-plane API reference.|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "count": 1,
+  "list": [
+    {
+      "subscriptionId": "sub-12345",
+      "apiId": "cp-api-12345",
+      "apiName": "Weather API",
+      "applicationId": "cp-app-98765",
+      "subscriptionPlanName": "Gold",
+      "status": "ACTIVE"
+    }
+  ]
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="list-subscriptions-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|List of subscription DTOs returned by the control plane.|Inline|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="list-subscriptions-responseschema">Response Schema</h3>
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|status|ACTIVE|
+|status|INACTIVE|
+|status|ON_HOLD|
+|status|REJECTED|
+|status|TIER_UPDATE_PENDING|
+
+## Get a subscription
+
+<a id="opIdgetSubscription"></a>
+
+`GET /organizations/{orgId}/subscriptions/{subscriptionId}`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId}/subscriptions/{subscriptionId} \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Retrieves a single subscription from the control plane by subscription ID.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="get-a-subscription-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+|subscriptionId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "subscriptionId": "sub-12345",
+  "apiId": "cp-api-12345",
+  "apiName": "Weather API",
+  "applicationId": "cp-app-98765",
+  "subscriptionPlanName": "Gold",
+  "status": "ACTIVE",
+  "createdTime": "2026-05-07T08:30:00Z"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="get-a-subscription-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Subscription DTO returned by the control plane.|[SubscriptionResponse](schemas.md#schemasubscriptionresponse)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+## Update a subscription
+
+<a id="opIdupdateSubscription"></a>
+
+`PUT /organizations/{orgId}/subscriptions/{subscriptionId}`
+
+> Code samples
+
+```shell
+
+curl -X PUT http://localhost:3000/devportal/organizations/{orgId}/subscriptions/{subscriptionId} \
+  -u {username}:{password} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Updates the subscription status in the control plane. The service accepts only `ACTIVE` or `INACTIVE`.
+
+> Payload
+
+```json
+{
+  "status": "ACTIVE"
+}
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="update-a-subscription-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[SubscriptionUpdateRequest](schemas.md#schemasubscriptionupdaterequest)|true|Subscription status update payload.|
+|orgId|path|string|true|none|
+|subscriptionId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "subscriptionId": "sub-12345",
+  "apiId": "cp-api-12345",
+  "apiName": "Weather API",
+  "applicationId": "cp-app-98765",
+  "subscriptionPlanName": "Gold",
+  "status": "ACTIVE",
+  "createdTime": "2026-05-07T08:30:00Z"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="update-a-subscription-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Subscription DTO returned by the control plane.|[SubscriptionResponse](schemas.md#schemasubscriptionresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="update-a-subscription-responseschema">Response Schema</h3>
+
+## Delete a subscription
+
+<a id="opIddeleteSubscription"></a>
+
+`DELETE /organizations/{orgId}/subscriptions/{subscriptionId}`
+
+> Code samples
+
+```shell
+
+curl -X DELETE http://localhost:3000/devportal/organizations/{orgId}/subscriptions/{subscriptionId} \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Deletes the subscription in the control plane and returns a success message from the Developer Portal.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="delete-a-subscription-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+|subscriptionId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "message": "string"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="delete-a-subscription-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|JSON message response.|[MessageResponse](schemas.md#schemamessageresponse)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|

--- a/docs/rest-apis/devportal/usage.md
+++ b/docs/rest-apis/devportal/usage.md
@@ -1,0 +1,97 @@
+<h1 id="wso2-api-developer-portal-core-devportal-routes-usage">Usage</h1>
+
+## Get subscription usage
+
+<a id="opIdgetSubscriptionUsage"></a>
+
+`GET /organizations/{orgId}/subscriptions/{subId}/usage`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId}/subscriptions/{subId}/usage \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Returns usage metrics for a subscription over a date range. When `usageFrom` or `usageTo` are not supplied, the service defaults to the last 30 days ending at the current time.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="get-subscription-usage-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|usageFrom|query|string(date-time)|false|Usage start timestamp. Defaults to 30 days before the request time.|
+|usageTo|query|string(date-time)|false|Usage end timestamp. Defaults to the request time.|
+|orgId|path|string|true|none|
+|subId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "subscriptionId": "cp-sub-12345",
+  "from": "2026-04-07T00:00:00Z",
+  "to": "2026-05-07T00:00:00Z",
+  "total_requests": 12000,
+  "avg_response_time": 145,
+  "currency": "USD"
+}
+```
+
+> 400 Response
+
+```json
+{
+  "error": "CustomError",
+  "message": "Invalid usageFrom date"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "error": "CustomError",
+  "message": "Invalid usageFrom date"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "error": "CustomError",
+  "message": "Invalid usageFrom date"
+}
+```
+
+> 502 Response
+
+```json
+{
+  "error": "CustomError",
+  "message": "Invalid usageFrom date"
+}
+```
+
+<h3 id="get-subscription-usage-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Usage metrics for a subscription.|[SubscriptionUsageResponse](schemas.md#schemasubscriptionusageresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Usage lookup error.|[ControllerErrorResponse](schemas.md#schemacontrollererrorresponse)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Usage lookup error.|[ControllerErrorResponse](schemas.md#schemacontrollererrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Usage lookup error.|[ControllerErrorResponse](schemas.md#schemacontrollererrorresponse)|
+|502|[Bad Gateway](https://tools.ietf.org/html/rfc7231#section-6.6.3)|Usage lookup error.|[ControllerErrorResponse](schemas.md#schemacontrollererrorresponse)|

--- a/docs/rest-apis/devportal/utilities.md
+++ b/docs/rest-apis/devportal/utilities.md
@@ -1,0 +1,100 @@
+<h1 id="wso2-api-developer-portal-core-devportal-routes-utilities">Utilities</h1>
+
+## Create a temporary Arazzo file
+
+<a id="opIdcreateTempArazzoFile"></a>
+
+`POST /temp-arazzo-file`
+
+> Code samples
+
+```shell
+
+curl -X POST http://localhost:3000/devportal/temp-arazzo-file \
+  -u {username}:{password} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Writes supplied Arazzo YAML content to a temporary file and returns its path.
+
+> Payload
+
+```json
+{
+  "content": "arazzo: 1.0.1\ninfo:\n  title: Weather onboarding\n  version: 1.0.0\nworkflows: []\n",
+  "filename": "workflow.arazzo.yaml"
+}
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="create-a-temporary-arazzo-file-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[TempArazzoFileRequest](schemas.md#schematemparazzofilerequest)|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "path": "/tmp/arazzo-abc123/workflow.arazzo.yaml"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="create-a-temporary-arazzo-file-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Path of the temporary Arazzo file.|[TempArazzoFileResponse](schemas.md#schematemparazzofileresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="create-a-temporary-arazzo-file-responseschema">Response Schema</h3>

--- a/docs/rest-apis/devportal/views.md
+++ b/docs/rest-apis/devportal/views.md
@@ -1,0 +1,534 @@
+<h1 id="wso2-api-developer-portal-core-devportal-routes-views">Views</h1>
+
+## Create a view
+
+<a id="opIdaddView"></a>
+
+`POST /organizations/{orgId}/views`
+
+> Code samples
+
+```shell
+
+curl -X POST http://localhost:3000/devportal/organizations/{orgId}/views \
+  -u {username}:{password} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Creates a Developer Portal view for an organization and associates it with the supplied label names. If `displayName` is omitted, the service stores the view name as the display name.
+
+> Payload
+
+```json
+{
+  "name": "partner-apis",
+  "displayName": "Partner APIs",
+  "labels": [
+    "partner",
+    "public"
+  ]
+}
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="create-a-view-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[ViewCreateRequest](schemas.md#schemaviewcreaterequest)|true|View creation payload with the label names that should be visible in the view.|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 201 Response
+
+```json
+{
+  "message": "string"
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 409 Response
+
+```json
+{
+  "code": "409",
+  "message": "Conflict",
+  "description": "Organization already exists"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="create-a-view-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|JSON message response.|[MessageResponse](schemas.md#schemamessageresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Duplicate organization data conflicts with an existing record.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="create-a-view-responseschema">Response Schema</h3>
+
+## List views
+
+<a id="opIdgetAllViews"></a>
+
+`GET /organizations/{orgId}/views`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId}/views \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Lists all views configured for the organization. Each view includes the label names attached to it.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="list-views-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+[
+  {
+    "name": "default",
+    "displayName": "Default",
+    "labels": [
+      "default"
+    ]
+  },
+  {
+    "name": "partner-apis",
+    "displayName": "Partner APIs",
+    "labels": [
+      "partner",
+      "public"
+    ]
+  }
+]
+```
+
+> 404 Response
+
+```
+"string"
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="list-views-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|List of view DTOs.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Plain text success response.|string|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="list-views-responseschema">Response Schema</h3>
+
+Status Code **200**
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|*anonymous*|[[ViewResponse](schemas.md#schemaviewresponse)]|false|none|none|
+|» name|string|true|none|none|
+|» displayName|string|true|none|none|
+|» labels|[string]|true|none|none|
+
+## Update a view
+
+<a id="opIdupdateView"></a>
+
+`PUT /organizations/{orgId}/views/{name}`
+
+> Code samples
+
+```shell
+
+curl -X PUT http://localhost:3000/devportal/organizations/{orgId}/views/{name} \
+  -u {username}:{password} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Updates the view display name and label associations. `addedLabels` are attached to the view and `removedLabels` are detached. The service returns the accepted request payload.
+
+> Payload
+
+```json
+{
+  "displayName": "Partner and Public APIs",
+  "addedLabels": [
+    "premium"
+  ],
+  "removedLabels": [
+    "internal"
+  ]
+}
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="update-a-view-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[ViewUpdateRequest](schemas.md#schemaviewupdaterequest)|true|View update payload. Include only the display-name or label changes that should be applied.|
+|orgId|path|string|true|none|
+|name|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "displayName": "Partner and Public APIs",
+  "addedLabels": [
+    "premium"
+  ],
+  "removedLabels": [
+    "internal"
+  ]
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 409 Response
+
+```json
+{
+  "code": "409",
+  "message": "Conflict",
+  "description": "Organization already exists"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="update-a-view-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Echo of the accepted view update payload.|[ViewUpdateRequest](schemas.md#schemaviewupdaterequest)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Duplicate organization data conflicts with an existing record.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="update-a-view-responseschema">Response Schema</h3>
+
+## Get a view
+
+<a id="opIdgetView"></a>
+
+`GET /organizations/{orgId}/views/{name}`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId}/views/{name} \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Retrieves one view by name, including the label names attached to that view.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="get-a-view-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+|name|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "name": "partner-apis",
+  "displayName": "Partner APIs",
+  "labels": [
+    "partner",
+    "public"
+  ]
+}
+```
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```
+"string"
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="get-a-view-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|View DTO response.|[ViewResponse](schemas.md#schemaviewresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Plain text success response.|string|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="get-a-view-responseschema">Response Schema</h3>
+
+## Delete a view
+
+<a id="opIddeleteView"></a>
+
+`DELETE /organizations/{orgId}/views/{name}`
+
+> Code samples
+
+```shell
+
+curl -X DELETE http://localhost:3000/devportal/organizations/{orgId}/views/{name} \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Deletes a view by name. A missing view is returned as a not-found error.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="delete-a-view-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+|name|path|string|true|none|
+
+> Example responses
+
+> Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.
+
+```json
+[
+  {
+    "code": "400",
+    "message": "input validation failed",
+    "description": "Invalid value"
+  }
+]
+```
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "Missing required parameter: 'orgId'"
+}
+```
+
+```json
+{
+  "message": "Missing or invalid fields in the request payload"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="delete-a-view-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|View deleted successfully.|None|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Input validation failures are returned as an array; other bad request errors are returned as a standard error object.|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="delete-a-view-responseschema">Response Schema</h3>

--- a/docs/rest-apis/devportal/webhook-events.md
+++ b/docs/rest-apis/devportal/webhook-events.md
@@ -1,0 +1,341 @@
+<h1 id="wso2-api-developer-portal-core-devportal-routes-webhook-events">Webhook Events</h1>
+
+## List webhook events
+
+<a id="opIdlistWebhookEvents"></a>
+
+`GET /organizations/{orgId}/events`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId}/events \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Returns a paginated list of webhook events for the organization. Each event includes a summary of its delivery rows. Requires dp:event_read scope.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="list-webhook-events-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|status|query|string|false|Filter events by status.|
+|limit|query|integer|false|none|
+|offset|query|integer|false|none|
+|orgId|path|string|true|none|
+
+#### Enumerated Values
+
+|Parameter|Value|
+|---|---|
+|status|PENDING|
+|status|DISPATCHED|
+|status|ALL_DELIVERED|
+|status|FAILED|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "total": 0,
+  "events": [
+    {
+      "eventId": "evt-abc123",
+      "eventType": "apikey.generated",
+      "orgId": "org-default",
+      "gatewayType": "default",
+      "aggregateType": "apikey",
+      "aggregateId": "key-12345",
+      "status": "ALL_DELIVERED",
+      "occurredAt": "2019-08-24T14:15:22Z",
+      "deliveries": [
+        {
+          "deliveryId": "del-abc123",
+          "subscriberId": "sub-xyz789",
+          "targetUrl": "https://example.com/webhook",
+          "status": "DELIVERED",
+          "attemptCount": 1,
+          "lastHttpStatus": 200,
+          "lastError": "string",
+          "lastAttemptAt": "2019-08-24T14:15:22Z",
+          "deliveredAt": "2019-08-24T14:15:22Z"
+        }
+      ]
+    }
+  ]
+}
+```
+
+> 403 Response
+
+```json
+{
+  "code": "403",
+  "message": "Forbidden",
+  "description": "Write operations are disabled in read-only mode"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="list-webhook-events-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Paginated list of webhook events.|Inline|
+|403|[Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)|Request is forbidden for the current runtime mode or caller permissions.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="list-webhook-events-responseschema">Response Schema</h3>
+
+Status Code **200**
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» total|integer|false|none|Total number of events matching the query.|
+|» events|[[WebhookEvent](schemas.md#schemawebhookevent)]|false|none|[A webhook event with its delivery rows.]|
+|»» eventId|string|false|none|none|
+|»» eventType|string|false|none|none|
+|»» orgId|string|false|none|none|
+|»» gatewayType|string¦null|false|none|none|
+|»» aggregateType|string|false|none|none|
+|»» aggregateId|string|false|none|none|
+|»» status|string|false|none|none|
+|»» occurredAt|string(date-time)|false|none|none|
+|»» deliveries|[[WebhookEventDelivery](schemas.md#schemawebhookeventdelivery)]|false|none|[A single webhook delivery attempt.]|
+|»»» deliveryId|string|false|none|none|
+|»»» subscriberId|string|false|none|none|
+|»»» targetUrl|string¦null|false|none|none|
+|»»» status|string|false|none|none|
+|»»» attemptCount|integer|false|none|none|
+|»»» lastHttpStatus|integer¦null|false|none|none|
+|»»» lastError|string¦null|false|none|none|
+|»»» lastAttemptAt|string(date-time)¦null|false|none|none|
+|»»» deliveredAt|string(date-time)¦null|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|status|PENDING|
+|status|DISPATCHED|
+|status|ALL_DELIVERED|
+|status|FAILED|
+|status|PENDING|
+|status|IN_FLIGHT|
+|status|DELIVERED|
+|status|FAILED|
+|status|DEAD_LETTERED|
+
+## Get a webhook event
+
+<a id="opIdgetWebhookEvent"></a>
+
+`GET /organizations/{orgId}/events/{eventId}`
+
+> Code samples
+
+```shell
+
+curl -X GET http://localhost:3000/devportal/organizations/{orgId}/events/{eventId} \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Returns a single webhook event with the full details of all its delivery rows. Requires dp:event_read scope.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="get-a-webhook-event-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+|eventId|path|string|true|Webhook event identifier.|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "eventId": "evt-abc123",
+  "eventType": "apikey.generated",
+  "orgId": "org-default",
+  "gatewayType": "default",
+  "aggregateType": "apikey",
+  "aggregateId": "key-12345",
+  "status": "ALL_DELIVERED",
+  "occurredAt": "2019-08-24T14:15:22Z",
+  "deliveries": [
+    {
+      "deliveryId": "del-abc123",
+      "subscriberId": "sub-xyz789",
+      "targetUrl": "https://example.com/webhook",
+      "status": "DELIVERED",
+      "attemptCount": 1,
+      "lastHttpStatus": 200,
+      "lastError": "string",
+      "lastAttemptAt": "2019-08-24T14:15:22Z",
+      "deliveredAt": "2019-08-24T14:15:22Z"
+    }
+  ]
+}
+```
+
+> 403 Response
+
+```json
+{
+  "code": "403",
+  "message": "Forbidden",
+  "description": "Write operations are disabled in read-only mode"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="get-a-webhook-event-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Single webhook event with full delivery details.|[WebhookEvent](schemas.md#schemawebhookevent)|
+|403|[Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)|Request is forbidden for the current runtime mode or caller permissions.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+## Retry a failed webhook delivery
+
+<a id="opIdretryWebhookDelivery"></a>
+
+`POST /organizations/{orgId}/deliveries/{deliveryId}/retry`
+
+> Code samples
+
+```shell
+
+curl -X POST http://localhost:3000/devportal/organizations/{orgId}/deliveries/{deliveryId}/retry \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Resets a `DEAD_LETTERED` or `FAILED` delivery back to `PENDING` so the delivery worker retries it immediately. Requires dp:delivery_manage scope.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="retry-a-failed-webhook-delivery-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|orgId|path|string|true|none|
+|deliveryId|path|string|true|Webhook delivery identifier.|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "message": "Delivery queued for retry"
+}
+```
+
+> 403 Response
+
+```json
+{
+  "code": "403",
+  "message": "Forbidden",
+  "description": "Write operations are disabled in read-only mode"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Resource Not Found",
+  "description": "Organization not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "code": "500",
+  "message": "Internal Server Error",
+  "description": "Internal Server Error"
+}
+```
+
+<h3 id="retry-a-failed-webhook-delivery-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Delivery queued for retry.|Inline|
+|403|[Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)|Request is forbidden for the current runtime mode or caller permissions.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+<h3 id="retry-a-failed-webhook-delivery-responseschema">Response Schema</h3>
+
+Status Code **200**
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» message|string|false|none|none|

--- a/portals/developer-portal/Makefile
+++ b/portals/developer-portal/Makefile
@@ -29,6 +29,12 @@ DOCKER_REGISTRY ?= ghcr.io/wso2/api-platform
 # Image name
 DEVPORTAL_IMAGE := $(DOCKER_REGISTRY)/developer-portal
 
+# API docs tooling
+REPO_ROOT         := $(shell git rev-parse --show-toplevel)
+APIDOCS_TOOLS_DIR := $(REPO_ROOT)/tools/apidocs
+DOCS_OUT_DIR      := $(REPO_ROOT)/docs/rest-apis/devportal
+OPENAPI_SPEC      := docs/devportal-openapi-spec-v1.yaml
+
 .DEFAULT_GOAL := help
 
 .PHONY: help
@@ -50,6 +56,9 @@ help: ## Show this help message
 	@echo '  make version-bump-major          - Bump major version'
 	@echo '  make version-bump-next-dev       - Bump to next minor dev version with SNAPSHOT'
 	@echo '  make version-get-release         - Get release version (strips SNAPSHOT suffix)'
+	@echo ''
+	@echo 'Docs Targets:'
+	@echo '  make generate-apidocs            - Generate REST API docs from OpenAPI spec'
 	@echo ''
 	@echo 'Clean Targets:'
 	@echo '  make clean                       - Clean all build artifacts'
@@ -143,3 +152,14 @@ clean-dist: ## Remove distribution staging dir and zip
 .PHONY: clean
 clean: clean-dist ## Clean all build artifacts
 	@echo "Cleaned developer portal build artifacts"
+
+# Docs Targets
+
+.PHONY: generate-apidocs
+generate-apidocs: ## Generate REST API docs from devportal OpenAPI spec
+	@command -v widdershins >/dev/null 2>&1 || { echo "widdershins not found, installing..."; npm install -g widdershins; }
+	@widdershins $(OPENAPI_SPEC) -o /tmp/dp-openapi.md \
+		--omitHeader --summary --language_tabs 'shell:Shell:curl' \
+		--user_templates $(APIDOCS_TOOLS_DIR)/widdershins_templates/
+	@bash $(APIDOCS_TOOLS_DIR)/split-openapi.sh /tmp/dp-openapi.md $(DOCS_OUT_DIR)
+	@echo "REST API docs generated at $(DOCS_OUT_DIR)"


### PR DESCRIPTION
## Purpose
Adding generated REST API docs for the developer portal at docs/rest-apis/devportal/, following the same pattern as the existing gateway docs. 

## Approach
Added a Makefile in portals/developer-portal/ with a generate-apidocs target that runs the shared widdershins + split-openapi.sh pipeline against the existing devportal-openapi-spec-v1.yaml, producing one Markdown file per API domain plus a master index and schemas reference. (Similar to other docs)
