### PR TITLE
fix(gateway-runtime): gracefully drain Router on shutdown

### DIFF
--- a/gateway/gateway-runtime/docker-entrypoint-debug.sh
+++ b/gateway/gateway-runtime/docker-entrypoint-debug.sh
@@ -89,6 +89,14 @@ export GOMAXPROCS="${GOMAXPROCS:-2}"
 export ROUTER_CONCURRENCY="${ROUTER_CONCURRENCY:-0}"
 export APIP_GW_POLICY_ENGINE_METRICS_ENABLED="${APIP_GW_POLICY_ENGINE_METRICS_ENABLED:-true}"
 
+# Graceful shutdown configuration (see docker-entrypoint.sh for details).
+# On SIGTERM the Router (Envoy) is drained before processes are terminated so in-flight
+# requests finish and keep-alive connections close cleanly instead of being reset.
+# Keep ROUTER_DRAIN_TIME_SECONDS < the pod terminationGracePeriodSeconds; 0 disables it.
+export ROUTER_ADMIN_HOST="${ROUTER_ADMIN_HOST:-127.0.0.1}"
+export ROUTER_ADMIN_PORT="${ROUTER_ADMIN_PORT:-9901}"
+export ROUTER_DRAIN_TIME_SECONDS="${ROUTER_DRAIN_TIME_SECONDS:-15}"
+
 # Derive Router (Envoy) xDS config — used by envsubst on config-override.yaml
 export XDS_SERVER_HOST="${GATEWAY_CONTROLLER_HOST}"
 export XDS_SERVER_PORT="${ROUTER_XDS_PORT}"
@@ -120,23 +128,53 @@ CONFIG_OVERRIDE=$(envsubst < /etc/envoy/config-override.yaml)
 PE_PID=""
 ENVOY_PID=""
 
