### PR TITLE
fix(gateway): reject identical main and sandbox vhosts

### DIFF
--- a/gateway/gateway-controller/cmd/controller/main.go
+++ b/gateway/gateway-controller/cmd/controller/main.go
@@ -124,7 +124,7 @@ func main() {
 	}
 
 	if strings.EqualFold(strings.TrimSpace(cfg.Router.VHosts.Main.Default), strings.TrimSpace(cfg.Router.VHosts.Sandbox.Default)) {
-		log.Warn("router.vhosts.main.default and router.vhosts.sandbox.default are identical: sandbox routes would collide with main routes, so REST API deployments will be rejected until the defaults differ")
+		log.Warn("router.vhosts.main.default and router.vhosts.sandbox.default are identical: sandbox routes would collide with main routes, so any REST API deployed without explicit distinct vhosts will be rejected until the defaults differ")
 	}
 
 	// In immutable mode, delete any stale SQLite files before opening the DB to

--- a/gateway/gateway-controller/cmd/controller/main.go
+++ b/gateway/gateway-controller/cmd/controller/main.go
@@ -124,7 +124,7 @@ func main() {
 	}
 
 	if strings.EqualFold(strings.TrimSpace(cfg.Router.VHosts.Main.Default), strings.TrimSpace(cfg.Router.VHosts.Sandbox.Default)) {
-		log.Warn("router.vhosts.main.default and router.vhosts.sandbox.default are identical: sandbox routes would collide with main routes, so APIs with sandbox upstreams will be rejected until the defaults differ")
+		log.Warn("router.vhosts.main.default and router.vhosts.sandbox.default are identical: sandbox routes would collide with main routes, so REST API deployments will be rejected until the defaults differ")
 	}
 
 	// In immutable mode, delete any stale SQLite files before opening the DB to

--- a/gateway/gateway-controller/cmd/controller/main.go
+++ b/gateway/gateway-controller/cmd/controller/main.go
@@ -38,10 +38,10 @@ import (
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/policyxds"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/service/restapi"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/storage"
-	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/webhooksecretxds"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/transform"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/utils"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/version"
+	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/webhooksecretxds"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/xds"
 )
 
@@ -121,6 +121,10 @@ func main() {
 
 	if !cfg.Controller.Auth.Basic.Enabled && !cfg.Controller.Auth.IDP.Enabled {
 		log.Warn("No authentication configured: both basic auth and IDP are disabled. Gateway Controller API will allow all requests without authentication")
+	}
+
+	if strings.EqualFold(strings.TrimSpace(cfg.Router.VHosts.Main.Default), strings.TrimSpace(cfg.Router.VHosts.Sandbox.Default)) {
+		log.Warn("router.vhosts.main.default and router.vhosts.sandbox.default are identical: sandbox routes would collide with main routes, so APIs with sandbox upstreams will be rejected until the defaults differ")
 	}
 
 	// In immutable mode, delete any stale SQLite files before opening the DB to

--- a/gateway/gateway-controller/pkg/config/api_validator.go
+++ b/gateway/gateway-controller/pkg/config/api_validator.go
@@ -421,15 +421,16 @@ func (v *APIValidator) validateRestData(spec *api.APIConfigData) []ValidationErr
 	}
 
 	// Validate vhosts: identical main and sandbox vhosts would collide on route keys.
+	// Rejected even without a sandbox upstream so the latent collision cannot be stored.
 	// Compared case-insensitively since Envoy matches domains case-insensitively.
 	// The xDS builders guard the case where vhosts only collide via router defaults.
