### PR TITLE
Add sample for ai-gw-llm-proxy

### DIFF
--- a/samples/ai-gw-llm-proxy/.env.example
+++ b/samples/ai-gw-llm-proxy/.env.example
@@ -1,7 +1,7 @@
-# Copy this file to .env before running sh run.sh
+# Copy this file to .env before running sh setup.sh
 
 # Inbound API key that callers must send in the api_key header
-INBOUND_API_KEY=demo-unlocked-sample-key
+INBOUND_API_KEY=demo-api-key
 
 # Ports exposed by the WSO2 AI Gateway bundle (defaults match the official distribution)
 MGMT_PORT=9090

--- a/samples/ai-gw-llm-proxy/.env.example
+++ b/samples/ai-gw-llm-proxy/.env.example
@@ -1,0 +1,12 @@
+# Copy this file to .env before running sh run.sh
+
+# Inbound API key that callers must send in the api_key header
+INBOUND_API_KEY=demo-unlocked-sample-key
+
+# Ports exposed by the WSO2 AI Gateway bundle (defaults match the official distribution)
+MGMT_PORT=9090
+HEALTH_PORT=9094
+TRAFFIC_PORT=8443
+
+# Maximum number of retries when polling for gateway readiness (each retry waits 2s)
+MAX_RETRIES=30

--- a/samples/ai-gw-llm-proxy/README.md
+++ b/samples/ai-gw-llm-proxy/README.md
@@ -1,63 +1,88 @@
-# AI Gateway: Single LLM Proxy + API Key + Rate Limiting
+# AI Gateway: Single LLM Proxy + Token-Based Rate Limiting
 
-Spins up a WSO2 AI Gateway that fronts a mock OpenAI backend, enforces API key auth, and hard-caps token usage to **30 total tokens per minute** — the mock returns exactly 30 tokens, so the second call gets a `429`.
+Spin up a WSO2 AI Gateway that fronts a mock OpenAI backend and hard-caps token usage to **30 total tokens per minute** — the mock returns exactly 30 tokens per response, so the second call gets a `429`.
 
-### Prerequisites
+## Prerequisites
+
 - Docker and Docker Compose
 - `curl`, `wget`, and `unzip` on your host
 
-### Quick Start
+## Getting Started
 
 ```bash
 cp .env.example .env
 sh run.sh
 ```
 
-### Verify It Works
+## Usage Examples
+
+**Call 1 — within quota (expect `200`):**
+```bash
+curl -sk -X POST https://localhost:8443/assistant/chat/completions \
+  -H "api_key: demo-unlocked-sample-key" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Hello"}]}'
+```
+
+Expected response:
+```json
+{
+  "id": "chatcmpl-mock777",
+  "object": "chat.completion",
+  "model": "gpt-4o-mini",
+  "choices": [{"message": {"role": "assistant", "content": "Hello! This response came through your local WSO2 AI Gateway — no real OpenAI call was made."}}],
+  "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30}
+}
+```
+
+**Call 2 immediately after — quota exhausted (expect `429`):**
+```bash
+curl -sk -X POST https://localhost:8443/assistant/chat/completions \
+  -H "api_key: demo-unlocked-sample-key" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Hello"}]}'
+```
+
+Expected response:
+```json
+{"error": "Too Many Requests", "message": "Rate limit exceeded. Please try again later."}
+```
+
+## Verify with test.sh
 
 ```bash
 sh test.sh
 ```
 
-**Expected output:**
+Expected output:
 ```
-========================================
- WSO2 AI Gateway — LLM Proxy Test
-========================================
+=== WSO2 AI Gateway — LLM Proxy Test ===
 
 Target  : https://localhost:8443/assistant/chat/completions
-API Key : demo-unlocked-sample-key
+API Key : demo-unlocked-****
 Payload : {"model":"gpt-4o-mini","messages":[{"role":"user","content":"Test call"}]}
 
-----------------------------------------
- Test 1: Valid API key — expect HTTP 200
-----------------------------------------
+=== Test 1: Valid API key — expect HTTP 200 ===
 Status   : HTTP 200
-[OK]    ✔  HTTP 200 received as expected
+✔  HTTP 200 received as expected
 
-----------------------------------------
- Test 2: Token quota exceeded — expect HTTP 429
-----------------------------------------
+=== Test 2: Token quota exceeded — expect HTTP 429 ===
 Status   : HTTP 429
-[OK]    ✔  HTTP 429 received as expected
+✔  HTTP 429 received as expected
 
-========================================
- ✅ PASSED — API key auth and rate limiting are working correctly.
-========================================
+✔  PASSED — Rate limiting is working correctly.
 ```
 
-### How It Works
+## Configuration
 
-- **API key auth** is enforced at the proxy level — requests without a valid `api_key` header are rejected with `401`.
-- **Rate limiting** is enforced at the provider level via `token-based-ratelimit` — the mock returns 30 total tokens per response, and the quota is set to 30 per minute, so the first call exhausts it and the second gets a `429`.
+| Variable         | Default                    | Description                        |
+|------------------|----------------------------|------------------------------------|
+| `INBOUND_API_KEY`| `demo-unlocked-sample-key` | API key callers must send          |
+| `MGMT_PORT`      | `9090`                     | Gateway management API port        |
+| `HEALTH_PORT`    | `9094`                     | Gateway health check port          |
+| `TRAFFIC_PORT`   | `8443`                     | Gateway traffic port               |
 
