### PR TITLE
Enhance AI Workspace TLS configuration and documentation

### DIFF
--- a/portals/ai-workspace/README.md
+++ b/portals/ai-workspace/README.md
@@ -163,9 +163,93 @@ const { isAuthenticated, isLoading, user, accessToken, hasPermission, login, log
 ```
   cd platform-api         && make build   # builds ghcr.io/.../platform-api:latest
   cd portals/ai-workspace && make build   # builds ghcr.io/.../ai-workspace:latest
-  cd portals/ai-workspace && docker compose up
+  docker-compose -f distribution/docker-compose.yaml --project-directory . up
 ```
 
+
+## Docker Distribution
+
+The `distribution/` folder contains the standalone compose release of AI Workspace. It brings up two containers — the React SPA served by nginx, and the Platform API Go backend — with no other dependencies.
+
+```
+distribution/
+├── docker-compose.yaml   # Orchestrates ai-workspace + platform-api
+└── configs/
+    └── config.toml       # Non-sensitive runtime settings (mounted into both containers)
+```
+
+### Port allocation
+
+| Service | Port | Protocol |
+|---|---|---|
+| AI Workspace (nginx) | `5380` | HTTPS |
+| Platform API | `9243` | HTTPS |
+
+Port **5380** was chosen for AI Workspace to avoid collision with the API Gateway, which occupies **8080**. All other commonly used ports in this repo (8081, 8090, 9001–9092, 18000–18001) were surveyed and excluded.
+
+### HTTPS
+
+Both containers are served over HTTPS. Both fall back to a self-signed certificate when no cert is explicitly provided — browsers will show a trust warning in that case.
+
+#### Providing your own certificate (removes the browser warning)
+
+Both services support mounting a CA-signed (or locally trusted) certificate via Docker volume. Uncomment the relevant lines in `docker-compose.yaml` under each service, then place your files in a `certs/` directory next to the compose file:
+
+```
+distribution/
+├── docker-compose.yaml
+├── configs/
+│   └── config.toml
+└── certs/                        ← create this directory
+    ├── ai-workspace.crt          ← PEM certificate or full chain
+    ├── ai-workspace.key          ← PEM private key
+    ├── platform-api.crt          ← PEM certificate or full chain
+    └── platform-api.key          ← PEM private key
+```
+
+**AI Workspace** reads from `/etc/ai-workspace/tls/tls.crt` and `/etc/ai-workspace/tls/tls.key` (the mount targets in `docker-compose.yaml`). If both files are present at container startup, `entrypoint.sh` copies them into place; otherwise it generates a self-signed cert.
+
+**Platform API** reads from its `TLS_CERT_DIR` (default `/app/data/certs`, configured via `[tls] cert_dir` in `config.toml`). If `cert.pem` and `key.pem` exist in that directory at startup, it uses them; otherwise it generates and saves a self-signed cert there. The mount targets in `docker-compose.yaml` write directly into the cert dir under the expected file names.
+
+#### Self-signed fallback
+
+When no cert is mounted, both containers auto-generate a self-signed certificate at startup. The self-signed cert is valid for 3650 days so it won't expire between rebuilds. To suppress the browser warning without providing a CA cert, add the cert to your system trust store:
+
+```sh
+# AI Workspace — extract the cert from the running container
+docker cp ai-workspace:/tmp/nginx/tls.crt ./ai-workspace.crt
+
+# Platform API — cert is persisted in the data volume
+docker cp platform-api:/app/data/certs/cert.pem ./platform-api.crt
+```
+
+Then add both `.crt` files to your OS trust store (Keychain on macOS, Certificate Manager on Windows, `/usr/local/share/ca-certificates/` on Linux).
+
+### nginx (`nginx.docker.conf`)
+
+nginx is the sole process in the AI Workspace container. Key decisions:
+
+- **All writable paths under `/tmp/`** — pid, cache, logs, and temp files all use `/tmp/` subtrees so the non-root user can write them. The Dockerfile symlinks `/var/cache/nginx`, `/var/log/nginx`, and `/var/run/nginx` to `/tmp/nginx/*` equivalents.
+- **SPA fallback** — `try_files $uri $uri/ /index.html` on the root location sends all unmatched paths to the React app for client-side routing.
+- **`index.html` served with `no-store`** — prevents the browser from caching the entry HTML, ensuring it always fetches the latest `runtime-config.js` on reload.
+- **`/runtime-config.js` aliased from `/tmp/`** — `entrypoint.sh` writes runtime `VITE_*` env vars to `/tmp/runtime-config.js` at startup; nginx aliases this path to serve it. This allows runtime configuration without rebuilding the image.
+- **TLS cipher suite** — matches the gateway's explicit ECDHE+AES-GCM/ChaCha20 list (Mozilla Intermediate). `ssl_prefer_server_ciphers on` ensures TLS 1.2 clients use the server's preferred cipher rather than a weaker client choice. Session cache (`shared:SSL:10m`) improves performance; `ssl_session_tickets off` preserves forward secrecy by preventing ticket-key reuse. HSTS (`max-age=31536000; includeSubDomains`) tells browsers to enforce HTTPS permanently once visited.
+- **WebSocket upgrade headers** — the `map $http_upgrade $connection_upgrade` block and `Upgrade`/`Connection` headers on the proxy location support WebSocket pass-through for streaming API responses.
+- **Reverse proxy to Platform API** — `/api-proxy/` is stripped and forwarded to `https://platform-api:9243/`. Read/send timeouts are set to 3600s to accommodate long-running streaming requests.
+- **Security headers on `index.html`** — `X-Frame-Options`, `Content-Security-Policy`, `X-Content-Type-Options`, `X-XSS-Protection`, and `X-Permitted-Cross-Domain-Policies` are set for the entry HTML only (not static assets, which don't need them).
+- **gzip** — enabled for text, CSS, SVG, JS, JSON, fonts, and zip.
+
+### `entrypoint.sh` startup sequence
+
+1. Create `/tmp/nginx/` subdirectories and re-establish symlinks for nginx's writable paths.
+2. Read `[ai_workspace]` section from the mounted `config.toml` and export matched keys as `VITE_*` env vars (env vars already set take priority).
+3. Write all current `VITE_*` env vars into `/tmp/runtime-config.js` so the SPA can read runtime config without a rebuild.
+4. If a user cert is mounted at `/etc/ai-workspace/tls/`, copy it into `/tmp/nginx/`; otherwise generate a self-signed cert there.
+5. Start nginx in the foreground (`daemon off`).
+
+### Non-root container user
+
+The container runs as UID/GID **10001** (`aiworkspace`). This satisfies the `CKV_CHOREO_1` Checkov policy. All files the process needs to write at runtime are under `/tmp/`, which is world-writable. Static app files under `/app/` are owned by this user at build time via `COPY --chown`.
 
 ## Other Documentations
 [Mock Backend Documentation](workspaces/apps/ai-workspace/mock-service/README.md)

--- a/portals/ai-workspace/configs/config.toml
+++ b/portals/ai-workspace/configs/config.toml
@@ -94,7 +94,7 @@ enabled = false
 # ---------------------------------------------------------------------------
 [ai_workspace]
 # Domain shown in the browser address bar (host:port or just host for port 80/443).
-domain = "localhost:8080"
+domain = "localhost:5380"
 
 # Authentication mode for the UI: "basic" (local) or "oidc" (external IDP).
 auth_mode = "basic"

--- a/portals/ai-workspace/distribution/docker-compose.yaml
+++ b/portals/ai-workspace/distribution/docker-compose.yaml
@@ -21,7 +21,18 @@
 #
 # Ports:
 #   AI Workspace  →  https://localhost:5380
-#   Platform API  →  https://localhost:9243  (self-signed TLS)
+#   Platform API  →  https://localhost:9243
+#
+# TLS certificates (optional — avoids browser trust warnings):
+#   Both services fall back to a self-signed certificate when no cert is mounted.
+#   To use your own certificate, uncomment the volume lines under each service
+#   and place your files in a certs/ directory next to this file:
+#
+#     certs/
+#       ai-workspace.crt   ← PEM certificate (or full chain)
+#       ai-workspace.key   ← PEM private key
+#       platform-api.crt   ← PEM certificate (or full chain)
+#       platform-api.key   ← PEM private key
 # --------------------------------------------------------------------
 
 services:
@@ -42,6 +53,10 @@ services:
     volumes:
       - ./configs/config.toml:/etc/platform-api/config.toml:ro
       - platform-api-data:/app/data
+      # Optional: mount your own TLS certificate to remove the browser trust warning.
+      # The file names must match exactly (cert.pem / key.pem).
+      # - ./certs/platform-api.crt:/app/data/certs/cert.pem:ro
+      # - ./certs/platform-api.key:/app/data/certs/key.pem:ro
     ports:
       - "9243:9243"
     healthcheck:
@@ -69,6 +84,10 @@ services:
       - VITE_PORTAL_API_BASE_URL=/api-proxy/api/portal/v1
     volumes:
       - ./configs/config.toml:/etc/ai-workspace/config.toml:ro
+      # Optional: mount your own TLS certificate to remove the browser trust warning.
+      # The file names must match exactly (tls.crt / tls.key).
+      # - ./certs/ai-workspace.crt:/etc/ai-workspace/tls/tls.crt:ro
+      # - ./certs/ai-workspace.key:/etc/ai-workspace/tls/tls.key:ro
     ports:
       - "5380:5380"
     healthcheck:

--- a/portals/ai-workspace/entrypoint.sh
+++ b/portals/ai-workspace/entrypoint.sh
@@ -104,15 +104,27 @@ var_count=$(env | grep -c '^VITE_' || echo "0")
 echo "Runtime configuration generated with $var_count VITE_* variables at /tmp/runtime-config.js"
 
 # ---------------------------------------------------------------------------
-# TLS — generate a self-signed certificate so nginx can serve HTTPS
+# TLS — use a user-provided certificate if mounted, otherwise self-signed.
+# Mount your cert/key at /etc/ai-workspace/tls/tls.crt and tls.key to avoid
+# the browser trust warning (see docker-compose.yaml for the volume example).
 # ---------------------------------------------------------------------------
-echo "Generating self-signed TLS certificate..."
-openssl req -x509 -nodes -newkey rsa:2048 -days 3650 \
-  -keyout /tmp/nginx/tls.key \
-  -out    /tmp/nginx/tls.crt \
-  -subj   "/CN=localhost" 2>/dev/null
-chmod 600 /tmp/nginx/tls.key
-echo "TLS certificate generated at /tmp/nginx/tls.crt"
+USER_CERT="/etc/ai-workspace/tls/tls.crt"
+USER_KEY="/etc/ai-workspace/tls/tls.key"
+
+if [ -f "$USER_CERT" ] && [ -f "$USER_KEY" ]; then
+  echo "Using user-provided TLS certificate from $USER_CERT"
+  cp "$USER_CERT" /tmp/nginx/tls.crt
+  cp "$USER_KEY"  /tmp/nginx/tls.key
+  chmod 600 /tmp/nginx/tls.key
+else
+  echo "No certificate found at $USER_CERT — generating self-signed certificate..."
+  openssl req -x509 -nodes -newkey rsa:2048 -days 3650 \
+    -keyout /tmp/nginx/tls.key \
+    -out    /tmp/nginx/tls.crt \
+    -subj   "/CN=localhost" 2>/dev/null
+  chmod 600 /tmp/nginx/tls.key
+  echo "Self-signed certificate generated (browsers will show a trust warning)"
+fi
 
 # Start nginx in foreground
 echo "Starting nginx..."

--- a/portals/ai-workspace/nginx.docker.conf
+++ b/portals/ai-workspace/nginx.docker.conf
@@ -33,10 +33,15 @@ http {
         ssl_certificate     /tmp/nginx/tls.crt;
         ssl_certificate_key /tmp/nginx/tls.key;
         ssl_protocols       TLSv1.2 TLSv1.3;
-        ssl_ciphers         HIGH:!aNULL:!MD5;
+        ssl_ciphers         ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305;
+        ssl_prefer_server_ciphers on;
+        ssl_session_cache   shared:SSL:10m;
+        ssl_session_timeout 1d;
+        ssl_session_tickets off;
 
         location /index.html {
             add_header 'Cache-Control'                 'no-store';
+            add_header Strict-Transport-Security       "max-age=31536000; includeSubDomains" always;
             add_header X-Frame-Options                 "sameorigin"    always;
             add_header Content-Security-Policy         "frame-ancestors 'self'" always;
             add_header X-Content-Type-Options          "nosniff"       always;


### PR DESCRIPTION
- Updated entrypoint.sh to allow the use of user-provided TLS certificates, falling back to self-signed certificates if none are found.
- Modified nginx.docker.conf to improve SSL configuration, including a more secure cipher suite and HSTS headers.
- Revised README.md to clarify the process for providing custom certificates and updated port allocation details.
- Adjusted config.toml to reflect the new port for AI Workspace.
- Enhanced docker-compose.yaml with comments on optional TLS certificate mounting for better user guidance.

