### PR TITLE
Improve Devportal CLI commands

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -4,7 +4,42 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Gate the release on the full CLI integration suite of Devportal.
+  # The release job below only runs if this succeeds.
+  integration-tests:
+    name: CLI Integration Tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26.2'
+          cache-dependency-path: '**/go.sum'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build developer-portal :test image
+        run: |
+          cd cli/it
+          make build-devportal-image
+
+      - name: Build CLI binary
+        run: |
+          cd cli/it
+          make build-cli
+
+      - name: Run CLI integration tests (gateway + devportal)
+        run: |
+          cd cli/it
+          make test-devportal
+
   release:
+    needs: integration-tests
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -55,6 +55,12 @@ jobs:
           cd cli/it
           make build-cli-coverage
 
+      - name: Build developer-portal :test image
+        continue-on-error: true
+        run: |
+          cd cli/it
+          make build-devportal-image
+
       - name: Run CLI integration tests
         continue-on-error: true
         run: |

--- a/cli/it/Makefile
+++ b/cli/it/Makefile
@@ -16,12 +16,13 @@
 # under the License.
 # --------------------------------------------------------------------
 
-.PHONY: test clean deps check-docker build-cli build-cli-coverage build-images test-all help
+.PHONY: test test-devportal clean deps check-docker build-cli build-cli-coverage build-images build-devportal-image test-all help
 
 # Directory locations
 CLI_SRC_DIR=../src
 GATEWAY_COMPOSE_FILE=../../gateway/it/docker-compose.test.yaml
 GATEWAY_DIR=../../gateway
+DEVPORTAL_DIR=../../portals/developer-portal
 
 # Default target
 help:
@@ -29,10 +30,12 @@ help:
 	@echo ""
 	@echo "Usage:"
 	@echo "  make test           - Run integration tests (requires CLI and images pre-built)"
-	@echo "  make test-all       - Build CLI (with coverage), gateway images, and run tests"
+	@echo "  make test-devportal - Build the devportal image and run ONLY the devportal suite"
+	@echo "  make test-all       - Build CLI (coverage), gateway + devportal images, and run the full suite"
 	@echo "  make build-cli      - Build the CLI binary (without coverage)"
 	@echo "  make build-cli-coverage - Build the CLI binary with coverage instrumentation"
 	@echo "  make build-images   - Build required gateway Docker images"
+	@echo "  make build-devportal-image - Build the developer-portal :test image (for devportal tests)"
 	@echo "  make clean          - Clean up containers, volumes, and logs"
 	@echo "  make deps           - Install Go dependencies"
 	@echo ""
@@ -40,6 +43,8 @@ help:
 	@echo "  - Docker must be running"
 	@echo "  - CLI must be built (run 'make build-cli' first)"
 	@echo "  - Gateway images must be built (run 'make build-images' first)"
+	@echo "  - For devportal tests, the developer-portal :test image must be built"
+	@echo "    (run 'make build-devportal-image' first)"
 
 # Run integration tests (assumes CLI and images are already built)
 test: check-docker
@@ -51,6 +56,12 @@ test: check-docker
 		go test -v -timeout 30m $$pkgs 2>&1 | awk '/^Logs directory:/{print;exit}1' ; \
 	fi
 
+# Run ONLY the developer-portal suite (no gateway images required). Builds the
+# developer-portal :test image first, then scopes the run with IT_SUITES.
+test-devportal: check-docker build-cli build-devportal-image
+	@mkdir -p logs
+	IT_SUITES=devportal go test -v -timeout 30m . 2>&1 | awk '/^Logs directory:/{print;exit}1'
+
 # Build CLI binary
 build-cli:
 	@echo "==============================================="
@@ -59,8 +70,9 @@ build-cli:
 	@$(MAKE) -C $(CLI_SRC_DIR) build-skip-tests
 	@echo "CLI binary built successfully"
 
-# Build CLI (with coverage), images, and run tests (full flow)
-test-all: build-cli-coverage build-images test
+# Build CLI (with coverage), gateway images, devportal image, and run the full
+# suite (gateway + devportal).
+test-all: build-cli-coverage build-images build-devportal-image test
 
 # Build required gateway Docker images locally
 build-images: check-docker
@@ -70,6 +82,17 @@ build-images: check-docker
 	@echo "This may take several minutes..."
 	@$(MAKE) -C $(GATEWAY_DIR) build-coverage
 	@echo "✓ Gateway images built successfully"
+
+# Build the developer-portal Docker image and tag it :test for devportal tests.
+# Required before running the DEVPORTAL-backed scenarios.
+build-devportal-image: check-docker
+	@echo "==============================================="
+	@echo "Building Developer Portal Docker Image"
+	@echo "==============================================="
+	@echo "This may take several minutes..."
+	@$(MAKE) -C $(DEVPORTAL_DIR) build
+	@$(MAKE) -C $(DEVPORTAL_DIR)/it ensure-test-tag
+	@echo "✓ Developer portal :test image ready"
 
 # Clean up containers, volumes, and logs
 clean:

--- a/cli/it/README.md
+++ b/cli/it/README.md
@@ -1,6 +1,6 @@
 # CLI Integration Tests
 
-End-to-end integration tests for the `ap` CLI, validating commands against real gateway and MCP server infrastructure.
+End-to-end integration tests for the `ap` CLI, validating commands against real gateway, MCP server, and developer portal infrastructure.
 
 ## Prerequisites
 
@@ -35,6 +35,69 @@ make clean
 make deps
 ```
 
+### Developer portal tests
+
+The devportal scenarios bring up a postgres + developer-portal stack (reusing
+`portals/developer-portal/it/docker-compose.test.yaml` with an override that
+publishes port 3000 to the host).
+
+> **`make test` runs every suite.** The gateway suite needs locally-built
+> coverage images (`gateway-controller-coverage:test`, etc.); without them the
+> run fails at infra startup with a registry `denied` error. To run **only** the
+> developer-portal suite (no gateway images needed):
+
+```bash
+# Builds the developer-portal :test image, then runs only the devportal suite
+make test-devportal
+```
+
+`make test-devportal` is shorthand for `IT_SUITES=devportal make test` with the
+devportal image built first. `IT_SUITES` scopes both which feature dirs run and
+which infrastructure starts:
+
+```bash
+IT_SUITES=devportal       # only developer-portal suite
+IT_SUITES=gateway         # only gateway suite
+IT_SUITES=gateway,devportal  # both (default when unset)
+```
+
+To run the full suite (`make test`), build both the gateway images and the
+developer-portal image first:
+
+```bash
+make build-images            # gateway coverage images
+make build-devportal-image   # developer-portal :test image
+make test
+```
+
+The portal is reached over plain HTTP on `http://localhost:3000` and authenticated
+with the api-key seeded via `DP_ADVANCED_APIKEY_KEYVALUE` (`devportal-it-test-key`),
+which grants admin access. Org-scoped scenarios target the seeded `ACME`
+organization (`1ba42a09-45c0-40f8-a1bf-e4aa7cde1575`) from
+`portals/developer-portal/database/02-seed_org.postgres.sql`.
+
+Scenarios tagged `@wip` are skipped (via the `~@wip` tag filter). These cover
+commands that still depend on server-side changes or fixtures not yet in place —
+notably the `application` happy-path commands (the CLI targets the org-scoped
+`/o/{orgId}/devportal/v1/applications` path, which the server spec does not yet
+expose). Remove the `@wip` tag once those are ready.
+
+The **end-to-end flow** (`features/devportal/e2e.feature`, `DP-E2E-001`) exercises
+the real publish lifecycle in one ordered scenario:
+
+1. `ap apiproject init` scaffolds an API project in a per-scenario temp dir.
+2. The provided echo artifacts (`resources/devportal/echo-devportal.yaml` +
+   `echo-definition.yaml`) are staged into the project's `devportal/` portal root.
+3. `ap devportal build` produces `build/devportal.zip`.
+4. `ap devportal rest-api publish` uploads it to the ACME org; the generated API
+   ID is captured from the response and reused by later steps.
+5. `ap devportal rest-api get` reads the API back.
+6. `ap devportal api-key generate` issues a key for the API.
+7. `ap devportal sub-plan publish` creates a new subscription plan
+   (`resources/devportal/subscription-plan.yaml`).
+8. `ap devportal subscription create` subscribes to the API on the `Gold` plan
+   (the API carries the seeded `Gold`/`Bronze` policies).
+
 ## Configuration
 
 Tests can be enabled/disabled by editing `test-config.yaml`:
@@ -55,10 +118,12 @@ tests:
 cli/it/
 ├── test-config.yaml      # Enable/disable tests
 ├── features/             # Gherkin feature files
-│   └── gateway/
+│   ├── gateway/
+│   └── devportal/
 ├── steps/                # Step definitions
 ├── resources/            # Test resources
