### PR TITLE
refactor(gateway-xds): remove unused defaultCluster parameter from createRoute

### DIFF
--- a/gateway/gateway-controller/pkg/xds/translator.go
+++ b/gateway/gateway-controller/pkg/xds/translator.go
@@ -749,7 +749,7 @@ func (t *Translator) translateAsyncAPIConfig(cfg *models.StoredConfig, allConfig
 	// Extract template handle and provider name for LLM provider/proxy scenarios
 	templateHandle := t.extractTemplateHandle(cfg, allConfigs)
 	providerName := t.extractProviderName(cfg, allConfigs)
-	r := t.createRoute(cfg.UUID, apiData.DisplayName, apiData.Version, apiData.Context, "POST", constants.WEBSUB_PATH, mainClusterName, "/", effectiveMainVHost, cfg.Kind, templateHandle, providerName, nil, apiProjectID, nil, false, "", nil)
+	r := t.createRoute(cfg.UUID, apiData.DisplayName, apiData.Version, apiData.Context, "POST", constants.WEBSUB_PATH, mainClusterName, "/", effectiveMainVHost, cfg.Kind, templateHandle, providerName, nil, apiProjectID, nil, false, nil)
 	routesList = append(routesList, mainRoutesList...)
 	routesList = append(routesList, r)
 
@@ -822,14 +822,9 @@ func (t *Translator) translateAPIConfig(cfg *models.StoredConfig, allConfigs []*
 		// Determine if dynamic cluster selection should be used
 		// When upstreamDefinitions exist, use cluster_header routing so policies can select the upstream
 		useClusterHeader := apiData.UpstreamDefinitions != nil && len(*apiData.UpstreamDefinitions) > 0
-		defaultCluster := ""
-		if useClusterHeader {
-			// Default to the main cluster (with the upstream_ prefix for cluster_header lookup)
-			defaultCluster = mainClusterName
-		}
 
 		r := t.createRoute(cfg.UUID, apiData.DisplayName, apiData.Version, apiData.Context, string(op.Method), op.Path,
-			mainClusterName, parsedMainURL.Path, effectiveMainVHost, cfg.Kind, templateHandle, providerName, apiData.Upstream.Main.HostRewrite, apiProjectID, mainTimeout, useClusterHeader, defaultCluster, upstreamDefPaths)
+			mainClusterName, parsedMainURL.Path, effectiveMainVHost, cfg.Kind, templateHandle, providerName, apiData.Upstream.Main.HostRewrite, apiProjectID, mainTimeout, useClusterHeader, upstreamDefPaths)
 		mainRoutesList = append(mainRoutesList, r)
 	}
 	routesList = append(routesList, mainRoutesList...)
@@ -851,16 +846,12 @@ func (t *Translator) translateAPIConfig(cfg *models.StoredConfig, allConfigs []*
 		clusters = append(clusters, sandboxCluster)
 
 		// Create sandbox routes. When upstreamDefinitions exist, enable dynamic cluster
-		// selection (mirrors main), defaulting to the sandbox cluster.
+		// selection (mirrors main).
 		sbRoutesList := make([]*route.Route, 0)
 		sbUseClusterHeader := apiData.UpstreamDefinitions != nil && len(*apiData.UpstreamDefinitions) > 0
-		sbDefaultCluster := ""
-		if sbUseClusterHeader {
-			sbDefaultCluster = sbClusterName
-		}
 		for _, op := range apiData.Operations {
 			r := t.createRoute(cfg.UUID, apiData.DisplayName, apiData.Version, apiData.Context, string(op.Method), op.Path,
-				sbClusterName, parsedSbURL.Path, effectiveSandboxVHost, cfg.Kind, templateHandle, providerName, apiData.Upstream.Sandbox.HostRewrite, apiProjectID, sbTimeout, sbUseClusterHeader, sbDefaultCluster, upstreamDefPaths)
+				sbClusterName, parsedSbURL.Path, effectiveSandboxVHost, cfg.Kind, templateHandle, providerName, apiData.Upstream.Sandbox.HostRewrite, apiProjectID, sbTimeout, sbUseClusterHeader, upstreamDefPaths)
 			sbRoutesList = append(sbRoutesList, r)
 		}
 		routesList = append(routesList, sbRoutesList...)
@@ -1741,11 +1732,12 @@ func (t *Translator) extractProviderName(cfg *models.StoredConfig, allConfigs []
 }
 
 // createRoute creates a route for an operation
