### PR TITLE
docs(skills): replace "IT test(s)" with "Integration Test(s)"

### DIFF
--- a/.agents/skills/gateway-debug/SKILL.md
+++ b/.agents/skills/gateway-debug/SKILL.md
@@ -31,7 +31,7 @@ Envoy itself is **never** the debug target — we always run it in Docker. We us
 - "Find and fix a bug in gateway-controller / policy-engine"
 - A specific request returns the wrong response and source-level inspection is
   needed (when [[gateway-integration-tests]] step 3 — logs / config dumps — wasn't enough)
-- An IT test reproducer exists but you need to step through the gateway side,
+- An Integration Test (IT) reproducer exists but you need to step through the gateway side,
   not the test side
 
 ## Workflow
@@ -626,7 +626,7 @@ require restarting the debugged process. Loop:
    either matches or it doesn't.
 5. If wrong again → reattach, refine breakpoints, iterate.
 
-For a finalised fix, also run the matching IT test feature so the regression is
+For a finalised fix, also run the matching Integration Test feature so the regression is
 covered (Step 8 cleanup must run first — the IT stack uses the same ports):
 
 ```bash

--- a/.agents/skills/gateway-integration-tests/SKILL.md
+++ b/.agents/skills/gateway-integration-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gateway-integration-tests
-description: Run or debug WSO2 API Platform gateway integration tests. Use when the user asks to run gateway IT tests, BDD tests, godog tests, or a specific `.feature` file; verify a feature file passes; or debug why a gateway integration test is failing.
+description: Run or debug WSO2 API Platform gateway integration tests. Use when the user asks to run gateway Integration Tests (IT), BDD tests, godog tests, or a specific `.feature` file; verify a feature file passes; or debug why a gateway integration test is failing.
 compatibility: Requires docker (with compose plugin), make, Go 1.23+. Optional: delve (`dlv`) for step-level debugging.
 allowed-tools: Bash Read Edit Grep Glob
 ---
@@ -15,7 +15,7 @@ container logs, and cleans up afterward.
 
 - "Run the gateway integration tests" / "run `<x>.feature`"
 - "Verify my new feature file passes"
-- "Why is this IT test failing?" — triage from container logs
+- "Why is this Integration Test failing?" — triage from container logs
 - After editing a `.feature` file, a policy, or gateway code, to confirm behavior
 
 ## Workflow


### PR DESCRIPTION
## Purpose

Follow-up to the `gateway-it-tests` → `gateway-integration-tests` skill rename in #2118. After that rename, both gateway agent skills still used the redundant abbreviation "IT test(s)" — since "IT" already expands to "integration test", the phrase reads as "integration test test(s)". This PR normalizes only that literal phrasing so the skill text is unambiguous.

## Goals

Replace every literal "IT test(s)" occurrence with "Integration Test(s)" across both gateway agent skills, while deliberately leaving all other identifiers and abbreviations untouched.

## Approach

- `gateway-integration-tests/SKILL.md`: expand "IT test(s)" in the description trigger phrase and the "When to use" line.
- `gateway-debug/SKILL.md`: expand "IT test(s)" in the reproducer note and the regression-feature note.
- Leave all non-"test" uses of "IT" as-is (e.g. "IT handoff" mode label, "IT compose", "IT stack", "IT workflow").
- Leave the `IT_FEATURE_PATHS` env var and the `it-*` Docker container names unchanged, since those are real identifiers.

## User stories

N/A — internal developer tooling (agent skill) wording cleanup.

## Documentation

N/A — the change is to developer-facing agent skills; each skill's own `SKILL.md` is updated in place.

## Automation tests
 - Unit tests
   > N/A — documentation/skill-metadata change only, no code.
 - Integration tests
   > N/A — no runtime behavior changes. Verified statically that only the literal "IT test(s)" phrasing changed, no remaining "IT test" occurrences exist, and the `IT_FEATURE_PATHS` env var, `it-*` container names, and `[[..]]` cross-references are all intact.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no code changed (Markdown skill files only)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

- #2118 — renamed the skill from `gateway-it-tests` to `gateway-integration-tests`; this PR is the follow-up wording cleanup.

## Test environment

N/A — documentation-only change; no JDK/OS/DB/browser dependency.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)