### PR TITLE
Update Devportal API Spec

### DIFF
--- a/portals/developer-portal/docs/devportal-openapi-spec-v1.yaml
+++ b/portals/developer-portal/docs/devportal-openapi-spec-v1.yaml
@@ -24,13 +24,15 @@ info:
     Fine-grained Developer Portal API for managing organizations, identity providers, providers,
     API metadata and content, applications, subscriptions, application credentials, billing, invoices, usage, and API flows.
 
-    All paths are served under the `/devportal` base path. Operations declare the least-privilege
-    OAuth2 scopes required for each resource action, and selected billing-related endpoints also
-    support API key authentication where configured.
+    Organization-scoped resources are served under `/o/{orgId}/devportal/v1`. Operations declare
+    the least-privilege OAuth2 scopes required for each resource action, and selected billing-related
+    endpoints also support API key authentication where configured.
 servers:
-  - url: http://localhost:3000/devportal
+  - url: https://devportal.api-platform.io
+    description: Production
+  - url: http://localhost:3000
     description: Local development server
-  - url: https://localhost:{port}/devportal
+  - url: https://localhost:{port}
     description: Local HTTPS server
     variables:
       port:
@@ -171,7 +173,7 @@ paths:
         - OAuth2Security:
             - dp:org_delete
             - dp:org_manage
-  /organizations/{orgId}/identityProvider:
+  /o/{orgId}/devportal/v1/identity-providers:
     parameters:
       - $ref: "#/components/parameters/OrgId"
     post:
@@ -256,10 +258,10 @@ paths:
         - OAuth2Security:
             - dp:idp_delete
             - dp:idp_manage
-  /organizations/{orgId}/views/{name}/layout:
+  /o/{orgId}/devportal/v1/views/{viewName}/layout:
     parameters:
       - $ref: "#/components/parameters/OrgId"
-      - $ref: "#/components/parameters/Name"
+      - $ref: "#/components/parameters/ViewName"
     post:
       tags:
         - Organization Content
@@ -356,10 +358,10 @@ paths:
             - dp:org_content_delete
             - dp:org_content_manage
             - dp:org_manage
-  /organizations/{orgId}/views/{name}/layout/{fileType}:
+  /o/{orgId}/devportal/v1/views/{viewName}/layout/{fileType}:
     parameters:
       - $ref: "#/components/parameters/OrgId"
-      - $ref: "#/components/parameters/Name"
+      - $ref: "#/components/parameters/ViewName"
       - $ref: "#/components/parameters/FileType"
     get:
       tags:
@@ -375,7 +377,7 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "404":
           $ref: "#/components/responses/TextMessageResponse"
-  /organizations/{orgId}/provider:
+  /o/{orgId}/devportal/v1/provider:
     parameters:
       - $ref: "#/components/parameters/OrgId"
     post:
@@ -470,7 +472,7 @@ paths:
         - OAuth2Security:
             - dp:provider_delete
             - dp:provider_manage
-  /organizations/{orgId}/apis:
+  /o/{orgId}/devportal/v1/apis:
     parameters:
       - $ref: "#/components/parameters/OrgId"
     post:
@@ -482,7 +484,7 @@ paths:
         file, or an `apiMetadata` JSON string. An API definition file is required unless supplied by the
         artifact ZIP. The service also stores labels, subscription policy mappings, image metadata, and
         schema definitions for MCP or GraphQL APIs when provided.
-      operationId: createAPIMetadata
+      operationId: createApiMetadata
       requestBody:
         $ref: "#/components/requestBodies/ApiMetadataMultipartBody"
       responses:
@@ -508,7 +510,7 @@ paths:
         Lists API metadata for an organization. The service supports exact filters by API name, version,
         and tags, free-text search with `query`, group filtering, and view filtering. Unknown query
         parameters are rejected.
-      operationId: getAllAPIMetadataForOrganization
+      operationId: getAllApiMetadataForOrganization
       parameters:
         - $ref: "#/components/parameters/ApiSearchQuery"
         - $ref: "#/components/parameters/ApiNameQuery"
@@ -527,7 +529,7 @@ paths:
         - OAuth2Security:
             - dp:api_read
             - dp:api_manage
-  /organizations/{orgId}/apis/{apiId}:
+  /o/{orgId}/devportal/v1/apis/{apiId}:
     parameters:
       - $ref: "#/components/parameters/OrgId"
       - $ref: "#/components/parameters/ApiId"