-	if spec.Upstream.Sandbox != nil && spec.Vhosts != nil && spec.Vhosts.Sandbox != nil {
+	if spec.Vhosts != nil && spec.Vhosts.Sandbox != nil {
 		mainVhost := strings.TrimSpace(spec.Vhosts.Main)
 		sandboxVhost := strings.TrimSpace(*spec.Vhosts.Sandbox)
 		if mainVhost != "" && strings.EqualFold(mainVhost, sandboxVhost) {
 			errors = append(errors, ValidationError{
 				Field:   "spec.vhosts",
-				Message: "Main and sandbox vhosts must differ when a sandbox upstream is configured",
+				Message: "Main and sandbox vhosts must differ",
 			})
 		}
 	}

--- a/gateway/gateway-controller/pkg/config/api_validator.go
+++ b/gateway/gateway-controller/pkg/config/api_validator.go
@@ -420,6 +420,20 @@ func (v *APIValidator) validateRestData(spec *api.APIConfigData) []ValidationErr
 		errors = append(errors, v.validateUpstream("sandbox", spec.Upstream.Sandbox, spec.UpstreamDefinitions)...)
 	}
 
+	// Validate vhosts: identical main and sandbox vhosts would collide on route keys.
+	// Compared case-insensitively since Envoy matches domains case-insensitively.
+	// The xDS builders guard the case where vhosts only collide via router defaults.
+	if spec.Upstream.Sandbox != nil && spec.Vhosts != nil && spec.Vhosts.Sandbox != nil {
+		mainVhost := strings.TrimSpace(spec.Vhosts.Main)
+		sandboxVhost := strings.TrimSpace(*spec.Vhosts.Sandbox)
+		if mainVhost != "" && strings.EqualFold(mainVhost, sandboxVhost) {
+			errors = append(errors, ValidationError{
+				Field:   "spec.vhosts",
+				Message: "Main and sandbox vhosts must differ when a sandbox upstream is configured",
+			})
+		}
+	}
+
 	// Validate operations
 	errors = append(errors, v.validateOperations(spec.Operations)...)
 

--- a/gateway/gateway-controller/pkg/config/api_validator_test.go
+++ b/gateway/gateway-controller/pkg/config/api_validator_test.go
@@ -508,6 +508,54 @@ func TestAPIValidator_ValidateAllHTTPMethods(t *testing.T) {
 	}
 }
 
