### PR TITLE
Add seperate configs for forwarding req and res payloads for analytics

### DIFF
--- a/event-gateway/gateway-runtime/configs/config.toml
+++ b/event-gateway/gateway-runtime/configs/config.toml
@@ -66,8 +66,12 @@ format = "text"
 [analytics]
 # Set to true to enable the analytics system policy on every chain.
 enabled = false
-# Set to true to include request/response payloads in analytics events.
-allow_payloads = false
+# Deprecated: allow_payloads is preserved for backward compatibility. When true
+# and when send_request_body/send_response_body are not explicitly set, both
+# request and response bodies will be included in analytics events.
+# allow_payloads = false
+send_request_body = false
+send_response_body = false
 
 # runtime_id is auto-generated if left empty
 # runtime_id = ""

--- a/event-gateway/gateway-runtime/configs/config.toml
+++ b/event-gateway/gateway-runtime/configs/config.toml
@@ -67,8 +67,9 @@ format = "text"
 # Set to true to enable the analytics system policy on every chain.
 enabled = false
 # Deprecated: allow_payloads is preserved for backward compatibility. When true
-# and when send_request_body/send_response_body are not explicitly set, both
-# request and response bodies will be included in analytics events.
+# and both send_request_body and send_response_body are false, both directions
+# are enabled (bool fields cannot distinguish "unset" from explicitly false).
+# To disable payloads entirely, set allow_payloads = false or remove it.
 # allow_payloads = false
 send_request_body = false
 send_response_body = false

--- a/gateway/configs/config-template.toml
+++ b/gateway/configs/config-template.toml
@@ -263,8 +263,10 @@ host = "localhost"
 [analytics]
 enabled = false
 # Deprecated: allow_payloads is preserved for backward compatibility. When true
-# and when send_request_body/send_response_body are not explicitly set, both
-# request and response bodies will be captured.
+# and both send_request_body and send_response_body are false, both directions
+# are enabled (bool fields cannot distinguish "unset" from explicitly false).
+# To disable payloads entirely, set allow_payloads = false or remove it; do not
+# rely on send_*_body = false while allow_payloads remains true.
 allow_payloads = false
 send_request_body = false
 send_response_body = false

--- a/gateway/configs/config-template.toml
+++ b/gateway/configs/config-template.toml
@@ -262,7 +262,12 @@ host = "localhost"
 # =============================================================================
 [analytics]
 enabled = false
+# Deprecated: allow_payloads is preserved for backward compatibility. When true
+# and when send_request_body/send_response_body are not explicitly set, both
+# request and response bodies will be captured.
 allow_payloads = false
+send_request_body = false
+send_response_body = false
 enabled_publishers = ["moesif"]
 
 [analytics.publishers.moesif]

--- a/gateway/configs/config.toml
+++ b/gateway/configs/config.toml
@@ -4,7 +4,7 @@ enabled = true
 # Deprecated: allow_payloads is preserved for backward compatibility. When true
 # and when send_request_body/send_response_body are not explicitly set, both
 # request and response bodies will be included in analytics events.
-# allow_payloads = false
+# allow_payloads = true
 send_request_body = false
 send_response_body = false
 enabled_publishers = ["moesif"]

--- a/gateway/configs/config.toml
+++ b/gateway/configs/config.toml
@@ -1,7 +1,12 @@
 
 [analytics]
 enabled = true
-allow_payloads = false
+# Deprecated: allow_payloads is preserved for backward compatibility. When true
+# and when send_request_body/send_response_body are not explicitly set, both
+# request and response bodies will be included in analytics events.
+# allow_payloads = false
+send_request_body = false
+send_response_body = false
 enabled_publishers = ["moesif"]
 
 [analytics.publishers.moesif]

