### PR TITLE
[APIP] Add TokenId field to AuthContext struct

### DIFF
--- a/gateway/gateway-runtime/api/proto/python_executor.proto
+++ b/gateway/gateway-runtime/api/proto/python_executor.proto
@@ -203,6 +203,7 @@ message AuthContext {
   string credential_id = 8;
   map<string, string> properties = 9;
   AuthContext previous = 10;
+  string token_id = 11;
 }
 
 message RequestHeaderContext {

--- a/gateway/gateway-runtime/policy-engine/internal/pythonbridge/proto/python_executor.pb.go
+++ b/gateway/gateway-runtime/policy-engine/internal/pythonbridge/proto/python_executor.pb.go
@@ -1552,6 +1552,7 @@ type AuthContext struct {
 	CredentialId  string                 `protobuf:"bytes,8,opt,name=credential_id,json=credentialId,proto3" json:"credential_id,omitempty"`
 	Properties    map[string]string      `protobuf:"bytes,9,rep,name=properties,proto3" json:"properties,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Previous      *AuthContext           `protobuf:"bytes,10,opt,name=previous,proto3" json:"previous,omitempty"`
+	TokenId       string                 `protobuf:"bytes,11,opt,name=token_id,json=tokenId,proto3" json:"token_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1654,6 +1655,13 @@ func (x *AuthContext) GetPrevious() *AuthContext {
 		return x.Previous
 	}
 	return nil
+}
+
+func (x *AuthContext) GetTokenId() string {
+	if x != nil {
+		return x.TokenId
+	}
+	return ""
 }
 
 type RequestHeaderContext struct {
@@ -4184,7 +4192,7 @@ const file_proto_python_executor_proto_rawDesc = "" +
 	"StreamBody\x12\x14\n" +
 	"\x05chunk\x18\x01 \x01(\fR\x05chunk\x12\"\n" +
 	"\rend_of_stream\x18\x02 \x01(\bR\vendOfStream\x12\x14\n" +
-	"\x05index\x18\x03 \x01(\x04R\x05index\"\xce\x04\n" +
+	"\x05index\x18\x03 \x01(\x04R\x05index\"\xe9\x04\n" +
 	"\vAuthContext\x12$\n" +
 	"\rauthenticated\x18\x01 \x01(\bR\rauthenticated\x12\x1e\n" +
 	"\n" +
@@ -4200,7 +4208,8 @@ const file_proto_python_executor_proto_rawDesc = "" +
 	"properties\x18\t \x03(\v29.wso2.gateway.python.v1alpha2.AuthContext.PropertiesEntryR\n" +
 	"properties\x12E\n" +
 	"\bprevious\x18\n" +
-	" \x01(\v2).wso2.gateway.python.v1alpha2.AuthContextR\bprevious\x1a9\n" +
+	" \x01(\v2).wso2.gateway.python.v1alpha2.AuthContextR\bprevious\x12\x19\n" +
+	"\btoken_id\x18\v \x01(\tR\atokenId\x1a9\n" +
 	"\vScopesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\bR\x05value:\x028\x01\x1a=\n" +

--- a/gateway/gateway-runtime/policy-engine/internal/pythonbridge/translator.go
+++ b/gateway/gateway-runtime/policy-engine/internal/pythonbridge/translator.go
@@ -258,6 +258,7 @@ func (t *Translator) toProtoAuthContext(ctx *policy.AuthContext) *proto.AuthCont
 		AuthType:      ctx.AuthType,
 		Subject:       ctx.Subject,
 		Issuer:        ctx.Issuer,
+		TokenId:       ctx.TokenId,
 		Audience:      append([]string(nil), ctx.Audience...),
 		Scopes:        scopes,
 		CredentialId:  ctx.CredentialID,

--- a/gateway/gateway-runtime/policy-engine/internal/pythonbridge/translator_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/pythonbridge/translator_test.go
@@ -40,6 +40,7 @@ func TestTranslatorToProtoSharedContextPreservesStructuredAuth(t *testing.T) {
 			Authorized:    true,
 			AuthType:      "jwt",
 			Subject:       "alice",
+			TokenId:       "tok-abc",
 			Scopes:        map[string]bool{"read:pets": true},
 			Properties:    map[string]string{"tenant": "demo"},
 			Previous: &policy.AuthContext{
@@ -57,6 +58,7 @@ func TestTranslatorToProtoSharedContextPreservesStructuredAuth(t *testing.T) {
 	assert.Equal(t, true, result.GetMetadata().GetFields()["flag"].GetBoolValue())
 	require.NotNil(t, result.GetAuthContext())
 	assert.Equal(t, "jwt", result.GetAuthContext().GetAuthType())
+	assert.Equal(t, "tok-abc", result.GetAuthContext().GetTokenId())
 	assert.Equal(t, true, result.GetAuthContext().GetScopes()["read:pets"])
 	require.NotNil(t, result.GetAuthContext().GetPrevious())
 	assert.Equal(t, "apikey", result.GetAuthContext().GetPrevious().GetAuthType())

--- a/sdk/core/policy/v1alpha2/auth_context.go
+++ b/sdk/core/policy/v1alpha2/auth_context.go
@@ -38,6 +38,9 @@ type AuthContext struct {
 	// fields above (e.g., custom JWT claims).
 	Properties map[string]string
 
+	// TokenId holds the unique identifier of a token (e.g. for a jwt it can be jti)
+	TokenId string
+
 	// Previous points to the AuthContext set by an earlier auth policy in a
 	// multi-layer auth chain. Nil if this is the only auth layer.
 	Previous *AuthContext


### PR DESCRIPTION
Related to https://github.com/wso2/api-platform/issues/2131

This is necessary to store the unique ID of tokens e.g. jti for jwt. This is required for backendJWT policy to be used as the key in token cacheing