+func TestAPIValidator_ValidateVhosts(t *testing.T) {
+	v := NewAPIValidator()
+
+	tests := []struct {
+		name                string
+		mainVhost           string
+		sandboxVhost        *string
+		withSandboxUpstream bool
+		wantError           bool
+	}{
+		{name: "Identical vhosts with sandbox upstream", mainVhost: "api.local", sandboxVhost: stringPtr("api.local"), withSandboxUpstream: true, wantError: true},
+		{name: "Case-insensitively identical vhosts rejected", mainVhost: "API.local", sandboxVhost: stringPtr("api.local"), withSandboxUpstream: true, wantError: true},
+		{name: "Identical vhosts without sandbox upstream", mainVhost: "api.local", sandboxVhost: stringPtr("api.local"), withSandboxUpstream: false, wantError: false},
+		{name: "Distinct vhosts with sandbox upstream", mainVhost: "api.local", sandboxVhost: stringPtr("sb.local"), withSandboxUpstream: true, wantError: false},
+		{name: "No vhosts with sandbox upstream", withSandboxUpstream: true, wantError: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := createValidRestAPIConfig()
+			if tt.withSandboxUpstream {
+				config.Spec.Upstream.Sandbox = &api.Upstream{Url: stringPtr("http://sb-backend:8080")}
+			}
+			if tt.mainVhost != "" || tt.sandboxVhost != nil {
+				config.Spec.Vhosts = &struct {
+					Main    string  `json:"main" yaml:"main"`
+					Sandbox *string `json:"sandbox,omitempty" yaml:"sandbox,omitempty"`
+				}{Main: tt.mainVhost, Sandbox: tt.sandboxVhost}
+			}
+
+			errors := v.Validate(config)
+			hasVhostError := false
+			for _, e := range errors {
+				if e.Field == "spec.vhosts" {
+					hasVhostError = true
+					break
+				}
+			}
+			if tt.wantError && !hasVhostError {
+				t.Errorf("expected vhosts error, got: %v", errors)
+			}
+			if !tt.wantError && hasVhostError {
+				t.Error("unexpected vhosts error")
+			}
+		})
+	}
+}
+
 func TestAPIValidator_ValidateWebSubAPI(t *testing.T) {
 	v := NewAPIValidator()
 

--- a/gateway/gateway-controller/pkg/config/api_validator_test.go
+++ b/gateway/gateway-controller/pkg/config/api_validator_test.go
@@ -520,7 +520,8 @@ func TestAPIValidator_ValidateVhosts(t *testing.T) {
 	}{
 		{name: "Identical vhosts with sandbox upstream", mainVhost: "api.local", sandboxVhost: stringPtr("api.local"), withSandboxUpstream: true, wantError: true},
 		{name: "Case-insensitively identical vhosts rejected", mainVhost: "API.local", sandboxVhost: stringPtr("api.local"), withSandboxUpstream: true, wantError: true},
-		{name: "Identical vhosts without sandbox upstream", mainVhost: "api.local", sandboxVhost: stringPtr("api.local"), withSandboxUpstream: false, wantError: false},
+		{name: "Identical vhosts without sandbox upstream", mainVhost: "api.local", sandboxVhost: stringPtr("api.local"), withSandboxUpstream: false, wantError: true},
+		{name: "Distinct vhosts without sandbox upstream", mainVhost: "api.local", sandboxVhost: stringPtr("sb.local"), withSandboxUpstream: false, wantError: false},
 		{name: "Distinct vhosts with sandbox upstream", mainVhost: "api.local", sandboxVhost: stringPtr("sb.local"), withSandboxUpstream: true, wantError: false},
 		{name: "No vhosts with sandbox upstream", withSandboxUpstream: true, wantError: false},
 	}

--- a/gateway/gateway-controller/pkg/service/restapi/service.go
+++ b/gateway/gateway-controller/pkg/service/restapi/service.go
@@ -305,6 +305,13 @@ func (s *RestAPIService) Update(params UpdateParams) (*UpdateResult, error) {
 	existing.Configuration = apiConfig
 	existing.SourceConfiguration = apiConfig
 
+	// Resolve gateway-default vhost sentinels before render, mirroring the create path,
+	// so validation compares effective vhosts and the stored values stay concrete.
+	if err := utils.ResolveVhostSentinels(&existing.Configuration, s.routerConfig); err != nil {
+		return nil, err
+	}
+	existing.SourceConfiguration = existing.Configuration
+
 	// Render template expressions before validation so the validator sees resolved values
 	// (e.g. {{ env "BACKEND_URL" }} → actual URL).
 	if err := templateengine.RenderSpec(existing, s.secretResolver, log); err != nil {

--- a/gateway/gateway-controller/pkg/service/restapi/service.go
+++ b/gateway/gateway-controller/pkg/service/restapi/service.go
@@ -318,6 +318,12 @@ func (s *RestAPIService) Update(params UpdateParams) (*UpdateResult, error) {
 		return nil, err
 	}
 
+	// Re-resolve vhosts after rendering so a templated vhost that renders blank is filled
+	// with the router default before validation (Configuration only).
+	if err := utils.ResolveVhostSentinels(&existing.Configuration, s.routerConfig); err != nil {
+		return nil, err
+	}
+
 	// Validate configuration against resolved values
 	renderedConfig := existing.Configuration.(api.RestAPI)
 	validationErrors := s.validator.Validate(&renderedConfig)

--- a/gateway/gateway-controller/pkg/transform/restapi.go
+++ b/gateway/gateway-controller/pkg/transform/restapi.go
@@ -147,7 +147,7 @@ func (t *RestAPITransformer) Transform(cfg *models.StoredConfig) (*models.Runtim
 	// Guard: sandbox and main vhosts must differ, otherwise sandbox routes would
 	// overwrite main routes (same route key) and the sandbox patch would leave only
 	// a sandbox-cluster route with no main-cluster route at all.
-	if hasSandbox && effectiveMainVHost == effectiveSandboxVHost {
+	if hasSandbox && strings.EqualFold(strings.TrimSpace(effectiveMainVHost), strings.TrimSpace(effectiveSandboxVHost)) {
 		return nil, fmt.Errorf("sandbox upstream is configured but resolves to the same vhost %q as the main upstream; configure distinct vhosts to avoid route conflicts", effectiveMainVHost)
 	}
 

--- a/gateway/gateway-controller/pkg/transform/restapi_test.go
+++ b/gateway/gateway-controller/pkg/transform/restapi_test.go
@@ -387,3 +387,38 @@ func TestRestAPITransformer_SandboxRouteClusterHeader(t *testing.T) {
 			"sandbox route must default to the sandbox cluster, not main")
 	})
 }
+
+// TestRestAPITransformer_SameVhostRejected verifies the transform path rejects an API whose
+// main and sandbox vhosts resolve to the same host (case-insensitively), matching the
+// validator and translator guards so the two xDS builders stay in lockstep.
+func TestRestAPITransformer_SameVhostRejected(t *testing.T) {
+	defs := map[string]models.PolicyDefinition{}
+
+	transform := func(mainVhost, sandboxVhost string) error {
+		transformer := NewRestAPITransformer(testRouterCfg(), &config.Config{}, defs)
+		cfg := makeRestAPIStoredConfig(nil, nil)
+		restAPI := cfg.Configuration.(api.RestAPI)
+		restAPI.Spec.Upstream.Sandbox = &api.Upstream{Url: ptrStr("http://sandbox-backend:9080/sandbox")}
+		restAPI.Spec.Vhosts = &struct {
+			Main    string  `json:"main" yaml:"main"`
+			Sandbox *string `json:"sandbox,omitempty" yaml:"sandbox,omitempty"`
+		}{Main: mainVhost, Sandbox: ptrStr(sandboxVhost)}
+		cfg.Configuration = restAPI
+		_, err := transformer.Transform(cfg)
+		return err
+	}
+
+	t.Run("identical vhosts rejected", func(t *testing.T) {
+		err := transform("api.local", "api.local")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "same vhost")
+	})
+
+	t.Run("case-insensitively identical vhosts rejected", func(t *testing.T) {
+		require.Error(t, transform("API.local", "api.local"))
+	})
+
+	t.Run("distinct vhosts allowed", func(t *testing.T) {
+		require.NoError(t, transform("api.local", "sandbox.local"))
+	})
+}

--- a/gateway/gateway-controller/pkg/utils/api_deployment.go
+++ b/gateway/gateway-controller/pkg/utils/api_deployment.go
@@ -688,7 +688,20 @@ func resolveVhostSentinels(cfg *any, routerCfg *config.RouterConfig) error {
 				c.Spec.Vhosts.Sandbox = nil
 			}
 		}
