### PR TITLE
refactor(policy-engine)!: single metadata channel for path/method/host rewrites

### DIFF
--- a/gateway/gateway-controller/lua/request_transformation.lua
+++ b/gateway/gateway-controller/lua/request_transformation.lua
@@ -26,28 +26,8 @@ local function resolve_target_method(metadata)
     return nil
   end
 
-  -- Check the new SDK format first (mods.Method sets this)
-  local method_key = metadata["method"]
-  if method_key ~= nil then
-    return method_key
-  end
-
-  local direct = metadata["request_transformation.target_method"]
-  if direct ~= nil then
-    return direct
-  end
-
-  local new_method = metadata["new_method"]
-  if new_method ~= nil then
-    return new_method
-  end
-
-  local nested = metadata["request_transformation"]
-  if type(nested) == "table" then
-    return nested["target_method"]
-  end
-
-  return nil
+  -- metadata["method"] is the single channel the policy engine uses (from mods.Method).
+  return metadata["method"]
 end
 
 local function resolve_target_host(metadata)
@@ -55,23 +35,8 @@ local function resolve_target_host(metadata)
     return nil
   end
 
-  -- New SDK format: mods.Host sets this
-  local host_key = metadata["host"]
-  if host_key ~= nil then
-    return host_key
-  end
-
-  local direct = metadata["request_transformation.target_host"]
-  if direct ~= nil then
-    return direct
-  end
-
-  local nested = metadata["request_transformation"]
-  if type(nested) == "table" then
-    return nested["target_host"]
-  end
-
-  return nil
+  -- metadata["host"] is the single channel the policy engine uses (from mods.Host).
+  return metadata["host"]
 end
 
 local function resolve_target_path(metadata)
@@ -79,23 +44,9 @@ local function resolve_target_path(metadata)
     return nil
   end
 
-  -- Check the new SDK format first (mods.Path sets this)
-  local path_key = metadata["path"]
-  if path_key ~= nil then
-    return path_key
-  end
-
-  local direct = metadata["request_transformation.target_path"]
-  if direct ~= nil then
-    return direct
-  end
-
-  local nested = metadata["request_transformation"]
-  if type(nested) == "table" then
-    return nested["target_path"]
-  end
-
-  return nil
+  -- metadata["path"] is the single channel the policy engine uses: the dynamic-endpoint
+  -- handler and path-changing policies (e.g. request-rewrite) both set it via mods.Path.
+  return metadata["path"]
 end
 
 -- Strip API context from path and prepend upstream base path

--- a/gateway/gateway-runtime/policy-engine/internal/kernel/translator.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/translator.go
@@ -278,14 +278,14 @@ func translateRequestActionsCore(result *executor.RequestExecutionResult, execCt
 					"targetUpstream", *targetUpstreamName,
 					"targetUpstreamPath", targetUpstreamPath)
 