--- a/gateway/gateway-controller/pkg/config/config.go
+++ b/gateway/gateway-controller/pkg/config/config.go
@@ -20,6 +20,7 @@ package config
 
 import (
 	"fmt"
+	"log/slog"
 	"net/url"
 	"strings"
 	"time"
@@ -63,7 +64,10 @@ type AnalyticsConfig struct {
 	GRPCEventServerCfg GRPCEventServerConfig     `koanf:"grpc_event_server"`
 	// AllowPayloads controls whether request and response bodies are captured
 	// into analytics metadata and forwarded to analytics publishers.
-	AllowPayloads bool `koanf:"allow_payloads"`
+	// Deprecated: use SendRequestBody and SendResponseBody instead.
+	AllowPayloads   bool `koanf:"allow_payloads"`
+	SendRequestBody bool `koanf:"send_request_body"`
+	SendResponseBody bool `koanf:"send_response_body"`
 }
 
 // SubscriptionsConfig holds configuration for application-level subscriptions.
@@ -767,7 +771,9 @@ func defaultConfig() *Config {
 				MaxMessageSize:      1000000000,
 				MaxHeaderLimit:      8192,
 			},
-			AllowPayloads: false,
+			AllowPayloads:    false,
+			SendRequestBody:  false,
+			SendResponseBody: false,
 		},
 		TracingConfig: TracingConfig{
 			Enabled:        false,
@@ -1439,6 +1445,15 @@ func validateDomains(field string, domains []string) error {
 func (c *Config) validateAnalyticsConfig() error {
 	// Validate analytics configuration
 	if c.Analytics.Enabled {
+		// Migration path for deprecated analytics.allow_payloads.
+		if c.Analytics.AllowPayloads {
+			slog.Warn("analytics.allow_payloads is deprecated; use analytics.send_request_body and analytics.send_response_body instead")
+			if !c.Analytics.SendRequestBody && !c.Analytics.SendResponseBody {
+				c.Analytics.SendRequestBody = true
+				c.Analytics.SendResponseBody = true
+			}
+		}
+
 		// Validate gRPC event server configuration
 		grpcEventServerCfg := c.Analytics.GRPCEventServerCfg
 

--- a/gateway/gateway-controller/pkg/config/config.go
+++ b/gateway/gateway-controller/pkg/config/config.go
@@ -65,8 +65,12 @@ type AnalyticsConfig struct {
 	// AllowPayloads controls whether request and response bodies are captured
 	// into analytics metadata and forwarded to analytics publishers.
 	// Deprecated: use SendRequestBody and SendResponseBody instead.
-	AllowPayloads   bool `koanf:"allow_payloads"`
-	SendRequestBody bool `koanf:"send_request_body"`
+	// When true, validateAnalyticsConfig maps both SendRequestBody and SendResponseBody
+	// to true if both are false. Because bools cannot represent "unset", this also
+	// applies when both new flags are explicitly false; remove allow_payloads when
+	// migrating and set the directional flags directly.
+	AllowPayloads    bool `koanf:"allow_payloads"`
+	SendRequestBody  bool `koanf:"send_request_body"`
 	SendResponseBody bool `koanf:"send_response_body"`
 }
 
@@ -1446,6 +1450,8 @@ func (c *Config) validateAnalyticsConfig() error {
 	// Validate analytics configuration
 	if c.Analytics.Enabled {
 		// Migration path for deprecated analytics.allow_payloads.
+		// Runs when both directional flags are false, which is indistinguishable
+		// from "not set" because bool fields cannot represent unset vs explicit false.
 		if c.Analytics.AllowPayloads {
 			slog.Warn("analytics.allow_payloads is deprecated; use analytics.send_request_body and analytics.send_response_body instead")
 			if !c.Analytics.SendRequestBody && !c.Analytics.SendResponseBody {

--- a/gateway/gateway-controller/pkg/config/config_test.go
+++ b/gateway/gateway-controller/pkg/config/config_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	commonconstants "github.com/wso2/api-platform/common/constants"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/constants"
 )
@@ -1157,6 +1158,74 @@ func TestConfig_ValidateAnalyticsConfig(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestConfig_ValidateAnalyticsPayloadMigration(t *testing.T) {
+	setValidAnalyticsGRPC := func(cfg *Config) {
+		cfg.Analytics.Enabled = true
+		cfg.Analytics.GRPCEventServerCfg.Mode = "uds"
+		cfg.Analytics.GRPCEventServerCfg.BufferFlushInterval = 1000
+		cfg.Analytics.GRPCEventServerCfg.BufferSizeBytes = 16384
+		cfg.Analytics.GRPCEventServerCfg.GRPCRequestTimeout = 5000
+		cfg.Analytics.GRPCEventServerCfg.ServerPort = 18090
+	}
+
+	tests := []struct {
+		name             string
+		allowPayloads    bool
+		sendRequestBody  bool
+		sendResponseBody bool
+		wantSendReq      bool
+		wantSendResp     bool
+	}{
+		{
+			name:             "legacy allow_payloads enables both when new flags false",
+			allowPayloads:    true,
+			sendRequestBody:  false,
+			sendResponseBody: false,
+			wantSendReq:      true,
+			wantSendResp:     true,
+		},
+		{
+			name:             "new flags win when at least one is true",
+			allowPayloads:    true,
+			sendRequestBody:  true,
+			sendResponseBody: false,
+			wantSendReq:      true,
+			wantSendResp:     false,
+		},
+		{
+			name:             "no migration when allow_payloads false",
+			allowPayloads:    false,
+			sendRequestBody:  false,
+			sendResponseBody: false,
+			wantSendReq:      false,
+			wantSendResp:     false,
+		},
+		{
+			name:             "new flags only without legacy",
+			allowPayloads:    false,
+			sendRequestBody:  true,
+			sendResponseBody: false,
+			wantSendReq:      true,
+			wantSendResp:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfig()
+			setValidAnalyticsGRPC(cfg)
+			cfg.Analytics.AllowPayloads = tt.allowPayloads
+			cfg.Analytics.SendRequestBody = tt.sendRequestBody
+			cfg.Analytics.SendResponseBody = tt.sendResponseBody
+
+			err := cfg.Validate()
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantSendReq, cfg.Analytics.SendRequestBody)
+			assert.Equal(t, tt.wantSendResp, cfg.Analytics.SendResponseBody)
 		})
 	}
 }

--- a/gateway/gateway-controller/pkg/utils/system_policies.go
+++ b/gateway/gateway-controller/pkg/utils/system_policies.go
@@ -89,7 +89,8 @@ var defaultSystemPolicies = []systemPolicyConfig{
 		},
 		// Default parameters (can be overridden via additionalProps)
 		Parameters: map[string]interface{}{
-			"allow_payloads": false,
+			"send_request_body":  false,
+			"send_response_body": false,
 		},
 		ExecutionCondition: nil,
 	},
@@ -196,9 +197,10 @@ func InjectSystemPolicies(policies []policyenginev1.PolicyInstance, cfg *config.
 			for k, v := range sysPol.Parameters {
 				effectiveDefaults[k] = v
 			}
-			// For the analytics system policy, propagate the allow_payloads flag from runtime config.
+			// For the analytics system policy, propagate the payload flags from runtime config.
 			if sysPol.Name == constants.ANALYTICS_SYSTEM_POLICY_NAME {
-				effectiveDefaults["allow_payloads"] = cfg.Analytics.AllowPayloads
+				effectiveDefaults["send_request_body"] = cfg.Analytics.SendRequestBody
+				effectiveDefaults["send_response_body"] = cfg.Analytics.SendResponseBody
 			}
 
 			// Merge parameters efficiently

--- a/gateway/gateway-controller/pkg/utils/system_policies_test.go
+++ b/gateway/gateway-controller/pkg/utils/system_policies_test.go
@@ -142,8 +142,7 @@ func TestInjectSystemPolicies_AnalyticsDisabled(t *testing.T) {
 func TestInjectSystemPolicies_AnalyticsEnabled(t *testing.T) {
 	cfg := &config.Config{
 		Analytics: config.AnalyticsConfig{
-			Enabled:       true,
-			AllowPayloads: false,
+			Enabled: true,
 		},
 	}
 	policies := []policyenginev1.PolicyInstance{
@@ -163,28 +162,32 @@ func TestInjectSystemPolicies_AnalyticsEnabled(t *testing.T) {
 func TestInjectSystemPolicies_AllowPayloadsTrue(t *testing.T) {
 	cfg := &config.Config{
 		Analytics: config.AnalyticsConfig{
-			Enabled:       true,
-			AllowPayloads: true,
+			Enabled:         true,
+			SendRequestBody: true,
+			SendResponseBody: true,
 		},
 	}
 
 	result := InjectSystemPolicies(nil, cfg, nil)
 	assert.Len(t, result, 1)
 	assert.Equal(t, constants.ANALYTICS_SYSTEM_POLICY_NAME, result[0].Name)
-	assert.Equal(t, true, result[0].Parameters["allow_payloads"])
+	assert.Equal(t, true, result[0].Parameters["send_request_body"])
+	assert.Equal(t, true, result[0].Parameters["send_response_body"])
 }
 
 func TestInjectSystemPolicies_AllowPayloadsFalse(t *testing.T) {
 	cfg := &config.Config{
 		Analytics: config.AnalyticsConfig{
-			Enabled:       true,
-			AllowPayloads: false,
+			Enabled:         true,
+			SendRequestBody: false,
+			SendResponseBody: false,
 		},
 	}
 
 	result := InjectSystemPolicies(nil, cfg, nil)
 	assert.Len(t, result, 1)
-	assert.Equal(t, false, result[0].Parameters["allow_payloads"])
+	assert.Equal(t, false, result[0].Parameters["send_request_body"])
+	assert.Equal(t, false, result[0].Parameters["send_response_body"])
 }
 
 func TestInjectSystemPolicies_WithAdditionalProps(t *testing.T) {

--- a/gateway/gateway-runtime/policy-engine/internal/analytics/analytics.go
+++ b/gateway/gateway-runtime/policy-engine/internal/analytics/analytics.go
@@ -435,18 +435,13 @@ func (c *Analytics) prepareAnalyticEvent(logEntry *v3.HTTPAccessLogEntry) *dto.E
 	}
 
 	// Optionally attach request and response payloads when enabled via configuration.
-	sendReq := c.cfg.Analytics.SendRequestBody
-	sendResp := c.cfg.Analytics.SendResponseBody
-	if c.cfg.Analytics.AllowPayloads && !sendReq && !sendResp {
-		sendReq, sendResp = true, true
-	}
-	if sendReq {
+	if c.cfg.Analytics.SendRequestBody {
 		if requestPayload, ok := keyValuePairsFromMetadata["request_payload"]; ok && requestPayload != "" {
 			event.Properties["request_payload"] = requestPayload
 			slog.Debug("Analytics request payload captured", "size_bytes", len(requestPayload))
 		}
 	}
-	if sendResp {
+	if c.cfg.Analytics.SendResponseBody {
 		if responsePayload, ok := keyValuePairsFromMetadata["response_payload"]; ok && responsePayload != "" {
 			event.Properties["response_payload"] = responsePayload
 			slog.Debug("Analytics response payload captured", "size_bytes", len(responsePayload))

--- a/gateway/gateway-runtime/policy-engine/internal/analytics/analytics.go
+++ b/gateway/gateway-runtime/policy-engine/internal/analytics/analytics.go
@@ -435,11 +435,18 @@ func (c *Analytics) prepareAnalyticEvent(logEntry *v3.HTTPAccessLogEntry) *dto.E
 	}
 
 	// Optionally attach request and response payloads when enabled via configuration.
-	if c.cfg.Analytics.AllowPayloads {
+	sendReq := c.cfg.Analytics.SendRequestBody
+	sendResp := c.cfg.Analytics.SendResponseBody
+	if c.cfg.Analytics.AllowPayloads && !sendReq && !sendResp {
+		sendReq, sendResp = true, true
+	}
+	if sendReq {
 		if requestPayload, ok := keyValuePairsFromMetadata["request_payload"]; ok && requestPayload != "" {
 			event.Properties["request_payload"] = requestPayload
 			slog.Debug("Analytics request payload captured", "size_bytes", len(requestPayload))
 		}
+	}
+	if sendResp {
 		if responsePayload, ok := keyValuePairsFromMetadata["response_payload"]; ok && responsePayload != "" {
 			event.Properties["response_payload"] = responsePayload
 			slog.Debug("Analytics response payload captured", "size_bytes", len(responsePayload))

--- a/gateway/gateway-runtime/policy-engine/internal/analytics/analytics_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/analytics/analytics_test.go
@@ -496,7 +496,8 @@ func TestPrepareAnalyticEvent_WithRequestResponseHeaders(t *testing.T) {
 func TestPrepareAnalyticEvent_WithPayloadsEnabled(t *testing.T) {
 	cfg := &config.Config{
 		Analytics: config.AnalyticsConfig{
-			AllowPayloads: true,
+			SendRequestBody:  true,
+			SendResponseBody: true,
 		},
 	}
 	analytics := NewAnalytics(cfg)
@@ -521,7 +522,8 @@ func TestPrepareAnalyticEvent_WithPayloadsEnabled(t *testing.T) {
 func TestPrepareAnalyticEvent_WithPayloadsDisabled(t *testing.T) {
 	cfg := &config.Config{
 		Analytics: config.AnalyticsConfig{
-			AllowPayloads: false,
+			SendRequestBody:  false,
+			SendResponseBody: false,
 		},
 	}
 	analytics := NewAnalytics(cfg)
@@ -534,8 +536,106 @@ func TestPrepareAnalyticEvent_WithPayloadsDisabled(t *testing.T) {
 	event := analytics.prepareAnalyticEvent(logEntry)
 
 	require.NotNil(t, event)
-	// Payloads should not be included when disabled
 	_, ok := event.Properties["request_payload"]
+	assert.False(t, ok)
+	_, ok = event.Properties["response_payload"]
+	assert.False(t, ok)
+}
+
+func TestPrepareAnalyticEvent_RequestPayloadOnly(t *testing.T) {
+	cfg := &config.Config{
+		Analytics: config.AnalyticsConfig{
+			SendRequestBody:  true,
+			SendResponseBody: false,
+		},
+	}
+	analytics := NewAnalytics(cfg)
+
+	logEntry := createLogEntryWithMetadata(map[string]string{
+		"request_payload":  `{"key": "value"}`,
+		"response_payload": `{"result": "ok"}`,
+	})
+
+	event := analytics.prepareAnalyticEvent(logEntry)
+
+	require.NotNil(t, event)
+	reqPayload, ok := event.Properties["request_payload"]
+	require.True(t, ok)
+	assert.Equal(t, `{"key": "value"}`, reqPayload)
+	_, ok = event.Properties["response_payload"]
+	assert.False(t, ok)
+}
+
+func TestPrepareAnalyticEvent_ResponsePayloadOnly(t *testing.T) {
+	cfg := &config.Config{
+		Analytics: config.AnalyticsConfig{
+			SendRequestBody:  false,
+			SendResponseBody: true,
+		},
+	}
+	analytics := NewAnalytics(cfg)
+
+	logEntry := createLogEntryWithMetadata(map[string]string{
+		"request_payload":  `{"key": "value"}`,
+		"response_payload": `{"result": "ok"}`,
+	})
+
+	event := analytics.prepareAnalyticEvent(logEntry)
+
+	require.NotNil(t, event)
+	_, ok := event.Properties["request_payload"]
+	assert.False(t, ok)
+	respPayload, ok := event.Properties["response_payload"]
+	require.True(t, ok)
+	assert.Equal(t, `{"result": "ok"}`, respPayload)
+}
+
+func TestPrepareAnalyticEvent_LegacyAllowPayloadsFallback(t *testing.T) {
+	cfg := &config.Config{
+		Analytics: config.AnalyticsConfig{
+			AllowPayloads: true,
+		},
+	}
+	analytics := NewAnalytics(cfg)
+
+	logEntry := createLogEntryWithMetadata(map[string]string{
+		"request_payload":  `{"key": "value"}`,
+		"response_payload": `{"result": "ok"}`,
+	})
+
+	event := analytics.prepareAnalyticEvent(logEntry)
+
+	require.NotNil(t, event)
+	reqPayload, ok := event.Properties["request_payload"]
+	require.True(t, ok)
+	assert.Equal(t, `{"key": "value"}`, reqPayload)
+	respPayload, ok := event.Properties["response_payload"]
+	require.True(t, ok)
+	assert.Equal(t, `{"result": "ok"}`, respPayload)
+}
+
+func TestPrepareAnalyticEvent_NewFlagsOverrideLegacyAllowPayloads(t *testing.T) {
+	cfg := &config.Config{
+		Analytics: config.AnalyticsConfig{
+			AllowPayloads:    true,
+			SendRequestBody:  true,
+			SendResponseBody: false,
+		},
+	}
+	analytics := NewAnalytics(cfg)
+
+	logEntry := createLogEntryWithMetadata(map[string]string{
+		"request_payload":  `{"key": "value"}`,
+		"response_payload": `{"result": "ok"}`,
+	})
+
+	event := analytics.prepareAnalyticEvent(logEntry)
+
+	require.NotNil(t, event)
+	reqPayload, ok := event.Properties["request_payload"]
+	require.True(t, ok)
+	assert.Equal(t, `{"key": "value"}`, reqPayload)
+	_, ok = event.Properties["response_payload"]
 	assert.False(t, ok)
 }
 

--- a/gateway/gateway-runtime/policy-engine/internal/analytics/analytics_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/analytics/analytics_test.go
@@ -19,6 +19,7 @@ package analytics
 
 import (
 	"testing"
+	"time"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	v3 "github.com/envoyproxy/go-control-plane/envoy/data/accesslog/v3"
@@ -41,6 +42,35 @@ type mockPublisher struct {
 func (m *mockPublisher) Publish(event *dto.Event) {
 	m.called = true
 	m.event = event
+}
+
+func validAnalyticsConfigForValidation(analytics config.AnalyticsConfig) *config.Config {
+	cfg := &config.Config{
+		PolicyEngine: config.PolicyEngine{
+			Server: config.ServerConfig{ExtProcPort: 9001},
+			Admin: config.AdminConfig{
+				Enabled:    true,
+				Port:       9002,
+				AllowedIPs: []string{"127.0.0.1"},
+			},
+			ConfigMode: config.ConfigModeConfig{Mode: "file"},
+			FileConfig: config.FileConfigConfig{Path: "configs/policy-chains.yaml"},
+			Logging:    config.LoggingConfig{Level: "info", Format: "json"},
+			PythonExecutor: config.PythonExecutorConfig{
+				Server:  config.PythonExecutorServerConfig{Port: 9010, Host: "localhost"},
+				Timeout: 30 * time.Second,
+			},
+		},
+		Analytics: analytics,
+	}
+	cfg.Analytics.Enabled = true
+	cfg.Analytics.AccessLogsServiceCfg = config.AccessLogsServiceConfig{
+		Mode:                  "uds",
+		ShutdownTimeout:       600 * time.Second,
+		ExtProcMaxMessageSize: 1000000,
+		ExtProcMaxHeaderLimit: 8192,
+	}
+	return cfg
 }
 
 // =============================================================================
@@ -591,11 +621,11 @@ func TestPrepareAnalyticEvent_ResponsePayloadOnly(t *testing.T) {
 }
 
 func TestPrepareAnalyticEvent_LegacyAllowPayloadsFallback(t *testing.T) {
-	cfg := &config.Config{
-		Analytics: config.AnalyticsConfig{
-			AllowPayloads: true,
-		},
-	}
+	cfg := validAnalyticsConfigForValidation(config.AnalyticsConfig{
+		AllowPayloads: true,
+	})
+	require.NoError(t, cfg.Validate())
+
 	analytics := NewAnalytics(cfg)
 
 	logEntry := createLogEntryWithMetadata(map[string]string{
@@ -614,14 +644,36 @@ func TestPrepareAnalyticEvent_LegacyAllowPayloadsFallback(t *testing.T) {
 	assert.Equal(t, `{"result": "ok"}`, respPayload)
 }
 
-func TestPrepareAnalyticEvent_NewFlagsOverrideLegacyAllowPayloads(t *testing.T) {
+func TestPrepareAnalyticEvent_AllowPayloadsWithoutValidationDoesNotCapture(t *testing.T) {
 	cfg := &config.Config{
 		Analytics: config.AnalyticsConfig{
-			AllowPayloads:    true,
-			SendRequestBody:  true,
-			SendResponseBody: false,
+			AllowPayloads: true,
 		},
 	}
+	analytics := NewAnalytics(cfg)
+
+	logEntry := createLogEntryWithMetadata(map[string]string{
+		"request_payload":  `{"key": "value"}`,
+		"response_payload": `{"result": "ok"}`,
+	})
+
+	event := analytics.prepareAnalyticEvent(logEntry)
+
+	require.NotNil(t, event)
+	_, ok := event.Properties["request_payload"]
+	assert.False(t, ok)
+	_, ok = event.Properties["response_payload"]
+	assert.False(t, ok)
+}
+
+func TestPrepareAnalyticEvent_NewFlagsOverrideLegacyAllowPayloads(t *testing.T) {
+	cfg := validAnalyticsConfigForValidation(config.AnalyticsConfig{
+		AllowPayloads:    true,
+		SendRequestBody:  true,
+		SendResponseBody: false,
+	})
+	require.NoError(t, cfg.Validate())
+
 	analytics := NewAnalytics(cfg)
 
 	logEntry := createLogEntryWithMetadata(map[string]string{

--- a/gateway/gateway-runtime/policy-engine/internal/config/config.go
+++ b/gateway/gateway-runtime/policy-engine/internal/config/config.go
@@ -20,6 +20,7 @@ package config
 
 import (
 	"fmt"
+	"log/slog"
 	"math"
 	"net/url"
 	"strings"
@@ -54,7 +55,10 @@ type AnalyticsConfig struct {
 	AccessLogsServiceCfg AccessLogsServiceConfig   `koanf:"access_logs_service"`
 	// AllowPayloads controls whether request and response bodies are captured
 	// into analytics metadata and forwarded to analytics publishers.
-	AllowPayloads bool `koanf:"allow_payloads"`
+	// Deprecated: use SendRequestBody and SendResponseBody instead.
+	AllowPayloads   bool `koanf:"allow_payloads"`
+	SendRequestBody bool `koanf:"send_request_body"`
+	SendResponseBody bool `koanf:"send_response_body"`
 }
 
 // AnalyticsPublishersConfig holds configuration for all analytics publishers
@@ -371,7 +375,9 @@ func defaultConfig() *Config {
 				ExtProcMaxMessageSize: 1000000000,
 				ExtProcMaxHeaderLimit: 8192,
 			},
-			AllowPayloads: false,
+			AllowPayloads:    false,
+			SendRequestBody:  false,
+			SendResponseBody: false,
 		},
 		TracingConfig: TracingConfig{
 			Enabled:            false,
@@ -530,6 +536,15 @@ func (c *Config) validateXDSConfig() error {
 func (c *Config) validateAnalyticsConfig() error {
 	// Validate analytics configuration
 	if c.Analytics.Enabled {
+		// Migration path for deprecated analytics.allow_payloads.
+		if c.Analytics.AllowPayloads {
+			slog.Warn("analytics.allow_payloads is deprecated; use analytics.send_request_body and analytics.send_response_body instead")
+			if !c.Analytics.SendRequestBody && !c.Analytics.SendResponseBody {
+				c.Analytics.SendRequestBody = true
+				c.Analytics.SendResponseBody = true
+			}
+		}
+
 		// Validate ALS server config (policy-engine side)
 		als := c.Analytics.AccessLogsServiceCfg
 

--- a/gateway/gateway-runtime/policy-engine/internal/config/config.go
+++ b/gateway/gateway-runtime/policy-engine/internal/config/config.go
@@ -56,8 +56,12 @@ type AnalyticsConfig struct {
 	// AllowPayloads controls whether request and response bodies are captured
 	// into analytics metadata and forwarded to analytics publishers.
 	// Deprecated: use SendRequestBody and SendResponseBody instead.
-	AllowPayloads   bool `koanf:"allow_payloads"`
-	SendRequestBody bool `koanf:"send_request_body"`
+	// When true, validateAnalyticsConfig maps both SendRequestBody and SendResponseBody
+	// to true if both are false. Because bools cannot represent "unset", this also
+	// applies when both new flags are explicitly false; remove allow_payloads when
+	// migrating and set the directional flags directly.
+	AllowPayloads    bool `koanf:"allow_payloads"`
+	SendRequestBody  bool `koanf:"send_request_body"`
 	SendResponseBody bool `koanf:"send_response_body"`
 }
 
@@ -537,6 +541,8 @@ func (c *Config) validateAnalyticsConfig() error {
 	// Validate analytics configuration
 	if c.Analytics.Enabled {
 		// Migration path for deprecated analytics.allow_payloads.
+		// Runs when both directional flags are false, which is indistinguishable
+		// from "not set" because bool fields cannot represent unset vs explicit false.
 		if c.Analytics.AllowPayloads {
 			slog.Warn("analytics.allow_payloads is deprecated; use analytics.send_request_body and analytics.send_response_body instead")
 			if !c.Analytics.SendRequestBody && !c.Analytics.SendResponseBody {

--- a/gateway/gateway-runtime/policy-engine/internal/config/config_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/config/config_test.go
@@ -1097,6 +1097,75 @@ func TestValidate_AnalyticsConfig(t *testing.T) {
 	}
 }
 
+func TestValidate_AnalyticsPayloadMigration(t *testing.T) {
+	setValidAnalyticsALS := func(cfg *Config) {
+		cfg.Analytics.Enabled = true
+		cfg.Analytics.AccessLogsServiceCfg = AccessLogsServiceConfig{
+			Mode:                  "uds",
+			ShutdownTimeout:       600 * time.Second,
+			ExtProcMaxMessageSize: 1000000,
+			ExtProcMaxHeaderLimit: 8192,
+		}
+	}
+
+	tests := []struct {
+		name             string
+		allowPayloads    bool
+		sendRequestBody  bool
+		sendResponseBody bool
+		wantSendReq      bool
+		wantSendResp     bool
+	}{
+		{
+			name:             "legacy allow_payloads enables both when new flags false",
+			allowPayloads:    true,
+			sendRequestBody:  false,
+			sendResponseBody: false,
+			wantSendReq:      true,
+			wantSendResp:     true,
+		},
+		{
+			name:             "new flags win when at least one is true",
+			allowPayloads:    true,
+			sendRequestBody:  true,
+			sendResponseBody: false,
+			wantSendReq:      true,
+			wantSendResp:     false,
+		},
+		{
+			name:             "no migration when allow_payloads false",
+			allowPayloads:    false,
+			sendRequestBody:  false,
+			sendResponseBody: false,
+			wantSendReq:      false,
+			wantSendResp:     false,
+		},
+		{
+			name:             "new flags only without legacy",
+			allowPayloads:    false,
+			sendRequestBody:  true,
+			sendResponseBody: false,
+			wantSendReq:      true,
+			wantSendResp:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfig()
+			setValidAnalyticsALS(cfg)
+			cfg.Analytics.AllowPayloads = tt.allowPayloads
+			cfg.Analytics.SendRequestBody = tt.sendRequestBody
+			cfg.Analytics.SendResponseBody = tt.sendResponseBody
+
+			err := cfg.Validate()
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantSendReq, cfg.Analytics.SendRequestBody)
+			assert.Equal(t, tt.wantSendResp, cfg.Analytics.SendResponseBody)
+		})
+	}
+}
+
 // TestValidate_AnalyticsPublishers tests analytics publisher validation
 func TestValidate_AnalyticsPublishers(t *testing.T) {
 	tests := []struct {

--- a/gateway/it/test-config.toml
+++ b/gateway/it/test-config.toml
@@ -113,6 +113,8 @@ pricing_file = "/home/wso2/conf/llm-pricing/model_prices.json"
 [analytics]
 enabled = true
 allow_payloads = false
+send_request_body = false
+send_response_body = false
 enabled_publishers = ["moesif"]
 
 [analytics.publishers.moesif]

--- a/gateway/it/test-config.vhosts-multi.toml
+++ b/gateway/it/test-config.vhosts-multi.toml
@@ -121,6 +121,8 @@ pricing_file = "/home/wso2/conf/llm-pricing/model_prices.json"
 [analytics]
 enabled = true
 allow_payloads = false
+send_request_body = false
+send_response_body = false
 enabled_publishers = ["moesif"]
 
 [analytics.publishers.moesif]

--- a/gateway/it/test-config.vhosts-single.toml
+++ b/gateway/it/test-config.vhosts-single.toml
@@ -119,6 +119,8 @@ pricing_file = "/home/wso2/conf/llm-pricing/model_prices.json"
 [analytics]
 enabled = true
 allow_payloads = false
+send_request_body = false
+send_response_body = false
 enabled_publishers = ["moesif"]
 
 [analytics.publishers.moesif]

--- a/gateway/system-policies/analytics/analytics.go
+++ b/gateway/system-policies/analytics/analytics.go
@@ -207,11 +207,11 @@ func (a *AnalyticsPolicy) OnResponseHeaders(_ context.Context, respCtx *policy.R
 // OnRequestBody performs Analytics collection process during the request phase (buffered).
 func (a *AnalyticsPolicy) OnRequestBody(_ context.Context, ctx *policy.RequestContext, params map[string]interface{}) policy.RequestAction {
 	slog.Debug("Analytics system policy: OnRequestBody called")
-	allowPayloads := getAllowPayloadsFlag(params)
+	sendReqBody, _ := getPayloadFlags(params)
 	analyticsMetadata := make(map[string]any)
 
-	// When allow_payloads is enabled, capture the raw request body into analytics metadata.
-	if allowPayloads && ctx != nil && ctx.Body != nil && len(ctx.Body.Content) > 0 {
+	// When request payload capture is enabled, capture the raw request body into analytics metadata.
+	if sendReqBody && ctx != nil && ctx.Body != nil && len(ctx.Body.Content) > 0 {
 		slog.Debug("Capturing request payload for analytics")
 		analyticsMetadata["request_payload"] = string(ctx.Body.Content)
 	}
@@ -288,7 +288,7 @@ func (a *AnalyticsPolicy) OnRequestBody(_ context.Context, ctx *policy.RequestCo
 // Called when the chain is in buffered mode (e.g. another policy does not support streaming).
 func (a *AnalyticsPolicy) OnResponseBody(_ context.Context, ctx *policy.ResponseContext, params map[string]interface{}) policy.ResponseAction {
 	slog.Debug("Analytics system policy: OnResponseBody called")
-	allowPayloads := getAllowPayloadsFlag(params)
+	_, sendRespBody := getPayloadFlags(params)
 
 	analyticsMetadata := make(map[string]any)
 
@@ -380,7 +380,7 @@ func (a *AnalyticsPolicy) OnResponseBody(_ context.Context, ctx *policy.Response
 		slog.Error("Invalid API kind")
 	}
 
-	if allowPayloads {
+	if sendRespBody {
 		if ctx != nil && ctx.ResponseBody != nil && len(ctx.ResponseBody.Content) > 0 {
 			slog.Debug("Capturing response payload for analytics")
 			analyticsMetadata["response_payload"] = string(ctx.ResponseBody.Content)
@@ -478,7 +478,8 @@ func (a *AnalyticsPolicy) OnResponseBodyChunk(_ context.Context, ctx *policy.Res
 		slog.Debug("Analytics streaming: unhandled API kind", "kind", apiKind)
 	}
 
-	if getAllowPayloadsFlag(params) && len(accumulated) > 0 {
+	_, sendRespBody := getPayloadFlags(params)
+	if sendRespBody && len(accumulated) > 0 {
 		analyticsMetadata["response_payload"] = string(accumulated)
 	}
 
@@ -873,24 +874,52 @@ func convertToInt64(value interface{}) (int64, error) {
 	}
 }
 
-// getAllowPayloadsFlag safely extracts the allow_payloads boolean from policy parameters.
-func getAllowPayloadsFlag(params map[string]interface{}) bool {
+// getPayloadFlags derives per-direction payload capture flags from policy parameters.
+// New parameters send_request_body and send_response_body take precedence. When neither
+// is provided, the deprecated allow_payloads flag is used as a fallback, mapping to
+// both directions for backward compatibility.
+func getPayloadFlags(params map[string]interface{}) (sendRequestBody, sendResponseBody bool) {
 	if params == nil {
-		return false
+		return false, false
 	}
-	raw, ok := params["allow_payloads"]
-	if !ok {
-		return false
+
+	parseBoolLike := func(v interface{}) bool {
+		switch val := v.(type) {
+		case bool:
+			return val
+		case string:
+			lower := strings.ToLower(strings.TrimSpace(val))
+			return lower == "true" || lower == "1" || lower == "yes"
+		default:
+			return false
+		}
 	}
-	switch v := raw.(type) {
-	case bool:
-		return v
-	case string:
-		lower := strings.ToLower(strings.TrimSpace(v))
-		return lower == "true" || lower == "1" || lower == "yes"
-	default:
-		return false
+
+	hasReq, hasResp := false, false
+
+	if raw, ok := params["send_request_body"]; ok {
+		sendRequestBody = parseBoolLike(raw)
+		hasReq = true
 	}
+	if raw, ok := params["send_response_body"]; ok {
+		sendResponseBody = parseBoolLike(raw)
+		hasResp = true
+	}
+
+	// If either of the new flags has been explicitly configured, do not consult
+	// the deprecated allow_payloads flag.
+	if hasReq || hasResp {
+		return sendRequestBody, sendResponseBody
+	}
+
+	// Backward compatibility: fall back to allow_payloads when new flags are absent.
+	if raw, ok := params["allow_payloads"]; ok {
+		if parseBoolLike(raw) {
+			return true, true
+		}
+	}
+
+	return false, false
 }
 
 // Helper to extract string values via JSONPath

--- a/gateway/system-policies/analytics/policy-definition.yaml
+++ b/gateway/system-policies/analytics/policy-definition.yaml
@@ -10,14 +10,33 @@ parameters:
   type: object
   additionalProperties: false
   properties:
+    send_request_body:
+      type: boolean
+      default: false
+      description: >
+        When true, the analytics system policy will capture the request body
+        into analytics metadata as request_payload, which is then forwarded
+        through the analytics pipeline (including publishers like Moesif).
+    send_response_body:
+      type: boolean
+      default: false
+      description: >
+        When true, the analytics system policy will capture the response body
+        into analytics metadata as response_payload, for both buffered and
+        streaming responses, which is then forwarded through the analytics
+        pipeline (including publishers like Moesif).
     allow_payloads:
       type: boolean
       default: false
       description: >
-        When true, the analytics system policy will capture request and response
-        bodies into analytics metadata as request_payload and response_payload,
-        which are then forwarded through the analytics pipeline (including
-        publishers like Moesif). When false, payloads are not captured.
+        Deprecated: use send_request_body and send_response_body instead.
+        When true, and when send_request_body and send_response_body are not
+        explicitly set, the analytics system policy behaves as if both
+        send_request_body and send_response_body are true, capturing request
+        and response bodies into analytics metadata as request_payload and
+        response_payload, which are then forwarded through the analytics
+        pipeline (including publishers like Moesif). When false, payloads are
+        not captured unless controlled by the newer flags.
 
 systemParameters:
   type: object


### PR DESCRIPTION
## Purpose
This change splits the single `analytics.allow_payloads` toggle into independent `analytics.send_request_body` and `analytics.send_response_body` flags (both defaulting to false), while keeping allow_payloads as a deprecated alias that maps to both new flags and emits a deprecation warning when used. 

- Fix for: https://github.com/wso2/api-platform/issues/2095
