### PR TITLE
feat(platform-api): per-op upstream routing via upstreamDefinitions

### DIFF
--- a/platform-api/src/resources/openapi.yaml
+++ b/platform-api/src/resources/openapi.yaml
@@ -6326,6 +6326,11 @@ components:
           example: "2023-10-12T10:30:00Z"
         upstream:
           $ref: "#/components/schemas/Upstream"
+        upstreamDefinitions:
+          type: array
+          description: List of reusable named upstream definitions, referenced by `ref` from both API-level and operation-level upstreams.
+          items:
+            $ref: "#/components/schemas/ReusableUpstream"
         lifeCycleStatus:
           type: string
           description: Current lifecycle status of the API
@@ -6473,6 +6478,90 @@ components:
           description: List of policies to be applied on the operation
           items:
             $ref: "#/components/schemas/Policy"
+        upstream:
+          $ref: "#/components/schemas/OperationUpstream"
+
+    OperationUpstream:
+      title: Operation Upstream
+      type: object
+      additionalProperties: false
+      minProperties: 1
+      description: Per-operation upstream override. Each sub-field must reference a named entry in upstreamDefinitions. Missing sub-fields fall back to the API-level upstream. At least one of main or sandbox must be set.
+      properties:
+        main:
+          type: object
+          additionalProperties: false
+          required:
+            - ref
+          properties:
+            ref:
+              $ref: '#/components/schemas/UpstreamReference'
+        sandbox:
+          type: object
+          additionalProperties: false
+          required:
+            - ref
+          properties:
+            ref:
+              $ref: '#/components/schemas/UpstreamReference'
+
+    UpstreamReference:
+      title: Upstream Reference
+      type: string
+      description: Name of a ReusableUpstream entry in the API's upstreamDefinitions pool. Used by both API-level and operation-level upstream refs.
+      minLength: 1
+      maxLength: 100
+      pattern: '^[a-zA-Z0-9\-_]+$'
+      example: my-upstream-1
+
+    ReusableUpstream:
+      title: Reusable Upstream
+      type: object
+      required:
+        - name
+        - upstreams
+      description: A reusable named upstream definition. Referenced by name from API-level and operation-level upstream refs.
+      properties:
+        name:
+          $ref: '#/components/schemas/UpstreamReference'
+        basePath:
+          type: string
+          description: Base path prefix prepended to all requests routed to this upstream (e.g., /api/v2)
+          example: /api/v2
+        timeout:
+          $ref: '#/components/schemas/UpstreamTimeout'
+        upstreams:
+          type: array
+          description: List of backend targets with optional weights for load balancing
+          minItems: 1
+          items:
+            type: object
+            additionalProperties: false
+            required:
+              - url
+            properties:
+              url:
+                type: string
+                format: uri
+                description: Backend URL (host and port only; path comes from basePath)
+                example: http://prod-backend-1:5000
+              weight:
+                type: integer
+                description: Weight for load balancing (optional, default 100)
+                minimum: 0
+                maximum: 100
+                example: 80
+
+    UpstreamTimeout:
+      title: Upstream Timeout
+      type: object
+      description: Timeout configuration for upstream requests
+      properties:
+        connect:
+          type: string
+          description: Connection timeout duration (e.g., "5s", "500ms")
+          pattern: '^\d+(\.\d+)?(ms|s|m|h)$'
+          example: 5s
 
     ChannelRequest:
       title: Channel Request
@@ -8379,8 +8468,7 @@ components:
           description: Direct backend URL to route traffic to
           example: http://prod-backend:5000/api/v2
         ref:
-          type: string
-          description: Reference to a predefined upstreamDefinition
+          $ref: '#/components/schemas/UpstreamReference'
         auth:
           $ref: '#/components/schemas/UpstreamAuth'
 


### PR DESCRIPTION
## Summary

Adds control-plane (platform-api) support for a per-operation `upstream` override on REST API operations: an operation can route its `main` and/or `sandbox` traffic to a different backend than the API-level upstream. Per-op targets are **ref-only**: each references a named entry in `upstreamDefinitions` rather than carrying an inline URL. The platform-api accepts, validates, persists, and emits this configuration in the deployment YAML the gateway resolves. Operations without a per-op upstream fall back to the API-level upstream, exactly as before.

Backends are declared once in an API-level `upstreamDefinitions` pool and referenced by name from both API-level and operation-level upstreams. The per-op upstream and the pool live inside the existing API configuration blob, so there is no database migration.

## Why

