### PR TITLE
fix(controller): reject query string or fragment in upstreamDefinitions URLs

### DIFF
--- a/gateway/gateway-controller/pkg/config/api_validator.go
+++ b/gateway/gateway-controller/pkg/config/api_validator.go
@@ -341,6 +341,22 @@ func (v *APIValidator) validateUpstreamDefinitions(definitions *[]api.UpstreamDe
 						Message: "URL must not include a path; set the base path in upstreamDefinitions[].basePath instead",
 					})
 				}
+
+				// A query string or fragment is not part of the upstream cluster
+				// (host[:port] only), so it would be silently dropped — reject it.
+				if parsedURL.RawQuery != "" || parsedURL.ForceQuery {
+					errors = append(errors, ValidationError{
+						Field:   fmt.Sprintf("spec.upstreamDefinitions[%d].upstreams[%d].url", i, j),
+						Message: "URL must not include a query string",
+					})
+				}
+
+				if parsedURL.Fragment != "" {
+					errors = append(errors, ValidationError{
+						Field:   fmt.Sprintf("spec.upstreamDefinitions[%d].upstreams[%d].url", i, j),
+						Message: "URL must not include a fragment",
+					})
+				}
 			}
 
 			// Validate weight if present

--- a/gateway/gateway-controller/pkg/config/api_validator.go
+++ b/gateway/gateway-controller/pkg/config/api_validator.go
@@ -347,14 +347,14 @@ func (v *APIValidator) validateUpstreamDefinitions(definitions *[]api.UpstreamDe
 				if parsedURL.RawQuery != "" || parsedURL.ForceQuery {
 					errors = append(errors, ValidationError{
 						Field:   fmt.Sprintf("spec.upstreamDefinitions[%d].upstreams[%d].url", i, j),
-						Message: "URL must not include a query string",
+						Message: "URL must not include a query string; it is not honored for upstreamDefinitions URLs",
 					})
 				}
 
 				if parsedURL.Fragment != "" {
 					errors = append(errors, ValidationError{
 						Field:   fmt.Sprintf("spec.upstreamDefinitions[%d].upstreams[%d].url", i, j),
-						Message: "URL must not include a fragment",
+						Message: "URL must not include a fragment; it is not honored for upstreamDefinitions URLs",
 					})
 				}
 			}

--- a/gateway/gateway-controller/pkg/config/api_validator.go
+++ b/gateway/gateway-controller/pkg/config/api_validator.go
@@ -343,18 +343,18 @@ func (v *APIValidator) validateUpstreamDefinitions(definitions *[]api.UpstreamDe
 				}
 
 				// A query string or fragment is not part of the upstream cluster
-				// (host[:port] only), so it would be silently dropped — reject it.
+				// (host[:port] only), so it would be silently dropped. Reject it.
 				if parsedURL.RawQuery != "" || parsedURL.ForceQuery {
 					errors = append(errors, ValidationError{
 						Field:   fmt.Sprintf("spec.upstreamDefinitions[%d].upstreams[%d].url", i, j),
-						Message: "URL must not include a query string; it is not honored for upstreamDefinitions URLs",
+						Message: "URL must not include a query string; only host[:port] is used",
 					})
 				}
 
 				if parsedURL.Fragment != "" {
 					errors = append(errors, ValidationError{
 						Field:   fmt.Sprintf("spec.upstreamDefinitions[%d].upstreams[%d].url", i, j),
-						Message: "URL must not include a fragment; it is not honored for upstreamDefinitions URLs",
+						Message: "URL must not include a fragment; only host[:port] is used",
 					})
 				}
 			}

--- a/gateway/gateway-controller/pkg/config/validator_test.go
+++ b/gateway/gateway-controller/pkg/config/validator_test.go
@@ -620,6 +620,72 @@ func TestValidateUpstreamDefinitions_URLWithPathRejected(t *testing.T) {
 	assert.Contains(t, errors[0].Message, "basePath")
 }
 
