### PR TITLE
fix(policy-engine): bump sdk/core to v0.2.14 for TokenId field

### DIFF
--- a/gateway/gateway-runtime/policy-engine/go.mod
+++ b/gateway/gateway-runtime/policy-engine/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/stretchr/testify v1.11.1
 	github.com/wso2/api-platform/common v0.0.0-20260326194347-3d85c50eae71
-	github.com/wso2/api-platform/sdk/core v0.2.12
+	github.com/wso2/api-platform/sdk/core v0.2.14
 	go.opentelemetry.io/otel v1.41.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.41.0
 	go.opentelemetry.io/otel/sdk v1.41.0

--- a/gateway/gateway-runtime/policy-engine/go.sum
+++ b/gateway/gateway-runtime/policy-engine/go.sum
@@ -92,8 +92,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/wso2/api-platform/sdk/core v0.2.12 h1:todO77VOlxw8bWniFK/GyEbuM1R5ELnULgR+37Xdrak=
-github.com/wso2/api-platform/sdk/core v0.2.12/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.2.14 h1:z3LgbgOBeXGoJ891YqrpbpLfgYHZIm4Asj4o3IP5wI4=
+github.com/wso2/api-platform/sdk/core v0.2.14/go.mod h1:TgjpOk3QBPc7xEQC+NctWcNq5dSPBkn7wSKh+hULTj8=
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=


### PR DESCRIPTION
## Purpose

The Gateway Integration Test pipeline fails at the **Build coverage-instrumented images** step with a compile error in the policy engine:

```
internal/pythonbridge/translator.go:261:22: ctx.TokenId undefined (type *policyv1alpha2.AuthContext has no field or method TokenId)
```

`translator.go` reads `AuthContext.TokenId`, a field added to the SDK and first published in `sdk/core v0.2.14`. The policy engine's `go.mod` still pinned `sdk/core v0.2.12`, which predates that field. Local builds were unaffected because `go.work` redirects `sdk/core` to the in-tree copy (which has the field); the Docker build runs without the workspace and pulls the real `v0.2.12` from the proxy, so it fails.

## Goals

Restore a green Gateway Integration Test pipeline by aligning the policy engine's published `sdk/core` dependency with the version that actually contains the `TokenId` field.

## Approach

- Bump `github.com/wso2/api-platform/sdk/core` from `v0.2.12` to `v0.2.14` in `gateway/gateway-runtime/policy-engine/go.mod`.
- Refresh `go.sum` with the `v0.2.14` hashes and prune the stale `v0.2.12` entries via `go mod tidy`.
- Verified with `GOWORK=off go build ./...` (replicating the Docker/CI environment) that the module now compiles against the published `v0.2.14` SDK.

Only the policy engine references `ctx.TokenId`, so no other module needed a bump (gateway-controller pins `v0.2.12` but never touches the field).

## User stories

N/A

## Documentation

N/A — internal dependency version fix with no user-facing or API impact.

## Automation tests

 - Unit tests
   > No new tests; this is a dependency version alignment. Existing `translator_test.go` already covers `TokenId` mapping.
 - Integration tests
   > Covered by the existing Gateway Integration Test pipeline, which this change unblocks.

## Security checks

 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — Go dependency version change only
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

- Related #2164

## Test environment

- Go module build verified locally with `GOWORK=off go build ./...` (macOS, Go workspace) to mirror the Docker/CI build environment.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)