Real-world APIs often need individual operations to reach different backend services. Today that needs path-based workarounds or splitting one API into several. This lets the API definition declare per-operation routing directly, while backend URLs stay defined once in `upstreamDefinitions` and are referenced by name. Because the platform-api is the publisher-facing front door, it validates the configuration up front and fails fast with HTTP 400, so a config the control plane accepts is one the gateway will accept on deploy instead of surfacing as a later deployment failure.

## Design decisions

**Ref-only at the operation level.** `operations[].upstream.main` / `.sandbox` carry only a `ref` to a named `upstreamDefinition`, with no inline `url` and no per-target timeout. Backends are declared once in `upstreamDefinitions`; the connect timeout lives on the definition. The wrapper and the leaf are both locked with `additionalProperties: false`, and at least one of `main` / `sandbox` is required. API-level `upstream` still accepts either `url` or `ref`, unchanged.

**Backends declared once in a named pool.** `upstreamDefinitions` is an array of named entries (`name`, optional `basePath`, optional connect `timeout`, and one or more weighted `upstreams`). Both API-level and operation-level `ref`s resolve against this pool, so a backend URL is defined in exactly one place and reused by name.

**Validate at the front door, aligned with the gateway.** The platform-api now rejects the same shapes the gateway rejects, so the two layers cannot disagree: a `ref` must resolve to a unique, well-formed definition; and an empty or absent per-op `ref`, an empty `upstream: {}` wrapper, an `upstreamDefinition` name that breaks the name contract (`^[a-zA-Z0-9\-_]+$`) or exceeds 100 characters, an `upstreamDefinition` url that is not host-only http/https, a weight outside 0..100, a connect timeout that is non-positive or not expressed in ms, s, m, or h units, and an invalid HTTP method are all rejected. Invalid upstream-definition and operation errors map to HTTP 400, and the same checks run on both the create and the update path.

**No schema migration.** The per-operation upstream and the `upstreamDefinitions` pool are stored inside the existing API configuration JSON, so persistence is purely additive with no database migration.

## What changed (platform-api / control-plane layer)

- **OpenAPI schema** (`resources/openapi.yaml`): a `ReusableUpstream` + `UpstreamTimeout` pool on the API, and a ref-only `OperationUpstream` / `OperationUpstreamTarget` on the operation. The operation wrapper and target are locked with `additionalProperties: false`; the wrapper requires at least one of `main` / `sandbox`; the `ref` is constrained to `^[a-zA-Z0-9\-_]+$`, max 100 characters. Go types regenerated (`api/generated.go`).
- **Model / DTO / utils**: carry the pool and the per-operation upstream through create, import, merge, and deployment-YAML emission. `BuildAPIDeploymentYAML` emits `spec.upstreamDefinitions` and `operations[].upstream.main/.sandbox.ref` in the gateway's shape, with the operation upstream emitted ref-only.
- **Service** (`internal/service/api.go`): ref resolution plus all the gateway-aligned validation rules above, applied on both the create and the update path.
- **Handler** (`internal/handler/api.go`): map invalid upstream-definition and operation errors to HTTP 400 on both create and update.

## Test coverage

- **Unit tests** across `internal/service`, `internal/utils`, and `internal/repository`: ref resolution; every validation rule (name pattern and length, host-only url with scheme and host checks, weight 0..100, connect timeout positive and restricted to ms, s, m, or h units, required and well-formed per-op ref, non-empty operation upstream wrapper, HTTP method enum); and DTO/model conversion across create, import, merge, and deployment-YAML emission (operation upstream emitted ref-only).
- **Integration tests** against a real SQLite database: a create then persist then read round-trip of the `upstreamDefinitions` pool and the per-operation upstream, and a deployment-YAML contract test asserting the emitted `operations[].upstream.main.ref` and `spec.upstreamDefinitions` match the gateway shape (the per-op ref is attached to the right operation and does not leak to others).

## Example

API configuration sent to the platform-api. The per-operation `upstream` is ref-only; backends are declared once in `upstreamDefinitions` and referenced by name:

```yaml
context: /shop/v1
upstream:
  main:
    url: http://default-backend:8080   # API-level default (accepts url or ref)
upstreamDefinitions:
  - name: user-service
    upstreams:
      - url: http://user-service:8080
  - name: order-service
    timeout:
      connect: 5s
    upstreams:
      - url: http://order-service:8080
operations:
  - method: GET
    path: /products
    # no per-op upstream -> uses the API-level default-backend
  - method: GET
    path: /users/{id}
    upstream:
      main:
        ref: user-service       # ref-only: points at an upstreamDefinition
  - method: POST
    path: /orders
    upstream:
      main:
        ref: order-service
```

## Related PRs

- #2012 (gateway-controller): the gateway-side per-operation upstream change, which resolves the per-op `ref` at deploy time and builds the Envoy clusters and routes.