### PR TITLE
Encrypt subscription token in webhook event payload

### DIFF
--- a/portals/developer-portal/docs/administer/gateway-integration.md
+++ b/portals/developer-portal/docs/administer/gateway-integration.md
@@ -42,10 +42,7 @@ webhooks:
       gatewayType: "wso2/api-platform"         # matches the API's gateway type; use "*" for all
       url: "https://gateway.example.com/devportal/events"
       secret: "change-me-minimum-32-chars"     # HMAC-SHA256 signing key
-      publicKey: |                             # RSA-2048 PEM — for encrypting sensitive fields
-        -----BEGIN PUBLIC KEY-----
-        MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA...
-        -----END PUBLIC KEY-----
+      publicKeyPath: "/run/secrets/gateway-pubkey.pem"  # RSA-2048 PEM file — for encrypting sensitive fields
       events:                                  # event type filter (omit to receive all events)
         - apikey.*
         - subscription.*
@@ -66,7 +63,7 @@ webhooks:
 | `gatewayType` | No | Filter events to APIs with this gateway type. Use `"*"` to match all |
 | `url` | Yes | HTTPS endpoint on your gateway that receives webhook POSTs |
 | `secret` | Yes | Minimum 32-character string used to sign each event with HMAC-SHA256 |
-| `publicKey` | Recommended | RSA-2048 public key (PEM) for envelope-encrypting sensitive fields in `apikey.generated`, `apikey.regenerated`, and `subscription.created` events |
+| `publicKeyPath` | Recommended | Path to an RSA-2048 public key PEM file for envelope-encrypting sensitive fields in `apikey.generated`, `apikey.regenerated`, and `subscription.created` events |
 | `events` | No | Event type allowlist. Wildcards supported (`apikey.*`). Omit to receive all |
 | `timeoutMs` | No | HTTP request timeout in milliseconds (default: 5000) |
 

--- a/portals/developer-portal/docs/administer/gateway-integration.md
+++ b/portals/developer-portal/docs/administer/gateway-integration.md
@@ -20,16 +20,16 @@ The portal fires events in the background via a delivery worker with automatic r
 
 ## Webhook Events
 
-| Event | Description | Payload |
+| Event | Description | Sensitive field |
 |---|---|---|
-| `apikey.generated` | A new API key was generated for a subscription | API key value (encrypted) |
-| `apikey.regenerated` | An existing API key was rotated | Old + new key value (encrypted) |
-| `apikey.revoked` | An API key was revoked | API key reference (encrypted) |
-| `subscription.created` | A developer subscribed an application to an API | Subscription details |
-| `subscription.updated` | A subscription's plan or state changed | Updated subscription details |
-| `subscription.deleted` | A developer unsubscribed | Subscription reference |
+| `apikey.generated` | A new API key was generated for a subscription | API key secret (`encrypted_key`) |
+| `apikey.regenerated` | An existing API key was rotated | New API key secret (`encrypted_key`) |
+| `apikey.revoked` | An API key was revoked | — |
+| `subscription.created` | A developer subscribed to an API | Subscription token (`encrypted_key`) |
+| `subscription.plan_changed` | A subscription's plan changed | — |
+| `subscription.deleted` | A developer unsubscribed | — |
 
-API key payloads are **envelope-encrypted** with the subscriber's RSA-2048 public key so that sensitive key material is never exposed in transit.
+For events that carry a sensitive field (`apikey.generated`, `apikey.regenerated`, `subscription.created`), the value is **envelope-encrypted** with the subscriber's RSA-2048 public key and delivered in `data.encrypted_key`. It is never included in plaintext.
 
 ## Configure a Webhook Subscriber
 
@@ -42,7 +42,7 @@ webhooks:
       gatewayType: "wso2/api-platform"         # matches the API's gateway type; use "*" for all
       url: "https://gateway.example.com/devportal/events"
       secret: "change-me-minimum-32-chars"     # HMAC-SHA256 signing key
-      publicKey: |                             # RSA-2048 PEM — for encrypting apikey.* payloads
+      publicKey: |                             # RSA-2048 PEM — for encrypting sensitive fields
         -----BEGIN PUBLIC KEY-----
         MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA...
         -----END PUBLIC KEY-----
@@ -66,7 +66,7 @@ webhooks:
 | `gatewayType` | No | Filter events to APIs with this gateway type. Use `"*"` to match all |
 | `url` | Yes | HTTPS endpoint on your gateway that receives webhook POSTs |
 | `secret` | Yes | Minimum 32-character string used to sign each event with HMAC-SHA256 |
