### PR TITLE
fix(gateway): dynamic-endpoint double path prefix on sandbox vhost

### DIFF
--- a/gateway/gateway-controller/pkg/transform/restapi.go
+++ b/gateway/gateway-controller/pkg/transform/restapi.go
@@ -227,8 +227,14 @@ func (t *RestAPITransformer) Transform(cfg *models.StoredConfig) (*models.Runtim
 			routeKey := xds.GenerateRouteName(string(op.Method), apiData.Context, apiData.Version, op.Path, effectiveSandboxVHost)
 			if r, exists := rdc.Routes[routeKey]; exists {
 				r.Upstream.ClusterKey = sbUpstream.ClusterKey
-				r.Upstream.UseClusterHeader = false
-				r.Upstream.DefaultCluster = ""
+				// Mirror main on sandbox routes: cluster_header lets a dynamic-endpoint policy
+				// divert sandbox traffic, defaulting to the sandbox cluster when none does.
+				r.Upstream.UseClusterHeader = useClusterHeader
+				if useClusterHeader {
+					r.Upstream.DefaultCluster = sbUpstream.EnvoyClusterName
+				} else {
+					r.Upstream.DefaultCluster = ""
+				}
 				r.AutoHostRewrite = sbAutoHostRewrite
 			}
 		}

--- a/gateway/gateway-controller/pkg/transform/restapi_test.go
+++ b/gateway/gateway-controller/pkg/transform/restapi_test.go
@@ -344,3 +344,46 @@ func TestResolvePort(t *testing.T) {
 		})
 	}
 }
+
+// TestRestAPITransformer_SandboxRouteClusterHeader pins the sandbox route's dynamic
+// cluster selection: with upstreamDefinitions the sandbox route uses cluster_header
+// routing (so a dynamic-endpoint policy can divert sandbox traffic) and defaults to the
+// sandbox cluster; without them it stays a static sandbox route.
+func TestRestAPITransformer_SandboxRouteClusterHeader(t *testing.T) {
+	defs := map[string]models.PolicyDefinition{}
+	const sandboxURL = "http://sandbox-backend:9080/sandbox"
+	const sandboxRouteKey = "GET|/test/hello|sandbox.local"
+	expectedSandboxCluster := sanitizeEnvoyClusterName("sandbox-backend:9080", "http")
+
+	t.Run("without upstreamDefinitions the sandbox route is static", func(t *testing.T) {
+		transformer := NewRestAPITransformer(testRouterCfg(), &config.Config{}, defs)
+		cfg := makeRestAPIStoredConfig(nil, nil)
+		restAPI := cfg.Configuration.(api.RestAPI)
+		restAPI.Spec.Upstream.Sandbox = &api.Upstream{Url: ptrStr(sandboxURL)}
+		cfg.Configuration = restAPI
+
+		rdc, err := transformer.Transform(cfg)
+		require.NoError(t, err)
+		r, exists := rdc.Routes[sandboxRouteKey]
+		require.True(t, exists, "sandbox route should exist")
+		assert.False(t, r.Upstream.UseClusterHeader)
+		assert.Equal(t, "", r.Upstream.DefaultCluster)
+	})
+
+	t.Run("with upstreamDefinitions the sandbox route uses cluster_header defaulting to the sandbox cluster", func(t *testing.T) {
+		transformer := NewRestAPITransformer(testRouterCfg(), &config.Config{}, defs)
+		cfg := makeRestAPIStoredConfig(nil, nil)
+		restAPI := cfg.Configuration.(api.RestAPI)
+		restAPI.Spec.Upstream.Sandbox = &api.Upstream{Url: ptrStr(sandboxURL)}
+		restAPI.Spec.UpstreamDefinitions = &[]api.UpstreamDefinition{{Name: "alt-upstream"}}
+		cfg.Configuration = restAPI
+
+		rdc, err := transformer.Transform(cfg)
+		require.NoError(t, err)
+		r, exists := rdc.Routes[sandboxRouteKey]
+		require.True(t, exists, "sandbox route should exist")
+		assert.True(t, r.Upstream.UseClusterHeader)
+		assert.Equal(t, expectedSandboxCluster, r.Upstream.DefaultCluster,
+			"sandbox route must default to the sandbox cluster, not main")
+	})
+}