-│   └── gateway/
+│   ├── gateway/
+│   └── devportal/
 └── logs/                 # Test logs (git-ignored)
 ```
 
@@ -69,6 +134,7 @@ cli/it/
 | `CLI` | CLI Binary | The `ap` binary built from `cli/src/` |
 | `GATEWAY` | Gateway Stack | Docker Compose services: controller, router, policy-engine |
 | `MCP_SERVER` | MCP Server | MCP backend for generate command tests |
+| `DEVPORTAL` | Developer Portal | Postgres + developer-portal stack (port 3000) for devportal command tests |
 
 ## Logs
 

--- a/cli/it/config.go
+++ b/cli/it/config.go
@@ -21,9 +21,54 @@ package it
 import (
 	"os"
 	"sort"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
+
+// Suite names used to scope a run to a subset of the test groups.
+const (
+	SuiteGateway   = "gateway"
+	SuiteDevPortal = "devportal"
+)
+
+// EnvSuites is the env var that scopes which suites run (comma-separated, e.g.
+// "devportal" or "gateway,devportal"). When unset/empty, all suites run.
+const EnvSuites = "IT_SUITES"
+
+// SelectedSuites returns the set of suites to run, parsed from IT_SUITES. An
+// unset/empty value selects all suites.
+func SelectedSuites() map[string]bool {
+	raw := strings.TrimSpace(os.Getenv(EnvSuites))
+	selected := map[string]bool{}
+	if raw == "" {
+		selected[SuiteGateway] = true
+		selected[SuiteDevPortal] = true
+		return selected
+	}
+	for _, part := range strings.Split(raw, ",") {
+		if name := strings.ToLower(strings.TrimSpace(part)); name != "" {
+			selected[name] = true
+		}
+	}
+	return selected
+}
+
+// FeaturePaths returns the gherkin feature directories for the selected suites.
+func FeaturePaths() []string {
+	selected := SelectedSuites()
+	var paths []string
+	if selected[SuiteGateway] {
+		paths = append(paths, "features/gateway")
+	}
+	if selected[SuiteDevPortal] {
+		paths = append(paths, "features/devportal")
+	}
+	if len(paths) == 0 {
+		paths = []string{"features"}
+	}
+	return paths
+}
 
 // TestConfig represents the test configuration file structure
 type TestConfig struct {
@@ -42,7 +87,8 @@ type InfrastructureConfig struct {
 
 // TestsConfig holds all test group configurations
 type TestsConfig struct {
-	Gateway GatewayTestsConfig `yaml:"gateway"`
+	Gateway   GatewayTestsConfig   `yaml:"gateway"`
+	DevPortal DevPortalTestsConfig `yaml:"devportal"`
 }
 
 // GatewayTestsConfig holds gateway-related test configurations
@@ -52,6 +98,17 @@ type GatewayTestsConfig struct {
 	API    []TestDefinition `yaml:"api"`
 	MCP    []TestDefinition `yaml:"mcp"`
 	Build  []TestDefinition `yaml:"build"`
+}
+
+// DevPortalTestsConfig holds developer-portal-related test configurations
+type DevPortalTestsConfig struct {
+	Manage       []TestDefinition `yaml:"manage"`
+	Organization []TestDefinition `yaml:"organization"`
+	API          []TestDefinition `yaml:"api"`
+	Subscription []TestDefinition `yaml:"subscription"`
+	APIKey       []TestDefinition `yaml:"apikey"`
+	Application  []TestDefinition `yaml:"application"`
+	E2E          []TestDefinition `yaml:"e2e"`
 }
 
 // TestDefinition represents a single test definition
@@ -72,6 +129,8 @@ const (
 	InfraGateway InfrastructureID = "GATEWAY"
 	// InfraMCPServer represents the MCP server
 	InfraMCPServer InfrastructureID = "MCP_SERVER"
+	// InfraDevPortal represents the developer portal stack (postgres + devportal)
+	InfraDevPortal InfrastructureID = "DEVPORTAL"
 )
 
 // LoadTestConfig loads the test configuration from a YAML file
@@ -89,38 +148,55 @@ func LoadTestConfig(path string) (*TestConfig, error) {
 	return &config, nil
 }
 
-// GetEnabledTests returns all enabled test definitions
+// GetEnabledTests returns all enabled test definitions for the selected suites.
 func (c *TestConfig) GetEnabledTests() []TestDefinition {
+	selected := SelectedSuites()
 	var enabled []TestDefinition
 
-	// Collect from all test groups
-	for _, t := range c.Tests.Gateway.Manage {
-		if t.Enabled {
-			enabled = append(enabled, t)
+	if selected[SuiteGateway] {
+		for _, group := range c.gatewayGroups() {
+			for _, t := range group {
+				if t.Enabled {
+					enabled = append(enabled, t)
+				}
+			}
 		}
 	}
-	for _, t := range c.Tests.Gateway.Apply {
-		if t.Enabled {
-			enabled = append(enabled, t)
-		}
-	}
-	for _, t := range c.Tests.Gateway.API {
-		if t.Enabled {
-			enabled = append(enabled, t)
-		}
-	}
-	for _, t := range c.Tests.Gateway.MCP {
-		if t.Enabled {
-			enabled = append(enabled, t)
-		}
-	}
-	for _, t := range c.Tests.Gateway.Build {
-		if t.Enabled {
-			enabled = append(enabled, t)
+	if selected[SuiteDevPortal] {
+		for _, group := range c.devPortalGroups() {
+			for _, t := range group {
+				if t.Enabled {
+					enabled = append(enabled, t)
+				}
+			}
 		}
 	}
 
 	return enabled
+}
+
+// gatewayGroups returns all gateway test groups for iteration.
+func (c *TestConfig) gatewayGroups() [][]TestDefinition {
+	return [][]TestDefinition{
+		c.Tests.Gateway.Manage,
+		c.Tests.Gateway.Apply,
+		c.Tests.Gateway.API,
+		c.Tests.Gateway.MCP,
+		c.Tests.Gateway.Build,
+	}
+}
+
+// devPortalGroups returns all developer-portal test groups for iteration.
+func (c *TestConfig) devPortalGroups() [][]TestDefinition {
+	return [][]TestDefinition{
+		c.Tests.DevPortal.Manage,
+		c.Tests.DevPortal.Organization,
+		c.Tests.DevPortal.API,
+		c.Tests.DevPortal.Subscription,
+		c.Tests.DevPortal.APIKey,
+		c.Tests.DevPortal.Application,
+		c.Tests.DevPortal.E2E,
+	}
 }
 
 // GetAllTests returns all test definitions regardless of enabled status
@@ -132,6 +208,9 @@ func (c *TestConfig) GetAllTests() []TestDefinition {
 	all = append(all, c.Tests.Gateway.API...)
 	all = append(all, c.Tests.Gateway.MCP...)
 	all = append(all, c.Tests.Gateway.Build...)
+	for _, group := range c.devPortalGroups() {
+		all = append(all, group...)
+	}
 
 	return all
 }
@@ -150,6 +229,7 @@ func (c *TestConfig) GetRequiredInfrastructure() []InfrastructureID {
 		InfraCLI,
 		InfraGateway,
 		InfraMCPServer,
+		InfraDevPortal,
 	}
 
 	var result []InfrastructureID

--- a/cli/it/docker-compose.devportal.override.yaml
+++ b/cli/it/docker-compose.devportal.override.yaml
@@ -1,0 +1,43 @@
+# --------------------------------------------------------------------
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# --------------------------------------------------------------------
+
+# Override for CLI IT tests, layered on top of the developer-portal IT compose
+# (portals/developer-portal/it/docker-compose.test.yaml).
+#
+# The base compose runs the devportal only inside the test network (for Cypress).
+# The CLI runs on the host, so it needs the devportal port published to localhost.
+# This override adds that port mapping. The cypress service is never started
+# because the CLI IT brings up only the `devportal` service (and its postgres
+# dependency).
+#
+# Used with:
+#   docker compose \
+#     -f ../../portals/developer-portal/it/docker-compose.test.yaml \
+#     -f docker-compose.devportal.override.yaml \
+#     up -d --wait devportal
+
+services:
+  devportal:
+    ports:
+      - "3000:3000"
+    environment:
+      # Subscription tokens (and key-manager secrets) are encrypted at rest with
+      # AES-256-GCM using config.advanced.encryptionKey, which must be a 64-char
+      # hex string. Without it, `subscription create` fails with HTTP 500
+      # "Encryption key not configured or invalid." This is a throwaway test key.
+      DP_ADVANCED_ENCRYPTIONKEY: "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"

--- a/cli/it/features/devportal/api.feature
+++ b/cli/it/features/devportal/api.feature
@@ -1,0 +1,72 @@
+# --------------------------------------------------------------------
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# --------------------------------------------------------------------
+
+Feature: DevPortal REST API Commands
+    As a CLI user
+    I want to manage developer portal APIs
+    So that I can publish and inspect APIs from the command line
+
+    Background:
+        Given the CLI is available
+        And the devportal is running
+        And I have a devportal named "dp-api" configured
+
+    # =========================================
+    # REST API List / Get (against the seeded ACME org)
+    # =========================================
+
+    @DP-API-001
+    Scenario: List APIs in an organization
+        When I run ap with arguments "devportal rest-api list --org 1ba42a09-45c0-40f8-a1bf-e4aa7cde1575"
+        Then the command should succeed
+        And the output should contain "No APIs found in the organization"
+
+    @DP-API-002
+    Scenario: List APIs without required org flag fails
+        When I run ap with arguments "devportal rest-api list"
+        Then the command should fail
+        And the stderr should contain "required flag"
+
+    @DP-API-003
+    Scenario: Get API without required flags fails
+        When I run ap with arguments "devportal rest-api get --org 1ba42a09-45c0-40f8-a1bf-e4aa7cde1575"
+        Then the command should fail
+        And the stderr should contain "required flag"
+
+    # =========================================
+    # REST API Publish / Get / Delete
+    #
+    # @wip — these mutate state and require a valid devportal API artifact ZIP
+    # fixture. Enable once the artifact (resources/devportal/api-artifact.zip) is
+    # produced (e.g. via `ap devportal build`).
+    # =========================================
+
+    @DP-API-004 @wip
+    Scenario: Publish an API
+        When I run ap with arguments "devportal rest-api publish -f resources/devportal/api-artifact.zip --org 1ba42a09-45c0-40f8-a1bf-e4aa7cde1575"
+        Then the command should succeed
+
+    @DP-API-005 @wip
+    Scenario: Get a published API
+        When I run ap with arguments "devportal rest-api get --org 1ba42a09-45c0-40f8-a1bf-e4aa7cde1575 --api-id it-test-api"
+        Then the command should succeed
+
+    @DP-API-006 @wip
+    Scenario: Delete a published API
+        When I run ap with arguments "devportal rest-api delete --org 1ba42a09-45c0-40f8-a1bf-e4aa7cde1575 --api-id it-test-api"
+        Then the command should succeed

--- a/cli/it/features/devportal/apikey.feature
+++ b/cli/it/features/devportal/apikey.feature
@@ -1,0 +1,54 @@
+# --------------------------------------------------------------------
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# --------------------------------------------------------------------
+
+Feature: DevPortal API Key Commands
+    As a CLI user
+    I want to manage developer portal API keys
+    So that I can issue and revoke API keys from the command line
+
+    Background:
+        Given the CLI is available
+        And the devportal is running
+        And I have a devportal named "dp-apikey" configured
+
+    # =========================================
+    # API Key flag validation
+    # =========================================
+
+    @DP-APIKEY-001
+    Scenario: List API keys without required flags fails
+        When I run ap with arguments "devportal api-key get --org 1ba42a09-45c0-40f8-a1bf-e4aa7cde1575"
+        Then the command should fail
+        And the stderr should contain "required flag"
+
+    # =========================================
+    # API Key Generate / Get / Regenerate / Revoke
+    #
+    # @wip — require an existing API to bind the key to. Enable once the API
+    # publish fixture exists.
+    # =========================================
+
+    @DP-APIKEY-002 @wip
+    Scenario: Generate an API key
+        When I run ap with arguments "devportal api-key generate --org 1ba42a09-45c0-40f8-a1bf-e4aa7cde1575 --api-id it-test-api --name it-test-key --no-interactive"
+        Then the command should succeed
+
+    @DP-APIKEY-003 @wip
+    Scenario: List API keys for an API
+        When I run ap with arguments "devportal api-key get --org 1ba42a09-45c0-40f8-a1bf-e4aa7cde1575 --api-id it-test-api"
+        Then the command should succeed

--- a/cli/it/features/devportal/application.feature
+++ b/cli/it/features/devportal/application.feature
@@ -1,0 +1,64 @@
+# --------------------------------------------------------------------
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# --------------------------------------------------------------------
+
+Feature: DevPortal Application Commands
+    As a CLI user
+    I want to manage developer portal applications
+    So that I can administer applications from the command line
+
+    # NOTE: All application happy-path scenarios are tagged @wip and therefore
+    # SKIPPED. The CLI now targets the org-scoped application path
+    # (/o/{orgId}/devportal/v1/applications), but the server spec still exposes the
+    # application endpoints without the org prefix, so these commands currently
+    # fail against the running devportal. Remove the @wip tag once the server side
+    # is aligned (see docs/devportal-openapi-spec-v1.yaml).
+
+    Background:
+        Given the CLI is available
+        And the devportal is running
+        And I have a devportal named "dp-app" configured
+
+    # =========================================
+    # Application flag validation (active even while the API is @wip)
+    # =========================================
+
+    @DP-APP-001
+    Scenario: Create application without required flags fails
+        When I run ap with arguments "devportal application create --org 1ba42a09-45c0-40f8-a1bf-e4aa7cde1575"
+        Then the command should fail
+        And the stderr should contain "required flag"
+
+    # =========================================
+    # Application Create / Get / Update / Delete
+    # =========================================
+
+    @DP-APP-002 @wip
+    Scenario: Create an application
+        When I run ap with arguments "devportal application create --org 1ba42a09-45c0-40f8-a1bf-e4aa7cde1575 --name it-test-app --type WEB"
+        Then the command should succeed
+        And the output should contain "Application created"
+
+    @DP-APP-003 @wip
+    Scenario: List applications
+        When I run ap with arguments "devportal application get --org 1ba42a09-45c0-40f8-a1bf-e4aa7cde1575"
+        Then the command should succeed
+
+    @DP-APP-004 @wip
+    Scenario: Delete an application
+        When I run ap with arguments "devportal application delete --org 1ba42a09-45c0-40f8-a1bf-e4aa7cde1575 --app-id it-test-app"
+        Then the command should succeed

--- a/cli/it/features/devportal/e2e.feature
+++ b/cli/it/features/devportal/e2e.feature
@@ -1,0 +1,47 @@
+# --------------------------------------------------------------------
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# --------------------------------------------------------------------
+
+Feature: DevPortal End-to-End Publish Flow
+    As a CLI user
+    I want to build an API project and publish it to the developer portal
+    So that I can generate API keys, manage subscription plans, and subscribe
+
+    Background:
+        Given the CLI is available
+        And the devportal is running
+        And I have a devportal named "dp-e2e" configured
+        And I target organization "1ba42a09-45c0-40f8-a1bf-e4aa7cde1575"
+
+    # One ordered scenario: the generated API ID is captured at publish time and
+    # reused by the get / api-key / subscription steps. The subscription plan is
+    # created BEFORE the API is published, because publish fails if a policy named
+    # in the API manifest does not already exist in the org. The subscription then
+    # uses that created plan (it-platinum) rather than a seeded one.
+    @DP-E2E-001
+    Scenario: Build, publish, key, plan, and subscribe end to end
+        When I build the echo API project
+        And I publish the subscription plan "resources/devportal/subscription-plan.yaml"
+        And I publish the built API
+        Then the output should contain "published"
+        And the published API should be retrievable
+
+        When I generate an API key named "echo-it-key" for the published API
+        Then the command should succeed
+
+        When I create a subscription for the published API with plan "it-platinum"
+        Then the command should succeed

--- a/cli/it/features/devportal/management.feature
+++ b/cli/it/features/devportal/management.feature
@@ -1,0 +1,134 @@
+# --------------------------------------------------------------------
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# --------------------------------------------------------------------
+
+Feature: DevPortal Configuration Commands
+    As a CLI user
+    I want to manage developer portal configurations
+    So that I can connect to and interact with API Platform developer portals
+
+    Background:
+        Given the CLI is available
+
+    # =========================================
+    # DevPortal Add Tests
+    # =========================================
+
+    @DP-MANAGE-001
+    Scenario: Add devportal with api-key auth
+        When I run ap with arguments "devportal add --display-name dp-add-test --server http://localhost:3000 --auth api-key --api-key devportal-it-test-key --no-interactive"
+        Then the command should succeed
+        And the output should contain "added"
+        And the output should contain "dp-add-test"
+
+    @DP-MANAGE-002
+    Scenario: Add devportal without server flag fails
+        When I run ap with arguments "devportal add --display-name dp-no-server --auth api-key --api-key devportal-it-test-key --no-interactive"
+        Then the command should fail
+        And the output should contain "server"
+
+    @DP-MANAGE-003
+    Scenario: Add devportal with invalid auth type fails
+        When I run ap with arguments "devportal add --display-name dp-bad-auth --server http://localhost:3000 --auth invalid --no-interactive"
+        Then the command should fail
+        And the output should contain "invalid auth type"
+
+    # =========================================
+    # DevPortal List Tests
+    # =========================================
+
+    @DP-MANAGE-004
+    Scenario: List devportals
+        Given I have a devportal named "dp-list-test" configured
+        When I run ap with arguments "devportal list"
+        Then the command should succeed
+        And the output should contain "dp-list-test"
+
+    @DP-MANAGE-005
+    Scenario: List devportals when none configured
+        Given I reset the CLI configuration
+        When I run ap with arguments "devportal list"
+        Then the command should succeed
+        And the output should contain "No devportal configured"
+
+    # =========================================
+    # DevPortal Use / Current Tests
+    # =========================================
+
+    @DP-MANAGE-006
+    Scenario: Use existing devportal
+        Given I have a devportal named "dp-use-test" configured
+        When I run ap with arguments "devportal use --display-name dp-use-test"
+        Then the command should succeed
+        And the output should contain "DevPortal set to dp-use-test"
+
+    @DP-MANAGE-007
+    Scenario: Use non-existent devportal fails
+        When I run ap with arguments "devportal use --display-name dp-missing"
+        Then the command should fail
+        And the output should contain "not found"
+
+    @DP-MANAGE-008
+    Scenario: Show current devportal
+        Given I have a devportal named "dp-current-test" configured
+        And I set the current devportal to "dp-current-test"
+        When I run ap with arguments "devportal current"
+        Then the command should succeed
+        And the output should contain "dp-current-test"
+
+    @DP-MANAGE-009
+    Scenario: Show current devportal when none set
+        Given I reset the CLI configuration
+        When I run ap with arguments "devportal current"
+        Then the command should fail
+        And the output should contain "no active devportal"
+
+    # =========================================
+    # DevPortal Remove Tests
+    # =========================================
+
+    @DP-MANAGE-010
+    Scenario: Remove existing devportal
+        Given I have a devportal named "dp-remove-test" configured
+        When I run ap with arguments "devportal remove --display-name dp-remove-test"
+        Then the command should succeed
+        And the output should contain "removed"
+
+    @DP-MANAGE-011
+    Scenario: Remove non-existent devportal fails
+        When I run ap with arguments "devportal remove --display-name dp-missing"
+        Then the command should fail
+        And the output should contain "not found"
+
+    # =========================================
+    # DevPortal Health Tests
+    # =========================================
+
+    @DP-MANAGE-012
+    Scenario: Check devportal health
+        Given the devportal is running
+        And I have a devportal named "dp-health-test" configured
+        When I run ap with arguments "devportal health"
+        Then the command should succeed
+        And the output should contain "DevPortal Status: ok"
+
+    @DP-MANAGE-013
+    Scenario: Check health of unreachable devportal
+        Given I run ap with arguments "devportal add --display-name dp-unreachable --server http://localhost:19998 --auth api-key --api-key x --no-interactive"
+        And I run ap with arguments "devportal use --display-name dp-unreachable"
+        When I run ap with arguments "devportal health"
+        Then the command should fail

--- a/cli/it/features/devportal/organization.feature
+++ b/cli/it/features/devportal/organization.feature
@@ -1,0 +1,67 @@
+# --------------------------------------------------------------------
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# --------------------------------------------------------------------
+
+Feature: DevPortal Organization Commands
+    As a CLI user
+    I want to manage developer portal organizations
+    So that I can administer organizations from the command line
+
+    Background:
+        Given the CLI is available
+        And the devportal is running
+        And I have a devportal named "dp-org" configured
+
+    # =========================================
+    # Organization List / Get (against the seeded ACME org)
+    # =========================================
+
+    @DP-ORG-001
+    Scenario: List organizations
+        When I run ap with arguments "devportal org list"
+        Then the command should succeed
+        And the output should contain "ACME"
+
+    @DP-ORG-002
+    Scenario: Get the seeded organization by id
+        When I run ap with arguments "devportal org get --org 1ba42a09-45c0-40f8-a1bf-e4aa7cde1575"
+        Then the command should succeed
+        And the output should contain "ACME"
+
+    @DP-ORG-003
+    Scenario: Get organization without required org flag fails
+        When I run ap with arguments "devportal org get"
+        Then the command should fail
+        And the stderr should contain "required flag"
+
+    # =========================================
+    # Organization Create / Delete
+    #
+    # @wip — create/delete mutate state and depend on the exact organization CR
+    # schema accepted by the server. Enable once the CR fixture is verified.
+    # =========================================
+
+    @DP-ORG-004 @wip
+    Scenario: Create an organization
+        When I run ap with arguments "devportal org add -f resources/devportal/organization.yaml"
+        Then the command should succeed
+        And the output should contain "Organization created"
+
+    @DP-ORG-005 @wip
+    Scenario: Delete an organization
+        When I run ap with arguments "devportal org delete --org it-test-org"
+        Then the command should succeed

--- a/cli/it/features/devportal/subscription.feature
+++ b/cli/it/features/devportal/subscription.feature
@@ -1,0 +1,66 @@
+# --------------------------------------------------------------------
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# --------------------------------------------------------------------
+
+Feature: DevPortal Subscription Commands
+    As a CLI user
+    I want to manage developer portal subscriptions
+    So that I can administer API subscriptions from the command line
+
+    Background:
+        Given the CLI is available
+        And the devportal is running
+        And I have a devportal named "dp-sub" configured
+
+    # =========================================
+    # Subscription List (against the seeded ACME org)
+    # =========================================
+
+    @DP-SUB-001
+    Scenario: List subscriptions in an organization
+        When I run ap with arguments "devportal subscription get --org 1ba42a09-45c0-40f8-a1bf-e4aa7cde1575"
+        Then the command should succeed
+        And the output should contain "Platform subscriptions"
+
+    @DP-SUB-002
+    Scenario: List subscriptions without required org flag fails
+        When I run ap with arguments "devportal subscription get"
+        Then the command should fail
+        And the stderr should contain "required flag"
+
+    @DP-SUB-003
+    Scenario: Create subscription without required flags fails
+        When I run ap with arguments "devportal subscription create --org 1ba42a09-45c0-40f8-a1bf-e4aa7cde1575"
+        Then the command should fail
+        And the stderr should contain "required flag"
+
+    # =========================================
+    # Subscription Create / Edit / Delete
+    #
+    # @wip — require an existing API with token-based subscriptions enabled,
+    # which in turn needs the API publish flow. Enable once that fixture exists.
+    # =========================================
+
+    @DP-SUB-004 @wip
+    Scenario: Create a subscription
+        When I run ap with arguments "devportal subscription create --org 1ba42a09-45c0-40f8-a1bf-e4aa7cde1575 --api-id it-test-api"
+        Then the command should succeed
+
+    @DP-SUB-005 @wip
+    Scenario: Delete a subscription
+        When I run ap with arguments "devportal subscription delete --org 1ba42a09-45c0-40f8-a1bf-e4aa7cde1575 --sub-id it-test-sub"
+        Then the command should succeed

--- a/cli/it/resources/devportal/echo-definition.yaml
+++ b/cli/it/resources/devportal/echo-definition.yaml
@@ -1,0 +1,74 @@
+openapi: 3.0.1
+info:
+  title: Ping API
+  version: 1.0.0
+  description: |
+    HTTP echo/probe API secured with an API key (`X-API-Key` header).
+    Use this API to inspect requests, test connectivity, and probe status codes.
+    No subscription plans are required — just an API key.
+servers:
+  - url: /ping
+security:
+  - ApiKeyHeader: []
+components:
+  securitySchemes:
+    ApiKeyHeader:
+      type: apiKey
+      in: header
+      name: X-API-Key
+  schemas:
+    PingResponse:
+      type: object
+      description: Response returned by the ping/echo service
+      additionalProperties: true
+
+paths:
+  /get:
+    get:
+      summary: Echo a GET request
+      description: Returns the query parameters and headers sent with the request.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PingResponse'
+
+  /post:
+    post:
+      summary: Echo a POST request
+      description: Echoes the posted JSON body back in the response.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PingResponse'
+
+  /status/{code}:
+    get:
+      summary: Return a specific HTTP status code
+      description: Returns the given HTTP status code — useful for testing error handling.
+      parameters:
+        - name: code
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: Proxy response (actual status depends on the `code` path parameter)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PingResponse'

--- a/cli/it/resources/devportal/echo-devportal.yaml
+++ b/cli/it/resources/devportal/echo-devportal.yaml
@@ -1,0 +1,33 @@
+apiVersion: devportal.api-platform.wso2.com/v1
+kind: RestApi
+metadata:
+    name: echo-api-v2.0
+spec:
+    displayName: Echo API
+    version: v2.0
+    description: Sample HTTP echo/probe API. Requires API key authentication. No subscription plans.
+    provider: WSO2
+    gatewayType: wso2/api-platform
+    status: PUBLISHED
+    referenceID: echo-api-v2.0
+    tags:
+        - ping
+        - api-key
+    labels:
+        - default
+    subscriptionPolicies:
+        - Gold
+        - Bronze
+        # Created by the E2E sub-plan publish step (must exist before this API is
+        # published; it is matched to org policies by POLICY_NAME = metadata.name).
+        - it-platinum
+    visibility: PUBLIC
+    visibleGroups: []
+    businessInformation:
+        businessOwner: Platform Owner
+        businessOwnerEmail: support@example.com
+        technicalOwner: API Team
+        technicalOwnerEmail: architecture@example.com
+    endpoints:
+        sandboxUrl: http://localhost:8080/ping
+        productionUrl: http://localhost:8080/ping

--- a/cli/it/resources/devportal/organization.yaml
+++ b/cli/it/resources/devportal/organization.yaml
@@ -1,0 +1,34 @@
+# --------------------------------------------------------------------
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# --------------------------------------------------------------------
+
+# Organization CR fixture used by the @wip `devportal org add` scenario.
+#
+# This is a best-effort fixture: the exact organization CR schema accepted by
+# `POST /organizations` (multipart field "organization") must be verified against
+# the running server before un-tagging DP-ORG-004. Adjust the fields below to
+# match the server contract, then remove the @wip tag in organization.feature.
+apiVersion: devportal.api-platform.wso2.com/v1
+kind: Organization
+metadata:
+  name: it-test-org
+spec:
+  orgName: it-test-org
+  orgHandle: it-test-org
+  organizationIdentifier: it-test-org
+  businessOwner: IT Test Owner
+  businessOwnerEmail: it-test@example.com

--- a/cli/it/resources/devportal/subscription-plan.yaml
+++ b/cli/it/resources/devportal/subscription-plan.yaml
@@ -1,0 +1,30 @@
+# --------------------------------------------------------------------
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# --------------------------------------------------------------------
+
+# Subscription plan CR uploaded by `ap devportal sub-plan publish`. Uses a unique
+# name so it does not collide with the seeded Bronze/Silver/Gold/Unlimited plans.
+apiVersion: devportal.api-platform.wso2.com/v1
+kind: SubscriptionPolicy
+metadata:
+  name: it-platinum
+spec:
+  displayName: IT Platinum Plan
+  billingPlan: FREE
+  type: requestcount
+  requestCount: 100000
+  description: Integration test subscription plan

--- a/cli/it/resources/values.go
+++ b/cli/it/resources/values.go
@@ -44,6 +44,33 @@ const (
 
 	// MCPServerMCPEndpoint is the MCP protocol endpoint
 	MCPServerMCPEndpoint = "http://localhost:3001/mcp"
+
+	// DevPortalURL is the developer portal REST API endpoint (published to host)
+	DevPortalURL = "http://localhost:3000"
+
+	// DevPortalHealthURL is the developer portal health endpoint
+	DevPortalHealthURL = DevPortalURL + "/health"
+)
+
+// Developer portal test configuration
+const (
+	// DevPortalName is the default devportal config name used in tests
+	DevPortalName = "test-devportal"
+
+	// DevPortalAuthType is the auth type used to talk to the test devportal
+	DevPortalAuthType = "api-key"
+
+	// DevPortalAPIKey is the api-key seeded into the test devportal via
+	// DP_ADVANCED_APIKEY_KEYVALUE in the IT docker-compose. It grants full
+	// admin access to the /devportal endpoints.
+	DevPortalAPIKey = "devportal-it-test-key"
+
+	// DevPortalDefaultOrgID is the seeded ACME organization UUID
+	// (database/02-seed_org.postgres.sql). Org-scoped commands target this org.
+	DevPortalDefaultOrgID = "1ba42a09-45c0-40f8-a1bf-e4aa7cde1575"
+
+	// DevPortalDefaultOrgHandle is the seeded ACME organization handle/name
+	DevPortalDefaultOrgHandle = "ACME"
 )
 
 // Timeouts and intervals
@@ -128,6 +155,14 @@ func GetResourcePath(filename string) string {
 // GetSampleAPIPath returns the path to the sample API YAML file
 func GetSampleAPIPath() string {
 	return GetResourcePath("sample-api.yaml")
+}
+
+// GetDevPortalResourcePath returns the absolute path to a resource file in the
+// devportal resources folder (resources/devportal/<filename>).
+func GetDevPortalResourcePath(filename string) string {
+	_, currentFile, _, _ := runtime.Caller(0)
+	resourcesDir := filepath.Dir(currentFile)
+	return filepath.Join(resourcesDir, "devportal", filename)
 }
 
 // GetSampleMCPConfigPath returns the path to the sample MCP config file

--- a/cli/it/setup.go
+++ b/cli/it/setup.go
@@ -50,6 +50,9 @@ const (
 
 	// MCPServerPort is the port for MCP server
 	MCPServerPort = "3001"
+
+	// DevPortalPort is the host port the developer portal is published on
+	DevPortalPort = "3000"
 )
 
 // InfrastructureManager manages the lifecycle of test infrastructure
@@ -65,6 +68,11 @@ type InfrastructureManager struct {
 	mu                  sync.Mutex
 	composeProjectName  string
 	reporter            *TestReporter
+
+	// Developer portal stack (separate compose project)
+	devportalComposeFile         string
+	devportalComposeOverrideFile string
+	devportalProjectName         string
 }
 
 func NewInfrastructureManager(reporter *TestReporter, cfg *TestConfig, cfgPath string) *InfrastructureManager {
@@ -80,6 +88,7 @@ func NewInfrastructureManager(reporter *TestReporter, cfg *TestConfig, cfgPath s
 
 	// Generate a per-run compose project name to avoid collisions
 	m.composeProjectName = fmt.Sprintf("cli-it-%d-%d", os.Getpid(), time.Now().UnixNano())
+	m.devportalProjectName = fmt.Sprintf("cli-it-dp-%d-%d", os.Getpid(), time.Now().UnixNano())
 
 	// Resolve compose file from config if set
 	if cfg != nil && cfg.Infrastructure.ComposeFile != "" {
@@ -154,6 +163,11 @@ func (m *InfrastructureManager) SetupInfrastructure(required []InfrastructureID)
 			// Only mark MCP as started if the gateway stack start reported success
 			// or MCP readiness was explicitly verified above.
 			m.startedServices[InfraMCPServer] = true
+		case InfraDevPortal:
+			if err := m.startDevPortalStack(); err != nil {
+				return fmt.Errorf("failed to start devportal stack: %w", err)
+			}
+			m.startedServices[InfraDevPortal] = true
 		}
 	}
 
@@ -326,6 +340,106 @@ func (m *InfrastructureManager) waitForMCPServer() error {
 	return fmt.Errorf("MCP server health check timed out after %v", m.startupTimeout)
 }
 
+// startDevPortalStack starts the developer portal Docker Compose stack. It reuses
+// the developer-portal IT compose file (postgres + devportal) and layers a small
+// override that publishes the devportal port to the host so the CLI (running on
+// the host) can reach it. The cypress service in that compose is never started
+// because it is not a dependency of the devportal service.
+func (m *InfrastructureManager) startDevPortalStack() error {
+	m.reporter.LogPhase1("DEVPORTAL", "Starting developer portal stack...")
+
+	if m.devportalComposeFile == "" {
+		composeFile, err := filepath.Abs("../../portals/developer-portal/it/docker-compose.test.yaml")
+		if err != nil {
+			return fmt.Errorf("failed to resolve devportal compose file path: %w", err)
+		}
+		m.devportalComposeFile = composeFile
+	}
+	if _, err := os.Stat(m.devportalComposeFile); os.IsNotExist(err) {
+		return fmt.Errorf("devportal compose file not found: %s", m.devportalComposeFile)
+	}
+
+	if m.devportalComposeOverrideFile == "" {
+		overrideFile, err := filepath.Abs("docker-compose.devportal.override.yaml")
+		if err != nil {
+			return fmt.Errorf("failed to resolve devportal compose override path: %w", err)
+		}
+		m.devportalComposeOverrideFile = overrideFile
+	}
+	if _, err := os.Stat(m.devportalComposeOverrideFile); os.IsNotExist(err) {
+		return fmt.Errorf("devportal compose override file not found: %s", m.devportalComposeOverrideFile)
+	}
+
+	// Stop any leftover containers from previous runs.
+	m.reporter.LogPhase1Detail("Cleaning up previous devportal containers...")
+	m.stopDevPortalStack()
+
+	m.reporter.LogPhase1Detail("Starting postgres container...")
+	m.reporter.LogPhase1Detail("Starting devportal container...")
+
+	// Start only the devportal service (and its postgres dependency); cypress is
+	// intentionally excluded. --wait blocks until both are healthy.
+	cmd := exec.CommandContext(m.ctx, "docker", "compose",
+		"-f", m.devportalComposeFile,
+		"-f", m.devportalComposeOverrideFile,
+		"-p", m.devportalProjectName,
+		"up", "-d", "--wait", "devportal",
+	)
+	cmd.Dir = filepath.Dir(m.devportalComposeFile)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		m.reporter.LogPhase1Fail("DEVPORTAL", "Failed to start stack", string(output))
+		return fmt.Errorf("failed to start devportal docker compose: %w\nOutput: %s", err, output)
+	}
+
+	m.reporter.LogPhase1Detail("Waiting for devportal health check...")
+	if err := m.waitForDevPortalHealth(); err != nil {
+		m.reporter.LogPhase1Fail("DEVPORTAL", "Health check failed", err.Error())
+		return err
+	}
+
+	m.reporter.LogPhase1Pass("DEVPORTAL", "Developer portal stack ready")
+	return nil
+}
+
+// stopDevPortalStack stops the developer portal Docker Compose stack.
+func (m *InfrastructureManager) stopDevPortalStack() {
+	if m.devportalComposeFile == "" {
+		return
+	}
+
+	args := []string{"compose", "-f", m.devportalComposeFile}
+	if m.devportalComposeOverrideFile != "" {
+		args = append(args, "-f", m.devportalComposeOverrideFile)
+	}
+	args = append(args, "-p", m.devportalProjectName, "down", "-v", "--remove-orphans")
+
+	cmd := exec.CommandContext(m.ctx, "docker", args...)
+	cmd.Dir = filepath.Dir(m.devportalComposeFile)
+	_ = cmd.Run() // Ignore errors during cleanup
+}
+
+// waitForDevPortalHealth waits for the developer portal /health endpoint to return 200.
+func (m *InfrastructureManager) waitForDevPortalHealth() error {
+	healthURL := fmt.Sprintf("http://localhost:%s/health", DevPortalPort)
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	deadline := time.Now().Add(m.startupTimeout)
+	for time.Now().Before(deadline) {
+		resp, err := client.Get(healthURL)
+		if err == nil && resp.StatusCode == http.StatusOK {
+			resp.Body.Close()
+			return nil
+		}
+		if resp != nil {
+			resp.Body.Close()
+		}
+		time.Sleep(m.healthCheckInterval)
+	}
+
+	return fmt.Errorf("devportal health check timed out after %v", m.startupTimeout)
+}
+
 // GetCLIBinaryPath returns the path to the CLI binary
 func (m *InfrastructureManager) GetCLIBinaryPath() string {
 	return m.cliBinaryPath
@@ -355,6 +469,11 @@ func (m *InfrastructureManager) Teardown() error {
 		_ = cmd.Run() // Ignore errors during cleanup
 	}
 
+	// Stop the devportal stack if it was started.
+	if m.startedServices[InfraDevPortal] {
+		m.stopDevPortalStack()
+	}
+
 	m.cancel()
 	return nil
 }
@@ -368,13 +487,28 @@ func CheckDockerAvailable() error {
 	return nil
 }
 
-// CheckPortsAvailable verifies required ports are free
-func CheckPortsAvailable() error {
-	ports := []string{
-		GatewayControllerPort,
-		"8080",  // Router HTTP
-		"18000", // xDS
-		MCPServerPort,
+// CheckPortsAvailable verifies the ports required by the enabled infrastructure
+// are free. Only the ports for infrastructure that will actually be started are
+// checked, so devportal-only runs don't require the gateway ports (and vice versa).
+func CheckPortsAvailable(required []InfrastructureID) error {
+	needed := make(map[InfrastructureID]bool)
+	for _, id := range required {
+		needed[id] = true
+	}
+
+	var ports []string
+	if needed[InfraGateway] {
+		ports = append(ports,
+			GatewayControllerPort,
+			"8080",  // Router HTTP
+			"18000", // xDS
+		)
+	}
+	if needed[InfraMCPServer] {
+		ports = append(ports, MCPServerPort)
+	}
+	if needed[InfraDevPortal] {
+		ports = append(ports, DevPortalPort)
 	}
 
 	for _, port := range ports {

--- a/cli/it/state.go
+++ b/cli/it/state.go
@@ -284,3 +284,12 @@ func (s *TestState) GetConfigDir() string {
 	defer s.mu.RUnlock()
 	return s.ConfigDir
 }
+
+// GetWorkingDir returns the per-scenario working directory (a fresh temp dir).
+// CLI commands run with this as their working directory, so it is also where
+// scaffolded API projects and their build output land.
+func (s *TestState) GetWorkingDir() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.WorkingDir
+}

--- a/cli/it/steps/cli_steps.go
+++ b/cli/it/steps/cli_steps.go
@@ -39,6 +39,7 @@ type TestState interface {
 	SetAPIInfo(name, version string)
 	SetMCPInfo(name, version string)
 	GetConfigDir() string
+	GetWorkingDir() string
 }
 
 // CLISteps provides CLI execution step definitions
@@ -77,6 +78,9 @@ func (s *CLISteps) RunWithArgs(args string) error {
 			// Extract filename and get absolute path
 			filename := filepath.Base(part)
 			parts[i] = resources.GetResourcePath(filename)
+		} else if strings.HasPrefix(part, "resources/devportal/") {
+			filename := filepath.Base(part)
+			parts[i] = resources.GetDevPortalResourcePath(filename)
 		}
 	}
 

--- a/cli/it/steps/devportal_steps.go
+++ b/cli/it/steps/devportal_steps.go
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package steps
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/wso2/api-platform/cli/it/resources"
+)
+
+// DevPortalSteps provides developer-portal-specific step definitions. Most
+// devportal commands are exercised through the generic `I run ap with arguments`
+// step; these helpers cover the setup steps (configuring and selecting a
+// devportal) and the end-to-end publish flow (build → publish → key → plan →
+// subscribe) that needs to thread the generated API ID between commands.
+type DevPortalSteps struct {
+	state TestState
+
+	// E2E flow state, captured between steps within a scenario.
+	projectDir string
+	zipPath    string
+	orgID      string
+	apiID      string
+}
+
+// NewDevPortalSteps creates a new DevPortalSteps instance.
+func NewDevPortalSteps(state TestState) *DevPortalSteps {
+	return &DevPortalSteps{state: state}
+}
+
+// EnsureDevPortalConfigured adds a devportal config pointing at the test
+// deployment (api-key auth) and makes it the active devportal so subsequent
+// commands that omit --display-name resolve to it.
+func (s *DevPortalSteps) EnsureDevPortalConfigured(name string) error {
+	err := s.state.ExecuteCLI(
+		"devportal", "add",
+		"--display-name", name,
+		"--server", resources.DevPortalURL,
+		"--auth", resources.DevPortalAuthType,
+		"--api-key", resources.DevPortalAPIKey,
+		"--no-interactive",
+	)
+	if err != nil {
+		return err
+	}
+	if s.state.GetExitCode() != 0 {
+		return fmt.Errorf("failed to add devportal %q: %s", name, s.state.GetCombinedOutput())
+	}
+
+	return s.SetCurrentDevPortal(name)
+}
+
+// SetCurrentDevPortal sets the active devportal.
+func (s *DevPortalSteps) SetCurrentDevPortal(name string) error {
+	if err := s.state.ExecuteCLI("devportal", "use", "--display-name", name); err != nil {
+		return err
+	}
+	if s.state.GetExitCode() != 0 {
+		return fmt.Errorf("failed to set current devportal %q: %s", name, s.state.GetCombinedOutput())
+	}
+	return nil
+}
+
+// runOK runs a CLI command and returns an error if it exits non-zero, so the
+// calling step fails with the combined output for easy diagnosis.
+func (s *DevPortalSteps) runOK(action string, args ...string) error {
+	if err := s.state.ExecuteCLI(args...); err != nil {
+		return fmt.Errorf("%s: %w", action, err)
+	}
+	if s.state.GetExitCode() != 0 {
+		return fmt.Errorf("%s failed (exit %d):\n%s", action, s.state.GetExitCode(), s.state.GetCombinedOutput())
+	}
+	return nil
+}
+
+// BuildEchoAPIProject scaffolds an API project with `ap apiproject init`, stages
+// the provided echo devportal artifact (devportal.yaml + definition.yaml) into a
+// `devportal/` portal root, points the project config at it, and runs
+// `ap devportal build` to produce build/devportal.zip.
+func (s *DevPortalSteps) BuildEchoAPIProject() error {
+	workDir := s.state.GetWorkingDir()
+	if workDir == "" {
+		return fmt.Errorf("working directory not set")
+	}
+
+	// 1. Scaffold the API project (created under workDir using the display name).
+	if err := s.runOK("apiproject init",
+		"apiproject", "init",
+		"--display-name", "echo-api",
+		"--type", "rest",
+		"--version", "v2.0",
+		"--context", "/ping",
+		"--no-interactive",
+	); err != nil {
+		return err
+	}
+	s.projectDir = filepath.Join(workDir, "echo-api")
+
+	// 2. Stage the devportal portal root with the provided artifact files.
+	portalRoot := filepath.Join(s.projectDir, "devportal")
+	for _, dir := range []string{portalRoot, filepath.Join(portalRoot, "docs"), filepath.Join(portalRoot, "content")} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("failed to create %s: %w", dir, err)
+		}
+	}
+	if err := copyResourceFile(resources.GetDevPortalResourcePath("echo-devportal.yaml"), filepath.Join(portalRoot, "devportal.yaml")); err != nil {
+		return err
+	}
+	if err := copyResourceFile(resources.GetDevPortalResourcePath("echo-definition.yaml"), filepath.Join(portalRoot, "definition.yaml")); err != nil {
+		return err
+	}
+
+	// 3. Point the project config at the staged portal root so `build` bundles
+	//    the provided artifacts as-is (instead of auto-generating a manifest).
+	if err := os.WriteFile(filepath.Join(s.projectDir, ".api-platform", "config.yaml"), []byte(echoProjectConfig), 0644); err != nil {
+		return fmt.Errorf("failed to write project config: %w", err)
+	}
+
+	// 4. Build the devportal artifact zip.
+	if err := s.runOK("devportal build", "devportal", "build", "-f", s.projectDir); err != nil {
+		return err
+	}
+	s.zipPath = filepath.Join(s.projectDir, "build", "devportal.zip")
+	if _, err := os.Stat(s.zipPath); err != nil {
+		return fmt.Errorf("expected built artifact at %s: %w", s.zipPath, err)
+	}
+	return nil
+}
+
+// TargetOrganization records the organization id used by the publish, plan,
+// api-key, and subscription steps of the end-to-end flow.
+func (s *DevPortalSteps) TargetOrganization(orgID string) error {
+	s.orgID = strings.TrimSpace(orgID)
+	if s.orgID == "" {
+		return fmt.Errorf("organization id must not be empty")
+	}
+	return nil
+}
+
+// PublishBuiltAPI publishes the built artifact to the targeted organization and
+// captures the generated Developer Portal API ID from the response.
+func (s *DevPortalSteps) PublishBuiltAPI() error {
+	if s.orgID == "" {
+		return fmt.Errorf("no target organization; run the target organization step first")
+	}
+	if s.zipPath == "" {
+		return fmt.Errorf("no built artifact; run the build step first")
+	}
+	if err := s.runOK("rest-api publish",
+		"devportal", "rest-api", "publish", "-f", s.zipPath, "--org", s.orgID,
+	); err != nil {
+		return err
+	}
+
+	apiID, err := extractAPIID(s.state.GetStdout())
+	if err != nil {
+		return fmt.Errorf("could not capture API ID from publish response: %w\n%s", err, s.state.GetStdout())
+	}
+	s.apiID = apiID
+	return nil
+}
+
+// GetPublishedAPI retrieves the published API by its captured ID. The CLI treats
+// a 404 as a non-error (exit 0), so this also asserts the response echoes the
+// captured API ID to confirm the API really is retrievable.
+func (s *DevPortalSteps) GetPublishedAPI() error {
+	if s.apiID == "" {
+		return fmt.Errorf("no published API ID captured; run the publish step first")
+	}
+	if err := s.runOK("rest-api get",
+		"devportal", "rest-api", "get", "--org", s.orgID, "--api-id", s.apiID,
+	); err != nil {
+		return err
+	}
+	if !strings.Contains(s.state.GetStdout(), s.apiID) {
+		return fmt.Errorf("rest-api get did not return the published API %q:\n%s", s.apiID, s.state.GetCombinedOutput())
+	}
+	return nil
+}
+
+// GenerateAPIKeyForPublishedAPI generates an API key bound to the published API.
+func (s *DevPortalSteps) GenerateAPIKeyForPublishedAPI(keyName string) error {
+	if s.apiID == "" {
+		return fmt.Errorf("no published API ID captured; run the publish step first")
+	}
+	return s.runOK("api-key generate",
+		"devportal", "api-key", "generate",
+		"--org", s.orgID, "--api-id", s.apiID, "--name", keyName, "--no-interactive",
+	)
+}
+
+// PublishSubscriptionPlan uploads a subscription plan CR to the targeted org.
+// Run before publishing the API so the API can reference the new plan (the
+// publish flow fails if a listed policy name does not exist in the org).
+func (s *DevPortalSteps) PublishSubscriptionPlan(resourcePath string) error {
+	if s.orgID == "" {
+		return fmt.Errorf("no target organization; run the target organization step first")
+	}
+	planPath := resources.GetDevPortalResourcePath(filepath.Base(resourcePath))
+	return s.runOK("sub-plan publish",
+		"devportal", "sub-plan", "publish", "-f", planPath, "--org", s.orgID,
+	)
+}
+
+// CreateSubscriptionForPublishedAPI subscribes to the published API with a plan.
+func (s *DevPortalSteps) CreateSubscriptionForPublishedAPI(plan string) error {
+	if s.apiID == "" {
+		return fmt.Errorf("no published API ID captured; run the publish step first")
+	}
+	return s.runOK("subscription create",
+		"devportal", "subscription", "create",
+		"--org", s.orgID, "--api-id", s.apiID, "--subscription-plan", plan,
+	)
+}
+
+// echoProjectConfig is the .api-platform/config.yaml written for the staged echo
+// project. The devportals entry makes `ap devportal build` bundle the staged
+// portal root verbatim.
+const echoProjectConfig = `version: 1.0.0
+filePaths:
+  deploymentArtifact: ./gateway.yaml
+  apiMetadata: ./api.yaml
+  apiDefinition: ./definition.yaml
+  docs: ./docs
+  tests: ./tests
+governanceRulesets: []
+autoSync:
+  gatewayArtifactFromDefinition: true
+devportals:
+  - name: default
+    portalRoot: ./devportal
+    filePaths:
+      apiMetadata: ./devportal.yaml
+      apiDefinition: ./definition.yaml
+      docs: ./docs
+      content: ./content
+`
+
+// copyResourceFile copies a source file to dst, creating parent directories.
+func copyResourceFile(src, dst string) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return fmt.Errorf("failed to read resource %s: %w", src, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return fmt.Errorf("failed to create dir for %s: %w", dst, err)
+	}
+	if err := os.WriteFile(dst, data, 0644); err != nil {
+		return fmt.Errorf("failed to write %s: %w", dst, err)
+	}
+	return nil
+}
+
+// extractAPIID pulls the top-level "apiID" field from the publish command's
+// stdout, which prints a header line followed by the pretty-printed JSON body.
+func extractAPIID(stdout string) (string, error) {
+	start := strings.Index(stdout, "{")
+	if start < 0 {
+		return "", fmt.Errorf("no JSON object found in output")
+	}
+	var body struct {
+		APIID string `json:"apiID"`
+	}
+	if err := json.Unmarshal([]byte(stdout[start:]), &body); err != nil {
+		return "", fmt.Errorf("failed to parse response JSON: %w", err)
+	}
+	if strings.TrimSpace(body.APIID) == "" {
+		return "", fmt.Errorf("response did not contain a non-empty apiID")
+	}
+	return body.APIID, nil
+}

--- a/cli/it/suite_test.go
+++ b/cli/it/suite_test.go
@@ -48,8 +48,9 @@ var (
 	testConfigPath string
 
 	// Step handlers
-	cliSteps    *steps.CLISteps
-	assertSteps *steps.AssertSteps
+	cliSteps       *steps.CLISteps
+	assertSteps    *steps.AssertSteps
+	devPortalSteps *steps.DevPortalSteps
 
 	// Coverage collector
 	coverageCollector *CoverageCollector
@@ -93,8 +94,13 @@ func TestFeatures(t *testing.T) {
 		TestSuiteInitializer: InitializeTestSuite,
 		ScenarioInitializer:  InitializeScenario,
 		Options: &godog.Options{
-			Format:   "progress",
-			Paths:    []string{"features"},
+			Format: "progress",
+			// Scope feature dirs to the selected suites (IT_SUITES env var);
+			// defaults to all suites.
+			Paths: FeaturePaths(),
+			// Skip work-in-progress scenarios (e.g. devportal commands that depend
+			// on server-side changes not yet in place, such as application APIs).
+			Tags:     "~@wip",
 			TestingT: t,
 			NoColors: false,
 			Output:   io.Discard,
@@ -140,8 +146,11 @@ func InitializeTestSuite(ctx *godog.TestSuiteContext) {
 			}
 		}
 
+		// Determine which infrastructure the enabled tests require.
+		required := testConfig.GetRequiredInfrastructure()
+
 		// Verify required ports are free before starting infrastructure
-		if err := CheckPortsAvailable(); err != nil {
+		if err := CheckPortsAvailable(required); err != nil {
 			log.Fatalf("Pre-flight check failed: Required ports are not available. %v", err)
 		}
 		fmt.Printf("  %s[PORTS]%s  Required ports free %s✓%s\n", ColorBlue, ColorReset, ColorGreen, ColorReset)
@@ -161,10 +170,7 @@ func InitializeTestSuite(ctx *godog.TestSuiteContext) {
 		// Initialize infrastructure manager
 		infraManager = NewInfrastructureManager(testReporter, testConfig, testConfigPath)
 
-		// Get required infrastructure based on enabled tests
-		required := testConfig.GetRequiredInfrastructure()
-
-		// Setup infrastructure
+		// Setup infrastructure (required computed above for port checks)
 		if err := infraManager.SetupInfrastructure(required); err != nil {
 			log.Fatalf("Phase 1 failed: %v", err)
 		}
@@ -288,6 +294,7 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 		// Initialize step handlers
 		cliSteps = steps.NewCLISteps(testState)
 		assertSteps = steps.NewAssertSteps(testState)
+		devPortalSteps = steps.NewDevPortalSteps(testState)
 
 		// Extract test ID from tags if available
 		for _, tag := range sc.Tags {
@@ -328,6 +335,7 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	registerAPISteps(ctx)
 	registerMCPSteps(ctx)
 	registerBuildSteps(ctx)
+	registerDevPortalSteps(ctx)
 }
 
 // registerInfrastructureSteps registers infrastructure-related step definitions
@@ -391,6 +399,21 @@ func registerMCPSteps(ctx *godog.ScenarioContext) {
 func registerBuildSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^I build gateway with manifest "([^"]*)"$`, iBuildGatewayWithManifest)
 	ctx.Step(`^the build should complete successfully$`, theBuildShouldComplete)