-| `publicKey` | Recommended | RSA-2048 public key (PEM) for envelope-encrypting API key payloads |
+| `publicKey` | Recommended | RSA-2048 public key (PEM) for envelope-encrypting sensitive fields in `apikey.generated`, `apikey.regenerated`, and `subscription.created` events |
 | `events` | No | Event type allowlist. Wildcards supported (`apikey.*`). Omit to receive all |
 | `timeoutMs` | No | HTTP request timeout in milliseconds (default: 5000) |
 
@@ -79,6 +79,29 @@ To avoid storing secrets in `config.yaml`, use environment variables. The ID is 
 export DP_WEBHOOK_SECRET_MY_GATEWAY="your-hmac-secret"
 export DP_WEBHOOK_PUBKEY_PATH_MY_GATEWAY="/run/secrets/gateway-pubkey.pem"
 ```
+
+### Encrypting subscription tokens at rest
+
+Subscription tokens are encrypted at rest in the database using AES-256-GCM. A 64-character hex key **must** be configured before starting the portal:
+
+```yaml
+advanced:
+  subscriptionTokenEncryptionKey: "<64-char hex string>"  # 32 random bytes as hex
+```
+
+Or via environment variable:
+
+```bash
+export DP_ADVANCED_SUBSCRIPTIONTOKENENCRYPTIONKEY="<64-char hex string>"
+```
+
+Generate a suitable key with:
+
+```bash
+openssl rand -hex 32
+```
+
+The portal will fail to encrypt or decrypt tokens if this key is missing or invalid.
 
 ## Webhook Request Format
 
@@ -148,7 +171,7 @@ Fired when a developer generates a new API key for an API.
 ```
 
 - `subscription` is present only when the key is bound to a subscription
