### PR TITLE
Implement WebSubAPI topic subscription state sharing across multiple event gateway instances

### DIFF
--- a/event-gateway/gateway-runtime/internal/connectors/brokerdriver/kafka/endpoint.go
+++ b/event-gateway/gateway-runtime/internal/connectors/brokerdriver/kafka/endpoint.go
@@ -89,6 +89,14 @@ func (e *KafkaBrokerDriver) Replay(ctx context.Context, topic string, handler co
 	return ReplayTopic(ctx, e.cfg, topic, handler)
 }
 
+// Watch tails a topic from the current offset and delivers all future messages
+// to handler until ctx is cancelled. consumerID is used as a stable consumer
+// group suffix so Kafka tracks the offset across restarts.
+func (e *KafkaBrokerDriver) Watch(_ context.Context, consumerID string, topic string, handler connectors.MessageHandler) (connectors.Receiver, error) {
+	groupID := "event-gateway-sync-" + consumerID
+	return NewConsumer(e.cfg, groupID, []string{topic}, handler)
+}
+
 // TopicExists checks whether a topic exists in the Kafka cluster.
 func (e *KafkaBrokerDriver) TopicExists(ctx context.Context, topic string) (bool, error) {
 	topics, err := e.admin.ListTopics(ctx)

--- a/event-gateway/gateway-runtime/internal/connectors/receiver/websub/connector.go
+++ b/event-gateway/gateway-runtime/internal/connectors/receiver/websub/connector.go
@@ -181,15 +181,15 @@ func (e *WebSubReceiver) Start(ctx context.Context) error {
 	return nil
 }
 
-// Stop stops all per-callback consumers, the sync watcher, and the sync producer.
+// Stop stops the sync watcher first, then all per-callback consumers, then the sync producer.
 func (e *WebSubReceiver) Stop(ctx context.Context) error {
-	e.consumerMgr.StopAll(ctx)
-
 	if e.syncWatcherReceiver != nil {
 		if err := e.syncWatcherReceiver.Stop(ctx); err != nil {
 			slog.Error("Failed to stop sync watcher", "api", e.channel.Name, "error", err)
 		}
 	}
+
+	e.consumerMgr.StopAll(ctx)
 
 	if e.syncProducer != nil {
 		e.syncProducer.Close()
@@ -205,7 +205,11 @@ func (e *WebSubReceiver) startSyncWatcher(ctx context.Context) {
 		return
 	}
 
-	apiID := binding.JoinNormalizedTopic(e.channel.Context, e.channel.Version)[:12]
+	normalized := binding.JoinNormalizedTopic(e.channel.Context, e.channel.Version)
+	apiID := normalized
+	if len(normalized) > 12 {
+		apiID = normalized[:12]
+	}
 	slog.Info("Subscription sync watcher API mapping",
 		"api", e.channel.Name,
 		"context", e.channel.Context,

--- a/event-gateway/gateway-runtime/internal/connectors/receiver/websub/connector.go
+++ b/event-gateway/gateway-runtime/internal/connectors/receiver/websub/connector.go
@@ -46,16 +46,17 @@ type Options struct {
 // It owns the topic registry, subscription store, delivery engine,
 // consumer manager, and the sync producer for subscription state.
 type WebSubReceiver struct {
-	hubHandler     *HubHandler
-	webhookHandler *WebhookReceiverHandler
-	deliverer      *Deliverer
-	topics         *TopicRegistry
-	store          subscription.SubscriptionStore
-	consumerMgr    *ConsumerManager
-	syncProducer   *subscription.SyncProducer
-	brokerDriver   connectors.BrokerDriver
-	channel        connectors.ChannelInfo
-	opts           Options
+	hubHandler          *HubHandler
+	webhookHandler      *WebhookReceiverHandler
+	deliverer           *Deliverer
+	topics              *TopicRegistry
+	store               subscription.SubscriptionStore
+	consumerMgr         *ConsumerManager
+	syncProducer        *subscription.SyncProducer
+	syncWatcherReceiver connectors.Receiver
+	brokerDriver        connectors.BrokerDriver
+	channel             connectors.ChannelInfo
+	opts                Options
 }
 
 // NewReceiver creates a WebSub receiver supporting multiple channels (topics).
@@ -166,6 +167,10 @@ func (e *WebSubReceiver) Start(ctx context.Context) error {
 	// subscriptions survive a binding update (remove + re-add).
 	e.reconcileSubscriptions(ctx)
 
+	// After reconcile, tail the sync topic to propagate subscription changes
+	// from other instances in real time.
+	e.startSyncWatcher(ctx)
+
 	basePath := binding.WebSubApiBasePath(e.channel.Context, e.channel.Version)
 	slog.Info("WebSub receiver started",
 		"api", e.channel.Name,
@@ -176,15 +181,73 @@ func (e *WebSubReceiver) Start(ctx context.Context) error {
 	return nil
 }
 
-// Stop stops all per-callback consumers and the sync producer.
+// Stop stops all per-callback consumers, the sync watcher, and the sync producer.
 func (e *WebSubReceiver) Stop(ctx context.Context) error {
 	e.consumerMgr.StopAll(ctx)
+
+	if e.syncWatcherReceiver != nil {
+		if err := e.syncWatcherReceiver.Stop(ctx); err != nil {
+			slog.Error("Failed to stop sync watcher", "api", e.channel.Name, "error", err)
+		}
+	}
 
 	if e.syncProducer != nil {
 		e.syncProducer.Close()
 	}
 
 	return nil
+}
+
+// startSyncWatcher tails the subscription sync topic after reconciliation so
+// that subscription changes made on other instances are applied in real time.
+func (e *WebSubReceiver) startSyncWatcher(ctx context.Context) {
+	if e.channel.InternalSubTopic == "" {
+		return
+	}
+
+	apiID := binding.JoinNormalizedTopic(e.channel.Context, e.channel.Version)[:12]
+	slog.Info("Subscription sync watcher API mapping",
+		"api", e.channel.Name,
+		"context", e.channel.Context,
+		"version", e.channel.Version,
+		"api_id", apiID)
+	watcher := subscription.NewSyncWatcher(e.brokerDriver, e.store, e.opts.RuntimeID, apiID, e.channel.InternalSubTopic)
+
+	ownedChannels := make(map[string]bool, len(e.channel.Channels))
+	for channelName := range e.channel.Channels {
+		ownedChannels[channelName] = true
+	}
+
+	watcher.SetCallback(func(sub *subscription.Subscription, isTombstone bool) {
+		kafkaTopic, ok := e.channel.Channels[sub.Topic]
+		if !ok {
+			return
+		}
+		if isTombstone {
+			if err := e.consumerMgr.RemoveSubscription(sub.CallbackURL, kafkaTopic); err != nil {
+				slog.Error("Sync watcher: failed to remove consumer",
+					"callback", sub.CallbackURL, "topic", sub.Topic, "error", err)
+			}
+			return
+		}
+		if sub.State != subscription.StateActive {
+			return
+		}
+		if !ownedChannels[sub.Topic] {
+			return
+		}
+		if err := e.consumerMgr.AddSubscription(sub.CallbackURL, sub.Secret, kafkaTopic); err != nil {
+			slog.Error("Sync watcher: failed to add consumer",
+				"callback", sub.CallbackURL, "topic", sub.Topic, "error", err)
+		}
+	})
+
+	receiver, err := watcher.Watch(ctx)
+	if err != nil {
+		slog.Warn("Failed to start subscription sync watcher (non-fatal)", "api", e.channel.Name, "error", err)
+		return
+	}
+	e.syncWatcherReceiver = receiver
 }
 
 // reconcileSubscriptions replays subscriptions from the Kafka sync topic and

--- a/event-gateway/gateway-runtime/internal/connectors/receiver/websub/handler.go
+++ b/event-gateway/gateway-runtime/internal/connectors/receiver/websub/handler.go
@@ -246,14 +246,29 @@ func (h *HubHandler) handleUnsubscribe(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Remove subscription from store.
+	// Remove subscription from local store. A miss is not immediately fatal —
+	// the subscription may have been created on another instance.
 	if err := h.store.Remove(topic, callback); err != nil {
-		slog.Error("Failed to remove subscription", "error", err)
-		http.Error(w, "subscription not found", http.StatusNotFound)
-		return
+		if h.syncProducer == nil {
+			slog.Error("Failed to remove subscription", "error", err)
+			http.Error(w, "subscription not found", http.StatusNotFound)
+			return
+		}
+		exists, lookupErr := h.syncProducer.ExistsInKafka(r.Context(), topic, callback)
+		if lookupErr != nil {
+			slog.Error("Failed to look up subscription in Kafka", "error", lookupErr)
+			http.Error(w, "failed to verify subscription", http.StatusInternalServerError)
+			return
+		}
+		if !exists {
+			slog.Error("Failed to remove subscription", "error", err)
+			http.Error(w, "subscription not found", http.StatusNotFound)
+			return
+		}
+		slog.Info("Subscription owned by another instance, proceeding with unsubscribe", "topic", topic, "callback", callback)
 	}
 
-	// Publish tombstone to sync topic.
+	// Publish tombstone to sync topic so all instances honour the unsubscription on restart.
 	if h.syncProducer != nil {
 		if err := h.syncProducer.PublishTombstone(r.Context(), topic, callback); err != nil {
 			slog.Error("Failed to sync unsubscription", "error", err)

--- a/event-gateway/gateway-runtime/internal/connectors/types.go
+++ b/event-gateway/gateway-runtime/internal/connectors/types.go
@@ -64,6 +64,11 @@ type BrokerDriver interface {
 	Subscribe(groupID string, topics []string, handler MessageHandler) (Receiver, error)
 	SubscribeManual(groupID string, topics []string, handler MessageHandler) (Receiver, error)
 	Replay(ctx context.Context, topic string, handler MessageHandler) error
+	// Watch tails a topic from the current offset and delivers all future messages
+	// to handler until ctx is cancelled. consumerID is a stable, broker-agnostic
+	// identity for this subscriber (e.g. runtimeID) — each unique consumerID receives
+	// all messages independently.
+	Watch(ctx context.Context, consumerID string, topic string, handler MessageHandler) (Receiver, error)
 	TopicExists(ctx context.Context, topic string) (bool, error)
 	EnsureTopics(ctx context.Context, topics []string, metadata map[string]map[string]string) error
 	EnsureCompactedTopic(ctx context.Context, topic string) error

--- a/event-gateway/gateway-runtime/internal/subscription/sync.go
+++ b/event-gateway/gateway-runtime/internal/subscription/sync.go
@@ -93,6 +93,25 @@ func (p *SyncProducer) PublishTombstone(_ context.Context, topic, callbackURL st
 	return nil
 }
 
+// ExistsInKafka checks whether an active subscription for the given topic and
+// callbackURL exists in the Kafka sync topic. It replays the compacted topic and
+// returns true only if the latest record for that key is a non-tombstone value.
+// Used to validate cross-instance unsubscribe requests.
+func (p *SyncProducer) ExistsInKafka(ctx context.Context, topic, callbackURL string) (bool, error) {
+	key := syncKey(topic, callbackURL)
+	found := false
+	err := p.driver.Replay(ctx, p.syncTopic, func(_ context.Context, msg *connectors.Message) error {
+		if string(msg.Key) == key {
+			found = msg.Value != nil
+		}
+		return nil
+	})
+	if err != nil {
+		return false, fmt.Errorf("failed to check subscription in Kafka: %w", err)
+	}
+	return found, nil
+}
+
 // Close flushes any buffered records and closes the sync producer.
 func (p *SyncProducer) Close() {
 }

--- a/event-gateway/gateway-runtime/internal/subscription/sync.go
+++ b/event-gateway/gateway-runtime/internal/subscription/sync.go
@@ -98,6 +98,12 @@ func (p *SyncProducer) PublishTombstone(_ context.Context, topic, callbackURL st
 // returns true only if the latest record for that key is a non-tombstone value.
 // Used to validate cross-instance unsubscribe requests.
 func (p *SyncProducer) ExistsInKafka(ctx context.Context, topic, callbackURL string) (bool, error) {
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+	}
+
 	key := syncKey(topic, callbackURL)
 	found := false
 	err := p.driver.Replay(ctx, p.syncTopic, func(_ context.Context, msg *connectors.Message) error {

--- a/event-gateway/gateway-runtime/internal/subscription/watcher.go
+++ b/event-gateway/gateway-runtime/internal/subscription/watcher.go
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package subscription
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+
+	"github.com/wso2/api-platform/event-gateway/gateway-runtime/internal/connectors"
+)
+
+// SyncWatcher tails the per-API subscription sync topic from the current offset
+// and keeps the in-memory store and consumer manager up-to-date in real time.
+// It complements the Reconciler (which handles startup replay) by propagating
+// subscription changes made on other instances while this instance is running.
+type SyncWatcher struct {
+	driver    connectors.BrokerDriver
+	store     SubscriptionStore
+	runtimeID string
+	apiID     string // collision-safe hash of the API's identifying parts (context + version)
+	syncTopic string
+	callback  SubscriptionCallback
+}
+
+// NewSyncWatcher creates a SyncWatcher for the given sync topic.
+// apiID is a collision-safe hash that uniquely identifies the API (computed by
+// the caller via JoinNormalizedTopic so that subscription package stays free of
+// binding package imports).
+func NewSyncWatcher(driver connectors.BrokerDriver, store SubscriptionStore, runtimeID, apiID, syncTopic string) *SyncWatcher {
+	return &SyncWatcher{
+		driver:    driver,
+		store:     store,
+		runtimeID: runtimeID,
+		apiID:     apiID,
+		syncTopic: syncTopic,
+	}
+}
+
+// SetCallback sets the function called for each subscription change. The
+// connector uses this to start or stop per-callback Kafka consumers via
+// the ConsumerManager. Signature is the same as Reconciler.SetCallback.
+func (w *SyncWatcher) SetCallback(cb SubscriptionCallback) {
+	w.callback = cb
+}
+
+// Watch starts tailing the sync topic and returns a Receiver whose lifecycle
+// the caller manages. It must be called after Reconciler.Reconcile so that the
+// initial state is already loaded; Watch only processes changes from this point
+// forward.
+func (w *SyncWatcher) Watch(ctx context.Context) (connectors.Receiver, error) {
+	consumerID := w.runtimeID + "-" + w.apiID
+	receiver, err := w.driver.Watch(ctx, consumerID, w.syncTopic, w.handleMessage)
+	if err != nil {
+		return nil, err
+	}
+	if err := receiver.Start(ctx); err != nil {
+		return nil, err
+	}
+	slog.Info("Subscription sync watcher started",
+		"topic", w.syncTopic,
+		"runtime_id", w.runtimeID,
+		"sync_group", "event-gateway-sync-"+consumerID)
+	return receiver, nil
+}
+
+func (w *SyncWatcher) handleMessage(ctx context.Context, msg *connectors.Message) error {
+	if msg.Value == nil {
+		// Tombstone — subscription removed on another instance.
+		parts := parseSyncKey(string(msg.Key))
+		if parts == nil {
+			return nil
+		}
+		_ = w.store.Remove(parts[0], parts[1])
+		if w.callback != nil {
+			w.callback(&Subscription{Topic: parts[0], CallbackURL: parts[1]}, true)
+		}
+		slog.Info("Subscription sync: removed", "topic", parts[0], "callback", parts[1])
+		return nil
+	}
+
+	var sub Subscription
+	if err := json.Unmarshal(msg.Value, &sub); err != nil {
+		slog.Error("Subscription sync: failed to unmarshal message", "error", err)
+		return nil
+	}
+
+	_ = w.store.Add(&sub)
+	if w.callback != nil {
+		w.callback(&sub, false)
+	}
+	slog.Debug("Subscription sync: added", "topic", sub.Topic, "callback", sub.CallbackURL, "origin", sub.RuntimeID)
+	return nil
+}


### PR DESCRIPTION
## Purpose
> When multiple Event Gateway instances are running behind a load balancer, topic subscription/unsubscription requests, and publish calls can hit any of them, due to reasons such as gateway downtime or load balancing. The topic subscription state of a particular Event Gateway instance should be visible to all other Event Gateway instances, so that:
- When a publish is made to a gateway that's different than the one a subscription call is made, the callback should receive the webhook
- When a subscription is made from a particular event gateway instance, and if that event gateway instance goes down, the remaining event gateway instances should takeover.

Resolves: https://github.com/wso2/api-platform/issues/1871

## Goals
Sample flow tested:
1. Deploy the same WebSubAPI to both egw-a and egw-b
2. Subscribe callbackUrlX to topic 'issues' via egw-a.
3. Subscribe callbackUrlY to topic 'issues' via egw-b.
4. Publishe to topic 'issues' via egw-b. callbackUrlX and callbackUrlY both should receive the event. **[Working as expected]**
5. Publishe to topic 'issues' via egw-a. callbackUrlX and callbackUrlY both should receive the event. **[Working as expected]**
6. Unsubscribed callbackUrlY from egw-a.
7. Publish to topic 'issues' via egw-b. Only callbackUrlX should receive the event. **[Working as expected]**
8. Subscribe callbackUrlZ to topic 'issues' via egw-a.
9. Shutdown egw-a.
10. Publish to topic 'issues' via egw-b. callbackUrlX and callbackUrlZ both should receive the event. **[Working as expected]**

## Approach
## Multi-instance WebSub subscription state propagation

In a multi-instance deployment, subscription state was only synced at startup via the `Reconciler`. Subscriptions created or removed on one instance were not visible to other running instances, causing missed deliveries and broken cross-instance unsubscriptions.

This PR adds two fixes:

**1. `SyncWatcher`** — tails the `__subscriptions` compacted topic from the current offset after startup reconciliation, applying subscription changes from other instances in real time. This ensures every instance maintains consumers for all active subscriptions regardless of which instance accepted them — so when an instance goes down, the remaining instances already have consumers running and Kafka failover kicks in immediately.

**2. Cross-instance unsubscription** — when an unsubscribe request arrives for a subscription not in the local store (i.e. it was created on another instance), the handler now falls back to a Kafka lookup before returning 404. If found, a tombstone is published to propagate the removal.

**Consumer groups:**

| Purpose | Group ID | Behaviour |
|---|---|---|
| Event delivery (per callback) | `event-gateway-websub-{sha256(callbackURL)[:16]}` | Shared across all instances — Kafka handles failover and exactly-once delivery |
| Subscription sync (SyncWatcher) | `event-gateway-sync-{runtimeID}-{apiID}` | Unique per instance — every instance independently receives all sync messages |




## User stories
> Summary of user stories addressed by this change>

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