@@ -536,7 +538,7 @@ paths:
         - APIs
       summary: Get API metadata
       description: Retrieves a single API metadata record by Developer Portal API ID.
-      operationId: getAPIMetadata
+      operationId: getApiMetadata
       responses:
         "200":
           $ref: "#/components/responses/ApiMetadataResponse"
@@ -558,7 +560,7 @@ paths:
         Updates Developer Portal API metadata and its stored definition. The update flow can also adjust
         label mappings, subscription policy mappings, schema definitions, and image metadata. Status
         changes to unpublished are rejected when active subscriptions exist.
-      operationId: updateAPIMetadata
+      operationId: updateApiMetadata
       requestBody:
         $ref: "#/components/requestBodies/ApiMetadataMultipartBody"
       responses:
@@ -581,7 +583,7 @@ paths:
         - APIs
       summary: Delete API metadata
       description: Deletes API metadata when the API has no active subscriptions.
-      operationId: deleteAPIMetadata
+      operationId: deleteApiMetadata
       responses:
         "200":
           $ref: "#/components/responses/TextMessageResponse"
@@ -597,9 +599,35 @@ paths:
         - OAuth2Security:
             - dp:api_delete
             - dp:api_manage
-  /organizations/{orgId}/subscription-policies:
+  /o/{orgId}/devportal/v1/subscription-policies:
     parameters:
       - $ref: "#/components/parameters/OrgId"
+    get:
+      tags:
+        - Subscription Policies
+      summary: List subscription policies
+      description: >-
+        Lists subscription policies for an organization. When `name` is supplied, only the matching
+        policy (if any) is returned. Policy names are unique within an organization.
+      operationId: listSubscriptionPolicies
+      parameters:
+        - in: query
+          name: name
+          required: false
+          schema:
+            type: string
+          description: Filter by exact policy name. Returns an array of zero or one items.
+      responses:
+        "200":
+          $ref: "#/components/responses/SubscriptionPolicyListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:sub_policy_read
+            - dp:sub_policy_manage
     post:
       tags:
         - Subscription Policies
@@ -655,16 +683,16 @@ paths:
         - OAuth2Security:
             - dp:sub_policy_write
             - dp:sub_policy_manage
-  /organizations/{orgId}/subscription-policies/{policyIdOrName}:
+  /o/{orgId}/devportal/v1/subscription-policies/{policyId}:
     parameters:
       - $ref: "#/components/parameters/OrgId"
-      - $ref: "#/components/parameters/PolicyIdOrName"
+      - $ref: "#/components/parameters/PolicyId"
     get:
       tags:
         - Subscription Policies
       summary: Get a subscription policy
       operationId: getSubscriptionPolicy
-      description: Uses the route value as `policyID`.
+      description: Retrieves a single subscription policy by `policyId`.
       responses:
         "200":
           $ref: "#/components/responses/SubscriptionPolicyResponse"
@@ -683,7 +711,7 @@ paths:
         - Subscription Policies
       summary: Delete a subscription policy
       operationId: deleteSubscriptionPolicy
-      description: Uses the route value as `policyName`.
+      description: Deletes a subscription policy by `policyId`.
       responses:
         "204":
           description: Subscription policy deleted successfully.
@@ -697,7 +725,7 @@ paths:
         - OAuth2Security:
             - dp:sub_policy_delete
             - dp:sub_policy_manage
-  /organizations/{orgId}/apis/{apiId}/content:
+  /o/{orgId}/devportal/v1/apis/{apiId}/content:
     parameters:
       - $ref: "#/components/parameters/OrgId"
       - $ref: "#/components/parameters/ApiId"
@@ -714,7 +742,7 @@ paths:
 
         Use `docMetadata` to add external document links that are stored alongside uploaded documents.
         Use `imageMetadata` to map uploaded images to API image roles such as the API icon.
-      operationId: createAPIContent
+      operationId: createApiContent
       requestBody:
         $ref: "#/components/requestBodies/ApiContentZipMultipartBody"
       responses:
@@ -737,10 +765,10 @@ paths:
       description: |
         Replaces or adds static content files for an existing API.
 
-        The upload format is the same as `POST /organizations/{orgId}/apis/{apiId}/content`.
+        The upload format is the same as `POST /o/{orgId}/devportal/v1/apis/{apiId}/content`.
         Existing files with the same stored `type` and `fileName` are updated; new files are created.
         Image metadata is updated only when image metadata can be resolved from the upload or request body.