-| Container          | Role                            | Port  |
-|--------------------|---------------------------------|-------|
-| `wso2-gateway`     | WSO2 AI Gateway (traffic)       | 8443  |
-| `wso2-controller`  | WSO2 management + policy engine | 9090  |
-| `mock-llm-openai`  | WireMock standing in for OpenAI | 8082  |
-
-### Teardown
+## Teardown
 
 ```bash
 sh teardown.sh

--- a/samples/ai-gw-llm-proxy/README.md
+++ b/samples/ai-gw-llm-proxy/README.md
@@ -1,0 +1,64 @@
+# AI Gateway: Single LLM Proxy + API Key + Rate Limiting
+
+Spins up a WSO2 AI Gateway that fronts a mock OpenAI backend, enforces API key auth, and hard-caps token usage to **30 total tokens per minute** — the mock returns exactly 30 tokens, so the second call gets a `429`.
+
+### Prerequisites
+- Docker and Docker Compose
+- `curl`, `wget`, and `unzip` on your host
+
+### Quick Start
+
+```bash
+cp .env.example .env
+sh run.sh
+```
+
+### Verify It Works
+
+```bash
+sh test.sh
+```
+
+**Expected output:**
+```
+========================================
+ WSO2 AI Gateway — LLM Proxy Test
+========================================
+
+Target  : https://localhost:8443/assistant/chat/completions
+API Key : demo-unlocked-sample-key
+Payload : {"model":"gpt-4o-mini","messages":[{"role":"user","content":"Test call"}]}
+
+----------------------------------------
+ Test 1: Valid API key — expect HTTP 200
+----------------------------------------
+Status   : HTTP 200
+[OK]    ✔  HTTP 200 received as expected
+
+----------------------------------------
+ Test 2: Token quota exceeded — expect HTTP 429
+----------------------------------------
+Status   : HTTP 429
+[OK]    ✔  HTTP 429 received as expected
+
+========================================
+ ✅ PASSED — API key auth and rate limiting are working correctly.
+========================================
+```
+
+### How It Works
+
+- **API key auth** is enforced at the proxy level — requests without a valid `api_key` header are rejected with `401`.
+- **Rate limiting** is enforced at the provider level via `token-based-ratelimit` — the mock returns 30 total tokens per response, and the quota is set to 30 per minute, so the first call exhausts it and the second gets a `429`.
+
+| Container          | Role                            | Port  |
+|--------------------|---------------------------------|-------|
+| `wso2-gateway`     | WSO2 AI Gateway (traffic)       | 8443  |
+| `wso2-controller`  | WSO2 management + policy engine | 9090  |
+| `mock-llm-openai`  | WireMock standing in for OpenAI | 8082  |
+
+### Teardown
+
+```bash
+sh teardown.sh
+```

--- a/samples/ai-gw-llm-proxy/README.md
+++ b/samples/ai-gw-llm-proxy/README.md
@@ -1,30 +1,45 @@
 # AI Gateway: Single LLM Proxy + Token-Based Rate Limiting
 
-Spin up a WSO2 AI Gateway that fronts a mock OpenAI backend and hard-caps token usage to **30 total tokens per minute** — the mock returns exactly 30 tokens per response, so the second call gets a `429`.
+This sample demonstrates how the WSO2 AI Gateway enforces token-based rate limiting on an LLM proxy. A mock OpenAI backend is wired up locally so no real API key or cloud account is needed. The gateway tracks token usage from each response and blocks further requests once the quota is exhausted — returning a `429 Too Many Requests`.
 
 ## Prerequisites
 
 - Docker and Docker Compose
-- `curl`, `wget`, and `unzip` on your host
+- `curl`, `wget`, or `unzip` on your host
 
 ## Getting Started
 
+Copy the environment file and start the stack:
+
 ```bash
 cp .env.example .env
-sh run.sh
+sh setup.sh
 ```
 
-## Usage Examples
+`setup.sh` does the following in order:
 
-**Call 1 — within quota (expect `200`):**
+1. Downloads and unzips the official WSO2 AI Gateway distribution
+2. Starts a WireMock container that stands in for the OpenAI API, serving a fixed mock response with 30 total tokens
+3. Starts the WSO2 AI Gateway stack (controller + runtime) via Docker Compose
+4. Waits for the gateway controller to become healthy
+5. Registers the LLM provider, LLM proxy, and inbound API key via the management API
+6. Polls the traffic endpoint until routes are live before exiting
+
+Once `setup.sh` completes, the gateway is fully ready to accept requests.
+
+## Try It Out
+
+**Call 1 — first request, within quota (expect `200`):**
+
 ```bash
 curl -sk -X POST https://localhost:8443/assistant/chat/completions \
-  -H "api_key: demo-unlocked-sample-key" \
+  -H "api_key: demo-api-key" \
   -H "Content-Type: application/json" \
   -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Hello"}]}'
 ```
 
 Expected response:
+
 ```json
 {
   "id": "chatcmpl-mock777",
@@ -35,31 +50,38 @@ Expected response:
 }
 ```
 
-**Call 2 immediately after — quota exhausted (expect `429`):**
+**Call 2 — immediately after, quota exhausted (expect `429`):**
+
 ```bash
 curl -sk -X POST https://localhost:8443/assistant/chat/completions \
