### PR TITLE
Fix panic during WebBroker API re-deployment

### DIFF
--- a/event-gateway/gateway-runtime/internal/runtime/runtime.go
+++ b/event-gateway/gateway-runtime/internal/runtime/runtime.go
@@ -64,7 +64,7 @@ type Runtime struct {
 	bindingPaths        map[string][]string // name → registered mux paths
 	bindingTopics       map[string][]string // name → Kafka topics (data + internal sub)
 	websubMux           *DynamicMux
-	wsMux               *http.ServeMux // WebSocket mux for dynamic WebBrokerApi bindings
+	wsMux               *DynamicMux // WebSocket mux for dynamic WebBrokerApi bindings
 	runCtx              context.Context
 	running             bool // true after Run() starts servers
 }
@@ -105,7 +105,7 @@ func New(cfg *config.Config, rawConfig map[string]interface{}, registry *connect
 		bindingPaths:        make(map[string][]string),
 		bindingTopics:       make(map[string][]string),
 		websubMux:           NewDynamicMux(),
-		wsMux:               http.NewServeMux(),
+		wsMux:               NewDynamicMux(),
 	}, nil
 }
 
@@ -128,7 +128,7 @@ func (r *Runtime) LoadChannels(channelsPath string) error {
 	}
 
 	// Create shared HTTP muxes for port sharing.
-	wsMux := http.NewServeMux()
+	wsMux := NewDynamicMux()
 	websubMux := http.NewServeMux()
 
 	// Store wsMux for dynamic bindings
