### PR TITLE
Implement role-to-scope mapping for IDP role validation

### DIFF
--- a/platform-api/src/config/config.go
+++ b/platform-api/src/config/config.go
@@ -109,9 +109,9 @@ type IDP struct {
 	UsernameClaimName     string `koanf:"username_claim_name"`
 	EmailClaimName        string `koanf:"email_claim_name"`
 	ScopeClaimName        string `koanf:"scope_claim_name"`
-	RolesClaimPath        string `koanf:"roles_claim_path"`
-	RoleMappings          []string `koanf:"role_mappings"`
-	ValidationMode        string `koanf:"validation_mode"`
+	RolesClaimPath   string `koanf:"roles_claim_path"`
+	RoleMappingsFile string `koanf:"role_mappings_file"`
+	ValidationMode   string `koanf:"validation_mode"`
 }
 
 // Gateway holds gateway-related configuration.
@@ -427,7 +427,7 @@ func envToKoanfKey(s string) string {
 	case "auth_idp_email_claim_name":         return "auth.idp.email_claim_name"
 	case "auth_idp_scope_claim_name":         return "auth.idp.scope_claim_name"
 	case "auth_idp_roles_claim_path":         return "auth.idp.roles_claim_path"
-	case "auth_idp_role_mappings":            return "auth.idp.role_mappings"
+	case "auth_idp_role_mappings_file":       return "auth.idp.role_mappings_file"
 	case "auth_idp_validation_mode":          return "auth.idp.validation_mode"
 
 	// Auth BasicAuth

--- a/platform-api/src/internal/middleware/auth.go
+++ b/platform-api/src/internal/middleware/auth.go
@@ -53,15 +53,18 @@ type AuthConfig struct {
 
 // PlatformClaimNames holds the JWT claim names used to extract platform-specific values.
 type PlatformClaimNames struct {
-	OrganizationClaim  string // active org UUID for this token (e.g. "organization")
-	OrgNameClaim       string // org display name (e.g. "org_name")
-	OrgHandleClaim     string // org URL-safe handle (e.g. "org_handle")
-	UserIDClaim        string
-	UsernameClaim      string
-	EmailClaim         string
-	ScopeClaim         string
-	RolesClaimPath     string
-	RoleMappings       []string // "idp-value=platform-role" pairs
+	OrganizationClaim string // active org UUID for this token (e.g. "organization")
+	OrgNameClaim      string // org display name (e.g. "org_name")
+	OrgHandleClaim    string // org URL-safe handle (e.g. "org_handle")
+	UserIDClaim       string
+	UsernameClaim     string
+	EmailClaim        string
+	ScopeClaim        string
+	RolesClaimPath    string
+	// RoleScopeMap maps each IDP role name to the platform scopes it grants.
+	// When a token carries multiple roles the effective scopes are the union.
+	// Nil means passthrough: IDP role names are used directly as scope values.
+	RoleScopeMap map[string][]string
 }
 
 // LocalJWTAuthMiddleware returns a Gin middleware for locally-issued JWT validation.
@@ -180,8 +183,6 @@ func validateLocalJWT(c *gin.Context, tokenString string, config AuthConfig) err
 // common/authenticators.AuthMiddleware (IDP mode) and populates the per-key context entries
 // that handlers rely on.
 func PlatformClaimsMiddleware(claimNames PlatformClaimNames) gin.HandlerFunc {
-	roleMapping := parseRoleMappings(claimNames.RoleMappings)
-
 	return func(c *gin.Context) {
 		authCtxVal, exists := c.Get(commonconstants.AuthContextKey)
 		if !exists {
@@ -235,7 +236,7 @@ func PlatformClaimsMiddleware(claimNames PlatformClaimNames) gin.HandlerFunc {
 			},
 		}
 
-		platformRoles := resolvePlatformRoles(mapClaims, claimNames.RolesClaimPath, roleMapping)
+		platformRoles := resolvePlatformRoles(mapClaims, claimNames.RolesClaimPath, claimNames.RoleScopeMap)
 
 		c.Set("user_id", userID)
 		c.Set("username", username)
@@ -263,27 +264,29 @@ func PlatformClaimsMiddleware(claimNames PlatformClaimNames) gin.HandlerFunc {
 	}
 }
 
-// resolvePlatformRoles extracts role values from the token at claimPath and maps them
-// to platform roles using the provided mapping. Raw IDP values are used when mapping is empty.
-func resolvePlatformRoles(claims jwt.MapClaims, claimPath string, mapping map[string]string) []string {
+// resolvePlatformRoles extracts IDP role names from the token at claimPath and
+// expands them to platform scopes using roleScopeMap. When a token carries multiple
+// IDP roles the result is the union of their scope lists (deduped, order preserved).
+// When roleScopeMap is nil the raw IDP role names are returned unchanged (passthrough).
+func resolvePlatformRoles(claims jwt.MapClaims, claimPath string, roleScopeMap map[string][]string) []string {
 	if claimPath == "" {
 		return nil
 	}
 	idpRoles := extractClaimByPath(claims, claimPath)
-	if len(mapping) == 0 {
+	if roleScopeMap == nil {
 		return idpRoles
 	}
-	var platformRoles []string
 	seen := make(map[string]struct{})
+	var effectiveScopes []string
 	for _, idpRole := range idpRoles {
-		if platformRole, ok := mapping[idpRole]; ok {
-			if _, dup := seen[platformRole]; !dup {
-				platformRoles = append(platformRoles, platformRole)
-				seen[platformRole] = struct{}{}
+		for _, scope := range roleScopeMap[idpRole] {
+			if _, dup := seen[scope]; !dup {
+				effectiveScopes = append(effectiveScopes, scope)
+				seen[scope] = struct{}{}
 			}
 		}
 	}
-	return platformRoles
+	return effectiveScopes
 }
 
 // extractClaimByPath navigates a dot-notation path through jwt.MapClaims and returns the
@@ -323,18 +326,6 @@ func toStringSlice(val interface{}) []string {
 		return result
 	}
 	return nil
-}
-
-// parseRoleMappings converts "idp-value=platform-role" pairs into a lookup map.
-func parseRoleMappings(mappings []string) map[string]string {
-	m := make(map[string]string, len(mappings))
-	for _, entry := range mappings {
-		parts := strings.SplitN(entry, "=", 2)
-		if len(parts) == 2 {
-			m[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
-		}
-	}
-	return m
 }
 
 // getStringClaim safely extracts a string value from jwt.MapClaims.

--- a/platform-api/src/internal/middleware/auth_role_extraction_test.go
+++ b/platform-api/src/internal/middleware/auth_role_extraction_test.go
@@ -1,0 +1,200 @@
+package middleware
+
+import (
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// TestExtractClaimByPath verifies dot-notation path traversal for all IDP layouts.
+func TestExtractClaimByPath(t *testing.T) {
+	tests := []struct {
+		name   string
+		claims jwt.MapClaims
+		path   string
+		want   []string
+	}{
+		{
+			name:   "flat array - Asgardeo / Entra ID style",
+			claims: jwt.MapClaims{"roles": []interface{}{"admin", "viewer"}},
+			path:   "roles",
+			want:   []string{"admin", "viewer"},
+		},
+		{
+			name:   "flat single-element array",
+			claims: jwt.MapClaims{"roles": []interface{}{"admin"}},
+			path:   "roles",
+			want:   []string{"admin"},
+		},
+		{
+			name:   "flat string - space-separated",
+			claims: jwt.MapClaims{"roles": "admin viewer"},
+			path:   "roles",
+			want:   []string{"admin", "viewer"},
+		},
+		{
+			name:   "flat string - single role",
+			claims: jwt.MapClaims{"roles": "admin"},
+			path:   "roles",
+			want:   []string{"admin"},
+		},
+		{
+			name: "nested two levels - Keycloak realm_access.roles",
+			claims: jwt.MapClaims{
+				"realm_access": map[string]interface{}{
+					"roles": []interface{}{"developer", "viewer"},
+				},
+			},
+			path: "realm_access.roles",
+			want: []string{"developer", "viewer"},
+		},
+		{
+			name: "nested three levels - Keycloak resource_access.<client>.roles",
+			claims: jwt.MapClaims{
+				"resource_access": map[string]interface{}{
+					"my-client": map[string]interface{}{
+						"roles": []interface{}{"platform-admin", "platform-developer"},
+					},
+				},
+			},
+			path: "resource_access.my-client.roles",
+			want: []string{"platform-admin", "platform-developer"},
+		},
+		{
+			name: "nested three levels - single role in array",
+			claims: jwt.MapClaims{
+				"resource_access": map[string]interface{}{
+					"my-client": map[string]interface{}{
+						"roles": []interface{}{"platform-admin"},
+					},
+				},
+			},
+			path: "resource_access.my-client.roles",
+			want: []string{"platform-admin"},
+		},
+		{
+			name:   "missing claim returns nil",
+			claims: jwt.MapClaims{"other": "value"},
+			path:   "roles",
+			want:   nil,
+		},
+		{
+			name: "missing nested key returns nil",
+			claims: jwt.MapClaims{
+				"resource_access": map[string]interface{}{
+					"other-client": map[string]interface{}{
+						"roles": []interface{}{"admin"},
+					},
+				},
+			},
+			path: "resource_access.my-client.roles",
+			want: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractClaimByPath(tc.claims, tc.path)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("index %d: got %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestResolvePlatformRoles verifies that multiple IDP roles produce a union of scopes
+// with no duplicates, and that nil map is a passthrough.
+func TestResolvePlatformRoles(t *testing.T) {
+	roleScopeMap := map[string][]string{
+		"admin":     {"ap:project:create", "ap:project:manage", "ap:gateway:manage"},
+		"developer": {"ap:project:create", "ap:rest_api:create"},
+		"viewer":    {"ap:project:read"},
+	}
+
+	tests := []struct {
+		name         string
+		claims       jwt.MapClaims
+		claimPath    string
+		roleScopeMap map[string][]string
+		want         []string
+	}{
+		{
+			name: "single role maps to multiple scopes",
+			claims: jwt.MapClaims{
+				"roles": []interface{}{"admin"},
+			},
+			claimPath:    "roles",
+			roleScopeMap: roleScopeMap,
+			want:         []string{"ap:project:create", "ap:project:manage", "ap:gateway:manage"},
+		},
+		{
+			name: "two roles produce union without duplicates",
+			claims: jwt.MapClaims{
+				"roles": []interface{}{"admin", "developer"},
+			},
+			claimPath:    "roles",
+			roleScopeMap: roleScopeMap,
+			// admin contributes 3, developer adds ap:rest_api:create (ap:project:create deduped)
+			want: []string{"ap:project:create", "ap:project:manage", "ap:gateway:manage", "ap:rest_api:create"},
+		},
+		{
+			name: "unmapped role grants no scopes",
+			claims: jwt.MapClaims{
+				"roles": []interface{}{"unknown-role"},
+			},
+			claimPath:    "roles",
+			roleScopeMap: roleScopeMap,
+			want:         nil,
+		},
+		{
+			name: "nil map is passthrough - returns raw role names",
+			claims: jwt.MapClaims{
+				"roles": []interface{}{"admin", "viewer"},
+			},
+			claimPath:    "roles",
+			roleScopeMap: nil,
+			want:         []string{"admin", "viewer"},
+		},
+		{
+			name: "keycloak resource_access path with role map",
+			claims: jwt.MapClaims{
+				"resource_access": map[string]interface{}{
+					"platform": map[string]interface{}{
+						"roles": []interface{}{"viewer"},
+					},
+				},
+			},
+			claimPath:    "resource_access.platform.roles",
+			roleScopeMap: roleScopeMap,
+			want:         []string{"ap:project:read"},
+		},
+		{
+			name: "empty claimPath returns nil",
+			claims: jwt.MapClaims{
+				"roles": []interface{}{"admin"},
+			},
+			claimPath:    "",
+			roleScopeMap: roleScopeMap,
+			want:         nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolvePlatformRoles(tc.claims, tc.claimPath, tc.roleScopeMap)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("index %d: got %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}

--- a/platform-api/src/internal/middleware/openapi_scope_registry.go
+++ b/platform-api/src/internal/middleware/openapi_scope_registry.go
@@ -44,6 +44,18 @@ func (r *ScopeRegistry) Lookup(method, ginPath string) ([]string, bool) {
 	return scopes, ok
 }
 
+// AllScopes returns the set of every scope name declared across all operations.
+// Used at startup to validate that roles.yaml only references known scopes.
+func (r *ScopeRegistry) AllScopes() map[string]struct{} {
+	known := make(map[string]struct{})
+	for _, scopes := range r.scopes {
+		for _, s := range scopes {
+			known[s] = struct{}{}
+		}
+	}
+	return known
+}
+
 // openAPIDoc is the minimal subset of an OpenAPI 3.x document we need to parse.
 type openAPIDoc struct {
 	Servers []struct {

--- a/platform-api/src/internal/middleware/role_scope_map.go
+++ b/platform-api/src/internal/middleware/role_scope_map.go
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package middleware
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// roleScopeEntry is a single entry in roles.yaml: an IDP role name and the
+// platform scopes it grants.
+type roleScopeEntry struct {
+	Name   string   `yaml:"name"`
+	Scopes []string `yaml:"scopes"`
+}
+
+// roleScopeConfig is the top-level structure of roles.yaml.
+type roleScopeConfig struct {
+	Roles []roleScopeEntry `yaml:"roles"`
+}
+
+// LoadRoleScopeMap reads a roles.yaml file and returns a map from IDP role name
+// to the list of platform scopes that role grants. Each user token may carry
+// multiple roles; the caller is expected to union the scope lists at request time.
+func LoadRoleScopeMap(path string) (map[string][]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("roles.yaml: read %q: %w", path, err)
+	}
+	var cfg roleScopeConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("roles.yaml: parse %q: %w", path, err)
+	}
+	m := make(map[string][]string, len(cfg.Roles))
+	for _, entry := range cfg.Roles {
+		if entry.Name == "" {
+			return nil, fmt.Errorf("roles.yaml: entry missing required 'name' field in %q", path)
+		}
+		m[entry.Name] = entry.Scopes
+	}
+	return m, nil
+}
+
+// ValidateRoleScopeMap checks that every scope referenced in the map is declared
+// in the OpenAPI spec. An unrecognized scope name is almost certainly a typo that
+// would silently deny access, so we fail fast at startup rather than at request time.
+func ValidateRoleScopeMap(m map[string][]string, registry *ScopeRegistry) error {
+	known := registry.AllScopes()
+	for role, scopes := range m {
+		for _, s := range scopes {
+			if _, ok := known[s]; !ok {
+				return fmt.Errorf("roles.yaml: role %q references unknown scope %q — check the OpenAPI spec for valid scope names", role, s)
+			}
+		}
+	}
+	return nil
+}

--- a/platform-api/src/internal/server/server.go
+++ b/platform-api/src/internal/server/server.go
@@ -329,7 +329,11 @@ func StartPlatformAPIServer(cfg *config.Server, slogger *slog.Logger) (*Server, 
 	}
 	slogger.Info("Loaded OpenAPI scope registry", "path", cfg.OpenAPISpecPath)
 
-
+	// Load and validate the role-to-scope map when roles.yaml is configured.
+	roleScopeMap, err := loadRoleScopeMap(cfg, scopeRegistry, slogger)
+	if err != nil {
+		return nil, err
+	}
 
 	if !cfg.EnableScopeValidation {
 		slogger.Warn("scope validation is disabled — all authenticated requests will be allowed regardless of scope")
@@ -349,7 +353,7 @@ func StartPlatformAPIServer(cfg *config.Server, slogger *slog.Logger) (*Server, 
 			SkipValidation: false,
 		}))
 	} else {
-		authenticator, err := buildAuthenticator(cfg, slogger)
+		authenticator, err := buildAuthenticator(cfg, slogger, roleScopeMap)
 		if err != nil {
 			return nil, err
 		}
@@ -416,7 +420,7 @@ func StartPlatformAPIServer(cfg *config.Server, slogger *slog.Logger) (*Server, 
 
 // buildAuthenticator constructs an Authenticator from the server configuration.
 // Only called when BasicAuth is disabled.
-func buildAuthenticator(cfg *config.Server, slogger *slog.Logger) (middleware.Authenticator, error) {
+func buildAuthenticator(cfg *config.Server, slogger *slog.Logger, roleScopeMap map[string][]string) (middleware.Authenticator, error) {
 	if !cfg.Auth.IDP.Enabled {
 		if cfg.Auth.JWT.SkipValidation {
 			if !cfg.DevMode {
@@ -467,7 +471,7 @@ func buildAuthenticator(cfg *config.Server, slogger *slog.Logger) (middleware.Au
 		EmailClaim:        cfg.Auth.IDP.EmailClaimName,
 		ScopeClaim:        cfg.Auth.IDP.ScopeClaimName,
 		RolesClaimPath:    cfg.Auth.IDP.RolesClaimPath,
-		RoleMappings:      cfg.Auth.IDP.RoleMappings,
+		RoleScopeMap:      roleScopeMap,
 	})
 
 	idpLabel := cfg.Auth.IDP.Name
@@ -483,6 +487,25 @@ func buildAuthenticator(cfg *config.Server, slogger *slog.Logger) (middleware.Au
 		authMiddleware,
 		claimsMiddleware,
 	), nil
+}
+
+// loadRoleScopeMap loads the role-to-scope mapping for IDP role mode.
+// Returns nil when role mode is not active or no mapping file is configured,
+// which causes IDP role names to be used as-is as scope values (passthrough).
+func loadRoleScopeMap(cfg *config.Server, registry *middleware.ScopeRegistry, slogger *slog.Logger) (map[string][]string, error) {
+	if !cfg.Auth.IDP.Enabled || cfg.Auth.IDP.ValidationMode != "role" || cfg.Auth.IDP.RoleMappingsFile == "" {
+		return nil, nil
+	}
+
+	m, err := middleware.LoadRoleScopeMap(cfg.Auth.IDP.RoleMappingsFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load role mappings file: %w", err)
+	}
+	if err := middleware.ValidateRoleScopeMap(m, registry); err != nil {
+		return nil, fmt.Errorf("invalid roles.yaml: %w", err)
+	}
+	slogger.Info("Loaded role-to-scope mapping", "path", cfg.Auth.IDP.RoleMappingsFile, "roles", len(m))
+	return m, nil
 }
 
 // generateSelfSignedCert creates a self-signed certificate for development and saves it to disk

--- a/platform-api/src/resources/roles.yaml
+++ b/platform-api/src/resources/roles.yaml
@@ -1,0 +1,83 @@
+# Role-to-scope mapping for IDP role mode (auth.idp.validation_mode: role).
+#
+# Each entry maps an IDP role name (as it appears in the token claim configured
+# by auth.idp.roles_claim_path) to the list of platform scopes that role grants.
+# When a token carries multiple roles, the effective scopes are the union of all
+# role entries — most-permissive wins.
+#
+# Supported IDPs:
+#   Asgardeo  — set roles_claim_path: roles
+#   Keycloak  — set roles_claim_path: realm_access.roles  (or resource_access.<client>.roles)
+#   Microsoft Entra ID — set roles_claim_path: roles
+#
+# All scope names must be declared in the OpenAPI spec; unrecognized scopes are
+# rejected at server startup so configuration mistakes surface immediately.
+#
+# This file requires a server restart to take effect.
+
+roles:
+  - name: platform-admin
+    scopes:
+      - ap:project:create
+      - ap:project:read
+      - ap:project:update
+      - ap:project:delete
+      - ap:project:manage
+      - ap:gateway:create
+      - ap:gateway:read
+      - ap:gateway:update
+      - ap:gateway:delete
+      - ap:gateway:manage
+      - ap:rest_api:create
+      - ap:rest_api:read
+      - ap:rest_api:update
+      - ap:rest_api:delete
+      - ap:rest_api:manage
+      - ap:rest_api:deployment:create
+      - ap:rest_api:deployment:read
+      - ap:rest_api:deployment:manage
+      - ap:rest_api:deployment:undeploy
+      - ap:devportal:create
+      - ap:devportal:read
+      - ap:devportal:update
+      - ap:devportal:delete
+      - ap:devportal:manage
+      - ap:application:create
+      - ap:application:read
+      - ap:application:update
+      - ap:application:delete
+      - ap:application:manage
+      - ap:subscription_plan:create
+      - ap:subscription_plan:read
+      - ap:subscription_plan:update
+      - ap:subscription_plan:delete
+      - ap:subscription_plan:manage
+
+  - name: platform-developer
+    scopes:
+      - ap:project:read
+      - ap:project:create
+      - ap:rest_api:create
+      - ap:rest_api:read
+      - ap:rest_api:update
+      - ap:rest_api:manage
+      - ap:rest_api:deployment:create
+      - ap:rest_api:deployment:read
+      - ap:rest_api:deployment:manage
+      - ap:rest_api:deployment:undeploy
+      - ap:gateway:read
+      - ap:devportal:read
+      - ap:application:create
+      - ap:application:read
+      - ap:application:update
+      - ap:application:manage
+      - ap:subscription_plan:read
+
+  - name: platform-viewer
+    scopes:
+      - ap:project:read
+      - ap:rest_api:read
+      - ap:gateway:read
+      - ap:devportal:read
+      - ap:application:read
+      - ap:subscription_plan:read


### PR DESCRIPTION
$subject

- Updated IDP configuration to replace role mappings with a role-to-scope mapping file.
- Introduced a new `roles.yaml` file to define mappings from IDP roles to platform scopes.
- Enhanced the `PlatformClaimsMiddleware` to utilize the new role-to-scope mapping.
- Added functions to load and validate the role-to-scope map at server startup.
- Created unit tests for role extraction and resolution logic to ensure correct functionality.
- Cleaned up related code to support the new mapping structure and improve maintainability.