-  -H "api_key: demo-unlocked-sample-key" \
+  -H "api_key: demo-api-key" \
   -H "Content-Type: application/json" \
   -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Hello"}]}'
 ```
 
 Expected response:
+
 ```json
 {"error": "Too Many Requests", "message": "Rate limit exceeded. Please try again later."}
 ```
 
+> The rate limit resets at the start of each fixed 1-minute window.
+
 ## Verify with test.sh
+
+`test.sh` fires two back-to-back requests with the registered API key and asserts the first returns `200` and the second returns `429`, proving the rate limit is correctly enforced.
 
 ```bash
 sh test.sh
 ```
 
 Expected output:
+
 ```
 === WSO2 AI Gateway — LLM Proxy Test ===
 
 Target  : https://localhost:8443/assistant/chat/completions
-API Key : demo-unlocked-****
+API Key : demo ****
 Payload : {"model":"gpt-4o-mini","messages":[{"role":"user","content":"Test call"}]}
 
 === Test 1: Valid API key — expect HTTP 200 ===
@@ -73,14 +95,29 @@ Status   : HTTP 429
 ✔  PASSED — Rate limiting is working correctly.
 ```
 
+## How It Works
+
+The mock LLM backend returns exactly 30 total tokens in every response. The `token-based-ratelimit` policy on the provider is configured with a quota of 30 total tokens per minute. The first request consumes the entire quota and succeeds. The second request finds the quota exhausted and is rejected with `429`.
+
+The `api-key-auth` policy on the proxy ensures only requests carrying a registered `api_key` header reach the rate limiter at all.
+
 ## Configuration
 
-| Variable         | Default                    | Description                        |
-|------------------|----------------------------|------------------------------------|
-| `INBOUND_API_KEY`| `demo-unlocked-sample-key` | API key callers must send          |
-| `MGMT_PORT`      | `9090`                     | Gateway management API port        |
-| `HEALTH_PORT`    | `9094`                     | Gateway health check port          |
-| `TRAFFIC_PORT`   | `8443`                     | Gateway traffic port               |
+| Variable          | Default                     | Description                                               |
+|-------------------|-----------------------------|-----------------------------------------------------------|
+| `INBOUND_API_KEY` | `demo-api-key`  | API key callers must send in the `api_key` header         |
+| `MGMT_PORT`       | `9090`                      | Gateway management API port                               |
+| `HEALTH_PORT`     | `9094`                      | Gateway health check port                                 |
+| `TRAFFIC_PORT`    | `8443`                      | Gateway traffic port                                      |
+| `MAX_RETRIES`     | `30`                        | Max readiness poll attempts before giving up (2s interval)|
+
+## What's Running
+
+| Container          | Role                            | Port  |
+|--------------------|---------------------------------|-------|
+| `wso2-gateway`     | WSO2 AI Gateway (traffic)       | 8443  |
+| `wso2-controller`  | WSO2 management + policy engine | 9090  |
+| `mock-llm-openai`  | WireMock standing in for OpenAI | 8082  |
 
 ## Teardown
 

--- a/samples/ai-gw-llm-proxy/inject-mock.sh
+++ b/samples/ai-gw-llm-proxy/inject-mock.sh
@@ -1,10 +1,15 @@
 #!/bin/sh
 set -eu
 
+# Initialise tput colors if available
+if command -v tput >/dev/null 2>&1 && [ -n "${TERM:-}" ] && tput setaf 2 >/dev/null 2>&1; then
+  GREEN="$(tput setaf 2)"; RESET="$(tput sgr0)"
+else
+  GREEN=""; RESET=""
+fi
+
 print_ok() {
-  tput setaf 2
-  echo "✔  $1"
-  tput sgr0
+  echo "${GREEN}✔  $1${RESET}"
 }
 
 print_info() {

--- a/samples/ai-gw-llm-proxy/inject-mock.sh
+++ b/samples/ai-gw-llm-proxy/inject-mock.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+set -eu
+
+print_ok() {
+  tput setaf 2
+  echo "✔  $1"
+  tput sgr0
+}
+
+print_info() {
+  echo "-->  $1"
+}
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+if [ -f "${SCRIPT_DIR}/.env" ]; then
+  . "${SCRIPT_DIR}/.env"
+fi
+
+MGMT_PORT="${MGMT_PORT:-9090}"
+INBOUND_API_KEY="${INBOUND_API_KEY:-demo-unlocked-sample-key}"
+MGMT_BASE="http://localhost:${MGMT_PORT}/api/management/v0.9"
+AUTH="Authorization: Basic YWRtaW46YWRtaW4="
+
+print_info "Registering LLM Provider (upstream: mock-llm-openai, policy: token-based-ratelimit)..."
+curl -sf -X POST "${MGMT_BASE}/llm-providers" \
+  -H "Content-Type: application/yaml" \
+  -H "${AUTH}" \
+  --data-binary @"${SCRIPT_DIR}/provider.yaml"
+echo ""
+print_ok "LLM Provider registered"
+
+sleep 3
+
+print_info "Registering LLM Proxy (context: /assistant, policy: api-key-auth)..."
+curl -sf -X POST "${MGMT_BASE}/llm-proxies" \
+  -H "Content-Type: application/yaml" \
+  -H "${AUTH}" \
+  --data-binary @"${SCRIPT_DIR}/proxy.yaml"
+echo ""
+print_ok "LLM Proxy registered"
+
+sleep 3
+
+print_info "Registering inbound API key for proxy 'openai-assistant'..."
+curl -sf -X POST "${MGMT_BASE}/llm-proxies/openai-assistant/api-keys" \
+  -H "Content-Type: application/json" \
+  -H "${AUTH}" \
+  -d "{\"apiKey\": \"${INBOUND_API_KEY}\"}"
+echo ""
+print_ok "API key registered"

--- a/samples/ai-gw-llm-proxy/inject-mock.sh
+++ b/samples/ai-gw-llm-proxy/inject-mock.sh
@@ -22,7 +22,7 @@ if [ -f "${SCRIPT_DIR}/.env" ]; then
 fi
 
 MGMT_PORT="${MGMT_PORT:-9090}"
-INBOUND_API_KEY="${INBOUND_API_KEY:-demo-unlocked-sample-key}"
+INBOUND_API_KEY="${INBOUND_API_KEY:-demo-api-key}"
 MGMT_BASE="http://localhost:${MGMT_PORT}/api/management/v0.9"
 AUTH="Authorization: Basic YWRtaW46YWRtaW4="
 

--- a/samples/ai-gw-llm-proxy/provider.yaml
+++ b/samples/ai-gw-llm-proxy/provider.yaml
@@ -1,0 +1,30 @@
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: openai-provider
+spec:
+  displayName: OpenAI Provider
+  version: v1.0
+  template: openai
+  context: /openai/latest
+  upstream:
+    url: http://mock-llm-openai:8080/v1
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer local-mock-key
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+  policies:
+    - name: token-based-ratelimit
+      version: v1
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            totalTokenLimits:
+              - count: 30
+                duration: "1m"

--- a/samples/ai-gw-llm-proxy/proxy.yaml
+++ b/samples/ai-gw-llm-proxy/proxy.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProxy
+metadata:
+  name: openai-assistant
+spec:
+  displayName: OpenAI Assistant
+  version: v1.0
+  context: /assistant
+  provider:
+    id: openai-provider
+  policies:
+    - name: api-key-auth
+      version: v1
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            key: api_key
+            in: header

--- a/samples/ai-gw-llm-proxy/run.sh
+++ b/samples/ai-gw-llm-proxy/run.sh
@@ -1,0 +1,94 @@
+#!/bin/sh
+set -eu
+
+print_ok() {
+  tput setaf 2
+  echo "✔  $1"
+  tput sgr0
+}
+
+print_info() {
+  echo "-->  $1"
+}
+
+print_warn() {
+  tput setaf 3
+  echo "⚠   $1"
+  tput sgr0
+}
+
+print_title() {
+  echo
+  tput bold
+  tput setaf 2
+  echo "=== $1 ==="
+  tput sgr0
+  echo
+}
+
+if [ -f .env ]; then
+  . .env
+else
+  print_warn "No .env found — copy .env.example to .env, or defaults will be used."
+  INBOUND_API_KEY="${INBOUND_API_KEY:-demo-unlocked-sample-key}"
+  MGMT_PORT="${MGMT_PORT:-9090}"
+  HEALTH_PORT="${HEALTH_PORT:-9094}"
+  TRAFFIC_PORT="${TRAFFIC_PORT:-8443}"
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+print_title "Downloading WSO2 AI Gateway"
+print_info "Downloading official distribution package..."
+wget -qN https://github.com/wso2/api-platform/releases/download/ai-gateway/v1.1.0/wso2apip-ai-gateway-1.1.0.zip
+print_info "Unzipping distribution..."
+unzip -o wso2apip-ai-gateway-1.1.0.zip
+
+print_title "Starting Containers"
+print_info "Starting WireMock mock LLM backend..."
+docker rm -f mock-llm-openai 2>/dev/null || true
+docker run -d --name mock-llm-openai \
+  -p 8082:8080 \
+  -v "${SCRIPT_DIR}/wiremock/mappings:/home/wiremock/mappings" \
+  wiremock/wiremock:3.3.1
+print_ok "Mock LLM backend started (WireMock on host port 8082)"
+
+print_info "Booting WSO2 AI Gateway stack..."
+cd "${SCRIPT_DIR}/wso2apip-ai-gateway-1.1.0/"
+docker compose up -d
+print_ok "Gateway stack started"
+
+print_title "Waiting for Gateway"
+print_info "Waiting for gateway controller to be ready..."
+until curl -s "http://localhost:${HEALTH_PORT:-9094}/health" > /dev/null 2>&1; do
+  sleep 2
+done
+print_ok "Gateway controller is healthy"
+
+print_info "Connecting mock LLM backend to gateway network..."
+GATEWAY_NETWORK=$(docker network ls --filter name=gateway-network --format "{{.Name}}" | head -1)
+if [ -n "$GATEWAY_NETWORK" ]; then
+  docker network connect "$GATEWAY_NETWORK" mock-llm-openai 2>/dev/null || true
+  print_ok "Connected mock-llm-openai to network: ${GATEWAY_NETWORK}"
+else
+  print_warn "Could not detect gateway network — mock routing may not work."
+fi
+
+print_title "Registering Resources"
+sh "${SCRIPT_DIR}/inject-mock.sh"
+
+print_title "Waiting for Routes"
+print_info "Polling gateway traffic endpoint until routes are live..."
+TRAFFIC_PORT="${TRAFFIC_PORT:-8443}"
+INBOUND_API_KEY="${INBOUND_API_KEY:-demo-unlocked-sample-key}"
+until [ "$(curl -sk -o /dev/null -w '%{http_code}' -X POST \
+  "https://localhost:${TRAFFIC_PORT}/assistant/chat/completions" \
+  -H "api_key: route-probe-key" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"ping"}]}')" = "401" ]; do
+  sleep 2
+done
+print_ok "Routes are live"
+
+echo ""
+print_ok "Setup complete. Run: sh test.sh"

--- a/samples/ai-gw-llm-proxy/run.sh
+++ b/samples/ai-gw-llm-proxy/run.sh
@@ -1,10 +1,19 @@
 #!/bin/sh
 set -eu
 
+# Initialise tput colors if available
+if command -v tput >/dev/null 2>&1 && [ -n "${TERM:-}" ] && tput setaf 2 >/dev/null 2>&1; then
+  GREEN="$(tput setaf 2)"
+  YELLOW="$(tput setaf 3)"
+  RED="$(tput setaf 1)"
+  BOLD="$(tput bold)"
+  RESET="$(tput sgr0)"
+else
+  GREEN=""; YELLOW=""; RED=""; BOLD=""; RESET=""
+fi
+
 print_ok() {
-  tput setaf 2
-  echo "✔  $1"
-  tput sgr0
+  echo "${GREEN}✔  $1${RESET}"
 }
 
 print_info() {
@@ -12,31 +21,33 @@ print_info() {
 }
 
 print_warn() {
-  tput setaf 3
-  echo "⚠   $1"
-  tput sgr0
+  echo "${YELLOW}⚠   $1${RESET}"
+}
+
+print_error() {
+  echo "${RED}✖  $1${RESET}"
 }
 
 print_title() {
-  echo
-  tput bold
-  tput setaf 2
-  echo "=== $1 ==="
-  tput sgr0
-  echo
+  echo ""
+  echo "${BOLD}${GREEN}=== $1 ===${RESET}"
+  echo ""
 }
 
-if [ -f .env ]; then
-  . .env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+if [ -f "${SCRIPT_DIR}/.env" ]; then
+  . "${SCRIPT_DIR}/.env"
 else
-  print_warn "No .env found — copy .env.example to .env, or defaults will be used."
+  print_warn "No .env found at ${SCRIPT_DIR}/.env — copy .env.example to .env, or defaults will be used."
   INBOUND_API_KEY="${INBOUND_API_KEY:-demo-unlocked-sample-key}"
   MGMT_PORT="${MGMT_PORT:-9090}"
   HEALTH_PORT="${HEALTH_PORT:-9094}"
   TRAFFIC_PORT="${TRAFFIC_PORT:-8443}"
 fi
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MAX_RETRIES="${MAX_RETRIES:-30}"
+RETRY_INTERVAL=2
 
 print_title "Downloading WSO2 AI Gateway"
 print_info "Downloading official distribution package..."
@@ -60,8 +71,14 @@ print_ok "Gateway stack started"
 
 print_title "Waiting for Gateway"
 print_info "Waiting for gateway controller to be ready..."
+retries=0
 until curl -s "http://localhost:${HEALTH_PORT:-9094}/health" > /dev/null 2>&1; do
-  sleep 2
+  retries=$((retries + 1))
+  if [ "$retries" -ge "$MAX_RETRIES" ]; then
+    print_error "Gateway controller did not become healthy after $((MAX_RETRIES * RETRY_INTERVAL))s. Check: docker compose logs"
+    exit 1
+  fi
+  sleep "$RETRY_INTERVAL"
 done
 print_ok "Gateway controller is healthy"
 
@@ -79,14 +96,18 @@ sh "${SCRIPT_DIR}/inject-mock.sh"
 
 print_title "Waiting for Routes"
 print_info "Polling gateway traffic endpoint until routes are live..."
-TRAFFIC_PORT="${TRAFFIC_PORT:-8443}"
-INBOUND_API_KEY="${INBOUND_API_KEY:-demo-unlocked-sample-key}"
+retries=0
 until [ "$(curl -sk -o /dev/null -w '%{http_code}' -X POST \
-  "https://localhost:${TRAFFIC_PORT}/assistant/chat/completions" \
+  "https://localhost:${TRAFFIC_PORT:-8443}/assistant/chat/completions" \
   -H "api_key: route-probe-key" \
   -H "Content-Type: application/json" \
   -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"ping"}]}')" = "401" ]; do
-  sleep 2
+  retries=$((retries + 1))
+  if [ "$retries" -ge "$MAX_RETRIES" ]; then
+    print_error "Routes did not become live after $((MAX_RETRIES * RETRY_INTERVAL))s. Check: docker compose logs"
+    exit 1
+  fi
+  sleep "$RETRY_INTERVAL"
 done
 print_ok "Routes are live"
 

--- a/samples/ai-gw-llm-proxy/setup.sh
+++ b/samples/ai-gw-llm-proxy/setup.sh
@@ -40,7 +40,7 @@ if [ -f "${SCRIPT_DIR}/.env" ]; then
   . "${SCRIPT_DIR}/.env"
 else
   print_warn "No .env found at ${SCRIPT_DIR}/.env — copy .env.example to .env, or defaults will be used."
-  INBOUND_API_KEY="${INBOUND_API_KEY:-demo-unlocked-sample-key}"
+  INBOUND_API_KEY="${INBOUND_API_KEY:-demo-api-key}"
   MGMT_PORT="${MGMT_PORT:-9090}"
   HEALTH_PORT="${HEALTH_PORT:-9094}"
   TRAFFIC_PORT="${TRAFFIC_PORT:-8443}"
@@ -49,11 +49,25 @@ fi
 MAX_RETRIES="${MAX_RETRIES:-30}"
 RETRY_INTERVAL=2
 
+ZIP_URL="https://github.com/wso2/api-platform/releases/download/ai-gateway/v1.1.0/wso2apip-ai-gateway-1.1.0.zip"
+ZIP_FILE="${SCRIPT_DIR}/wso2apip-ai-gateway-1.1.0.zip"
+
 print_title "Downloading WSO2 AI Gateway"
-print_info "Downloading official distribution package..."
-wget -qN https://github.com/wso2/api-platform/releases/download/ai-gateway/v1.1.0/wso2apip-ai-gateway-1.1.0.zip
+if [ -f "$ZIP_FILE" ]; then
+  print_info "Distribution zip already exists, skipping download."
+else
+  print_info "Downloading official distribution package..."
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$ZIP_URL" -o "$ZIP_FILE"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q "$ZIP_URL" -O "$ZIP_FILE"
+  else
+    print_error "Neither curl nor wget found. Please install one and retry."
+    exit 1
+  fi
+fi
 print_info "Unzipping distribution..."
-unzip -o wso2apip-ai-gateway-1.1.0.zip
+unzip -o "$ZIP_FILE" -d "${SCRIPT_DIR}"
 
 print_title "Starting Containers"
 print_info "Starting WireMock mock LLM backend..."
@@ -72,7 +86,7 @@ print_ok "Gateway stack started"
 print_title "Waiting for Gateway"
 print_info "Waiting for gateway controller to be ready..."
 retries=0
-until curl -s "http://localhost:${HEALTH_PORT:-9094}/health" > /dev/null 2>&1; do
+until [ "$(curl -s -o /dev/null -w '%{http_code}' "http://localhost:${HEALTH_PORT:-9094}/health")" = "200" ]; do
   retries=$((retries + 1))
   if [ "$retries" -ge "$MAX_RETRIES" ]; then
     print_error "Gateway controller did not become healthy after $((MAX_RETRIES * RETRY_INTERVAL))s. Check: docker compose logs"

--- a/samples/ai-gw-llm-proxy/teardown.sh
+++ b/samples/ai-gw-llm-proxy/teardown.sh
@@ -1,10 +1,15 @@
 #!/bin/sh
 set -eu
 
+# Initialise tput colors if available
+if command -v tput >/dev/null 2>&1 && [ -n "${TERM:-}" ] && tput setaf 2 >/dev/null 2>&1; then
+  GREEN="$(tput setaf 2)"; RESET="$(tput sgr0)"
+else
+  GREEN=""; RESET=""
+fi
+
 print_ok() {
-  tput setaf 2
-  echo "✔  $1"
-  tput sgr0
+  echo "${GREEN}✔  $1${RESET}"
 }
 
 print_info() {
@@ -12,12 +17,9 @@ print_info() {
 }
 
 print_title() {
-  echo
-  tput bold
-  tput setaf 2
-  echo "=== $1 ==="
-  tput sgr0
-  echo
+  echo ""
+  echo "${GREEN}=== $1 ===${RESET}"
+  echo ""
 }
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -27,7 +29,11 @@ print_info "Removing mock LLM container..."
 docker rm -f mock-llm-openai 2>/dev/null || true
 print_ok "mock-llm-openai removed"
 
-print_info "Stopping WSO2 AI Gateway stack..."
-cd "${SCRIPT_DIR}/wso2apip-ai-gateway-1.1.0/"
-docker compose down -v
-print_ok "Teardown complete."
+BUNDLE_DIR="${SCRIPT_DIR}/wso2apip-ai-gateway-1.1.0"
+if [ -d "$BUNDLE_DIR" ]; then
+  print_info "Stopping WSO2 AI Gateway stack..."
+  cd "$BUNDLE_DIR" && docker compose down -v
+  print_ok "Teardown complete."
+else
+  print_info "Bundle directory not found at ${BUNDLE_DIR} — skipping docker compose down."
+fi

--- a/samples/ai-gw-llm-proxy/teardown.sh
+++ b/samples/ai-gw-llm-proxy/teardown.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -eu
+
+print_ok() {
+  tput setaf 2
+  echo "✔  $1"
+  tput sgr0
+}
+
+print_info() {
+  echo "-->  $1"
+}
+
+print_title() {
+  echo
+  tput bold
+  tput setaf 2
+  echo "=== $1 ==="
+  tput sgr0
+  echo
+}
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+print_title "Teardown"
+print_info "Removing mock LLM container..."
+docker rm -f mock-llm-openai 2>/dev/null || true
+print_ok "mock-llm-openai removed"
+
+print_info "Stopping WSO2 AI Gateway stack..."
+cd "${SCRIPT_DIR}/wso2apip-ai-gateway-1.1.0/"
+docker compose down -v
+print_ok "Teardown complete."

--- a/samples/ai-gw-llm-proxy/test.sh
+++ b/samples/ai-gw-llm-proxy/test.sh
@@ -1,31 +1,32 @@
 #!/bin/sh
 set -eu
 
+# Initialise tput colors if available
+if command -v tput >/dev/null 2>&1 && [ -n "${TERM:-}" ] && tput setaf 2 >/dev/null 2>&1; then
+  GREEN="$(tput setaf 2)"
+  RED="$(tput setaf 1)"
+  BOLD="$(tput bold)"
+  RESET="$(tput sgr0)"
+else
+  GREEN=""; RED=""; BOLD=""; RESET=""
+fi
+
 print_ok() {
-  tput setaf 2
-  echo "✔  $1"
-  tput sgr0
+  echo "${GREEN}✔  $1${RESET}"
 }
 
 print_error() {
-  tput setaf 1
-  echo "✖  $1"
-  tput sgr0
+  echo "${RED}✖  $1${RESET}"
 }
 
 print_title() {
-  echo
-  tput bold
-  tput setaf 2
-  echo "=== $1 ==="
-  tput sgr0
-  echo
+  echo ""
+  echo "${BOLD}${GREEN}=== $1 ===${RESET}"
+  echo ""
 }
 
 print_result() {
-  tput bold
-  echo "$1"
-  tput sgr0
+  echo "${BOLD}$1${RESET}"
 }
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -38,15 +39,18 @@ INBOUND_API_KEY="${INBOUND_API_KEY:-demo-unlocked-sample-key}"
 TARGET="https://localhost:${TRAFFIC_PORT}/assistant/chat/completions"
 PAYLOAD='{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Test call"}]}'
 
+# Mask API key for display — show prefix and last 4 chars
+KEY_MASKED="$(echo "$INBOUND_API_KEY" | sed 's/\(.\{4\}\).*/\1/') ****"
+
 print_title "WSO2 AI Gateway — LLM Proxy Test"
 echo "Target  : ${TARGET}"
-echo "API Key : ${INBOUND_API_KEY}"
+echo "API Key : ${KEY_MASKED}"
 echo "Payload : ${PAYLOAD}"
 
 print_title "Test 1: Valid API key — expect HTTP 200"
 echo "Running:"
 echo "  curl -sk -X POST ${TARGET} \\"
-echo "    -H 'api_key: ${INBOUND_API_KEY}' \\"
+echo "    -H 'api_key: ${KEY_MASKED}' \\"
 echo "    -H 'Content-Type: application/json' \\"
 echo "    -d '${PAYLOAD}'"
 echo ""
@@ -75,7 +79,7 @@ echo "This call is made immediately after with the same key."
 echo ""
 echo "Running:"
 echo "  curl -sk -X POST ${TARGET} \\"
-echo "    -H 'api_key: ${INBOUND_API_KEY}' \\"
+echo "    -H 'api_key: ${KEY_MASKED}' \\"
 echo "    -H 'Content-Type: application/json' \\"
 echo "    -d '${PAYLOAD}'"
 echo ""
@@ -100,7 +104,7 @@ fi
 
 echo ""
 if [ "$STATUS_1" -eq 200 ] && [ "$STATUS_2" -eq 429 ]; then
-  print_result "✔  PASSED — API key auth and rate limiting are working correctly."
+  print_result "✔  PASSED — Rate limiting is working correctly."
   exit 0
 else
   print_result "✖  FAILED — Expected HTTP 200 then HTTP 429, got ${STATUS_1} then ${STATUS_2}."

--- a/samples/ai-gw-llm-proxy/test.sh
+++ b/samples/ai-gw-llm-proxy/test.sh
@@ -1,0 +1,113 @@
+#!/bin/sh
+set -eu
+
+print_ok() {
+  tput setaf 2
+  echo "✔  $1"
+  tput sgr0
+}
+
+print_error() {
+  tput setaf 1
+  echo "✖  $1"
+  tput sgr0
+}
+
+print_title() {
+  echo
+  tput bold
+  tput setaf 2
+  echo "=== $1 ==="
+  tput sgr0
+  echo
+}
+
+print_result() {
+  tput bold
+  echo "$1"
+  tput sgr0
+}
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+if [ -f "${SCRIPT_DIR}/.env" ]; then
+  . "${SCRIPT_DIR}/.env"
+fi
+
+TRAFFIC_PORT="${TRAFFIC_PORT:-8443}"
+INBOUND_API_KEY="${INBOUND_API_KEY:-demo-unlocked-sample-key}"
+TARGET="https://localhost:${TRAFFIC_PORT}/assistant/chat/completions"
+PAYLOAD='{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Test call"}]}'
+
+print_title "WSO2 AI Gateway — LLM Proxy Test"
+echo "Target  : ${TARGET}"
+echo "API Key : ${INBOUND_API_KEY}"
+echo "Payload : ${PAYLOAD}"
+
+print_title "Test 1: Valid API key — expect HTTP 200"
+echo "Running:"
+echo "  curl -sk -X POST ${TARGET} \\"
+echo "    -H 'api_key: ${INBOUND_API_KEY}' \\"
+echo "    -H 'Content-Type: application/json' \\"
+echo "    -d '${PAYLOAD}'"
+echo ""
+
+FULL_1=$(curl -sk -w "\n%{http_code}" -X POST "$TARGET" \
+  -H "api_key: ${INBOUND_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d "$PAYLOAD") || {
+  print_error "Could not reach gateway at ${TARGET}. Is the gateway running? Run: sh run.sh"
+  exit 1
+}
+STATUS_1=$(echo "$FULL_1" | tail -1)
+BODY_1=$(echo "$FULL_1" | sed '$d')
+
+echo "Response : ${BODY_1}"
+echo "Status   : HTTP ${STATUS_1}"
+if [ "$STATUS_1" -eq 200 ]; then
+  print_ok "HTTP 200 received as expected"
+else
+  print_error "Expected HTTP 200, got ${STATUS_1}"
+fi
+
+print_title "Test 2: Token quota exceeded — expect HTTP 429"
+echo "Test 1 consumed the full 30-token quota."
+echo "This call is made immediately after with the same key."
+echo ""
+echo "Running:"
+echo "  curl -sk -X POST ${TARGET} \\"
+echo "    -H 'api_key: ${INBOUND_API_KEY}' \\"
+echo "    -H 'Content-Type: application/json' \\"
+echo "    -d '${PAYLOAD}'"
+echo ""
+
+FULL_2=$(curl -sk -w "\n%{http_code}" -X POST "$TARGET" \
+  -H "api_key: ${INBOUND_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d "$PAYLOAD") || {
+  print_error "Could not reach gateway at ${TARGET}. Is the gateway running? Run: sh run.sh"
+  exit 1
+}
+STATUS_2=$(echo "$FULL_2" | tail -1)
+BODY_2=$(echo "$FULL_2" | sed '$d')
+
+echo "Response : ${BODY_2}"
+echo "Status   : HTTP ${STATUS_2}"
+if [ "$STATUS_2" -eq 429 ]; then
+  print_ok "HTTP 429 received as expected"
+else
+  print_error "Expected HTTP 429, got ${STATUS_2}"
+fi
+
+echo ""
+if [ "$STATUS_1" -eq 200 ] && [ "$STATUS_2" -eq 429 ]; then
+  print_result "✔  PASSED — API key auth and rate limiting are working correctly."
+  exit 0
+else
+  print_result "✖  FAILED — Expected HTTP 200 then HTTP 429, got ${STATUS_1} then ${STATUS_2}."
+  echo ""
+  echo "Troubleshooting:"
+  echo "  - Check setup completed: cd wso2apip-ai-gateway-1.1.0 && docker compose logs"
+  echo "  - Verify containers are up: docker ps"
+  echo "  - Re-run setup: sh run.sh"
+  exit 1
+fi

--- a/samples/ai-gw-llm-proxy/test.sh
+++ b/samples/ai-gw-llm-proxy/test.sh
@@ -35,7 +35,7 @@ if [ -f "${SCRIPT_DIR}/.env" ]; then
 fi
 
 TRAFFIC_PORT="${TRAFFIC_PORT:-8443}"
-INBOUND_API_KEY="${INBOUND_API_KEY:-demo-unlocked-sample-key}"
+INBOUND_API_KEY="${INBOUND_API_KEY:-demo-api-key}"
 TARGET="https://localhost:${TRAFFIC_PORT}/assistant/chat/completions"
 PAYLOAD='{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Test call"}]}'
 
@@ -59,7 +59,7 @@ FULL_1=$(curl -sk -w "\n%{http_code}" -X POST "$TARGET" \
   -H "api_key: ${INBOUND_API_KEY}" \
   -H "Content-Type: application/json" \
   -d "$PAYLOAD") || {
-  print_error "Could not reach gateway at ${TARGET}. Is the gateway running? Run: sh run.sh"
+  print_error "Could not reach gateway at ${TARGET}. Is the gateway running? Run: sh setup.sh"
   exit 1
 }
 STATUS_1=$(echo "$FULL_1" | tail -1)
@@ -88,7 +88,7 @@ FULL_2=$(curl -sk -w "\n%{http_code}" -X POST "$TARGET" \
   -H "api_key: ${INBOUND_API_KEY}" \
   -H "Content-Type: application/json" \
   -d "$PAYLOAD") || {
-  print_error "Could not reach gateway at ${TARGET}. Is the gateway running? Run: sh run.sh"
+  print_error "Could not reach gateway at ${TARGET}. Is the gateway running? Run: sh setup.sh"
   exit 1
 }
 STATUS_2=$(echo "$FULL_2" | tail -1)
@@ -112,6 +112,6 @@ else
   echo "Troubleshooting:"
   echo "  - Check setup completed: cd wso2apip-ai-gateway-1.1.0 && docker compose logs"
   echo "  - Verify containers are up: docker ps"
-  echo "  - Re-run setup: sh run.sh"
+  echo "  - Re-run setup: sh setup.sh"
   exit 1
 fi

--- a/samples/ai-gw-llm-proxy/wiremock/mappings/openai-mock.json
+++ b/samples/ai-gw-llm-proxy/wiremock/mappings/openai-mock.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "/v1/chat/completions"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "id": "chatcmpl-mock777",
+      "object": "chat.completion",
+      "created": 1700000000,
+      "model": "gpt-4o-mini",
+      "choices": [
+        {
+          "index": 0,
+          "message": {
+            "role": "assistant",
+            "content": "Hello! This response came through your local WSO2 AI Gateway — no real OpenAI call was made."
+          },
+          "finish_reason": "stop"
+        }
+      ],
+      "usage": {
+        "prompt_tokens": 10,
+        "completion_tokens": 20,
+        "total_tokens": 30
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Purpose
> Adds the ai-gw-llm-proxy sample under the platform samples. 

## Approach
> The sample spins up a local WSO2 AI Gateway stack using Docker. The gateway proxies requests to a WireMock container that stands in for the OpenAI backend. It demonstrates token-based rate limiting through a single LLM proxy. The mock returns 30 total tokens per response, the quota is set to 30 tokens per minute, so the first call succeeds with `200` and the second call is rejected with `429`.

### What's in the folder :

- `setup.sh` — single command to bring up the full stack, register all resources, and wait until the gateway is ready
- `test.sh` — verifies the 200 then 429 behavior end to end
- `teardown.sh` — cleanly removes all containers and volumes in one pass
- `inject-mock.sh` — registers the LLM provider, proxy, and API key via the management API
- `provider.yaml` / `proxy.yaml`— declarative gateway configuration
- `wiremock/mappings/openai-mock.json` — mock LLM response with a fixed token count
- `.env.example` — API key and ports are configurable
- `README.md` — prerequisites, setup steps, manual curl examples with expected output, and teardown

### Implementation notes:

- Rate limiting uses token-based-ratelimit at the provider level with path-scoped params
- `setup.sh` polls the traffic endpoint with a dummy key until it receives 401, ensuring routes are fully synced before `test.sh` runs
- Health check loop verifies HTTP 200 

## Related Issue
- https://github.com/wso2-enterprise/apim-gtm/issues/422