-      operationId: updateAPIContent
+      operationId: replaceApiContent
       requestBody:
         $ref: "#/components/requestBodies/ApiContentZipMultipartBody"
       responses:
@@ -766,7 +794,7 @@ paths:
         The `type` query parameter selects the stored content category and `fileName` selects the file
         within that category. Text files and external document links are returned as text. Image files are
         returned as binary content with a media type derived from the file extension.
-      operationId: getAPIContentFile
+      operationId: getApiContentFile
       security:
         - OAuth2Security:
             - dp:api_content_read
@@ -792,7 +820,7 @@ paths:
 
         Send both `type` and `fileName` to delete one file. Send only `type` to delete all stored content
         files matching that content category for the API.
-      operationId: deleteAPIContentFile
+      operationId: deleteApiContentFile
       parameters:
         - $ref: "#/components/parameters/ApiContentTypeQuery"
         - $ref: "#/components/parameters/FileNameQuery"
@@ -809,7 +837,7 @@ paths:
         - OAuth2Security:
             - dp:api_content_delete
             - dp:api_content_manage
-  /organizations/{orgId}/labels:
+  /o/{orgId}/devportal/v1/labels:
     parameters:
       - $ref: "#/components/parameters/OrgId"
     post:
@@ -892,7 +920,7 @@ paths:
         - OAuth2Security:
             - dp:label_delete
             - dp:label_manage
-  /organizations/{orgId}/applications:
+  /o/{orgId}/devportal/v1/applications:
     parameters:
       - $ref: "#/components/parameters/OrgId"
     post:
@@ -936,7 +964,7 @@ paths:
         - OAuth2Security:
             - dp:app_read
             - dp:app_manage
-  /organizations/{orgId}/applications/{appId}:
+  /o/{orgId}/devportal/v1/applications/{appId}:
     parameters:
       - $ref: "#/components/parameters/OrgId"
       - $ref: "#/components/parameters/AppId"
@@ -997,7 +1025,7 @@ paths:
         - OAuth2Security:
             - dp:app_delete
             - dp:app_manage
-  /organizations/{orgId}/applications/import:
+  /o/{orgId}/devportal/v1/applications/import:
     parameters:
       - $ref: "#/components/parameters/OrgId"
     post:
@@ -1124,7 +1152,7 @@ paths:
         - OAuth2Security:
             - dp:app_write
             - dp:app_manage
-  /organizations/{orgId}/subscriptions:
+  /o/{orgId}/devportal/v1/subscriptions:
     parameters:
       - $ref: "#/components/parameters/OrgId"
     post:
@@ -1174,10 +1202,10 @@ paths:
         - OAuth2Security:
             - dp:subscription_read
             - dp:subscription_manage
-  /organizations/{orgId}/subscriptions/{subscriptionId}:
+  /o/{orgId}/devportal/v1/subscriptions/{subId}:
     parameters:
       - $ref: "#/components/parameters/OrgId"
-      - $ref: "#/components/parameters/SubscriptionId"
+      - $ref: "#/components/parameters/SubId"
     get:
       tags:
         - Subscriptions
@@ -1233,7 +1261,7 @@ paths:
         - OAuth2Security:
             - dp:subscription_delete
             - dp:subscription_manage
-  /organizations/{orgId}/api-keys/generate:
+  /o/{orgId}/devportal/v1/api-keys/generate:
     parameters:
       - $ref: "#/components/parameters/OrgId"
     post:
@@ -1264,7 +1292,7 @@ paths:
         - OAuth2Security:
             - dp:api_key_write
             - dp:api_key_manage
-  /organizations/{orgId}/api-keys:
+  /o/{orgId}/devportal/v1/api-keys:
     parameters:
       - $ref: "#/components/parameters/OrgId"
     get:
@@ -1290,7 +1318,7 @@ paths:
         - OAuth2Security:
             - dp:api_key_read
             - dp:api_key_manage
-  /organizations/{orgId}/api-keys/{apiKeyId}/regenerate:
+  /o/{orgId}/devportal/v1/api-keys/{apiKeyId}/regenerate:
     parameters:
       - $ref: "#/components/parameters/OrgId"
       - $ref: "#/components/parameters/ApiKeyId"