@@ -170,7 +170,7 @@ func (r *Runtime) LoadChannels(channelsPath string) error {
 		r.brokerDrivers = append(r.brokerDrivers, brokerDriver)
 
 		receiverType := resolveReceiverType(b)
-		var mux *http.ServeMux
+		var mux connectors.RouteMux
 		switch receiverType {
 		case "websub":
 			mux = websubMux
@@ -1253,6 +1253,7 @@ func (r *Runtime) AddWebBrokerApiBinding(wbb binding.WebBrokerApiBinding) error 
 		return fmt.Errorf("failed to create receiver for WebBrokerApi %q: %w", wbb.Name, err)
 	}
 	r.activeReceivers[wbb.Name] = receiver
+	r.bindingPaths[wbb.Name] = []string{wbb.Context}
 
 	startNow := r.running
 	startCtx := r.runCtx
@@ -1311,7 +1312,7 @@ func (r *Runtime) RemoveWebBrokerApiBinding(name string) error {
 	// Deregister HTTP routes from the mux.
 	if paths, ok := r.bindingPaths[name]; ok {
 		for _, p := range paths {
-			r.websubMux.Remove(p)
+			r.wsMux.Remove(p)
 		}
 		delete(r.bindingPaths, name)
 	}

--- a/event-gateway/gateway-runtime/internal/runtime/runtime_test.go
+++ b/event-gateway/gateway-runtime/internal/runtime/runtime_test.go
@@ -325,6 +325,64 @@ func TestNewManagedServerWebSocketAcceptsReadableTLSFiles(t *testing.T) {
 	}
 }
 
+func TestAddWebBrokerApiBinding_RedeployDoesNotPanic(t *testing.T) {
+	eng, err := enginepkg.New(nil)
+	if err != nil {
+		t.Fatalf("failed to create engine: %v", err)
+	}
+
+	reg := connectors.NewRegistry()
+	reg.RegisterBrokerDriver("kafka", func(_ map[string]interface{}) (connectors.BrokerDriver, error) {
+		return &testBrokerDriver{}, nil
+	})
+	reg.RegisterReceiver("websocket-broker-api", func(cfg connectors.ReceiverConfig) (connectors.Receiver, error) {
+		cfg.Mux.HandleFunc(cfg.Channel.Context, func(http.ResponseWriter, *http.Request) {})
+		return &flakyReceiver{}, nil
+	})
+
+	rt := &Runtime{
+		cfg:                 &config.Config{},
+		engine:              eng,
+		hub:                 hub.NewHub(eng),
+		registry:            reg,
+		activeReceivers:     make(map[string]connectors.Receiver),
+		activeBrokerDrivers: make(map[string]connectors.BrokerDriver),
+		bindingPaths:        make(map[string][]string),
+		bindingTopics:       make(map[string][]string),
+		websubMux:           NewDynamicMux(),
+		wsMux:               NewDynamicMux(),
+	}
+
+	wbb := binding.WebBrokerApiBinding{
+		APIID:   "api-1",
+		Name:    "webbroker-test",
+		Context: "/default/webbroker-test",
+		Version: "v1.0",
+		BrokerDriver: binding.BrokerDriverSpec{
+			Type: "kafka",
+		},
+	}
+
+	if err := rt.AddWebBrokerApiBinding(wbb); err != nil {
+		t.Fatalf("first AddWebBrokerApiBinding failed: %v", err)
+	}
+	if _, ok := rt.bindingPaths[wbb.Name]; !ok {
+		t.Fatal("expected bindingPaths to be populated after first add")
+	}
+
+	if err := rt.RemoveWebBrokerApiBinding(wbb.Name); err != nil {
+		t.Fatalf("RemoveWebBrokerApiBinding failed: %v", err)
+	}
+	if _, ok := rt.bindingPaths[wbb.Name]; ok {
+		t.Fatal("expected bindingPaths to be cleared after remove")
+	}
+
+	// Before the fix this panicked: "pattern already registered" on the http.ServeMux.
+	if err := rt.AddWebBrokerApiBinding(wbb); err != nil {
+		t.Fatalf("second AddWebBrokerApiBinding (redeploy) failed: %v", err)
+	}
+}
+
 type testNoopPolicy struct{}
 
 type flakyReceiver struct {
@@ -354,6 +412,31 @@ func (r *flakyReceiver) Attempts() int {
 	defer r.mu.Unlock()
 	return r.attempts
 }
+
+type testBrokerDriver struct{}
+
+func (testBrokerDriver) Publish(_ context.Context, _ string, _ *connectors.Message) error {
+	return nil
+}
+func (testBrokerDriver) Subscribe(_ string, _ []string, _ connectors.MessageHandler) (connectors.Receiver, error) {
+	return &flakyReceiver{}, nil
+}
+func (testBrokerDriver) SubscribeManual(_ string, _ []string, _ connectors.MessageHandler) (connectors.Receiver, error) {
+	return &flakyReceiver{}, nil
+}
+func (testBrokerDriver) Replay(_ context.Context, _ string, _ connectors.MessageHandler) error {
+	return nil
+}
+func (testBrokerDriver) Watch(_ context.Context, _ string, _ string, _ connectors.MessageHandler) (connectors.Receiver, error) {
+	return &flakyReceiver{}, nil
+}
+func (testBrokerDriver) TopicExists(_ context.Context, _ string) (bool, error) { return true, nil }
+func (testBrokerDriver) EnsureTopics(_ context.Context, _ []string, _ map[string]map[string]string) error {
+	return nil
+}
+func (testBrokerDriver) EnsureCompactedTopic(_ context.Context, _ string) error { return nil }
+func (testBrokerDriver) DeleteTopics(_ context.Context, _ []string) error        { return nil }
+func (testBrokerDriver) Close() error                                             { return nil }
 
 func newTestNoopPolicy(policy.PolicyMetadata, map[string]interface{}) (policy.Policy, error) {
 	return testNoopPolicy{}, nil


### PR DESCRIPTION
## Purpose
> As of now, when redeploying a WebBroker API (tried that via Bijira UI: updated the mappings and redeployed), the following error was thrown in the Event Gateway logs:
```
gateway-controller-1  | time=2026-06-15T06:05:23.240Z level=INFO source=/build/pkg/controlplane/client.go:1245 msg="Received WebSocket event" type=webbroker.deployed payload="{\"type\":\"webbroker.deployed\",\"payload\":{\"apiId\":\"019ec9dc-d8df-7676-8b1c-819e40693e14\",\"deploymentId\":\"019ec9e2-7a39-7b89-b9f9-3979c6051809\",\"performedAt\":\"2026-06-15T06:05:23.821Z\"},\"timestamp\":\"2026-06-15T06:05:23Z\",\"correlationId\":\"30ef81fc-98ce-4b03-a59f-8e6fdfa6cd3e\"}"
gateway-controller-1  | time=2026-06-15T06:05:23.247Z level=INFO source=/build/pkg/controlplane/client.go:2747 msg="Processing WebBroker API deployment" api_id=019ec9dc-d8df-7676-8b1c-819e40693e14 deployment_id=019ec9e2-7a39-7b89-b9f9-3979c6051809 correlation_id=30ef81fc-98ce-4b03-a59f-8e6fdfa6cd3e
gateway-controller-1  | time=2026-06-15T06:05:24.069Z level=INFO source=/build/pkg/utils/api_utils.go:490 msg="Found YAML file in zip" filename=webbroker-api-019ec9dc-d8df-7676-8b1c-819e40693e14.yaml
gateway-controller-1  | time=2026-06-15T06:05:24.090Z level=INFO source=/build/pkg/storage/sql_store.go:565 msg="Configuration upserted" uuid=019ec9dc-d8df-7676-8b1c-819e40693e14 kind=WebBrokerApi handle=6a2f94b118fb1b71ed7ba2d5 deployment_id=019ec9e2-7a39-7b89-b9f9-3979c6051809
gateway-controller-1  | time=2026-06-15T06:05:24.090Z level=INFO source=/build/pkg/utils/api_deployment.go:377 msg="API configuration updated" api_id=019ec9dc-d8df-7676-8b1c-819e40693e14 name=webbroker-15jun-1128am version=v1.0 correlation_id=30ef81fc-98ce-4b03-a59f-8e6fdfa6cd3e
gateway-controller-1  | time=2026-06-15T06:05:24.092Z level=INFO source=/build/pkg/controlplane/client.go:657 msg="Deployment ack sent" deployment_id=019ec9e2-7a39-7b89-b9f9-3979c6051809 artifact_id=019ec9dc-d8df-7676-8b1c-819e40693e14 resource_type=webbroker action=deploy status=success
gateway-controller-1  | time=2026-06-15T06:05:24.092Z level=INFO source=/build/pkg/controlplane/client.go:2802 msg="Successfully processed WebBroker API deployment event" api_id=019ec9dc-d8df-7676-8b1c-819e40693e14 correlation_id=30ef81fc-98ce-4b03-a59f-8e6fdfa6cd3e
gateway-controller-1  | time=2026-06-15T06:05:24.450Z level=INFO source=/build/pkg/eventlistener/listener.go:205 msg="Processing replica sync event" event_type=API action=UPDATE entity_id=019ec9dc-d8df-7676-8b1c-819e40693e14 event_id=30ef81fc-98ce-4b03-a59f-8e6fdfa6cd3e
gateway-controller-1  | time=2026-06-15T06:05:24.451Z level=INFO source=/build/pkg/eventlistener/api_processor.go:67 msg="Processing API create/update event" api_id=019ec9dc-d8df-7676-8b1c-819e40693e14 action=UPDATE event_id=30ef81fc-98ce-4b03-a59f-8e6fdfa6cd3e
gateway-controller-1  | time=2026-06-15T06:05:24.454Z level=INFO source=/build/pkg/policyxds/snapshot.go:123 msg="Updating policy snapshot" rdc_count=0 node_id=policy-node
gateway-controller-1  | time=2026-06-15T06:05:24.454Z level=INFO source=/build/pkg/policyxds/snapshot.go:260 msg="Translated runtime configs to xDS resources" total_rdcs=0 policy_resources=0 route_resources=0
gateway-controller-1  | time=2026-06-15T06:05:24.455Z level=INFO source=/build/pkg/policyxds/event_channel_translator.go:61 msg="Translated WebSubApis to EventChannelConfig resources" input_configs=0 output_resources=0
gateway-controller-1  | 2026/06/15 06:05:24 INFO DEBUG: Building EventChannelConfig for WebBrokerApi name=6a2f94b118fb1b71ed7ba2d5 receiverName=websocket-receiver brokerDriverName=kafka-broker brokerDriverType=KAFKA
gateway-controller-1  | time=2026-06-15T06:05:24.458Z level=INFO source=/build/pkg/policyxds/event_channel_translator.go:99 msg="Translated WebBrokerApis to EventChannelConfig resources" input_configs=1 output_resources=1
gateway-controller-1  | time=2026-06-15T06:05:24.458Z level=INFO source=/build/pkg/policyxds/snapshot.go:183 msg="Event channel config cache updated" event_channel_resources=1
gateway-controller-1  | time=2026-06-15T06:05:24.458Z level=INFO source=/build/pkg/policyxds/snapshot.go:188 msg="Policy snapshot updated successfully" version=3 policy_resources=0 route_resources=0
gateway-controller-1  | time=2026-06-15T06:05:24.459Z level=INFO source=/build/pkg/eventlistener/api_processor.go:119 msg="Successfully processed API create/update event" api_id=019ec9dc-d8df-7676-8b1c-819e40693e14 event_id=30ef81fc-98ce-4b03-a59f-8e6fdfa6cd3e
gateway-controller-1  | time=2026-06-15T06:05:24.460Z level=INFO source=/build/pkg/policyxds/server.go:255 msg="Policy xDS stream response" stream_id=3 type_url=api-platform.wso2.org/v1.EventChannelConfig version=3 resource_count=1
event-gateway-1       | time=2026-06-15T06:05:24.474Z level=INFO msg="Updating binding via xDS" name=6a2f94b118fb1b71ed7ba2d5 uuid=019ec9dc-d8df-7676-8b1c-819e40693e14 kind=WebBrokerApi
event-gateway-1       | time=2026-06-15T06:05:24.482Z level=INFO msg="Dynamically removed WebBrokerApi binding" name=6a2f94b118fb1b71ed7ba2d5
event-gateway-1       | time=2026-06-15T06:05:24.483Z level=INFO msg="Built policy chains for WebBrokerApi channel" api=6a2f94b118fb1b71ed7ba2d5 channel=alerts topics=[alerts]
event-gateway-1       | time=2026-06-15T06:05:24.483Z level=INFO msg="Built policy chains for WebBrokerApi channel" api=6a2f94b118fb1b71ed7ba2d5 channel=prices topics="[pricesConsumer pricesProducer]"
gateway-controller-1  | time=2026-06-15T06:05:24.495Z level=INFO source=/build/pkg/policyxds/server.go:209 msg="Policy xDS stream closed" stream_id=3 node_id=event-gateway-node
event-gateway-1       | panic: pattern "/default/webbroker-15jun-1128am/v1.0" (registered at /api-platform/event-gateway/gateway-runtime/internal/connectors/receiver/websocket/broker_api_connector.go:85) conflicts with pattern "/default/webbroker-15jun-1128am/v1.0" (registered at /api-platform/event-gateway/gateway-runtime/internal/connectors/receiver/websocket/broker_api_connector.go:85):
event-gateway-1       | 	/default/webbroker-15jun-1128am/v1.0 matches the same requests as /default/webbroker-15jun-1128am/v1.0
event-gateway-1       |
event-gateway-1       | goroutine 49 [running]:
event-gateway-1       | net/http.(*ServeMux).register(...)
event-gateway-1       | 	/usr/local/go/src/net/http/server.go:2882
event-gateway-1       | net/http.(*ServeMux).HandleFunc(0x0?, {0x6a086246e1b0?, 0x0?}, 0x0?)
event-gateway-1       | 	/usr/local/go/src/net/http/server.go:2856 +0x74
event-gateway-1       | github.com/wso2/api-platform/event-gateway/gateway-runtime/internal/connectors/receiver/websocket.NewBrokerApiReceiver({{{0x6a086298c270, 0x18}, {0x1048ced, 0x12}, {0x6a086246e1b0, 0x24}, {0x6a08625a0acc, 0x4}, {0x10a9ef8, 0x1}, ...}, ...}, ...)
event-gateway-1       | 	/api-platform/event-gateway/gateway-runtime/internal/connectors/receiver/websocket/broker_api_connector.go:85 +0x198
event-gateway-1       | main.registerConnectors.func4({{{0x6a086298c270, 0x18}, {0x1048ced, 0x12}, {0x6a086246e1b0, 0x24}, {0x6a08625a0acc, 0x4}, {0x10a9ef8, 0x1}, ...}, ...})
event-gateway-1       | 	/api-platform/event-gateway/gateway-runtime/cmd/event-gateway/plugins.go:65 +0x9c
event-gateway-1       | github.com/wso2/api-platform/event-gateway/gateway-runtime/internal/connectors.(*Registry).CreateReceiver(_, {_, _}, {{{0x6a086298c270, 0x18}, {0x1048ced, 0x12}, {0x6a086246e1b0, 0x24}, {0x6a08625a0acc, ...}, ...}, ...})
event-gateway-1       | 	/api-platform/event-gateway/gateway-runtime/internal/connectors/registry.go:74 +0x1e4
event-gateway-1       | github.com/wso2/api-platform/event-gateway/gateway-runtime/internal/runtime.(*Runtime).AddWebBrokerApiBinding(_, {{0x1041412, 0xc}, {0x6a086246e1e0, 0x24}, {0x6a086298c270, 0x18}, {0x6a08625a0acc, 0x4}, {0x6a086246e1b0, ...}, ...})
event-gateway-1       | 	/api-platform/event-gateway/gateway-runtime/internal/runtime/runtime.go:1244 +0x1068
event-gateway-1       | github.com/wso2/api-platform/event-gateway/gateway-runtime/internal/xdsclient.(*Handler).addBinding(0x6a086260a420, {{0x6a086246e1e0, 0x24}, {0x6a086298c270, 0x18}, {0x6a08625a0a90, 0xc}, {0x6a086246e1b0, 0x24}, {0x6a08625a0acc, ...}, ...})
event-gateway-1       | 	/api-platform/event-gateway/gateway-runtime/internal/xdsclient/handler.go:392 +0x1d0
event-gateway-1       | github.com/wso2/api-platform/event-gateway/gateway-runtime/internal/xdsclient.(*Handler).HandleResources(0x6a086260a420, {0x0?, 0x6a0862697b48?}, {0x6a08624040a0, 0x1, 0xfb5c40?}, {0x6a086268e601?, 0x6a086268e6e0?})
event-gateway-1       | 	/api-platform/event-gateway/gateway-runtime/internal/xdsclient/handler.go:222 +0xc70
event-gateway-1       | github.com/wso2/api-platform/event-gateway/gateway-runtime/internal/xdsclient.(*Client).processStream(0x6a086260a4d0, {0x10d3b38, 0x6a0862980380})
event-gateway-1       | 	/api-platform/event-gateway/gateway-runtime/internal/xdsclient/client.go:245 +0x25c
event-gateway-1       | github.com/wso2/api-platform/event-gateway/gateway-runtime/internal/xdsclient.(*Client).connectAndRun(0x6a086260a4d0)
event-gateway-1       | 	/api-platform/event-gateway/gateway-runtime/internal/xdsclient/client.go:196 +0x478
event-gateway-1       | github.com/wso2/api-platform/event-gateway/gateway-runtime/internal/xdsclient.(*Client).run(0x6a086260a4d0)
event-gateway-1       | 	/api-platform/event-gateway/gateway-runtime/internal/xdsclient/client.go:133 +0x80
event-gateway-1       | created by github.com/wso2/api-platform/event-gateway/gateway-runtime/internal/xdsclient.(*Client).Start in goroutine 1
event-gateway-1       | 	/api-platform/event-gateway/gateway-runtime/internal/xdsclient/client.go:99 +0x12c
gateway-controller-1  | time=2026-06-15T06:05:24.529Z level=INFO source=/build/pkg/policyxds/server.go:209 msg="Policy xDS stream closed" stream_id=2 node_id=event-gateway-node
gateway-controller-1  | time=2026-06-15T06:05:24.531Z level=INFO source=/build/pkg/policyxds/server.go:209 msg="Policy xDS stream closed" stream_id=1 node_id=event-gateway-node
event-gateway-1 exited with code 2
```
### Bug

Redeploying a WebBroker API caused the event-gateway process to panic and exit with code 2.

When a WebBroker API is redeployed, the xDS handler removes the existing binding and immediately adds
the updated one. The remove step was supposed to deregister the API's HTTP route from the WebSocket
mux before the add step re-registered it. Instead, three compounding bugs meant the route was never
actually removed:

1. `AddWebBrokerApiBinding` never stored the API's context path into `bindingPaths`, so the cleanup
   block in `RemoveWebBrokerApiBinding` always found an empty map and skipped entirely.
2. Even if it hadn't skipped, the cleanup block called `r.websubMux.Remove(p)` — the WebSub mux —
   instead of `r.wsMux`, where WebBrokerApi routes actually live. The removal would have been a
   silent no-op on the wrong mux.
3. `r.wsMux` was a `*http.ServeMux` (Go stdlib), which panics when the same path pattern is
   registered twice. Since the old route was never removed, the re-add in `AddWebBrokerApiBinding`
   hit this panic and crashed the process.

## Goals

### Fix

- Changed `r.wsMux` from `*http.ServeMux` to `*DynamicMux` (already present in `runtime/mux.go`),
  which overwrites duplicate registrations instead of panicking.
- Added `r.bindingPaths[wbb.Name] = []string{wbb.Context}` in `AddWebBrokerApiBinding` so the
  context path is tracked and available for cleanup on removal.
- Changed `r.websubMux.Remove(p)` to `r.wsMux.Remove(p)` in `RemoveWebBrokerApiBinding` so the
  route is deregistered from the correct mux.


## Approach
> Describe **how** you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