-# Shutdown handler - gracefully terminate both processes
+# Gracefully drain the Router (Envoy) listeners via its admin API so in-flight requests
+# complete and keep-alive connections close cleanly (Connection: close) rather than being
+# reset. No curl/wget in the image, so use a bash /dev/tcp socket. Best-effort.
+drain_router() {
+    local host="${ROUTER_ADMIN_HOST}" port="${ROUTER_ADMIN_PORT}"
+    if ! { exec 3<>"/dev/tcp/${host}/${port}"; } 2>/dev/null; then
+        log "  WARN: Router admin ${host}:${port} unreachable; skipping graceful drain"
+        return 1
+    fi
+    printf 'POST /drain_listeners?graceful HTTP/1.1\r\nHost: %s\r\nConnection: close\r\n\r\n' "$host" >&3 2>/dev/null || true
+    while IFS= read -r -t 3 -u 3 _line 2>/dev/null; do :; done
+    exec 3<&- 3>&- 2>/dev/null || true
+    return 0
+}
+
+# SIGTERM a tracked process and wait for it to fully exit before returning.
+stop_proc() {
+    local pid_var="$1" label="$2" pid
+    pid="${!pid_var}"
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        log "Stopping ${label} (PID $pid)..."
+        kill -TERM "$pid" 2>/dev/null || true
+        wait "$pid" 2>/dev/null || true
+        log "${label} exited"
+    fi
+}
+
+# Shutdown handler - gracefully drain the Router, then terminate both processes
 shutdown() {
-    log "Received shutdown signal, terminating processes..."
+    log "Received shutdown signal..."
 
-    # Send SIGTERM to both processes
-    if [ -n "$PE_PID" ] && kill -0 "$PE_PID" 2>/dev/null; then
-        log "Stopping Policy Engine / dlv (PID $PE_PID)..."
-        kill -TERM "$PE_PID" 2>/dev/null || true
+    # Drain the Router first so in-flight requests finish and keep-alive connections are
+    # closed cleanly — prevents client-visible connection resets during rolling restarts.
+    if [ -n "$ENVOY_PID" ] && kill -0 "$ENVOY_PID" 2>/dev/null \
+       && [ "${ROUTER_DRAIN_TIME_SECONDS}" -gt 0 ] 2>/dev/null; then
+        log "Draining Router (Envoy); waiting up to ${ROUTER_DRAIN_TIME_SECONDS}s for in-flight requests..."
+        if drain_router; then
+            sleep "${ROUTER_DRAIN_TIME_SECONDS}"
+        fi
     fi
 
-    if [ -n "$ENVOY_PID" ] && kill -0 "$ENVOY_PID" 2>/dev/null; then
-        log "Stopping Envoy (PID $ENVOY_PID)..."
-        kill -TERM "$ENVOY_PID" 2>/dev/null || true
-    fi
-
-    # Wait for processes to exit
-    wait
+    # Terminate in dependency order: the Router (Envoy) exits first; once it is gone the
+    # Policy Engine exits. Each step waits for the process to fully exit before the next.
+    set +e
+    stop_proc ENVOY_PID "Router (Envoy)"
+    stop_proc PE_PID    "Policy Engine / dlv"
+    set -e
 
     # Cleanup socket
     rm -f "${POLICY_ENGINE_SOCKET}"

--- a/gateway/gateway-runtime/docker-entrypoint.sh
+++ b/gateway/gateway-runtime/docker-entrypoint.sh
@@ -115,6 +115,19 @@ export PYTHON_POLICY_WORKERS="${PYTHON_POLICY_WORKERS:-4}"
 export PYTHON_POLICY_MAX_CONCURRENT="${PYTHON_POLICY_MAX_CONCURRENT:-100}"
 export PYTHON_POLICY_TIMEOUT="${PYTHON_POLICY_TIMEOUT:-30}"
 
+# Graceful shutdown configuration
+# On SIGTERM the Router (Envoy) is drained before any process is terminated, so in-flight
+# requests complete and keep-alive connections are closed cleanly (Connection: close)
+# instead of being reset. This avoids connection-reset errors for clients during rolling
+# restarts / pod evictions.
+#   ROUTER_ADMIN_HOST/PORT    : Router (Envoy) admin endpoint used to trigger the drain
+#   ROUTER_DRAIN_TIME_SECONDS : how long to wait for in-flight requests to finish before
+#       terminating. Keep this LESS than the pod's terminationGracePeriodSeconds (k8s
+#       default 30s) or the container is SIGKILLed mid-drain. Set to 0 to disable draining.
+export ROUTER_ADMIN_HOST="${ROUTER_ADMIN_HOST:-127.0.0.1}"
+export ROUTER_ADMIN_PORT="${ROUTER_ADMIN_PORT:-9901}"
+export ROUTER_DRAIN_TIME_SECONDS="${ROUTER_DRAIN_TIME_SECONDS:-15}"
+
 # Derive Router (Envoy) xDS config — used by envsubst on config-override.yaml
 export XDS_SERVER_HOST="${GATEWAY_CONTROLLER_HOST}"
 export XDS_SERVER_PORT="${ROUTER_XDS_PORT}"
@@ -153,22 +166,56 @@ PY_PID=""
 PE_PID=""
 ENVOY_PID=""
 
-# Shutdown handler - gracefully terminate all processes
+# Gracefully drain the Router (Envoy) listeners via its admin API so in-flight requests
+# complete and keep-alive connections close cleanly (Connection: close) rather than being
+# reset. The runtime image has no curl/wget, so use a bash /dev/tcp socket to POST to the
+# admin endpoint. Best-effort: never blocks shutdown if the admin is unreachable.
+drain_router() {
+    local host="${ROUTER_ADMIN_HOST}" port="${ROUTER_ADMIN_PORT}"
+    if ! { exec 3<>"/dev/tcp/${host}/${port}"; } 2>/dev/null; then
+        log "  WARN: Router admin ${host}:${port} unreachable; skipping graceful drain"
+        return 1
+    fi
+    printf 'POST /drain_listeners?graceful HTTP/1.1\r\nHost: %s\r\nConnection: close\r\n\r\n' "$host" >&3 2>/dev/null || true
+    # Read/discard the response, bounded by a short read timeout so we never hang.
+    while IFS= read -r -t 3 -u 3 _line 2>/dev/null; do :; done
+    exec 3<&- 3>&- 2>/dev/null || true
+    return 0
+}
+
+# SIGTERM a tracked process and wait for it to fully exit before returning.
+stop_proc() {
+    local pid_var="$1" label="$2" pid
+    pid="${!pid_var}"
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        log "Stopping ${label} (PID $pid)..."
+        kill -TERM "$pid" 2>/dev/null || true
+        wait "$pid" 2>/dev/null || true
+        log "${label} exited"
+    fi
+}
+
+# Shutdown handler - gracefully drain the Router, then terminate all processes
 shutdown() {
-    log "Received shutdown signal, terminating processes..."
+    log "Received shutdown signal..."
 
-    # Send SIGTERM to all processes
-    for pid_var in PY_PID PE_PID ENVOY_PID; do
-        pid="${!pid_var}"
-        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
-            log "Stopping $pid_var (PID $pid)..."
-            kill -TERM "$pid" 2>/dev/null || true
+    # Drain the Router first so in-flight requests finish and keep-alive connections are
+    # closed cleanly — prevents client-visible connection resets during rolling restarts.
+    if [ -n "$ENVOY_PID" ] && kill -0 "$ENVOY_PID" 2>/dev/null \
+       && [ "${ROUTER_DRAIN_TIME_SECONDS}" -gt 0 ] 2>/dev/null; then
+        log "Draining Router (Envoy); waiting up to ${ROUTER_DRAIN_TIME_SECONDS}s for in-flight requests..."
+        if drain_router; then
+            sleep "${ROUTER_DRAIN_TIME_SECONDS}"
         fi
-    done
+    fi
 
-    # Wait for processes to exit
+    # Terminate in dependency order: the Router (Envoy) exits first; once it is gone the
+    # Policy Engine exits; once that is gone the Python Executor exits. Each step waits for
+    # the process to fully exit so a dependency is never killed while something still needs it.
     set +e
-    wait
+    stop_proc ENVOY_PID "Router (Envoy)"
+    stop_proc PE_PID    "Policy Engine"
+    stop_proc PY_PID    "Python Executor"
     set -e
 
     # Cleanup sockets


### PR DESCRIPTION
## Purpose

On `SIGTERM` (Kubernetes rolling restart, pod eviction, or scale-down) the gateway-runtime entrypoint forwarded the signal straight to Envoy, which exits its event loop immediately with no drain, so in-flight keep-alive connections on the terminating pod are reset and clients see connection errors (`NoHttpResponseException` / connection reset) for the duration of the rollout.
This was confirmed against the Envoy source (see the Envoy analysis under Approach): a plain `SIGTERM` never enters Envoy's drain manager — graceful draining is only triggered by the admin `POST /drain_listeners?graceful` endpoint, `POST /healthcheck/fail`, or the hot-restart RPC, and no other signal triggers it either.

Resolves #2121

## Goals

Make pod termination graceful so a rolling restart is zero-error: in-flight requests complete and keep-alive connections close cleanly (`Connection: close`) instead of being reset, with no client-visible failures.

## Approach

- On `SIGTERM`, the entrypoint now first drains the Router (Envoy) via the admin `POST /drain_listeners?graceful` endpoint before terminating anything.
- The admin call uses a bash `/dev/tcp` socket because the runtime image ships no `curl`/`wget`; it is best-effort and never blocks shutdown if the admin is unreachable.
- It then waits `ROUTER_DRAIN_TIME_SECONDS` (default `15`) for in-flight requests to finish, then terminates processes in dependency order **Router → Policy Engine → Python Executor**, each waiting for the previous to fully exit so a dependency is never killed while something still needs it.
- New env vars: `ROUTER_ADMIN_HOST` (default `127.0.0.1`), `ROUTER_ADMIN_PORT` (default `9901`), `ROUTER_DRAIN_TIME_SECONDS` (default `15`, set `0` to disable); keep the drain time below the pod `terminationGracePeriodSeconds` (k8s default `30s`) or the container is `SIGKILL`ed mid-drain.
- Applied to both `docker-entrypoint.sh` and `docker-entrypoint-debug.sh` (kept in sync).

**Envoy source analysis (why the admin drain is required):**
- `source/server/server.cc`: `SIGTERM`/`SIGINT` call `instance.shutdown()` → `dispatcher_->exit()`, which breaks the libevent loop immediately with no drain-manager involvement (Envoy logs "main dispatch loop exited" ~3 ms after `SIGTERM`).
- `DrainManager::startDrainSequence` is only reachable from the admin `/drain_listeners` handler, the hot-restart `kDrainListeners` RPC (a domain-socket message, not a signal), and LDS listener add/remove.
- `--drain-time-s` / `--drain-strategy` apply only to hot-restart / LDS drains and have no effect on plain `SIGTERM`.
- No signal triggers a graceful drain (`SIGUSR1` reopens access logs, `SIGHUP` is ignored, `SIGINT` is an immediate shutdown like `SIGTERM`).

## User stories

N/A

## Documentation

N/A — internal shutdown behaviour. The new env vars are documented inline in `docker-entrypoint.sh`.

## Automation tests

- Unit tests: N/A (shell entrypoint script).
- Integration tests: validated end-to-end on Kubernetes (Helm chart 1.1.3, gateway-runtime built with this change, 2 runtime replicas, a 1000-resource REST API with a `set-headers` response policy), under JMeter load (100 threads, ~3,800 TPS) while issuing `kubectl rollout restart` on the runtime Deployment.

Test results — rolling restart under load:

| Metric | stock runtime (no fix) | with this fix |
|---|---:|---:|
| Failed requests | **105 (0.023%)** — `NoHttpResponseException` connection resets | **0 (0.000%)** |
| Samples | 452,389 | 463,349 |
| Response codes | 200 + 105 conn-resets | all 200 |

With the fix, success stays at 100% throughout the rollout; the only cost is a slightly longer rollout (each pod drains ~15 s before exiting). No `503`/`404` and no dropped response headers in either case.

## Security checks

- Followed secure coding standards? **yes**
- Ran FindSecurityBugs plugin and verified report? **N/A** (shell script, no Java).
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Samples

N/A

## Related PRs

N/A

## Test environment

- Kubernetes: k3s `v1.33` (colima), 1 controller + 2 runtime replicas, capped resources.
- Envoy `1.37.1` (the version shipped in gateway-runtime).
- Load: Apache JMeter (100 threads, 1000 resources round-robin, keep-alive).