@@ -1318,7 +1346,7 @@ paths:
         - OAuth2Security:
             - dp:api_key_write
             - dp:api_key_manage
-  /organizations/{orgId}/api-keys/{apiKeyId}/revoke:
+  /o/{orgId}/devportal/v1/api-keys/{apiKeyId}/revoke:
     parameters:
       - $ref: "#/components/parameters/OrgId"
       - $ref: "#/components/parameters/ApiKeyId"
@@ -1345,7 +1373,7 @@ paths:
         - OAuth2Security:
             - dp:api_key_revoke
             - dp:api_key_manage
-  /organizations/{orgId}/app-key-mapping:
+  /o/{orgId}/devportal/v1/app-key-mapping:
     parameters:
       - $ref: "#/components/parameters/OrgId"
     post:
@@ -1376,7 +1404,7 @@ paths:
         - OAuth2Security:
             - dp:app_key_mapping_write
             - dp:app_key_mapping_manage
-  /organizations/{orgId}/app-key-mapping/{appId}:
+  /o/{orgId}/devportal/v1/app-key-mapping/{appId}:
     parameters:
       - $ref: "#/components/parameters/OrgId"
       - $ref: "#/components/parameters/AppId"
@@ -1400,7 +1428,7 @@ paths:
         - OAuth2Security:
             - dp:app_key_mapping_read
             - dp:app_key_mapping_manage
-  /organizations/{orgId}/views:
+  /o/{orgId}/devportal/v1/views:
     parameters:
       - $ref: "#/components/parameters/OrgId"
     post:
@@ -1443,10 +1471,10 @@ paths:
         - OAuth2Security:
             - dp:view_read
             - dp:view_manage
-  /organizations/{orgId}/views/{name}:
+  /o/{orgId}/devportal/v1/views/{viewName}:
     parameters:
       - $ref: "#/components/parameters/OrgId"
-      - $ref: "#/components/parameters/Name"
+      - $ref: "#/components/parameters/ViewName"
     put:
       tags:
         - Views
@@ -1635,7 +1663,7 @@ paths:
         - OAuth2Security:
             - dp:app_key_write
             - dp:app_key_manage
-  /organizations/{orgId}/billing/usage-data:
+  /o/{orgId}/devportal/v1/billing/usage-data:
     parameters:
       - $ref: "#/components/parameters/OrgId"
     get:
@@ -1664,7 +1692,7 @@ paths:
             - dp:billing_read
             - dp:billing_manage
         - apiKeyAuth: []
-  /organizations/{orgId}/billing/payment-methods:
+  /o/{orgId}/devportal/v1/billing/payment-methods:
     parameters:
       - $ref: "#/components/parameters/OrgId"
     get:
@@ -1687,7 +1715,7 @@ paths:
             - dp:billing_read
             - dp:billing_manage
         - apiKeyAuth: []
-  /organizations/{orgId}/billing-engine-keys:
+  /o/{orgId}/devportal/v1/billing-engine-keys:
     parameters:
       - $ref: "#/components/parameters/OrgId"
     post:
@@ -1780,7 +1808,7 @@ paths:
         - OAuth2Security:
             - dp:billing_config_read
             - dp:billing_config_manage
-  /organizations/{orgId}/billing/info:
+  /o/{orgId}/devportal/v1/billing/info:
     parameters:
       - $ref: "#/components/parameters/OrgId"
     get:
@@ -1803,7 +1831,7 @@ paths:
             - dp:billing_read
             - dp:billing_manage
         - apiKeyAuth: []
-  /organizations/{orgId}/billing/subscriptions:
+  /o/{orgId}/devportal/v1/billing/subscriptions:
     parameters:
       - $ref: "#/components/parameters/OrgId"
     get:
@@ -1824,7 +1852,7 @@ paths:
             - dp:billing_read
             - dp:billing_manage
         - apiKeyAuth: []
-  /organizations/{orgId}/monetization/checkout:
+  /o/{orgId}/devportal/v1/monetization/checkout:
     parameters:
       - $ref: "#/components/parameters/OrgId"
     post:
@@ -1855,7 +1883,7 @@ paths:
             - dp:billing_write
             - dp:billing_manage
         - apiKeyAuth: []
-  /organizations/{orgId}/monetization/stripe/register/{checkoutSessionId}:
+  /o/{orgId}/devportal/v1/monetization/stripe/register/{checkoutSessionId}:
     parameters:
       - $ref: "#/components/parameters/OrgId"
       - $ref: "#/components/parameters/CheckoutSessionId"