+// upstreamDefinitions URLs must be host[:port] only; a query string is dropped, not honored.
+func TestValidateUpstreamDefinitions_URLWithQueryRejected(t *testing.T) {
+	validator := NewAPIValidator()
+
+	definitions := &[]api.UpstreamDefinition{
+		{
+			Name: "my-upstream-1",
+			Upstreams: []struct {
+				Url    string `json:"url" yaml:"url"`
+				Weight *int   `json:"weight,omitempty" yaml:"weight,omitempty"`
+			}{
+				{Url: "http://backend-1:8080?foo=bar"},
+			},
+		},
+	}
+
+	errors := validator.validateUpstreamDefinitions(definitions)
+	require.Len(t, errors, 1)
+	assert.Equal(t, "spec.upstreamDefinitions[0].upstreams[0].url", errors[0].Field)
+	assert.Contains(t, errors[0].Message, "query string")
+}
+
+// upstreamDefinitions URLs must be host[:port] only; a bare "?" query marker is dropped, not honored.
+func TestValidateUpstreamDefinitions_URLWithBareQueryRejected(t *testing.T) {
+	validator := NewAPIValidator()
+
+	definitions := &[]api.UpstreamDefinition{
+		{
+			Name: "my-upstream-1",
+			Upstreams: []struct {
+				Url    string `json:"url" yaml:"url"`
+				Weight *int   `json:"weight,omitempty" yaml:"weight,omitempty"`
+			}{
+				{Url: "http://backend-1:8080?"},
+			},
+		},
+	}
+
+	errors := validator.validateUpstreamDefinitions(definitions)
+	require.Len(t, errors, 1)
+	assert.Equal(t, "spec.upstreamDefinitions[0].upstreams[0].url", errors[0].Field)
+	assert.Contains(t, errors[0].Message, "query string")
+}
+
+// upstreamDefinitions URLs must be host[:port] only; a fragment is dropped, not honored.
+func TestValidateUpstreamDefinitions_URLWithFragmentRejected(t *testing.T) {
+	validator := NewAPIValidator()
+
+	definitions := &[]api.UpstreamDefinition{
+		{
+			Name: "my-upstream-1",
+			Upstreams: []struct {
+				Url    string `json:"url" yaml:"url"`
+				Weight *int   `json:"weight,omitempty" yaml:"weight,omitempty"`
+			}{
+				{Url: "http://backend-1:8080#section"},
+			},
+		},
+	}
+
+	errors := validator.validateUpstreamDefinitions(definitions)
+	require.Len(t, errors, 1)
+	assert.Equal(t, "spec.upstreamDefinitions[0].upstreams[0].url", errors[0].Field)
+	assert.Contains(t, errors[0].Message, "fragment")
+}
+
 func TestValidateUpstreamDefinitions_DuplicateNames(t *testing.T) {
 	validator := NewAPIValidator()
 

--- a/gateway/gateway-controller/pkg/config/validator_test.go
+++ b/gateway/gateway-controller/pkg/config/validator_test.go
@@ -620,7 +620,7 @@ func TestValidateUpstreamDefinitions_URLWithPathRejected(t *testing.T) {
 	assert.Contains(t, errors[0].Message, "basePath")
 }
 
-// upstreamDefinitions URLs must be host[:port] only; a query string is dropped, not honored.
+// upstreamDefinitions URLs must be host[:port] only; a query string is dropped.
 func TestValidateUpstreamDefinitions_URLWithQueryRejected(t *testing.T) {
 	validator := NewAPIValidator()
 
@@ -642,7 +642,7 @@ func TestValidateUpstreamDefinitions_URLWithQueryRejected(t *testing.T) {
 	assert.Contains(t, errors[0].Message, "query string")
 }
 
-// upstreamDefinitions URLs must be host[:port] only; a bare "?" query marker is dropped, not honored.
+// upstreamDefinitions URLs must be host[:port] only; a bare "?" query marker is dropped.
 func TestValidateUpstreamDefinitions_URLWithBareQueryRejected(t *testing.T) {
 	validator := NewAPIValidator()
 
@@ -664,7 +664,7 @@ func TestValidateUpstreamDefinitions_URLWithBareQueryRejected(t *testing.T) {
 	assert.Contains(t, errors[0].Message, "query string")
 }
 
-// upstreamDefinitions URLs must be host[:port] only; a fragment is dropped, not honored.
+// upstreamDefinitions URLs must be host[:port] only; a fragment is dropped.
 func TestValidateUpstreamDefinitions_URLWithFragmentRejected(t *testing.T) {
 	validator := NewAPIValidator()
 

--- a/gateway/gateway-controller/pkg/config/validator_test.go
+++ b/gateway/gateway-controller/pkg/config/validator_test.go
@@ -686,6 +686,31 @@ func TestValidateUpstreamDefinitions_URLWithFragmentRejected(t *testing.T) {
 	assert.Contains(t, errors[0].Message, "fragment")
 }
 
+// upstreamDefinitions URLs must be host[:port] only; a URL carrying both a query and a
+// fragment is rejected with a separate error for each.
+func TestValidateUpstreamDefinitions_URLWithQueryAndFragmentRejected(t *testing.T) {
+	validator := NewAPIValidator()
+
+	definitions := &[]api.UpstreamDefinition{
+		{
+			Name: "my-upstream-1",
+			Upstreams: []struct {
+				Url    string `json:"url" yaml:"url"`
+				Weight *int   `json:"weight,omitempty" yaml:"weight,omitempty"`
+			}{
+				{Url: "http://backend-1:8080?a=1#top"},
+			},
+		},
+	}
+
+	errors := validator.validateUpstreamDefinitions(definitions)
+	require.Len(t, errors, 2)
+	assert.Equal(t, "spec.upstreamDefinitions[0].upstreams[0].url", errors[0].Field)
+	assert.Contains(t, errors[0].Message, "query string")
+	assert.Equal(t, "spec.upstreamDefinitions[0].upstreams[0].url", errors[1].Field)
+	assert.Contains(t, errors[1].Message, "fragment")
+}
+
 func TestValidateUpstreamDefinitions_DuplicateNames(t *testing.T) {
 	validator := NewAPIValidator()
 

--- a/gateway/it/features/api_deploy.feature
+++ b/gateway/it/features/api_deploy.feature
@@ -160,3 +160,100 @@ Feature: API Deployment and Invocation
     And the JSON response field "status" should be "error"
     And the response body should contain "Configuration validation failed"
     And the response body should contain "must not include a query string"
+
+  Scenario: Deploy an API with a bare query marker in an upstreamDefinitions URL should fail
+    Given I authenticate using basic auth as "admin"
+    When I deploy this API configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1alpha1
+      kind: RestApi
+      metadata:
+        name: invalid-upstream-bare-query-api-v1.0
+      spec:
+        displayName: Invalid-Upstream-Bare-Query-API
+        version: v1.0
+        context: /invalid-upstream-bare-query/$version
+        vhosts:
+          main: invalid-upstream-bare-query.local
+        upstreamDefinitions:
+          - name: backend-default
+            basePath: /api-main
+            upstreams:
+              - url: http://sample-backend:9080?
+        upstream:
+          main:
+            ref: backend-default
+        operations:
+          - method: GET
+            path: /endpoint
+      """
+    Then the response should be a client error
+    And the response should be valid JSON
+    And the JSON response field "status" should be "error"
+    And the response body should contain "Configuration validation failed"
+    And the response body should contain "must not include a query string"
+
+  Scenario: Deploy an API with a fragment in an upstreamDefinitions URL should fail
+    Given I authenticate using basic auth as "admin"
+    When I deploy this API configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1alpha1
+      kind: RestApi
+      metadata:
+        name: invalid-upstream-fragment-api-v1.0
+      spec:
+        displayName: Invalid-Upstream-Fragment-API
+        version: v1.0
+        context: /invalid-upstream-fragment/$version
+        vhosts:
+          main: invalid-upstream-fragment.local
+        upstreamDefinitions:
+          - name: backend-default
+            basePath: /api-main
+            upstreams:
+              - url: http://sample-backend:9080#section
+        upstream:
+          main:
+            ref: backend-default
+        operations:
+          - method: GET
+            path: /endpoint
+      """
+    Then the response should be a client error
+    And the response should be valid JSON
+    And the JSON response field "status" should be "error"
+    And the response body should contain "Configuration validation failed"
+    And the response body should contain "must not include a fragment"
+
+  Scenario: Deploy an API with both a query string and a fragment in an upstreamDefinitions URL should fail
+    Given I authenticate using basic auth as "admin"
+    When I deploy this API configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1alpha1
+      kind: RestApi
+      metadata:
+        name: invalid-upstream-query-fragment-api-v1.0
+      spec:
+        displayName: Invalid-Upstream-Query-Fragment-API
+        version: v1.0
+        context: /invalid-upstream-query-fragment/$version
+        vhosts:
+          main: invalid-upstream-query-fragment.local
+        upstreamDefinitions:
+          - name: backend-default
+            basePath: /api-main
+            upstreams:
+              - url: http://sample-backend:9080?a=1#top
+        upstream:
+          main:
+            ref: backend-default
+        operations:
+          - method: GET
+            path: /endpoint
+      """
+    Then the response should be a client error
+    And the response should be valid JSON
+    And the JSON response field "status" should be "error"
+    And the response body should contain "Configuration validation failed"
+    And the response body should contain "must not include a query string"
+    And the response body should contain "must not include a fragment"

--- a/gateway/it/features/api_deploy.feature
+++ b/gateway/it/features/api_deploy.feature
@@ -128,3 +128,35 @@ Feature: API Deployment and Invocation
     And the response should be valid JSON
     And the JSON response field "status" should be "error"
     And the response body should contain "Configuration validation failed"
+
+  Scenario: Deploy an API with a query string in an upstreamDefinitions URL should fail
+    Given I authenticate using basic auth as "admin"
+    When I deploy this API configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1alpha1
+      kind: RestApi
+      metadata:
+        name: invalid-upstream-query-api-v1.0
+      spec:
+        displayName: Invalid-Upstream-Query-API
+        version: v1.0
+        context: /invalid-upstream-query/$version
+        vhosts:
+          main: invalid-upstream-query.local
+        upstreamDefinitions:
+          - name: backend-default
+            basePath: /api-main
+            upstreams:
+              - url: http://sample-backend:9080?region=eu
+        upstream:
+          main:
+            ref: backend-default
+        operations:
+          - method: GET
+            path: /endpoint
+      """
+    Then the response should be a client error
+    And the response should be valid JSON
+    And the JSON response field "status" should be "error"
+    And the response body should contain "Configuration validation failed"
+    And the response body should contain "must not include a query string"


### PR DESCRIPTION
## Purpose

`upstreamDefinitions[].upstreams[].url` is intended to be host[:port] only — an upstream definition's base path is configured exclusively via `upstreamDefinitions[].basePath` (per #2064 and https://github.com/wso2/api-platform/discussions/369#discussioncomment-16021268).
A path in such a URL is already rejected with a 400 (#2065), but a query string (`?foo=bar`) or fragment (`#section`) is silently accepted: the upstream cluster is built from host:port only, so the query string and fragment are dropped and never reach the upstream — with no signal to the user that the value was ignored.
Fixes #2068.
Related #2064.

## Goals

Reject a query string or fragment in an `upstreamDefinitions` URL with a 400 at deploy time, consistent with how an embedded path is already handled — giving the user a clear, unambiguous contract that these URLs are host[:port] only.

## Approach

- `pkg/config/api_validator.go`: in `validateUpstreamDefinitions`, immediately after the existing #2065 path check, reject a URL whose `RawQuery` is non-empty or that carries a bare `?` (`ForceQuery`) with "URL must not include a query string", and a URL with a non-empty `Fragment` with "URL must not include a fragment".
- The validator is the single deploy-time gate for `upstreamDefinitions` URLs; the downstream consumers (`pkg/transform/restapi.go`, `pkg/xds/translator.go`) run after validation and read only host/scheme, so no change is needed there.
- Direct `upstream.main`/`upstream.sandbox` URLs are unchanged — they legitimately carry a base path in the URL path and are validated separately (`validateUpstreamUrl`); query/fragment handling for those is outside the scope of this issue.

## User stories

As an API developer, when I mistakenly put a query string or fragment in an `upstreamDefinitions` URL, I get a clear 400 at deploy time instead of having the value silently dropped at runtime.

## Documentation

N/A — no new configuration is introduced; this tightens validation of an existing field to match the documented host[:port]-only contract.

## Automation tests

 - Unit tests
   > Added `TestValidateUpstreamDefinitions_URLWithQueryRejected` and `TestValidateUpstreamDefinitions_URLWithFragmentRejected`, mirroring the existing `TestValidateUpstreamDefinitions_URLWithPathRejected`. `go test ./pkg/config/` passes with no regression.
 - Integration tests
   > N/A — this is deploy-time input validation with no runtime behavior change.

## Security checks

 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (Go code)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

#2065 (take upstreamDefinitions base path from basePath) introduced the path rejection this builds on; #2059 (dynamic-endpoint sandbox routing) is adjacent work on the same area.

## Test environment

Go (multi-module workspace); `go test ./pkg/config/`.
