### PR TITLE
fix(helm): drop unused control-plane port from gateway charts

### DIFF
--- a/docs/gateway/kubernetes/kubernetes-standalone.md
+++ b/docs/gateway/kubernetes/kubernetes-standalone.md
@@ -69,8 +69,7 @@ helm install ap-gateway oci://ghcr.io/wso2/api-platform/helm-charts/gateway \
 
 ```bash
 helm install ap-gateway oci://ghcr.io/wso2/api-platform/helm-charts/gateway \
-  --set gateway.controller.controlPlane.host="platform.example.com" \
-  --set gateway.controller.controlPlane.port=8443 \
+  --set gateway.controller.controlPlane.host="platform.example.com:8443" \
   --set gateway.controller.controlPlane.token.value="your-token-here" \
   --set gateway.developmentMode=true
 ```

--- a/kubernetes/gateway-operator/config/gateway_values.yaml
+++ b/kubernetes/gateway-operator/config/gateway_values.yaml
@@ -182,8 +182,9 @@ gateway:
       expose:
         admin: false
     controlPlane:
-      host: host.docker.internal
-      port: 8443
+      # Control plane endpoint. Used directly as the HTTPS/WSS authority, so include
+      # a non-default port here (e.g. "host.docker.internal:8443"); 443 is assumed if omitted.
+      host: host.docker.internal:8443
       token:
         value: ""
         secretName: ""

--- a/kubernetes/helm/event-gateway-helm-chart/templates/event-gateway/controller/deployment.yaml
+++ b/kubernetes/helm/event-gateway-helm-chart/templates/event-gateway/controller/deployment.yaml
@@ -88,8 +88,6 @@ spec:
           env:
             - name: APIP_GW_CONTROLPLANE_HOST
               value: {{ $controller.controlPlane.host | quote }}
-            - name: APIP_GW_CONTROLPLANE_PORT
-              value: {{ printf "%d" (int $controller.controlPlane.port) | quote }}
             - name: APIP_GW_GATEWAY_REGISTRATION_TOKEN
               {{- if $controller.controlPlane.token.secretName }}
               valueFrom:

--- a/kubernetes/helm/event-gateway-helm-chart/values.yaml
+++ b/kubernetes/helm/event-gateway-helm-chart/values.yaml
@@ -184,8 +184,10 @@ eventGateway:
         metrics: 9091
 
     controlPlane:
-      host: ""  # Required for non-development installs; set to your control plane hostname/IP
-      port: 8443
+      # Control plane endpoint. Used directly as the HTTPS/WSS authority, so include a
+      # non-default port here (e.g. "host.docker.internal:8443"); 443 is assumed if omitted.
+      # Required for non-development installs; set to your control plane hostname/IP.
+      host: ""
       token:
         value: ""
         secretName: ""

--- a/kubernetes/helm/gateway-helm-chart/README.md
+++ b/kubernetes/helm/gateway-helm-chart/README.md
@@ -42,8 +42,7 @@ helm install ap-gateway .
 Install with custom control plane configuration:
 ```bash
 helm install ap-gateway . \
-  --set gateway.controller.controlPlane.host="host.docker.internal" \
-  --set gateway.controller.controlPlane.port=8443 \
+  --set gateway.controller.controlPlane.host="host.docker.internal:8443" \
   --set gateway.controller.controlPlane.token.value="your-token-here"
 ```
 
@@ -52,8 +51,7 @@ Install in a specific namespace:
 kubectl create namespace api-gateway
 helm install ap-gateway . \
   --namespace api-gateway \
