### PR TITLE
docs(skills): rename gateway-it-tests to gateway-integration-tests

### DIFF
--- a/.agents/skills/gateway-debug/SKILL.md
+++ b/.agents/skills/gateway-debug/SKILL.md
@@ -30,7 +30,7 @@ Envoy itself is **never** the debug target — we always run it in Docker. We us
 - "Step through controller code when I POST to /rest-apis"
 - "Find and fix a bug in gateway-controller / policy-engine"
 - A specific request returns the wrong response and source-level inspection is
-  needed (when [[gateway-it-tests]] step 3 — logs / config dumps — wasn't enough)
+  needed (when [[gateway-integration-tests]] step 3 — logs / config dumps — wasn't enough)
 - An IT test reproducer exists but you need to step through the gateway side,
   not the test side
 
@@ -124,7 +124,7 @@ cd "$REPO_ROOT/gateway" && docker compose down
 > | Mode | Compose file (`<COMPOSE>`) | Run `docker compose` from (`<COMPOSE_CWD>`) | Use when |
 > |---|---|---|---|
 > | **Standalone** *(default)* | `<REPO_ROOT>/gateway/docker-compose.yaml` | `<REPO_ROOT>/gateway` (default filename, no `-f` needed) | Investigating from scratch; no IT scenario in play |
-> | **IT handoff** | `<REPO_ROOT>/gateway/it/docker-compose.test.yaml` | `<REPO_ROOT>/gateway/it` (use `-f docker-compose.test.yaml` — non-default filename) | Reproducing a failing integration test (handoff from [[gateway-it-tests]]) — keeps the IT mocks (`mock-jwks`, `mock-platform-api`, …) that the scenario depends on |
+> | **IT handoff** | `<REPO_ROOT>/gateway/it/docker-compose.test.yaml` | `<REPO_ROOT>/gateway/it` (use `-f docker-compose.test.yaml` — non-default filename) | Reproducing a failing integration test (handoff from [[gateway-integration-tests]]) — keeps the IT mocks (`mock-jwks`, `mock-platform-api`, …) that the scenario depends on |
 
 > **Pick a path before doing any 2x substep.** Two flows in the gateway
 > need different setups; choose based on what the bug actually involves.
@@ -636,7 +636,7 @@ make build-coverage                                # rebuild containerised image
 cd it && IT_FEATURE_PATHS=features/<area>.feature make test
 ```
 
-See [[gateway-it-tests]] for the full IT workflow.
+See [[gateway-integration-tests]] for the full IT workflow.
 
 ## Step 8: Clean up — always run when finished
 

--- a/.agents/skills/gateway-integration-tests/SKILL.md
+++ b/.agents/skills/gateway-integration-tests/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: gateway-it-tests
+name: gateway-integration-tests
 description: Run or debug WSO2 API Platform gateway integration tests. Use when the user asks to run gateway IT tests, BDD tests, godog tests, or a specific `.feature` file; verify a feature file passes; or debug why a gateway integration test is failing.
 compatibility: Requires docker (with compose plugin), make, Go 1.23+. Optional: delve (`dlv`) for step-level debugging.
 allowed-tools: Bash Read Edit Grep Glob


### PR DESCRIPTION
## Purpose

The `gateway-it-tests` agent skill had a redundant name: "IT" already expands to "integration test", so the slug read as "gateway-integration-test-tests". This renames it to the unambiguous `gateway-integration-tests` and fixes the cross-references that pointed at the old name.

## Goals

- Give the integration-tests skill a clear, non-redundant name consistent with the other `gateway-*` skills.
- Keep all `[[..]]` cross-references between skills resolving correctly.

## Approach

- Rename `.agents/skills/gateway-it-tests/` → `.agents/skills/gateway-integration-tests/` (git rename, 99% similarity).
- Update the `name:` frontmatter field in `SKILL.md` to `gateway-integration-tests`.
- Update the three `[[gateway-it-tests]]` wiki-links in the `gateway-debug` skill to `[[gateway-integration-tests]]`.
- The `description` retains "IT tests" as a natural-language trigger phrase, so requests like "run gateway IT tests" still match — no behavioral change.

## User stories

N/A — internal developer tooling (agent skill) rename.

## Documentation

N/A — the change is to a developer-facing agent skill; the skill's own `SKILL.md` is updated in place.

## Automation tests
 - Unit tests
   > N/A — documentation/skill-metadata change only, no code.
 - Integration tests
   > N/A — no runtime behavior changes. Validated the rename statically: directory ↔ `name:` match, valid frontmatter, all `[[..]]` cross-references resolve, and no stale `gateway-it-tests` identifier remains anywhere in the repo.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no code changed (Markdown skill files only)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

- #2014 — original PR that added the `gateway-debug` and `gateway-it-tests` skills (this PR renames the latter).

## Test environment

N/A — documentation-only change; no JDK/OS/DB/browser dependency.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)