--- a/gateway/gateway-controller/pkg/xds/translator.go
+++ b/gateway/gateway-controller/pkg/xds/translator.go
@@ -853,13 +853,17 @@ func (t *Translator) translateAPIConfig(cfg *models.StoredConfig, allConfigs []*
 		sandboxCluster := t.createCluster(sbClusterName, parsedSbURL, nil, sbUpstreamClusterConnectTimeout)
 		clusters = append(clusters, sandboxCluster)
 
-		// Create sandbox routes for each operation
+		// Create sandbox routes. When upstreamDefinitions exist, enable dynamic cluster
+		// selection (mirrors main), defaulting to the sandbox cluster.
 		sbRoutesList := make([]*route.Route, 0)
+		sbUseClusterHeader := apiData.UpstreamDefinitions != nil && len(*apiData.UpstreamDefinitions) > 0
+		sbDefaultCluster := ""
+		if sbUseClusterHeader {
+			sbDefaultCluster = sbClusterName
+		}
 		for _, op := range apiData.Operations {
-			// Use sbClusterName for sandbox upstream path
-			// Sandbox routes don't support dynamic cluster selection
 			r := t.createRoute(cfg.UUID, apiData.DisplayName, apiData.Version, apiData.Context, string(op.Method), op.Path,
-				sbClusterName, parsedSbURL.Path, effectiveSandboxVHost, cfg.Kind, templateHandle, providerName, apiData.Upstream.Sandbox.HostRewrite, apiProjectID, sbTimeout, false, "", nil)
+				sbClusterName, parsedSbURL.Path, effectiveSandboxVHost, cfg.Kind, templateHandle, providerName, apiData.Upstream.Sandbox.HostRewrite, apiProjectID, sbTimeout, sbUseClusterHeader, sbDefaultCluster, upstreamDefPaths)
 			sbRoutesList = append(sbRoutesList, r)
 		}
 		routesList = append(routesList, sbRoutesList...)

--- a/gateway/gateway-controller/pkg/xds/translator_test.go
+++ b/gateway/gateway-controller/pkg/xds/translator_test.go
@@ -1529,6 +1529,47 @@ func TestTranslator_CreateRoute_Basic(t *testing.T) {
 	assert.Contains(t, route.Name, "/api/users")
 }
 