-  --set gateway.controller.controlPlane.host="platform.example.com" \
-  --set gateway.controller.controlPlane.port=8443
+  --set gateway.controller.controlPlane.host="platform.example.com"
 ```
 
 Install with custom values file:

--- a/kubernetes/helm/gateway-helm-chart/templates/gateway/controller/deployment.yaml
+++ b/kubernetes/helm/gateway-helm-chart/templates/gateway/controller/deployment.yaml
@@ -78,8 +78,6 @@ spec:
           env:
             - name: APIP_GW_CONTROLPLANE_HOST
               value: {{ $controller.controlPlane.host | quote }}
-            - name: APIP_GW_CONTROLPLANE_PORT
-              value: {{ printf "%d" (int $controller.controlPlane.port) | quote }}
             - name: APIP_GW_GATEWAY_REGISTRATION_TOKEN
               {{- if $controller.controlPlane.token.secretName }}
               valueFrom:

--- a/kubernetes/helm/gateway-helm-chart/values.yaml
+++ b/kubernetes/helm/gateway-helm-chart/values.yaml
@@ -405,8 +405,9 @@ gateway:
       expose:
         admin: false
     controlPlane:
-      host: host.docker.internal
-      port: 8443
+      # Control plane endpoint. Used directly as the HTTPS/WSS authority, so include
+      # a non-default port here (e.g. "host.docker.internal:8443"); 443 is assumed if omitted.
+      host: host.docker.internal:8443
       token:
         value: ""
         secretName: ""

--- a/kubernetes/helm/operator-helm-chart/values.yaml
+++ b/kubernetes/helm/operator-helm-chart/values.yaml
@@ -425,8 +425,9 @@ gateway:
           expose:
             admin: false
         controlPlane:
-          host: host.docker.internal
-          port: 8443
+          # Control plane endpoint. Used directly as the HTTPS/WSS authority, so include
+          # a non-default port here (e.g. "host.docker.internal:8443"); 443 is assumed if omitted.
+          host: host.docker.internal:8443
           token:
             value: ""
             secretName: ""

--- a/kubernetes/helm/resources/apim-apigateway-restapi-operator-demo/01-gateway-values-configmap.yaml
+++ b/kubernetes/helm/resources/apim-apigateway-restapi-operator-demo/01-gateway-values-configmap.yaml
@@ -27,7 +27,6 @@ data:
       controller:
         controlPlane:
           host: host.docker.internal:9444
-          port: 443
           token:
             value: "xxx"
 

--- a/kubernetes/helm/resources/apim-gateway-api-operator-demo/01-gateway-values-configmap.yaml
+++ b/kubernetes/helm/resources/apim-gateway-api-operator-demo/01-gateway-values-configmap.yaml
@@ -27,7 +27,6 @@ data:
       controller:
         controlPlane:
           host: host.docker.internal:9444
-          port: 443
           token:
             value: "xxx"
 

--- a/kubernetes/helm/resources/apim-gateway-api-operator-demo/README.md
+++ b/kubernetes/helm/resources/apim-gateway-api-operator-demo/README.md
@@ -117,7 +117,7 @@ See [GATEWAY_API_IMPLEMENTATION_NOTES](../../../gateway-operator/docs/GATEWAY_AP
 | `Gateway` never Programmed | `kubectl describe gateway platform-gw-apim -n gateway-api-demo-apim`; operator logs; Helm chart/image pull; `GatewayClass` must match operator `managedGatewayClassNames`. |
 | Controller logs `control_plane_token_configured:false` | Ensure ConfigMap uses key `values.yaml` and path `gateway.controller.controlPlane.token.value` (camelCase `controlPlane`). Re-apply `01-gateway-values-configmap.yaml` and `02-gateway.yaml`. |
 | Controller logs `Control plane token not configured, skipping connection` | Verify merged Helm values and deployment env var `APIP_GW_GATEWAY_REGISTRATION_TOKEN` in `platform-gw-apim-gateway-controller`. |
-| APIM still unreachable | Verify `gateway.controller.controlPlane.host` and `port` values and network reachability from cluster/pods. |
+| APIM still unreachable | Verify the `gateway.controller.controlPlane.host` value (include the port, e.g. `apim:9444`) and network reachability from cluster/pods. |
 | Helm fails with `gateway.controller.encryptionKeys must be enabled when gateway.developmentMode is false` | Keep `gateway.developmentMode: true` for demo, or configure `gateway.controller.encryptionKeys` for production-like setups. |
 | `HTTPRoute` stuck, parent not accepted | Parent `Gateway` must be same namespace or `parentRefs` namespace set; registry only after Gateway sync succeeds. |
 | `RestApi` deploys to Kubernetes `Gateway` release instead of `APIGateway` | Ensure this `Gateway` has `gateway.api-platform.wso2.com/api-selector` annotation and `RestApi` labels use a different `gateway.api-platform.wso2.com/restapi-target` value in mixed demos. |


### PR DESCRIPTION
## Purpose

The gateway-controller has no separate control-plane port setting — it uses `controller.controlplane.host` directly as the HTTPS/WSS authority, and there is no `controlplane_port` environment-variable mapping in the controller config.
The Helm charts still rendered a `controlPlane.port` value into an `APIP_GW_CONTROLPLANE_PORT` env var that the controller never reads, so anyone setting it to reach a non-443 control plane was silently ignored.
This PR removes that dead knob and makes the charts consistent with how the controller is configured directly.

Resolves N/A

## Goals

- Remove the misleading `controlPlane.port` value and the inert `APIP_GW_CONTROLPLANE_PORT` env var from the gateway Helm charts.
- Make control-plane endpoint configuration consistent: the port is expressed as part of `controlPlane.host` (e.g. `apim:9443`), matching the operator CRD and direct controller config which are already host-only.

## Approach

- gateway-helm-chart and event-gateway-helm-chart: drop the `APIP_GW_CONTROLPLANE_PORT` env var and the `controlPlane.port` value; the host now carries the port.
- operator-helm-chart, operator `config/gateway_values.yaml`, and the operator demo ConfigMaps: remove the vestigial port from the values fed into the chart.
- Update the chart README and standalone docs to put the port in the host.

## User stories

N/A

## Documentation

Documentation updated in this PR: `kubernetes/helm/gateway-helm-chart/README.md`, `docs/gateway/kubernetes/kubernetes-standalone.md`, and the gateway-api operator demo README.
No external product-doc impact.

## Automation tests

 - Unit tests
   > N/A — the change touches Helm templates/values and docs only; no Go code changed, so code coverage is unaffected.
 - Integration tests
   > Validated with `helm lint` and `helm template` on both the gateway and event-gateway charts. The rendered controller Deployment emits only `APIP_GW_CONTROLPLANE_HOST` (plus the registration-token env), confirming the dead port env var is gone and the host carries the port.

## Security checks

 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no Java/Go code changed (Helm chart and docs only).
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

Configure the control-plane host with the port included in the host value (443 is assumed when the port is omitted).

gateway-helm-chart via a values file:

```yaml
gateway:
  controller:
    controlPlane:
      host: "apim.example.com:9443"   # host:port — 443 assumed if no port
      token:
        value: "<registration-token>"
```

gateway-helm-chart via `--set`:

```bash
helm install ap-gateway . \
  --set gateway.controller.controlPlane.host="apim.example.com:9443" \
  --set gateway.controller.controlPlane.token.value="<registration-token>"
```

Gateway Operator (`ApiGateway` CRD) — the same host:port convention:

```yaml
apiVersion: gateway.api-platform.wso2.com/v1alpha1
kind: ApiGateway
metadata:
  name: my-gateway
spec:
  controlPlane:
    host: "apim.example.com:9443"
```

## Related PRs

N/A

## Test environment

- Helm v3.18.3
- macOS (darwin)