### PR TITLE
fix(controller): apply most-specific match for overlapping LLM policies

### DIFF
--- a/gateway/gateway-controller/pkg/utils/llm_transformer.go
+++ b/gateway/gateway-controller/pkg/utils/llm_transformer.go
@@ -246,7 +246,7 @@ func (t *LLMProviderTransformer) transformProxy(proxy *api.LLMProxyConfiguration
 							if attachedPolicyPaths[targetPath] {
 								continue
 							}
-							if moreSpecificPolicyAttachmentCovers(targetPath, policyMethod, attachment, *proxy.Spec.Policies) {
+							if moreSpecificPolicyAttachmentCovers(targetPath, policyMethod, attachment) {
 								continue
 							}
 							targetKey := pathMethodKey{path: targetPath, method: policyMethod}
@@ -467,7 +467,7 @@ func (t *LLMProviderTransformer) transformProvider(provider *api.LLMProviderConf
 								if attachedPolicyPaths[targetPath] {
 									continue
 								}
-								if moreSpecificPolicyAttachmentCovers(targetPath, policyMethod, attachment, *provider.Spec.Policies) {
+								if moreSpecificPolicyAttachmentCovers(targetPath, policyMethod, attachment) {
 									continue
 								}
 								targetKey := pathMethodKey{path: targetPath, method: policyMethod}
@@ -557,7 +557,7 @@ func (t *LLMProviderTransformer) transformProvider(provider *api.LLMProviderConf
 								if attachedPolicyPaths[targetPath] {
 									continue
 								}
-								if moreSpecificPolicyAttachmentCovers(targetPath, policyMethod, attachment, *provider.Spec.Policies) {
+								if moreSpecificPolicyAttachmentCovers(targetPath, policyMethod, attachment) {
 									continue
 								}
 								targetKey := pathMethodKey{path: targetPath, method: policyMethod}
@@ -812,30 +812,25 @@ func methodsInclude(methods []string, method string) bool {
 	return false
 }
 
-// moreSpecificPolicyAttachmentCovers reports whether another path entry of the SAME policy
-// covers targetPath for the given HTTP method and is strictly more specific than the current
-// entry. When true, the current (less specific) entry must not be layered onto targetPath, so
-// the most specific match wins for that policy. Specificity is compared by path first
-// (see isMoreSpecificPath) and then, for entries on an equally specific path, by method
-// (a concrete method beats the '*' wildcard). Different policy names still layer (e.g. a
-// wildcard set-headers plus a path-specific rate limit); only same-name overlaps are collapsed.
-func moreSpecificPolicyAttachmentCovers(targetPath, method string, current llmPolicyAttachment,
-	policies []api.LLMPolicy) bool {
-	for _, llmPol := range policies {
-		if llmPol.Name != current.policy.Name {
+// moreSpecificPolicyAttachmentCovers reports whether another path entry WITHIN THE SAME policy
+// block covers targetPath for the given HTTP method and is strictly more specific than the
+// current entry. When true, the current (less specific) entry must not be layered onto
+// targetPath, so the most specific match wins within that block. Specificity is compared by
+// path first (see isMoreSpecificPath) and then, for entries on an equally specific path, by
+// method (the narrower method set wins). Resolution is scoped to a single block, so separate
+// policy blocks - even ones with the same name - each contribute their most specific match and
+// all layer onto the route.
+func moreSpecificPolicyAttachmentCovers(targetPath, method string, current llmPolicyAttachment) bool {
+	for i := range current.policy.Paths {
+		other := current.policy.Paths[i]
+		if !pathsMatch(targetPath, other.Path) {
 			continue
 		}
-		for i := range llmPol.Paths {
-			other := llmPol.Paths[i]
-			if !pathsMatch(targetPath, other.Path) {
-				continue
-			}
-			if !methodsInclude(expandLLMPolicyMethods(other.Methods), method) {
-				continue
-			}
-			if isMoreSpecificAttachment(other, current.pathEntry) {
-				return true
-			}
+		if !methodsInclude(expandLLMPolicyMethods(other.Methods), method) {
+			continue
+		}
+		if isMoreSpecificAttachment(other, current.pathEntry) {
+			return true
 		}
 	}
 	return false

--- a/gateway/gateway-controller/pkg/utils/llm_transformer.go
+++ b/gateway/gateway-controller/pkg/utils/llm_transformer.go
@@ -246,6 +246,9 @@ func (t *LLMProviderTransformer) transformProxy(proxy *api.LLMProxyConfiguration
 							if attachedPolicyPaths[targetPath] {
 								continue
 							}
+							if moreSpecificPolicyAttachmentCovers(targetPath, policyMethod, attachment, *proxy.Spec.Policies) {
+								continue
+							}
 							targetKey := pathMethodKey{path: targetPath, method: policyMethod}
 							targetOp, exists := operationRegistry[targetKey]
 							if !exists {
@@ -464,6 +467,9 @@ func (t *LLMProviderTransformer) transformProvider(provider *api.LLMProviderConf
 								if attachedPolicyPaths[targetPath] {
 									continue
 								}
+								if moreSpecificPolicyAttachmentCovers(targetPath, policyMethod, attachment, *provider.Spec.Policies) {
+									continue
+								}
 								targetKey := pathMethodKey{path: targetPath, method: policyMethod}
 								targetOp, exists := operationRegistry[targetKey]
 								if !exists {
@@ -549,6 +555,9 @@ func (t *LLMProviderTransformer) transformProvider(provider *api.LLMProviderConf
 						if pathsMatch(op.Path, attachment.pathEntry.Path) {
 							for _, targetPath := range expandPolicyTargetPaths(op.Path, &tmpl.Configuration.Spec) {
 								if attachedPolicyPaths[targetPath] {
+									continue
+								}
+								if moreSpecificPolicyAttachmentCovers(targetPath, policyMethod, attachment, *provider.Spec.Policies) {
 									continue
 								}
 								targetKey := pathMethodKey{path: targetPath, method: policyMethod}
@@ -779,6 +788,96 @@ func shouldAttachPathBefore(leftPath, rightPath string) bool {
 	}
 
 	return leftPath < rightPath
+}
+
+// isMoreSpecificPath reports whether policy path a is strictly more specific than b.
+// A concrete (non-wildcard) path is more specific than a wildcard one; among paths with
+// the same wildcard-ness, the longer path is more specific.
+func isMoreSpecificPath(a, b string) bool {
+	aWildcard := strings.Contains(a, constants.WILD_CARD)
+	bWildcard := strings.Contains(b, constants.WILD_CARD)
+	if aWildcard != bWildcard {
+		return !aWildcard
+	}
+	return len(a) > len(b)
+}
+
+// methodsInclude reports whether method is present in methods.
+func methodsInclude(methods []string, method string) bool {
+	for _, m := range methods {
+		if m == method {
+			return true
+		}
+	}
+	return false
+}
+
+// moreSpecificPolicyAttachmentCovers reports whether another path entry of the SAME policy
+// covers targetPath for the given HTTP method and is strictly more specific than the current
+// entry. When true, the current (less specific) entry must not be layered onto targetPath, so
+// the most specific match wins for that policy. Specificity is compared by path first
+// (see isMoreSpecificPath) and then, for entries on an equally specific path, by method
+// (a concrete method beats the '*' wildcard). Different policy names still layer (e.g. a
+// wildcard set-headers plus a path-specific rate limit); only same-name overlaps are collapsed.
+func moreSpecificPolicyAttachmentCovers(targetPath, method string, current llmPolicyAttachment,
+	policies []api.LLMPolicy) bool {
+	for _, llmPol := range policies {
+		if llmPol.Name != current.policy.Name {
+			continue
+		}
+		for i := range llmPol.Paths {
+			other := llmPol.Paths[i]
+			if !pathsMatch(targetPath, other.Path) {
+				continue
+			}
+			if !methodsInclude(expandLLMPolicyMethods(other.Methods), method) {
+				continue
+			}
+			if isMoreSpecificAttachment(other, current.pathEntry) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isMoreSpecificAttachment reports whether path entry a is strictly more specific than b.
+// Path specificity dominates (see isMoreSpecificPath); for entries on an equally specific
+// path, the narrower HTTP method set is more specific.
+func isMoreSpecificAttachment(a, b api.LLMPolicyPath) bool {
+	if isMoreSpecificPath(a.Path, b.Path) {
+		return true
+	}
+	if isMoreSpecificPath(b.Path, a.Path) {
+		return false
+	}
+	return isStrictMethodSubset(a.Methods, b.Methods)
+}
+
+// isStrictMethodSubset reports whether the methods covered by a are a strict subset of the
+// methods covered by b ('*' expands to the full supported method set). This makes e.g.
+// [POST] more specific than [GET, POST], which in turn is more specific than '*'.
+func isStrictMethodSubset(a, b []api.LLMPolicyPathMethods) bool {
+	aSet := methodSet(a)
+	bSet := methodSet(b)
+	if len(aSet) == 0 || len(aSet) >= len(bSet) {
+		return false
+	}
+	for m := range aSet {
+		if !bSet[m] {
+			return false
+		}
+	}
+	return true
+}
+
+// methodSet returns the set of concrete HTTP methods an entry covers, with '*' expanded.
+func methodSet(methods []api.LLMPolicyPathMethods) map[string]bool {
+	set := make(map[string]bool)
+	for _, m := range expandLLMPolicyMethods(methods) {
+		set[m] = true
+	}
+	return set
 }
 
 // ensureOperation checks if an operation for the given path+method exists in the registry, and creates it if not

--- a/gateway/gateway-controller/pkg/utils/llm_transformer_test.go
+++ b/gateway/gateway-controller/pkg/utils/llm_transformer_test.go
@@ -1095,6 +1095,604 @@ func TestTransformProvider_PolicyOrderDoesNotAffectWildcardCoverage(t *testing.T
 	})
 }
 
+func TestTransformProvider_MostSpecificPathWinsForSamePolicy(t *testing.T) {
+	store := storage.NewConfigStore()
+	db := newTestMockDB()
+	routerConfig := &config.RouterConfig{ListenerPort: 8080}
+	transformer := NewLLMProviderTransformer(store, db, routerConfig, newTestPolicyVersionResolver())
+
+	template := &models.StoredLLMProviderTemplate{
+		UUID: "0000-template-1-0000-000000000002",
+		Configuration: api.LLMProviderTemplate{
+			Metadata: api.Metadata{Name: "openai"},
+			Spec:     api.LLMProviderTemplateData{},
+		},
+	}
+	db.SaveLLMProviderTemplate(template)
+	require.NoError(t, store.AddTemplate(template))
+
+	rateLimitParams := func(quotaName string, limit int) map[string]interface{} {
+		return map[string]interface{}{
+			"quotas": []interface{}{
+				map[string]interface{}{
+					"name": quotaName,
+					"limits": []interface{}{
+						map[string]interface{}{"limit": limit, "duration": "1h"},
+					},
+				},
+			},
+		}
+	}
+
+	upstreamURL := "https://api.openai.com"
+	// The same policy (advanced-ratelimit) is attached to a specific path (4/h) and to the
+	// wildcard catch-all (1/h). The most specific path must win, so /chat/completions keeps
+	// only its own quota and is not also limited by the wildcard quota.
+	provider := &api.LLMProviderConfiguration{
+		Metadata: api.Metadata{Name: "openai-provider"},
+		Spec: api.LLMProviderConfigData{
+			DisplayName: "OpenAI Provider",
+			Version:     "1.0.0",
+			Template:    "openai",
+			Upstream: api.LLMProviderConfigData_Upstream{
+				Url: &upstreamURL,
+			},
+			AccessControl: api.LLMAccessControl{Mode: api.AllowAll},
+			Policies: &[]api.LLMPolicy{
+				{
+					Name:    "advanced-ratelimit",
+					Version: "v1",
+					Paths: []api.LLMPolicyPath{
+						{
+							Path:    "/chat/completions",
+							Methods: []api.LLMPolicyPathMethods{"POST"},
+							Params:  rateLimitParams("chat-quota", 4),
+						},
+						{
+							Path:    "/*",
+							Methods: []api.LLMPolicyPathMethods{"*"},
+							Params:  rateLimitParams("wildcard-quota", 1),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := transformer.Transform(provider, &api.RestAPI{})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	firstQuotaName := func(params *map[string]interface{}) string {
+		require.NotNil(t, params)
+		quotas, ok := (*params)["quotas"].([]interface{})
+		require.True(t, ok, "params should contain a quotas slice")
+		require.NotEmpty(t, quotas)
+		first, ok := quotas[0].(map[string]interface{})
+		require.True(t, ok)
+		name, ok := first["name"].(string)
+		require.True(t, ok)
+		return name
+	}
+
+	// POST /chat/completions must carry ONLY the specific advanced-ratelimit (chat-quota),
+	// not the wildcard one.
+	chatOp := findOperation(result.Spec.Operations, "/chat/completions", "POST")
+	require.NotNil(t, chatOp)
+	require.NotNil(t, chatOp.Policies)
+	require.Len(t, *chatOp.Policies, 1, "/chat/completions should not stack the wildcard policy on top of its specific one")
+	assert.Equal(t, "advanced-ratelimit", (*chatOp.Policies)[0].Name)
+	assert.Equal(t, "chat-quota", firstQuotaName((*chatOp.Policies)[0].Params))
+
+	// POST /* keeps the wildcard advanced-ratelimit (wildcard-quota) so other paths remain governed by it.
+	wildcardOp := findOperation(result.Spec.Operations, "/*", "POST")
+	require.NotNil(t, wildcardOp)
+	require.NotNil(t, wildcardOp.Policies)
+	require.Len(t, *wildcardOp.Policies, 1)
+	assert.Equal(t, "advanced-ratelimit", (*wildcardOp.Policies)[0].Name)
+	assert.Equal(t, "wildcard-quota", firstQuotaName((*wildcardOp.Policies)[0].Params))
+}
+
+func TestTransformProvider_MostSpecificPathWinsAcrossNestedWildcards(t *testing.T) {
+	store := storage.NewConfigStore()
+	db := newTestMockDB()
+	routerConfig := &config.RouterConfig{ListenerPort: 8080}
+	transformer := NewLLMProviderTransformer(store, db, routerConfig, newTestPolicyVersionResolver())
+
+	template := &models.StoredLLMProviderTemplate{
+		UUID: "0000-template-1-0000-000000000003",
+		Configuration: api.LLMProviderTemplate{
+			Metadata: api.Metadata{Name: "openai"},
+			Spec:     api.LLMProviderTemplateData{},
+		},
+	}
+	db.SaveLLMProviderTemplate(template)
+	require.NoError(t, store.AddTemplate(template))
+
+	rlParams := func(limit int) map[string]interface{} {
+		return map[string]interface{}{
+			"quotas": []interface{}{
+				map[string]interface{}{
+					"name": "request-limit",
+					"limits": []interface{}{
+						map[string]interface{}{"limit": limit, "duration": "1h"},
+					},
+				},
+			},
+		}
+	}
+
+	upstreamURL := "https://api.openai.com"
+	// One policy attached to three overlapping paths of decreasing specificity. Each path's
+	// limit differs so we can tell which one governs each operation. The most specific path
+	// must win for every operation - this must work for nested wildcards (/chat/*), not just
+	// the root catch-all (/*).
+	provider := &api.LLMProviderConfiguration{
+		Metadata: api.Metadata{Name: "openai-provider"},
+		Spec: api.LLMProviderConfigData{
+			DisplayName: "OpenAI Provider",
+			Version:     "1.0.0",
+			Template:    "openai",
+			Upstream: api.LLMProviderConfigData_Upstream{
+				Url: &upstreamURL,
+			},
+			AccessControl: api.LLMAccessControl{Mode: api.AllowAll},
+			Policies: &[]api.LLMPolicy{
+				{
+					Name:    "advanced-ratelimit",
+					Version: "v1",
+					Paths: []api.LLMPolicyPath{
+						{Path: "/chat/completions", Methods: []api.LLMPolicyPathMethods{"*"}, Params: rlParams(4)},
+						{Path: "/chat/*", Methods: []api.LLMPolicyPathMethods{"*"}, Params: rlParams(2)},
+						{Path: "/*", Methods: []api.LLMPolicyPathMethods{"*"}, Params: rlParams(1)},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := transformer.Transform(provider, &api.RestAPI{})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	firstLimit := func(params *map[string]interface{}) int {
+		require.NotNil(t, params)
+		quotas, ok := (*params)["quotas"].([]interface{})
+		require.True(t, ok)
+		require.NotEmpty(t, quotas)
+		quota, ok := quotas[0].(map[string]interface{})
+		require.True(t, ok)
+		limits, ok := quota["limits"].([]interface{})
+		require.True(t, ok)
+		require.NotEmpty(t, limits)
+		limit, ok := limits[0].(map[string]interface{})
+		require.True(t, ok)
+		v, ok := limit["limit"].(int)
+		require.True(t, ok)
+		return v
+	}
+
+	assertSingleLimit := func(t *testing.T, path string, want int) {
+		t.Helper()
+		op := findOperation(result.Spec.Operations, path, "POST")
+		require.NotNil(t, op, "expected a POST operation for %s", path)
+		require.NotNil(t, op.Policies)
+		require.Len(t, *op.Policies, 1, "%s should carry exactly one advanced-ratelimit (most specific path wins)", path)
+		assert.Equal(t, "advanced-ratelimit", (*op.Policies)[0].Name)
+		assert.Equal(t, want, firstLimit((*op.Policies)[0].Params), "%s should be governed by its own limit", path)
+	}
+
+	// /chat/completions (exact) -> 4, /chat/* (nested wildcard) -> 2, /* (root) -> 1.
+	assertSingleLimit(t, "/chat/completions", 4)
+	assertSingleLimit(t, "/chat/*", 2)
+	assertSingleLimit(t, "/*", 1)
+}
+
+func TestTransformProvider_MostSpecificPathWinsAcrossMethodsAndOrder(t *testing.T) {
+	rlParams := func(limit int) map[string]interface{} {
+		return map[string]interface{}{
+			"quotas": []interface{}{
+				map[string]interface{}{
+					"name": "request-limit",
+					"limits": []interface{}{
+						map[string]interface{}{"limit": limit, "duration": "1h"},
+					},
+				},
+			},
+		}
+	}
+
+	ccPost := api.LLMPolicyPath{Path: "/chat/completions", Methods: []api.LLMPolicyPathMethods{"POST"}, Params: rlParams(4)}
+	ccGet := api.LLMPolicyPath{Path: "/chat/completions", Methods: []api.LLMPolicyPathMethods{"GET"}, Params: rlParams(10)}
+	chatWild := api.LLMPolicyPath{Path: "/chat/*", Methods: []api.LLMPolicyPathMethods{"*"}, Params: rlParams(2)}
+	rootWild := api.LLMPolicyPath{Path: "/*", Methods: []api.LLMPolicyPathMethods{"*"}, Params: rlParams(1)}
+
+	// The expected outcome must be identical regardless of declaration order, including a
+	// same path with different methods carrying different limits (POST=4, GET=10).
+	cases := []struct {
+		name  string
+		paths []api.LLMPolicyPath
+	}{
+		{"specific first", []api.LLMPolicyPath{ccPost, ccGet, chatWild, rootWild}},
+		{"wildcards first", []api.LLMPolicyPath{rootWild, chatWild, ccGet, ccPost}},
+		{"interleaved", []api.LLMPolicyPath{rootWild, ccPost, chatWild, ccGet}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := storage.NewConfigStore()
+			db := newTestMockDB()
+			routerConfig := &config.RouterConfig{ListenerPort: 8080}
+			transformer := NewLLMProviderTransformer(store, db, routerConfig, newTestPolicyVersionResolver())
+
+			template := &models.StoredLLMProviderTemplate{
+				UUID:          "0000-template-1-0000-000000000004",
+				Configuration: api.LLMProviderTemplate{Metadata: api.Metadata{Name: "openai"}, Spec: api.LLMProviderTemplateData{}},
+			}
+			db.SaveLLMProviderTemplate(template)
+			require.NoError(t, store.AddTemplate(template))
+
+			upstreamURL := "https://api.openai.com"
+			provider := &api.LLMProviderConfiguration{
+				Metadata: api.Metadata{Name: "openai-provider"},
+				Spec: api.LLMProviderConfigData{
+					DisplayName:   "OpenAI Provider",
+					Version:       "1.0.0",
+					Template:      "openai",
+					Upstream:      api.LLMProviderConfigData_Upstream{Url: &upstreamURL},
+					AccessControl: api.LLMAccessControl{Mode: api.AllowAll},
+					Policies: &[]api.LLMPolicy{
+						{Name: "advanced-ratelimit", Version: "v1", Paths: tc.paths},
+					},
+				},
+			}
+
+			result, err := transformer.Transform(provider, &api.RestAPI{})
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			firstLimit := func(params *map[string]interface{}) int {
+				require.NotNil(t, params)
+				quotas, ok := (*params)["quotas"].([]interface{})
+				require.True(t, ok)
+				require.NotEmpty(t, quotas)
+				quota, ok := quotas[0].(map[string]interface{})
+				require.True(t, ok)
+				limits, ok := quota["limits"].([]interface{})
+				require.True(t, ok)
+				require.NotEmpty(t, limits)
+				limit, ok := limits[0].(map[string]interface{})
+				require.True(t, ok)
+				v, ok := limit["limit"].(int)
+				require.True(t, ok)
+				return v
+			}
+			assertLimit := func(path, method string, want int) {
+				op := findOperation(result.Spec.Operations, path, method)
+				require.NotNil(t, op, "expected %s %s operation", method, path)
+				require.NotNil(t, op.Policies)
+				require.Len(t, *op.Policies, 1, "%s %s should carry exactly one advanced-ratelimit", method, path)
+				assert.Equal(t, want, firstLimit((*op.Policies)[0].Params), "%s %s limit", method, path)
+			}
+
+			// Same path, method-specific limits win over the wildcards.
+			assertLimit("/chat/completions", "POST", 4)
+			assertLimit("/chat/completions", "GET", 10)
+			// Nested wildcard wins over root wildcard, for every method.
+			assertLimit("/chat/*", "POST", 2)
+			assertLimit("/chat/*", "GET", 2)
+			// Root wildcard governs everything else.
+			assertLimit("/*", "POST", 1)
+		})
+	}
+}
+
+func TestTransformProvider_MostSpecificMethodWinsOnSamePath(t *testing.T) {
+	rlParams := func(limit int) map[string]interface{} {
+		return map[string]interface{}{
+			"quotas": []interface{}{
+				map[string]interface{}{
+					"name": "request-limit",
+					"limits": []interface{}{
+						map[string]interface{}{"limit": limit, "duration": "1h"},
+					},
+				},
+			},
+		}
+	}
+
+	// Same path /chat/completions with a wildcard-method entry (limit 4) and a GET-specific
+	// entry (limit 10), plus nested and root wildcards. GET must win on /chat/completions;
+	// every other method falls to the '*' entry.
+	ccAll := api.LLMPolicyPath{Path: "/chat/completions", Methods: []api.LLMPolicyPathMethods{"*"}, Params: rlParams(4)}
+	ccGet := api.LLMPolicyPath{Path: "/chat/completions", Methods: []api.LLMPolicyPathMethods{"GET"}, Params: rlParams(10)}
+	rootWild := api.LLMPolicyPath{Path: "/*", Methods: []api.LLMPolicyPathMethods{"*"}, Params: rlParams(1)}
+	chatWild := api.LLMPolicyPath{Path: "/chat/*", Methods: []api.LLMPolicyPathMethods{"*"}, Params: rlParams(2)}
+
+	cases := []struct {
+		name  string
+		paths []api.LLMPolicyPath
+	}{
+		{"as declared", []api.LLMPolicyPath{ccAll, ccGet, rootWild, chatWild}},
+		{"reversed", []api.LLMPolicyPath{chatWild, rootWild, ccGet, ccAll}},
+		{"get before all", []api.LLMPolicyPath{ccGet, ccAll, chatWild, rootWild}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := storage.NewConfigStore()
+			db := newTestMockDB()
+			routerConfig := &config.RouterConfig{ListenerPort: 8080}
+			transformer := NewLLMProviderTransformer(store, db, routerConfig, newTestPolicyVersionResolver())
+
+			template := &models.StoredLLMProviderTemplate{
+				UUID:          "0000-template-1-0000-000000000005",
+				Configuration: api.LLMProviderTemplate{Metadata: api.Metadata{Name: "openai"}, Spec: api.LLMProviderTemplateData{}},
+			}
+			db.SaveLLMProviderTemplate(template)
+			require.NoError(t, store.AddTemplate(template))
+
+			upstreamURL := "https://api.openai.com"
+			provider := &api.LLMProviderConfiguration{
+				Metadata: api.Metadata{Name: "openai-provider"},
+				Spec: api.LLMProviderConfigData{
+					DisplayName:   "OpenAI Provider",
+					Version:       "1.0.0",
+					Template:      "openai",
+					Upstream:      api.LLMProviderConfigData_Upstream{Url: &upstreamURL},
+					AccessControl: api.LLMAccessControl{Mode: api.AllowAll},
+					Policies:      &[]api.LLMPolicy{{Name: "advanced-ratelimit", Version: "v1", Paths: tc.paths}},
+				},
+			}
+
+			result, err := transformer.Transform(provider, &api.RestAPI{})
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			firstLimit := func(params *map[string]interface{}) int {
+				require.NotNil(t, params)
+				quotas, ok := (*params)["quotas"].([]interface{})
+				require.True(t, ok)
+				require.NotEmpty(t, quotas)
+				quota, ok := quotas[0].(map[string]interface{})
+				require.True(t, ok)
+				limits, ok := quota["limits"].([]interface{})
+				require.True(t, ok)
+				require.NotEmpty(t, limits)
+				limit, ok := limits[0].(map[string]interface{})
+				require.True(t, ok)
+				v, ok := limit["limit"].(int)
+				require.True(t, ok)
+				return v
+			}
+			assertLimit := func(path, method string, want int) {
+				op := findOperation(result.Spec.Operations, path, method)
+				require.NotNil(t, op, "expected %s %s operation", method, path)
+				require.NotNil(t, op.Policies)
+				require.Len(t, *op.Policies, 1, "%s %s should carry exactly one advanced-ratelimit", method, path)
+				assert.Equal(t, want, firstLimit((*op.Policies)[0].Params), "%s %s limit", method, path)
+			}
+
+			// GET is the most specific (concrete method on the most specific path) -> 10.
+			assertLimit("/chat/completions", "GET", 10)
+			// Every other method on /chat/completions falls to the '*' entry -> 4.
+			assertLimit("/chat/completions", "POST", 4)
+			assertLimit("/chat/completions", "PUT", 4)
+			// Nested and root wildcards unchanged.
+			assertLimit("/chat/*", "POST", 2)
+			assertLimit("/*", "POST", 1)
+		})
+	}
+}
+
+// --- shared helpers for policy path/method specificity tests ---
+
+func rlQuota(limit int) map[string]interface{} {
+	return map[string]interface{}{
+		"quotas": []interface{}{
+			map[string]interface{}{
+				"name": "request-limit",
+				"limits": []interface{}{
+					map[string]interface{}{"limit": limit, "duration": "1h"},
+				},
+			},
+		},
+	}
+}
+
+func quotaLimitOf(t *testing.T, p api.Policy) int {
+	t.Helper()
+	require.NotNil(t, p.Params)
+	quotas, ok := (*p.Params)["quotas"].([]interface{})
+	require.True(t, ok)
+	require.NotEmpty(t, quotas)
+	q, ok := quotas[0].(map[string]interface{})
+	require.True(t, ok)
+	limits, ok := q["limits"].([]interface{})
+	require.True(t, ok)
+	require.NotEmpty(t, limits)
+	lim, ok := limits[0].(map[string]interface{})
+	require.True(t, ok)
+	v, ok := lim["limit"].(int)
+	require.True(t, ok)
+	return v
+}
+
+func transformProviderWithPolicies(t *testing.T, uuid string, tmplSpec api.LLMProviderTemplateData,
+	ac api.LLMAccessControl, policies []api.LLMPolicy) *api.RestAPI {
+	t.Helper()
+	store := storage.NewConfigStore()
+	db := newTestMockDB()
+	routerConfig := &config.RouterConfig{ListenerPort: 8080}
+	transformer := NewLLMProviderTransformer(store, db, routerConfig, newTestPolicyVersionResolver())
+	template := &models.StoredLLMProviderTemplate{
+		UUID:          uuid,
+		Configuration: api.LLMProviderTemplate{Metadata: api.Metadata{Name: "openai"}, Spec: tmplSpec},
+	}
+	db.SaveLLMProviderTemplate(template)
+	require.NoError(t, store.AddTemplate(template))
+	upstreamURL := "https://api.openai.com"
+	provider := &api.LLMProviderConfiguration{
+		Metadata: api.Metadata{Name: "openai-provider"},
+		Spec: api.LLMProviderConfigData{
+			DisplayName:   "OpenAI Provider",
+			Version:       "1.0.0",
+			Template:      "openai",
+			Upstream:      api.LLMProviderConfigData_Upstream{Url: &upstreamURL},
+			AccessControl: ac,
+			Policies:      &policies,
+		},
+	}
+	result, err := transformer.Transform(provider, &api.RestAPI{})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	return result
+}
+
+// #1: a narrower HTTP method set is more specific than a broader one on the same path.
+func TestTransformProvider_NarrowerMethodSetWins(t *testing.T) {
+	result := transformProviderWithPolicies(t, "0000-template-1-0000-000000000006",
+		api.LLMProviderTemplateData{}, api.LLMAccessControl{Mode: api.AllowAll},
+		[]api.LLMPolicy{{Name: "advanced-ratelimit", Version: "v1", Paths: []api.LLMPolicyPath{
+			{Path: "/chat/completions", Methods: []api.LLMPolicyPathMethods{"GET", "POST"}, Params: rlQuota(3)},
+			{Path: "/chat/completions", Methods: []api.LLMPolicyPathMethods{"POST"}, Params: rlQuota(100)},
+		}}})
+
+	// GET is only covered by [GET, POST] -> 3.
+	getOp := findOperation(result.Spec.Operations, "/chat/completions", "GET")
+	require.NotNil(t, getOp)
+	require.NotNil(t, getOp.Policies)
+	require.Len(t, *getOp.Policies, 1)
+	assert.Equal(t, 3, quotaLimitOf(t, (*getOp.Policies)[0]))
+
+	// POST is covered by both; the narrower [POST] entry wins -> 100.
+	postOp := findOperation(result.Spec.Operations, "/chat/completions", "POST")
+	require.NotNil(t, postOp)
+	require.NotNil(t, postOp.Policies)
+	require.Len(t, *postOp.Policies, 1, "POST should be governed only by the narrower [POST] entry")
+	assert.Equal(t, 100, quotaLimitOf(t, (*postOp.Policies)[0]))
+}
+
+// #2: path specificity dominates method specificity (confirmed behavior).
+func TestTransformProvider_PathDominatesMethodSpecificity(t *testing.T) {
+	result := transformProviderWithPolicies(t, "0000-template-1-0000-000000000007",
+		api.LLMProviderTemplateData{}, api.LLMAccessControl{Mode: api.AllowAll},
+		[]api.LLMPolicy{{Name: "advanced-ratelimit", Version: "v1", Paths: []api.LLMPolicyPath{
+			{Path: "/chat/*", Methods: []api.LLMPolicyPathMethods{"POST"}, Params: rlQuota(100)},
+			{Path: "/chat/completions", Methods: []api.LLMPolicyPathMethods{"*"}, Params: rlQuota(2)},
+		}}})
+
+	// POST /chat/completions: the more specific PATH wins over a method-specific rule on a
+	// less specific (wildcard) path -> 2.
+	postOp := findOperation(result.Spec.Operations, "/chat/completions", "POST")
+	require.NotNil(t, postOp)
+	require.NotNil(t, postOp.Policies)
+	require.Len(t, *postOp.Policies, 1, "the most specific path must win over a method-specific rule on a wildcard path")
+	assert.Equal(t, 2, quotaLimitOf(t, (*postOp.Policies)[0]))
+
+	// POST /chat/<other> is still governed by /chat/* [POST] -> 100.
+	wildOp := findOperation(result.Spec.Operations, "/chat/*", "POST")
+	require.NotNil(t, wildOp)
+	require.NotNil(t, wildOp.Policies)
+	require.Len(t, *wildOp.Policies, 1)
+	assert.Equal(t, 100, quotaLimitOf(t, (*wildOp.Policies)[0]))
+}
+
+// #3: different policy names resolve their specificity independently (no cross-policy suppression).
+func TestTransformProvider_DifferentPoliciesResolveIndependently(t *testing.T) {
+	hdr := func(scope string) map[string]interface{} {
+		return map[string]interface{}{"scope": scope}
+	}
+	result := transformProviderWithPolicies(t, "0000-template-1-0000-000000000008",
+		api.LLMProviderTemplateData{}, api.LLMAccessControl{Mode: api.AllowAll},
+		[]api.LLMPolicy{
+			{Name: "advanced-ratelimit", Version: "v1", Paths: []api.LLMPolicyPath{
+				{Path: "/chat/completions", Methods: []api.LLMPolicyPathMethods{"*"}, Params: rlQuota(4)},
+				{Path: "/*", Methods: []api.LLMPolicyPathMethods{"*"}, Params: rlQuota(1)},
+			}},
+			{Name: "set-headers", Version: "v1", Paths: []api.LLMPolicyPath{
+				{Path: "/chat/*", Methods: []api.LLMPolicyPathMethods{"*"}, Params: hdr("chat")},
+				{Path: "/*", Methods: []api.LLMPolicyPathMethods{"*"}, Params: hdr("root")},
+			}},
+		})
+
+	// /chat/completions POST: advanced-ratelimit from its own specific path (4) AND
+	// set-headers from /chat/* (the most specific set-headers path covering it).
+	op := findOperation(result.Spec.Operations, "/chat/completions", "POST")
+	require.NotNil(t, op)
+	require.NotNil(t, op.Policies)
+	require.Len(t, *op.Policies, 2, "two different policies must both apply (no cross-policy suppression)")
+	byName := map[string]api.Policy{}
+	for _, p := range *op.Policies {
+		byName[p.Name] = p
+	}
+	require.Contains(t, byName, "advanced-ratelimit")
+	require.Contains(t, byName, "set-headers")
+	assert.Equal(t, 4, quotaLimitOf(t, byName["advanced-ratelimit"]))
+	assert.Equal(t, "chat", (*byName["set-headers"].Params)["scope"])
+}
+
+// #4: most specific wins under deny_all access control (over allowed exception paths).
+func TestTransformProvider_DenyAllModeMostSpecificWins(t *testing.T) {
+	exceptions := []api.RouteException{
+		{Path: "/chat/completions", Methods: []api.RouteExceptionMethods{"*"}},
+		{Path: "/chat/other", Methods: []api.RouteExceptionMethods{"*"}},
+	}
+	result := transformProviderWithPolicies(t, "0000-template-1-0000-000000000009",
+		api.LLMProviderTemplateData{},
+		api.LLMAccessControl{Mode: api.DenyAll, Exceptions: &exceptions},
+		[]api.LLMPolicy{{Name: "advanced-ratelimit", Version: "v1", Paths: []api.LLMPolicyPath{
+			{Path: "/chat/completions", Methods: []api.LLMPolicyPathMethods{"*"}, Params: rlQuota(4)},
+			{Path: "/chat/*", Methods: []api.LLMPolicyPathMethods{"*"}, Params: rlQuota(2)},
+		}}})
+
+	// /chat/completions keeps only its own quota (4), not the /chat/* one.
+	ccOp := findOperation(result.Spec.Operations, "/chat/completions", "POST")
+	require.NotNil(t, ccOp)
+	require.NotNil(t, ccOp.Policies)
+	require.Len(t, *ccOp.Policies, 1, "/chat/completions should keep only its own quota in deny_all mode")
+	assert.Equal(t, 4, quotaLimitOf(t, (*ccOp.Policies)[0]))
+
+	// /chat/other (covered only by /chat/*) gets the /chat/* quota (2).
+	otherOp := findOperation(result.Spec.Operations, "/chat/other", "POST")
+	require.NotNil(t, otherOp)
+	require.NotNil(t, otherOp.Policies)
+	require.Len(t, *otherOp.Policies, 1)
+	assert.Equal(t, 2, quotaLimitOf(t, (*otherOp.Policies)[0]))
+}
+
+// #6: a wildcard policy expanded onto template resource paths still loses to a same-name
+// policy attached directly to that resource path.
+func TestTransformProvider_TemplateExpansionDedupesSameNamePolicy(t *testing.T) {
+	tmplSpec := api.LLMProviderTemplateData{
+		ResourceMappings: &api.LLMProviderTemplateResourceMappings{
+			Resources: &[]api.LLMProviderTemplateResourceMapping{
+				{Resource: "/responses"},
+			},
+		},
+	}
+	result := transformProviderWithPolicies(t, "0000-template-1-0000-000000000010",
+		tmplSpec, api.LLMAccessControl{Mode: api.AllowAll},
+		[]api.LLMPolicy{{Name: "advanced-ratelimit", Version: "v1", Paths: []api.LLMPolicyPath{
+			{Path: "/*", Methods: []api.LLMPolicyPathMethods{"*"}, Params: rlQuota(1)},
+			{Path: "/responses", Methods: []api.LLMPolicyPathMethods{"*"}, Params: rlQuota(5)},
+		}}})
+
+	// /responses (an expanded template resource) keeps ONLY its specific limit (5).
+	respOp := findOperation(result.Spec.Operations, "/responses", "POST")
+	require.NotNil(t, respOp)
+	require.NotNil(t, respOp.Policies)
+	require.Len(t, *respOp.Policies, 1, "/responses should not also carry the wildcard policy after template expansion")
+	assert.Equal(t, 5, quotaLimitOf(t, (*respOp.Policies)[0]))
+
+	// /* keeps the wildcard limit (1).
+	wildOp := findOperation(result.Spec.Operations, "/*", "POST")
+	require.NotNil(t, wildOp)
+	require.NotNil(t, wildOp.Policies)
+	require.Len(t, *wildOp.Policies, 1)
+	assert.Equal(t, 1, quotaLimitOf(t, (*wildOp.Policies)[0]))
+}
+
 func TestTransformProvider_WithUpstreamAuth(t *testing.T) {
 	store := storage.NewConfigStore()
 	db := newTestMockDB()

--- a/gateway/gateway-controller/pkg/utils/llm_transformer_test.go
+++ b/gateway/gateway-controller/pkg/utils/llm_transformer_test.go
@@ -622,6 +622,231 @@ func TestIsAllowedByAccessControl(t *testing.T) {
 	})
 }
 
+func TestIsMoreSpecificPath(t *testing.T) {
+	// isMoreSpecificPath is only ever invoked (via moreSpecificPolicyAttachmentCovers) on two
+	// paths that both already match the same target, so "concrete beats wildcard, then longer
+	// beats shorter" is a sound specificity ordering for the path forms in use (exact paths and
+	// trailing "/*" wildcards). These cases pin that behaviour.
+	tests := []struct {
+		name string
+		a    string
+		b    string
+		want bool
+	}{
+		{"concrete beats wildcard", "/chat/completions", "/chat/*", true},
+		{"wildcard loses to concrete", "/chat/*", "/chat/completions", false},
+		{"concrete beats root wildcard", "/chat/completions", "/*", true},
+		{"root wildcard loses to concrete", "/*", "/chat/completions", false},
+		{"longer wildcard prefix beats shorter", "/chat/*", "/*", true},
+		{"shorter wildcard prefix loses", "/*", "/chat/*", false},
+		{"deeper nested wildcard beats shallower", "/chat/completions/*", "/chat/*", true},
+		{"shallower nested wildcard loses", "/chat/*", "/chat/completions/*", false},
+		{"three-level nesting beats one-level", "/a/b/c/*", "/a/*", true},
+		{"identical concrete is not strictly more specific", "/chat/completions", "/chat/completions", false},
+		{"identical wildcard is not strictly more specific", "/chat/*", "/chat/*", false},
+		{"identical root wildcard", "/*", "/*", false},
+		{"longer concrete wins on length", "/chat/completions", "/chat", true},
+		{"shorter concrete loses on length", "/chat", "/chat/completions", false},
+		{"equal-length concrete paths tie", "/aaa/bbb", "/bbb/aaa", false},
+		{"equal-length wildcards tie", "/ab/*", "/cd/*", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isMoreSpecificPath(tc.a, tc.b))
+		})
+	}
+
+	// Properties: a path is never strictly more specific than itself (irreflexive), and two
+	// distinct paths cannot each be strictly more specific than the other (antisymmetric).
+	paths := []string{"/chat/completions", "/chat/*", "/*", "/chat/completions/*", "/a"}
+	for _, p := range paths {
+		assert.Falsef(t, isMoreSpecificPath(p, p), "%q should not be more specific than itself", p)
+	}
+	for _, x := range paths {
+		for _, y := range paths {
+			if x != y && isMoreSpecificPath(x, y) {
+				assert.Falsef(t, isMoreSpecificPath(y, x),
+					"%q>%q and %q>%q cannot both hold", x, y, y, x)
+			}
+		}
+	}
+}
+
+func TestMoreSpecificPolicyAttachmentCovers(t *testing.T) {
+	// The function is block-scoped by signature: it only inspects current.policy.Paths, so
+	// these cases construct the block (and the current entry within it) directly. It returns
+	// true iff some OTHER entry in the same block both covers (targetPath, method) and is
+	// strictly more specific than the current entry.
+	mk := func(path string, methods ...string) api.LLMPolicyPath {
+		ms := make([]api.LLMPolicyPathMethods, len(methods))
+		for i, m := range methods {
+			ms[i] = api.LLMPolicyPathMethods(m)
+		}
+		return api.LLMPolicyPath{Path: path, Methods: ms}
+	}
+	ccAll := mk("/chat/completions", "*")
+	ccGet := mk("/chat/completions", "GET")
+	ccPost := mk("/chat/completions", "POST")
+	ccGetPost := mk("/chat/completions", "GET", "POST")
+	chatWild := mk("/chat/*", "*")
+	chatWildPost := mk("/chat/*", "POST")
+	root := mk("/*", "*")
+
+	tests := []struct {
+		name       string
+		block      []api.LLMPolicyPath
+		current    api.LLMPolicyPath
+		targetPath string
+		method     string
+		want       bool
+	}{
+		// --- nothing more specific present ---
+		{"only the current entry in the block", []api.LLMPolicyPath{root}, root, "/chat/completions", "POST", false},
+		{"current is the most specific entry", []api.LLMPolicyPath{ccAll, chatWild, root}, ccAll, "/chat/completions", "POST", false},
+		{"only a less specific sibling", []api.LLMPolicyPath{ccAll, root}, ccAll, "/chat/completions", "POST", false},
+
+		// --- more specific by PATH ---
+		{"more specific concrete sibling covers target", []api.LLMPolicyPath{ccAll, root}, root, "/chat/completions", "POST", true},
+		{"more specific nested-wildcard sibling covers target", []api.LLMPolicyPath{chatWild, root}, root, "/chat/foo", "POST", true},
+		{"more specific sibling does not cover target", []api.LLMPolicyPath{ccAll, root}, root, "/models", "POST", false},
+
+		// --- method gating of the more specific sibling ---
+		{"more specific sibling does not apply to method", []api.LLMPolicyPath{ccGet, root}, root, "/chat/completions", "POST", false},
+		{"more specific sibling applies to method", []api.LLMPolicyPath{ccGet, root}, root, "/chat/completions", "GET", true},
+
+		// --- method specificity on the SAME path ---
+		{"concrete method beats wildcard method", []api.LLMPolicyPath{ccAll, ccGet}, ccAll, "/chat/completions", "GET", true},
+		{"wildcard method not suppressed for uncovered method", []api.LLMPolicyPath{ccAll, ccGet}, ccAll, "/chat/completions", "POST", false},
+		{"concrete-method current not suppressed by wildcard-method sibling", []api.LLMPolicyPath{ccAll, ccGet}, ccGet, "/chat/completions", "GET", false},
+		{"narrower method set beats broader", []api.LLMPolicyPath{ccGetPost, ccPost}, ccGetPost, "/chat/completions", "POST", true},
+		{"broader method set does not suppress narrower", []api.LLMPolicyPath{ccGetPost, ccPost}, ccPost, "/chat/completions", "POST", false},
+
+		// --- ties ---
+		{"equal-specificity duplicate is a tie", []api.LLMPolicyPath{ccPost, mk("/chat/completions", "POST")}, ccPost, "/chat/completions", "POST", false},
+
+		// --- path dominates method ---
+		{"specific path beats method-specific wildcard path", []api.LLMPolicyPath{chatWildPost, ccAll}, chatWildPost, "/chat/completions", "POST", true},
+		{"method-specific wildcard path does not beat specific path", []api.LLMPolicyPath{chatWildPost, ccAll}, ccAll, "/chat/completions", "POST", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			att := llmPolicyAttachment{
+				policy:    api.LLMPolicy{Name: "advanced-ratelimit", Version: "v1", Paths: tc.block},
+				pathEntry: tc.current,
+			}
+			assert.Equal(t, tc.want, moreSpecificPolicyAttachmentCovers(tc.targetPath, tc.method, att))
+		})
+	}
+}
+
+func TestMethodSet(t *testing.T) {
+	mm := func(methods ...string) []api.LLMPolicyPathMethods {
+		out := make([]api.LLMPolicyPathMethods, len(methods))
+		for i, m := range methods {
+			out[i] = api.LLMPolicyPathMethods(m)
+		}
+		return out
+	}
+
+	t.Run("single concrete method", func(t *testing.T) {
+		assert.Equal(t, map[string]bool{"GET": true}, methodSet(mm("GET")))
+	})
+	t.Run("multiple concrete methods", func(t *testing.T) {
+		assert.Equal(t, map[string]bool{"GET": true, "POST": true}, methodSet(mm("GET", "POST")))
+	})
+	t.Run("duplicate methods are de-duplicated", func(t *testing.T) {
+		assert.Equal(t, map[string]bool{"GET": true}, methodSet(mm("GET", "GET")))
+	})
+	t.Run("empty methods yield empty set", func(t *testing.T) {
+		assert.Empty(t, methodSet(mm()))
+	})
+	t.Run("lone wildcard expands to all supported methods", func(t *testing.T) {
+		got := methodSet(mm("*"))
+		require.Len(t, got, len(constants.WILDCARD_HTTP_METHODS))
+		for _, m := range constants.WILDCARD_HTTP_METHODS {
+			assert.Truef(t, got[m], "expected %s in expanded wildcard set", m)
+		}
+		assert.False(t, got["*"], "the literal '*' must not be a member of the expanded set")
+	})
+	t.Run("wildcard only expands when it is the sole element", func(t *testing.T) {
+		// expandLLMPolicyMethods only treats a single-element ["*"] as the wildcard; mixed with
+		// other methods the '*' stays literal.
+		assert.Equal(t, map[string]bool{"GET": true, "*": true}, methodSet(mm("GET", "*")))
+	})
+}
+
+func TestIsStrictMethodSubset(t *testing.T) {
+	mm := func(methods ...string) []api.LLMPolicyPathMethods {
+		out := make([]api.LLMPolicyPathMethods, len(methods))
+		for i, m := range methods {
+			out[i] = api.LLMPolicyPathMethods(m)
+		}
+		return out
+	}
+	tests := []struct {
+		name string
+		a, b []api.LLMPolicyPathMethods
+		want bool
+	}{
+		{"strict subset", mm("POST"), mm("GET", "POST"), true},
+		{"multi-element strict subset", mm("POST", "PUT"), mm("GET", "POST", "PUT"), true},
+		{"superset is not a subset", mm("GET", "POST"), mm("POST"), false},
+		{"equal single set is not strict", mm("POST"), mm("POST"), false},
+		{"equal multi set is not strict", mm("GET", "POST"), mm("GET", "POST"), false},
+		{"concrete is strict subset of wildcard", mm("POST"), mm("*"), true},
+		{"two concrete are strict subset of wildcard", mm("GET", "POST"), mm("*"), true},
+		{"wildcard is not subset of concrete", mm("*"), mm("POST"), false},
+		{"wildcard equals wildcard is not strict", mm("*"), mm("*"), false},
+		{"disjoint equal length", mm("GET"), mm("POST"), false},
+		{"smaller but not a member subset", mm("GET"), mm("POST", "PUT"), false},
+		{"empty is not a strict subset", mm(), mm("POST"), false},
+		{"both empty", mm(), mm(), false},
+		{"duplicates collapse before comparison", mm("POST", "POST"), mm("POST"), false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isStrictMethodSubset(tc.a, tc.b))
+		})
+	}
+}
+
+func TestIsMoreSpecificAttachment(t *testing.T) {
+	mk := func(path string, methods ...string) api.LLMPolicyPath {
+		ms := make([]api.LLMPolicyPathMethods, len(methods))
+		for i, m := range methods {
+			ms[i] = api.LLMPolicyPathMethods(m)
+		}
+		return api.LLMPolicyPath{Path: path, Methods: ms}
+	}
+	tests := []struct {
+		name string
+		a, b api.LLMPolicyPath
+		want bool
+	}{
+		// Path specificity dominates, regardless of methods.
+		{"more specific path wins over broader-path narrower-method", mk("/chat/completions", "*"), mk("/chat/*", "POST"), true},
+		{"less specific path loses even with narrower method", mk("/chat/*", "GET"), mk("/chat/completions", "*"), false},
+		{"concrete path beats root wildcard", mk("/chat/completions", "POST"), mk("/*", "*"), true},
+		{"nested wildcard beats root wildcard", mk("/chat/*", "*"), mk("/*", "*"), true},
+		// Same path -> method specificity decides.
+		{"same path, narrower method set wins", mk("/chat/completions", "POST"), mk("/chat/completions", "GET", "POST"), true},
+		{"same path, broader method set loses", mk("/chat/completions", "GET", "POST"), mk("/chat/completions", "POST"), false},
+		{"same path, concrete method beats wildcard method", mk("/chat/completions", "GET"), mk("/chat/completions", "*"), true},
+		{"same path, wildcard method loses to concrete", mk("/chat/completions", "*"), mk("/chat/completions", "GET"), false},
+		{"same path, equal methods are not more specific", mk("/chat/completions", "POST"), mk("/chat/completions", "POST"), false},
+		// Equal path-specificity (different, non-overlapping paths) falls through to method
+		// comparison; unreachable in practice but pins the documented ordering.
+		{"equal path specificity falls through to method subset", mk("/ab/*", "POST"), mk("/cd/*", "GET", "POST"), true},
+		{"equal path specificity, method not a subset", mk("/ab/*", "GET"), mk("/cd/*", "POST"), false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isMoreSpecificAttachment(tc.a, tc.b))
+		})
+	}
+}
+
 func TestPathsMatch(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/gateway/gateway-controller/pkg/utils/llm_transformer_test.go
+++ b/gateway/gateway-controller/pkg/utils/llm_transformer_test.go
@@ -1108,7 +1108,7 @@ func TestTransformProvider_MostSpecificPathWinsForSamePolicy(t *testing.T) {
 			Spec:     api.LLMProviderTemplateData{},
 		},
 	}
-	db.SaveLLMProviderTemplate(template)
+	require.NoError(t, db.SaveLLMProviderTemplate(template))
 	require.NoError(t, store.AddTemplate(template))
 
 	rateLimitParams := func(quotaName string, limit int) map[string]interface{} {
@@ -1206,7 +1206,7 @@ func TestTransformProvider_MostSpecificPathWinsAcrossNestedWildcards(t *testing.
 			Spec:     api.LLMProviderTemplateData{},
 		},
 	}
-	db.SaveLLMProviderTemplate(template)
+	require.NoError(t, db.SaveLLMProviderTemplate(template))
 	require.NoError(t, store.AddTemplate(template))
 
 	rlParams := func(limit int) map[string]interface{} {
@@ -1329,7 +1329,7 @@ func TestTransformProvider_MostSpecificPathWinsAcrossMethodsAndOrder(t *testing.
 				UUID:          "0000-template-1-0000-000000000004",
 				Configuration: api.LLMProviderTemplate{Metadata: api.Metadata{Name: "openai"}, Spec: api.LLMProviderTemplateData{}},
 			}
-			db.SaveLLMProviderTemplate(template)
+			require.NoError(t, db.SaveLLMProviderTemplate(template))
 			require.NoError(t, store.AddTemplate(template))
 
 			upstreamURL := "https://api.openai.com"
@@ -1429,7 +1429,7 @@ func TestTransformProvider_MostSpecificMethodWinsOnSamePath(t *testing.T) {
 				UUID:          "0000-template-1-0000-000000000005",
 				Configuration: api.LLMProviderTemplate{Metadata: api.Metadata{Name: "openai"}, Spec: api.LLMProviderTemplateData{}},
 			}
-			db.SaveLLMProviderTemplate(template)
+			require.NoError(t, db.SaveLLMProviderTemplate(template))
 			require.NoError(t, store.AddTemplate(template))
 
 			upstreamURL := "https://api.openai.com"
@@ -1529,7 +1529,7 @@ func transformProviderWithPolicies(t *testing.T, uuid string, tmplSpec api.LLMPr
 		UUID:          uuid,
 		Configuration: api.LLMProviderTemplate{Metadata: api.Metadata{Name: "openai"}, Spec: tmplSpec},
 	}
-	db.SaveLLMProviderTemplate(template)
+	require.NoError(t, db.SaveLLMProviderTemplate(template))
 	require.NoError(t, store.AddTemplate(template))
 	upstreamURL := "https://api.openai.com"
 	provider := &api.LLMProviderConfiguration{
@@ -1691,6 +1691,41 @@ func TestTransformProvider_TemplateExpansionDedupesSameNamePolicy(t *testing.T) 
 	require.NotNil(t, wildOp.Policies)
 	require.Len(t, *wildOp.Policies, 1)
 	assert.Equal(t, 1, quotaLimitOf(t, (*wildOp.Policies)[0]))
+}
+
+// Two separate policy blocks of the SAME name each resolve most-specific-within-block and
+// both layer onto every route (the user's two-advanced-ratelimit scenario).
+func TestTransformProvider_SeparatePoliciesOfSameNameBothApply(t *testing.T) {
+	block1 := api.LLMPolicy{Name: "advanced-ratelimit", Version: "v1", Paths: []api.LLMPolicyPath{
+		{Path: "/chat/completions", Methods: []api.LLMPolicyPathMethods{"*"}, Params: rlQuota(4)},
+		{Path: "/chat/completions", Methods: []api.LLMPolicyPathMethods{"GET"}, Params: rlQuota(10)},
+		{Path: "/*", Methods: []api.LLMPolicyPathMethods{"*"}, Params: rlQuota(1)},
+		{Path: "/chat/*", Methods: []api.LLMPolicyPathMethods{"*"}, Params: rlQuota(2)},
+	}}
+	block2 := api.LLMPolicy{Name: "advanced-ratelimit", Version: "v1", Paths: []api.LLMPolicyPath{
+		{Path: "/*", Methods: []api.LLMPolicyPathMethods{"*"}, Params: rlQuota(100)},
+	}}
+	result := transformProviderWithPolicies(t, "0000-template-1-0000-000000000011",
+		api.LLMProviderTemplateData{}, api.LLMAccessControl{Mode: api.AllowAll},
+		[]api.LLMPolicy{block1, block2})
+
+	limitsFor := func(path, method string) []int {
+		op := findOperation(result.Spec.Operations, path, method)
+		require.NotNil(t, op, "expected %s %s operation", method, path)
+		require.NotNil(t, op.Policies)
+		out := []int{}
+		for _, p := range *op.Policies {
+			assert.Equal(t, "advanced-ratelimit", p.Name)
+			out = append(out, quotaLimitOf(t, p))
+		}
+		return out
+	}
+
+	// Each route carries block #1's most-specific match AND block #2's /* (100). Both apply.
+	assert.ElementsMatch(t, []int{4, 100}, limitsFor("/chat/completions", "POST"))
+	assert.ElementsMatch(t, []int{10, 100}, limitsFor("/chat/completions", "GET"))
+	assert.ElementsMatch(t, []int{2, 100}, limitsFor("/chat/*", "POST"))
+	assert.ElementsMatch(t, []int{1, 100}, limitsFor("/*", "POST"))
 }
 
 func TestTransformProvider_WithUpstreamAuth(t *testing.T) {

--- a/gateway/it/features/llm-policy-path-specificity.feature
+++ b/gateway/it/features/llm-policy-path-specificity.feature
@@ -1,0 +1,911 @@
+# --------------------------------------------------------------------
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# --------------------------------------------------------------------
+
+@policy-path-specificity @llm
+Feature: LLM policy path and method specificity
+  As an API developer
+  I want a policy attached to overlapping paths and methods on an LLM provider or proxy
+  to apply only the most specific match (path first, then method) to each request
+  So that overlapping path/method policies do not stack on the same route
+  # Note: this applies to LlmProvider and LlmProxy (both go through the LLM transformer);
+  # RestApi operations use explicit per-operation policies and are unaffected.
+
+  Background:
+    Given the gateway services are running
+    And I authenticate using basic auth as "admin"
+
+  # ------------------------------------------------------------------
+  # Reproduces a path-specificity bug using an LLM provider with the
+  # advanced-ratelimit policy attached to TWO overlapping paths:
+  #
+  #   - POST /chat/completions -> 4 requests / hour   (specific)
+  #   - /* (all methods)       -> 1 request  / hour   (wildcard catch-all)
+  #
+  # EXPECTED: a POST to /chat/completions is governed ONLY by the specific
+  #           4/hour quota; the 1/hour wildcard quota governs every OTHER path.
+  #
+  # ACTUAL (bug): the controller's LLM transformer fans the wildcard policy out
+  #           onto the /chat/completions operation too, so that route's policy
+  #           chain ends up with BOTH advanced-ratelimit instances (visible in
+  #           the policy-engine config dump). The 1/hour wildcard quota is then
+  #           also enforced on /chat/completions and blocks the 2nd request.
+  #
+  # This scenario asserts the EXPECTED behaviour, so it FAILS on the current
+  # (buggy) gateway at request #2 — which is how it validates the issue — and
+  # PASSES once the most-specific-path-wins fix is in place.
+  # ------------------------------------------------------------------
+  Scenario: Overlapping specific and wildcard advanced-ratelimit paths apply only the most specific match
+    When I create this LLM provider template:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1alpha1
+      kind: LlmProviderTemplate
+      metadata:
+        name: advrl-path-template
+      spec:
+        displayName: AdvRL Path Specificity Template
+      """
+    Then the response status code should be 201
+
+    When I create this LLM provider:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1alpha1
+      kind: LlmProvider
+      metadata:
+        name: advrl-path-provider
+      spec:
+        displayName: AdvRL Path Specificity Provider
+        version: v1.0
+        context: /advrl-path
+        template: advrl-path-template
+        upstream:
+          url: http://echo-backend-multi-arch:8080/anything
+          auth:
+            type: api-key
+            header: Authorization
+            value: test-api-key
+        accessControl:
+          mode: allow_all
+        policies:
+          - name: advanced-ratelimit
+            version: v1
+            paths:
+              - path: /chat/completions
+                methods: [POST]
+                params:
+                  quotas:
+                    - name: chat-quota
+                      limits:
+                        - limit: 4
+                          duration: "1h"
+              - path: /*
+                methods:
+                  - '*'
+                params:
+                  quotas:
+                    - name: wildcard-quota
+                      limits:
+                        - limit: 1
+                          duration: "1h"
+      """
+    Then the response status code should be 201
+    And I wait for 2 seconds
+    And I wait for policy snapshot sync
+
+    Given I set header "Content-Type" to "application/json"
+
+    # ----- /chat/completions must be governed ONLY by the specific 4/hour quota -----
+
+    # Request 1 - allowed (chat-quota 1/4)
+    When I send a POST request to "http://localhost:8080/advrl-path/chat/completions" with body:
+      """
+      {"model": "gpt-4", "messages": [{"role": "user", "content": "Hello"}]}
+      """
+    Then the response status code should be 200
+
+    # Request 2 - EXPECTED allowed (chat-quota 2/4).
+    # BUG: current gateway returns 429 here because the /* wildcard quota (1/hour)
+    # is wrongly applied to /chat/completions and is already exhausted after request 1.
+    When I send a POST request to "http://localhost:8080/advrl-path/chat/completions" with body:
+      """
+      {"model": "gpt-4", "messages": [{"role": "user", "content": "Hello"}]}
+      """
+    Then the response status code should be 200
+
+    # Request 3 - allowed (chat-quota 3/4)
+    When I send a POST request to "http://localhost:8080/advrl-path/chat/completions" with body:
+      """
+      {"model": "gpt-4", "messages": [{"role": "user", "content": "Hello"}]}
+      """
+    Then the response status code should be 200
+
+    # Request 4 - allowed (chat-quota 4/4)
+    When I send a POST request to "http://localhost:8080/advrl-path/chat/completions" with body:
+      """
+      {"model": "gpt-4", "messages": [{"role": "user", "content": "Hello"}]}
+      """
+    Then the response status code should be 200
+
+    # Request 5 - blocked: the specific 4/hour chat-quota is now exhausted
+    When I send a POST request to "http://localhost:8080/advrl-path/chat/completions" with body:
+      """
+      {"model": "gpt-4", "messages": [{"role": "user", "content": "Hello"}]}
+      """
+    Then the response status code should be 429
+    And the response body should contain "Rate limit exceeded"
+
+    # ----- every OTHER path is governed by the 1/hour wildcard quota (intended) -----
+
+    # Request 1 to /embeddings - allowed (wildcard-quota 1/1)
+    When I send a POST request to "http://localhost:8080/advrl-path/embeddings" with body:
+      """
+      {"model": "text-embedding-3-small", "input": "Hello"}
+      """
+    Then the response status code should be 200
+
+    # Request 2 to /embeddings - blocked by the 1/hour wildcard quota (intended)
+    When I send a POST request to "http://localhost:8080/advrl-path/embeddings" with body:
+      """
+      {"model": "text-embedding-3-small", "input": "Hello"}
+      """
+    Then the response status code should be 429
+    And the response body should contain "Rate limit exceeded"
+
+    # Cleanup
+    Given I authenticate using basic auth as "admin"
+    When I delete the LLM provider "advrl-path-provider"
+    Then the response status code should be 200
+    When I delete the LLM provider template "advrl-path-template"
+    Then the response status code should be 200
+
+  # ------------------------------------------------------------------
+  # Generalises the fix beyond the root /*: the SAME policy attached to three
+  # overlapping paths of decreasing specificity must apply only the most specific
+  # match to each request -
+  #   - /chat/completions -> 4 / hour   (exact, most specific)
+  #   - /chat/*           -> 2 / hour   (nested wildcard)
+  #   - /*                -> 1 / hour   (root catch-all)
+  # Distinct quota names keep the per-path buckets isolated, and the X-RateLimit-Limit
+  # header proves which quota governs each path. A naive "/* only" fix would still
+  # wrongly stack /chat/* onto /chat/completions; this asserts that does not happen.
+  # ------------------------------------------------------------------
+  Scenario: Overlapping nested paths each apply only their most specific advanced-ratelimit
+    When I create this LLM provider template:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1alpha1
+      kind: LlmProviderTemplate
+      metadata:
+        name: nestedrl-template
+      spec:
+        displayName: Nested RL Template
+      """
+    Then the response status code should be 201
+
+    When I create this LLM provider:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1alpha1
+      kind: LlmProvider
+      metadata:
+        name: nestedrl-provider
+      spec:
+        displayName: Nested RL Provider
+        version: v1.0
+        context: /nestedrl
+        template: nestedrl-template
+        upstream:
+          url: http://echo-backend-multi-arch:8080/anything
+          auth:
+            type: api-key
+            header: Authorization
+            value: test-api-key
+        accessControl:
+          mode: allow_all
+        policies:
+          - name: advanced-ratelimit
+            version: v1
+            paths:
+              - path: /chat/completions
+                methods:
+                  - '*'
+                params:
+                  quotas:
+                    - name: chat-exact-quota
+                      limits:
+                        - limit: 4
+                          duration: "1h"
+              - path: /chat/*
+                methods:
+                  - '*'
+                params:
+                  quotas:
+                    - name: chat-wild-quota
+                      limits:
+                        - limit: 2
+                          duration: "1h"
+              - path: /*
+                methods:
+                  - '*'
+                params:
+                  quotas:
+                    - name: root-wild-quota
+                      limits:
+                        - limit: 1
+                          duration: "1h"
+      """
+    Then the response status code should be 201
+    And I wait for 2 seconds
+    And I wait for policy snapshot sync
+
+    Given I set header "Content-Type" to "application/json"
+
+    # /chat/completions -> governed ONLY by the exact-path quota (4/hour)
+    When I send a POST request to "http://localhost:8080/nestedrl/chat/completions" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 200
+    And the response header "X-RateLimit-Limit" should be "4"
+    When I send a POST request to "http://localhost:8080/nestedrl/chat/completions" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 200
+    When I send a POST request to "http://localhost:8080/nestedrl/chat/completions" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 200
+    When I send a POST request to "http://localhost:8080/nestedrl/chat/completions" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 200
+    # 5th request exceeds the exact-path limit of 4
+    When I send a POST request to "http://localhost:8080/nestedrl/chat/completions" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 429
+
+    # /chat/<other> -> governed ONLY by the nested wildcard /chat/* quota (2/hour)
+    When I send a POST request to "http://localhost:8080/nestedrl/chat/embeddings" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 200
+    And the response header "X-RateLimit-Limit" should be "2"
+    When I send a POST request to "http://localhost:8080/nestedrl/chat/embeddings" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 200
+    # 3rd request exceeds the /chat/* limit of 2
+    When I send a POST request to "http://localhost:8080/nestedrl/chat/embeddings" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 429
+
+    # any other path -> governed ONLY by the root /* quota (1/hour)
+    When I send a POST request to "http://localhost:8080/nestedrl/models" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 200
+    And the response header "X-RateLimit-Limit" should be "1"
+    # 2nd request exceeds the /* limit of 1
+    When I send a POST request to "http://localhost:8080/nestedrl/models" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 429
+
+    # Cleanup
+    Given I authenticate using basic auth as "admin"
+    When I delete the LLM provider "nestedrl-provider"
+    Then the response status code should be 200
+    When I delete the LLM provider template "nestedrl-template"
+    Then the response status code should be 200
+
+  # ------------------------------------------------------------------
+  # Same path with different methods + order independence. The wildcard paths are
+  # declared FIRST (before the specific /chat/completions entries) to prove the
+  # outcome does not depend on declaration order:
+  #   - POST /chat/completions -> 4  / hour
+  #   - GET  /chat/completions -> 10 / hour
+  #   - /chat/* (any method)   -> 2  / hour
+  #   - /*      (any method)   -> 1  / hour
+  # ------------------------------------------------------------------
+  Scenario: Per-method limits on the same path win over wildcards regardless of declaration order
+    When I create this LLM provider template:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1alpha1
+      kind: LlmProviderTemplate
+      metadata:
+        name: methodrl-template
+      spec:
+        displayName: Method RL Template
+      """
+    Then the response status code should be 201
+
+    When I create this LLM provider:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1alpha1
+      kind: LlmProvider
+      metadata:
+        name: methodrl-provider
+      spec:
+        displayName: Method RL Provider
+        version: v1.0
+        context: /methodrl
+        template: methodrl-template
+        upstream:
+          url: http://echo-backend-multi-arch:8080/anything
+          auth:
+            type: api-key
+            header: Authorization
+            value: test-api-key
+        accessControl:
+          mode: allow_all
+        policies:
+          - name: advanced-ratelimit
+            version: v1
+            paths:
+              - path: /*
+                methods:
+                  - '*'
+                params:
+                  quotas:
+                    - name: root-quota
+                      limits:
+                        - limit: 1
+                          duration: "1h"
+              - path: /chat/*
+                methods:
+                  - '*'
+                params:
+                  quotas:
+                    - name: chatwild-quota
+                      limits:
+                        - limit: 2
+                          duration: "1h"
+              - path: /chat/completions
+                methods:
+                  - 'GET'
+                params:
+                  quotas:
+                    - name: cc-get-quota
+                      limits:
+                        - limit: 10
+                          duration: "1h"
+              - path: /chat/completions
+                methods:
+                  - 'POST'
+                params:
+                  quotas:
+                    - name: cc-post-quota
+                      limits:
+                        - limit: 4
+                          duration: "1h"
+      """
+    Then the response status code should be 201
+    And I wait for 2 seconds
+    And I wait for policy snapshot sync
+
+    Given I set header "Content-Type" to "application/json"
+
+    # POST /chat/completions -> the POST-specific quota (4/hour)
+    When I send a POST request to "http://localhost:8080/methodrl/chat/completions" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 200
+    And the response header "X-RateLimit-Limit" should be "4"
+    And the response header "X-RateLimit-Remaining" should be "3"
+    When I send a POST request to "http://localhost:8080/methodrl/chat/completions" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 200
+    When I send a POST request to "http://localhost:8080/methodrl/chat/completions" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 200
+    When I send a POST request to "http://localhost:8080/methodrl/chat/completions" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 200
+    # 5th POST exceeds the POST limit of 4
+    When I send a POST request to "http://localhost:8080/methodrl/chat/completions" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 429
+
+    # GET /chat/completions -> the GET-specific quota (10/hour), a SEPARATE bucket from POST.
+    # These succeed even though the POST quota is exhausted, proving method-level isolation
+    # and that GET is governed by 10 (not 4, 2, or 1).
+    When I send a GET request to "http://localhost:8080/methodrl/chat/completions"
+    Then the response status code should be 200
+    And the response header "X-RateLimit-Limit" should be "10"
+    And the response header "X-RateLimit-Remaining" should be "9"
+    When I send a GET request to "http://localhost:8080/methodrl/chat/completions"
+    Then the response status code should be 200
+    When I send a GET request to "http://localhost:8080/methodrl/chat/completions"
+    Then the response status code should be 200
+    When I send a GET request to "http://localhost:8080/methodrl/chat/completions"
+    Then the response status code should be 200
+    When I send a GET request to "http://localhost:8080/methodrl/chat/completions"
+    Then the response status code should be 200
+
+    # /chat/<other> -> the /chat/* quota (2/hour)
+    When I send a POST request to "http://localhost:8080/methodrl/chat/embeddings" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 200
+    And the response header "X-RateLimit-Limit" should be "2"
+    When I send a POST request to "http://localhost:8080/methodrl/chat/embeddings" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 200
+    # 3rd exceeds the /chat/* limit of 2
+    When I send a POST request to "http://localhost:8080/methodrl/chat/embeddings" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 429
+
+    # any other path -> the root /* quota (1/hour)
+    When I send a POST request to "http://localhost:8080/methodrl/models" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 200
+    And the response header "X-RateLimit-Limit" should be "1"
+    # 2nd exceeds the /* limit of 1
+    When I send a POST request to "http://localhost:8080/methodrl/models" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 429
+
+    # Cleanup
+    Given I authenticate using basic auth as "admin"
+    When I delete the LLM provider "methodrl-provider"
+    Then the response status code should be 200
+    When I delete the LLM provider template "methodrl-template"
+    Then the response status code should be 200
+
+  # ------------------------------------------------------------------
+  # Method specificity on the SAME path: a concrete method beats the '*' wildcard method,
+  # mirroring how a specific path beats a wildcard path.
+  #   - /chat/completions '*'  -> 4  / hour  (all methods)
+  #   - /chat/completions GET  -> 10 / hour  (GET wins over '*' for GET requests)
+  #   - /chat/*           '*'  -> 2  / hour
+  #   - /*                '*'  -> 1  / hour
+  # So GET /chat/completions = 10, every other method on /chat/completions = 4.
+  # ------------------------------------------------------------------
+  Scenario: A concrete method beats the wildcard method on the same path
+    When I create this LLM provider template:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1alpha1
+      kind: LlmProviderTemplate
+      metadata:
+        name: methodspec-template
+      spec:
+        displayName: Method Spec Template
+      """
+    Then the response status code should be 201
+
+    When I create this LLM provider:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1alpha1
+      kind: LlmProvider
+      metadata:
+        name: methodspec-provider
+      spec:
+        displayName: Method Spec Provider
+        version: v1.0
+        context: /methodspec
+        template: methodspec-template
+        upstream:
+          url: http://echo-backend-multi-arch:8080/anything
+          auth:
+            type: api-key
+            header: Authorization
+            value: test-api-key
+        accessControl:
+          mode: allow_all
+        policies:
+          - name: advanced-ratelimit
+            version: v1
+            paths:
+              - path: /chat/completions
+                methods:
+                  - '*'
+                params:
+                  quotas:
+                    - name: cc-all-quota
+                      limits:
+                        - limit: 4
+                          duration: "1h"
+              - path: /chat/completions
+                methods:
+                  - 'GET'
+                params:
+                  quotas:
+                    - name: cc-get-quota
+                      limits:
+                        - limit: 10
+                          duration: "1h"
+              - path: /*
+                methods:
+                  - '*'
+                params:
+                  quotas:
+                    - name: root-quota
+                      limits:
+                        - limit: 1
+                          duration: "1h"
+              - path: /chat/*
+                methods:
+                  - '*'
+                params:
+                  quotas:
+                    - name: chatwild-quota
+                      limits:
+                        - limit: 2
+                          duration: "1h"
+      """
+    Then the response status code should be 201
+    And I wait for 2 seconds
+    And I wait for policy snapshot sync
+
+    Given I set header "Content-Type" to "application/json"
+
+    # GET /chat/completions -> the GET-specific quota (10/hour), winning over the '*' entry (4)
+    When I send a GET request to "http://localhost:8080/methodspec/chat/completions"
+    Then the response status code should be 200
+    And the response header "X-RateLimit-Limit" should be "10"
+    And the response header "X-RateLimit-Remaining" should be "9"
+    When I send a GET request to "http://localhost:8080/methodspec/chat/completions"
+    Then the response status code should be 200
+    When I send a GET request to "http://localhost:8080/methodspec/chat/completions"
+    Then the response status code should be 200
+    When I send a GET request to "http://localhost:8080/methodspec/chat/completions"
+    Then the response status code should be 200
+    # 5th GET still succeeds (limit is 10, not 4) - proves GET is NOT governed by the '*' entry
+    When I send a GET request to "http://localhost:8080/methodspec/chat/completions"
+    Then the response status code should be 200
+
+    # POST /chat/completions -> the '*' entry (4/hour); GET's usage did not touch this bucket
+    When I send a POST request to "http://localhost:8080/methodspec/chat/completions" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 200
+    And the response header "X-RateLimit-Limit" should be "4"
+    And the response header "X-RateLimit-Remaining" should be "3"
+    When I send a POST request to "http://localhost:8080/methodspec/chat/completions" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 200
+    When I send a POST request to "http://localhost:8080/methodspec/chat/completions" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 200
+    When I send a POST request to "http://localhost:8080/methodspec/chat/completions" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 200
+    # 5th POST exceeds the '*' entry limit of 4
+    When I send a POST request to "http://localhost:8080/methodspec/chat/completions" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 429
+
+    # /chat/<other> -> the /chat/* quota (2/hour)
+    When I send a POST request to "http://localhost:8080/methodspec/chat/embeddings" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 200
+    And the response header "X-RateLimit-Limit" should be "2"
+    When I send a POST request to "http://localhost:8080/methodspec/chat/embeddings" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 200
+    When I send a POST request to "http://localhost:8080/methodspec/chat/embeddings" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 429
+
+    # any other path -> the root /* quota (1/hour)
+    When I send a POST request to "http://localhost:8080/methodspec/models" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 200
+    And the response header "X-RateLimit-Limit" should be "1"
+    When I send a POST request to "http://localhost:8080/methodspec/models" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 429
+
+    # Cleanup
+    Given I authenticate using basic auth as "admin"
+    When I delete the LLM provider "methodspec-provider"
+    Then the response status code should be 200
+    When I delete the LLM provider template "methodspec-template"
+    Then the response status code should be 200
+
+  # ------------------------------------------------------------------
+  # Narrower method set wins on the same path: [POST] is more specific than [GET, POST].
+  #   - /chat/completions [GET, POST] -> 3   / hour
+  #   - /chat/completions [POST]      -> 100 / hour
+  # So GET = 3 (only the [GET, POST] entry covers it), POST = 100 (the narrower [POST] entry).
+  # ------------------------------------------------------------------
+  Scenario: A narrower method set wins over a broader one on the same path
+    When I create this LLM provider template:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1alpha1
+      kind: LlmProviderTemplate
+      metadata:
+        name: narrowrl-template
+      spec:
+        displayName: Narrow RL Template
+      """
+    Then the response status code should be 201
+
+    When I create this LLM provider:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1alpha1
+      kind: LlmProvider
+      metadata:
+        name: narrowrl-provider
+      spec:
+        displayName: Narrow RL Provider
+        version: v1.0
+        context: /narrowrl
+        template: narrowrl-template
+        upstream:
+          url: http://echo-backend-multi-arch:8080/anything
+          auth:
+            type: api-key
+            header: Authorization
+            value: test-api-key
+        accessControl:
+          mode: allow_all
+        policies:
+          - name: advanced-ratelimit
+            version: v1
+            paths:
+              - path: /chat/completions
+                methods: [GET, POST]
+                params:
+                  quotas:
+                    - name: cc-readwrite-quota
+                      limits:
+                        - limit: 3
+                          duration: "1h"
+              - path: /chat/completions
+                methods: [POST]
+                params:
+                  quotas:
+                    - name: cc-write-quota
+                      limits:
+                        - limit: 100
+                          duration: "1h"
+      """
+    Then the response status code should be 201
+    And I wait for 2 seconds
+    And I wait for policy snapshot sync
+
+    Given I set header "Content-Type" to "application/json"
+
+    # GET is covered only by the [GET, POST] entry -> 3/hour
+    When I send a GET request to "http://localhost:8080/narrowrl/chat/completions"
+    Then the response status code should be 200
+    And the response header "X-RateLimit-Limit" should be "3"
+    And the response header "X-RateLimit-Remaining" should be "2"
+    When I send a GET request to "http://localhost:8080/narrowrl/chat/completions"
+    Then the response status code should be 200
+    When I send a GET request to "http://localhost:8080/narrowrl/chat/completions"
+    Then the response status code should be 200
+    # 4th GET exceeds the [GET, POST] limit of 3
+    When I send a GET request to "http://localhost:8080/narrowrl/chat/completions"
+    Then the response status code should be 429
+
+    # POST is covered by the narrower [POST] entry -> 100/hour (NOT capped at 3)
+    When I send a POST request to "http://localhost:8080/narrowrl/chat/completions" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 200
+    And the response header "X-RateLimit-Limit" should be "100"
+    And the response header "X-RateLimit-Remaining" should be "99"
+    When I send a POST request to "http://localhost:8080/narrowrl/chat/completions" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 200
+    When I send a POST request to "http://localhost:8080/narrowrl/chat/completions" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 200
+    When I send a POST request to "http://localhost:8080/narrowrl/chat/completions" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 200
+    # 5th POST still succeeds (limit is 100, not 3) - proves POST uses the narrower [POST] entry
+    When I send a POST request to "http://localhost:8080/narrowrl/chat/completions" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 200
+
+    # Cleanup
+    Given I authenticate using basic auth as "admin"
+    When I delete the LLM provider "narrowrl-provider"
+    Then the response status code should be 200
+    When I delete the LLM provider template "narrowrl-template"
+    Then the response status code should be 200
+
+  # ------------------------------------------------------------------
+  # The same most-specific-wins logic applies to an LlmProxy's own policies.
+  #   proxy policies: /chat/completions -> 4 / hour, /* -> 1 / hour
+  # So /chat/completions = 4 (not also limited by the /* entry), other paths = 1.
+  # ------------------------------------------------------------------
+  Scenario: Most specific wins for an LLM proxy's policies
+    # Backing provider (no policies, just forwards to the echo backend)
+    When I create this LLM provider template:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1alpha1
+      kind: LlmProviderTemplate
+      metadata:
+        name: proxyspec-template
+      spec:
+        displayName: Proxy Spec Template
+      """
+    Then the response status code should be 201
+    When I create this LLM provider:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1alpha1
+      kind: LlmProvider
+      metadata:
+        name: proxyspec-provider
+      spec:
+        displayName: Proxy Spec Provider
+        version: v1.0
+        context: /proxyspec-provider
+        template: proxyspec-template
+        upstream:
+          url: http://echo-backend-multi-arch:8080/anything
+          auth:
+            type: api-key
+            header: Authorization
+            value: test-api-key
+        accessControl:
+          mode: allow_all
+      """
+    Then the response status code should be 201
+
+    # Proxy carrying the overlapping-path advanced-ratelimit policy
+    When I deploy this LLM proxy configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1alpha1
+      kind: LlmProxy
+      metadata:
+        name: proxyspec-proxy
+      spec:
+        displayName: Proxy Spec Proxy
+        version: v1.0
+        context: /proxyspec
+        provider:
+          id: proxyspec-provider
+        policies:
+          - name: advanced-ratelimit
+            version: v1
+            paths:
+              - path: /chat/completions
+                methods:
+                  - '*'
+                params:
+                  quotas:
+                    - name: proxy-cc-quota
+                      limits:
+                        - limit: 4
+                          duration: "1h"
+              - path: /*
+                methods:
+                  - '*'
+                params:
+                  quotas:
+                    - name: proxy-root-quota
+                      limits:
+                        - limit: 1
+                          duration: "1h"
+      """
+    Then the response status code should be 201
+    And I wait for 2 seconds
+    And I wait for policy snapshot sync
+
+    Given I set header "Content-Type" to "application/json"
+
+    # POST /chat/completions on the proxy -> the specific quota (4/hour)
+    When I send a POST request to "http://localhost:8080/proxyspec/chat/completions" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 200
+    And the response header "X-RateLimit-Limit" should be "4"
+    When I send a POST request to "http://localhost:8080/proxyspec/chat/completions" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 200
+    When I send a POST request to "http://localhost:8080/proxyspec/chat/completions" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 200
+    When I send a POST request to "http://localhost:8080/proxyspec/chat/completions" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 200
+    # 5th exceeds the specific limit of 4
+    When I send a POST request to "http://localhost:8080/proxyspec/chat/completions" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 429
+
+    # any other path on the proxy -> the /* quota (1/hour)
+    When I send a POST request to "http://localhost:8080/proxyspec/embeddings" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 200
+    And the response header "X-RateLimit-Limit" should be "1"
+    When I send a POST request to "http://localhost:8080/proxyspec/embeddings" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 429
+
+    # Cleanup
+    Given I authenticate using basic auth as "admin"
+    When I send a DELETE request to the "gateway-controller" service at "/llm-proxies/proxyspec-proxy"
+    Then the response should be successful
+    When I delete the LLM provider "proxyspec-provider"
+    Then the response status code should be 200
+    When I delete the LLM provider template "proxyspec-template"
+    Then the response status code should be 200

--- a/gateway/it/features/llm-policy-path-specificity.feature
+++ b/gateway/it/features/llm-policy-path-specificity.feature
@@ -909,3 +909,138 @@ Feature: LLM policy path and method specificity
     Then the response status code should be 200
     When I delete the LLM provider template "proxyspec-template"
     Then the response status code should be 200
+
+  # ------------------------------------------------------------------
+  # Two separate policy blocks of the SAME name both apply. Each block is resolved
+  # most-specific-within-itself, and every block layers onto the route. set-headers is used
+  # (two blocks setting DIFFERENT response headers) so "both applied" is directly assertable:
+  #   Block 1 (set-headers, X-Tier):  /chat/completions [*]->chat-all, [GET]->chat-get,
+  #                                   /chat/* [*]->chat-wild, /* [*]->root
+  #   Block 2 (set-headers, X-Global): /* [*]->global-applied
+  # Every response carries the block-1 X-Tier for its most specific path/method AND the
+  # block-2 X-Global, proving both same-name blocks apply.
+  # ------------------------------------------------------------------
+  Scenario: Two policy blocks of the same name both apply, each most-specific within itself
+    When I create this LLM provider template:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1alpha1
+      kind: LlmProviderTemplate
+      metadata:
+        name: twoblocks-template
+      spec:
+        displayName: Two Blocks Template
+      """
+    Then the response status code should be 201
+
+    When I create this LLM provider:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1alpha1
+      kind: LlmProvider
+      metadata:
+        name: twoblocks-provider
+      spec:
+        displayName: Two Blocks Provider
+        version: v1.0
+        context: /twoblocks
+        template: twoblocks-template
+        upstream:
+          url: http://echo-backend-multi-arch:8080/anything
+          auth:
+            type: api-key
+            header: Authorization
+            value: test-api-key
+        accessControl:
+          mode: allow_all
+        policies:
+          - name: set-headers
+            version: v1
+            paths:
+              - path: /chat/completions
+                methods:
+                  - '*'
+                params:
+                  response:
+                    headers:
+                      - name: X-Tier
+                        value: chat-all
+              - path: /chat/completions
+                methods:
+                  - 'GET'
+                params:
+                  response:
+                    headers:
+                      - name: X-Tier
+                        value: chat-get
+              - path: /chat/*
+                methods:
+                  - '*'
+                params:
+                  response:
+                    headers:
+                      - name: X-Tier
+                        value: chat-wild
+              - path: /*
+                methods:
+                  - '*'
+                params:
+                  response:
+                    headers:
+                      - name: X-Tier
+                        value: root
+          - name: set-headers
+            version: v1
+            paths:
+              - path: /*
+                methods:
+                  - '*'
+                params:
+                  response:
+                    headers:
+                      - name: X-Global
+                        value: global-applied
+      """
+    Then the response status code should be 201
+    And I wait for 2 seconds
+    And I wait for policy snapshot sync
+
+    Given I set header "Content-Type" to "application/json"
+
+    # POST /chat/completions -> block 1 most-specific is the [*] entry (chat-all); block 2 also applies
+    When I send a POST request to "http://localhost:8080/twoblocks/chat/completions" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 200
+    And the response header "X-Tier" should be "chat-all"
+    And the response header "X-Global" should be "global-applied"
+
+    # GET /chat/completions -> block 1 most-specific is the [GET] entry (chat-get); block 2 also applies
+    When I send a GET request to "http://localhost:8080/twoblocks/chat/completions"
+    Then the response status code should be 200
+    And the response header "X-Tier" should be "chat-get"
+    And the response header "X-Global" should be "global-applied"
+
+    # /chat/<other> -> block 1 /chat/* (chat-wild); block 2 also applies
+    When I send a POST request to "http://localhost:8080/twoblocks/chat/embeddings" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 200
+    And the response header "X-Tier" should be "chat-wild"
+    And the response header "X-Global" should be "global-applied"
+
+    # any other path -> block 1 /* (root); block 2 also applies
+    When I send a POST request to "http://localhost:8080/twoblocks/models" with body:
+      """
+      {"model": "gpt-4"}
+      """
+    Then the response status code should be 200
+    And the response header "X-Tier" should be "root"
+    And the response header "X-Global" should be "global-applied"
+
+    # Cleanup
+    Given I authenticate using basic auth as "admin"
+    When I delete the LLM provider "twoblocks-provider"
+    Then the response status code should be 200
+    When I delete the LLM provider template "twoblocks-template"
+    Then the response status code should be 200


### PR DESCRIPTION
## Purpose

Resolves #2057.

On an `LlmProvider` or `LlmProxy`, the same policy can be attached to several `paths`/`methods`. The LLM transformer fanned every matching attachment onto each operation, so a route's policy chain stacked multiple instances and the most restrictive one silently dominated — for example `POST /chat/completions` was limited by a `/*` quota (1/h) instead of its own (4/h).

## Goals

Resolve overlapping policy attachments to the most specific match per route, so each path+method is governed only by its most specific rule. Within a single policy block this collapses to one effective policy per route; separate policy blocks (even with the same name) still each contribute and layer.

## Approach

- In `gateway/gateway-controller/pkg/utils/llm_transformer.go`, before layering a policy onto a target path, skip it when a strictly more specific attachment in the **same policy block** also covers that path+method (`moreSpecificPolicyAttachmentCovers`).
- Specificity ordering (`isMoreSpecificAttachment`): **path first** — concrete beats wildcard, longer prefix beats shorter (`isMoreSpecificPath`); then **method** — the narrower HTTP method set wins, so `[POST]` is more specific than `[GET, POST]`, which is more specific than `*` (`isStrictMethodSubset`).
- Resolution is scoped to a single block, so separate `spec.policies[]` entries — even ones with the same name, such as two `advanced-ratelimit` blocks — each resolve their own most-specific match and all layer onto the route.
- Wired into all three transform paths — `transformProvider` (`allow_all` and `deny_all`) and `transformProxy` — and the result is independent of declaration order.
- Scope: `LlmProvider` and `LlmProxy` only. `RestApi` is unaffected because its operations carry explicit per-operation policies with no wildcard fan-out.

## User stories

As an API developer, when I attach a policy to a specific path/method and a broader fallback (such as `/*`), I expect the specific rule to govern that path and the fallback to govern everything else, rather than both stacking on the specific route. When I declare two separate policy blocks of the same type, I expect both to apply, each resolved to its own most specific match.

## Documentation

N/A. This corrects internal policy-resolution behaviour; the `LlmProvider`/`LlmProxy` `spec.policies[].paths` format is unchanged.

## Automation tests

- Unit tests
  > Added in `pkg/utils/llm_transformer_test.go`: `MostSpecificPathWinsForSamePolicy`, `MostSpecificPathWinsAcrossNestedWildcards`, `MostSpecificPathWinsAcrossMethodsAndOrder`, `MostSpecificMethodWinsOnSamePath`, `NarrowerMethodSetWins`, `PathDominatesMethodSpecificity`, `DifferentPoliciesResolveIndependently`, `DenyAllModeMostSpecificWins`, `TemplateExpansionDedupesSameNamePolicy`, and `SeparatePoliciesOfSameNameBothApply`. The existing `PolicyOrderDoesNotAffectWildcardCoverage` and `ExpandsWildcardPolicyPathWithTemplateMappings` still pass. `go test ./pkg/utils/...` is green.
- Integration tests
  > Added `gateway/it/features/llm-policy-path-specificity.feature` with 7 scenarios validated end-to-end via response headers and 429 enforcement: specific-vs-wildcard, nested paths (4/2/1), per-method on the same path, concrete-method-beats-`*`, narrower-method-set, an `LlmProxy` scenario, and two same-name `set-headers` blocks both applying. Full run (with `health` + `api_deploy` warm-up): 16 scenarios / 329 steps passing.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
- Ran FindSecurityBugs plugin and verified report? **N/A** — FindSecurityBugs is a Java/SpotBugs plugin and this change is Go.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Samples

All samples attach policies to an `LlmProvider` via `spec.policies[].paths` (each entry is `path` + `methods` + a per-hour `limit`). `=>` shows the resolved per-route limit after this fix; before the fix every overlapping route collapsed to the most restrictive limit.

Sample 1 — specific path beats the wildcard fallback:
```
/chat/completions  [POST] -> 4/h
/*                 [*]    -> 1/h
=> POST /chat/completions: 4/h ; every other path: 1/h
```

Sample 2 — nested wildcards (not just `/*`):
```
/chat/completions  [*] -> 4/h
/chat/*            [*] -> 2/h
/*                 [*] -> 1/h
=> /chat/completions: 4/h ; /chat/<other>: 2/h ; everything else: 1/h
```

Sample 3 — different methods on the same path, plus wildcards:
```
/chat/completions  [POST] -> 4/h
/chat/completions  [GET]  -> 10/h
/chat/*            [*]     -> 2/h
/*                 [*]     -> 1/h
=> POST /chat/completions: 4/h ; GET /chat/completions: 10/h ; /chat/<other>: 2/h ; else: 1/h
```

Sample 4 — a concrete method beats the `*` method on the same path:
```
/chat/completions  [*]   -> 4/h
/chat/completions  [GET] -> 10/h
=> GET /chat/completions: 10/h ; every other method on /chat/completions: 4/h
```

Sample 5 — a narrower method set beats a broader one on the same path:
```
/chat/completions  [GET, POST] -> 3/h
/chat/completions  [POST]      -> 100/h
=> GET /chat/completions: 3/h ; POST /chat/completions: 100/h
```

Sample 6 — same resolution applies to an `LlmProxy`'s own policies:
```
proxy policies:  /chat/completions [*] -> 4/h ;  /* [*] -> 1/h
=> proxy POST /chat/completions: 4/h ; every other proxy path: 1/h
```

Sample 7 — two separate blocks of the same policy name both apply, each most-specific within itself:
```
block 1 (advanced-ratelimit):  /chat/completions [*] -> 4/h , [GET] -> 10/h , /chat/* [*] -> 2/h , /* [*] -> 1/h
block 2 (advanced-ratelimit):  /* [*] -> 100/day
=> POST /chat/completions: 4/h AND 100/day ; GET /chat/completions: 10/h AND 100/day ; /chat/<other>: 2/h AND 100/day ; else: 1/h AND 100/day
```

Declaration order of the `paths` entries does not affect any of the above. Across separate blocks, every block's most-specific match is applied.

## Related PRs

N/A

## Test environment

- Go 1.23+ (gateway-controller module); `go test ./pkg/utils/...`.
- Gateway integration suite (Godog + Docker Compose: gateway-controller, gateway-runtime with Envoy + policy-engine, echo/mock backends) using coverage-instrumented images.
- Docker via Colima on macOS (darwin/arm64).
