### PR TITLE
fix(controller): normalize vhost values on the write path

### DIFF
--- a/gateway/gateway-controller/pkg/config/config.go
+++ b/gateway/gateway-controller/pkg/config/config.go
@@ -1418,6 +1418,11 @@ func (c *Config) validateVHostsConfig() error {
 		return fmt.Errorf("router.vhosts.sandbox.default must be a non-empty string")
 	}
 
+	// Canonicalize default vhosts (lower-case and trim) so they match the normalized vhost
+	// values stored on deploy and the case-insensitive way Envoy compares domains.
+	c.Router.VHosts.Main.Default = strings.ToLower(strings.TrimSpace(c.Router.VHosts.Main.Default))
+	c.Router.VHosts.Sandbox.Default = strings.ToLower(strings.TrimSpace(c.Router.VHosts.Sandbox.Default))
+
 	// Validate main.domains (only if not nil)
 	if err := validateDomains("router.vhosts.main.domains", c.Router.VHosts.Main.Domains); err != nil {
 		return err

--- a/gateway/gateway-controller/pkg/config/config_test.go
+++ b/gateway/gateway-controller/pkg/config/config_test.go
@@ -1045,6 +1045,16 @@ func TestConfig_ValidateVHostsConfig(t *testing.T) {
 	}
 }
 