-// When useClusterHeader is true, the route uses cluster_header for dynamic cluster selection,
-// and defaultCluster specifies the cluster to use when no policy overrides it.
+// When useClusterHeader is true, the route uses cluster_header for dynamic cluster selection;
+// the no-policy fallback cluster is supplied by the policy engine (default_upstream_cluster),
+// not by the route action.
 // upstreamDefPaths maps upstream definition names to their URL paths for dynamic path rewriting.
 func (t *Translator) createRoute(apiId, apiName, apiVersion, context, method, path, clusterName,
-	upstreamPath string, vhost string, apiKind string, templateHandle string, providerName string, hostRewrite *api.UpstreamHostRewrite, projectID string, timeoutCfg *resolvedTimeout, useClusterHeader bool, defaultCluster string, upstreamDefPaths map[string]string) *route.Route {
+	upstreamPath string, vhost string, apiKind string, templateHandle string, providerName string, hostRewrite *api.UpstreamHostRewrite, projectID string, timeoutCfg *resolvedTimeout, useClusterHeader bool, upstreamDefPaths map[string]string) *route.Route {
 	// Resolve version placeholder in context
 	context = strings.ReplaceAll(context, "$version", apiVersion)
 

--- a/gateway/gateway-controller/pkg/xds/translator_test.go
+++ b/gateway/gateway-controller/pkg/xds/translator_test.go
@@ -565,7 +565,7 @@ func TestTranslator_CreateRoute_PathSpecifier(t *testing.T) {
 				"test-id", "TestAPI", tt.apiVersion, tt.context,
 				"GET", tt.path, "test-cluster", "/",
 				"localhost", "http/rest", "", "", nil, "", nil,
-				false, "", nil,
+				false, nil,
 			)
 			require.NotNil(t, r)
 			{
@@ -616,7 +616,7 @@ func TestTranslator_WildcardRegexBoundary(t *testing.T) {
 			"test-id", "TestAPI", tc.apiVersion, tc.context,
 			"GET", tc.path, "test-cluster", "/",
 			"localhost", "http/rest", "", "", nil, "", nil,
-			false, "", nil,
+			false, nil,
 		)
 		require.NotNil(t, r)
 		regexSpec, ok := r.Match.PathSpecifier.(*route.RouteMatch_SafeRegex)
@@ -686,7 +686,7 @@ func TestTranslator_WildcardUpstreamRewrite(t *testing.T) {
 				"test-id", "TestAPI", "v1.0", tt.context,
 				"GET", tt.path, "test-cluster", tt.upstreamPath,
 				"localhost", "http/rest", "", "", nil, "", nil,
-				false, "", nil,
+				false, nil,
 			)
 			require.NotNil(t, r)
 			assert.Equal(t, tt.wantUpstream, applyEnvoyRewrite(t, r, tt.request))
@@ -1629,7 +1629,6 @@ func TestTranslator_CreateRoute_Basic(t *testing.T) {
 		"proj-001",                        // projectID
 		nil,                               // timeoutCfg
 		false,                             // useClusterHeader
-		"",                                // defaultCluster
 		nil,                               // upstreamDefPaths
 	)
 
@@ -1652,7 +1651,7 @@ func TestTranslator_CreateRoute_DynamicRouting(t *testing.T) {
 		r := translator.createRoute(
 			"api-123", "0000-test-api-0000-000000000000", "v1", "/api", "GET", "/users",
 			"static-cluster", "", "localhost", "API", "", "", nil, "proj-001", nil,
-			false, "", nil,
+			false, nil,
 		)
 		require.NotNil(t, r)
 		routeAction, ok := r.Action.(*route.Route_Route)
@@ -1667,7 +1666,7 @@ func TestTranslator_CreateRoute_DynamicRouting(t *testing.T) {
 		r := translator.createRoute(
 			"api-123", "0000-test-api-0000-000000000000", "v1", "/api", "GET", "/users",
 			"static-cluster", "", "localhost", "API", "", "", nil, "proj-001", nil,
-			true, "default-cluster", nil,
+			true, nil,
 		)
 		require.NotNil(t, r)
 		routeAction, ok := r.Action.(*route.Route_Route)


### PR DESCRIPTION
## Purpose

`createRoute` in the gateway xDS translator (`pkg/xds/translator.go`) accepts a
`defaultCluster` parameter that is never read in its body. When
`useClusterHeader` is true the route uses an Envoy `ClusterHeader` specifier —
which has no fallback-cluster field — and otherwise a static cluster. The
no-policy fallback is supplied by the policy engine via `default_upstream_cluster`
(`pkg/transform/restapi.go` → `pkg/policyxds`), not by the route action, so the
parameter is dead and cannot be wired into the route action.

Resolves https://github.com/wso2/api-platform/issues/2062

## Goals

Remove the dead `defaultCluster` parameter (and the local
`defaultCluster`/`sbDefaultCluster` computations that only fed it) from
`createRoute` and every caller, with no behaviour change.

## Approach

- Drop `defaultCluster` from the `createRoute` signature.
- Remove the `defaultCluster` / `sbDefaultCluster` local variables at the main,
  sandbox, and WebSub call sites and stop passing the argument.
- Update the doc comment to note the no-policy fallback is supplied by the policy
  engine (`default_upstream_cluster`), not the route action.
- Update the 5 `createRoute` call sites in `translator_test.go`.

The working fallback path (`Upstream.DefaultCluster` → `policyxds/snapshot.go` →
policy engine) is untouched. Build + `pkg/xds` / `pkg/transform` / `pkg/policyxds`
tests pass.

## Related PRs

- #2059 (dynamic-endpoint sandbox routing) — this PR is based on it and also
  removes the `sbDefaultCluster` it introduced, so it must be merged **after**
  #2059. Until #2059 lands in `main`, this PR also shows #2059's commit.
- #2065 (take upstreamDefinitions base path from `basePath`) — adjacent work in
  the same area. It does **not** conflict with this PR: #2065 changes
  `resolveUpstreamCluster`, this PR changes `createRoute`. Suggested merge order:
  #2059 → #2065 → this PR.