-- `encrypted_key` is present only when a `publicKey` is configured for the subscriber (see [Envelope Encryption](#envelope-encryption-for-api-key-events))
+- `encrypted_key` is present only when a `publicKey` is configured for the subscriber (see [Envelope Encryption](#envelope-encryption))
 - `expires_at` is `null` for non-expiring keys
 
 ### `apikey.regenerated`
@@ -199,14 +222,13 @@ No `encrypted_key` is included — the gateway only needs the `key_id` to revoke
 
 ### `subscription.created`
 
-Fired when a developer subscribes to an API.
+Fired when a developer subscribes to an API. The subscription token is delivered in `encrypted_key` — it is never included in plaintext.
 
 ```json
 {
   "event_type": "subscription.created",
   "data": {
     "subscription": {
-      "token": "sub-token",
       "plan_name": "Gold",
       "plan_ref_id": "policy-uuid",
       "status": "ACTIVE"
@@ -215,12 +237,19 @@ Fired when a developer subscribes to an API.
       "name": "Order API",
       "version": "v1.0",
       "ref_id": "cp-api-uuid"
+    },
+    "encrypted_key": {
+      "wrappedKey": "<base64>",
+      "iv": "<base64>",
+      "tag": "<base64>",
+      "ciphertext": "<base64>"
     }
   }
 }
 ```
 
-The `subscription.token` is the value developers must include as `X-Subscription-Token` on APIs that use token-based subscription enforcement.
+- `encrypted_key` decrypts to the subscription token — the value developers must include as `X-Subscription-Token` on APIs that use token-based subscription enforcement
+- `encrypted_key` is present only when a `publicKey` is configured for the subscriber; if no public key is configured, the token is not delivered
 
 ### `subscription.plan_changed`
 
@@ -231,7 +260,6 @@ Fired when a subscription's plan changes.
   "event_type": "subscription.plan_changed",
   "data": {
     "subscription": {
-      "token": "sub-token",
       "plan_name": "Bronze",
       "plan_ref_id": "policy-uuid",
       "status": "ACTIVE"
@@ -245,19 +273,20 @@ Fired when a subscription's plan changes.
 }
 ```
 
+The gateway identifies the affected subscription via the `aggregateId` in the event. No token is included.
+
 ### `subscription.deleted`
 
-Fired when a developer unsubscribes. The gateway should revoke access for the subscription token.
+Fired when a developer unsubscribes. The gateway should revoke access for the corresponding subscription.
 
 ```json
 {
   "event_type": "subscription.deleted",
   "data": {
     "subscription": {
-      "token": "sub-token",
       "plan_name": "Gold",
       "plan_ref_id": "policy-uuid",
-      "status": "CANCELLED"
+      "status": "ACTIVE"
     },
     "api": {
       "name": "Order API",
@@ -267,6 +296,8 @@ Fired when a developer unsubscribes. The gateway should revoke access for the su
   }
 }
 ```
+
+The gateway identifies the affected subscription via the `aggregateId` in the event. No token is included.
 
 ---
 
@@ -313,9 +344,9 @@ function verifySignature(secret, rawBody, signatureHeader) {
 }
 ```
 
-### Envelope encryption for API key events
+### Envelope encryption
 
-API key payloads (`apikey.generated`, `apikey.regenerated`) include an `encrypted_key` object when a `publicKey` is configured for the subscriber. The key is never included in plaintext.
+`apikey.generated`, `apikey.regenerated`, and `subscription.created` events include an `encrypted_key` object when a `publicKey` is configured for the subscriber. The sensitive value (API key secret or subscription token) is never included in plaintext.
 
 **Encryption scheme:** hybrid RSA-OAEP + AES-256-GCM.
 
@@ -324,21 +355,21 @@ encrypted_key = {
   wrappedKey  — RSA-OAEP(SHA-256) encrypted 256-bit AES key (base64)
   iv          — 12-byte AES-GCM IV (base64)
   tag         — 16-byte AES-GCM authentication tag (base64)
-  ciphertext  — AES-256-GCM encrypted API key secret (base64)
+  ciphertext  — AES-256-GCM encrypted secret value (base64)
 }
 ```
 
 **Decryption steps:**
 
 1. RSA-decrypt `wrappedKey` with your private key using OAEP+SHA-256 → `aesKey`
-2. AES-256-GCM decrypt `ciphertext` using `aesKey`, `iv`, and `tag` → plaintext API key secret
+2. AES-256-GCM decrypt `ciphertext` using `aesKey`, `iv`, and `tag` → plaintext secret
 
 **Example (Node.js):**
 
 ```js
 const crypto = require('crypto');
 
-function decryptApiKey(privateKeyPem, encryptedKey) {
+function decryptSecret(privateKeyPem, encryptedKey) {
     const aesKey = crypto.privateDecrypt(
         { key: privateKeyPem, padding: crypto.constants.RSA_PKCS1_OAEP_PADDING, oaepHash: 'sha256' },
         Buffer.from(encryptedKey.wrappedKey, 'base64')
@@ -351,7 +382,7 @@ function decryptApiKey(privateKeyPem, encryptedKey) {
 }
 ```
 
-If no `publicKey` is configured for the subscriber, `encrypted_key` is omitted and the API key secret is not delivered at all — configure a public key before going to production.
+If no `publicKey` is configured for the subscriber, `encrypted_key` is omitted and the sensitive value is not delivered at all — configure a public key before going to production.
 
 ## Delivery Retry
 

--- a/portals/developer-portal/docs/administer/gateway-integration.md
+++ b/portals/developer-portal/docs/administer/gateway-integration.md
@@ -82,17 +82,17 @@ export DP_WEBHOOK_PUBKEY_PATH_MY_GATEWAY="/run/secrets/gateway-pubkey.pem"
 
 ### Encrypting subscription tokens at rest
 
-Subscription tokens are encrypted at rest in the database using AES-256-GCM. A 64-character hex key **must** be configured before starting the portal:
+Subscription tokens are encrypted at rest in the database using AES-256-GCM. The key **must** be configured before starting the portal:
 
 ```yaml
 advanced:
-  subscriptionTokenEncryptionKey: "<64-char hex string>"  # 32 random bytes as hex
+  encryptionKey: "<64-char hex string>"  # 32 random bytes as hex
 ```
 
 Or via environment variable:
 
 ```bash
-export DP_ADVANCED_SUBSCRIPTIONTOKENENCRYPTIONKEY="<64-char hex string>"
+export DP_ADVANCED_ENCRYPTIONKEY="<64-char hex string>"
 ```
 
 Generate a suitable key with:

--- a/portals/developer-portal/docs/administer/gateway-integration.md
+++ b/portals/developer-portal/docs/administer/gateway-integration.md
@@ -77,29 +77,6 @@ export DP_WEBHOOK_SECRET_MY_GATEWAY="your-hmac-secret"
 export DP_WEBHOOK_PUBKEY_PATH_MY_GATEWAY="/run/secrets/gateway-pubkey.pem"
 ```
 
-### Encrypting subscription tokens at rest
-
-Subscription tokens are encrypted at rest in the database using AES-256-GCM. The key **must** be configured before starting the portal:
-
-```yaml
-advanced:
-  encryptionKey: "<64-char hex string>"  # 32 random bytes as hex
-```
-
-Or via environment variable:
-
-```bash
-export DP_ADVANCED_ENCRYPTIONKEY="<64-char hex string>"
-```
-
-Generate a suitable key with:
-
-```bash
-openssl rand -hex 32
-```
-
-The portal will fail to encrypt or decrypt tokens if this key is missing or invalid.
-
 ## Webhook Request Format
 
 Every event is delivered as an HTTP POST with a JSON body and the following headers:
@@ -282,8 +259,7 @@ Fired when a developer unsubscribes. The gateway should revoke access for the co
   "data": {
     "subscription": {
       "plan_name": "Gold",
-      "plan_ref_id": "policy-uuid",
-      "status": "ACTIVE"
+      "plan_ref_id": "policy-uuid"
     },
     "api": {
       "name": "Order API",

--- a/portals/developer-portal/docs/administer/key-manager-integration.md
+++ b/portals/developer-portal/docs/administer/key-manager-integration.md
@@ -4,11 +4,11 @@ A key manager is the OAuth2 authorization server used by the Developer Portal to
 
 ## Prerequisites
 
-Before adding a key manager, set the encryption key in `config.yaml`. This key protects key manager credentials stored in the database:
+Before adding a key manager, set the encryption key in `config.yaml`. This key protects sensitive data stored in the database, including key manager credentials and subscription tokens:
 
 ```yaml
 advanced:
-  keyManagerEncryptionKey: ""   # 64-character hex string (AES-256-GCM)
+  encryptionKey: ""   # 64-character hex string (AES-256-GCM)
 ```
 
 Generate a suitable key:
@@ -17,9 +17,9 @@ Generate a suitable key:
 openssl rand -hex 32
 ```
 
-Set the output as `keyManagerEncryptionKey`. You can also provide it via the environment variable `DP_ADVANCED_KEYMANAGERENCRYPTIONKEY`.
+Set the output as `encryptionKey`. You can also provide it via the environment variable `DP_ADVANCED_ENCRYPTIONKEY`.
 
-> **Important:** Store this key securely. If it is lost, stored key manager credentials cannot be decrypted.
+> **Important:** Store this key securely. If it is lost, all encrypted data in the database cannot be decrypted.
 
 ## Add a Key Manager
 

--- a/portals/developer-portal/sample_config.yaml
+++ b/portals/developer-portal/sample_config.yaml
@@ -52,7 +52,7 @@ advanced:
   disableOrgCallback: true
   disableScopeValidation: true
   disableSilentSSO: false
-  keyManagerEncryptionKey: ""  # 64-char hex key for AES-256-GCM key manager credential encryption
+  encryptionKey: ""  # 64-char hex key for AES-256-GCM encryption of sensitive data at rest
   apiKey:
     enabled: true
     keyType: "x-wso2-api-key"

--- a/portals/developer-portal/src/config/configLoader.js
+++ b/portals/developer-portal/src/config/configLoader.js
@@ -67,6 +67,7 @@ const CONFIG_DEFAULTS = {
         disableScopeValidation: true,
         disableSilentSSO: false,
         keyManagerEncryptionKey: '',
+        subscriptionTokenEncryptionKey: '',
         apiKey: {
             enabled: false,
             keyType: 'x-wso2-api-key',

--- a/portals/developer-portal/src/config/configLoader.js
+++ b/portals/developer-portal/src/config/configLoader.js
@@ -66,8 +66,7 @@ const CONFIG_DEFAULTS = {
         disableOrgCallback: true,
         disableScopeValidation: true,
         disableSilentSSO: false,
-        keyManagerEncryptionKey: '',
-        subscriptionTokenEncryptionKey: '',
+        encryptionKey: '',
         apiKey: {
             enabled: false,
             keyType: 'x-wso2-api-key',

--- a/portals/developer-portal/src/dao/keyManager.js
+++ b/portals/developer-portal/src/dao/keyManager.js
@@ -21,7 +21,7 @@ const { createCryptoUtil } = require('../utils/cryptoUtil');
 const { config } = require('../config/configLoader');
 const logger = require('../config/logger');
 
-const kmCrypto = createCryptoUtil(config.advanced.keyManagerEncryptionKey);
+const kmCrypto = createCryptoUtil(config.advanced.encryptionKey);
 
 /**
  * Create a new key manager for an organization.
@@ -31,7 +31,7 @@ const createKeyManager = async (orgId, kmData) => {
     try {
         if (!kmCrypto.enabled) {
             throw new Error('Key manager encryption key is not configured. ' +
-                'Set config.advanced.keyManagerEncryptionKey to a 64-char hex string.');
+                'Set config.advanced.encryptionKey to a 64-char hex string.');
         }
         const record = await KeyManager.create({
             ORG_ID: orgId,

--- a/portals/developer-portal/src/dao/subscription.js
+++ b/portals/developer-portal/src/dao/subscription.js
@@ -19,6 +19,26 @@ const crypto = require('crypto');
 const { SubscriptionMapping } = require('../models/application');
 const { APIMetadata } = require('../models/apiMetadata');
 const SubscriptionPolicy = require('../models/subscriptionPolicy');
+const { createCryptoUtil } = require('../utils/cryptoUtil');
+const { config } = require('../config/configLoader');
+
+const subCrypto = createCryptoUtil(config.advanced.subscriptionTokenEncryptionKey);
+
+function encryptToken(token) {
+    return subCrypto.encrypt(token);
+}
+
+function decryptToken(value) {
+    if (!value) return value;
+    return subCrypto.decrypt(value);
+}
+
+function decryptSubRecord(sub) {
+    if (!sub) return sub;
+    const dv = sub.dataValues || sub;
+    if (dv.SUB_TOKEN) dv.SUB_TOKEN = decryptToken(dv.SUB_TOKEN);
+    return sub;
+}
 
 const INCLUDE_API_AND_POLICY = [
     {
@@ -43,17 +63,20 @@ async function createSubscription(orgId, apiId, policyId, transaction) {
     for (let attempt = 0; attempt < 3; attempt++) {
         const subToken = generateSubToken();
         try {
-            return await SubscriptionMapping.create(
+            const record = await SubscriptionMapping.create(
                 {
                     APP_ID: null,
                     ORG_ID: orgId,
                     API_ID: apiId,
                     POLICY_ID: policyId || null,
-                    SUB_TOKEN: subToken,
+                    SUB_TOKEN: encryptToken(subToken),
                     STATUS: 'ACTIVE',
                 },
                 { transaction }
             );
+            // Expose the plaintext token to callers (never the encrypted form).
+            record.dataValues.SUB_TOKEN = subToken;
+            return record;
         } catch (err) {
             const isTokenCollision =
                 err.name === 'SequelizeUniqueConstraintError' &&
@@ -69,18 +92,19 @@ async function createSubscription(orgId, apiId, policyId, transaction) {
 async function listSubscriptions(orgId, { apiId } = {}) {
     const where = { ORG_ID: orgId, APP_ID: null };
     if (apiId) where.API_ID = apiId;
-    return SubscriptionMapping.findAll({
+    const rows = await SubscriptionMapping.findAll({
         where,
         include: INCLUDE_API_AND_POLICY,
         order: [['SUB_ID', 'ASC']],
     });
+    return rows.map(decryptSubRecord);
 }
 
 async function getSubscription(orgId, subId) {
-    return SubscriptionMapping.findOne({
+    return decryptSubRecord(await SubscriptionMapping.findOne({
         where: { SUB_ID: subId, ORG_ID: orgId, APP_ID: null },
         include: INCLUDE_API_AND_POLICY,
-    });
+    }));
 }
 
 async function updateSubscriptionStatus(orgId, subId, status, transaction) {
@@ -100,10 +124,10 @@ async function deleteSubscription(orgId, subId, transaction) {
 }
 
 async function getSubscriptionById(orgId, subId) {
-    return SubscriptionMapping.findOne({
+    return decryptSubRecord(await SubscriptionMapping.findOne({
         where: { SUB_ID: subId, ORG_ID: orgId },
         include: INCLUDE_API_AND_POLICY,
-    });
+    }));
 }
 
 module.exports = {

--- a/portals/developer-portal/src/dao/subscription.js
+++ b/portals/developer-portal/src/dao/subscription.js
@@ -22,7 +22,7 @@ const SubscriptionPolicy = require('../models/subscriptionPolicy');
 const { createCryptoUtil } = require('../utils/cryptoUtil');
 const { config } = require('../config/configLoader');
 
-const subCrypto = createCryptoUtil(config.advanced.subscriptionTokenEncryptionKey);
+const subCrypto = createCryptoUtil(config.advanced.encryptionKey);
 
 function encryptToken(token) {
     return subCrypto.encrypt(token);

--- a/portals/developer-portal/src/services/subscriptionService.js
+++ b/portals/developer-portal/src/services/subscriptionService.js
@@ -36,7 +36,6 @@ function buildWebhookPayload(sub, apiMetadata, policy) {
     return {
         subscription: {
             plan_ref_id: policy ? (policy.REF_ID || null) : null,
-            token: sub.SUB_TOKEN,
             plan_name: policy ? (policy.DISPLAY_NAME || policy.POLICY_NAME || null) : null,
             status: sub.STATUS,
         },
@@ -116,6 +115,7 @@ const createSubscription = async (req, res) => {
                 gatewayType: apiMetadata.GATEWAY_TYPE,
                 aggregateType: 'subscription',
                 aggregateId: newSub.SUB_ID,
+                plaintextKey: newSub.SUB_TOKEN,
             });
         });
 

--- a/portals/developer-portal/src/services/webhooks/eventPublisher.js
+++ b/portals/developer-portal/src/services/webhooks/eventPublisher.js
@@ -34,14 +34,17 @@ const VALID_EVENT_TYPES = new Set([
     'apikey.revoked'
 ]);
 
-const KEY_EVENT_TYPES = new Set(['apikey.generated', 'apikey.regenerated']);
+const SECRET_EVENT_TYPES = new Set([
+    'apikey.generated', 'apikey.regenerated',
+    'subscription.created',
+]);
 
 /**
  * Publish a domain event inside an existing Sequelize transaction.
  *
- * For apikey.generated / apikey.regenerated: pass `opts.plaintextKey` (string).
- * The key is encrypted per-subscriber and stored in DP_EVENT_DELIVERY.ENCRYPTED_FIELDS.
- * It is NOT written to DP_EVENT.PAYLOAD.
+ * For SECRET_EVENT_TYPES (apikey.* and subscription.*): pass `opts.plaintextKey` (string).
+ * The value is encrypted per-subscriber into DP_EVENT_DELIVERY.ENCRYPTED_FIELDS and
+ * is NOT written to DP_EVENT.PAYLOAD.
  *
  * @param {string} eventType
  * @param {object} payload          — event data (no plaintext keys here)
@@ -51,7 +54,7 @@ const KEY_EVENT_TYPES = new Set(['apikey.generated', 'apikey.regenerated']);
  * @param {string} [opts.gatewayType]
  * @param {string} [opts.aggregateType]
  * @param {string} opts.aggregateId  — PK of the primary entity (keyId, subId, etc.)
- * @param {string} [opts.plaintextKey] — only for apikey.* events; zeroized after use
+ * @param {string} [opts.plaintextKey] — required for SECRET_EVENT_TYPES; zeroized after use for apikey.* events
  * @returns {Promise<string>} eventId
  */
 async function publish(eventType, payload, opts) {
@@ -72,7 +75,7 @@ async function publish(eventType, payload, opts) {
         payload
     }, transaction);
 
-    if (KEY_EVENT_TYPES.has(eventType) && !plaintextKey) {
+    if (SECRET_EVENT_TYPES.has(eventType) && !plaintextKey) {
         logger.error('[eventPublisher] key event missing plaintextKey — rejecting', {
             eventType, orgId, aggregateId
         });
@@ -83,7 +86,7 @@ async function publish(eventType, payload, opts) {
 
     // For key events, encrypt the plaintext per subscriber and write delivery rows now
     // (inside the same TX) so the plaintext never leaves this call's stack.
-    if (KEY_EVENT_TYPES.has(eventType) && plaintextKey) {
+    if (SECRET_EVENT_TYPES.has(eventType) && plaintextKey) {
         const subscribers = matchSubscribers(eventType, gatewayType || null);
         const perSubscriberEncrypted = {};
 
@@ -112,7 +115,7 @@ async function publish(eventType, payload, opts) {
 
         bus.emit('key_event_published');
     } else {
-        // Non-key events: dispatcher will fan-out and create delivery rows.
+        // Non-sensitive events: dispatcher will fan-out and create delivery rows.
         bus.emit('event_published');
     }
 


### PR DESCRIPTION
## Purpose
Encrypt the subscription token in the webhook event (similar to API keys)

## Goals
Preventing other gateways from retrieving plaintext subscription tokens intended for different gateways.

## Approach
- Subscription tokens are encrypted before sending the subscription.created events
- Also the tokens are encrypted before storing in the db.
  - Introduced a new `advanced.encryptionKey` to store the encryption key. (reused this when storing key manager secrets as well)