-				// Set target_path to trigger Lua filter path transformation if not already set
-				// If request-rewrite policy set it, use that; otherwise use original request path
-				if _, hasTargetPath := out.DynamicMetadata[extProcNS]["request_transformation.target_path"]; !hasTargetPath {
-					out.DynamicMetadata[extProcNS]["request_transformation.target_path"] = execCtx.requestBodyCtx.Path
-					execCtx.dynamicMetadata[extProcNS]["request_transformation.target_path"] = execCtx.requestBodyCtx.Path
-					slog.Info("UpstreamName: set target_path", "path", execCtx.requestBodyCtx.Path)
+				// Surface the raw request path as metadata["path"] so Lua rewrites :path once;
+				// guard so an earlier path-changing policy (e.g. request-rewrite) isn't clobbered.
+				if out.Mutations.Path == nil {
+					rawPath := execCtx.requestBodyCtx.Path
+					out.Mutations.Path = &rawPath
+					slog.Info("UpstreamName: set mutations.Path", "path", rawPath)
 				} else {
-					slog.Info("UpstreamName: target_path already set by policy")
+					slog.Info("UpstreamName: mutations.Path already set by policy")
 				}
 			} else {
 				slog.Warn("UpstreamName: target upstream not found in upstreamDefinitionPaths",
@@ -462,14 +462,13 @@ func TranslateRequestHeaderActions(result *executor.RequestHeaderExecutionResult
 		dynamicMetadata[extProcNS]["upstream_base_path"] = execCtx.upstreamBasePath
 		if execCtx.upstreamDefinitionPaths != nil {
 			if targetUpstreamPath, ok := execCtx.upstreamDefinitionPaths[*targetUpstreamName]; ok {
-				// Advertise the target upstream base path; the Lua filter prepends it once.
-				// Do NOT set mutations.Path here -- it surfaces as metadata["path"], which Lua reads
-				// before target_path and would double-prefix (e.g. /sandbox/alternate/whoami on sandbox).
 				dynamicMetadata[extProcNS]["target_upstream_base_path"] = targetUpstreamPath
 				execCtx.dynamicMetadata[extProcNS]["target_upstream_base_path"] = targetUpstreamPath
-				if _, hasTargetPath := dynamicMetadata[extProcNS]["request_transformation.target_path"]; !hasTargetPath {
-					dynamicMetadata[extProcNS]["request_transformation.target_path"] = execCtx.requestBodyCtx.Path
-					execCtx.dynamicMetadata[extProcNS]["request_transformation.target_path"] = execCtx.requestBodyCtx.Path
+				// Surface the raw request path as metadata["path"] so Lua rewrites :path once;
+				// guard so an earlier path-changing policy (e.g. request-rewrite) isn't clobbered.
+				if mutations.Path == nil {
+					rawPath := execCtx.requestBodyCtx.Path
+					mutations.Path = &rawPath
 				}
 			}
 		}
@@ -690,14 +689,13 @@ func TranslateRequestHeaderActionsWithBodyMerge(
 		dynamicMetadata[extProcNS]["upstream_base_path"] = execCtx.upstreamBasePath
 		if execCtx.upstreamDefinitionPaths != nil {
 			if targetUpstreamPath, ok := execCtx.upstreamDefinitionPaths[*targetUpstreamName]; ok {
-				// Advertise the target upstream base path; the Lua filter prepends it once.
-				// Do NOT set mutations.Path here -- it surfaces as metadata["path"], which Lua reads
-				// before target_path and would double-prefix (e.g. /sandbox/alternate/whoami on sandbox).
 				dynamicMetadata[extProcNS]["target_upstream_base_path"] = targetUpstreamPath
 				execCtx.dynamicMetadata[extProcNS]["target_upstream_base_path"] = targetUpstreamPath
-				if _, hasTargetPath := dynamicMetadata[extProcNS]["request_transformation.target_path"]; !hasTargetPath {
-					dynamicMetadata[extProcNS]["request_transformation.target_path"] = execCtx.requestBodyCtx.Path
-					execCtx.dynamicMetadata[extProcNS]["request_transformation.target_path"] = execCtx.requestBodyCtx.Path
+				// Surface the raw request path as metadata["path"] so Lua rewrites :path once;
+				// guard so an earlier path-changing policy (e.g. request-rewrite) isn't clobbered.
+				if mutations.Path == nil {
+					rawPath := execCtx.requestBodyCtx.Path
+					mutations.Path = &rawPath
 				}
 			}
 		}

--- a/gateway/gateway-runtime/policy-engine/internal/kernel/translator_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/translator_test.go
@@ -754,10 +754,11 @@ func TestTranslateResponseActionsCore_NoShortCircuit(t *testing.T) {
 // Dynamic-endpoint request-header translation
 // =============================================================================
 
-// A dynamic-endpoint policy sets UpstreamName: the header phase must advertise the
-// target upstream base path in dynamic metadata and leave target_path at the original
-// request path, without baking a "path" mutation that Lua reads first and would
-// double-prefix on the sandbox vhost (e.g. /sandbox/alternate/whoami).
+// A dynamic-endpoint policy sets UpstreamName: the header phase must advertise the target
+// upstream base path in dynamic metadata and surface the RAW request path as metadata["path"]
+// (via the mutation struct). The Lua filter strips api_context and prepends the target base
+// exactly once, so the value must be the raw path, never a pre-baked one. A path-changing
+// policy that already set mutations.Path must win (not be clobbered).
 func TestTranslateRequestHeaderActions_DynamicEndpoint(t *testing.T) {
 	newExecCtx := func() *PolicyExecutionContext {
 		kernel := NewKernel()
@@ -778,7 +779,7 @@ func TestTranslateRequestHeaderActions_DynamicEndpoint(t *testing.T) {
 	targetUpstream := "alt-upstream"
 	chain := &registry.PolicyChain{}
 
-	t.Run("advertises target upstream base path without baking a path mutation", func(t *testing.T) {
+	t.Run("surfaces the raw request path and target upstream base path", func(t *testing.T) {
 		execCtx := newExecCtx()
 		result := &executor.RequestHeaderExecutionResult{
 			Results: []executor.RequestHeaderPolicyResult{
@@ -804,19 +805,18 @@ func TestTranslateRequestHeaderActions_DynamicEndpoint(t *testing.T) {
 		extProc := resp.DynamicMetadata.Fields[constants.ExtProcFilterName].GetStructValue()
 		require.NotNil(t, extProc)
 		assert.Equal(t, "/alternate", extProc.Fields["target_upstream_base_path"].GetStringValue())
-		assert.Equal(t, "/api/whoami", extProc.Fields["request_transformation.target_path"].GetStringValue())
-		assert.NotContains(t, extProc.Fields, "path")
+		assert.Equal(t, "/api/whoami", extProc.Fields["path"].GetStringValue())
+		assert.NotContains(t, extProc.Fields, "request_transformation.target_path")
 	})
 
-	t.Run("preserves a target_path already set by an earlier policy", func(t *testing.T) {
+	t.Run("does not clobber a path set by an earlier policy", func(t *testing.T) {
 		execCtx := newExecCtx()
+		rewrittenPath := "/rewritten/path"
 		result := &executor.RequestHeaderExecutionResult{
 			Results: []executor.RequestHeaderPolicyResult{
 				{Action: policy.UpstreamRequestHeaderModifications{
 					UpstreamName: &targetUpstream,
-					DynamicMetadata: map[string]map[string]interface{}{
-						constants.ExtProcFilterName: {"request_transformation.target_path": "/rewritten/path"},
-					},
+					Path:         &rewrittenPath,
 				}},
 			},
 		}
@@ -825,15 +825,15 @@ func TestTranslateRequestHeaderActions_DynamicEndpoint(t *testing.T) {
 		require.NoError(t, err)
 		extProc := resp.DynamicMetadata.Fields[constants.ExtProcFilterName].GetStructValue()
 		require.NotNil(t, extProc)
-		assert.Equal(t, "/rewritten/path", extProc.Fields["request_transformation.target_path"].GetStringValue())
+		assert.Equal(t, "/rewritten/path", extProc.Fields["path"].GetStringValue())
 		assert.Equal(t, "/alternate", extProc.Fields["target_upstream_base_path"].GetStringValue())
-		assert.NotContains(t, extProc.Fields, "path")
+		assert.NotContains(t, extProc.Fields, "request_transformation.target_path")
 	})
 }
 
 // The body-merge variant (body-less requests) shares the same dynamic-endpoint contract:
-// the policy runs in the header phase, must not bake a path, and preserves a target_path
-// already chosen by an earlier policy.
+// the policy runs in the header phase, surfaces the raw request path as metadata["path"],
+// and must not clobber a path already set by an earlier policy.
 func TestTranslateRequestHeaderActionsWithBodyMerge_DynamicEndpoint(t *testing.T) {
 	newExecCtx := func() *PolicyExecutionContext {
 		kernel := NewKernel()
@@ -855,7 +855,7 @@ func TestTranslateRequestHeaderActionsWithBodyMerge_DynamicEndpoint(t *testing.T
 		return &executor.RequestExecutionResult{Results: []executor.RequestPolicyResult{}}
 	}
 
-	t.Run("advertises target upstream base path without baking a path mutation", func(t *testing.T) {
+	t.Run("surfaces the raw request path and target upstream base path", func(t *testing.T) {
 		execCtx := newExecCtx()
 		headerResult := &executor.RequestHeaderExecutionResult{
 			Results: []executor.RequestHeaderPolicyResult{
@@ -868,19 +868,18 @@ func TestTranslateRequestHeaderActionsWithBodyMerge_DynamicEndpoint(t *testing.T
 		extProc := resp.DynamicMetadata.Fields[constants.ExtProcFilterName].GetStructValue()
 		require.NotNil(t, extProc)
 		assert.Equal(t, "/alternate", extProc.Fields["target_upstream_base_path"].GetStringValue())
-		assert.Equal(t, "/api/whoami", extProc.Fields["request_transformation.target_path"].GetStringValue())
-		assert.NotContains(t, extProc.Fields, "path")
+		assert.Equal(t, "/api/whoami", extProc.Fields["path"].GetStringValue())
+		assert.NotContains(t, extProc.Fields, "request_transformation.target_path")
 	})
 
-	t.Run("preserves a target_path already set by an earlier policy", func(t *testing.T) {
+	t.Run("does not clobber a path set by an earlier policy", func(t *testing.T) {
 		execCtx := newExecCtx()
+		rewrittenPath := "/rewritten/path"
 		headerResult := &executor.RequestHeaderExecutionResult{
 			Results: []executor.RequestHeaderPolicyResult{
 				{Action: policy.UpstreamRequestHeaderModifications{
 					UpstreamName: &targetUpstream,
-					DynamicMetadata: map[string]map[string]interface{}{
-						constants.ExtProcFilterName: {"request_transformation.target_path": "/rewritten/path"},
-					},
+					Path:         &rewrittenPath,
 				}},
 			},
 		}
@@ -888,8 +887,8 @@ func TestTranslateRequestHeaderActionsWithBodyMerge_DynamicEndpoint(t *testing.T
 		require.NoError(t, err)
 		extProc := resp.DynamicMetadata.Fields[constants.ExtProcFilterName].GetStructValue()
 		require.NotNil(t, extProc)
-		assert.Equal(t, "/rewritten/path", extProc.Fields["request_transformation.target_path"].GetStringValue())
+		assert.Equal(t, "/rewritten/path", extProc.Fields["path"].GetStringValue())
 		assert.Equal(t, "/alternate", extProc.Fields["target_upstream_base_path"].GetStringValue())
-		assert.NotContains(t, extProc.Fields, "path")
+		assert.NotContains(t, extProc.Fields, "request_transformation.target_path")
 	})
 }

--- a/gateway/it/features/dynamic-endpoint.feature
+++ b/gateway/it/features/dynamic-endpoint.feature
@@ -371,3 +371,116 @@ Feature: Dynamic Endpoint policy
     Given I authenticate using basic auth as "admin"
     When I delete the API "dynamic-endpoint-sandbox-mixed-v1.0"
     Then the response should be successful
+
+  # A path-changing policy (request-rewrite) and dynamic-endpoint on the SAME operation must
+  # compose: the rewrite sets mutations.Path -> metadata["path"], and the dynamic-endpoint
+  # handler must NOT clobber it. The Lua filter prepends the target upstream base (/alternate)
+  # exactly once, so the rewrite AND the routing both apply -> /alternate/rewritten.
+  Scenario: Dynamic-endpoint combined with a path-rewrite policy on the same operation
+    Given I authenticate using basic auth as "admin"
+    When I deploy this API configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1alpha1
+      kind: RestApi
+      metadata:
+        name: dynamic-endpoint-rewrite-v1.0
+      spec:
+        displayName: Dynamic-Endpoint-Rewrite-API
+        version: v1.0
+        context: /dynamic-endpoint-rewrite/$version
+        upstreamDefinitions:
+          - name: alt-upstream
+            basePath: /alternate
+            upstreams:
+              - url: http://sample-backend:9080
+        upstream:
+          main:
+            url: http://sample-backend:9080
+        operations:
+          - method: GET
+            path: /whoami
+            policies:
+              - name: request-rewrite
+                version: v1
+                params:
+                  pathRewrite:
+                    type: ReplaceFullPath
+                    replaceFullPath: /rewritten
+              - name: dynamic-endpoint
+                version: v1
+                params:
+                  targetUpstream: alt-upstream
+      """
+    Then the response should be successful
+    And I wait for the endpoint "http://localhost:8080/dynamic-endpoint-rewrite/v1.0/whoami" to be ready
+
+    # Both the rewrite (/whoami -> /rewritten) and the dynamic-endpoint base (/alternate) apply,
+    # prefixed exactly once.
+    When I clear all headers
+    And I send a GET request to "http://localhost:8080/dynamic-endpoint-rewrite/v1.0/whoami"
+    Then the response should be successful
+    And the response should be valid JSON
+    And the JSON response field "path" should be "/alternate/rewritten"
+
+    Given I authenticate using basic auth as "admin"
+    When I delete the API "dynamic-endpoint-rewrite-v1.0"
+    Then the response should be successful
+
+  # The same request-rewrite + dynamic-endpoint combination on the SANDBOX vhost: the sandbox
+  # base (/sandbox) must NOT leak in. The request diverts to the target upstream (/alternate)
+  # with the rewritten path, prefixed exactly once -> /alternate/rewritten.
+  Scenario: Dynamic-endpoint and a path-rewrite policy combined on the sandbox vhost
+    Given I authenticate using basic auth as "admin"
+    When I deploy this API configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1alpha1
+      kind: RestApi
+      metadata:
+        name: dynamic-endpoint-rewrite-sandbox-v1.0
+      spec:
+        displayName: Dynamic-Endpoint-Rewrite-Sandbox-API
+        version: v1.0
+        context: /dynamic-endpoint-rewrite-sandbox/$version
+        vhosts:
+          main: dyn-rw-sb-main.local
+          sandbox: dyn-rw-sb-sandbox.local
+        upstreamDefinitions:
+          - name: alt-upstream
+            basePath: /alternate
+            upstreams:
+              - url: http://sample-backend:9080
+        upstream:
+          main:
+            url: http://sample-backend:9080
+          sandbox:
+            url: http://sample-backend:9080/sandbox
+        operations:
+          - method: GET
+            path: /whoami
+            policies:
+              - name: request-rewrite
+                version: v1
+                params:
+                  pathRewrite:
+                    type: ReplaceFullPath
+                    replaceFullPath: /rewritten
+              - name: dynamic-endpoint
+                version: v1
+                params:
+                  targetUpstream: alt-upstream
+      """
+    Then the response should be successful
+    And I wait for the endpoint "http://localhost:8080/dynamic-endpoint-rewrite-sandbox/v1.0/whoami" to be ready with host "dyn-rw-sb-sandbox.local"
+
+    # Sandbox vhost: rewrite under the target upstream base (/alternate), prefixed once.
+    # The sandbox base (/sandbox) must not appear.
+    When I clear all headers
+    And I set request host to "dyn-rw-sb-sandbox.local"
+    And I send a GET request to "http://localhost:8080/dynamic-endpoint-rewrite-sandbox/v1.0/whoami"
+    Then the response should be successful
+    And the response should be valid JSON
+    And the JSON response field "path" should be "/alternate/rewritten"
+
+    Given I authenticate using basic auth as "admin"
+    When I delete the API "dynamic-endpoint-rewrite-sandbox-v1.0"
+    Then the response should be successful


### PR DESCRIPTION
## Purpose

The policy engine communicates request path/method/host rewrites to the Envoy Lua filter (`request_transformation.lua`) through two parallel dynamic-metadata channels: `metadata["path"|"method"|"host"]` (set from policy `mods.Path/Method/Host`) and the `request_transformation.target_path|target_method|target_host` keys (plus a nested table and `new_method`) read by Lua as fallbacks. Only the engine writes `request_transformation.target_path` (in the dynamic-endpoint handler) and only Lua reads it; the `target_method`/`target_host`/`new_method` fallbacks have no producers at all (all v1 policies use `mods.*`). This dual channel creates a metadata precedence ambiguity (raised in the PR #2059 review, where `metadata["path"]` outranks `request_transformation.target_path` in Lua) and carries dead code.

Resolves #2091.

## Goals

Collapse to the single `metadata["path"|"method"|"host"]` channel so there is exactly one source of truth for path/method/host rewrites, removing the precedence ambiguity by construction and deleting the dead fallbacks.

## Approach

- `translator.go`: in the three dynamic-endpoint (`targetUpstreamName`) blocks, set `mutations.Path` to the RAW request path (nil-guarded so a path-changing policy such as `request-rewrite` set earlier in the chain is not clobbered) instead of writing `request_transformation.target_path`. The Lua filter strips the API context and prepends `target_upstream_base_path` exactly once, so passing the raw path avoids the double-prefix while still surfacing via `metadata["path"]`.
- `request_transformation.lua`: reduce `resolve_target_path/method/host` to read only `metadata["path"|"method"|"host"]`; drop the `request_transformation.target_*`, nested-table, and `new_method` fallbacks. `compute_upstream_path` and the `target_upstream_base_path` override are unchanged.
- Fix the misleading in-code comments that described the old dual-channel behavior.

## User stories

N/A — internal policy-engine/Lua mechanism; no user-facing behavior change for first-party policies.

## Documentation

N/A — this is an internal metadata contract between the policy engine and the Envoy Lua filter; there is no user-facing documentation impact.

## Automation tests

 - Unit tests
   > Updated the dynamic-endpoint tests in `translator_test.go` to assert the path is surfaced as `metadata["path"]` and that an earlier policy's `mods.Path` is not clobbered. The `internal/kernel` package passes.
 - Integration tests
   > Ran `request-rewrite`, `host-rewrite`, `dynamic-endpoint`, and `sandbox-routing` features against coverage-instrumented images: 57/57 scenarios, 716/716 steps pass. Added a combined `request-rewrite` + `dynamic-endpoint` scenario to `dynamic-endpoint.feature` (the case the nil-guard protects), asserting the backend receives `/alternate/rewritten`.

## Security checks

 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (Go code)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

- #2059 (dynamic-endpoint sandbox path fix; its review raised the dual-channel precedence concern addressed here)

## Test environment

- Go 1.23
- macOS (darwin)
- Docker / gateway IT Docker Compose stack (coverage-instrumented images)

## Remarks

**Breaking change:** the `request_transformation.target_path`/`target_method`/`target_host` and `new_method` dynamic-metadata keys are no longer honored by the Lua filter. Policies must communicate path/method/host rewrites via the SDK `Path`/`Method`/`Host` modification fields — all v1 first-party policies (`request-rewrite`, `host-rewrite`) already do. Custom/third-party policies that emit those metadata keys directly will no longer affect routing.