### PR TITLE
feat(helm)!: gate gateway admin ports behind expose toggles

### DIFF
--- a/.github/workflows/operator-integration-test.yml
+++ b/.github/workflows/operator-integration-test.yml
@@ -738,7 +738,7 @@ jobs:
                     ports:
                       http: 8080
                       https: 8443
-                      envoyAdmin: 9901
+                      routerAdmin: 9901
                       policyEngineAdmin: 9002
                       policyEngineMetrics: 9003
                   deployment:
@@ -1326,8 +1326,11 @@ jobs:
           echo "APIGateway rollout complete. Verifying Controller health..."
           # Give it a moment to stabilize
           sleep 20
-          # Port forward the new controller to check health
-          kubectl port-forward svc/test-gateway-gateway-controller 9092:9092 &
+          # Port forward the new controller to check health.
+          # Use deploy/ (not svc/) because the admin port (9092) is no longer published on
+          # the controller Service by default (gateway.controller.service.expose.admin=false);
+          # the container still listens on 9092, so forward to the pod via the Deployment.
+          kubectl port-forward deploy/test-gateway-gateway-controller 9092:9092 &
           PF_PID=$!
           sleep 5
 

--- a/kubernetes/gateway-operator/config/gateway_values.yaml
+++ b/kubernetes/gateway-operator/config/gateway_values.yaml
@@ -180,6 +180,9 @@ gateway:
         policy: 18001
         admin: 9092
         metrics: 9091
+      # Publish admin/debug ports on the Service. Off by default — keep pod-internal.
+      expose:
+        admin: false
     controlPlane:
       host: host.docker.internal
       port: 8443
@@ -317,9 +320,14 @@ gateway:
       ports:
         http: 8080
         https: 8443
-        envoyAdmin: 9901
+        routerAdmin: 9901
         policyEngineAdmin: 9002
         policyEngineMetrics: 9003
+      # Publish the runtime admin/debug ports on the Service. Off by default.
+      # routerAdmin (Envoy admin) has mutating endpoints — leave OFF unless trusted.
+      expose:
+        routerAdmin: false
+        policyEngineAdmin: false
     deployment:
       enabled: true
       replicaCount: 1

--- a/kubernetes/gateway-operator/config/samples/api_v1_apigateway.yaml
+++ b/kubernetes/gateway-operator/config/samples/api_v1_apigateway.yaml
@@ -500,7 +500,7 @@ data:
           ports:
             http: 8080
             https: 8443
-            envoyAdmin: 9901
+            routerAdmin: 9901
             policyEngineAdmin: 9002
             policyEngineMetrics: 9003
         deployment:

--- a/kubernetes/gateway-operator/config/samples/gateway-custom-config.yaml
+++ b/kubernetes/gateway-operator/config/samples/gateway-custom-config.yaml
@@ -174,7 +174,7 @@ data:
           ports:
             http: 8080
             https: 8443
-            envoyAdmin: 9901
+            routerAdmin: 9901
             policyEngineAdmin: 9002
             policyEngineMetrics: 9003
         deployment:

--- a/kubernetes/gateway-operator/internal/controller/gateway_listeners_overlay_test.go
+++ b/kubernetes/gateway-operator/internal/controller/gateway_listeners_overlay_test.go
@@ -115,7 +115,7 @@ func TestApplyListenerOverlayToValues_OverridesHTTPAndHTTPSPorts(t *testing.T) {
       ports:
         http: 9090
         https: 9443
-        envoyAdmin: 9901
+        routerAdmin: 9901
   replicaCount: 2
 `
 	gw := newGatewayWithListeners(listener("HTTP", 80), listener("HTTPS", 443))
@@ -144,7 +144,7 @@ func TestApplyListenerOverlayToValues_OverridesHTTPAndHTTPSPorts(t *testing.T) {
 	if ports["https"] != 443 {
 		t.Errorf("gatewayRuntime.service.ports.https = %v, want 443", ports["https"])
 	}
-	if ports["envoyAdmin"] != 9901 {
+	if ports["routerAdmin"] != 9901 {
 		t.Errorf("sibling service port keys dropped; ports=%v", ports)
 	}
 }

--- a/kubernetes/helm/gateway-helm-chart/Chart.yaml
+++ b/kubernetes/helm/gateway-helm-chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: gateway
 kubeVersion: ">=1.24.0-0"
 description: Helm chart for deploying the Gateway Operator components
-version: 1.1.1
+version: 1.1.2
 appVersion: "1.1.0"
 type: application
 home: https://github.com/wso2/api-platform

--- a/kubernetes/helm/gateway-helm-chart/README.md
+++ b/kubernetes/helm/gateway-helm-chart/README.md
@@ -127,6 +127,7 @@ All configurable values are documented in `values.yaml`. Component blocks are fu
 - `gateway.controller.image` / `gateway.gatewayRuntime.image` – container image metadata and pull policies.
 - `gateway.<component>.deployment.*` – pod-level knobs (replicas, probes, affinities, env overrides, extra volumes) and enable/disable switches.
 - `gateway.<component>.service.*` – service type/ports plus optional annotations and labels.
+- `gateway.<component>.service.expose.*` – per-port toggles for publishing admin/debug ports on the Service. **All default to `false`** so admin surfaces stay pod-internal (reach them with `kubectl port-forward`). Available toggles: `controller.service.expose.admin` (controller admin, 9092), `gatewayRuntime.service.expose.routerAdmin` (Router/Envoy admin, 9901 — includes mutating endpoints, leave off unless trusted), `gatewayRuntime.service.expose.policyEngineAdmin` (policy-engine admin, 9002). Probes are unaffected; they target container ports directly. Note: the controller admin port is no longer exposed by default — set `expose.admin=true` to restore prior behavior. The runtime port key was renamed `envoyAdmin` → `routerAdmin`.
 - `gateway.controller.persistence` / `gateway.controller.configMap` – PVC sizing/claims and component configuration payloads.
 - `gateway.controller.controlPlane` and `gateway.controller.logging` – control-plane connectivity plus controller logging level.
 - `gateway.controller.tls.*` – TLS certificate configuration for HTTPS listener using cert-manager or existing secrets.

--- a/kubernetes/helm/gateway-helm-chart/templates/NOTES.txt
+++ b/kubernetes/helm/gateway-helm-chart/templates/NOTES.txt
@@ -14,6 +14,9 @@ Gateway Controller has been deployed:
   - REST API Port: {{ .Values.gateway.controller.service.ports.rest }}
   - xDS Port: {{ .Values.gateway.controller.service.ports.xds }}
   - Policy xDS Port: {{ .Values.gateway.controller.service.ports.policy }}
+{{- if .Values.gateway.controller.service.expose.admin }}
+  - Admin Port: {{ .Values.gateway.controller.service.ports.admin }} (exposed on the Service — serves config_dump/health)
+{{- end }}
 {{- if .Values.gateway.controller.tls.enabled }}
   - HTTPS Enabled: Yes
   {{- if eq .Values.gateway.controller.tls.certificateProvider "cert-manager" }}
@@ -37,6 +40,12 @@ Gateway Runtime (Router + Policy Engine) has been deployed:
   - Service: {{ include "gateway-operator.fullname" . }}-gateway-runtime
   - HTTP Port: {{ .Values.gateway.gatewayRuntime.service.ports.http }}
   - HTTPS Port: {{ .Values.gateway.gatewayRuntime.service.ports.https }}
+{{- if .Values.gateway.gatewayRuntime.service.expose.routerAdmin }}
+  - Router Admin Port: {{ .Values.gateway.gatewayRuntime.service.ports.routerAdmin }} (exposed — includes MUTATING admin endpoints; restrict access)
+{{- end }}
+{{- if .Values.gateway.gatewayRuntime.service.expose.policyEngineAdmin }}
+  - Policy Engine Admin Port: {{ .Values.gateway.gatewayRuntime.service.ports.policyEngineAdmin }} (exposed — serves config_dump/health)
+{{- end }}
 
 To access the Gateway Runtime:
   {{- if eq .Values.gateway.gatewayRuntime.service.type "LoadBalancer" }}

--- a/kubernetes/helm/gateway-helm-chart/templates/gateway/controller/service.yaml
+++ b/kubernetes/helm/gateway-helm-chart/templates/gateway/controller/service.yaml
@@ -29,10 +29,12 @@ spec:
       port: {{ $service.ports.policy }}
       targetPort: policy
       protocol: TCP
+    {{- if $service.expose.admin }}
     - name: admin
       port: {{ $service.ports.admin }}
       targetPort: admin
       protocol: TCP
+    {{- end }}
     - name: metrics
       port: {{ $service.ports.metrics }}
       targetPort: metrics

--- a/kubernetes/helm/gateway-helm-chart/templates/gateway/gateway-runtime/deployment.yaml
+++ b/kubernetes/helm/gateway-helm-chart/templates/gateway/gateway-runtime/deployment.yaml
@@ -93,8 +93,8 @@ spec:
             - name: https
               containerPort: {{ $unified.service.ports.https }}
               protocol: TCP
-            - name: envoy-admin
-              containerPort: {{ $unified.service.ports.envoyAdmin }}
+            - name: router-admin
+              containerPort: {{ $unified.service.ports.routerAdmin }}
               protocol: TCP
             - name: pe-admin
               containerPort: {{ $unified.service.ports.policyEngineAdmin }}

--- a/kubernetes/helm/gateway-helm-chart/templates/gateway/gateway-runtime/service.yaml
+++ b/kubernetes/helm/gateway-helm-chart/templates/gateway/gateway-runtime/service.yaml
@@ -27,6 +27,18 @@ spec:
       targetPort: pe-metrics
       protocol: TCP
       name: pe-metrics
+    {{- if $unified.service.expose.routerAdmin }}
+    - port: {{ $unified.service.ports.routerAdmin }}
+      targetPort: router-admin
+      protocol: TCP
+      name: router-admin
+    {{- end }}
+    {{- if $unified.service.expose.policyEngineAdmin }}
+    - port: {{ $unified.service.ports.policyEngineAdmin }}
+      targetPort: pe-admin
+      protocol: TCP
+      name: pe-admin
+    {{- end }}
   selector:
     {{- include "gateway-operator.componentSelectorLabels" (list . "gateway-runtime") | nindent 4 }}
 {{- end }}

--- a/kubernetes/helm/gateway-helm-chart/values.yaml
+++ b/kubernetes/helm/gateway-helm-chart/values.yaml
@@ -404,6 +404,12 @@ gateway:
         policy: 18001
         admin: 9092
         metrics: 9091
+      # Publish admin/debug ports on the controller Service. Off by default — the admin
+      # server serves config_dump and xds_sync_status, so keep it pod-internal (reach it
+      # via `kubectl port-forward`) unless you need in-cluster Service access. Liveness/
+      # readiness probes are unaffected: they hit the container port directly, not the Service.
+      expose:
+        admin: false
     controlPlane:
       host: host.docker.internal
       port: 8443
@@ -585,9 +591,17 @@ gateway:
       ports:
         http: 8080
         https: 8443
-        envoyAdmin: 9901
+        routerAdmin: 9901
         policyEngineAdmin: 9002
         policyEngineMetrics: 9003
+      # Publish the runtime admin/debug ports on the Service. Off by default — these serve
+      # config_dump and health; keep them pod-internal unless needed. Probes are unaffected.
+      expose:
+        # Router (Envoy) admin: exposes MUTATING endpoints (/quitquitquit, /healthcheck/fail,
+        # /runtime_modify) — leave OFF unless you fully trust in-cluster network access.
+        routerAdmin: false
+        # Policy-engine admin: config_dump + health.
+        policyEngineAdmin: false
     # Policy-related file mounts for the gateway runtime
     policies:
       # LLM pricing data for the llm_cost_v1 policy.

--- a/kubernetes/helm/operator-helm-chart/Chart.yaml
+++ b/kubernetes/helm/operator-helm-chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: gateway-operator
 description: Helm chart to install the Gateway Operator
 type: application
-version: 0.8.0
+version: 0.9.0
 appVersion: "0.8.0"

--- a/kubernetes/helm/operator-helm-chart/values.yaml
+++ b/kubernetes/helm/operator-helm-chart/values.yaml
@@ -427,6 +427,9 @@ gateway:
             policy: 18001
             admin: 9092
             metrics: 9091
+          # Publish admin/debug ports on the Service. Off by default — keep pod-internal.
+          expose:
+            admin: false
         controlPlane:
           host: host.docker.internal
           port: 8443
@@ -563,9 +566,14 @@ gateway:
           ports:
             http: 8080
             https: 8443
-            envoyAdmin: 9901
+            routerAdmin: 9901
             policyEngineAdmin: 9002
             policyEngineMetrics: 9003
+          # Publish the runtime admin/debug ports on the Service. Off by default.
+          # routerAdmin (Envoy admin) has mutating endpoints — leave OFF unless trusted.
+          expose:
+            routerAdmin: false
+            policyEngineAdmin: false
         deployment:
           enabled: true
           replicaCount: 1


### PR DESCRIPTION
## Purpose

The gateway Helm charts expose admin/debug ports inconsistently and with no way to configure them. The `gateway-controller` admin port (9092) is always published on its Service — including `config_dump` and `xds_sync_status` — while the `gateway-runtime` admin ports (Router/Envoy 9901 and Policy Engine 9002) cannot be exposed on a Service at all without editing templates. This PR makes admin-port exposure explicit and secure-by-default. Resolves #2101.

## Goals

Add per-port `service.expose.*` toggles to `gateway-helm-chart`, all defaulting to `false`, so admin surfaces stay pod-internal by default and operators opt in per port. Rename the runtime port key `envoyAdmin` to `routerAdmin` so the port map uses the platform's component vocabulary, matching `policyEngineAdmin` and `policyEngineMetrics`.

## Approach

- Add `service.expose` maps under `gateway.controller.service` (`admin`) and `gateway.gatewayRuntime.service` (`routerAdmin`, `policyEngineAdmin`) in `values.yaml`, all defaulting to `false`.
- Guard the controller `admin` Service port and add guarded `router-admin` / `pe-admin` Service ports in the runtime Service template.
- Gate the Router (Envoy) admin port independently from the Policy Engine admin port because it serves mutating endpoints (`/quitquitquit`, `/healthcheck/fail`, `/runtime_modify`).
- Rename `envoyAdmin` to `routerAdmin` across the chart, operator-helm-chart values, operator config and samples, the CI workflow, and the overlay unit test.
- Document the toggles in `README.md` and `NOTES.txt`, and bump the `gateway-helm-chart` and `operator-helm-chart` chart versions.
- Note: liveness and readiness probes are unaffected because they target container ports directly, not the Service.

**Breaking change:** the controller admin port is no longer published on the Service by default; set `gateway.controller.service.expose.admin=true` to restore the previous behavior. The values key `gatewayRuntime.service.ports.envoyAdmin` was renamed to `routerAdmin`.

## User stories

As a cluster operator, I want admin and debug ports kept off the Service by default so that `config_dump` and Envoy's mutating admin endpoints are not reachable cluster-wide unless I explicitly opt in.

## Documentation

Documented in-chart in `kubernetes/helm/gateway-helm-chart/README.md` and `templates/NOTES.txt`. No external product-documentation impact.

## Automation tests

 - Unit tests
   > Updated `gateway_listeners_overlay_test.go` for the `routerAdmin` rename. `go test ./internal/controller/ -run TestApplyListenerOverlay` passes (`ok`).
 - Integration tests
   > No automated IT suite covers the Helm charts. Verified manually end-to-end on a local cluster (see below).

### Verification performed

**Static validation**
- `helm lint` on `gateway-helm-chart` and `operator-helm-chart` — 0 failures.
- `helm template … | kubectl apply --dry-run=client` — all rendered resources valid (ServiceAccount, ConfigMap x2, Service x2, Deployment x2, PVC, cert-manager Certificate/Issuer).
- Render assertions on the templated output:
   - Default render (no toggles): neither Service publishes `admin`, `router-admin`, or `pe-admin`.
   - `controller.service.expose.admin=true` → controller Service gains `admin` (9092); runtime unaffected.
   - `gatewayRuntime.service.expose.policyEngineAdmin=true` only → runtime Service gains `pe-admin` (9002), not `router-admin`.
   - `gatewayRuntime.service.expose.routerAdmin=true` only → runtime Service gains `router-admin` (9901), not `pe-admin`.
   - Deployment containerPorts renamed to `router-admin` / `pe-admin`; no `envoy-admin` remains, and no stale `envoyAdmin` key anywhere under `kubernetes/`.

**Live deploy** — `helm install` on a local Kubernetes cluster with all three toggles enabled.
- Both `gateway-controller` and `gateway-runtime` pods reached `Running 1/1`.
- Live Services confirmed: controller exposes `rest,xds,policy,admin,metrics`; runtime exposes `http,https,pe-metrics,router-admin,pe-admin`.
- Each admin health endpoint reachable through its Service (via `kubectl port-forward` + `curl`):

   | Admin service | Endpoint | Result |
   |---|---|---|
   | Controller admin (9092) | `GET /api/admin/v0.9/health` | `200` — `{"status":"healthy"}` |
   | Policy Engine admin (9002) | `GET /health` | `200` — `{"status":"healthy"}` |
   | Router/Envoy admin (9901) | `GET /ready` | `200` — `LIVE` |

```
  curl -s http://localhost:9092/api/admin/v0.9/health   # controller → {"status":"healthy"}
  curl -s http://localhost:9002/health                  # policy engine → {"status":"healthy"}
  curl -s http://localhost:9901/ready                   # router/Envoy → LIVE
```

## Security checks

 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no — Helm chart and YAML change, no Java code
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

N/A

## Test environment

helm v3.18.3, kubectl v1.32.3, local Kubernetes (colima) with cert-manager and the local-path StorageClass, on macOS (darwin).