@@ -1885,7 +1913,7 @@ paths:
             - dp:billing_write
             - dp:billing_manage
         - apiKeyAuth: []
-  /organizations/{orgId}/subscriptions/{subId}/cancel:
+  /o/{orgId}/devportal/v1/subscriptions/{subId}/cancel:
     parameters:
       - $ref: "#/components/parameters/OrgId"
       - $ref: "#/components/parameters/SubId"
@@ -1913,7 +1941,7 @@ paths:
             - dp:billing_write
             - dp:billing_manage
         - apiKeyAuth: []
-  /organizations/{orgId}/subscriptions/{subId}/billing-status:
+  /o/{orgId}/devportal/v1/subscriptions/{subId}/billing-status:
     parameters:
       - $ref: "#/components/parameters/OrgId"
       - $ref: "#/components/parameters/SubId"
@@ -1937,7 +1965,7 @@ paths:
             - dp:billing_read
             - dp:billing_manage
         - apiKeyAuth: []
-  /organizations/{orgId}/billing-portal:
+  /o/{orgId}/devportal/v1/billing-portal:
     parameters:
       - $ref: "#/components/parameters/OrgId"
     post:
@@ -1962,7 +1990,7 @@ paths:
             - dp:billing_write
             - dp:billing_manage
         - apiKeyAuth: []
-  /organizations/{orgId}/subscriptions/{subId}/billing-portal:
+  /o/{orgId}/devportal/v1/subscriptions/{subId}/billing-portal:
     parameters:
       - $ref: "#/components/parameters/OrgId"
       - $ref: "#/components/parameters/SubId"
@@ -1988,7 +2016,7 @@ paths:
             - dp:billing_write
             - dp:billing_manage
         - apiKeyAuth: []
-  /organizations/{orgId}/subscriptions/{subId}/usage:
+  /o/{orgId}/devportal/v1/subscriptions/{subId}/usage:
     parameters:
       - $ref: "#/components/parameters/OrgId"
       - $ref: "#/components/parameters/SubId"
@@ -2019,7 +2047,7 @@ paths:
             - dp:usage_read
             - dp:usage_manage
         - apiKeyAuth: []
-  /organizations/{orgId}/invoices:
+  /o/{orgId}/devportal/v1/invoices:
     parameters:
       - $ref: "#/components/parameters/OrgId"
     get:
@@ -2046,7 +2074,7 @@ paths:
             - dp:invoice_read
             - dp:invoice_manage
         - apiKeyAuth: []
-  /organizations/{orgId}/invoices/{invoiceId}:
+  /o/{orgId}/devportal/v1/invoices/{invoiceId}:
     parameters:
       - $ref: "#/components/parameters/OrgId"
       - $ref: "#/components/parameters/InvoiceId"
@@ -2072,7 +2100,7 @@ paths:
             - dp:invoice_read
             - dp:invoice_manage
         - apiKeyAuth: []
-  /organizations/{orgId}/subscriptions/{subId}/invoices:
+  /o/{orgId}/devportal/v1/subscriptions/{subId}/invoices:
     parameters:
       - $ref: "#/components/parameters/OrgId"
       - $ref: "#/components/parameters/SubId"
@@ -2101,7 +2129,7 @@ paths:
             - dp:invoice_read
             - dp:invoice_manage
         - apiKeyAuth: []
-  /organizations/{orgId}/invoices/{invoiceId}/pdf:
+  /o/{orgId}/devportal/v1/invoices/{invoiceId}/pdf:
     parameters:
       - $ref: "#/components/parameters/OrgId"
       - $ref: "#/components/parameters/InvoiceId"
@@ -2127,7 +2155,7 @@ paths:
             - dp:invoice_read
             - dp:invoice_manage
         - apiKeyAuth: []
-  /organizations/{orgId}/invoices/{invoiceId}/hosted:
+  /o/{orgId}/devportal/v1/invoices/{invoiceId}/hosted:
     parameters:
       - $ref: "#/components/parameters/OrgId"
       - $ref: "#/components/parameters/InvoiceId"
@@ -2157,14 +2185,14 @@ paths:
             - dp:invoice_read
             - dp:invoice_manage
         - apiKeyAuth: []
