### PR TITLE
fix(controller): preserve matched prefix on upstream for /foo/* routes

### DIFF
--- a/gateway/gateway-controller/pkg/xds/translator.go
+++ b/gateway/gateway-controller/pkg/xds/translator.go
@@ -325,14 +325,11 @@ func (t *Translator) createRouteFromRDC(routeKey string, rdcRoute *models.Route,
 		upstreamPath = ""
 	}
 
-	// Derive context prefix from fullPath minus operationPath
-	// fullPath = contextWithVersion + operationPath
+	// Derive context prefix from fullPath minus operationPath (fullPath = context + operationPath).
+	// For a wildcard operation path like "/foo/*", strip only the context so the matched literal
+	// prefix ("/foo") is PRESERVED on the upstream — consistent with exact paths. The bare "/*"
+	// catch-all (empty literal prefix) and "/" root are unaffected. See issue #2071.
 	contextWithVersion := strings.TrimSuffix(fullPath, operationPath)
-	if isWildcardPath {
-		// For wildcard, include the path up to the /* in the context for rewriting
-		pathWithoutWildcard := strings.TrimSuffix(operationPath, "/*")
-		contextWithVersion = strings.TrimSuffix(fullPath, operationPath) + pathWithoutWildcard
-	}
 
 	escapedContext := regexp.QuoteMeta(contextWithVersion)
 	if isRootPath {
@@ -1870,15 +1867,12 @@ func (t *Translator) createRoute(apiId, apiName, apiVersion, context, method, pa
 	if upstreamIsRoot {
 		upstreamPath = ""
 	}
-	// For wildcard routes, construct the regex to match everything after the prefix
-	var contextWithVersion string
-	if isWildcardPath {
-		// Remove the /* from the end before constructing the context
-		pathWithoutWildcard := strings.TrimSuffix(path, "/*")
-		contextWithVersion = ConstructFullPath(context, apiVersion, pathWithoutWildcard)
-	} else {
-		contextWithVersion = ConstructFullPath(context, apiVersion, "")
-	}
+	// Strip only the API context (with version) from the upstream path. For a wildcard
+	// operation path like "/foo/*", the matched literal prefix ("/foo") is PRESERVED on the
+	// upstream — the capture group below already includes everything after the context — so
+	// behavior is consistent with exact paths (exact "/foo" also forwards "/foo"). The bare
+	// "/*" catch-all (empty literal prefix) and "/" root are unaffected. See issue #2071.
+	contextWithVersion := ConstructFullPath(context, apiVersion, "")
 	escapedContext := regexp.QuoteMeta(contextWithVersion)
 	if isRootPath {
 		// Root path ("/") matches both /ctx and /ctx/. Using a non-capturing pattern

--- a/gateway/gateway-controller/pkg/xds/translator_test.go
+++ b/gateway/gateway-controller/pkg/xds/translator_test.go
@@ -23,6 +23,7 @@ import (
 	"math"
 	"net/url"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -626,6 +627,112 @@ func TestTranslator_WildcardRegexBoundary(t *testing.T) {
 		for _, p := range tc.shouldNotMatch {
 			assert.False(t, re.MatchString(p), "regex %q should NOT match %q", regexSpec.SafeRegex.Regex, p)
 		}
+	}
+}
+
+// applyEnvoyRewrite emulates how Envoy applies a route's RegexRewrite to a request path:
+// the request must first be matched by the route's path specifier, then the rewrite regex
+// substitution is applied. Envoy uses "\1" substitution syntax; Go's regexp uses "$1".
+func applyEnvoyRewrite(t *testing.T, r *route.Route, requestPath string) string {
+	t.Helper()
+	spec, ok := r.Match.PathSpecifier.(*route.RouteMatch_SafeRegex)
+	require.True(t, ok, "expected SafeRegex path specifier")
+	require.True(t, regexp.MustCompile(spec.SafeRegex.Regex).MatchString(requestPath),
+		"match regex %q should match request %q", spec.SafeRegex.Regex, requestPath)
+
+	rw := r.GetRoute().GetRegexRewrite()
+	require.NotNil(t, rw, "route should have a RegexRewrite")
+	pattern := regexp.MustCompile(rw.GetPattern().GetRegex())
+	goSub := strings.ReplaceAll(rw.GetSubstitution(), `\1`, `${1}`)
+	return pattern.ReplaceAllString(requestPath, goSub)
+}
+
+// TestTranslator_WildcardUpstreamRewrite verifies that a non-root wildcard operation path
+// ("/foo/*") preserves the matched literal prefix ("/foo") on the upstream — consistent with
+// exact paths — while the bare "/*" catch-all and base-path upstreams behave as before.
+// Regression test for issue #2071 (PathPrefix-derived routes forwarded the wrong upstream path).
+func TestTranslator_WildcardUpstreamRewrite(t *testing.T) {
+	logger := createTestLogger()
+	routerCfg := testRouterConfig()
+	cfg := testConfig()
+	translator := NewTranslator(logger, routerCfg, nil, cfg)
+
+	tests := []struct {
+		name         string
+		context      string
+		path         string
+		upstreamPath string
+		request      string
+		wantUpstream string
+	}{
+		// Non-root wildcard: the matched literal prefix "/forecast" must be preserved (the bug).
+		{"wildcard subpath, root upstream, bare prefix", "/route/$version", "/forecast/*", "/", "/route/v1.0/forecast", "/forecast"},
+		{"wildcard subpath, root upstream, with subpath", "/route/$version", "/forecast/*", "/", "/route/v1.0/forecast/today", "/forecast/today"},
+		{"wildcard subpath, base-path upstream, bare prefix", "/route/$version", "/forecast/*", "/api/v2", "/route/v1.0/forecast", "/api/v2/forecast"},
+		{"wildcard subpath, base-path upstream, with subpath", "/route/$version", "/forecast/*", "/api/v2", "/route/v1.0/forecast/today", "/api/v2/forecast/today"},
+		// Bare /* catch-all: unchanged — the whole context is the stripped prefix.
+		{"bare wildcard, root upstream, subpath", "/api/$version", "/*", "/", "/api/v1.0/users", "/users"},
+		{"bare wildcard, root upstream, bare context", "/api/$version", "/*", "/", "/api/v1.0", "/"},
+		{"bare wildcard, base-path upstream, subpath", "/api/$version", "/*", "/svc", "/api/v1.0/users", "/svc/users"},
+		// Exact path: unchanged — operation path preserved on the upstream.
+		{"exact path, root upstream", "/route/$version", "/weather", "/", "/route/v1.0/weather", "/weather"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := translator.createRoute(
+				"test-id", "TestAPI", "v1.0", tt.context,
+				"GET", tt.path, "test-cluster", tt.upstreamPath,
+				"localhost", "http/rest", "", "", nil, "", nil,
+				false, "", nil,
+			)
+			require.NotNil(t, r)
+			assert.Equal(t, tt.wantUpstream, applyEnvoyRewrite(t, r, tt.request))
+		})
+	}
+}
+
+// TestTranslator_WildcardUpstreamRewriteFromRDC verifies the same prefix-preserving behavior on
+// the RuntimeDeployConfig path (createRouteFromRDC), which the policy/runtime xDS pipeline uses.
+func TestTranslator_WildcardUpstreamRewriteFromRDC(t *testing.T) {
+	logger := createTestLogger()
+	routerCfg := testRouterConfig()
+	cfg := testConfig()
+	translator := NewTranslator(logger, routerCfg, nil, cfg)
+
+	tests := []struct {
+		name          string
+		fullPath      string
+		operationPath string
+		basePath      string
+		request       string
+		wantUpstream  string
+	}{
+		{"wildcard subpath, root upstream, bare prefix", "/route/v1.0/forecast/*", "/forecast/*", "", "/route/v1.0/forecast", "/forecast"},
+		{"wildcard subpath, root upstream, with subpath", "/route/v1.0/forecast/*", "/forecast/*", "", "/route/v1.0/forecast/today", "/forecast/today"},
+		{"wildcard subpath, base-path upstream", "/route/v1.0/forecast/*", "/forecast/*", "/api/v2", "/route/v1.0/forecast/today", "/api/v2/forecast/today"},
+		{"bare wildcard, root upstream, subpath", "/api/v1.0/*", "/*", "", "/api/v1.0/users", "/users"},
+		{"bare wildcard, root upstream, bare context", "/api/v1.0/*", "/*", "", "/api/v1.0", "/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rdc := &models.RuntimeDeployConfig{
+				UpstreamClusters: map[string]*models.UpstreamCluster{
+					"main": {BasePath: tt.basePath, Endpoints: []models.Endpoint{{Host: "echo", Port: 80}}},
+				},
+			}
+			rdcRoute := &models.Route{
+				Method:          "GET",
+				Path:            tt.fullPath,
+				OperationPath:   tt.operationPath,
+				AutoHostRewrite: true,
+				Upstream:        models.RouteUpstream{ClusterKey: "main"},
+			}
+			r := translator.createRouteFromRDC("GET|"+tt.fullPath+"|", rdcRoute, rdc)
+			require.NotNil(t, r)
+			assert.Equal(t, tt.wantUpstream, applyEnvoyRewrite(t, r, tt.request))
+		})
 	}
 }
 

--- a/gateway/it/features/route-path-matching.feature
+++ b/gateway/it/features/route-path-matching.feature
@@ -238,3 +238,57 @@ Feature: Route Path Matching
 
     When I delete the API "route-exact-upstream-slash-api"
     Then the response should be successful
+
+  Scenario: Wildcard /foo/* preserves the matched prefix (and method) on the upstream path
+    # A wildcard operation path "/foo/*" must forward "/foo" and any sub-path to the upstream,
+    # not strip it down to "/". The PUT /put/* operation checks that the matched prefix and method
+    # both reach a method-specific endpoint. The sample backend echoes the path/method it received,
+    # so each assertion pins the upstream request.
+    When I deploy this API configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1alpha1
+      kind: RestApi
+      metadata:
+        name: route-wildcard-prefix-api
+      spec:
+        displayName: Route-Wildcard-Prefix-API
+        version: v1.0
+        context: /route-wc-prefix/$version
+        upstream:
+          main:
+            url: http://sample-backend:9080
+        operations:
+          - method: GET
+            path: /forecast/*
+          - method: PUT
+            path: /put/*
+      """
+    Then the response should be successful
+    And I wait for 2 seconds
+
+    # Bare prefix — upstream must receive /forecast (before the fix it was stripped to /)
+    When I send a GET request to "http://localhost:8080/route-wc-prefix/v1.0/forecast"
+    Then the response status code should be 200
+    And the JSON response field "path" should be "/forecast"
+
+    # Single sub-path segment — upstream must receive /forecast/today (was /today before the fix)
+    When I send a GET request to "http://localhost:8080/route-wc-prefix/v1.0/forecast/today"
+    Then the response status code should be 200
+    And the JSON response field "path" should be "/forecast/today"
+
+    # Nested sub-paths
+    When I send a GET request to "http://localhost:8080/route-wc-prefix/v1.0/forecast/a/b/c"
+    Then the response status code should be 200
+    And the JSON response field "path" should be "/forecast/a/b/c"
+
+    # Explicit non-GET method — matched prefix and method must both reach the upstream
+    When I send a PUT request to "http://localhost:8080/route-wc-prefix/v1.0/put" with body:
+      """
+      {"hello":"world"}
+      """
+    Then the response status code should be 200
+    And the JSON response field "path" should be "/put"
+    And the JSON response field "method" should be "PUT"
+
+    When I delete the API "route-wildcard-prefix-api"
+    Then the response should be successful


### PR DESCRIPTION
## Purpose

The gateway-controller's xDS translator stripped the literal matched prefix from the upstream path for non-root wildcard operation paths (e.g. `/foo/*`).
An operation path `/foo/*` folded `/foo` into the stripped context, so a request to `/ctx/foo` reached the backend as `/` instead of `/foo`, and `/ctx/foo/bar` reached it as `/bar` instead of `/foo/bar`.
This is inconsistent with exact-path behavior (exact `/foo` is forwarded as `/foo`) and breaks Gateway API `HTTPRoute` `PathPrefix` routing, where a `PathPrefix /foo` maps to the operation path `/foo/*`.
Resolves #2071.

## Goals

Forward the full matched path to the upstream for wildcard operation paths: `/foo/*` must preserve `/foo` and any sub-path, while leaving the bare `/*` catch-all and `/` root behavior unchanged.

## Approach

- In both `createRoute` and `createRouteFromRDC`, derive the rewrite context from the API context (with version) only, instead of `context + matched-prefix`.
- The existing capture group already includes everything after the context, so the matched literal prefix (`/foo`) is preserved on the upstream automatically.
- The bare `/*` catch-all (empty literal prefix) and the `/` root case are unaffected, because for those the literal prefix is empty.

## User stories

As an API developer using a wildcard prefix operation (`/foo/*`) — including Gateway API `HTTPRoute` `PathPrefix` matches that map to it — I want the gateway to forward the matched prefix and sub-path to my backend, so that path-sensitive and method-specific endpoints are routed correctly.

## Documentation

N/A — this aligns wildcard upstream-path behavior with the existing exact-path semantics; no new user-facing configuration is introduced.

## Automation tests

 - Unit tests
   > Added `TestTranslator_WildcardUpstreamRewrite` and `TestTranslator_WildcardUpstreamRewriteFromRDC` asserting the `RegexRewrite` output for `/foo/*` (root and base-path upstreams, bare prefix and nested sub-paths) plus bare-`/*` and exact-path regression cases. `go test ./pkg/xds/` passes.
 - Integration tests
   > Added a scenario to `gateway/it/features/route-path-matching.feature`: a RestApi with `GET /forecast/*` and `PUT /put/*` over the sample backend (which echoes the received path/method). Asserts `/forecast` → `/forecast`, `/forecast/today` → `/forecast/today`, `/forecast/a/b/c` → `/forecast/a/b/c`, and `PUT /put` → path `/put`, method `PUT`. The full feature passes (8 scenarios, 97 steps) against a coverage build of the controller with no regression.

## Security checks

 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — FindSecurityBugs is a Java/SpotBugs plugin and this change is Go code.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

Surfaced by #2066 (operator HTTPRoute `PathPrefix` support): once this controller fix lands, a `PUT /k8s/put` HTTPRoute reaches the backend as `/put` instead of `/`.

## Test environment

- Go 1.26.x
- macOS; Docker (gateway-controller coverage image + Docker Compose IT stack)

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)