### PR TITLE
refactor(gateway)!: remove ext_proc failure/override configs

### DIFF
--- a/.github/workflows/operator-integration-test.yml
+++ b/.github/workflows/operator-integration-test.yml
@@ -444,15 +444,9 @@ jobs:
                       # Timeout for gRPC service connection (in milliseconds)
                       timeout_ms: 60000
 
-                      # Failure mode: false = fail closed (deny requests on error), true = fail open (allow requests on error)
-                      failure_mode_allow: false
-
                       # Route cache action: DEFAULT, RETAIN, or CLEAR
                       # RETAIN: Maintain the route cache across requests (recommended for performance)
                       route_cache_action: RETAIN
-
-                      # Allow per-route override of ext_proc configuration
-                      allow_mode_override: true
 
                       # Message timeout for policy engine processing (in milliseconds)
                       message_timeout_ms: 60000

--- a/gateway/configs/config-template.toml
+++ b/gateway/configs/config-template.toml
@@ -193,8 +193,6 @@ server_header_value = "WSO2 API Platform"
 host = "policy-engine"
 port = 9001
 timeout_ms = 60000
-failure_mode_allow = false
-allow_mode_override = true
 message_timeout_ms = 60000
 
 [router.policy_engine.tls]

--- a/gateway/gateway-controller/pkg/config/config.go
+++ b/gateway/gateway-controller/pkg/config/config.go
@@ -375,8 +375,6 @@ type PolicyEngineConfig struct {
 	Host              string          `koanf:"host"` // Policy engine hostname/IP (TCP mode only)
 	Port              uint32          `koanf:"port"` // Policy engine ext_proc port (TCP mode only)
 	TimeoutMs         uint32          `koanf:"timeout_ms"`
-	FailureModeAllow  bool            `koanf:"failure_mode_allow"`
-	AllowModeOverride bool            `koanf:"allow_mode_override"`
 	MessageTimeoutMs  uint32          `koanf:"message_timeout_ms"`
 	TLS               PolicyEngineTLS `koanf:"tls"` // TLS configuration (TCP mode only)
 }