+}
+
+// registerDevPortalSteps registers developer-portal step definitions
+func registerDevPortalSteps(ctx *godog.ScenarioContext) {
+	ctx.Step(`^the devportal is running$`, theDevPortalIsRunning)
+	ctx.Step(`^I have a devportal named "([^"]*)" configured$`, iHaveDevPortalConfigured)
+	ctx.Step(`^I set the current devportal to "([^"]*)"$`, iSetCurrentDevPortal)
+	// End-to-end publish flow
+	ctx.Step(`^I target organization "([^"]*)"$`, iTargetOrganization)
+	ctx.Step(`^I build the echo API project$`, iBuildEchoAPIProject)
+	ctx.Step(`^I publish the built API$`, iPublishBuiltAPI)
+	ctx.Step(`^the published API should be retrievable$`, thePublishedAPIShouldBeRetrievable)
+	ctx.Step(`^I generate an API key named "([^"]*)" for the published API$`, iGenerateAPIKeyForPublishedAPI)
+	ctx.Step(`^I publish the subscription plan "([^"]*)"$`, iPublishSubscriptionPlan)
+	ctx.Step(`^I create a subscription for the published API with plan "([^"]*)"$`, iCreateSubscriptionForPublishedAPI)
 }
 
 // Step implementations
@@ -540,4 +563,44 @@ func iResetCLIConfiguration() error {
 
 func iApplyResourceFile(filePath string) error {
 	return cliSteps.ApplyResourceFile(filePath)
+}
+
+func theDevPortalIsRunning() error {
+	return infraManager.waitForDevPortalHealth()
+}
+
+func iHaveDevPortalConfigured(name string) error {
+	return devPortalSteps.EnsureDevPortalConfigured(name)
+}
+
+func iSetCurrentDevPortal(name string) error {
+	return devPortalSteps.SetCurrentDevPortal(name)
+}
+
+func iTargetOrganization(orgID string) error {
+	return devPortalSteps.TargetOrganization(orgID)
+}
+
+func iBuildEchoAPIProject() error {
+	return devPortalSteps.BuildEchoAPIProject()
+}
+
+func iPublishBuiltAPI() error {
+	return devPortalSteps.PublishBuiltAPI()
+}
+
+func thePublishedAPIShouldBeRetrievable() error {
+	return devPortalSteps.GetPublishedAPI()
+}
+
+func iGenerateAPIKeyForPublishedAPI(keyName string) error {
+	return devPortalSteps.GenerateAPIKeyForPublishedAPI(keyName)
+}
+
+func iPublishSubscriptionPlan(resourcePath string) error {
+	return devPortalSteps.PublishSubscriptionPlan(resourcePath)
+}
+
+func iCreateSubscriptionForPublishedAPI(plan string) error {
+	return devPortalSteps.CreateSubscriptionForPublishedAPI(plan)
 }

--- a/cli/it/test-config.yaml
+++ b/cli/it/test-config.yaml
@@ -218,3 +218,207 @@ tests:
         name: build missing manifest file
         enabled: true
         requires: [CLI]
+
+  # Developer portal CLI command tests.
+  # The DEVPORTAL infrastructure starts a postgres + developer-portal stack from
+  # portals/developer-portal/it/docker-compose.test.yaml (port 3000 published).
+  # Requires the developer-portal :test image to be built first
+  # (see `make build-devportal-image`).
+  #
+  # Scenarios tagged @wip in the feature files are SKIPPED regardless of the flags
+  # below (they depend on server-side changes / fixtures not yet in place, e.g.
+  # application APIs and the API publish artifact).
+  devportal:
+    manage:
+      - id: DP-MANAGE-001
+        name: devportal add with api-key auth
+        enabled: true
+        requires: [CLI]
+
+      - id: DP-MANAGE-002
+        name: devportal add without server flag
+        enabled: true
+        requires: [CLI]
+
+      - id: DP-MANAGE-003
+        name: devportal add with invalid auth type
+        enabled: true
+        requires: [CLI]
+
+      - id: DP-MANAGE-004
+        name: devportal list
+        enabled: true
+        requires: [CLI]
+
+      - id: DP-MANAGE-005
+        name: devportal list when empty
+        enabled: true
+        requires: [CLI]
+
+      - id: DP-MANAGE-006
+        name: devportal use existing
+        enabled: true
+        requires: [CLI]
+
+      - id: DP-MANAGE-007
+        name: devportal use non-existent
+        enabled: true
+        requires: [CLI]
+
+      - id: DP-MANAGE-008
+        name: devportal current
+        enabled: true
+        requires: [CLI]
+
+      - id: DP-MANAGE-009
+        name: devportal current when none set
+        enabled: true
+        requires: [CLI]
+
+      - id: DP-MANAGE-010
+        name: devportal remove existing
+        enabled: true
+        requires: [CLI]
+
+      - id: DP-MANAGE-011
+        name: devportal remove non-existent
+        enabled: true
+        requires: [CLI]
+
+      - id: DP-MANAGE-012
+        name: devportal health
+        enabled: true
+        requires: [CLI, DEVPORTAL]
+
+      - id: DP-MANAGE-013
+        name: devportal health unreachable
+        enabled: true
+        requires: [CLI]
+
+    organization:
+      - id: DP-ORG-001
+        name: org list
+        enabled: true
+        requires: [CLI, DEVPORTAL]
+
+      - id: DP-ORG-002
+        name: org get seeded organization
+        enabled: true
+        requires: [CLI, DEVPORTAL]
+
+      - id: DP-ORG-003
+        name: org get without org flag
+        enabled: true
+        requires: [CLI, DEVPORTAL]
+
+      - id: DP-ORG-004
+        name: org create (wip)
+        enabled: false
+        requires: [CLI, DEVPORTAL]
+
+      - id: DP-ORG-005
+        name: org delete (wip)
+        enabled: false
+        requires: [CLI, DEVPORTAL]
+
+    api:
+      - id: DP-API-001
+        name: rest-api list
+        enabled: true
+        requires: [CLI, DEVPORTAL]
+
+      - id: DP-API-002
+        name: rest-api list without org flag
+        enabled: true
+        requires: [CLI, DEVPORTAL]
+
+      - id: DP-API-003
+        name: rest-api get without flags
+        enabled: true
+        requires: [CLI, DEVPORTAL]
+
+      - id: DP-API-004
+        name: rest-api publish (wip)
+        enabled: false
+        requires: [CLI, DEVPORTAL]
+
+      - id: DP-API-005
+        name: rest-api get (wip)
+        enabled: false
+        requires: [CLI, DEVPORTAL]
+
+      - id: DP-API-006
+        name: rest-api delete (wip)
+        enabled: false
+        requires: [CLI, DEVPORTAL]
+
+    subscription:
+      - id: DP-SUB-001
+        name: subscription list
+        enabled: true
+        requires: [CLI, DEVPORTAL]
+
+      - id: DP-SUB-002
+        name: subscription list without org flag
+        enabled: true
+        requires: [CLI, DEVPORTAL]
+
+      - id: DP-SUB-003
+        name: subscription create without flags
+        enabled: true
+        requires: [CLI, DEVPORTAL]
+
+      - id: DP-SUB-004
+        name: subscription create (wip)
+        enabled: false
+        requires: [CLI, DEVPORTAL]
+
+      - id: DP-SUB-005
+        name: subscription delete (wip)
+        enabled: false
+        requires: [CLI, DEVPORTAL]
+
+    apikey:
+      - id: DP-APIKEY-001
+        name: api-key get without flags
+        enabled: true
+        requires: [CLI, DEVPORTAL]
+
+      - id: DP-APIKEY-002
+        name: api-key generate (wip)
+        enabled: false
+        requires: [CLI, DEVPORTAL]
+
+      - id: DP-APIKEY-003
+        name: api-key get (wip)
+        enabled: false
+        requires: [CLI, DEVPORTAL]
+
+    application:
+      - id: DP-APP-001
+        name: application create without flags
+        enabled: true
+        requires: [CLI, DEVPORTAL]
+
+      - id: DP-APP-002
+        name: application create (wip - server alignment pending)
+        enabled: false
+        requires: [CLI, DEVPORTAL]
+
+      - id: DP-APP-003
+        name: application list (wip - server alignment pending)
+        enabled: false
+        requires: [CLI, DEVPORTAL]
+
+      - id: DP-APP-004
+        name: application delete (wip - server alignment pending)
+        enabled: false
+        requires: [CLI, DEVPORTAL]
+
+    # End-to-end flow: apiproject init -> devportal build -> rest-api publish ->
+    # api-key generate -> sub-plan publish -> subscription create.
+    e2e:
+      - id: DP-E2E-001
+        name: build publish key plan subscribe end to end
+        enabled: true
+        requires: [CLI, DEVPORTAL]

--- a/cli/src/cmd/devportal/apikey/commands_test.go
+++ b/cli/src/cmd/devportal/apikey/commands_test.go
@@ -36,7 +36,7 @@ func TestRunGenerateCommand_SendsPayload(t *testing.T) {
 		if req.Method != http.MethodPost {
 			t.Fatalf("expected POST request, got %s", req.Method)
 		}
-		if req.URL.Path != "/devportal/organizations/org-1/api-keys/generate" {
+		if req.URL.Path != "/o/org-1/devportal/v1/api-keys/generate" {
 			t.Fatalf("unexpected request path %s", req.URL.Path)
 		}
 		body, err := io.ReadAll(req.Body)
@@ -75,7 +75,7 @@ func TestRunGetCommand_ListsAPIKeys(t *testing.T) {
 		if req.Method != http.MethodGet {
 			t.Fatalf("expected GET request, got %s", req.Method)
 		}
-		if req.URL.Path != "/devportal/organizations/org-1/api-keys" {
+		if req.URL.Path != "/o/org-1/devportal/v1/api-keys" {
 			t.Fatalf("unexpected request path %s", req.URL.Path)
 		}
 		if got := req.URL.Query().Get("apiId"); got != "api-1" {
@@ -105,7 +105,7 @@ func TestRunRegenerateCommand_PostsToRegenerate(t *testing.T) {
 		if req.Method != http.MethodPost {
 			t.Fatalf("expected POST request, got %s", req.Method)
 		}
-		if req.URL.Path != "/devportal/organizations/org-1/api-keys/key-1/regenerate" {
+		if req.URL.Path != "/o/org-1/devportal/v1/api-keys/key-1/regenerate" {
 			t.Fatalf("unexpected request path %s", req.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -132,7 +132,7 @@ func TestRunRevokeCommand_PostsToRevoke(t *testing.T) {
 		if req.Method != http.MethodPost {
 			t.Fatalf("expected POST request, got %s", req.Method)
 		}
-		if req.URL.Path != "/devportal/organizations/org-1/api-keys/key-1/revoke" {
+		if req.URL.Path != "/o/org-1/devportal/v1/api-keys/key-1/revoke" {
 			t.Fatalf("unexpected request path %s", req.URL.Path)
 		}
 		w.WriteHeader(http.StatusNoContent)

--- a/cli/src/cmd/devportal/apikey/generate.go
+++ b/cli/src/cmd/devportal/apikey/generate.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 	"os"
 	"regexp"
 	"strings"
@@ -123,7 +122,7 @@ func runGenerateCommand() error {
 	}
 
 	client := internaldevportal.NewClientWithOptions(devPortal, generateInsecure)
-	path := fmt.Sprintf("/devportal/organizations/%s/api-keys/generate", url.PathEscape(orgID))
+	path := internaldevportal.OrgScopedPath(orgID, "api-keys/generate")
 	resp, err := client.PostJSON(path, payload)
 	if err != nil {
 		return internaldevportal.WrapRequestError("generate API key", err, generateInsecure)

--- a/cli/src/cmd/devportal/apikey/get.go
+++ b/cli/src/cmd/devportal/apikey/get.go
@@ -93,7 +93,7 @@ func runGetCommand() error {
 	}
 
 	client := internaldevportal.NewClientWithOptions(devPortal, getInsecure)
-	path := fmt.Sprintf("/devportal/organizations/%s/api-keys?apiId=%s", url.PathEscape(orgID), url.QueryEscape(apiID))
+	path := internaldevportal.OrgScopedPath(orgID, "api-keys?apiId="+url.QueryEscape(apiID))
 	resp, err := client.Get(path)
 	if err != nil {
 		return internaldevportal.WrapRequestError("get API keys", err, getInsecure)

--- a/cli/src/cmd/devportal/apikey/regenerate.go
+++ b/cli/src/cmd/devportal/apikey/regenerate.go
@@ -95,7 +95,7 @@ func runRegenerateCommand() error {
 
 	client := internaldevportal.NewClientWithOptions(devPortal, regenerateInsecure)
 	baseURL := strings.TrimSuffix(devPortal.URL, "/")
-	path := fmt.Sprintf("/devportal/organizations/%s/api-keys/%s/regenerate", url.PathEscape(orgID), url.PathEscape(apiKeyID))
+	path := internaldevportal.OrgScopedPath(orgID, "api-keys/"+url.PathEscape(apiKeyID)+"/regenerate")
 	req, err := http.NewRequest(http.MethodPost, baseURL+path, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)

--- a/cli/src/cmd/devportal/apikey/revoke.go
+++ b/cli/src/cmd/devportal/apikey/revoke.go
@@ -95,7 +95,7 @@ func runRevokeCommand() error {
 
 	client := internaldevportal.NewClientWithOptions(devPortal, revokeInsecure)
 	baseURL := strings.TrimSuffix(devPortal.URL, "/")
-	path := fmt.Sprintf("/devportal/organizations/%s/api-keys/%s/revoke", url.PathEscape(orgID), url.PathEscape(apiKeyID))
+	path := internaldevportal.OrgScopedPath(orgID, "api-keys/"+url.PathEscape(apiKeyID)+"/revoke")
 	req, err := http.NewRequest(http.MethodPost, baseURL+path, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)

--- a/cli/src/cmd/devportal/application/commands_test.go
+++ b/cli/src/cmd/devportal/application/commands_test.go
@@ -37,7 +37,7 @@ func TestRunCreateCommand_SendsJSONPayload(t *testing.T) {
 		if req.Method != http.MethodPost {
 			t.Fatalf("expected POST request, got %s", req.Method)
 		}
-		if req.URL.Path != "/devportal/organizations/org-1/applications" {
+		if req.URL.Path != "/o/org-1/devportal/v1/applications" {
 			t.Fatalf("unexpected request path %s", req.URL.Path)
 		}
 		body, err := io.ReadAll(req.Body)
@@ -109,7 +109,7 @@ func TestRunUpdateCommand_SendsJSONPayload(t *testing.T) {
 		if req.Method != http.MethodPut {
 			t.Fatalf("expected PUT request, got %s", req.Method)
 		}
-		if req.URL.Path != "/devportal/organizations/org-1/applications/app-1" {
+		if req.URL.Path != "/o/org-1/devportal/v1/applications/app-1" {
 			t.Fatalf("unexpected request path %s", req.URL.Path)
 		}
 		body, err := io.ReadAll(req.Body)
@@ -145,13 +145,13 @@ func TestRunGetCommand_ListAllAndSingle(t *testing.T) {
 
 	server := testutil.NewDevPortalServer(t, func(w http.ResponseWriter, req *http.Request) {
 		switch req.URL.Path {
-		case "/devportal/organizations/org-1/applications":
+		case "/o/org-1/devportal/v1/applications":
 			if req.Method != http.MethodGet {
 				t.Fatalf("expected GET request, got %s", req.Method)
 			}
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`[{"applicationId":"app-1"}]`))
-		case "/devportal/organizations/org-1/applications/app-1":
+		case "/o/org-1/devportal/v1/applications/app-1":
 			if req.Method != http.MethodGet {
 				t.Fatalf("expected GET request, got %s", req.Method)
 			}
@@ -197,7 +197,7 @@ func TestRunDeleteCommand_SendsDelete(t *testing.T) {
 		if req.Method != http.MethodDelete {
 			t.Fatalf("expected DELETE request, got %s", req.Method)
 		}
-		if req.URL.Path != "/devportal/organizations/org-1/applications/app-1" {
+		if req.URL.Path != "/o/org-1/devportal/v1/applications/app-1" {
 			t.Fatalf("unexpected request path %s", req.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")

--- a/cli/src/cmd/devportal/application/create.go
+++ b/cli/src/cmd/devportal/application/create.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 
@@ -110,7 +109,7 @@ func runCreateCommand() error {
 	}
 
 	client := internaldevportal.NewClientWithOptions(devPortal, createInsecure)
-	path := fmt.Sprintf("/devportal/organizations/%s/applications", url.PathEscape(orgID))
+	path := internaldevportal.OrgScopedPath(orgID, "applications")
 	resp, err := client.PostJSON(path, payload)
 	if err != nil {
 		return internaldevportal.WrapRequestError("create application", err, createInsecure)

--- a/cli/src/cmd/devportal/application/delete.go
+++ b/cli/src/cmd/devportal/application/delete.go
@@ -93,7 +93,7 @@ func runDeleteCommand() error {
 	}
 
 	client := internaldevportal.NewClientWithOptions(devPortal, deleteInsecure)
-	path := fmt.Sprintf("/devportal/organizations/%s/applications/%s", url.PathEscape(orgID), url.PathEscape(appID))
+	path := internaldevportal.OrgScopedPath(orgID, "applications/"+url.PathEscape(appID))
 	resp, err := client.Delete(path)
 	if err != nil {
 		return internaldevportal.WrapRequestError("delete application", err, deleteInsecure)

--- a/cli/src/cmd/devportal/application/get.go
+++ b/cli/src/cmd/devportal/application/get.go
@@ -90,7 +90,7 @@ func runGetCommand() error {
 	}
 
 	client := internaldevportal.NewClientWithOptions(devPortal, getInsecure)
-	path := fmt.Sprintf("/devportal/organizations/%s/applications", url.PathEscape(orgID))
+	path := internaldevportal.OrgScopedPath(orgID, "applications")
 	appID := strings.TrimSpace(getAppID)
 	if appID != "" {
 		path = fmt.Sprintf("%s/%s", path, url.PathEscape(appID))

--- a/cli/src/cmd/devportal/application/update.go
+++ b/cli/src/cmd/devportal/application/update.go
@@ -110,7 +110,7 @@ func runUpdateCommand() error {
 	}
 
 	client := internaldevportal.NewClientWithOptions(devPortal, updateInsecure)
-	path := fmt.Sprintf("/devportal/organizations/%s/applications/%s", url.PathEscape(orgID), url.PathEscape(appID))
+	path := internaldevportal.OrgScopedPath(orgID, "applications/"+url.PathEscape(appID))
 	resp, err := client.PutJSON(path, payload)
 	if err != nil {
 		return internaldevportal.WrapRequestError("update application", err, updateInsecure)

--- a/cli/src/cmd/devportal/org/add.go
+++ b/cli/src/cmd/devportal/org/add.go
@@ -84,7 +84,7 @@ func runAddCommand() error {
 	}
 
 	client := internaldevportal.NewClientWithOptions(devPortal, addInsecure)
-	resp, err := client.PostMultipartFile("/devportal/organizations", "organization", organizationPath)
+	resp, err := client.PostMultipartFile("/organizations", "organization", organizationPath)
 	if err != nil {
 		return internaldevportal.WrapRequestError("create organization", err, addInsecure)
 	}

--- a/cli/src/cmd/devportal/org/commands_test.go
+++ b/cli/src/cmd/devportal/org/commands_test.go
@@ -37,7 +37,7 @@ func TestRunListCommand_PrintsOrganizationTable(t *testing.T) {
 		if req.Method != http.MethodGet {
 			t.Fatalf("expected GET request, got %s", req.Method)
 		}
-		if req.URL.Path != "/devportal/organizations" {
+		if req.URL.Path != "/organizations" {
 			t.Fatalf("unexpected request path %s", req.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -70,7 +70,7 @@ func TestRunGetCommand_PrintsJSON(t *testing.T) {
 		if req.Method != http.MethodGet {
 			t.Fatalf("expected GET request, got %s", req.Method)
 		}
-		if req.URL.Path != "/devportal/organizations/org-1" {
+		if req.URL.Path != "/organizations/org-1" {
 			t.Fatalf("unexpected request path %s", req.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -101,7 +101,7 @@ func TestRunAddCommand_SendsOrganizationYAMLMultipart(t *testing.T) {
 		if req.Method != http.MethodPost {
 			t.Fatalf("expected POST request, got %s", req.Method)
 		}
-		if req.URL.Path != "/devportal/organizations" {
+		if req.URL.Path != "/organizations" {
 			t.Fatalf("unexpected request path %s", req.URL.Path)
 		}
 		assertMultipartOrganization(t, req, "org.yaml", "apiVersion: devportal.api-platform.wso2.com/v1\nkind: Organization\n")
@@ -170,7 +170,7 @@ func TestRunEditCommand_SendsJSONPayload(t *testing.T) {
 		if req.Method != http.MethodPut {
 			t.Fatalf("expected PUT request, got %s", req.Method)
 		}
-		if req.URL.Path != "/devportal/organizations/org-1" {
+		if req.URL.Path != "/organizations/org-1" {
 			t.Fatalf("unexpected request path %s", req.URL.Path)
 		}
 		body, err := io.ReadAll(req.Body)
@@ -228,7 +228,7 @@ func TestRunDeleteCommand_SendsDelete(t *testing.T) {
 		if req.Method != http.MethodDelete {
 			t.Fatalf("expected DELETE request, got %s", req.Method)
 		}
-		if req.URL.Path != "/devportal/organizations/org-1" {
+		if req.URL.Path != "/organizations/org-1" {
 			t.Fatalf("unexpected request path %s", req.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")

--- a/cli/src/cmd/devportal/org/delete.go
+++ b/cli/src/cmd/devportal/org/delete.go
@@ -84,7 +84,7 @@ func runDeleteCommand() error {
 	}
 
 	client := internaldevportal.NewClientWithOptions(devPortal, deleteInsecure)
-	path := fmt.Sprintf("/devportal/organizations/%s", url.PathEscape(orgID))
+	path := fmt.Sprintf("/organizations/%s", url.PathEscape(orgID))
 	resp, err := client.Delete(path)
 	if err != nil {
 		return internaldevportal.WrapRequestError("delete organization", err, deleteInsecure)

--- a/cli/src/cmd/devportal/org/edit.go
+++ b/cli/src/cmd/devportal/org/edit.go
@@ -92,7 +92,7 @@ func runEditCommand() error {
 	}
 
 	client := internaldevportal.NewClientWithOptions(devPortal, editInsecure)
-	path := fmt.Sprintf("/devportal/organizations/%s", url.PathEscape(orgID))
+	path := fmt.Sprintf("/organizations/%s", url.PathEscape(orgID))
 	resp, err := client.PutJSON(path, payload)
 	if err != nil {
 		return internaldevportal.WrapRequestError("update organization", err, editInsecure)

--- a/cli/src/cmd/devportal/org/get.go
+++ b/cli/src/cmd/devportal/org/get.go
@@ -84,7 +84,7 @@ func runGetCommand() error {
 	}
 
 	client := internaldevportal.NewClientWithOptions(devPortal, getInsecure)
-	path := fmt.Sprintf("/devportal/organizations/%s", url.PathEscape(orgID))
+	path := fmt.Sprintf("/organizations/%s", url.PathEscape(orgID))
 	resp, err := client.Get(path)
 	if err != nil {
 		return internaldevportal.WrapRequestError("get organization", err, getInsecure)

--- a/cli/src/cmd/devportal/org/list.go
+++ b/cli/src/cmd/devportal/org/list.go
@@ -84,7 +84,7 @@ func runListCommand() error {
 	}
 
 	client := internaldevportal.NewClientWithOptions(devPortal, listInsecure)
-	resp, err := client.Get("/devportal/organizations")
+	resp, err := client.Get("/organizations")
 	if err != nil {
 		return internaldevportal.WrapRequestError("list organizations", err, listInsecure)
 	}

--- a/cli/src/cmd/devportal/restapi/commands_test.go
+++ b/cli/src/cmd/devportal/restapi/commands_test.go
@@ -38,7 +38,7 @@ func TestRunListCommand_PrintsTable(t *testing.T) {
 		if req.Method != http.MethodGet {
 			t.Fatalf("expected GET request, got %s", req.Method)
 		}
-		if req.URL.Path != "/devportal/organizations/org-1/apis" {
+		if req.URL.Path != "/o/org-1/devportal/v1/apis" {
 			t.Fatalf("unexpected request path %s", req.URL.Path)
 		}
 		if req.URL.RawQuery != "tags=default" {
@@ -138,7 +138,7 @@ func TestRunGetCommand_PrintsJSON(t *testing.T) {
 		if req.Method != http.MethodGet {
 			t.Fatalf("expected GET request, got %s", req.Method)
 		}
-		if req.URL.Path != "/devportal/organizations/org-1/apis/api-1" {
+		if req.URL.Path != "/o/org-1/devportal/v1/apis/api-1" {
 			t.Fatalf("unexpected request path %s", req.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -174,7 +174,7 @@ func TestRunPublishCommand_DefaultArtifactAndMultipartUpload(t *testing.T) {
 		if req.Method != http.MethodPost {
 			t.Fatalf("expected POST request, got %s", req.Method)
 		}
-		if req.URL.Path != "/devportal/organizations/org-1/apis" {
+		if req.URL.Path != "/o/org-1/devportal/v1/apis" {
 			t.Fatalf("unexpected request path %s", req.URL.Path)
 		}
 		assertMultipartArtifact(t, req, "devportal.zip")
@@ -227,7 +227,7 @@ func TestRunEditCommand_UploadsArtifact(t *testing.T) {
 		if req.Method != http.MethodPut {
 			t.Fatalf("expected PUT request, got %s", req.Method)
 		}
-		if req.URL.Path != "/devportal/organizations/org-1/apis/api-1" {
+		if req.URL.Path != "/o/org-1/devportal/v1/apis/api-1" {
 			t.Fatalf("unexpected request path %s", req.URL.Path)
 		}
 		assertMultipartArtifact(t, req, "artifact.zip")
@@ -254,7 +254,7 @@ func TestRunDeleteCommand_SendsDelete(t *testing.T) {
 		if req.Method != http.MethodDelete {
 			t.Fatalf("expected DELETE request, got %s", req.Method)
 		}
-		if req.URL.Path != "/devportal/organizations/org-1/apis/api-1" {
+		if req.URL.Path != "/o/org-1/devportal/v1/apis/api-1" {
 			t.Fatalf("unexpected request path %s", req.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")

--- a/cli/src/cmd/devportal/restapi/delete.go
+++ b/cli/src/cmd/devportal/restapi/delete.go
@@ -92,7 +92,7 @@ func runDeleteCommand() error {
 	}
 
 	client := internaldevportal.NewClientWithOptions(devPortal, deleteInsecure)
-	path := fmt.Sprintf("/devportal/organizations/%s/apis/%s", url.PathEscape(orgID), url.PathEscape(apiID))
+	path := internaldevportal.OrgScopedPath(orgID, "apis/"+url.PathEscape(apiID))
 	resp, err := client.Delete(path)
 	if err != nil {
 		return internaldevportal.WrapRequestError("delete api artifact", err, deleteInsecure)

--- a/cli/src/cmd/devportal/restapi/edit.go
+++ b/cli/src/cmd/devportal/restapi/edit.go
@@ -102,7 +102,7 @@ func runEditCommand() error {
 	}
 
 	client := internaldevportal.NewClientWithOptions(devPortal, editInsecure)
-	path := fmt.Sprintf("/devportal/organizations/%s/apis/%s", url.PathEscape(orgID), url.PathEscape(apiID))
+	path := internaldevportal.OrgScopedPath(orgID, "apis/"+url.PathEscape(apiID))
 	resp, err := client.PutMultipartFile(path, "artifact", artifactPath)
 	if err != nil {
 		return internaldevportal.WrapRequestError("edit api artifact", err, editInsecure)

--- a/cli/src/cmd/devportal/restapi/get.go
+++ b/cli/src/cmd/devportal/restapi/get.go
@@ -92,7 +92,7 @@ func runGetCommand() error {
 	}
 
 	client := internaldevportal.NewClientWithOptions(devPortal, getInsecure)
-	path := fmt.Sprintf("/devportal/organizations/%s/apis/%s", url.PathEscape(orgID), url.PathEscape(apiID))
+	path := internaldevportal.OrgScopedPath(orgID, "apis/"+url.PathEscape(apiID))
 	resp, err := client.Get(path)
 	if err != nil {
 		return internaldevportal.WrapRequestError("get api artifact", err, getInsecure)

--- a/cli/src/cmd/devportal/restapi/list.go
+++ b/cli/src/cmd/devportal/restapi/list.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 
@@ -96,7 +95,7 @@ func runListCommand() error {
 	}
 
 	client := internaldevportal.NewClientWithOptions(devPortal, listInsecure)
-	path := fmt.Sprintf("/devportal/organizations/%s/apis?tags=default", url.PathEscape(orgID))
+	path := internaldevportal.OrgScopedPath(orgID, "apis?tags=default")
 	resp, err := client.Get(path)
 	if err != nil {
 		return internaldevportal.WrapRequestError("list api artifacts", err, listInsecure)

--- a/cli/src/cmd/devportal/restapi/publish.go
+++ b/cli/src/cmd/devportal/restapi/publish.go
@@ -20,7 +20,6 @@ package restapi
 
 import (
 	"fmt"
-	"net/url"
 	"os"
 	"strings"
 
@@ -96,7 +95,7 @@ func runPublishCommand() error {
 	}
 
 	client := internaldevportal.NewClientWithOptions(devPortal, publishInsecure)
-	path := fmt.Sprintf("/devportal/organizations/%s/apis", url.PathEscape(orgID))
+	path := internaldevportal.OrgScopedPath(orgID, "apis")
 	resp, err := client.PostMultipartFile(path, "artifact", artifactPath)
 	if err != nil {
 		return internaldevportal.WrapRequestError("publish api artifact", err, publishInsecure)

--- a/cli/src/cmd/devportal/subplan/commands_test.go
+++ b/cli/src/cmd/devportal/subplan/commands_test.go
@@ -70,7 +70,7 @@ func TestRunPublishCommand_UploadsSinglePlanMultipart(t *testing.T) {
 		if req.Method != http.MethodPost {
 			t.Fatalf("expected POST request, got %s", req.Method)
 		}
-		if req.URL.Path != "/devportal/organizations/org-1/subscription-policies" {
+		if req.URL.Path != "/o/org-1/devportal/v1/subscription-policies" {
 			t.Fatalf("unexpected request path %s", req.URL.Path)
 		}
 		assertMultipartPlan(t, req, "plan.yaml", singlePlanYAML)
@@ -100,7 +100,7 @@ func TestRunPublishCommand_UploadsPlanListMultipart(t *testing.T) {
 	testutil.WithTempHome(t)
 
 	server := testutil.NewDevPortalServer(t, func(w http.ResponseWriter, req *http.Request) {
-		if req.URL.Path != "/devportal/organizations/org-1/subscription-policies" {
+		if req.URL.Path != "/o/org-1/devportal/v1/subscription-policies" {
 			t.Fatalf("unexpected request path %s", req.URL.Path)
 		}
 		assertMultipartPlan(t, req, "plans.yaml", planListYAML)
@@ -177,7 +177,7 @@ func TestRunGetCommand_GetsPlanByPolicyID(t *testing.T) {
 		if req.Method != http.MethodGet {
 			t.Fatalf("expected GET request, got %s", req.Method)
 		}
-		if req.URL.Path != "/devportal/organizations/org-1/subscription-policies/plan-1" {
+		if req.URL.Path != "/o/org-1/devportal/v1/subscription-policies/plan-1" {
 			t.Fatalf("unexpected request path %s", req.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -215,7 +215,7 @@ func TestRunDeleteCommand_DeletesPlanByPolicyID(t *testing.T) {
 		if req.Method != http.MethodDelete {
 			t.Fatalf("expected DELETE request, got %s", req.Method)
 		}
-		if req.URL.Path != "/devportal/organizations/org-1/subscription-policies/plan-1" {
+		if req.URL.Path != "/o/org-1/devportal/v1/subscription-policies/plan-1" {
 			t.Fatalf("unexpected request path %s", req.URL.Path)
 		}
 		w.WriteHeader(http.StatusNoContent)

--- a/cli/src/cmd/devportal/subplan/delete.go
+++ b/cli/src/cmd/devportal/subplan/delete.go
@@ -93,7 +93,7 @@ func runDeleteCommand() error {
 	}
 
 	client := internaldevportal.NewClientWithOptions(devPortal, deleteInsecure)
-	path := fmt.Sprintf("/devportal/organizations/%s/subscription-policies/%s", url.PathEscape(orgID), url.PathEscape(policyID))
+	path := internaldevportal.OrgScopedPath(orgID, "subscription-policies/"+url.PathEscape(policyID))
 	resp, err := client.Delete(path)
 	if err != nil {
 		return internaldevportal.WrapRequestError("delete subscription plan", err, deleteInsecure)

--- a/cli/src/cmd/devportal/subplan/get.go
+++ b/cli/src/cmd/devportal/subplan/get.go
@@ -93,7 +93,7 @@ func runGetCommand() error {
 	}
 
 	client := internaldevportal.NewClientWithOptions(devPortal, getInsecure)
-	path := fmt.Sprintf("/devportal/organizations/%s/subscription-policies/%s", url.PathEscape(orgID), url.PathEscape(policyID))
+	path := internaldevportal.OrgScopedPath(orgID, "subscription-policies/"+url.PathEscape(policyID))
 	resp, err := client.Get(path)
 	if err != nil {
 		return internaldevportal.WrapRequestError("get subscription plan", err, getInsecure)

--- a/cli/src/cmd/devportal/subplan/publish.go
+++ b/cli/src/cmd/devportal/subplan/publish.go
@@ -20,7 +20,6 @@ package subplan
 
 import (
 	"fmt"
-	"net/url"
 	"os"
 	"strings"
 
@@ -138,7 +137,7 @@ func runPublishCommand() error {
 	}
 
 	client := internaldevportal.NewClientWithOptions(devPortal, publishInsecure)
-	path := fmt.Sprintf("/devportal/organizations/%s/subscription-policies", url.PathEscape(orgID))
+	path := internaldevportal.OrgScopedPath(orgID, "subscription-policies")
 	resp, err := client.PostMultipartFile(path, multipartFieldName, filePath)
 	if err != nil {
 		return internaldevportal.WrapRequestError("publish subscription plan", err, publishInsecure)

--- a/cli/src/cmd/devportal/subscription/commands_test.go
+++ b/cli/src/cmd/devportal/subscription/commands_test.go
@@ -36,7 +36,7 @@ func TestRunCreateCommand_SendsJSONPayload(t *testing.T) {
 		if req.Method != http.MethodPost {
 			t.Fatalf("expected POST request, got %s", req.Method)
 		}
-		if req.URL.Path != "/devportal/organizations/org-1/subscriptions" {
+		if req.URL.Path != "/o/org-1/devportal/v1/subscriptions" {
 			t.Fatalf("unexpected request path %s", req.URL.Path)
 		}
 		body, err := io.ReadAll(req.Body)
@@ -74,7 +74,7 @@ func TestRunEditCommand_SendsJSONPayload(t *testing.T) {
 		if req.Method != http.MethodPut {
 			t.Fatalf("expected PUT request, got %s", req.Method)
 		}
-		if req.URL.Path != "/devportal/organizations/org-1/subscriptions/sub-1" {
+		if req.URL.Path != "/o/org-1/devportal/v1/subscriptions/sub-1" {
 			t.Fatalf("unexpected request path %s", req.URL.Path)
 		}
 		body, err := io.ReadAll(req.Body)
@@ -108,13 +108,13 @@ func TestRunGetCommand_ListAllAndSingle(t *testing.T) {
 
 	server := testutil.NewDevPortalServer(t, func(w http.ResponseWriter, req *http.Request) {
 		switch req.URL.Path {
-		case "/devportal/organizations/org-1/subscriptions":
+		case "/o/org-1/devportal/v1/subscriptions":
 			if req.Method != http.MethodGet {
 				t.Fatalf("expected GET request, got %s", req.Method)
 			}
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`[{"subscriptionId":"sub-1"}]`))
-		case "/devportal/organizations/org-1/subscriptions/sub-1":
+		case "/o/org-1/devportal/v1/subscriptions/sub-1":
 			if req.Method != http.MethodGet {
 				t.Fatalf("expected GET request, got %s", req.Method)
 			}
@@ -160,7 +160,7 @@ func TestRunDeleteCommand_SendsDelete(t *testing.T) {
 		if req.Method != http.MethodDelete {
 			t.Fatalf("expected DELETE request, got %s", req.Method)
 		}
-		if req.URL.Path != "/devportal/organizations/org-1/subscriptions/sub-1" {
+		if req.URL.Path != "/o/org-1/devportal/v1/subscriptions/sub-1" {
 			t.Fatalf("unexpected request path %s", req.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")

--- a/cli/src/cmd/devportal/subscription/create.go
+++ b/cli/src/cmd/devportal/subscription/create.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 
@@ -96,7 +95,7 @@ func runCreateCommand() error {
 	}
 
 	client := internaldevportal.NewClientWithOptions(devPortal, createInsecure)
-	resp, err := client.PostJSON(fmt.Sprintf("/devportal/organizations/%s/subscriptions", url.PathEscape(orgID)), payload)
+	resp, err := client.PostJSON(internaldevportal.OrgScopedPath(orgID, "subscriptions"), payload)
 	if err != nil {
 		return internaldevportal.WrapRequestError("create platform subscription", err, createInsecure)
 	}

--- a/cli/src/cmd/devportal/subscription/delete.go
+++ b/cli/src/cmd/devportal/subscription/delete.go
@@ -93,7 +93,7 @@ func runDeleteCommand() error {
 	}
 
 	client := internaldevportal.NewClientWithOptions(devPortal, deleteInsecure)
-	path := fmt.Sprintf("/devportal/organizations/%s/subscriptions/%s", url.PathEscape(orgID), url.PathEscape(subscriptionID))
+	path := internaldevportal.OrgScopedPath(orgID, "subscriptions/"+url.PathEscape(subscriptionID))
 	resp, err := client.Delete(path)
 	if err != nil {
 		return internaldevportal.WrapRequestError("delete platform subscription", err, deleteInsecure)

--- a/cli/src/cmd/devportal/subscription/edit.go
+++ b/cli/src/cmd/devportal/subscription/edit.go
@@ -97,7 +97,7 @@ func runEditCommand() error {
 	}
 
 	client := internaldevportal.NewClientWithOptions(devPortal, editInsecure)
-	path := fmt.Sprintf("/devportal/organizations/%s/subscriptions/%s", url.PathEscape(editOrgID), url.PathEscape(subscriptionID))
+	path := internaldevportal.OrgScopedPath(editOrgID, "subscriptions/"+url.PathEscape(subscriptionID))
 	resp, err := client.PutJSON(path, payload)
 	if err != nil {
 		return internaldevportal.WrapRequestError("update platform subscription", err, editInsecure)

--- a/cli/src/cmd/devportal/subscription/get.go
+++ b/cli/src/cmd/devportal/subscription/get.go
@@ -87,7 +87,7 @@ func runGetCommand() error {
 	}
 
 	client := internaldevportal.NewClientWithOptions(devPortal, getInsecure)
-	path := fmt.Sprintf("/devportal/organizations/%s/subscriptions", url.PathEscape(orgID))
+	path := internaldevportal.OrgScopedPath(orgID, "subscriptions")
 	if subscriptionID := strings.TrimSpace(getSubscription); subscriptionID != "" {
 		path = fmt.Sprintf("%s/%s", path, url.PathEscape(subscriptionID))
 	}

--- a/cli/src/internal/devportal/helpers.go
+++ b/cli/src/internal/devportal/helpers.go
@@ -25,12 +25,32 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/wso2/api-platform/cli/internal/config"
 )
+
+// APIVersion is the Developer Portal REST API version segment used in all
+// organization-scoped resource paths. Bump this in one place when the API
+// version changes (for example "v1" -> "v2").
+const APIVersion = "v1"
+
+// OrgScopedPath builds an organization-scoped Developer Portal resource path of
+// the form /o/{orgId}/devportal/{version}/{resource}. The orgID is path-escaped
+// here, so callers pass it raw. The resource is appended as-is, so callers
+// escape any path segments they interpolate and may include a trailing query
+// string (for example "apis/"+url.PathEscape(apiID) or "api-keys?apiId=x").
+//
+// Only organization-management endpoints (under /organizations) live outside
+// this prefix; every other devportal endpoint should be built through here so
+// the /o/{orgId}/devportal/{version} prefix is defined in a single place.
+func OrgScopedPath(orgID, resource string) string {
+	return fmt.Sprintf("/o/%s/devportal/%s/%s",
+		url.PathEscape(orgID), APIVersion, strings.TrimPrefix(resource, "/"))
+}
 
 // ResolveDevPortal resolves the DevPortal to use from either explicit flags
 // or the active DevPortal in the resolved platform.


### PR DESCRIPTION
### Purpose

- This PR updates the devportal endpoint invocation urls, as the devportal openapi spec was changed recently through the PR https://github.com/wso2/api-platform/pull/2117
- Add the Integration tests for Devportal related CLI commands
- Add step to run devportal it when perform a release to ensure the new release doesn't break the existing behavior