-  /organizations/{orgId}/views/{viewName}/api-flows:
+  /o/{orgId}/devportal/v1/views/{viewName}/api-flows:
     parameters:
       - $ref: "#/components/parameters/OrgId"
       - $ref: "#/components/parameters/ViewName"
     post:
       tags:
         - API Flows
-      operationId: createAPIFlow
+      operationId: createApiFlow
       summary: Create an API flow
       description: >-
         Creates an API flow in the selected view. If `handle` is omitted, the service generates one from
@@ -2187,7 +2215,7 @@ paths:
     get:
       tags:
         - API Flows
-      operationId: getAllAPIFlows
+      operationId: getAllApiFlows
       summary: List API flows
       description: Lists all API flows for the selected organization view.
       responses:
@@ -2199,7 +2227,7 @@ paths:
         - OAuth2Security:
             - dp:api_flow_read
             - dp:api_flow_manage
-  /organizations/{orgId}/views/{viewName}/api-flows/{apiFlowId}:
+  /o/{orgId}/devportal/v1/views/{viewName}/api-flows/{apiFlowId}:
     parameters:
       - $ref: "#/components/parameters/OrgId"
       - $ref: "#/components/parameters/ViewName"
@@ -2207,7 +2235,7 @@ paths:
     get:
       tags:
         - API Flows
-      operationId: getAPIFlow
+      operationId: getApiFlow
       summary: Get an API flow
       description: Retrieves a single API flow by ID from the selected view.
       responses:
@@ -2224,7 +2252,7 @@ paths:
     put:
       tags:
         - API Flows
-      operationId: updateAPIFlow
+      operationId: updateApiFlow
       summary: Update an API flow
       description: Updates API flow metadata and content for the selected view. Duplicate handles return a conflict.
       requestBody:
@@ -2247,7 +2275,7 @@ paths:
     delete:
       tags:
         - API Flows
-      operationId: deleteAPIFlow
+      operationId: deleteApiFlow
       summary: Delete an API flow
       description: Deletes an API flow from the selected view.
       responses:
@@ -2261,7 +2289,7 @@ paths:
         - OAuth2Security:
             - dp:api_flow_delete
             - dp:api_flow_manage
-  /organizations/{orgId}/views/{viewName}/api-flows/generate-prompt:
+  /o/{orgId}/devportal/v1/views/{viewName}/api-flows/generate-prompt:
     parameters:
       - $ref: "#/components/parameters/OrgId"
       - $ref: "#/components/parameters/ViewName"
@@ -2306,7 +2334,7 @@ paths:
         - OAuth2Security:
             - dp:utility_write
             - dp:utility_manage
-  /organizations/{orgId}/key-managers:
+  /o/{orgId}/devportal/v1/key-managers:
     parameters:
       - $ref: "#/components/parameters/OrgId"
     post:
@@ -2348,7 +2376,7 @@ paths:
         - OAuth2Security:
             - dp:km_read
             - dp:km_manage
-  /organizations/{orgId}/key-managers/discover:
+  /o/{orgId}/devportal/v1/key-managers/discover:
     parameters:
       - $ref: "#/components/parameters/OrgId"
     get:
@@ -2368,7 +2396,7 @@ paths:
       security:
         - OAuth2Security:
             - dp:km_read
-  /organizations/{orgId}/key-managers/{kmId}:
+  /o/{orgId}/devportal/v1/key-managers/{kmId}:
     parameters:
       - $ref: "#/components/parameters/OrgId"
       - $ref: "#/components/parameters/KmId"
@@ -2443,7 +2471,7 @@ paths:
       responses:
         default:
           $ref: "#/components/responses/DefaultResponse"
-  /organizations/{orgId}/events:
+  /o/{orgId}/devportal/v1/webhook-events:
     parameters:
       - $ref: "#/components/parameters/OrgId"
     get:
@@ -2487,7 +2515,7 @@ paths:
       security:
         - OAuth2Security:
             - dp:event_read
-  /organizations/{orgId}/events/{eventId}:
+  /o/{orgId}/devportal/v1/webhook-events/{eventId}:
     parameters:
       - $ref: "#/components/parameters/OrgId"
       - $ref: "#/components/parameters/EventId"
@@ -2511,7 +2539,7 @@ paths:
       security:
         - OAuth2Security:
             - dp:event_read