@@ -722,8 +720,6 @@ func defaultConfig() *Config {
 				Host:              "policy-engine", // Only used in TCP mode
 				Port:              9001,            // Only used in TCP mode
 				TimeoutMs:         60000,
-				FailureModeAllow:  false,
-				AllowModeOverride: true,
 				MessageTimeoutMs:  60000,
 				TLS: PolicyEngineTLS{
 					Enabled:    false,

--- a/gateway/gateway-controller/pkg/xds/translator.go
+++ b/gateway/gateway-controller/pkg/xds/translator.go
@@ -2960,9 +2960,12 @@ func (t *Translator) createExtProcFilter() (*hcm.HttpFilter, error) {
 			},
 			Timeout: durationpb.New(time.Duration(policyEngine.TimeoutMs) * time.Millisecond),
 		},
-		FailureModeAllow:  policyEngine.FailureModeAllow,
-		RouteCacheAction:  extproc.ExternalProcessor_DEFAULT,
-		AllowModeOverride: policyEngine.AllowModeOverride,
+		// Always fail closed: if the policy engine fails, the request must not reach the upstream.
+		FailureModeAllow: false,
+		RouteCacheAction: extproc.ExternalProcessor_DEFAULT,
+		// Always allow mode override: the policy engine sets the per-request body mode
+		// (skip/buffered/streamed); without this Envoy would ignore it and never send bodies.
+		AllowModeOverride: true,
 		RequestAttributes: []string{constants.ExtProcRequestAttributeRouteName},
 		ProcessingMode: &extproc.ProcessingMode{
 			RequestHeaderMode: extproc.ProcessingMode_SEND,

--- a/kubernetes/gateway-operator/config/gateway_values.yaml
+++ b/kubernetes/gateway-operator/config/gateway_values.yaml
@@ -101,9 +101,7 @@ gateway:
         host: ""
         port: 9001
         timeout_ms: 60000
-        failure_mode_allow: false
         route_cache_action: RETAIN
-        allow_mode_override: true
         message_timeout_ms: 60000
         tls:
           enabled: false

--- a/kubernetes/gateway-operator/config/samples/api_v1_apigateway.yaml
+++ b/kubernetes/gateway-operator/config/samples/api_v1_apigateway.yaml
@@ -231,15 +231,9 @@ data:
             # Timeout for gRPC service connection (in milliseconds)
             timeout_ms: 60000
 
-            # Failure mode: false = fail closed (deny requests on error), true = fail open (allow requests on error)
-            failure_mode_allow: false
-
             # Route cache action: DEFAULT, RETAIN, or CLEAR
             # RETAIN: Maintain the route cache across requests (recommended for performance)
             route_cache_action: RETAIN
-
-            # Allow per-route override of ext_proc configuration
-            allow_mode_override: true
 
             # Message timeout for policy engine processing (in milliseconds)
             message_timeout_ms: 60000

--- a/kubernetes/gateway-operator/config/samples/gateway-custom-config.yaml
+++ b/kubernetes/gateway-operator/config/samples/gateway-custom-config.yaml
@@ -82,9 +82,7 @@ data:
             host: ""
             port: 9001
             timeout_ms: 60000
-            failure_mode_allow: false
             route_cache_action: RETAIN
-            allow_mode_override: true
             message_timeout_ms: 60000
             tls:
               enabled: false

--- a/kubernetes/helm/gateway-helm-chart/templates/gateway/gateway-config.yaml
+++ b/kubernetes/helm/gateway-helm-chart/templates/gateway/gateway-config.yaml
@@ -127,9 +127,7 @@ data:
     host = {{ $router.policy_engine.host | default "" | quote }}
     port = {{ $router.policy_engine.port | default 9001 }}
     timeout_ms = {{ $router.policy_engine.timeout_ms }}
-    failure_mode_allow = {{ $router.policy_engine.failure_mode_allow }}
     route_cache_action = {{ $router.policy_engine.route_cache_action | quote }}
-    allow_mode_override = {{ $router.policy_engine.allow_mode_override }}
     message_timeout_ms = {{ $router.policy_engine.message_timeout_ms }}
 
     {{- if $router.policy_engine.tls }}

--- a/kubernetes/helm/gateway-helm-chart/values.yaml
+++ b/kubernetes/helm/gateway-helm-chart/values.yaml
@@ -277,15 +277,9 @@ gateway:
         # Timeout for gRPC service connection (in milliseconds)
         timeout_ms: 60000
 
-        # Failure mode: false = fail closed (deny requests on error), true = fail open (allow requests on error)
-        failure_mode_allow: false
-
         # Route cache action: DEFAULT, RETAIN, or CLEAR
         # RETAIN: Maintain the route cache across requests (recommended for performance)
         route_cache_action: RETAIN
-
-        # Allow per-route override of ext_proc configuration
-        allow_mode_override: true
 
         # Message timeout for policy engine processing (in milliseconds)
         message_timeout_ms: 60000

--- a/kubernetes/helm/operator-helm-chart/values.yaml
+++ b/kubernetes/helm/operator-helm-chart/values.yaml
@@ -306,15 +306,9 @@ gateway:
             # Timeout for gRPC service connection (in milliseconds)
             timeout_ms: 60000
 
-            # Failure mode: false = fail closed (deny requests on error), true = fail open (allow requests on error)
-            failure_mode_allow: false
-
             # Route cache action: DEFAULT, RETAIN, or CLEAR
             # RETAIN: Maintain the route cache across requests (recommended for performance)
             route_cache_action: RETAIN
-
-            # Allow per-route override of ext_proc configuration
-            allow_mode_override: true
 
             # Message timeout for policy engine processing (in milliseconds)
             message_timeout_ms: 60000


### PR DESCRIPTION
## Purpose

The gateway-controller exposed two `[router.policy_engine]` ext_proc options that have no valid reason to be operator-tunable, and one of them is a footgun if changed.

- `allow_mode_override` must always be `true`. The Policy Engine returns a per-request `mode_override` to control body handling (skip/buffered/streamed). The static ext_proc filter only sends headers, so the engine depends entirely on this override to ever receive bodies. Envoy ignores the override unless `allow_mode_override=true`, so setting it `false` breaks every body-touching policy and the streaming path.
- `failure_mode_allow` must always be `false`. If the Policy Engine fails (unreachable, errors, or times out), the request must not be forwarded to the upstream.

Resolves #2093.

## Goals

Remove both knobs from the configuration surface and hardcode them to their only correct values, so the gateway can never be misconfigured into a broken or fail-open state.

## Approach

- Remove `FailureModeAllow` and `AllowModeOverride` from `PolicyEngineConfig` and its defaults in `gateway/gateway-controller/pkg/config/config.go`.
- Hardcode `FailureModeAllow: false` and `AllowModeOverride: true` inline where the ext_proc filter is built in `gateway/gateway-controller/pkg/xds/translator.go`, matching the file's existing idiom for fixed ext_proc values.
- Drop the now-dead keys from `gateway/configs/config-template.toml`, the gateway and operator Helm charts (values + templates), the operator config and samples, and the operator integration-test CI workflow.
- Leave the static Envoy configs (`policy-engine/configs/envoy.yaml`, `envoy-backup.yaml`) untouched — their `allow_mode_override: true` must stay, since dropping it falls back to Envoy's default of `false`.

The config loader uses `mapstructure` without `ErrorUnused`, so unknown keys are silently ignored — existing TOMLs that still carry these keys will not error after upgrade.

## User stories

N/A

## Documentation

N/A — removes internal configuration knobs with no user-facing documentation impact.

## Automation tests
 - Unit tests
   > No new tests required — no existing test constructed or asserted on these fields. `go build`, `go vet`, and `go test ./pkg/config/... ./pkg/xds/...` all pass.
 - Integration tests
   > Covered by existing gateway integration tests, which exercise the policy engine ext_proc path (body policies + streaming) that depends on these hardcoded values.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no — Go change, FindSecurityBugs is a Java/SpotBugs plugin and not applicable.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

N/A

## Test environment

> go build / go vet / go test on the gateway-controller module; `helm template` rendering for both the gateway and operator Helm charts.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks

BREAKING CHANGE: `failure_mode_allow` and `allow_mode_override` are no longer configurable. Unknown keys are ignored on load, so stale configs will not error, but any deployment that set `failure_mode_allow=true` (fail-open) now always fails closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)