+func TestConfig_ValidateVHostsConfig_NormalizesDefaults(t *testing.T) {
+	cfg := validConfig()
+	cfg.Router.VHosts.Main.Default = "  API.WSO2.COM  "
+	cfg.Router.VHosts.Sandbox.Default = "API-SANDBOX.WSO2.COM"
+
+	assert.NoError(t, cfg.Validate())
+	assert.Equal(t, "api.wso2.com", cfg.Router.VHosts.Main.Default, "main default should be lower-cased and trimmed")
+	assert.Equal(t, "api-sandbox.wso2.com", cfg.Router.VHosts.Sandbox.Default, "sandbox default should be lower-cased and trimmed")
+}
+
 func TestConfig_ValidateAnalyticsConfig(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/gateway/gateway-controller/pkg/utils/api_deployment.go
+++ b/gateway/gateway-controller/pkg/utils/api_deployment.go
@@ -650,6 +650,31 @@ func (s *APIDeploymentService) sendTopicRequestToHub(ctx context.Context, httpCl
 	return fmt.Errorf("WebSubHub request failed after %d retries; last status: %d", maxRetries, lastStatus)
 }
 
+// normalizeVhost lower-cases and trims surrounding whitespace from a vhost so that the stored
+// value is canonical. Envoy compares virtual-host domains case-insensitively and ignores
+// surrounding whitespace, so two values that differ only in case or whitespace would otherwise
+// be emitted as separate virtual hosts with duplicate domains and the whole route configuration
+// would be rejected.
+func normalizeVhost(vhost string) string {
+	return strings.ToLower(strings.TrimSpace(vhost))
+}
+
+// isGatewayDefaultVhost reports whether a vhost is the gateway-default sentinel, ignoring case
+// and surrounding whitespace.
+func isGatewayDefaultVhost(vhost string) bool {
+	return normalizeVhost(vhost) == constants.VHostGatewayDefault
+}
+
+// canonicalizeVhost normalizes a vhost, except when it contains a template expression
+// ("{{"). Such values are rendered later by RenderSpec and their case must be preserved
+// for the lookup key (e.g. {{ env "API_HOST" }}), so they are left untouched here.
+func canonicalizeVhost(vhost string) string {
+	if strings.Contains(vhost, "{{") {
+		return vhost
+	}
+	return normalizeVhost(vhost)
+}
+
 // resolveVhostSentinels replaces the gateway-default sentinel in a RestAPI or WebSubAPI's vhosts
 // with the actual default values from the router config. This ensures that the stored value is
 // always a concrete hostname, making deployments immune to future gateway config changes.
@@ -664,82 +689,103 @@ func resolveVhostSentinels(cfg *any, routerCfg *config.RouterConfig) error {
 			// Populate defaults when vhosts is omitted entirely (e.g. direct gateway deployment
 			// without platform-api injecting sentinels). This freezes the current gateway defaults
 			// so that routing is immune to future config changes.
-			main := routerCfg.VHosts.Main.Default
+			main := normalizeVhost(routerCfg.VHosts.Main.Default)
 			c.Spec.Vhosts = &struct {
 				Main    string  `json:"main" yaml:"main"`
 				Sandbox *string `json:"sandbox,omitempty" yaml:"sandbox,omitempty"`
 			}{
 				Main: main,
 			}
-			if sandboxDefault := routerCfg.VHosts.Sandbox.Default; sandboxDefault != "" {
+			if sandboxDefault := normalizeVhost(routerCfg.VHosts.Sandbox.Default); sandboxDefault != "" {
 				c.Spec.Vhosts.Sandbox = &sandboxDefault
 			}
 			*cfg = c
 			return nil
 		}
-		if c.Spec.Vhosts.Main == constants.VHostGatewayDefault {
-			c.Spec.Vhosts.Main = routerCfg.VHosts.Main.Default
+		if isGatewayDefaultVhost(c.Spec.Vhosts.Main) {
+			c.Spec.Vhosts.Main = normalizeVhost(routerCfg.VHosts.Main.Default)
+		} else {
+			c.Spec.Vhosts.Main = canonicalizeVhost(c.Spec.Vhosts.Main)
 		}
-		if c.Spec.Vhosts.Sandbox != nil && *c.Spec.Vhosts.Sandbox == constants.VHostGatewayDefault {
-			resolved := routerCfg.VHosts.Sandbox.Default
-			if resolved != "" {
-				c.Spec.Vhosts.Sandbox = &resolved
+		if c.Spec.Vhosts.Sandbox != nil {
+			if isGatewayDefaultVhost(*c.Spec.Vhosts.Sandbox) {
+				resolved := normalizeVhost(routerCfg.VHosts.Sandbox.Default)
+				if resolved != "" {
+					c.Spec.Vhosts.Sandbox = &resolved
+				} else {
+					c.Spec.Vhosts.Sandbox = nil
+				}
 			} else {
-				c.Spec.Vhosts.Sandbox = nil
+				resolved := canonicalizeVhost(*c.Spec.Vhosts.Sandbox)
+				c.Spec.Vhosts.Sandbox = &resolved
 			}
 		}
 		*cfg = c
 	case api.WebSubAPI:
 		if c.Spec.Vhosts == nil {
-			main := routerCfg.VHosts.Main.Default
+			main := normalizeVhost(routerCfg.VHosts.Main.Default)
 			c.Spec.Vhosts = &struct {
 				Main    string  `json:"main" yaml:"main"`
 				Sandbox *string `json:"sandbox,omitempty" yaml:"sandbox,omitempty"`
 			}{
 				Main: main,
 			}
-			if sandboxDefault := routerCfg.VHosts.Sandbox.Default; sandboxDefault != "" {
+			if sandboxDefault := normalizeVhost(routerCfg.VHosts.Sandbox.Default); sandboxDefault != "" {
 				c.Spec.Vhosts.Sandbox = &sandboxDefault
 			}
 			*cfg = c
 			return nil
 		}
-		if c.Spec.Vhosts.Main == constants.VHostGatewayDefault {
-			c.Spec.Vhosts.Main = routerCfg.VHosts.Main.Default
+		if isGatewayDefaultVhost(c.Spec.Vhosts.Main) {
+			c.Spec.Vhosts.Main = normalizeVhost(routerCfg.VHosts.Main.Default)
+		} else {
+			c.Spec.Vhosts.Main = canonicalizeVhost(c.Spec.Vhosts.Main)
 		}
-		if c.Spec.Vhosts.Sandbox != nil && *c.Spec.Vhosts.Sandbox == constants.VHostGatewayDefault {
-			resolved := routerCfg.VHosts.Sandbox.Default
-			if resolved != "" {
-				c.Spec.Vhosts.Sandbox = &resolved
+		if c.Spec.Vhosts.Sandbox != nil {
+			if isGatewayDefaultVhost(*c.Spec.Vhosts.Sandbox) {
+				resolved := normalizeVhost(routerCfg.VHosts.Sandbox.Default)
+				if resolved != "" {
+					c.Spec.Vhosts.Sandbox = &resolved
+				} else {
+					c.Spec.Vhosts.Sandbox = nil
+				}
 			} else {
-				c.Spec.Vhosts.Sandbox = nil
+				resolved := canonicalizeVhost(*c.Spec.Vhosts.Sandbox)
+				c.Spec.Vhosts.Sandbox = &resolved
 			}
 		}
 		*cfg = c
 	case api.WebBrokerApi:
 		if c.Spec.Vhosts == nil {
-			main := routerCfg.VHosts.Main.Default
+			main := normalizeVhost(routerCfg.VHosts.Main.Default)
 			c.Spec.Vhosts = &struct {
 				Main    string  `json:"main" yaml:"main"`
 				Sandbox *string `json:"sandbox,omitempty" yaml:"sandbox,omitempty"`
 			}{
 				Main: main,
 			}
-			if sandboxDefault := routerCfg.VHosts.Sandbox.Default; sandboxDefault != "" {
+			if sandboxDefault := normalizeVhost(routerCfg.VHosts.Sandbox.Default); sandboxDefault != "" {
 				c.Spec.Vhosts.Sandbox = &sandboxDefault
 			}
 			*cfg = c
 			return nil
 		}
-		if c.Spec.Vhosts.Main == constants.VHostGatewayDefault {
-			c.Spec.Vhosts.Main = routerCfg.VHosts.Main.Default
+		if isGatewayDefaultVhost(c.Spec.Vhosts.Main) {
+			c.Spec.Vhosts.Main = normalizeVhost(routerCfg.VHosts.Main.Default)
+		} else {
+			c.Spec.Vhosts.Main = canonicalizeVhost(c.Spec.Vhosts.Main)
 		}
-		if c.Spec.Vhosts.Sandbox != nil && *c.Spec.Vhosts.Sandbox == constants.VHostGatewayDefault {
-			resolved := routerCfg.VHosts.Sandbox.Default
-			if resolved != "" {
-				c.Spec.Vhosts.Sandbox = &resolved
+		if c.Spec.Vhosts.Sandbox != nil {
+			if isGatewayDefaultVhost(*c.Spec.Vhosts.Sandbox) {
+				resolved := normalizeVhost(routerCfg.VHosts.Sandbox.Default)
+				if resolved != "" {
+					c.Spec.Vhosts.Sandbox = &resolved
+				} else {
+					c.Spec.Vhosts.Sandbox = nil
+				}
 			} else {
-				c.Spec.Vhosts.Sandbox = nil
+				resolved := canonicalizeVhost(*c.Spec.Vhosts.Sandbox)
+				c.Spec.Vhosts.Sandbox = &resolved
 			}
 		}
 		*cfg = c

--- a/gateway/gateway-controller/pkg/utils/api_deployment_test.go
+++ b/gateway/gateway-controller/pkg/utils/api_deployment_test.go
@@ -996,6 +996,100 @@ func TestResolveVhostSentinels_ExplicitValuesUnchanged(t *testing.T) {
 	assert.Equal(t, "custom-sandbox.example.com", *resolved.Vhosts.Sandbox)
 }
 
+func TestResolveVhostSentinels_PreservesTemplateExpressions(t *testing.T) {
+	sandboxValue := `{{ secret "SandboxHost" }}`
+	routerCfg := &config.RouterConfig{
+		VHosts: config.VHostsConfig{
+			Main:    config.VHostEntry{Default: "*.wso2.com"},
+			Sandbox: config.VHostEntry{Default: "*-sandbox.wso2.com"},
+		},
+	}
+
+	var cfg any = api.RestAPI{
+		Kind: api.RestAPIKindRestApi,
+		Spec: api.APIConfigData{
+			Vhosts: &struct {
+				Main    string  `json:"main" yaml:"main"`
+				Sandbox *string `json:"sandbox,omitempty" yaml:"sandbox,omitempty"`
+			}{
+				Main:    `{{ env "API_HOST" }}`,
+				Sandbox: &sandboxValue,
+			},
+		},
+	}
+
+	require.NoError(t, resolveVhostSentinels(&cfg, routerCfg))
+
+	resolved := cfg.(api.RestAPI).Spec
+	require.NotNil(t, resolved.Vhosts)
+	assert.Equal(t, `{{ env "API_HOST" }}`, resolved.Vhosts.Main, "template expressions must be left untouched for later rendering")
+	require.NotNil(t, resolved.Vhosts.Sandbox)
+	assert.Equal(t, `{{ secret "SandboxHost" }}`, *resolved.Vhosts.Sandbox, "template expressions must be left untouched for later rendering")
+}
+
+func TestResolveVhostSentinels_NormalizesCaseAndWhitespace(t *testing.T) {
+	sandboxValue := "  Custom-Sandbox.Example.COM  "
+	routerCfg := &config.RouterConfig{
+		VHosts: config.VHostsConfig{
+			Main:    config.VHostEntry{Default: "*.wso2.com"},
+			Sandbox: config.VHostEntry{Default: "*-sandbox.wso2.com"},
+		},
+	}
+
+	var cfg any = api.RestAPI{
+		Kind: api.RestAPIKindRestApi,
+		Spec: api.APIConfigData{
+			Vhosts: &struct {
+				Main    string  `json:"main" yaml:"main"`
+				Sandbox *string `json:"sandbox,omitempty" yaml:"sandbox,omitempty"`
+			}{
+				Main:    "API.WSO2.COM",
+				Sandbox: &sandboxValue,
+			},
+		},
+	}
+
+	require.NoError(t, resolveVhostSentinels(&cfg, routerCfg))
+
+	resolved := cfg.(api.RestAPI).Spec
+	require.NotNil(t, resolved.Vhosts)
+	assert.Equal(t, "api.wso2.com", resolved.Vhosts.Main, "explicit main vhost should be lower-cased and trimmed")
+	require.NotNil(t, resolved.Vhosts.Sandbox)
+	assert.Equal(t, "custom-sandbox.example.com", *resolved.Vhosts.Sandbox, "explicit sandbox vhost should be lower-cased and trimmed")
+}
+
+func TestResolveVhostSentinels_NormalizesSentinelCaseAndWhitespace(t *testing.T) {
+	sandbox := "  _GATEWAY_DEFAULT_  "
+	routerCfg := &config.RouterConfig{
+		VHosts: config.VHostsConfig{
+			Main:    config.VHostEntry{Default: "*.wso2.com"},
+			Sandbox: config.VHostEntry{Default: "*-sandbox.wso2.com"},
+		},
+	}
+
+	main := "_GATEWAY_DEFAULT_"
+	var cfg any = api.RestAPI{
+		Kind: api.RestAPIKindRestApi,
+		Spec: api.APIConfigData{
+			Vhosts: &struct {
+				Main    string  `json:"main" yaml:"main"`
+				Sandbox *string `json:"sandbox,omitempty" yaml:"sandbox,omitempty"`
+			}{
+				Main:    main,
+				Sandbox: &sandbox,
+			},
+		},
+	}
+
+	require.NoError(t, resolveVhostSentinels(&cfg, routerCfg))
+
+	resolved := cfg.(api.RestAPI).Spec
+	require.NotNil(t, resolved.Vhosts)
+	assert.Equal(t, "*.wso2.com", resolved.Vhosts.Main, "case and whitespace variant of the sentinel should resolve to the main default")
+	require.NotNil(t, resolved.Vhosts.Sandbox)
+	assert.Equal(t, "*-sandbox.wso2.com", *resolved.Vhosts.Sandbox, "case and whitespace variant of the sentinel should resolve to the sandbox default")
+}
+
 func TestResolveVhostSentinels_NilVhostsPopulatesDefaults(t *testing.T) {
 	routerCfg := &config.RouterConfig{
 		VHosts: config.VHostsConfig{

--- a/gateway/gateway-controller/pkg/xds/translator.go
+++ b/gateway/gateway-controller/pkg/xds/translator.go
@@ -682,14 +682,14 @@ func (t *Translator) getVHostDomains(effectiveVHost string) []string {
 	}
 
 	mainVHost := t.config.Router.VHosts.Main
-	if effectiveVHost == mainVHost.Default && len(mainVHost.Domains) > 0 {
+	if strings.EqualFold(strings.TrimSpace(effectiveVHost), mainVHost.Default) && len(mainVHost.Domains) > 0 {
 		if expanded := expand(mainVHost.Domains); len(expanded) > 0 {
 			return expanded
 		}
 	}
 
 	sandboxVHost := t.config.Router.VHosts.Sandbox
-	if effectiveVHost == sandboxVHost.Default && len(sandboxVHost.Domains) > 0 {
+	if strings.EqualFold(strings.TrimSpace(effectiveVHost), sandboxVHost.Default) && len(sandboxVHost.Domains) > 0 {
 		if expanded := expand(sandboxVHost.Domains); len(expanded) > 0 {
 			return expanded
 		}

--- a/gateway/gateway-controller/pkg/xds/translator_test.go
+++ b/gateway/gateway-controller/pkg/xds/translator_test.go
@@ -1227,6 +1227,20 @@ func TestTranslator_GetVHostDomains(t *testing.T) {
 		domains := translator.getVHostDomains("api.wso2.com")
 		assert.Equal(t, []string{"api.wso2.com", "api.wso2.com:*", "api.wso2.com:8443"}, domains)
 	})
+
+	t.Run("matches default case- and whitespace-insensitively for pre-existing vhosts", func(t *testing.T) {
+		routerCfg := testRouterConfig()
+		routerCfg.VHosts.Main.Default = "*.wso2.com"
+		routerCfg.VHosts.Main.Domains = []string{"*.wso2.com", "*.foo.com"}
+		cfg := testConfig()
+		cfg.Router = *routerCfg
+		translator := NewTranslator(logger, routerCfg, nil, cfg)
+
+		// A vhost stored before canonicalization (mixed case or padded) still matches the
+		// canonical default and expands its configured domains.
+		domains := translator.getVHostDomains("  *.WSO2.COM  ")
+		assert.Equal(t, []string{"*.wso2.com", "*.wso2.com:*", "*.foo.com", "*.foo.com:*"}, domains)
+	})
 }
 
 func TestTranslator_GetCertStore_Nil(t *testing.T) {


### PR DESCRIPTION
## Purpose

The gateway controller stored API vhost values verbatim and emitted them as Envoy virtual-host domains. Envoy compares domains case-insensitively, ignores surrounding whitespace, and requires every domain in a route configuration to be unique. Two APIs whose vhosts differed only in case or whitespace therefore produced duplicate Envoy domains. The control plane returned success (`201`), but Envoy rejected the entire `shared_route_config` and stopped applying any further route updates gateway-wide until the offending API was removed.

Resolves #2183.

## Goals

Store vhost values in a canonical form (lower-cased and trimmed) so that values differing only in case or surrounding whitespace are no longer emitted as separate, colliding Envoy domains, while keeping legitimate vhost sharing (multiple APIs on one host, routed by path) working.

## Approach

Normalize vhost values inside the shared `resolveVhostSentinels` resolver, which runs on the deploy path before vhosts are persisted and rendered. Helpers `normalizeVhost` and `isGatewayDefaultVhost` are added, and the resolver now:

- populates omitted vhosts with the normalized router defaults,
- detects the gateway-default sentinel case- and whitespace-insensitively, and
- normalizes explicit main and sandbox values.

Supporting changes that keep the canonical form consistent everywhere it is compared:

- The configured router defaults (`router.vhosts.main.default` and `router.vhosts.sandbox.default`) are canonicalized once at config validation (`validateVHostsConfig`), so a mixed-case configured default cannot drift from the stored values.
- The xDS translator's default-domain expansion (`getVHostDomains`) compares the stored vhost against the configured default case- and whitespace-insensitively. This keeps domain expansion working for APIs that were stored before this change with a non-canonical default (for example a previously mixed-case configured default), so the change is safe on upgrade without a redeploy.

Template expressions in a vhost (for example `{{ env "API_HOST" }}`) are left untouched by normalization, because they are rendered later by `RenderSpec` and their case is significant for the lookup key. A helper, `canonicalizeVhost`, normalizes a value only when it is not a template (does not contain `{{`), matching the template check `RenderSpec` itself uses. Sentinel and configured-default substitutions are never templates, so they continue to be normalized directly.

Because normalization collapses case and whitespace variants to the same string, they group into a single Envoy virtual host instead of duplicate domains.

A cross-API vhost uniqueness rejection is intentionally **not** added: multiple APIs may legitimately share a vhost and route by path (this is how the default host is used), so rejecting a shared vhost would break normal routing. The fix is canonical storage, not rejection.

## User stories

As an API developer, when I deploy an API whose vhost differs only in letter case or surrounding whitespace from another API's vhost, the gateway should keep programming routes normally instead of silently freezing all route updates.

## Documentation

N/A. This is a bug fix. The stored and echoed vhost value is now lower-cased and trimmed; a vhost is a hostname and is case-insensitive, so this does not change routing behavior. Templated vhosts are unaffected, their template text is preserved for rendering. Existing deployments are unaffected on upgrade, the translator's default-domain comparison is case-insensitive, so already-stored non-canonical vhosts still match the configured default.

## Automation tests

 - Unit tests
   > New tests in `pkg/utils/api_deployment_test.go`: `TestResolveVhostSentinels_NormalizesCaseAndWhitespace` (explicit main and sandbox values are lower-cased and trimmed), `TestResolveVhostSentinels_NormalizesSentinelCaseAndWhitespace` (case and whitespace variants of the gateway-default sentinel resolve to the configured defaults), and `TestResolveVhostSentinels_PreservesTemplateExpressions` (a vhost containing a template expression is left untouched). New test in `pkg/config/config_test.go`: `TestConfig_ValidateVHostsConfig_NormalizesDefaults` (configured defaults are canonicalized at validation). New subtest in `pkg/xds/translator_test.go` under `TestTranslator_GetVHostDomains` (a non-canonical stored vhost still matches the canonical default case- and whitespace-insensitively). The existing tests continue to pass.
 - Integration tests
   > None added in this PR. The resolver runs on the existing deploy path that the vhost-routing integration suite already exercises.

## Security checks

 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (Go module; FindSecurityBugs is a Java/SpotBugs tool)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

Two APIs deployed on the same host with different letter case:

```yaml
# API A
spec:
  vhosts:
    main: a.example.com
```

```yaml
# API B (same host, different case)
spec:
  vhosts:
    main: A.EXAMPLE.COM
```

Before: API B was stored as `A.EXAMPLE.COM`, Envoy saw two `a.example.com` domains, rejected the whole route configuration, and route programming froze gateway-wide. After: API B is stored as `a.example.com`, both APIs share one virtual host and route by path, and the route configuration is applied normally.

## Related PRs

N/A.

## Test environment

 - Go (version per `gateway/gateway-controller/go.mod`)
 - Unit tests pass (`go test ./pkg/utils/... ./pkg/config/... ./pkg/xds/...`).
