### PR TITLE
Update Makefile to correct path for platform API version and streamline distribution process

### DIFF
--- a/portals/ai-workspace/Makefile
+++ b/portals/ai-workspace/Makefile
@@ -92,14 +92,14 @@ DIST_VERSION  := $(shell echo "$(VERSION)" | sed 's/-SNAPSHOT//')
 DIST_NAME     := wso2apip-ai-workspace-$(DIST_VERSION)
 DIST_DIR      := target/$(DIST_NAME)
 DIST_ZIP      := target/$(DIST_NAME).zip
-PLATFORM_API_VERSION ?= $(shell cat ../../../platform-api/VERSION 2>/dev/null | sed 's/-SNAPSHOT//' || echo "0.0.0")
+PLATFORM_API_VERSION ?= $(shell cat ../../platform-api/VERSION 2>/dev/null | sed 's/-SNAPSHOT//' || echo "0.0.0")
 
 .PHONY: dist clean-dist
 dist: clean-dist ## Build standalone AI Workspace + Platform API distribution zip
 	@echo "Building distribution $(DIST_NAME)..."
 	@mkdir -p $(DIST_DIR)/configs $(DIST_DIR)/resources/certificates
 	@cp -R configs/. $(DIST_DIR)/configs/
-	@cp distribution/docker-compose.yaml $(DIST_DIR)/docker-compose.yaml
+	@cp docker-compose.yaml $(DIST_DIR)/docker-compose.yaml
 	@sed -i.bak \
 	    -e 's|/ai-workspace:[^[:space:]]*|/ai-workspace:$(DIST_VERSION)|g' \
 	    -e 's|/platform-api:[^[:space:]]*|/platform-api:$(PLATFORM_API_VERSION)|g' \


### PR DESCRIPTION
- https://github.com/wso2/api-platform/issues/2172

- Adjusted the path for reading the PLATFORM_API_VERSION to ensure it points to the correct location.
- Simplified the distribution process by modifying the copy command for the Docker Compose file, enhancing clarity in the build steps.