### PR TITLE
fix(controller): enforce clean absolute basePath in upstreamDefinitions

### DIFF
--- a/gateway/gateway-controller/pkg/config/api_validator.go
+++ b/gateway/gateway-controller/pkg/config/api_validator.go
@@ -354,6 +354,34 @@ func (v *APIValidator) validateUpstreamDefinitions(definitions *[]api.UpstreamDe
 			}
 		}
 
+		// basePath, when set, must be a clean absolute path: it has to start with
+		// "/", carry no trailing "/", and have no surrounding whitespace. The raw
+		// value is validated (not a trimmed copy) because the xDS/transform layers
+		// consume it verbatim, so a relative "svc" (Envoy 400 plus wedged deploys),
+		// a trailing "/svc/" (double slash "/svc//users"), or a padded " /svc " must
+		// all be rejected at deploy time rather than producing a malformed route.
+		if def.BasePath != nil {
+			bp := *def.BasePath
+			if bp != "" {
+				if strings.TrimSpace(bp) != bp {
+					errors = append(errors, ValidationError{
+						Field:   fmt.Sprintf("spec.upstreamDefinitions[%d].basePath", i),
+						Message: "basePath must not contain leading or trailing whitespace",
+					})
+				} else if !strings.HasPrefix(bp, "/") {
+					errors = append(errors, ValidationError{
+						Field:   fmt.Sprintf("spec.upstreamDefinitions[%d].basePath", i),
+						Message: "basePath must be an absolute path starting with '/'",
+					})
+				} else if len(bp) > 1 && strings.HasSuffix(bp, "/") {
+					errors = append(errors, ValidationError{
+						Field:   fmt.Sprintf("spec.upstreamDefinitions[%d].basePath", i),
+						Message: "basePath must not end with a trailing '/'",
+					})
+				}
+			}
+		}
+
 		// Timeout validation is limited to connect timeout; request and idle
 		// timeouts are no longer supported at the upstream definition level.
 		if def.Timeout != nil && def.Timeout.Connect != nil {

--- a/gateway/gateway-controller/pkg/config/validator_test.go
+++ b/gateway/gateway-controller/pkg/config/validator_test.go
@@ -620,6 +620,113 @@ func TestValidateUpstreamDefinitions_URLWithPathRejected(t *testing.T) {
 	assert.Contains(t, errors[0].Message, "basePath")
 }
 
+// upstreamDefinitions basePath, when set, must be absolute (start with "/"); a
+// relative basePath like "svc" yields "svc/users" which Envoy rejects with 400.
+func TestValidateUpstreamDefinitions_BasePathWithoutLeadingSlashRejected(t *testing.T) {
+	validator := NewAPIValidator()
+
+	basePath := "svc"
+	definitions := &[]api.UpstreamDefinition{
+		{
+			Name:     "my-upstream-1",
+			BasePath: &basePath,
+			Upstreams: []struct {
+				Url    string `json:"url" yaml:"url"`
+				Weight *int   `json:"weight,omitempty" yaml:"weight,omitempty"`
+			}{
+				{Url: "http://backend-1:8080"},
+			},
+		},
+	}
+
+	errors := validator.validateUpstreamDefinitions(definitions)
+	require.Len(t, errors, 1)
+	assert.Equal(t, "spec.upstreamDefinitions[0].basePath", errors[0].Field)
+	assert.Contains(t, errors[0].Message, "absolute path")
+}
+
+// upstreamDefinitions basePath must not carry a trailing "/"; "/svc/" + "/users"
+// would otherwise yield the double slash "/svc//users".
+func TestValidateUpstreamDefinitions_BasePathTrailingSlashRejected(t *testing.T) {
+	validator := NewAPIValidator()
+
+	basePath := "/svc/"
+	definitions := &[]api.UpstreamDefinition{
+		{
+			Name:     "my-upstream-1",
+			BasePath: &basePath,
+			Upstreams: []struct {
+				Url    string `json:"url" yaml:"url"`
+				Weight *int   `json:"weight,omitempty" yaml:"weight,omitempty"`
+			}{
+				{Url: "http://backend-1:8080"},
+			},
+		},
+	}
+
+	errors := validator.validateUpstreamDefinitions(definitions)
+	require.Len(t, errors, 1)
+	assert.Equal(t, "spec.upstreamDefinitions[0].basePath", errors[0].Field)
+	assert.Contains(t, errors[0].Message, "trailing")
+}
+
+// basePath is consumed verbatim by the xDS/transform layers, so surrounding
+// whitespace (which a trimmed-then-validated check would let slip through and a
+// whitespace-only value would skip entirely) must be rejected on the raw value.
+func TestValidateUpstreamDefinitions_BasePathWhitespaceRejected(t *testing.T) {
+	validator := NewAPIValidator()
+
+	for _, bc := range []string{" ", "   ", " /svc", "/svc ", "/svc/ "} {
+		t.Run(bc, func(t *testing.T) {
+			basePath := bc
+			definitions := &[]api.UpstreamDefinition{
+				{
+					Name:     "my-upstream-1",
+					BasePath: &basePath,
+					Upstreams: []struct {
+						Url    string `json:"url" yaml:"url"`
+						Weight *int   `json:"weight,omitempty" yaml:"weight,omitempty"`
+					}{
+						{Url: "http://backend-1:8080"},
+					},
+				},
+			}
+
+			errors := validator.validateUpstreamDefinitions(definitions)
+			require.Len(t, errors, 1)
+			assert.Equal(t, "spec.upstreamDefinitions[0].basePath", errors[0].Field)
+			assert.Contains(t, errors[0].Message, "whitespace")
+		})
+	}
+}
+
+// nil/empty basePath is untouched and root "/" is accepted (the trailing-slash
+// rule only fires for len > 1), alongside ordinary absolute paths.
+func TestValidateUpstreamDefinitions_BasePathValidEdgeCases(t *testing.T) {
+	validator := NewAPIValidator()
+
+	for _, bc := range []string{"/", "", "/svc", "/api/v2"} {
+		t.Run(bc, func(t *testing.T) {
+			basePath := bc
+			definitions := &[]api.UpstreamDefinition{
+				{
+					Name:     "my-upstream-1",
+					BasePath: &basePath,
+					Upstreams: []struct {
+						Url    string `json:"url" yaml:"url"`
+						Weight *int   `json:"weight,omitempty" yaml:"weight,omitempty"`
+					}{
+						{Url: "http://backend-1:8080"},
+					},
+				},
+			}
+
+			errors := validator.validateUpstreamDefinitions(definitions)
+			assert.Empty(t, errors)
+		})
+	}
+}
+
 func TestValidateUpstreamDefinitions_DuplicateNames(t *testing.T) {
 	validator := NewAPIValidator()
 


### PR DESCRIPTION
## Purpose

Fixes #2105.

On deploy, the gateway accepted an `upstreamDefinitions[].basePath` with no value validation, so a malformed basePath deploys (HTTP 201) but breaks the route at runtime:

- without a leading slash (e.g. `svc`): every request to the operation returns HTTP 400, and while that API is deployed any further deploy is rejected with HTTP 409 (the bad config blocks the deploy pipeline until it is removed).
- with a trailing slash (e.g. `/svc/`): the upstream path becomes a double slash (`/svc//item`) and the backend returns a 307 redirect instead of serving the request.
- with a surrounding or whitespace-only value (e.g. `" /svc "`, `"   "`): the value is consumed verbatim by the xDS/transform layers and produces a malformed path.

## Approach

Validate the raw `basePath` value in `validateUpstreamDefinitions` (the raw value, because the xDS/transform layers consume it verbatim) and reject at deploy time with a clear message:

- a value with leading or trailing whitespace
- a value that does not start with `/`
- a value that ends with a trailing `/` (root `/` stays allowed)

A nil or empty basePath is left untouched; the runtime defaults it to root.

## Tests

Unit tests in `validator_test.go` cover the missing leading slash, trailing slash, whitespace cases (`" "`, `"   "`, `" /svc"`, `"/svc "`, `"/svc/ "`), and valid edge cases (`/`, empty, `/svc`, `/api/v2`). `go test ./pkg/config/` passes.