### PR TITLE
fix(gateway): resolve vhost sentinel on the REST API update path

### DIFF
--- a/gateway/gateway-controller/pkg/api/handlers/handlers_test.go
+++ b/gateway/gateway-controller/pkg/api/handlers/handlers_test.go
@@ -3820,6 +3820,137 @@ func TestUpdateRestAPISyncsDisplayNameAndVersion(t *testing.T) {
 	assert.Len(t, mockHub.publishedEvents, 1)
 }
 
+func TestUpdateRestAPIResolvesVhostSentinels(t *testing.T) {
+	server := createTestAPIServer()
+	mockDB := server.db.(*MockStorage)
+	mockHub := &mockEventHub{}
+	attachTestEventHub(server, mockHub, "test-gateway")
+
+	existing := createTestStoredConfig("0000-test-id-0000-000000000000", "test-display-name", "v1.0.0", "/test")
+	existing.Handle = "test-handle"
+	require.NoError(t, mockDB.SaveConfig(existing))
+
+	// Construct request body with sentinel vhosts
+	sandboxSentinel := "_gateway_default_"
+	apiConfig := api.RestAPI{
+		ApiVersion: api.RestAPIApiVersionGatewayApiPlatformWso2Comv1alpha1,
+		Kind:       api.RestAPIKindRestApi,
+		Metadata: api.Metadata{
+			Name: "test-handle",
+		},
+		Spec: api.APIConfigData{
+			DisplayName: "test-display-name",
+			Version:     "v1.0.0",
+			Context:     "/test",
+			Vhosts: &struct {
+				Main    string  `json:"main" yaml:"main"`
+				Sandbox *string `json:"sandbox,omitempty" yaml:"sandbox,omitempty"`
+			}{
+				Main:    "_gateway_default_",
+				Sandbox: &sandboxSentinel,
+			},
+			Upstream: struct {
+				Main    api.Upstream  `json:"main" yaml:"main"`
+				Sandbox *api.Upstream `json:"sandbox,omitempty" yaml:"sandbox,omitempty"`
+			}{
+				Main: api.Upstream{
+					Url: stringPtr("http://backend.example.com"),
+				},
+			},
+			Operations: []api.Operation{
+				{
+					Method: "GET",
+					Path:   "/resource",
+				},
+			},
+		},
+	}
+
+	body, err := json.Marshal(apiConfig)
+	require.NoError(t, err)
+
+	c, w := createTestContextWithHeader("PUT", "/rest-apis/test-handle", body, map[string]string{
+		"Content-Type": "application/json",
+	})
+
+	server.UpdateRestAPI(c, "test-handle")
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	stored, err := mockDB.GetConfig(existing.UUID)
+	require.NoError(t, err)
+
+	storedRest, ok := stored.SourceConfiguration.(api.RestAPI)
+	require.True(t, ok)
+	require.NotNil(t, storedRest.Spec.Vhosts)
+	assert.Equal(t, "localhost", storedRest.Spec.Vhosts.Main)
+	require.NotNil(t, storedRest.Spec.Vhosts.Sandbox)
+	assert.Equal(t, "sandbox-localhost", *storedRest.Spec.Vhosts.Sandbox)
+}
+
+// TestUpdateRestAPIPopulatesOmittedVhosts covers the omitted-vhosts case, where the resolver
+// allocates a fresh Vhosts pointer. This specifically guards the SourceConfiguration re-sync on
+// the update path: the explicit-vhost test above would still pass without it (the resolver
+// mutates a shared pointer), but here the resolved value only reaches the stored row via that
+// re-sync.
+func TestUpdateRestAPIPopulatesOmittedVhosts(t *testing.T) {
+	server := createTestAPIServer()
+	mockDB := server.db.(*MockStorage)
+	mockHub := &mockEventHub{}
+	attachTestEventHub(server, mockHub, "test-gateway")
+
+	existing := createTestStoredConfig("0000-test-id-0000-000000000000", "test-display-name", "v1.0.0", "/test")
+	existing.Handle = "test-handle"
+	require.NoError(t, mockDB.SaveConfig(existing))
+
+	// Vhosts omitted entirely (nil) in the request body.
+	apiConfig := api.RestAPI{
+		ApiVersion: api.RestAPIApiVersionGatewayApiPlatformWso2Comv1alpha1,
+		Kind:       api.RestAPIKindRestApi,
+		Metadata:   api.Metadata{Name: "test-handle"},
+		Spec: api.APIConfigData{
+			DisplayName: "test-display-name",
+			Version:     "v1.0.0",
+			Context:     "/test",
+			Upstream: struct {
+				Main    api.Upstream  `json:"main" yaml:"main"`
+				Sandbox *api.Upstream `json:"sandbox,omitempty" yaml:"sandbox,omitempty"`
+			}{
+				Main: api.Upstream{
+					Url: stringPtr("http://backend.example.com"),
+				},
+			},
+			Operations: []api.Operation{
+				{
+					Method: "GET",
+					Path:   "/resource",
+				},
+			},
+		},
+	}
+
+	body, err := json.Marshal(apiConfig)
+	require.NoError(t, err)
+
+	c, w := createTestContextWithHeader("PUT", "/rest-apis/test-handle", body, map[string]string{
+		"Content-Type": "application/json",
+	})
+
+	server.UpdateRestAPI(c, "test-handle")
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	stored, err := mockDB.GetConfig(existing.UUID)
+	require.NoError(t, err)
+
+	storedRest, ok := stored.SourceConfiguration.(api.RestAPI)
+	require.True(t, ok)
+	require.NotNil(t, storedRest.Spec.Vhosts, "omitted vhosts must be populated with defaults and persisted")
+	assert.Equal(t, "localhost", storedRest.Spec.Vhosts.Main)
+	require.NotNil(t, storedRest.Spec.Vhosts.Sandbox)
+	assert.Equal(t, "sandbox-localhost", *storedRest.Spec.Vhosts.Sandbox)
+}
+
 // TestGetMCPProxyByIdDBUnavailable tests GetMCPProxyById with DB unavailable
 // Note: This test requires full deployment service setup
 func TestGetMCPProxyByIdDBUnavailable(t *testing.T) {

--- a/gateway/gateway-controller/pkg/service/restapi/service.go
+++ b/gateway/gateway-controller/pkg/service/restapi/service.go
@@ -305,6 +305,13 @@ func (s *RestAPIService) Update(params UpdateParams) (*UpdateResult, error) {
 	existing.Configuration = apiConfig
 	existing.SourceConfiguration = apiConfig
 
+	// Resolve gateway-default vhost sentinels before render and validation, mirroring the
+	// create path, so the stored vhost is a concrete host rather than the raw sentinel.
+	if err := utils.ResolveVhostSentinels(&existing.Configuration, s.routerConfig); err != nil {
+		return nil, fmt.Errorf("failed to resolve vhost sentinels: %w", err)
+	}
+	existing.SourceConfiguration = existing.Configuration
+
 	// Render template expressions before validation so the validator sees resolved values
 	// (e.g. {{ env "BACKEND_URL" }} → actual URL).
 	if err := templateengine.RenderSpec(existing, s.secretResolver, log); err != nil {

--- a/gateway/gateway-controller/pkg/utils/api_deployment.go
+++ b/gateway/gateway-controller/pkg/utils/api_deployment.go
@@ -747,6 +747,11 @@ func resolveVhostSentinels(cfg *any, routerCfg *config.RouterConfig) error {
 	return nil
 }
 
+// ResolveVhostSentinels exposes vhost sentinel resolution to write paths outside this package.
+func ResolveVhostSentinels(cfg *any, routerCfg *config.RouterConfig) error {
+	return resolveVhostSentinels(cfg, routerCfg)
+}
+
 // annotationValue safely reads a single annotation key from a pointer-to-map.
 func annotationValue(annotations *map[string]string, key string) string {
 	if annotations == nil {

--- a/gateway/it/features/vhost-routing-single.feature
+++ b/gateway/it/features/vhost-routing-single.feature
@@ -175,3 +175,79 @@ Feature: Gateway vhost routing with single-domain defaults
     Given I authenticate using basic auth as "admin"
     When I delete the API "vhost-single-sentinel-v1.0"
     Then the response should be successful
+
+  Scenario: Sentinel vhost stays resolved after an update
+    When I deploy this API configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1alpha1
+      kind: RestApi
+      metadata:
+        name: vhost-single-sentinel-update-v1.0
+      spec:
+        displayName: VHost-Single-Sentinel-Update
+        version: v1.0
+        context: /vhost-single-sentinel-update/$version
+        vhosts:
+          main: _gateway_default_
+          sandbox: _gateway_default_
+        upstream:
+          main:
+            url: http://sample-backend:9080
+          sandbox:
+            url: http://sample-backend:9080/sandbox
+        operations:
+          - method: GET
+            path: /whoami
+      """
+    Then the response should be successful
+    And I wait for the endpoint "http://localhost:8080/vhost-single-sentinel-update/v1.0/whoami" to be ready with host "api.wso2.com"
+
+    # Re-send the full spec with the sentinel (as the platform does on every update) and add a
+    # new operation. The new route only exists once the update applies, and it must land on the
+    # RESOLVED host. Before the fix the update stored the raw marker, so the new route would not be
+    # reachable on the resolved host (the unresolved sentinel is used literally or rejected) and the
+    # wait below would time out.
+    When I update the API "vhost-single-sentinel-update-v1.0" with this configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1alpha1
+      kind: RestApi
+      metadata:
+        name: vhost-single-sentinel-update-v1.0
+      spec:
+        displayName: VHost-Single-Sentinel-Update
+        version: v1.0
+        context: /vhost-single-sentinel-update/$version
+        vhosts:
+          main: _gateway_default_
+          sandbox: _gateway_default_
+        upstream:
+          main:
+            url: http://sample-backend:9080
+          sandbox:
+            url: http://sample-backend:9080/sandbox
+        operations:
+          - method: GET
+            path: /whoami
+          - method: GET
+            path: /after-update
+      """
+    Then the response should be successful
+    And I wait for the endpoint "http://localhost:8080/vhost-single-sentinel-update/v1.0/after-update" to be ready with host "api.wso2.com"
+
+    # The original route still serves on the resolved host
+    When I clear all headers
+    And I set request host to "api.wso2.com"
+    And I send a GET request to "http://localhost:8080/vhost-single-sentinel-update/v1.0/whoami"
+    Then the response should be successful
+    And the response should be valid JSON
+    And the JSON response field "path" should be "/whoami"
+
+    # The sentinel string itself must NOT be a usable host after the update
+    When I clear all headers
+    And I set request host to "_gateway_default_"
+    And I send a GET request to "http://localhost:8080/vhost-single-sentinel-update/v1.0/after-update"
+    Then the response status code should be 404
+
+    Given I authenticate using basic auth as "admin"
+    When I delete the API "vhost-single-sentinel-update-v1.0"
+    Then the response should be successful


### PR DESCRIPTION
## Purpose

The REST API update (PUT) path did not resolve the gateway-default vhost sentinel (`_gateway_default_`) before persisting and rendering. The create path already resolves and stores the concrete hostname; the update path stored the raw sentinel.

Because the xDS route builders use the stored vhost value literally (they fall back to the router default only for blank values, not the sentinel), an updated API ended up with the literal string `_gateway_default_` as its vhost and became unreachable (404). The update itself returned success, so the failure was silent until traffic was tested.

Fixes #2174.

## Goals

Make the update path resolve the gateway-default vhost sentinel and persist the concrete hostname, exactly as the create path does, so editing an API that uses the gateway default does not silently break its routing. A redeploy then refreshes the vhost to the current default: an API on the default stays frozen until it is redeployed.

## Approach

- Export `ResolveVhostSentinels` from `pkg/utils/api_deployment.go` (a thin wrapper over the existing internal `resolveVhostSentinels`) so the service layer can call it.
- Call it in `RestAPIService.Update` (`pkg/service/restapi/service.go`) before template rendering and validation, mirroring the create path, and re-sync `SourceConfiguration` so the resolved value is what gets persisted.
- No change to the resolver logic itself; the update path now reuses the same resolution the create path already performs.

## User stories

As an API developer, when I edit an API that was deployed using the gateway default vhost (for example to change a backend URL), the API should keep serving on its resolved hostname instead of silently dropping off its address.

## Documentation

N/A. This is a bug fix with no change to the user-facing API contract or configuration.

## Automation tests

 - Unit tests
   > Two handler-level tests cover the update path: `TestUpdateRestAPIResolvesVhostSentinels` (a PUT with a sentinel vhost persists the resolved host) and `TestUpdateRestAPIPopulatesOmittedVhosts` (an omitted vhost is populated with the gateway defaults and persisted; this case specifically guards the `SourceConfiguration` re-sync, the explicit-vhost case passes via pointer aliasing even without it). The underlying resolver is already covered by existing unit tests.
 - Integration tests
   > New scenario "Sentinel vhost stays resolved after an update" in `gateway/it/features/vhost-routing-single.feature`: deploys an API with the sentinel vhost, updates it (PUT), and asserts it still routes on the resolved host and that the literal `_gateway_default_` string is not a usable host (404). This scenario fails without the fix.

## Security checks

 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (Go module; FindSecurityBugs is a Java/SpotBugs tool)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

Gateway config:

```yaml
router:
  vhosts:
    main:
      default: apis.acme.com
```

An API deployed with the default vhost, then updated (the platform sends the marker on every deploy and update):

```yaml
spec:
  vhosts:
    main: _gateway_default_
  upstream:
    main:
      url: http://order-svc:9090
```

Before: after an update, `vhosts.main` was stored as the literal `_gateway_default_` and the API returned 404. After: the update resolves it to `apis.acme.com` and the API keeps serving.

## Notes

- The PUT response now echoes the **resolved** vhost values rather than the sentinel the client sent. This is consistent with the create path.
- This change does not add write-path validation for identical main and sandbox vhosts. If both resolve to the same host, the deploy still returns 200 and the collision is only caught at xDS build time. That write-path rejection is a separate concern and applies once this fix lands on a branch that carries it. Create behaves the same way today, so this is not a regression.
- Rows that were already persisted with the unresolved sentinel by the previous (buggy) update path are not repaired on upgrade. They resolve on the next deploy/update of that API (the platform re-sends the full spec on every reconcile). Such an API was already unreachable before the upgrade, so this introduces no new breakage.

## Related PRs

N/A.

## Test environment

 - Go (version per `gateway/gateway-controller/go.mod`)
 - Unit tests pass; integration scenario added to the vhost-routing-single suite.