+		// Blank or omitted fields fall back to router defaults at translation time;
+		// freeze them here too so validation sees the effective values.
+		if strings.TrimSpace(c.Spec.Vhosts.Main) == "" {
+			c.Spec.Vhosts.Main = routerCfg.VHosts.Main.Default
+		}
+		if c.Spec.Vhosts.Sandbox == nil || strings.TrimSpace(*c.Spec.Vhosts.Sandbox) == "" {
+			if sandboxDefault := routerCfg.VHosts.Sandbox.Default; sandboxDefault != "" {
+				c.Spec.Vhosts.Sandbox = &sandboxDefault
+			} else {
+				c.Spec.Vhosts.Sandbox = nil
+			}
+		}
 		*cfg = c
+	// Async kinds below keep sentinel/whole-nil resolution only; they have no sandbox vhost routing.
 	case api.WebSubAPI:
 		if c.Spec.Vhosts == nil {
 			main := routerCfg.VHosts.Main.Default
@@ -745,6 +758,11 @@ func resolveVhostSentinels(cfg *any, routerCfg *config.RouterConfig) error {
 		*cfg = c
 	}
 	return nil
+}
+
+// ResolveVhostSentinels exposes vhost resolution to write paths outside this package.
+func ResolveVhostSentinels(cfg *any, routerCfg *config.RouterConfig) error {
+	return resolveVhostSentinels(cfg, routerCfg)
 }
 
 // annotationValue safely reads a single annotation key from a pointer-to-map.

