### PR TITLE
feat(controller)!: take upstreamDefinitions base path from basePath

### DIFF
--- a/gateway/gateway-controller/pkg/config/api_validator.go
+++ b/gateway/gateway-controller/pkg/config/api_validator.go
@@ -332,6 +332,15 @@ func (v *APIValidator) validateUpstreamDefinitions(definitions *[]api.UpstreamDe
 						Message: "URL must include a host",
 					})
 				}
+
+				// upstreamDefinitions URLs must be host[:port] only — the base path is
+				// configured exclusively via upstreamDefinitions[].basePath.
+				if parsedURL.Path != "" && parsedURL.Path != "/" {
+					errors = append(errors, ValidationError{
+						Field:   fmt.Sprintf("spec.upstreamDefinitions[%d].upstreams[%d].url", i, j),
+						Message: "URL must not include a path; set the base path in upstreamDefinitions[].basePath instead",
+					})
+				}
 			}
 
 			// Validate weight if present

--- a/gateway/gateway-controller/pkg/config/validator_test.go
+++ b/gateway/gateway-controller/pkg/config/validator_test.go
@@ -576,6 +576,50 @@ func TestValidateUpstreamDefinitions_Valid(t *testing.T) {
 	assert.Empty(t, errors)
 }
 
+// A host-only URL with the base path supplied via basePath is the canonical form.
+func TestValidateUpstreamDefinitions_WithBasePathValid(t *testing.T) {
+	validator := NewAPIValidator()
+
+	basePath := "/api/v2"
+	definitions := &[]api.UpstreamDefinition{
+		{
+			Name:     "my-upstream-1",
+			BasePath: &basePath,
+			Upstreams: []struct {
+				Url    string `json:"url" yaml:"url"`
+				Weight *int   `json:"weight,omitempty" yaml:"weight,omitempty"`
+			}{
+				{Url: "http://backend-1:8080"},
+			},
+		},
+	}
+
+	errors := validator.validateUpstreamDefinitions(definitions)
+	assert.Empty(t, errors)
+}
+
+// upstreamDefinitions URLs must be host[:port] only; a path belongs in basePath.
+func TestValidateUpstreamDefinitions_URLWithPathRejected(t *testing.T) {
+	validator := NewAPIValidator()
+
+	definitions := &[]api.UpstreamDefinition{
+		{
+			Name: "my-upstream-1",
+			Upstreams: []struct {
+				Url    string `json:"url" yaml:"url"`
+				Weight *int   `json:"weight,omitempty" yaml:"weight,omitempty"`
+			}{
+				{Url: "http://backend-1:8080/api/v2"},
+			},
+		},
+	}
+
+	errors := validator.validateUpstreamDefinitions(definitions)
+	require.Len(t, errors, 1)
+	assert.Equal(t, "spec.upstreamDefinitions[0].upstreams[0].url", errors[0].Field)
+	assert.Contains(t, errors[0].Message, "basePath")
+}
+
 func TestValidateUpstreamDefinitions_DuplicateNames(t *testing.T) {
 	validator := NewAPIValidator()
 

--- a/gateway/gateway-controller/pkg/transform/restapi.go
+++ b/gateway/gateway-controller/pkg/transform/restapi.go
@@ -194,9 +194,11 @@ func (t *RestAPITransformer) Transform(cfg *models.StoredConfig) (*models.Runtim
 				return nil, fmt.Errorf("invalid URL in upstream definition '%s': %w", def.Name, err)
 			}
 			port := ResolvePort(parsedURL)
-			basePath := parsedURL.Path
-			if basePath == "" {
-				basePath = "/"
+			// Base path comes solely from the explicit basePath field; upstreamDefinitions
+			// URLs are host[:port] only (a path in the URL is rejected during validation).
+			basePath := "/"
+			if def.BasePath != nil && *def.BasePath != "" {
+				basePath = *def.BasePath
 			}
 			rdc.UpstreamClusters[defClusterKey] = &models.UpstreamCluster{
 				Name:     def.Name,
@@ -305,7 +307,7 @@ func (t *RestAPITransformer) addUpstreamCluster(
 	up *api.Upstream,
 	upstreamDefinitions *[]api.UpstreamDefinition,
 ) (*upstreamClusterResult, error) {
-	rawURL, err := resolveUpstreamURL(upstreamName, up, upstreamDefinitions)
+	rawURL, refBasePath, err := resolveUpstreamURL(upstreamName, up, upstreamDefinitions)
 	if err != nil {
 		return nil, err
 	}
@@ -319,7 +321,12 @@ func (t *RestAPITransformer) addUpstreamCluster(
 	}
 
 	port := ResolvePort(parsedURL)
+	// Direct URLs carry their base path in the path; a ref takes its base path solely from
+	// the definition's basePath field (upstreamDefinitions URLs are host[:port] only).
 	basePath := parsedURL.Path
+	if refBasePath != nil {
+		basePath = *refBasePath
+	}
 	if basePath == "" {
 		basePath = "/"
 	}
@@ -350,27 +357,33 @@ func sanitizeEnvoyClusterName(host, scheme string) string {
 	return "cluster_" + scheme + "_" + name
 }
 
-// resolveUpstreamURL resolves the URL from an upstream (direct URL or ref).
-func resolveUpstreamURL(name string, up *api.Upstream, defs *[]api.UpstreamDefinition) (string, error) {
+// resolveUpstreamURL resolves the URL from an upstream (direct URL or ref). For a ref it
+// also returns the referenced definition's base path (from basePath, never the URL); for a
+// direct URL the returned base-path pointer is nil, signalling the caller to use the URL path.
+func resolveUpstreamURL(name string, up *api.Upstream, defs *[]api.UpstreamDefinition) (string, *string, error) {
 	if up.Url != nil && strings.TrimSpace(*up.Url) != "" {
-		return strings.TrimSpace(*up.Url), nil
+		return strings.TrimSpace(*up.Url), nil, nil
 	}
 	if up.Ref != nil && strings.TrimSpace(*up.Ref) != "" {
 		refName := strings.TrimSpace(*up.Ref)
 		if defs == nil {
-			return "", fmt.Errorf("upstream definition '%s' referenced but no definitions provided", refName)
+			return "", nil, fmt.Errorf("upstream definition '%s' referenced but no definitions provided", refName)
 		}
 		for _, def := range *defs {
 			if def.Name == refName {
 				if len(def.Upstreams) == 0 || def.Upstreams[0].Url == "" {
-					return "", fmt.Errorf("upstream definition '%s' has no URLs", refName)
+					return "", nil, fmt.Errorf("upstream definition '%s' has no URLs", refName)
 				}
-				return def.Upstreams[0].Url, nil
+				basePath := ""
+				if def.BasePath != nil {
+					basePath = *def.BasePath
+				}
+				return def.Upstreams[0].Url, &basePath, nil
 			}
 		}
-		return "", fmt.Errorf("upstream definition '%s' not found", refName)
+		return "", nil, fmt.Errorf("upstream definition '%s' not found", refName)
 	}
-	return "", fmt.Errorf("%s upstream has no URL or ref", name)
+	return "", nil, fmt.Errorf("%s upstream has no URL or ref", name)
 }
 
 // ResolvePort returns the port from a URL, defaulting to 80/443.

--- a/gateway/gateway-controller/pkg/transform/restapi_test.go
+++ b/gateway/gateway-controller/pkg/transform/restapi_test.go
@@ -265,21 +265,21 @@ func TestResolveUpstreamURL(t *testing.T) {
 	t.Run("direct URL", func(t *testing.T) {
 		u := "http://direct:8080"
 		up := &api.Upstream{Url: &u}
-		got, err := resolveUpstreamURL("main", up, nil)
+		got, _, err := resolveUpstreamURL("main", up, nil)
 		require.NoError(t, err)
 		assert.Equal(t, u, got)
 	})
 
 	t.Run("ref to existing definition", func(t *testing.T) {
 		up := &api.Upstream{Ref: &refName}
-		got, err := resolveUpstreamURL("main", up, defs)
+		got, _, err := resolveUpstreamURL("main", up, defs)
 		require.NoError(t, err)
 		assert.Equal(t, defURL, got)
 	})
 
 	t.Run("ref but no definitions provided", func(t *testing.T) {
 		up := &api.Upstream{Ref: &refName}
-		_, err := resolveUpstreamURL("main", up, nil)
+		_, _, err := resolveUpstreamURL("main", up, nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), refName)
 	})
@@ -287,14 +287,14 @@ func TestResolveUpstreamURL(t *testing.T) {
 	t.Run("ref to unknown definition", func(t *testing.T) {
 		unknownRef := "unknown-def"
 		up := &api.Upstream{Ref: &unknownRef}
-		_, err := resolveUpstreamURL("main", up, defs)
+		_, _, err := resolveUpstreamURL("main", up, defs)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not found")
 	})
 
 	t.Run("neither URL nor ref", func(t *testing.T) {
 		up := &api.Upstream{}
-		_, err := resolveUpstreamURL("main", up, defs)
+		_, _, err := resolveUpstreamURL("main", up, defs)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "no URL or ref")
 	})
@@ -302,7 +302,7 @@ func TestResolveUpstreamURL(t *testing.T) {
 	t.Run("whitespace-only URL treated as missing", func(t *testing.T) {
 		blank := "   "
 		up := &api.Upstream{Url: &blank}
-		_, err := resolveUpstreamURL("main", up, nil)
+		_, _, err := resolveUpstreamURL("main", up, nil)
 		require.Error(t, err)
 	})
 
@@ -318,7 +318,7 @@ func TestResolveUpstreamURL(t *testing.T) {
 		}
 		emptyRef := "empty-def"
 		up := &api.Upstream{Ref: &emptyRef}
-		_, err := resolveUpstreamURL("main", up, emptyDefs)
+		_, _, err := resolveUpstreamURL("main", up, emptyDefs)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "no URLs")
 	})

--- a/gateway/gateway-controller/pkg/xds/translator.go
+++ b/gateway/gateway-controller/pkg/xds/translator.go
@@ -925,6 +925,7 @@ func (t *Translator) translateAPIConfig(cfg *models.StoredConfig, allConfigs []*
 func (t *Translator) resolveUpstreamCluster(upstreamName string, up *api.Upstream, upstreamDefinitions *[]api.UpstreamDefinition) (string, *url.URL, *resolvedTimeout, error) {
 	var rawURL string
 	var timeout *resolvedTimeout
+	var refBasePath *string
 
 	// Resolve URL and timeout
 	if up.Url != nil && strings.TrimSpace(*up.Url) != "" {
@@ -947,6 +948,14 @@ func (t *Translator) resolveUpstreamCluster(upstreamName string, up *api.Upstrea
 		}
 		rawURL = definition.Upstreams[0].Url
 
+		// A referenced definition's base path comes solely from its basePath field
+		// (upstreamDefinitions URLs are host[:port] only).
+		defBasePath := ""
+		if definition.BasePath != nil {
+			defBasePath = *definition.BasePath
+		}
+		refBasePath = &defBasePath
+
 		// Extract timeout if specified in the definition (may be nil)
 		if definition.Timeout != nil {
 			resolved, err := resolveTimeoutFromDefinition(definition)
@@ -966,6 +975,11 @@ func (t *Translator) resolveUpstreamCluster(upstreamName string, up *api.Upstrea
 	}
 	if parsedURL.Host == "" || (parsedURL.Scheme != "http" && parsedURL.Scheme != "https") {
 		return "", nil, nil, fmt.Errorf("invalid %s upstream URL: must include host and http/https scheme", upstreamName)
+	}
+
+	// A referenced definition's base path overrides the URL path (which must be empty).
+	if refBasePath != nil {
+		parsedURL.Path = *refBasePath
 	}
 
 	// Generate cluster name

--- a/gateway/gateway-controller/pkg/xds/translator_test.go
+++ b/gateway/gateway-controller/pkg/xds/translator_test.go
@@ -178,12 +178,14 @@ func TestResolveUpstreamCluster_WithRef_WithTimeout(t *testing.T) {
 	translator := &Translator{}
 	ref := "my-upstream"
 	timeoutStr := "45s"
+	basePath := "/v2"
 	upstream := &api.Upstream{
 		Ref: &ref,
 	}
 	definitions := &[]api.UpstreamDefinition{
 		{
-			Name: "my-upstream",
+			Name:     "my-upstream",
+			BasePath: &basePath,
 			Timeout: &api.UpstreamTimeout{
 				Connect: &timeoutStr,
 			},
@@ -192,7 +194,7 @@ func TestResolveUpstreamCluster_WithRef_WithTimeout(t *testing.T) {
 				Weight *int   `json:"weight,omitempty" yaml:"weight,omitempty"`
 			}{
 				{
-					Url: "http://backend-1:9000/v2",
+					Url: "http://backend-1:9000",
 				},
 			},
 		},

--- a/gateway/it/features/dynamic-endpoint.feature
+++ b/gateway/it/features/dynamic-endpoint.feature
@@ -41,8 +41,9 @@ Feature: Dynamic Endpoint policy
         context: /dynamic-endpoint/$version
         upstreamDefinitions:
           - name: alt-upstream
+            basePath: /alternate
             upstreams:
-              - url: http://sample-backend:9080/alternate
+              - url: http://sample-backend:9080
         upstream:
           main:
             url: http://sample-backend:9080
@@ -96,11 +97,13 @@ Feature: Dynamic Endpoint policy
         context: /dynamic-endpoint-routes/$version
         upstreamDefinitions:
           - name: foo-upstream
+            basePath: /foo
             upstreams:
-              - url: http://sample-backend:9080/foo
+              - url: http://sample-backend:9080
           - name: bar-upstream
+            basePath: /bar
             upstreams:
-              - url: http://sample-backend:9080/bar
+              - url: http://sample-backend:9080
           - name: root-upstream
             upstreams:
               - url: http://sample-backend:9080

--- a/gateway/it/features/sandbox-routing.feature
+++ b/gateway/it/features/sandbox-routing.feature
@@ -138,8 +138,9 @@ Feature: Sandbox Routing
           sandbox: sandbox-sandbox-ref.local
         upstreamDefinitions:
           - name: sandbox-upstream
+            basePath: /sandbox
             upstreams:
-              - url: http://sample-backend:9080/sandbox
+              - url: http://sample-backend:9080
         upstream:
           main:
             url: http://sample-backend:9080
@@ -243,8 +244,9 @@ Feature: Sandbox Routing
           sandbox: sandbox-sandbox-policy.local
         upstreamDefinitions:
           - name: sandbox-upstream
+            basePath: /sandbox
             upstreams:
-              - url: http://sample-backend:9080/sandbox
+              - url: http://sample-backend:9080
         upstream:
           main:
             url: http://sample-backend:9080
@@ -301,8 +303,9 @@ Feature: Sandbox Routing
             upstreams:
               - url: http://sample-backend:9080
           - name: sandbox-upstream
+            basePath: /sandbox
             upstreams:
-              - url: http://sample-backend:9080/sandbox
+              - url: http://sample-backend:9080
         upstream:
           main:
             ref: main-upstream
@@ -348,8 +351,9 @@ Feature: Sandbox Routing
           sandbox: sandbox-sandbox-manual.local
         upstreamDefinitions:
           - name: sandbox-upstream
+            basePath: /anything
             upstreams:
-              - url: http://echo-backend:80/anything
+              - url: http://echo-backend:80
         upstream:
           main:
             url: http://sample-backend:9080
@@ -433,8 +437,9 @@ Feature: Sandbox Routing
           sandbox: sandbox-sandbox-https.local
         upstreamDefinitions:
           - name: sandbox-http-upstream
+            basePath: /openai/v1
             upstreams:
-              - url: http://mock-openapi:4010/openai/v1
+              - url: http://mock-openapi:4010
         upstream:
           main:
             url: http://sample-backend:9080
@@ -470,7 +475,9 @@ Feature: Sandbox Routing
     When I delete the API "env-routing-sandbox-https-ref-v1.0"
     Then the response should be successful
 
-  Scenario: Sandbox ref with multiple urls should use the first url
+  # upstreamDefinitions URLs must be host[:port] only; the base path belongs in basePath.
+  # A path embedded in the URL (here on load-balanced URLs) is rejected with a 400.
+  Scenario: Deploy fails when an upstreamDefinitions URL contains a path
     Given I authenticate using basic auth as "admin"
     When I deploy this API configuration:
       """
@@ -482,9 +489,6 @@ Feature: Sandbox Routing
         displayName: Env-Routing-Sandbox-Multi-URL-Ref-API
         version: v1.0
         context: /env-sandbox-multi/$version
-        vhosts:
-          main: main-sandbox-multi.local
-          sandbox: sandbox-sandbox-multi.local
         upstreamDefinitions:
           - name: sandbox-multi-upstream
             upstreams:
@@ -492,25 +496,15 @@ Feature: Sandbox Routing
               - url: http://sample-backend:9080/sandbox
         upstream:
           main:
-            url: http://sample-backend:9080
-          sandbox:
             ref: sandbox-multi-upstream
         operations:
           - method: GET
             path: /whoami
       """
-    Then the response should be successful
-    And I wait for the endpoint "http://localhost:8080/env-sandbox-multi/v1.0/whoami" to be ready with host "sandbox-sandbox-multi.local"
-
-    When I clear all headers
-    And I set request host to "sandbox-sandbox-multi.local"
-    And I send a GET request to "http://localhost:8080/env-sandbox-multi/v1.0/whoami"
-    Then the response should be successful
-    And the JSON response field "path" should be "/first/whoami"
-
-    Given I authenticate using basic auth as "admin"
-    When I delete the API "env-routing-sandbox-multi-url-ref-v1.0"
-    Then the response should be successful
+    Then the response should be a client error
+    And the response should be valid JSON
+    And the JSON response field "status" should be "error"
+    And the response body should contain "must not include a path"
 
   Scenario: Path params should route correctly with sandbox ref
     Given I authenticate using basic auth as "admin"
@@ -529,8 +523,9 @@ Feature: Sandbox Routing
           sandbox: sandbox-sandbox-params.local
         upstreamDefinitions:
           - name: sandbox-upstream
+            basePath: /sandbox
             upstreams:
-              - url: http://sample-backend:9080/sandbox
+              - url: http://sample-backend:9080
         upstream:
           main:
             url: http://sample-backend:9080
@@ -576,8 +571,9 @@ Feature: Sandbox Routing
           sandbox: sandbox-sandbox-wild.local
         upstreamDefinitions:
           - name: sandbox-upstream
+            basePath: /sandbox
             upstreams:
-              - url: http://sample-backend:9080/sandbox
+              - url: http://sample-backend:9080
         upstream:
           main:
             url: http://sample-backend:9080
@@ -679,8 +675,9 @@ Feature: Sandbox Routing
             upstreams:
               - url: http://sample-backend:9080
           - name: sandbox-upstream
+            basePath: /sandbox
             upstreams:
-              - url: http://sample-backend:9080/sandbox
+              - url: http://sample-backend:9080
         upstream:
           main:
             ref: main-upstream


### PR DESCRIPTION
## Purpose

`upstreamDefinitions[].basePath` is ignored by the gateway-controller: the upstream base path is silently derived from the path component of the upstream URL instead, so the documented `basePath` field has no effect at runtime.
Per the agreed design (https://github.com/wso2/api-platform/discussions/369#discussioncomment-16021268), `basePath` is the canonical source of an upstream definition's base path and these URLs must be host[:port] only.
Fixes #2064.
Related #2049.

## Goals

Make `basePath` the single source of an `upstreamDefinitions` base path, and reject a path embedded in an `upstreamDefinitions` URL with a 400 at deploy time.

## Approach

- `pkg/transform/restapi.go`: the `dynamic-endpoint` policy's `targetUpstream` cluster and `upstream.main`/`upstream.sandbox` `ref` resolution now take the base path solely from `def.BasePath` (no URL-path fallback).
- `pkg/xds/translator.go`: the legacy `resolveUpstreamCluster` applies a referenced definition's `basePath` to the route rewrite.
- `pkg/config/api_validator.go`: any `upstreamDefinitions[].upstreams[].url` with a non-root path is rejected with a 400 ("URL must not include a path; set the base path in upstreamDefinitions[].basePath instead").
- Direct `upstream.main`/`upstream.sandbox` URLs are unchanged — they legitimately carry their base path in the URL.
- Migrated `dynamic-endpoint.feature` and `sandbox-routing.feature` to `basePath` + host-only URLs, and rewrote the obsolete multi-URL "first wins" scenario into a negative test asserting the 400.

## User stories

As an API developer, I set an upstream definition's base path via `basePath` and have it honored at runtime, and I get a clear 400 if I mistakenly put a path in the upstream URL.

## Documentation

N/A — the `basePath` field already exists in the API spec; this change makes the runtime honor it as the canonical source.

## Automation tests

 - Unit tests
   > Added `TestValidateUpstreamDefinitions_URLWithPathRejected` and `TestValidateUpstreamDefinitions_WithBasePathValid`; updated `TestResolveUpstreamCluster_WithRef_WithTimeout` and the `resolveUpstreamURL` tests for the basePath-sourced behavior.
 - Integration tests
   > `features/dynamic-endpoint.feature` and `features/sandbox-routing.feature` migrated to `basePath`; new negative scenario "Deploy fails when an upstreamDefinitions URL contains a path" asserts the 400. Full run (health, api_deploy, dynamic-endpoint, sandbox-routing): 35 scenarios / 465 steps passing locally.

## Security checks

 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (Go code)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

#2059 (dynamic-endpoint sandbox routing) is adjacent work on the same area.

## Test environment

Go (multi-module workspace), Docker (integration tests via Docker Compose), macOS (darwin/arm64).