+// TestTranslator_CreateRoute_DynamicRouting pins the cluster specifier createRoute emits:
+// a static cluster when useClusterHeader is false, and cluster_header routing (with the
+// x-target-upstream header stripped before forwarding) when it is true. This is the
+// legacy-xDS half of the sandbox dynamic-endpoint fix.
+func TestTranslator_CreateRoute_DynamicRouting(t *testing.T) {
+	logger := createTestLogger()
+	routerCfg := testRouterConfig()
+	cfg := testConfig()
+	translator := NewTranslator(logger, routerCfg, nil, cfg)
+
+	t.Run("static cluster when useClusterHeader is false", func(t *testing.T) {
+		r := translator.createRoute(
+			"api-123", "0000-test-api-0000-000000000000", "v1", "/api", "GET", "/users",
+			"static-cluster", "", "localhost", "API", "", "", nil, "proj-001", nil,
+			false, "", nil,
+		)
+		require.NotNil(t, r)
+		routeAction, ok := r.Action.(*route.Route_Route)
+		require.True(t, ok)
+		clusterSpec, ok := routeAction.Route.ClusterSpecifier.(*route.RouteAction_Cluster)
+		require.True(t, ok, "expected a static cluster specifier")
+		assert.Equal(t, "static-cluster", clusterSpec.Cluster)
+		assert.NotContains(t, r.RequestHeadersToRemove, constants.TargetUpstreamHeader)
+	})
+
+	t.Run("cluster_header routing when useClusterHeader is true", func(t *testing.T) {
+		r := translator.createRoute(
+			"api-123", "0000-test-api-0000-000000000000", "v1", "/api", "GET", "/users",
+			"static-cluster", "", "localhost", "API", "", "", nil, "proj-001", nil,
+			true, "default-cluster", nil,
+		)
+		require.NotNil(t, r)
+		routeAction, ok := r.Action.(*route.Route_Route)
+		require.True(t, ok)
+		clusterSpec, ok := routeAction.Route.ClusterSpecifier.(*route.RouteAction_ClusterHeader)
+		require.True(t, ok, "expected a cluster_header specifier for dynamic selection")
+		assert.Equal(t, constants.TargetUpstreamHeader, clusterSpec.ClusterHeader)
+		assert.Contains(t, r.RequestHeadersToRemove, constants.TargetUpstreamHeader)
+	})
+}
+
 func TestTranslator_ExtractTemplateHandle_ValidLLMProvider(t *testing.T) {
 	logger := createTestLogger()
 	routerCfg := testRouterConfig()

--- a/gateway/gateway-runtime/policy-engine/internal/kernel/translator.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/translator.go
@@ -455,17 +455,21 @@ func TranslateRequestHeaderActions(result *executor.RequestHeaderExecutionResult
 		}
 		execCtx.dynamicMetadata[extProcNS][constants.TargetUpstreamClusterKey] = clusterName
 		execCtx.dynamicMetadata[extProcNS][constants.TargetUpstreamNameKey] = *targetUpstreamName
-		dynamicMetadata[extProcNS] = map[string]interface{}{
-			"api_context":        execCtx.apiContext,
-			"upstream_base_path": execCtx.upstreamBasePath,
+		if dynamicMetadata[extProcNS] == nil {
+			dynamicMetadata[extProcNS] = make(map[string]interface{})
 		}
+		dynamicMetadata[extProcNS]["api_context"] = execCtx.apiContext
+		dynamicMetadata[extProcNS]["upstream_base_path"] = execCtx.upstreamBasePath
 		if execCtx.upstreamDefinitionPaths != nil {
 			if targetUpstreamPath, ok := execCtx.upstreamDefinitionPaths[*targetUpstreamName]; ok {
-				if mutations.Path == nil {
-					computedPath := computeUpstreamPath(execCtx.requestBodyCtx.Path, execCtx.apiContext, targetUpstreamPath)
-					mutations.Path = &computedPath
-					dynamicMetadata[extProcNS]["request_transformation.target_path"] = computedPath
-					execCtx.dynamicMetadata[extProcNS]["request_transformation.target_path"] = computedPath
+				// Advertise the target upstream base path; the Lua filter prepends it once.
+				// Do NOT set mutations.Path here -- it surfaces as metadata["path"], which Lua reads
+				// before target_path and would double-prefix (e.g. /sandbox/alternate/whoami on sandbox).
+				dynamicMetadata[extProcNS]["target_upstream_base_path"] = targetUpstreamPath
+				execCtx.dynamicMetadata[extProcNS]["target_upstream_base_path"] = targetUpstreamPath
+				if _, hasTargetPath := dynamicMetadata[extProcNS]["request_transformation.target_path"]; !hasTargetPath {
+					dynamicMetadata[extProcNS]["request_transformation.target_path"] = execCtx.requestBodyCtx.Path
+					execCtx.dynamicMetadata[extProcNS]["request_transformation.target_path"] = execCtx.requestBodyCtx.Path
 				}
 			}
 		}
@@ -475,10 +479,11 @@ func TranslateRequestHeaderActions(result *executor.RequestHeaderExecutionResult
 		if execCtx.dynamicMetadata[extProcNS] == nil {
 			execCtx.dynamicMetadata[extProcNS] = make(map[string]interface{})
 		}
-		dynamicMetadata[extProcNS] = map[string]interface{}{
-			"api_context":        execCtx.apiContext,
-			"upstream_base_path": execCtx.upstreamBasePath,
+		if dynamicMetadata[extProcNS] == nil {
+			dynamicMetadata[extProcNS] = make(map[string]interface{})
 		}
+		dynamicMetadata[extProcNS]["api_context"] = execCtx.apiContext
+		dynamicMetadata[extProcNS]["upstream_base_path"] = execCtx.upstreamBasePath
 	}
 
 	mergeHeaderMutations(headerMutation, headerOps)
@@ -685,11 +690,14 @@ func TranslateRequestHeaderActionsWithBodyMerge(
 		dynamicMetadata[extProcNS]["upstream_base_path"] = execCtx.upstreamBasePath
 		if execCtx.upstreamDefinitionPaths != nil {
 			if targetUpstreamPath, ok := execCtx.upstreamDefinitionPaths[*targetUpstreamName]; ok {
-				if mutations.Path == nil {
-					computedPath := computeUpstreamPath(execCtx.requestBodyCtx.Path, execCtx.apiContext, targetUpstreamPath)
-					mutations.Path = &computedPath
-					dynamicMetadata[extProcNS]["request_transformation.target_path"] = computedPath
-					execCtx.dynamicMetadata[extProcNS]["request_transformation.target_path"] = computedPath
+				// Advertise the target upstream base path; the Lua filter prepends it once.
+				// Do NOT set mutations.Path here -- it surfaces as metadata["path"], which Lua reads
+				// before target_path and would double-prefix (e.g. /sandbox/alternate/whoami on sandbox).
+				dynamicMetadata[extProcNS]["target_upstream_base_path"] = targetUpstreamPath
+				execCtx.dynamicMetadata[extProcNS]["target_upstream_base_path"] = targetUpstreamPath
+				if _, hasTargetPath := dynamicMetadata[extProcNS]["request_transformation.target_path"]; !hasTargetPath {
+					dynamicMetadata[extProcNS]["request_transformation.target_path"] = execCtx.requestBodyCtx.Path
+					execCtx.dynamicMetadata[extProcNS]["request_transformation.target_path"] = execCtx.requestBodyCtx.Path
 				}
 			}
 		}
@@ -699,10 +707,11 @@ func TranslateRequestHeaderActionsWithBodyMerge(
 		if execCtx.dynamicMetadata[extProcNS] == nil {
 			execCtx.dynamicMetadata[extProcNS] = make(map[string]interface{})
 		}
-		dynamicMetadata[extProcNS] = map[string]interface{}{
-			"api_context":        execCtx.apiContext,
-			"upstream_base_path": execCtx.upstreamBasePath,
+		if dynamicMetadata[extProcNS] == nil {
+			dynamicMetadata[extProcNS] = make(map[string]interface{})
 		}
+		dynamicMetadata[extProcNS]["api_context"] = execCtx.apiContext
+		dynamicMetadata[extProcNS]["upstream_base_path"] = execCtx.upstreamBasePath
 	}
 
 	if bodyModified {
@@ -1741,47 +1750,4 @@ func sanitizeUpstreamDefinitionName(name string) string {
 	sanitized := strings.ReplaceAll(name, ".", "_")
 	sanitized = strings.ReplaceAll(sanitized, ":", "_")
 	return sanitized
-}
-
-// computeUpstreamPath computes the final upstream path by stripping the API context
-// from the current path and prepending the target upstream's path.
-// Example: currentPath="/weather/v1.0/pets", apiContext="/weather/v1.0", upstreamPath="/alternate-backend"
-// Result: "/alternate-backend/pets"
-func computeUpstreamPath(currentPath, apiContext, upstreamPath string) string {
-	if currentPath == "" {
-		return ""
-	}
-
-	// Default values
-	if apiContext == "" {
-		apiContext = "/"
-	}
-	if upstreamPath == "" {
-		upstreamPath = ""
-	}
-
-	// Strip the API context prefix from the current path
-	relativePath := currentPath
-	if apiContext != "/" {
-		if strings.HasPrefix(currentPath, apiContext) {
-			relativePath = strings.TrimPrefix(currentPath, apiContext)
-			if relativePath == "" {
-				relativePath = "/"
-			}
-		}
-	}
-
-	// Prepend the upstream path
-	if upstreamPath == "" || upstreamPath == "/" {
-		return relativePath
-	}
-
-	// Handle trailing slash in upstreamPath and leading slash in relativePath
-	if strings.HasSuffix(upstreamPath, "/") && strings.HasPrefix(relativePath, "/") {
-		return upstreamPath + relativePath[1:]
-	}
-	if !strings.HasSuffix(upstreamPath, "/") && !strings.HasPrefix(relativePath, "/") {
-		return upstreamPath + "/" + relativePath
-	}
-	return upstreamPath + relativePath
 }

--- a/gateway/gateway-runtime/policy-engine/internal/kernel/translator_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/translator_test.go
@@ -749,3 +749,147 @@ func TestTranslateResponseActionsCore_NoShortCircuit(t *testing.T) {
 	require.NotNil(t, headerMutation)
 	assert.Len(t, headerMutation.SetHeaders, 1)
 }
+
+// =============================================================================
+// Dynamic-endpoint request-header translation
+// =============================================================================
+
+// A dynamic-endpoint policy sets UpstreamName: the header phase must advertise the
+// target upstream base path in dynamic metadata and leave target_path at the original
+// request path, without baking a "path" mutation that Lua reads first and would
+// double-prefix on the sandbox vhost (e.g. /sandbox/alternate/whoami).
+func TestTranslateRequestHeaderActions_DynamicEndpoint(t *testing.T) {
+	newExecCtx := func() *PolicyExecutionContext {
+		kernel := NewKernel()
+		chainExecutor := executor.NewChainExecutor(nil, nil, nil)
+		server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+		execCtx := newPolicyExecutionContext(server, "test-route", &registry.PolicyChain{})
+		execCtx.sharedCtx = &policy.SharedContext{APIKind: "API", APIId: "api-123"}
+		execCtx.requestBodyCtx = &policy.RequestContext{
+			Path:          "/api/whoami",
+			SharedContext: execCtx.sharedCtx,
+		}
+		execCtx.apiContext = "/api"
+		execCtx.upstreamBasePath = "/sandbox"
+		execCtx.upstreamDefinitionPaths = map[string]string{"alt-upstream": "/alternate"}
+		return execCtx
+	}
+
+	targetUpstream := "alt-upstream"
+	chain := &registry.PolicyChain{}
+
+	t.Run("advertises target upstream base path without baking a path mutation", func(t *testing.T) {
+		execCtx := newExecCtx()
+		result := &executor.RequestHeaderExecutionResult{
+			Results: []executor.RequestHeaderPolicyResult{
+				{Action: policy.UpstreamRequestHeaderModifications{UpstreamName: &targetUpstream}},
+			},
+		}
+
+		resp, err := TranslateRequestHeaderActions(result, chain, execCtx)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		hm := resp.GetRequestHeaders().GetResponse().GetHeaderMutation()
+		require.NotNil(t, hm)
+		expectedCluster := constants.UpstreamDefinitionClusterPrefix + "API_api-123_" + sanitizeUpstreamDefinitionName(targetUpstream)
+		var headerValue string
+		for _, h := range hm.SetHeaders {
+			if h.Header.Key == constants.TargetUpstreamHeader {
+				headerValue = string(h.Header.RawValue)
+			}
+		}
+		assert.Equal(t, expectedCluster, headerValue, "x-target-upstream must select the alt-upstream cluster")
+
+		extProc := resp.DynamicMetadata.Fields[constants.ExtProcFilterName].GetStructValue()
+		require.NotNil(t, extProc)
+		assert.Equal(t, "/alternate", extProc.Fields["target_upstream_base_path"].GetStringValue())
+		assert.Equal(t, "/api/whoami", extProc.Fields["request_transformation.target_path"].GetStringValue())
+		assert.NotContains(t, extProc.Fields, "path")
+	})
+
+	t.Run("preserves a target_path already set by an earlier policy", func(t *testing.T) {
+		execCtx := newExecCtx()
+		result := &executor.RequestHeaderExecutionResult{
+			Results: []executor.RequestHeaderPolicyResult{
+				{Action: policy.UpstreamRequestHeaderModifications{
+					UpstreamName: &targetUpstream,
+					DynamicMetadata: map[string]map[string]interface{}{
+						constants.ExtProcFilterName: {"request_transformation.target_path": "/rewritten/path"},
+					},
+				}},
+			},
+		}
+
+		resp, err := TranslateRequestHeaderActions(result, chain, execCtx)
+		require.NoError(t, err)
+		extProc := resp.DynamicMetadata.Fields[constants.ExtProcFilterName].GetStructValue()
+		require.NotNil(t, extProc)
+		assert.Equal(t, "/rewritten/path", extProc.Fields["request_transformation.target_path"].GetStringValue())
+		assert.Equal(t, "/alternate", extProc.Fields["target_upstream_base_path"].GetStringValue())
+		assert.NotContains(t, extProc.Fields, "path")
+	})
+}
+
+// The body-merge variant (body-less requests) shares the same dynamic-endpoint contract:
+// the policy runs in the header phase, must not bake a path, and preserves a target_path
+// already chosen by an earlier policy.
+func TestTranslateRequestHeaderActionsWithBodyMerge_DynamicEndpoint(t *testing.T) {
+	newExecCtx := func() *PolicyExecutionContext {
+		kernel := NewKernel()
+		chainExecutor := executor.NewChainExecutor(nil, nil, nil)
+		server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+		execCtx := newPolicyExecutionContext(server, "test-route", &registry.PolicyChain{})
+		execCtx.sharedCtx = &policy.SharedContext{APIKind: "API", APIId: "api-123"}
+		execCtx.requestBodyCtx = &policy.RequestContext{
+			Path:          "/api/whoami",
+			SharedContext: execCtx.sharedCtx,
+		}
+		execCtx.apiContext = "/api"
+		execCtx.upstreamBasePath = "/sandbox"
+		execCtx.upstreamDefinitionPaths = map[string]string{"alt-upstream": "/alternate"}
+		return execCtx
+	}
+	targetUpstream := "alt-upstream"
+	emptyBody := func() *executor.RequestExecutionResult {
+		return &executor.RequestExecutionResult{Results: []executor.RequestPolicyResult{}}
+	}
+
+	t.Run("advertises target upstream base path without baking a path mutation", func(t *testing.T) {
+		execCtx := newExecCtx()
+		headerResult := &executor.RequestHeaderExecutionResult{
+			Results: []executor.RequestHeaderPolicyResult{
+				{Action: policy.UpstreamRequestHeaderModifications{UpstreamName: &targetUpstream}},
+			},
+		}
+		resp, err := TranslateRequestHeaderActionsWithBodyMerge(headerResult, emptyBody(), execCtx)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		extProc := resp.DynamicMetadata.Fields[constants.ExtProcFilterName].GetStructValue()
+		require.NotNil(t, extProc)
+		assert.Equal(t, "/alternate", extProc.Fields["target_upstream_base_path"].GetStringValue())
+		assert.Equal(t, "/api/whoami", extProc.Fields["request_transformation.target_path"].GetStringValue())
+		assert.NotContains(t, extProc.Fields, "path")
+	})
+
+	t.Run("preserves a target_path already set by an earlier policy", func(t *testing.T) {
+		execCtx := newExecCtx()
+		headerResult := &executor.RequestHeaderExecutionResult{
+			Results: []executor.RequestHeaderPolicyResult{
+				{Action: policy.UpstreamRequestHeaderModifications{
+					UpstreamName: &targetUpstream,
+					DynamicMetadata: map[string]map[string]interface{}{
+						constants.ExtProcFilterName: {"request_transformation.target_path": "/rewritten/path"},
+					},
+				}},
+			},
+		}
+		resp, err := TranslateRequestHeaderActionsWithBodyMerge(headerResult, emptyBody(), execCtx)
+		require.NoError(t, err)
+		extProc := resp.DynamicMetadata.Fields[constants.ExtProcFilterName].GetStructValue()
+		require.NotNil(t, extProc)
+		assert.Equal(t, "/rewritten/path", extProc.Fields["request_transformation.target_path"].GetStringValue())
+		assert.Equal(t, "/alternate", extProc.Fields["target_upstream_base_path"].GetStringValue())
+		assert.NotContains(t, extProc.Fields, "path")
+	})
+}

--- a/gateway/it/features/dynamic-endpoint.feature
+++ b/gateway/it/features/dynamic-endpoint.feature
@@ -206,8 +206,9 @@ Feature: Dynamic Endpoint policy
           sandbox: dyn-sb-sandbox.local
         upstreamDefinitions:
           - name: alt-upstream
+            basePath: /alternate
             upstreams:
-              - url: http://sample-backend:9080/alternate
+              - url: http://sample-backend:9080
         upstream:
           main:
             url: http://sample-backend:9080
@@ -265,8 +266,9 @@ Feature: Dynamic Endpoint policy
           sandbox: dyn-api-sb-sandbox.local
         upstreamDefinitions:
           - name: alt-upstream
+            basePath: /alternate
             upstreams:
-              - url: http://sample-backend:9080/alternate
+              - url: http://sample-backend:9080
         upstream:
           main:
             url: http://sample-backend:9080
@@ -325,8 +327,9 @@ Feature: Dynamic Endpoint policy
           sandbox: dyn-mixed-sandbox.local
         upstreamDefinitions:
           - name: alt-upstream
+            basePath: /alternate
             upstreams:
-              - url: http://sample-backend:9080/alternate
+              - url: http://sample-backend:9080
         upstream:
           main:
             url: http://sample-backend:9080

--- a/gateway/it/features/dynamic-endpoint.feature
+++ b/gateway/it/features/dynamic-endpoint.feature
@@ -186,3 +186,182 @@ Feature: Dynamic Endpoint policy
     And the response should be valid JSON
     And the JSON response field "status" should be "error"
     And the response body should contain "targetUpstream"
+
+  # Regression: a dynamic-endpoint policy on the SANDBOX vhost must route to the target
+  # upstream (base /alternate), not prepend the sandbox base path (/sandbox/alternate/whoami).
+  Scenario: Dynamic-endpoint policy applies on the sandbox vhost
+    Given I authenticate using basic auth as "admin"
+    When I deploy this API configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1alpha1
+      kind: RestApi
+      metadata:
+        name: dynamic-endpoint-sandbox-v1.0
+      spec:
+        displayName: Dynamic-Endpoint-Sandbox-API
+        version: v1.0
+        context: /dynamic-endpoint-sandbox/$version
+        vhosts:
+          main: dyn-sb-main.local
+          sandbox: dyn-sb-sandbox.local
+        upstreamDefinitions:
+          - name: alt-upstream
+            upstreams:
+              - url: http://sample-backend:9080/alternate
+        upstream:
+          main:
+            url: http://sample-backend:9080
+          sandbox:
+            url: http://sample-backend:9080/sandbox
+        operations:
+          - method: GET
+            path: /whoami
+            policies:
+              - name: dynamic-endpoint
+                version: v1
+                params:
+                  targetUpstream: alt-upstream
+      """
+    Then the response should be successful
+    And I wait for the endpoint "http://localhost:8080/dynamic-endpoint-sandbox/v1.0/whoami" to be ready with host "dyn-sb-main.local"
+
+    # Main vhost: policy diverts to alt-upstream (base path /alternate).
+    When I clear all headers
+    And I set request host to "dyn-sb-main.local"
+    And I send a GET request to "http://localhost:8080/dynamic-endpoint-sandbox/v1.0/whoami"
+    Then the response should be successful
+    And the response should be valid JSON
+    And the JSON response field "path" should be "/alternate/whoami"
+
+    # Sandbox vhost: the same policy must divert to alt-upstream (base /alternate), not the static sandbox upstream.
+    When I clear all headers
+    And I set request host to "dyn-sb-sandbox.local"
+    And I send a GET request to "http://localhost:8080/dynamic-endpoint-sandbox/v1.0/whoami"
+    Then the response should be successful
+    And the response should be valid JSON
+    And the JSON response field "path" should be "/alternate/whoami"
+
+    Given I authenticate using basic auth as "admin"
+    When I delete the API "dynamic-endpoint-sandbox-v1.0"
+    Then the response should be successful
+
+  # An API-level dynamic-endpoint (under spec.policies) applies to every operation on both
+  # vhosts. On the sandbox vhost it must still divert to the target upstream (base /alternate),
+  # not prepend the sandbox base path.
+  Scenario: API-level dynamic-endpoint policy applies on the sandbox vhost
+    Given I authenticate using basic auth as "admin"
+    When I deploy this API configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1alpha1
+      kind: RestApi
+      metadata:
+        name: dynamic-endpoint-api-sandbox-v1.0
+      spec:
+        displayName: Dynamic-Endpoint-API-Sandbox-API
+        version: v1.0
+        context: /dynamic-endpoint-api-sandbox/$version
+        vhosts:
+          main: dyn-api-sb-main.local
+          sandbox: dyn-api-sb-sandbox.local
+        upstreamDefinitions:
+          - name: alt-upstream
+            upstreams:
+              - url: http://sample-backend:9080/alternate
+        upstream:
+          main:
+            url: http://sample-backend:9080
+          sandbox:
+            url: http://sample-backend:9080/sandbox
+        policies:
+          - name: dynamic-endpoint
+            version: v1
+            params:
+              targetUpstream: alt-upstream
+        operations:
+          - method: GET
+            path: /whoami
+          - method: GET
+            path: /ping
+      """
+    Then the response should be successful
+    And I wait for the endpoint "http://localhost:8080/dynamic-endpoint-api-sandbox/v1.0/whoami" to be ready with host "dyn-api-sb-main.local"
+
+    # Main vhost: the API-level policy diverts every operation to alt-upstream (base /alternate).
+    When I clear all headers
+    And I set request host to "dyn-api-sb-main.local"
+    And I send a GET request to "http://localhost:8080/dynamic-endpoint-api-sandbox/v1.0/whoami"
+    Then the response should be successful
+    And the response should be valid JSON
+    And the JSON response field "path" should be "/alternate/whoami"
+
+    # Sandbox vhost: the same API-level policy must divert to alt-upstream (base /alternate), not the static sandbox upstream.
+    When I clear all headers
+    And I set request host to "dyn-api-sb-sandbox.local"
+    And I send a GET request to "http://localhost:8080/dynamic-endpoint-api-sandbox/v1.0/ping"
+    Then the response should be successful
+    And the response should be valid JSON
+    And the JSON response field "path" should be "/alternate/ping"
+
+    Given I authenticate using basic auth as "admin"
+    When I delete the API "dynamic-endpoint-api-sandbox-v1.0"
+    Then the response should be successful
+
+  # Adding cluster_header routing to sandbox routes must not break operations WITHOUT a
+  # dynamic-endpoint policy: those fall back to the sandbox upstream (base /sandbox).
+  Scenario: Sandbox operation without the policy falls back to the sandbox upstream
+    Given I authenticate using basic auth as "admin"
+    When I deploy this API configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1alpha1
+      kind: RestApi
+      metadata:
+        name: dynamic-endpoint-sandbox-mixed-v1.0
+      spec:
+        displayName: Dynamic-Endpoint-Sandbox-Mixed-API
+        version: v1.0
+        context: /dynamic-endpoint-sandbox-mixed/$version
+        vhosts:
+          main: dyn-mixed-main.local
+          sandbox: dyn-mixed-sandbox.local
+        upstreamDefinitions:
+          - name: alt-upstream
+            upstreams:
+              - url: http://sample-backend:9080/alternate
+        upstream:
+          main:
+            url: http://sample-backend:9080
+          sandbox:
+            url: http://sample-backend:9080/sandbox
+        operations:
+          - method: GET
+            path: /whoami
+            policies:
+              - name: dynamic-endpoint
+                version: v1
+                params:
+                  targetUpstream: alt-upstream
+          - method: GET
+            path: /ping
+      """
+    Then the response should be successful
+    And I wait for the endpoint "http://localhost:8080/dynamic-endpoint-sandbox-mixed/v1.0/ping" to be ready with host "dyn-mixed-sandbox.local"
+
+    # Sandbox vhost, operation WITH the policy: diverted to alt-upstream (base /alternate).
+    When I clear all headers
+    And I set request host to "dyn-mixed-sandbox.local"
+    And I send a GET request to "http://localhost:8080/dynamic-endpoint-sandbox-mixed/v1.0/whoami"
+    Then the response should be successful
+    And the response should be valid JSON
+    And the JSON response field "path" should be "/alternate/whoami"
+
+    # Sandbox vhost, operation WITHOUT the policy: falls back to the sandbox upstream (base /sandbox).
+    When I clear all headers
+    And I set request host to "dyn-mixed-sandbox.local"
+    And I send a GET request to "http://localhost:8080/dynamic-endpoint-sandbox-mixed/v1.0/ping"
+    Then the response should be successful
+    And the response should be valid JSON
+    And the JSON response field "path" should be "/sandbox/ping"
+
+    Given I authenticate using basic auth as "admin"
+    When I delete the API "dynamic-endpoint-sandbox-mixed-v1.0"
+    Then the response should be successful


### PR DESCRIPTION
## Purpose
Fixes #2049.

Sandbox vhost routes double-prefixed the path when a `dynamic-endpoint` policy targeted an alternate upstream, e.g. `/sandbox/alternate/whoami` instead of `/alternate/whoami`.

## Approach

### Controller layer
- Enable `cluster_header` routing on sandbox routes when `upstreamDefinitions` exist.
- Default sandbox dynamic routes to the sandbox cluster so operations without `dynamic-endpoint` still use the sandbox upstream.
- Apply the same sandbox routing behavior in both the RDC transform path (`pkg/transform`) and legacy xDS path (`pkg/xds`).

### Policy engine layer
- Stop baking the computed upstream path into `mutations.Path` during request-header processing.
- Instead emit:
  - `target_upstream_base_path`
  - `request_transformation.target_path`
  - `api_context`
  - `upstream_base_path`
- Let the Lua filter strip the API context and prepend the selected target upstream base path exactly once.
- Preserve an existing `request_transformation.target_path` from earlier policies in both header-phase variants.
- Remove the now-unused `computeUpstreamPath` helper.

### IT alignment with #2065
- Migrated the dynamic-endpoint IT's sandbox `upstreamDefinitions` to the `basePath` field (host[:port]-only URLs), since #2065 made `basePath` the authoritative source for upstream base paths and now rejects a path in `upstreamDefinitions[].upstreams[].url`.

## Related PRs
- #2065 (take upstreamDefinitions base path from basePath) — this PR's IT sandbox scenarios follow its basePath convention.

## Tests

### Unit tests
- `TestRestAPITransformer_SandboxRouteClusterHeader`
- `TestTranslator_CreateRoute_DynamicRouting`
- `TestTranslateRequestHeaderActions_DynamicEndpoint`
- `TestTranslateRequestHeaderActionsWithBodyMerge_DynamicEndpoint`

### Integration tests
- `Dynamic-endpoint policy applies on the sandbox vhost`
- `API-level dynamic-endpoint policy applies on the sandbox vhost`
- `Sandbox operation without the policy falls back to the sandbox upstream`

## Verification
- `go test ./gateway/gateway-runtime/policy-engine/internal/kernel`
- `go test ./gateway/gateway-controller/pkg/transform ./gateway/gateway-controller/pkg/xds`
- `go vet ./gateway/gateway-runtime/policy-engine/internal/kernel ./gateway/gateway-controller/pkg/transform ./gateway/gateway-controller/pkg/xds`

## Security checks
- Followed secure coding standards: yes
- FindSecurityBugs: N/A, Go code
- Confirmed no secrets committed: yes

## Test environment
- Go 1.23
- Docker / Testcontainers via Rancher Desktop
- Windows 11 / WSL