--- a/gateway/gateway-controller/pkg/utils/api_deployment.go
+++ b/gateway/gateway-controller/pkg/utils/api_deployment.go
@@ -297,6 +297,13 @@ func (s *APIDeploymentService) DeployAPIConfiguration(params APIDeploymentParams
 		return nil, err
 	}
 
+	// Re-resolve vhosts after rendering: a templated vhost may render blank, which would
+	// otherwise slip past validation. Fill blanks on Configuration only (SourceConfiguration
+	// keeps the template) so the validator compares effective vhosts.
+	if err := resolveVhostSentinels(&storedCfg.Configuration, s.routerConfig); err != nil {
+		return nil, fmt.Errorf("failed to resolve vhost sentinels after render: %w", err)
+	}
+
 	// Validate against the rendered Configuration and extract spec-level identifiers.
 	var apiName, apiVersion string
 	switch c := storedCfg.Configuration.(type) {

--- a/gateway/gateway-controller/pkg/utils/api_deployment_test.go
+++ b/gateway/gateway-controller/pkg/utils/api_deployment_test.go
@@ -1038,6 +1038,53 @@ func TestResolveVhostSentinels_NilVhostsNoSandboxDefault(t *testing.T) {
 	assert.Nil(t, resolved.Vhosts.Sandbox, "sandbox should remain nil when no sandbox default configured")
 }
 
+func TestResolveVhostSentinels_PartialVhostsFilled(t *testing.T) {
+	routerCfg := &config.RouterConfig{
+		VHosts: config.VHostsConfig{
+			Main:    config.VHostEntry{Default: "*.wso2.com"},
+			Sandbox: config.VHostEntry{Default: "*-sandbox.wso2.com"},
+		},
+	}
+
+	blank := "   "
+	tests := []struct {
+		name        string
+		main        string
+		sandbox     *string
+		wantMain    string
+		wantSandbox string
+	}{
+		{name: "omitted sandbox filled", main: "custom.example.com", sandbox: nil, wantMain: "custom.example.com", wantSandbox: "*-sandbox.wso2.com"},
+		{name: "blank sandbox filled", main: "custom.example.com", sandbox: &blank, wantMain: "custom.example.com", wantSandbox: "*-sandbox.wso2.com"},
+		{name: "blank main filled", main: "", sandbox: stringPtr("custom-sb.example.com"), wantMain: "*.wso2.com", wantSandbox: "custom-sb.example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cfg any = api.RestAPI{
+				Kind: api.RestAPIKindRestApi,
+				Spec: api.APIConfigData{
+					Vhosts: &struct {
+						Main    string  `json:"main" yaml:"main"`
+						Sandbox *string `json:"sandbox,omitempty" yaml:"sandbox,omitempty"`
+					}{
+						Main:    tt.main,
+						Sandbox: tt.sandbox,
+					},
+				},
+			}
+
+			require.NoError(t, resolveVhostSentinels(&cfg, routerCfg))
+
+			resolved := cfg.(api.RestAPI).Spec
+			require.NotNil(t, resolved.Vhosts)
+			assert.Equal(t, tt.wantMain, resolved.Vhosts.Main)
+			require.NotNil(t, resolved.Vhosts.Sandbox)
+			assert.Equal(t, tt.wantSandbox, *resolved.Vhosts.Sandbox)
+		})
+	}
+}
+
 func TestResolveVhostSentinels_WebSubApi_NilVhostsPopulatesDefaults(t *testing.T) {
 	routerCfg := &config.RouterConfig{
 		VHosts: config.VHostsConfig{

--- a/gateway/gateway-controller/pkg/utils/api_deployment_test.go
+++ b/gateway/gateway-controller/pkg/utils/api_deployment_test.go
@@ -420,6 +420,61 @@ spec:
 	assert.Nil(t, result)
 }
 
+// A vhost written as a template can render to blank. Because vhost resolution also runs
+// after rendering, both blanks are filled with the (equal) router default, so the
+// same-vhost collision is rejected cleanly at deploy instead of failing later in xDS.
+func TestDeployAPIConfiguration_TemplatedVhostRendersBlankRejected(t *testing.T) {
+	store := storage.NewConfigStore()
+	validator := config.NewAPIValidator()
+	routerCfg := &config.RouterConfig{
+		VHosts: config.VHostsConfig{
+			Main:    config.VHostEntry{Default: "shared.example.com"},
+			Sandbox: config.VHostEntry{Default: "shared.example.com"},
+		},
+	}
+	service := newTestAPIDeploymentService(store, nil, nil, validator, routerCfg)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	yamlData := `
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: templated-vhost-api
+spec:
+  displayName: Templated Vhost API
+  version: v1.0
+  context: /tpl
+  vhosts:
+    main: '{{ env "TPL_MAIN_HOST_UNSET" }}'
+    sandbox: '{{ env "TPL_SANDBOX_HOST_UNSET" }}'
+  upstream:
+    main:
+      url: http://backend:9090
+  operations:
+    - method: GET
+      path: /data
+`
+	params := APIDeploymentParams{
+		Data:          []byte(yamlData),
+		ContentType:   "application/yaml",
+		CorrelationID: "test-corr",
+		Origin:        models.OriginGatewayAPI,
+		Logger:        logger,
+	}
+
+	_, err := service.DeployAPIConfiguration(params)
+	require.Error(t, err)
+	var verr *ValidationErrorListError
+	require.ErrorAs(t, err, &verr)
+	found := false
+	for _, e := range verr.Errors {
+		if e.Field == "spec.vhosts" {
+			found = true
+		}
+	}
+	assert.True(t, found, "expected a spec.vhosts validation error, got %v", verr.Errors)
+}
+
 func TestDeployAPIConfiguration_DBConflictValidation(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	validator := config.NewAPIValidator()

--- a/gateway/gateway-controller/pkg/xds/translator.go
+++ b/gateway/gateway-controller/pkg/xds/translator.go
@@ -831,6 +831,13 @@ func (t *Translator) translateAPIConfig(cfg *models.StoredConfig, allConfigs []*
 
 	// -------- SANDBOX UPSTREAM --------
 	if apiData.Upstream.Sandbox != nil {
+		// Guard: sandbox and main vhosts must differ, otherwise sandbox routes share
+		// the route key with main routes and collide. Compared case-insensitively
+		// (Envoy matches domains case-insensitively). Mirrors the transform-path guard.
+		if strings.EqualFold(strings.TrimSpace(effectiveMainVHost), strings.TrimSpace(effectiveSandboxVHost)) {
+			return nil, nil, fmt.Errorf("sandbox upstream is configured but resolves to the same vhost %q as the main upstream; configure distinct vhosts to avoid route conflicts", effectiveMainVHost)
+		}
+
 		sbClusterName, parsedSbURL, sbTimeout, err := t.resolveUpstreamCluster("sandbox", apiData.Upstream.Sandbox, apiData.UpstreamDefinitions)
 		if err != nil {
 			return nil, nil, err

--- a/gateway/gateway-controller/pkg/xds/translator_test.go
+++ b/gateway/gateway-controller/pkg/xds/translator_test.go
@@ -2163,3 +2163,109 @@ func TestTranslator_CreateDynamicFwdListenerForWebSubHub(t *testing.T) {
 		assert.Equal(t, core.SocketAddress_TCP, listener.GetAddress().GetSocketAddress().GetProtocol())
 	})
 }
+
+func TestTranslateAPIConfig_SameVhostRejected(t *testing.T) {
+	translator := createTestTranslator()
+
+	sameVhost := "collide.local"
+	apiData := api.APIConfigData{
+		DisplayName: "Same-Vhost-API",
+		Context:     "/same-vhost",
+		Version:     "v1.0",
+		Vhosts: &struct {
+			Main    string  `json:"main" yaml:"main"`
+			Sandbox *string `json:"sandbox,omitempty" yaml:"sandbox,omitempty"`
+		}{Main: sameVhost, Sandbox: &sameVhost},
+		Upstream: struct {
+			Main    api.Upstream  `json:"main" yaml:"main"`
+			Sandbox *api.Upstream `json:"sandbox,omitempty" yaml:"sandbox,omitempty"`
+		}{
+			Main:    api.Upstream{Url: strPtr("http://main-be:8080")},
+			Sandbox: &api.Upstream{Url: strPtr("http://sb-be:8080")},
+		},
+		Operations: []api.Operation{{Method: "GET", Path: "/endpoint"}},
+	}
+	cfg := &models.StoredConfig{
+		UUID: "same-vhost-api",
+		Kind: string(api.RestAPIKindRestApi),
+		Configuration: api.RestAPI{
+			Kind:     api.RestAPIKindRestApi,
+			Metadata: api.Metadata{Name: "same-vhost-api"},
+			Spec:     apiData,
+		},
+	}
+
+	_, _, err := translator.translateAPIConfig(cfg, []*models.StoredConfig{cfg})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "same vhost")
+}
+
+func TestTranslateAPIConfig_CaseOnlyVhostCollisionRejected(t *testing.T) {
+	translator := createTestTranslator()
+
+	mainVhost := "Collide.local"
+	sandboxVhost := "collide.local"
+	apiData := api.APIConfigData{
+		DisplayName: "Case-Vhost-API",
+		Context:     "/case-vhost",
+		Version:     "v1.0",
+		Vhosts: &struct {
+			Main    string  `json:"main" yaml:"main"`
+			Sandbox *string `json:"sandbox,omitempty" yaml:"sandbox,omitempty"`
+		}{Main: mainVhost, Sandbox: &sandboxVhost},
+		Upstream: struct {
+			Main    api.Upstream  `json:"main" yaml:"main"`
+			Sandbox *api.Upstream `json:"sandbox,omitempty" yaml:"sandbox,omitempty"`
+		}{
+			Main:    api.Upstream{Url: strPtr("http://main-be:8080")},
+			Sandbox: &api.Upstream{Url: strPtr("http://sb-be:8080")},
+		},
+		Operations: []api.Operation{{Method: "GET", Path: "/endpoint"}},
+	}
+	cfg := &models.StoredConfig{
+		UUID: "case-vhost-api",
+		Kind: string(api.RestAPIKindRestApi),
+		Configuration: api.RestAPI{
+			Kind:     api.RestAPIKindRestApi,
+			Metadata: api.Metadata{Name: "case-vhost-api"},
+			Spec:     apiData,
+		},
+	}
+
+	_, _, err := translator.translateAPIConfig(cfg, []*models.StoredConfig{cfg})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "same vhost")
+}
+
+func TestTranslateAPIConfig_DefaultVhostCollisionRejected(t *testing.T) {
+	translator := createTestTranslator()
+	translator.config.Router.VHosts.Main.Default = "collide.local"
+	translator.config.Router.VHosts.Sandbox.Default = "collide.local"
+
+	apiData := api.APIConfigData{
+		DisplayName: "Default-Vhost-API",
+		Context:     "/default-vhost",
+		Version:     "v1.0",
+		Upstream: struct {
+			Main    api.Upstream  `json:"main" yaml:"main"`
+			Sandbox *api.Upstream `json:"sandbox,omitempty" yaml:"sandbox,omitempty"`
+		}{
+			Main:    api.Upstream{Url: strPtr("http://main-be:8080")},
+			Sandbox: &api.Upstream{Url: strPtr("http://sb-be:8080")},
+		},
+		Operations: []api.Operation{{Method: "GET", Path: "/endpoint"}},
+	}
+	cfg := &models.StoredConfig{
+		UUID: "default-vhost-api",
+		Kind: string(api.RestAPIKindRestApi),
+		Configuration: api.RestAPI{
+			Kind:     api.RestAPIKindRestApi,
+			Metadata: api.Metadata{Name: "default-vhost-api"},
+			Spec:     apiData,
+		},
+	}
+
+	_, _, err := translator.translateAPIConfig(cfg, []*models.StoredConfig{cfg})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "same vhost")
+}


### PR DESCRIPTION
## Purpose

A RestApi with a sandbox upstream whose vhost resolves to the same value as the main vhost was rejected by the RuntimeDeployConfig transform path but accepted by the Envoy xDS translator. Because per-API translation errors are only logged and swallowed, the deployment returned `201 Created` while the policy xDS received no configuration for the API. With the policy engine running fail-closed, every request to the API then returned `500` at runtime, with no signal to the API author beyond a swallowed log line.

Resolves #2145

## Goals

Reject the same-vhost collision consistently and at deploy time, returning a clear `400` to the author instead of accepting a misconfiguration that silently fails at runtime. Ensure the two xDS builders can never disagree about whether a configuration is valid, since that disagreement was the root cause.

## Approach

The collision is now caught at every layer it can arise:

- Vhost resolution, which already froze router defaults into fully-omitted vhosts on create, now also fills blank or individually-omitted fields, and runs on the update (PUT) path in addition to create. Validation therefore always compares the effective vhosts, whether they come from explicit values, partial configurations, or router defaults.
- The API validator rejects identical main and sandbox vhosts (when a sandbox upstream is configured) with a `400` at deploy time. The comparison is case-insensitive and whitespace-trimmed, since Envoy matches domains case-insensitively.
- Both xDS builders (the Envoy translator and the RuntimeDeployConfig transform path) now apply the same case-insensitive guard, kept identical to each other, so they reject any remaining collision consistently and the inconsistent main-xDS / policy-xDS state can no longer occur.
- A gateway configured with identical main and sandbox vhost defaults logs a startup warning instead of failing to boot, so main-only APIs keep working while sandbox-enabled APIs are rejected per API.

## User stories

As an API developer, when I deploy an API whose main and sandbox vhosts collide, I want it rejected immediately with a clear error, rather than accepted and then failing every request at runtime.

## Documentation

N/A. This changes internal validation and xDS-translation behavior only; there is no user-facing API or product-documentation impact.

## Automation tests

 - Unit tests
   > Added validator cases (identical, case-insensitively identical, distinct, no-sandbox-upstream, absent vhosts); vhost-resolution cases (omitted/blank sandbox and blank main filled from defaults, existing sentinel/nil behaviour unchanged); and translator cases (explicit identical, case-only, and defaults-derived collisions all rejected). All existing unit tests in the affected packages (`pkg/config`, `pkg/utils`, `pkg/xds`, `pkg/transform`) pass.
 - Integration tests
   > No new integration tests; the change is covered by unit tests at the validator, the resolver, and both xDS builders. The existing integration suite is unaffected.

## Security checks

 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (Go module; FindSecurityBugs is a Java/SpotBugs tool)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

Before the fix, this configuration deployed with `201` and then returned `500` on every request:

```yaml
apiVersion: gateway.api-platform.wso2.com/v1alpha1
kind: RestApi
metadata:
  name: same-vhost-demo-v1.0
spec:
  displayName: Same-Vhost-Demo
  version: v1.0
  context: /same-vhost-demo/$version
  vhosts:
    main: collide.local
    sandbox: collide.local
  upstream:
    main:
      url: http://backend:8080/main-be
    sandbox:
      url: http://backend:8080/sb-be
  operations:
    - method: GET
      path: /endpoint
```

After the fix, the same deployment is rejected at admission:

```
spec.vhosts: Main and sandbox vhosts must differ when a sandbox upstream is configured
```

## Related PRs

None.

## Test environment

 - Go (version per `gateway/gateway-controller/go.mod`)
 - Reproduced and verified on the gateway integration Docker stack (Linux containers) via Rancher Desktop on a Windows host
 - Controller storage backend: SQLite (default)