### PR TITLE
Fix the multipart handling issue when openapi validator is enabled

### DIFF
--- a/portals/developer-portal/src/openapi/devportalApiRouter.js
+++ b/portals/developer-portal/src/openapi/devportalApiRouter.js
@@ -106,7 +106,20 @@ function operationResolver(handlersPath, route, apiDoc) {
     if (typeof handler !== 'function') {
         return notImplementedHandler(operationId, tag);
     }
-    return handler;
+    // express-openapi-validator uses multer.any() internally, which stores uploaded
+    // files in req.files as a flat array [{fieldname, buffer, ...}, ...].
+    // Service code expects the multer.fields() shape: { fieldname: [file, ...] }.
+    // Normalize here so no service file needs to know which format it received.
+    return (req, res, next) => {
+        if (Array.isArray(req.files)) {
+            const byField = {};
+            for (const file of req.files) {
+                (byField[file.fieldname] = byField[file.fieldname] || []).push(file);
+            }
+            req.files = byField;
+        }
+        return handler(req, res, next);
+    };
 }
 
 /**
@@ -159,8 +172,12 @@ function build() {
             },
             // Multipart endpoints in the spec (org content upload, API
             // metadata upload, etc.) are handled by the validator's built-in
-            // multer. Disk storage matches the legacy multer config.
-            fileUploader: { dest: require('os').tmpdir() },
+            // multer. Memory storage is required: service code reads file.buffer
+            // for YAML files and artifact ZIPs (extractFullApiBundleFromUploadedZip,
+            // parseApiMetadataFromYamlRequest). extractApiContentFromUploadedZip
+            // handles both file.path and file.buffer so memory storage is safe
+            // for all endpoints including API content ZIP uploads.
+            fileUploader: { storage: require('multer').memoryStorage() },
             // Format strictness — use 'fast' for runtime cost; 'full' is too
             // strict for some of our existing schemas (e.g. uri formats).
             validateFormats: 'fast',

--- a/portals/developer-portal/src/openapi/handlers/keyManagers.js
+++ b/portals/developer-portal/src/openapi/handlers/keyManagers.js
@@ -18,13 +18,15 @@
  */
 
 /*
- * Tag: Subscription Policies
+ * Tag: Key Managers
  */
-const apiMetadataService = require('../../services/apiMetadataService');
+const keyManagerService = require('../../services/keyManagerService');
 
 module.exports = {
-    addSubscriptionPolicies: apiMetadataService.addSubscriptionPolicies,
-    putSubscriptionPolicies: apiMetadataService.putSubscriptionPolicies,
-    getSubscriptionPolicy: apiMetadataService.getSubscriptionPolicy,
-    deleteSubscriptionPolicy: apiMetadataService.deleteSubscriptionPolicy,
+    createKeyManager: keyManagerService.createKeyManager,
+    getKeyManagers: keyManagerService.getKeyManagers,
+    getAvailableKeyManagers: keyManagerService.getAvailableKeyManagers,
+    getKeyManager: keyManagerService.getKeyManager,
+    updateKeyManager: keyManagerService.updateKeyManager,
+    deleteKeyManager: keyManagerService.deleteKeyManager,
 };

--- a/portals/developer-portal/src/openapi/handlers/organizations.js
+++ b/portals/developer-portal/src/openapi/handlers/organizations.js
@@ -22,13 +22,11 @@
  */
 const adminService = require('../../services/adminService');
 const devportalService = require('../../services/devportalService');
-const { requireCsrfForMutatingApi } = require('../../middlewares/csrfProtection')
-const { compose } = require('./_compose');
 
 module.exports = {
-    createOrganization: compose(requireCsrfForMutatingApi, adminService.createOrganization),
+    createOrganization: adminService.createOrganization,
     getOrganizations: adminService.getOrganizations,
-    updateOrganization: compose(requireCsrfForMutatingApi, adminService.updateOrganization),
+    updateOrganization: adminService.updateOrganization,
     getOrganization: devportalService.getOrganization,
-    deleteOrganization: compose(requireCsrfForMutatingApi, adminService.deleteOrganization),
+    deleteOrganization: adminService.deleteOrganization,
 };

