### PR TITLE
Improve revokeAppKeyMappings to safely handle OAuth client revocation

### DIFF
--- a/portals/developer-portal/src/controllers/devportalController.js
+++ b/portals/developer-portal/src/controllers/devportalController.js
@@ -139,11 +139,7 @@ const revokeAppKeyMappings = async (orgID, appID) => {
             succeededMappingIds.push(mapping.MAPPING_ID);
         }
     }
-    if (succeededMappingIds.length > 0) {
-        await ApplicationKeyMapping.destroy({
-            where: { MAPPING_ID: succeededMappingIds, ORG_ID: orgID },
-        });
-    }
+    await adminDao.deleteAppMappingsByIds(orgID, succeededMappingIds);
 };
 
 const deleteApplication = async (req, res) => {

--- a/portals/developer-portal/src/controllers/devportalController.js
+++ b/portals/developer-portal/src/controllers/devportalController.js
@@ -119,6 +119,7 @@ const revokeAppKeyMappings = async (orgID, appID) => {
         where: { APP_ID: appID, ORG_ID: orgID },
     });
     const succeededMappingIds = [];
+    const failedMappingIds = [];
     for (const mapping of mappings) {
         if (mapping.KM_ID && mapping.AS_CLIENT_ID) {
             try {
@@ -133,6 +134,7 @@ const revokeAppKeyMappings = async (orgID, appID) => {
                     kmId: mapping.KM_ID,
                     errorMessage: err.message,
                 });
+                failedMappingIds.push(mapping.MAPPING_ID);
             }
         } else {
             // No OAuth client to revoke — safe to remove the local mapping.
@@ -140,6 +142,12 @@ const revokeAppKeyMappings = async (orgID, appID) => {
         }
     }
     await adminDao.deleteAppMappingsByIds(orgID, succeededMappingIds);
+    if (failedMappingIds.length > 0) {
+        throw new Error(
+            `Failed to revoke OAuth clients for ${failedMappingIds.length} mapping(s) ` +
+            `(mappingIds: ${failedMappingIds.join(', ')}). Application deletion aborted.`
+        );
+    }
 };
 
 const deleteApplication = async (req, res) => {

--- a/portals/developer-portal/src/controllers/devportalController.js
+++ b/portals/developer-portal/src/controllers/devportalController.js
@@ -118,12 +118,14 @@ const revokeAppKeyMappings = async (orgID, appID) => {
     const mappings = await ApplicationKeyMapping.findAll({
         where: { APP_ID: appID, ORG_ID: orgID },
     });
+    const succeededMappingIds = [];
     for (const mapping of mappings) {
         if (mapping.KM_ID && mapping.AS_CLIENT_ID) {
             try {
                 const kmRecord = await kmDao.getKeyManager(mapping.KM_ID);
                 const adapter = getKeyManagerAdapter(kmRecord);
                 await adapter.deleteOAuthClient(mapping.AS_CLIENT_ID);
+                succeededMappingIds.push(mapping.MAPPING_ID);
             } catch (err) {
                 logger.warn('Failed to revoke OAuth client during application deletion', {
                     appId: appID,
@@ -132,9 +134,16 @@ const revokeAppKeyMappings = async (orgID, appID) => {
                     errorMessage: err.message,
                 });
             }
+        } else {
+            // No OAuth client to revoke — safe to remove the local mapping.
+            succeededMappingIds.push(mapping.MAPPING_ID);
         }
     }
-    await adminDao.deleteAppMappings(orgID, appID);
+    if (succeededMappingIds.length > 0) {
+        await ApplicationKeyMapping.destroy({
+            where: { MAPPING_ID: succeededMappingIds, ORG_ID: orgID },
+        });
+    }
 };
 
 const deleteApplication = async (req, res) => {

--- a/portals/developer-portal/src/dao/admin.js
+++ b/portals/developer-portal/src/dao/admin.js
@@ -785,6 +785,19 @@ const deleteSubscription = async (orgID, subID, t) => {
 }
 
 
+const deleteAppMappingsByIds = async (orgID, mappingIds, t) => {
+    if (!mappingIds || mappingIds.length === 0) return 0;
+    try {
+        return await ApplicationKeyMapping.destroy({
+            where: { MAPPING_ID: mappingIds, ORG_ID: orgID },
+            transaction: t,
+        });
+    } catch (error) {
+        if (error instanceof Sequelize.EmptyResultError) throw error;
+        throw new Sequelize.DatabaseError(error);
+    }
+};
+
 const deleteAppMappings = async (orgID, appID, t) => {
     try {
         const deletedRowsCount = await ApplicationKeyMapping.destroy({
@@ -1026,6 +1039,7 @@ module.exports = {
     createApplicationKeyMapping,
     upsertApplicationKeyMapping,
     deleteAppMappings,
+    deleteAppMappingsByIds,
     findSubscriptionByUniqueKey,
     listSubscriptionsByOrg,
     listSubscriptionsByUser,


### PR DESCRIPTION
## Purpose
Fix https://github.com/wso2/api-platform/issues/2069

## Approach
Updated the logic to remove the mapping from the db only if the revocation is success from the key manager side