-  /organizations/{orgId}/deliveries/{deliveryId}/retry:
+  /o/{orgId}/devportal/v1/webhook-deliveries/{deliveryId}/retry:
     parameters:
       - $ref: "#/components/parameters/OrgId"
       - $ref: "#/components/parameters/DeliveryId"
@@ -2649,12 +2677,6 @@ components:
       required: true
       schema:
         type: string
-    Name:
-      name: name
-      in: path
-      required: true
-      schema:
-        type: string
     FileType:
       name: fileType
       in: path
@@ -2668,8 +2690,8 @@ components:
       schema:
         type: string
         example: api-7f4c2a6b
-    PolicyIdOrName:
-      name: policyIdOrName
+    PolicyId:
+      name: policyId
       in: path
       required: true
       schema:
@@ -2681,12 +2703,6 @@ components:
       schema:
         type: string
         example: app-12345
-    SubscriptionId:
-      name: subscriptionId
-      in: path
-      required: true
-      schema:
-        type: string
     SubId:
       name: subId
       in: path
@@ -4058,6 +4074,14 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/SubscriptionPolicyResponse"
+    SubscriptionPolicyListResponse:
+      description: List of subscription policy DTOs. Empty array when no policies match.
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/SubscriptionPolicyResponse"
     SubscriptionPolicyMutationResponse:
       description: Subscription policy create/update response for single or bulk operations.
       content:


### PR DESCRIPTION
### Purpose

- Restructures the Devportal API Spec `devportal-openapi-spec-v1.yaml` with below things:
  - New URL shape for org-scoped resources: `/o/{orgId}/devportal/v1/{resource}` (was `/devportal/organizations/{orgId}/{resource}`)
  - Naming normalization — kebab-case resources, consistent camelCase path params, Api casing in operationIds.
  - **Subscription-policies lookup redesign** — name lookup is now a collection filter, not an overloaded path segment.

### URL shape

- `servers.url` is now `https://devportal.api-platform.io` (prod) plus the local HTTP/HTTPS variants. The `/devportal` base path is gone from `servers.url` and reintroduced after `{orgId}` in each path.
- All org-scoped paths rewritten: `/organizations/{orgId}/X` → `/o/{orgId}/devportal/v1/X` (~50 paths).
- Org-collection meta endpoints (`POST /organizations`, `GET/PATCH/DELETE /organizations/{orgId}`) kept at the root — they manage the org collection itself, not resources within an org.
- Non-org paths (`/login`, `/temp-arazzo-file`, `/applications/*`) untouched; these will be dropped from the spec in a follow-up when the legacy-only routes are removed.

### Naming changes

| Before | After |
|---|---|
| `/identityProvider` (singular, camelCase) | `/identity-providers` (plural, kebab) |
| `/events`, `/events/{eventId}` | `/webhook-events`, `/webhook-events/{eventId}` |
| `/deliveries/{deliveryId}/retry` | `/webhook-deliveries/{deliveryId}/retry` |
| `{subscriptionId}` (1 path, 1 param ref) | `{subId}` — consolidated on existing `SubId` component |
| `{name}` (view name, 3 paths) | `{viewName}` — consolidated on existing `ViewName` component |
| `{policyIdOrName}` (overloaded) | `{policyId}` (see subscription policies redesign) |

Component cleanup: removed unused `Name` and duplicate `SubscriptionId` parameter components; renamed `PolicyIdOrName` → `PolicyId`.

OperationIds normalized so `API` is rendered as `Api` (14 IDs across API metadata, API content, API flows): e.g. `createAPIMetadata` → `createApiMetadata`, `getAPIFlow` → `getApiFlow`. The PUT API-content endpoint is renamed from `updateAPIContent` to `replaceApiContent` to better reflect its replace-semantics. `OAuth*` operationIds left as-is (proper noun).


### Subscription policies — lookup-by-name redesign

- The old {policyIdOrName} path overloaded one segment to mean either UUID or name (with GET/DELETE interpreting it differently). Replaced with the standard REST split:

  - GET `/subscription-policies` — new listSubscriptionPolicies operation with optional ?name= filter. Returns an array (0 or 1 item when filtered). New SubscriptionPolicyListResponse component added.
  - GET `/subscription-policies/{policyId}` — ID-only, single-resource fetch. 
  - DELETE `/subscription-policies/{policyId}` — ID-only, single-resource delete.
Callers that only have a name now do list?name=X then operate on the returned policyId. New endpoint will need a matching controller method when the spec-driven router is enabled.