--- a/portals/developer-portal/src/services/adminService.js
+++ b/portals/developer-portal/src/services/adminService.js
@@ -545,23 +545,30 @@ const deleteIdentityProvider = async (req, res) => {
 const createOrgContent = async (req, res) => {
     const orgId = req.params.orgId;
     const viewName = req.params.name;
+    const zipFile = req.files?.file?.[0] ?? req.file;
     logger.info('Initiate create organization content...', {
         orgId,
         viewName
     });
 
     const extractPath = path.join(process.cwd(), '..', '.tmp', orgId);
+    let tempZipPath;
 
     try {
         if (!orgId) {
             throw new CustomError(400, "Bad Request", "Missing required parameter: 'orgId'");
         }
-        const zipPath = req.file?.path;
-        if (!zipPath) {
+        if (!zipFile) {
             throw new CustomError(400, "Bad Request", "Missing required zip file");
         }
-        if (req.file.size > 50 * 1024 * 1024) {
+        if (zipFile.size > 50 * 1024 * 1024) {
             throw new CustomError(400, "Bad Request", "File size exceeds the 50MB limit");
+        }
+        let zipPath = zipFile.path;
+        if (!zipPath && zipFile.buffer) {
+            tempZipPath = path.join(require('os').tmpdir(), `org-content-${orgId}-${Date.now()}.zip`);
+            fs.writeFileSync(tempZipPath, zipFile.buffer);
+            zipPath = tempZipPath;
         }
         await util.unzipDirectory(zipPath, extractPath);
         const files = await util.readFilesInDirectory(extractPath, orgId, req.protocol, req.get('host'), viewName);
@@ -572,8 +579,9 @@ const createOrgContent = async (req, res) => {
             orgId,
             viewName
         });
-        res.status(201).send({ "orgId": orgId, "fileName": req.file.originalname });
+        res.status(201).send({ "orgId": orgId, "fileName": zipFile.originalname });
         fs.rmSync(extractPath, { recursive: true, force: true });
+        if (tempZipPath) fs.rmSync(tempZipPath, { force: true });
 
     } catch (error) {
         logger.error('Organization content creation failed', {
@@ -581,9 +589,10 @@ const createOrgContent = async (req, res) => {
             stack: error.stack,
             orgId,
             viewName,
-            fileName: req.file?.originalname
+            fileName: zipFile?.originalname
         });
         fs.rmSync(extractPath, { recursive: true, force: true });
+        if (tempZipPath) fs.rmSync(tempZipPath, { force: true });
         return util.handleError(res, error);
     }
 };
@@ -611,21 +620,28 @@ const createContent = async (filePath, fileName, fileContent, fileType, orgId, v
 const updateOrgContent = async (req, res) => {
     const orgId = req.params.orgId;
     const viewName = req.params.name;
+    const zipFile = req.files?.file?.[0] ?? req.file;
     logger.info('Initiate update organization content...', {
         orgId,
         viewName
     });
     const extractPath = path.join(process.cwd(), '..', '.tmp', orgId);
+    let tempZipPath;
     try {
         if (!orgId) {
             throw new CustomError(400, "Bad Request", "Missing required parameter: 'orgId'");
         }
-        const zipPath = req.file?.path;
-        if (!zipPath) {
+        if (!zipFile) {
             throw new CustomError(400, "Bad Request", "Missing required zip file");
         }
-        if (req.file.size > 50 * 1024 * 1024) {
+        if (zipFile.size > 50 * 1024 * 1024) {
             throw new CustomError(400, "Bad Request", "File size exceeds the 50MB limit");
+        }
+        let zipPath = zipFile.path;
+        if (!zipPath && zipFile.buffer) {
+            tempZipPath = path.join(require('os').tmpdir(), `org-content-${orgId}-${Date.now()}.zip`);
+            fs.writeFileSync(tempZipPath, zipFile.buffer);
+            zipPath = tempZipPath;
         }
         await util.unzipDirectory(zipPath, extractPath);
         const files = await util.readFilesInDirectory(extractPath, orgId, req.protocol, req.get('host'), viewName);
@@ -654,20 +670,22 @@ const updateOrgContent = async (req, res) => {
             }
         }
         fs.rmSync(extractPath, { recursive: true, force: true });
+        if (tempZipPath) fs.rmSync(tempZipPath, { force: true });
         logger.info('Organization content updated successfully', {
             orgId,
             viewName
         });
-        res.status(201).send({ "orgId": orgId, "fileName": req.file.originalname });
+        res.status(201).send({ "orgId": orgId, "fileName": zipFile.originalname });
     } catch (error) {
         logger.error('Organization content update failed', {
             error: error.message,
             stack: error.stack,
             orgId,
             viewName,
-            fileName: req.file?.originalname
+            fileName: zipFile?.originalname
         });
         fs.rmSync(extractPath, { recursive: true, force: true });
+        if (tempZipPath) fs.rmSync(tempZipPath, { force: true });
         util.handleError(res, error);
     }
 };

--- a/portals/developer-portal/src/services/apiMetadataService.js
+++ b/portals/developer-portal/src/services/apiMetadataService.js
@@ -697,17 +697,18 @@ const createAPITemplate = async (req, res) => {
 };
 
 const createAPIContent = async (req, res) => {
+    const uploadedFile = req.files?.apiContent?.[0] ?? req.file;
     logger.info('Creating API content...', {
         orgId: req.params.orgId,
         apiId: req.params.apiId,
-        fileName: req.file?.originalname,
+        fileName: uploadedFile?.originalname,
     });
     try {
         const { orgId, apiId } = req.params;
         if (!orgId) {
             throw new CustomError(400, "Bad Request", "Missing required parameter: 'orgId'");
         }
-        let apiContent = await extractApiContentFromUploadedZip(req.file, orgId, apiId, 'classic');
+        let apiContent = await extractApiContentFromUploadedZip(uploadedFile, orgId, apiId, 'classic');
         let docMetadata = "";
         if (req.body.docMetadata) {
             docMetadata = JSON.parse(req.body.docMetadata);
@@ -747,7 +748,7 @@ const createAPIContent = async (req, res) => {
             stack: error.stack,
             orgId: req.params.orgId,
             apiId: req.params.apiId,
-            fileName: req.file?.originalname,
+            fileName: uploadedFile?.originalname,
         });
         util.handleError(res, error);
     }
@@ -855,10 +856,11 @@ const updateAPITemplate = async (req, res) => {
 };
 
 const updateAPIContent = async (req, res) => {
+    const uploadedFile = req.files?.apiContent?.[0] ?? req.file;
     logger.info('Updating API content...', {
         orgId: req.params.orgId,
         apiId: req.params.apiId,
-        fileName: req.file?.originalname
+        fileName: uploadedFile?.originalname
     });
     try {
         const { orgId, apiId } = req.params;
@@ -869,7 +871,7 @@ const updateAPIContent = async (req, res) => {
         if (!orgId) {
             throw new CustomError(400, "Bad Request", "Missing required parameter: 'orgId'");
         }
-        let apiContent = await extractApiContentFromUploadedZip(req.file, orgId, apiId, 'classic');
+        let apiContent = await extractApiContentFromUploadedZip(uploadedFile, orgId, apiId, 'classic');
 
         if (req.body.docMetadata) {
             const docMetadata = JSON.parse(req.body.docMetadata);
@@ -900,7 +902,7 @@ const updateAPIContent = async (req, res) => {
             stack: error.stack,
             orgId: req.params.orgId,
             apiId: req.params.apiId,
-            fileName: req.file?.originalname
+            fileName: uploadedFile?.originalname
         });
         util.handleError(res, error);
     }


### PR DESCRIPTION
## Purpose
Fix the multipart handling issue when openapi validator is enabled

## Issues addressed
- req.files format mismatch — openapiValidator uses multer.any() which puts files in a flat array ([{fieldname, buffer}]), but service level code accessed them as req.files?.artifact?.[0]. Added a normalization step in operationResolver to convert the array to { fieldname: [file] } format before each handler runs.
- No file.buffer with disk storage — fileUploader was configured with dest: os.tmpdir() (disk storage), leaving file.buffer undefined. Switched to memoryStorage() so buffers are always populated.
- req.file never set in OAV path — createAPIContent, updateAPIContent, createOrgContent, and updateOrgContent referenced req.file (only set by multer.single()). Updated to read from req.files?.apiContent?.[0] / req.files?.file?.[0] with a req.file fallback for the legacy route. Org content handlers also write the buffer to a temp file before unzipping since util.unzipDirectory requires a path.

- Apart from the above, the missing `keymanager` handler was added.
- Also the csrf validation was removed from non-browser paths