### PR TITLE
[Devportal] Integrate platform API for local authentication

### DIFF
--- a/portals/developer-portal/.gitignore
+++ b/portals/developer-portal/.gitignore
@@ -100,3 +100,4 @@ resources/mock
 
 config.yaml
 .env
+configs/config-platform-api.toml

--- a/portals/developer-portal/configs/config-platform-api.toml.example
+++ b/portals/developer-portal/configs/config-platform-api.toml.example
@@ -1,0 +1,84 @@
+# --------------------------------------------------------------------
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+# --------------------------------------------------------------------
+#
+# Platform API configuration for the Developer Portal.
+#
+# This file defines the local users who can log in to the Developer Portal
+# via the username/password login form. Credentials are validated by the
+# Platform API; the Developer Portal never sees the raw passwords.
+#
+# Changing passwords:
+#   Generate a bcrypt hash: htpasswd -bnBC 12 "" <password> | tr -d ':\n'
+#   Default credentials below: admin / admin
+#
+# Secrets:
+#   Set AUTH_JWT_SECRET_KEY in your environment (or .env file) to keep
+#   sessions alive across Platform API restarts. When unset, a random key
+#   is generated at startup and all sessions are invalidated on restart.
+# --------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Server
+# ---------------------------------------------------------------------------
+log_level = "INFO"   # DEBUG | INFO | WARN | ERROR
+port      = "9243"
+
+# ---------------------------------------------------------------------------
+# Database
+# ---------------------------------------------------------------------------
+[database]
+driver = "sqlite3"
+path   = "/app/data/platform-api-devportal.db"
+
+# ---------------------------------------------------------------------------
+# Authentication
+# ---------------------------------------------------------------------------
+[auth.jwt]
+enabled = true
+issuer  = "platform-api"
+
+[auth.idp]
+enabled = false
+
+[auth.file_based]
+enabled = true
+
+[auth.file_based.organization]
+id     = "99089a17-72e0-4dd8-a2f4-c8dfbb085295"
+name   = "Default Organization"
+handle = "default"
+region = "us"
+
+# Admin user — password: admin
+# Change this before deploying to a shared environment.
+# Scopes use the dp:* namespace understood by the Developer Portal REST API.
+# Add dp:*_manage scopes to grant full access to every resource area.
+[[auth.file_based.users]]
+username      = "admin"
+password_hash = "$2y$10$U2yKMwGamGwDoMu0hRPT7u8nCuP8z/qxHFOKV6dhIxkJN9NJ0eVQ."
+scopes        = "dp:org_read dp:org_write dp:org_manage dp:org_delete dp:org_content_read dp:org_content_write dp:org_content_manage dp:org_content_delete dp:api_read dp:api_write dp:api_manage dp:api_delete dp:api_content_read dp:api_content_write dp:api_content_manage dp:api_content_delete dp:api_key_read dp:api_key_write dp:api_key_manage dp:api_key_revoke dp:api_flow_read dp:api_flow_write dp:api_flow_manage dp:api_flow_delete dp:app_read dp:app_write dp:app_manage dp:app_delete dp:app_key_write dp:app_key_manage dp:app_key_revoke dp:app_key_mapping_read dp:app_key_mapping_write dp:app_key_mapping_manage dp:subscription_read dp:subscription_write dp:subscription_manage dp:subscription_delete dp:sub_policy_read dp:sub_policy_write dp:sub_policy_manage dp:sub_policy_delete dp:idp_read dp:idp_write dp:idp_manage dp:idp_delete dp:view_read dp:view_write dp:view_manage dp:view_delete dp:km_read dp:km_write dp:km_manage dp:km_delete dp:label_read dp:label_write dp:label_manage dp:label_delete dp:provider_read dp:provider_write dp:provider_manage dp:provider_delete dp:event_read dp:delivery_manage dp:utility_write dp:utility_manage dev"
+
+[[auth.file_based.users]]
+username      = "readonly"
+password_hash = "$2y$10$U2yKMwGamGwDoMu0hRPT7u8nCuP8z/qxHFOKV6dhIxkJN9NJ0eVQ."  # password: admin
+scopes        = "dp:api_read dp:org_read dp:app_read dp:app_write dp:subscription_read"
+
+# ---------------------------------------------------------------------------
+# TLS
+# ---------------------------------------------------------------------------
+[tls]
+cert_dir = "/app/data/certs"
+
+# ---------------------------------------------------------------------------
+# DevPortal integration — disabled (devportal calls us, not the other way)
+# ---------------------------------------------------------------------------
+[default_devportal]
+enabled = false

--- a/portals/developer-portal/configs/config-platform-api.toml.example
+++ b/portals/developer-portal/configs/config-platform-api.toml.example
@@ -66,11 +66,6 @@ username      = "admin"
 password_hash = "$2y$10$U2yKMwGamGwDoMu0hRPT7u8nCuP8z/qxHFOKV6dhIxkJN9NJ0eVQ."
 scopes        = "dp:org_read dp:org_write dp:org_manage dp:org_delete dp:org_content_read dp:org_content_write dp:org_content_manage dp:org_content_delete dp:api_read dp:api_write dp:api_manage dp:api_delete dp:api_content_read dp:api_content_write dp:api_content_manage dp:api_content_delete dp:api_key_read dp:api_key_write dp:api_key_manage dp:api_key_revoke dp:api_flow_read dp:api_flow_write dp:api_flow_manage dp:api_flow_delete dp:app_read dp:app_write dp:app_manage dp:app_delete dp:app_key_write dp:app_key_manage dp:app_key_revoke dp:app_key_mapping_read dp:app_key_mapping_write dp:app_key_mapping_manage dp:subscription_read dp:subscription_write dp:subscription_manage dp:subscription_delete dp:sub_policy_read dp:sub_policy_write dp:sub_policy_manage dp:sub_policy_delete dp:idp_read dp:idp_write dp:idp_manage dp:idp_delete dp:view_read dp:view_write dp:view_manage dp:view_delete dp:km_read dp:km_write dp:km_manage dp:km_delete dp:label_read dp:label_write dp:label_manage dp:label_delete dp:provider_read dp:provider_write dp:provider_manage dp:provider_delete dp:event_read dp:delivery_manage dp:utility_write dp:utility_manage dev"
 
-[[auth.file_based.users]]
-username      = "readonly"
-password_hash = "$2y$10$U2yKMwGamGwDoMu0hRPT7u8nCuP8z/qxHFOKV6dhIxkJN9NJ0eVQ."  # password: admin
-scopes        = "dp:api_read dp:org_read dp:app_read dp:app_write dp:subscription_read"
-
 # ---------------------------------------------------------------------------
 # TLS
 # ---------------------------------------------------------------------------

--- a/portals/developer-portal/distribution/docker-compose.yaml
+++ b/portals/developer-portal/distribution/docker-compose.yaml
@@ -21,15 +21,21 @@
 # the docker-compose.yml one level up.
 #
 # Quick start:
-#   docker compose up
-#   Then open https://localhost:3000/default/views/default  (accept the self-signed cert warning)
-#   Login: admin / admin  (or developer / developer)
+#   1. Copy configs/config-platform-api.toml.example to configs/config-platform-api.toml
+#      and adjust users/org as needed.
+#   2. docker compose up
+#   3. Open https://localhost:3000/default/views/default  (accept the self-signed cert warning)
+#      Login with a user defined in configs/config-platform-api.toml (default: admin / admin)
+#
+# Secrets:
+#   Set AUTH_JWT_SECRET_KEY in your shell or in a .env file to persist login sessions
+#   across Platform API restarts. When unset a random key is generated at startup.
 #
 # Configuration:
-#   Edit configs/config.yaml to customise settings.
-#   Every config value can also be overridden via a DP_* env var.
+#   Edit configs/config.yaml to customise devportal settings.
+#   Edit configs/config-platform-api.toml to customise Platform API settings (users, org, etc.).
+#   Every devportal config value can also be overridden via a DP_* env var.
 #   Create a .env file next to this file for persistent overrides.
-#   See configs/config.yaml for the full list of available settings.
 #
 # Database:
 #   SQLite is used by default — no external database required.
@@ -47,6 +53,28 @@
 #   and ensure it contains server.crt and server.key.
 
 services:
+  # ── Platform API (Go HTTPS backend — handles local auth) ────────────────────
+  platform-api:
+    image: ghcr.io/wso2/api-platform/platform-api:0.10.0
+    container_name: platform-api
+    restart: unless-stopped
+    command: ["-config", "/etc/platform-api/config-platform-api.toml"]
+    environment:
+      - AUTH_JWT_SECRET_KEY=${AUTH_JWT_SECRET_KEY:-}
+    volumes:
+      - ./configs/config-platform-api.toml:/etc/platform-api/config-platform-api.toml:ro
+      - platform-api-data:/app/data
+    ports:
+      - "9243:9243"
+    healthcheck:
+      test: ["CMD", "curl", "-fk", "https://localhost:9243/health"]
+      interval: 30s
+      timeout: 5s
+      start_period: 20s
+      retries: 3
+    networks:
+      - devportal-network
+
   # ── PostgreSQL (optional) ────────────────────────────────────────────────────
   # Uncomment this service and replace the DP_DB_* block in `devportal` below
   # with the PostgreSQL block to switch from SQLite to PostgreSQL.
@@ -71,9 +99,13 @@ services:
 
   devportal:
     image: ghcr.io/wso2/api-platform/developer-portal:0.3.0-SNAPSHOT
+    depends_on:
+      platform-api:
+        condition: service_healthy
     ports:
       - "3000:3000"   # Developer Portal UI (HTTPS)
-    # depends_on:           # Uncomment when using PostgreSQL
+    # Also uncomment depends_on postgres when using PostgreSQL:
+    # depends_on:
     #   postgres:
     #     condition: service_healthy
     volumes:
@@ -113,6 +145,9 @@ services:
 
       # Log to console only (no rotating log files)
       DP_LOGGING_CONSOLEONLY: "true"
+
+      # Platform API — used for local auth credential validation
+      DP_PLATFORMAPI_BASEURL: "https://platform-api:9243"
     env_file:
       - path: .env
         required: false   # Optional — create a .env file to add your own overrides
@@ -123,6 +158,8 @@ volumes:
   sqlite_data:
     driver: local
   certs_data:
+    driver: local
+  platform-api-data:
     driver: local
   # postgres_data:      # Uncomment when using PostgreSQL
   #   driver: local

--- a/portals/developer-portal/distribution/docker-compose.yaml
+++ b/portals/developer-portal/distribution/docker-compose.yaml
@@ -146,8 +146,11 @@ services:
       # Log to console only (no rotating log files)
       DP_LOGGING_CONSOLEONLY: "true"
 
-      # Platform API — used for local auth credential validation
+      # Platform API — used for local auth credential validation.
+      # Set DP_PLATFORMAPI_JWTSECRET to the same value as AUTH_JWT_SECRET_KEY so
+      # the devportal can verify Platform API JWTs locally (no per-request login call).
       DP_PLATFORMAPI_BASEURL: "https://platform-api:9243"
+      DP_PLATFORMAPI_JWTSECRET: ${AUTH_JWT_SECRET_KEY:-}
     env_file:
       - path: .env
         required: false   # Optional — create a .env file to add your own overrides

--- a/portals/developer-portal/distribution/docker-compose.yaml
+++ b/portals/developer-portal/distribution/docker-compose.yaml
@@ -102,12 +102,11 @@ services:
     depends_on:
       platform-api:
         condition: service_healthy
+      # Uncomment when using PostgreSQL:
+      # postgres:
+      #   condition: service_healthy
     ports:
       - "3000:3000"   # Developer Portal UI (HTTPS)
-    # Also uncomment depends_on postgres when using PostgreSQL:
-    # depends_on:
-    #   postgres:
-    #     condition: service_healthy
     volumes:
       # Mount config from the configs/ directory.
       - ./configs/config.yaml:/app/configs/config.yaml:ro
@@ -151,6 +150,7 @@ services:
       # the devportal can verify Platform API JWTs locally (no per-request login call).
       DP_PLATFORMAPI_BASEURL: "https://platform-api:9243"
       DP_PLATFORMAPI_JWTSECRET: ${AUTH_JWT_SECRET_KEY:-}
+      DP_PLATFORMAPI_INSECURE: "true"   # Platform API uses a self-signed cert in this dev setup
     env_file:
       - path: .env
         required: false   # Optional — create a .env file to add your own overrides

--- a/portals/developer-portal/docker-compose.yaml
+++ b/portals/developer-portal/docker-compose.yaml
@@ -111,6 +111,7 @@ services:
       # the devportal can verify Platform API JWTs locally (no per-request login call).
       DP_PLATFORMAPI_BASEURL: "https://platform-api:9243"
       DP_PLATFORMAPI_JWTSECRET: ${AUTH_JWT_SECRET_KEY:-}
+      DP_PLATFORMAPI_INSECURE: "true"   # Platform API uses a self-signed cert in this dev setup
     env_file:
       - path: .env
         required: false   # Optional — create a .env file to add your own overrides

--- a/portals/developer-portal/docker-compose.yaml
+++ b/portals/developer-portal/docker-compose.yaml
@@ -23,9 +23,15 @@
 #       diverge: uses `build: .` here vs pre-built GHCR image in distribution.
 #
 # Quick start:
-#   docker compose up
-#   Then open https://localhost:3000/default/views/default  (accept the self-signed cert warning)
-#   Login: admin / admin  (or developer / developer)
+#   1. Copy configs/config-platform-api.toml.example to configs/config-platform-api.toml
+#      and adjust users/org as needed.
+#   2. docker compose up
+#   3. Open https://localhost:3000/default/views/default  (accept the self-signed cert warning)
+#      Login with a user defined in configs/config-platform-api.toml (default: admin / admin)
+#
+# Secrets:
+#   Set AUTH_JWT_SECRET_KEY in your shell or in a .env file to persist login sessions
+#   across Platform API restarts. When unset a random key is generated at startup.
 #
 # TLS:
 #   A self-signed certificate is generated automatically on first start and stored
@@ -36,19 +42,42 @@
 #   and ensure it contains server.crt and server.key.
 #
 # Configuration:
-#   Edit configs/config.yaml (copied from sample.config.yaml) to customise settings.
-#   Every config value can be overridden with a DP_* env var.
+#   Edit configs/config.yaml to customise devportal settings.
+#   Edit configs/config-platform-api.toml to customise Platform API settings (users, org, etc.).
+#   Every devportal config value can be overridden with a DP_* env var.
 #   Create a .env file at the project root for persistent overrides.
-#   See sample.config.yaml for the full list of settings.
 
 services:
+  # ── Platform API (Go HTTPS backend — handles local auth) ────────────────────
+  platform-api:
+    image: ghcr.io/wso2/api-platform/platform-api:0.10.0
+    container_name: platform-api
+    restart: unless-stopped
+    command: ["-config", "/etc/platform-api/config-platform-api.toml"]
+    environment:
+      - AUTH_JWT_SECRET_KEY=${AUTH_JWT_SECRET_KEY:-}
+    volumes:
+      - ./configs/config-platform-api.toml:/etc/platform-api/config-platform-api.toml:ro
+      - platform-api-data:/app/data
+    ports:
+      - "9243:9243"
+    healthcheck:
+      test: ["CMD", "curl", "-fk", "https://localhost:9243/health"]
+      interval: 30s
+      timeout: 5s
+      start_period: 20s
+      retries: 3
+
   devportal:
     build: .
     image: ghcr.io/wso2/api-platform/developer-portal:0.2.0-SNAPSHOT
+    depends_on:
+      platform-api:
+        condition: service_healthy
     ports:
       - "3000:3000"
     volumes:
-      # Mount config from the configs/ directory (copy of sample.config.yaml).
+      # Mount config from the configs/ directory.
       - ./configs/config.yaml:/app/configs/config.yaml:ro
       # Persist the SQLite database across container restarts.
       - sqlite_data:/app/data
@@ -76,6 +105,9 @@ services:
 
       # Log to console only (no rotating log files)
       DP_LOGGING_CONSOLEONLY: "true"
+
+      # Platform API — used for local auth credential validation
+      DP_PLATFORMAPI_BASEURL: "https://platform-api:9243"
     env_file:
       - path: .env
         required: false   # Optional — create a .env file to add your own overrides
@@ -83,3 +115,4 @@ services:
 volumes:
   sqlite_data:
   certs_data:
+  platform-api-data:

--- a/portals/developer-portal/docker-compose.yaml
+++ b/portals/developer-portal/docker-compose.yaml
@@ -106,8 +106,11 @@ services:
       # Log to console only (no rotating log files)
       DP_LOGGING_CONSOLEONLY: "true"
 
-      # Platform API — used for local auth credential validation
+      # Platform API — used for local auth credential validation.
+      # Set DP_PLATFORMAPI_JWTSECRET to the same value as AUTH_JWT_SECRET_KEY so
+      # the devportal can verify Platform API JWTs locally (no per-request login call).
       DP_PLATFORMAPI_BASEURL: "https://platform-api:9243"
+      DP_PLATFORMAPI_JWTSECRET: ${AUTH_JWT_SECRET_KEY:-}
     env_file:
       - path: .env
         required: false   # Optional — create a .env file to add your own overrides

--- a/portals/developer-portal/docs/administer/manage-organizations.md
+++ b/portals/developer-portal/docs/administer/manage-organizations.md
@@ -40,7 +40,7 @@ spec:
 
 ```bash
 curl -X POST http://localhost:3000/organizations \
-  -u admin:admin \
+  -H "Authorization: Bearer $TOKEN" \
   -F "organization=@org.yaml"
 ```
 
@@ -67,7 +67,7 @@ After creation, the organization is accessible at `/<orgHandle>/views/<viewName>
 ## List Organizations
 
 ```bash
-curl http://localhost:3000/organizations -u admin:admin
+curl http://localhost:3000/organizations -H "Authorization: Bearer $TOKEN"
 ```
 
 ## Update an Organization
@@ -88,14 +88,14 @@ spec:
 
 ```bash
 curl -X PUT http://localhost:3000/organizations/{orgId} \
-  -u admin:admin \
+  -H "Authorization: Bearer $TOKEN" \
   -F "organization=@org-update.yaml"
 ```
 
 ## Delete an Organization
 
 ```bash
-curl -X DELETE http://localhost:3000/organizations/{orgId} -u admin:admin
+curl -X DELETE http://localhost:3000/organizations/{orgId} -H "Authorization: Bearer $TOKEN"
 ```
 
 > **Warning:** Deleting an organization removes all of its views, APIs, subscriptions, and applications. This action is irreversible.
@@ -131,7 +131,7 @@ spec:
 
 ```bash
 curl -X POST http://localhost:3000/organizations/{orgId}/identityProvider \
-  -u admin:admin \
+  -H "Authorization: Bearer $TOKEN" \
   -F "identityProvider=@idp.yaml"
 ```
 
@@ -176,14 +176,14 @@ spec:
 
 ```bash
 curl -X PUT http://localhost:3000/organizations/{orgId}/identityProvider \
-  -u admin:admin \
+  -H "Authorization: Bearer $TOKEN" \
   -F "identityProvider=@idp-update.yaml"
 ```
 
 ### Remove an IdP
 
 ```bash
-curl -X DELETE http://localhost:3000/organizations/{orgId}/identityProvider -u admin:admin
+curl -X DELETE http://localhost:3000/organizations/{orgId}/identityProvider -H "Authorization: Bearer $TOKEN"
 ```
 
 ---
@@ -257,7 +257,7 @@ TOKEN=$(curl -sk -X POST "https://localhost:9243/api/portal/v1/auth/login" \
 curl -s -H "Authorization: Bearer $TOKEN" http://localhost:3000/organizations
 ```
 
-The token is verified locally by the devportal using the shared `AUTH_JWT_SECRET_KEY` with no extra call to the Platform API per request.
+The token is verified locally by the Developer Portal using the shared `AUTH_JWT_SECRET_KEY` with no extra call to the Platform API per request.
 
 > **Note:** Local auth is for development only. For production, configure an OIDC identity provider per organization (see [Identity Provider Configuration](#identity-provider-configuration)).
 

--- a/portals/developer-portal/docs/administer/manage-organizations.md
+++ b/portals/developer-portal/docs/administer/manage-organizations.md
@@ -190,26 +190,76 @@ curl -X DELETE http://localhost:3000/organizations/{orgId}/identityProvider -u a
 
 ## Local Auth (Development Only)
 
-For local development and first-time setup, the portal ships with built-in user support. Configure users in `config.yaml`:
+For local development and first-time setup, the portal ships with a built-in username/password login form. Credentials are validated by a Platform API sidecar — the Developer Portal never handles raw passwords directly.
 
-```yaml
-defaultAuth:
-  users:
-    - username: "admin"
-      password: "admin"
-      roles:
-        - "admin"
-      orgClaimName: "ACME"
-      organizationIdentifier: "ACME"
-    - username: "developer"
-      password: "developer"
-      roles:
-        - "subscriber"
-      orgClaimName: "ACME"
-      organizationIdentifier: "ACME"
+### How it works
+
+1. The user submits the login form.
+2. The Developer Portal forwards the credentials to the Platform API (`POST /api/portal/v1/auth/login`).
+3. The Platform API verifies the bcrypt-hashed password and returns a signed JWT containing `dp:*` scopes.
+4. The Developer Portal stores the JWT in the server-side session and uses the scopes for all subsequent authorization checks.
+
+### Configuration
+
+Users and their scopes are defined in `configs/config-platform-api.toml`. Copy the example file to get started:
+
+```bash
+cp configs/config-platform-api.toml.example configs/config-platform-api.toml
 ```
 
-> **Important:** Remove the `defaultAuth` block before deploying to production. It is not a substitute for a real IdP.
+Add or modify users in the `[[auth.file_based.users]]` sections:
+
+```toml
+[[auth.file_based.users]]
+username      = "admin"
+password_hash = "$2y$10$..."   # bcrypt hash — see below
+scopes        = "dp:org_read dp:org_manage dp:api_read dp:api_manage ..."
+
+[[auth.file_based.users]]
+username      = "developer"
+password_hash = "$2y$10$..."
+scopes        = "dp:api_read dp:app_read dp:app_write dp:subscription_read"
+```
+
+Generate a bcrypt password hash with:
+
+```bash
+htpasswd -bnBC 12 "" <password> | tr -d ':\n'
+```
+
+### Scope-based authorization
+
+Every devportal REST API operation requires a specific `dp:*` scope. Users without the required scope receive a `403 Forbidden` response. Common scope sets:
+
+| Access level | Scopes to grant |
+|---|---|
+| Full admin | All `dp:*_manage` scopes + `dp:*_read` |
+| API publisher | `dp:api_manage dp:api_content_manage dp:org_read dp:label_read` |
+| Developer / subscriber | `dp:api_read dp:app_read dp:app_write dp:subscription_read dp:subscription_write` |
+
+See `configs/config-platform-api.toml.example` for the complete scope list used by the default admin user.
+
+### Session persistence and scripted access
+
+The Platform API generates a random JWT signing key at startup. Sessions are invalidated when it restarts unless you pin the key. Set the **same value** in both services so the devportal can verify JWTs locally without a network round-trip:
+
+```bash
+# In .env (read by both services via docker-compose env_file / DP_* override)
+AUTH_JWT_SECRET_KEY=<random-64-char-string>
+```
+
+For scripts and CLI tools, get a Bearer token directly from the Platform API and pass it on each request — no session cookie required:
+
+```bash
+TOKEN=$(curl -sk -X POST "https://localhost:9243/api/portal/v1/auth/login" \
+  -d "username=admin&password=admin" | jq -r .token)
+
+curl -s -H "Authorization: Bearer $TOKEN" http://localhost:3000/organizations
+```
+
+The token is verified locally by the devportal using the shared `AUTH_JWT_SECRET_KEY` with no extra call to the Platform API per request.
+
+> **Note:** Local auth is for development only. For production, configure an OIDC identity provider per organization (see [Identity Provider Configuration](#identity-provider-configuration)).
 
 ---
 

--- a/portals/developer-portal/docs/introduction/quick-start.md
+++ b/portals/developer-portal/docs/introduction/quick-start.md
@@ -16,13 +16,17 @@ git clone https://github.com/wso2/api-platform.git
 cd api-platform/portals/developer-portal/
 ```
 
-### 2. Create a configuration file
+### 2. Create configuration files
 
-Copy the sample configuration and set the minimum required values:
+Copy both sample configuration files:
 
 ```bash
-mkdir -p configs && cp sample.config.yaml configs/config.yaml
+mkdir -p configs
+cp sample.config.yaml configs/config.yaml
+cp configs/config-platform-api.toml.example configs/config-platform-api.toml
 ```
+
+`config.yaml` controls the Developer Portal itself. `config-platform-api.toml` configures the Platform API sidecar that validates login credentials and issues signed tokens. The default credentials in the example file are `admin` / `admin`.
 
 ### 3. Start the portal
 
@@ -40,7 +44,7 @@ Navigate to:
 https://localhost:3000/default/views/default
 ```
 
-Sign in with `admin` / `admin` (or the credentials you set in `defaultAuth`).
+Sign in with `admin` / `admin` (the credentials defined in `configs/config-platform-api.toml`).
 
 You should see the default API catalog page.
 
@@ -168,13 +172,20 @@ paths:
 
 ```
 
-```bash
-# Get the default org UUID
-ORG_ID=$(curl -sk -u admin:admin https://localhost:3000/organizations | jq -r '.[0].orgID')
+Scripts and CLI tools authenticate with a Bearer token obtained directly from the Platform API. Get one once, then reuse it until it expires:
 
-# Create the API
-curl -sk -X POST "https://localhost:3000/o/$ORG_ID/devportal/v1/apis" \
-  -u admin:admin \
+```bash
+# Get a token from the Platform API (runs alongside the devportal)
+TOKEN=$(curl -sk -X POST "https://localhost:9243/api/portal/v1/auth/login" \
+  -d "username=admin&password=admin" | jq -r .token)
+
+# Find the org UUID
+curl -s -H "Authorization: Bearer $TOKEN" \
+  http://localhost:3000/organizations | jq '.[0].id'
+
+# Publish the API (replace {orgId} with the UUID from above)
+curl -s -H "Authorization: Bearer $TOKEN" \
+  -X POST "http://localhost:3000/devportal/organizations/{orgId}/apis" \
   -F "api=@api.yaml;type=application/yaml" \
   -F "apiDefinition=@openapi.yaml;type=application/yaml"
 ```
@@ -188,7 +199,7 @@ Refresh the portal — the Ping API now appears in the catalog. Click it to view
 | Organization | `default` |
 | Default view | `default` |
 | Portal URL | `https://localhost:3000/default/views/default` |
-| Admin credentials | `admin` / `admin` (local auth) |
+| Admin credentials | `admin` / `admin` (Platform API — see `configs/config-platform-api.toml`) |
 | Sample API | `Ping API` visible in the catalog |
 
 ## Next steps

--- a/portals/developer-portal/src/config/configLoader.js
+++ b/portals/developer-portal/src/config/configLoader.js
@@ -107,6 +107,7 @@ const CONFIG_DEFAULTS = {
     platformApi: {
         baseUrl: '',
         jwtSecret: '',
+        insecure: false,
     },
 };
 

--- a/portals/developer-portal/src/config/configLoader.js
+++ b/portals/developer-portal/src/config/configLoader.js
@@ -106,6 +106,7 @@ const CONFIG_DEFAULTS = {
     },
     platformApi: {
         baseUrl: '',
+        jwtSecret: '',
     },
 };
 

--- a/portals/developer-portal/src/config/configLoader.js
+++ b/portals/developer-portal/src/config/configLoader.js
@@ -66,7 +66,6 @@ const CONFIG_DEFAULTS = {
         resourceLoadFromBaseUrl: false,
         disabledRoleValidation: true,
         disableOrgCallback: true,
-        disableScopeValidation: true,
         disableSilentSSO: false,
         encryptionKey: '',
         apiKey: {
@@ -104,6 +103,9 @@ const CONFIG_DEFAULTS = {
         url: '',
         graphqlURL: '',
         disableCertValidation: false,
+    },
+    platformApi: {
+        baseUrl: '',
     },
 };
 

--- a/portals/developer-portal/src/controllers/authController.js
+++ b/portals/developer-portal/src/controllers/authController.js
@@ -282,14 +282,14 @@ const handleLocalLogin = async (req, res) => {
             new URLSearchParams({ username, password }).toString(),
             {
                 headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-                httpsAgent: new https.Agent({ rejectUnauthorized: false }),
+                httpsAgent: new https.Agent({ rejectUnauthorized: !config.platformApi?.insecure }),
                 timeout: 10000,
             }
         );
         platformToken = response.data.token;
     } catch (error) {
         if (error.response?.status === 401) {
-            logger.warn('Platform API login failed: invalid credentials', { orgName, username });
+            logger.warn('Platform API login failed: invalid credentials', { orgName });
             return res.redirect(`${baseUrl}/login?error=Invalid+username+or+password`);
         }
         logger.error('Platform API login request failed', { error: error.message, orgName });
@@ -309,8 +309,8 @@ const handleLocalLogin = async (req, res) => {
     const superAdminRole = config.superAdminRole || 'superAdmin';
     const subscriberRole = config.subscriberRole || 'Internal/subscriber';
     const scopes = (claims.scope || '').split(' ');
-    // Users with any :manage scope are treated as admins in the devportal
-    const isAdmin = scopes.some(s => s.endsWith(':manage'));
+    // Users with any _manage scope are treated as admins in the devportal
+    const isAdmin = scopes.some(s => s.endsWith('_manage'));
     const roles = isAdmin ? [adminRole] : [subscriberRole];
 
     const returnTo = req.session.returnTo;
@@ -330,18 +330,18 @@ const handleLocalLogin = async (req, res) => {
         imageURL: 'https://raw.githubusercontent.com/wso2/docs-bijira/refs/heads/main/en/devportal-theming/profile.svg',
         view,
         idToken: null,
-        [constants.ROLES.ORGANIZATION_CLAIM]: orgName,
+        [constants.ROLES.ORGANIZATION_CLAIM]: claims.org_handle || orgName,
         returnTo: returnTo || baseUrl,
         accessToken: platformToken,
         refreshToken: null,
         exchangeToken: null,
-        authorizedOrgs: [orgName],
+        authorizedOrgs: [claims.org_handle || orgName],
         [constants.ROLES.ROLE_CLAIM]: roles,
         [constants.ROLES.GROUP_CLAIM]: [],
         isAdmin,
         isSuperAdmin: false,
         [constants.USER_ID]: claims.sub || username,
-        userOrg: orgName,
+        userOrg: claims.org_handle || orgName,
         isLocalAuth: true,
     };
 

--- a/portals/developer-portal/src/controllers/authController.js
+++ b/portals/developer-portal/src/controllers/authController.js
@@ -30,6 +30,7 @@ const minimatch = require('minimatch');
 const { validationResult } = require('express-validator');
 const { renderGivenTemplate } = require('../utils/util');
 const { trackLoginTrigger, trackLogoutTrigger } = require('../utils/telemetry');
+const { extractPlatformJwtClaims } = require('../utils/platformJwt');
 
 
 const fetchAuthJsonContent = async (req, orgName) => {
@@ -297,20 +298,17 @@ const handleLocalLogin = async (req, res) => {
     }
 
     // Decode JWT claims (token is already verified by the platform API)
-    let claims;
-    try {
-        claims = JSON.parse(Buffer.from(platformToken.split('.')[1], 'base64url').toString('utf8'));
-    } catch (err) {
-        logger.error('Failed to decode platform API token', { error: err.message });
+    const claims = extractPlatformJwtClaims(platformToken, null);
+    if (!claims) {
+        logger.error('Failed to decode platform API token');
         return res.redirect(`${baseUrl}/login?error=Login+failed%2C+please+try+again`);
     }
 
     const adminRole = config.adminRole || 'admin';
     const superAdminRole = config.superAdminRole || 'superAdmin';
     const subscriberRole = config.subscriberRole || 'Internal/subscriber';
-    const scopes = (claims.scope || '').split(' ');
     // Users with any _manage scope are treated as admins in the devportal
-    const isAdmin = scopes.some(s => s.endsWith('_manage'));
+    const isAdmin = claims.scopes.some(s => s.endsWith('_manage'));
     const roles = isAdmin ? [adminRole] : [subscriberRole];
 
     const returnTo = req.session.returnTo;

--- a/portals/developer-portal/src/controllers/authController.js
+++ b/portals/developer-portal/src/controllers/authController.js
@@ -17,6 +17,8 @@
  */
 /* eslint-disable no-undef */
 const passport = require('passport');
+const axios = require('axios');
+const https = require('https');
 const logger = require('../config/logger');
 const { logUserAction } = require('../middlewares/auditLogger');
 const { config } = require('../config/configLoader');
@@ -187,31 +189,8 @@ const handleLogOut = async (req, res) => {
     }
     const currentPathURI = req.originalUrl.replace('/logout', '');
     res.set('Cache-Control', 'no-store');
-    if (req.user && req.user.accessToken) {
-        const referer = req.get('referer');
-        const regex = /(.+\/views\/[^\/]+)\/?/;
-        const match = referer.match(regex);
-        const logoutURL = match ? match[1] : null;
-        req.logout((err) => {
-            if (err) {
-                logger.error("Logout error", {
-                    userId: req.user?.id || req.user?.username || 'unknown',
-                    orgName: req.params.orgName,
-                    error: err.message,
-                    stack: err.stack
-                });
-            }
-            // Log successful logout action
-            logUserAction('USER_LOGOUT', req, {
-                orgName: req.params.orgName,
-                logoutURL: logoutURL
-            });
-            trackLogoutTrigger({ orgName: req.params.orgName }, req);
-            req.session.currentPathURI = currentPathURI;
-            res.redirect(`${authJsonContent.logoutURL}?post_logout_redirect_uri=${authJsonContent.logoutRedirectURI}&id_token_hint=${idToken}`);
-        });
-    } else if (req.user?.isLocalAuth) {
-        // Local-auth users have no IDP — destroy session and go to login
+    if (req.user?.isLocalAuth) {
+        // Local-auth users have no IDP — destroy session and redirect to login
         req.logout((err) => {
             if (err) {
                 logger.error('Logout error (local-auth)', {
@@ -225,6 +204,28 @@ const handleLogOut = async (req, res) => {
                 res.set('Cache-Control', 'no-store');
                 res.redirect(req.originalUrl.replace('/logout', '/login'));
             });
+        });
+    } else if (req.user && req.user.accessToken) {
+        const referer = req.get('referer');
+        const regex = /(.+\/views\/[^\/]+)\/?/;
+        const match = referer.match(regex);
+        const logoutURL = match ? match[1] : null;
+        req.logout((err) => {
+            if (err) {
+                logger.error("Logout error", {
+                    userId: req.user?.id || req.user?.username || 'unknown',
+                    orgName: req.params.orgName,
+                    error: err.message,
+                    stack: err.stack
+                });
+            }
+            logUserAction('USER_LOGOUT', req, {
+                orgName: req.params.orgName,
+                logoutURL: logoutURL
+            });
+            trackLogoutTrigger({ orgName: req.params.orgName }, req);
+            req.session.currentPathURI = currentPathURI;
+            res.redirect(`${authJsonContent.logoutURL}?post_logout_redirect_uri=${authJsonContent.logoutRedirectURI}&id_token_hint=${idToken}`);
         });
     } else {
         // Unauthenticated or session already gone — original behaviour
@@ -268,17 +269,49 @@ const handleLocalLogin = async (req, res) => {
         return res.redirect(`${baseUrl}/login?error=Username+and+password+are+required`);
     }
 
-    const users = config.defaultAuth?.users || [];
-    const matchedUser = users.find(u => u.username === username && u.password === password);
+    const platformApiUrl = config.platformApi?.baseUrl;
+    if (!platformApiUrl) {
+        logger.error('Local auth attempted but platformApi.baseUrl is not configured');
+        return res.redirect(`${baseUrl}/login?error=Authentication+service+not+configured`);
+    }
 
-    if (!matchedUser) {
-        logger.warn('Local-auth login failed: invalid credentials', { orgName });
-        return res.redirect(`${baseUrl}/login?error=Invalid+username+or+password`);
+    let platformToken;
+    try {
+        const response = await axios.post(
+            `${platformApiUrl}/api/portal/v1/auth/login`,
+            new URLSearchParams({ username, password }).toString(),
+            {
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                httpsAgent: new https.Agent({ rejectUnauthorized: false }),
+                timeout: 10000,
+            }
+        );
+        platformToken = response.data.token;
+    } catch (error) {
+        if (error.response?.status === 401) {
+            logger.warn('Platform API login failed: invalid credentials', { orgName, username });
+            return res.redirect(`${baseUrl}/login?error=Invalid+username+or+password`);
+        }
+        logger.error('Platform API login request failed', { error: error.message, orgName });
+        return res.redirect(`${baseUrl}/login?error=Login+failed%2C+please+try+again`);
+    }
+
+    // Decode JWT claims (token is already verified by the platform API)
+    let claims;
+    try {
+        claims = JSON.parse(Buffer.from(platformToken.split('.')[1], 'base64url').toString('utf8'));
+    } catch (err) {
+        logger.error('Failed to decode platform API token', { error: err.message });
+        return res.redirect(`${baseUrl}/login?error=Login+failed%2C+please+try+again`);
     }
 
     const adminRole = config.adminRole || 'admin';
     const superAdminRole = config.superAdminRole || 'superAdmin';
-    const roles = matchedUser.roles || [];
+    const subscriberRole = config.subscriberRole || 'Internal/subscriber';
+    const scopes = (claims.scope || '').split(' ');
+    // Users with any :manage scope are treated as admins in the devportal
+    const isAdmin = scopes.some(s => s.endsWith(':manage'));
+    const roles = isAdmin ? [adminRole] : [subscriberRole];
 
     const returnTo = req.session.returnTo;
     let view = viewName;
@@ -291,35 +324,35 @@ const handleLocalLogin = async (req, res) => {
     }
 
     const profile = {
-        firstName: matchedUser.firstName || username,
-        lastName: matchedUser.lastName || '',
-        email: matchedUser.email || username,
+        firstName: claims.username || username,
+        lastName: '',
+        email: claims.email || username,
         imageURL: 'https://raw.githubusercontent.com/wso2/docs-bijira/refs/heads/main/en/devportal-theming/profile.svg',
         view,
         idToken: null,
-        [constants.ROLES.ORGANIZATION_CLAIM]: matchedUser.orgClaimName,
+        [constants.ROLES.ORGANIZATION_CLAIM]: orgName,
         returnTo: returnTo || baseUrl,
-        accessToken: null,
+        accessToken: platformToken,
         refreshToken: null,
         exchangeToken: null,
-        authorizedOrgs: [matchedUser.organizationIdentifier],
+        authorizedOrgs: [orgName],
         [constants.ROLES.ROLE_CLAIM]: roles,
         [constants.ROLES.GROUP_CLAIM]: [],
-        isAdmin: roles.includes(adminRole) || roles.includes(superAdminRole),
-        isSuperAdmin: roles.includes(superAdminRole),
-        [constants.USER_ID]: username,
-        userOrg: matchedUser.organizationIdentifier,
+        isAdmin,
+        isSuperAdmin: false,
+        [constants.USER_ID]: claims.sub || username,
+        userOrg: orgName,
         isLocalAuth: true,
     };
 
     req.session.regenerate((err) => {
         if (err) {
-            logger.error('Session regeneration failed (config-auth)', { error: err.message, stack: err.stack });
+            logger.error('Session regeneration failed (platform-auth)', { error: err.message, stack: err.stack });
             return res.redirect(`${baseUrl}/login?error=Login+failed%2C+please+try+again`);
         }
         req.logIn(profile, (loginErr) => {
             if (loginErr) {
-                logger.error('Config-auth login session error', { error: loginErr.message, stack: loginErr.stack });
+                logger.error('Platform-auth login session error', { error: loginErr.message, stack: loginErr.stack });
                 return res.redirect(`${baseUrl}/login?error=Login+failed%2C+please+try+again`);
             }
             res.set('Cache-Control', 'no-store');

--- a/portals/developer-portal/src/controllers/devportalController.js
+++ b/portals/developer-portal/src/controllers/devportalController.js
@@ -421,7 +421,7 @@ const login = async (req, res) => {
             new URLSearchParams({ username, password }).toString(),
             {
                 headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-                httpsAgent: new https.Agent({ rejectUnauthorized: false }),
+                httpsAgent: new https.Agent({ rejectUnauthorized: !config.platformApi?.insecure }),
                 timeout: 10000,
             }
         );
@@ -434,15 +434,19 @@ const login = async (req, res) => {
         return res.status(503).json({ message: 'Authentication service unavailable' });
     }
 
-    let claims = {};
+    let claims;
     try {
         claims = JSON.parse(Buffer.from(platformToken.split('.')[1], 'base64url').toString('utf8'));
     } catch (_) {}
+    if (!claims?.org_handle) {
+        logger.error('Platform API token missing required claims', { operation: 'devportalLogin' });
+        return res.status(503).json({ message: 'Authentication service error' });
+    }
 
     const scopes = (claims.scope || '').split(' ');
     const adminRole = config.adminRole || 'admin';
     const subscriberRole = config.subscriberRole || 'Internal/subscriber';
-    const isAdmin = scopes.some(s => s.endsWith(':manage'));
+    const isAdmin = scopes.some(s => s.endsWith('_manage'));
 
     const profile = {
         firstName: claims.username || username,

--- a/portals/developer-portal/src/controllers/devportalController.js
+++ b/portals/developer-portal/src/controllers/devportalController.js
@@ -16,11 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+const axios = require('axios');
+const https = require('https');
 const { config } = require('../config/configLoader');
 const logger = require('../config/logger');
 const util = require('../utils/util');
-const passport = require('passport');
-const { Strategy: CustomStrategy } = require('passport-custom');
 const adminDao = require('../dao/admin');
 const constants = require('../utils/constants');
 const { ApplicationDTO } = require('../dto/application');
@@ -407,40 +407,74 @@ const updateOAuthKeys = async (req, res) => {
 };
 
 const login = async (req, res) => {
-    const username = req.body.username;
-    const password = req.body.password;
+    const { username, password } = req.body;
 
-    const defaultUser = config.defaultAuth.users.find(user => user.username === username && user.password === password);
-    passport.use(
-        'default-auth',
-        new CustomStrategy((req, done) => {
-            if (defaultUser) {
-                const user = { ...defaultUser };
-                return done(null, user);
-            } else {
-                return done(null, false, { message: 'Invalid credentials' });
+    const platformApiUrl = config.platformApi?.baseUrl;
+    if (!platformApiUrl) {
+        return res.status(503).json({ message: 'Authentication service not configured' });
+    }
+
+    let platformToken;
+    try {
+        const response = await axios.post(
+            `${platformApiUrl}/api/portal/v1/auth/login`,
+            new URLSearchParams({ username, password }).toString(),
+            {
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                httpsAgent: new https.Agent({ rejectUnauthorized: false }),
+                timeout: 10000,
             }
-        })
-    );
-
-    passport.authenticate('default-auth', (err, user, info) => {
-        if (err) {
-            logger.error("Error occurred while logging in", {
-                error: err.message,
-                stack: err.stack
-            });
-            return util.handleError(res, err);
-        }
-        if (!user) {
+        );
+        platformToken = response.data.token;
+    } catch (error) {
+        if (error.response?.status === 401) {
             return res.status(401).json({ message: 'Invalid credentials' });
         }
-        req.logIn(user, (err) => {
-            if (err) {
-                return util.handleError(res, err);
+        logger.error('Platform API login request failed', { error: error.message });
+        return res.status(503).json({ message: 'Authentication service unavailable' });
+    }
+
+    let claims = {};
+    try {
+        claims = JSON.parse(Buffer.from(platformToken.split('.')[1], 'base64url').toString('utf8'));
+    } catch (_) {}
+
+    const scopes = (claims.scope || '').split(' ');
+    const adminRole = config.adminRole || 'admin';
+    const subscriberRole = config.subscriberRole || 'Internal/subscriber';
+    const isAdmin = scopes.some(s => s.endsWith(':manage'));
+
+    const profile = {
+        firstName: claims.username || username,
+        lastName: '',
+        email: claims.email || username,
+        [constants.ROLES.ORGANIZATION_CLAIM]: claims.org_handle || '',
+        [constants.ROLES.ROLE_CLAIM]: isAdmin ? [adminRole] : [subscriberRole],
+        [constants.ROLES.GROUP_CLAIM]: [],
+        [constants.USER_ID]: claims.sub || username,
+        accessToken: platformToken,
+        refreshToken: null,
+        exchangeToken: null,
+        authorizedOrgs: [claims.org_handle || ''],
+        userOrg: claims.org_handle || '',
+        isAdmin,
+        isSuperAdmin: false,
+        isLocalAuth: true,
+    };
+
+    req.session.regenerate((err) => {
+        if (err) {
+            logger.error('Session regeneration failed', { error: err.message });
+            return util.handleError(res, err);
+        }
+        req.logIn(profile, (loginErr) => {
+            if (loginErr) {
+                logger.error('Login session error', { error: loginErr.message });
+                return util.handleError(res, loginErr);
             }
-            res.status(200).json({ message: 'Login successful' });
+            req.session.save(() => res.status(200).json({ message: 'Login successful' }));
         });
-    })(req, res);
+    });
 };
 module.exports = {
     saveApplication,

--- a/portals/developer-portal/src/controllers/devportalController.js
+++ b/portals/developer-portal/src/controllers/devportalController.js
@@ -30,6 +30,7 @@ const yaml = require('js-yaml');
 const kmDao = require('../dao/keyManager');
 const { getKeyManagerAdapter } = require('../adapters/keyManager');
 const { CustomError } = require('../utils/errors/customErrors');
+const { extractPlatformJwtClaims } = require('../utils/platformJwt');
 // ***** POST / DELETE / PUT Functions ***** (Only work in production)
 
 function parseApplicationDataFromRequest(req) {
@@ -434,16 +435,13 @@ const login = async (req, res) => {
         return res.status(503).json({ message: 'Authentication service unavailable' });
     }
 
-    let claims;
-    try {
-        claims = JSON.parse(Buffer.from(platformToken.split('.')[1], 'base64url').toString('utf8'));
-    } catch (_) {}
+    const claims = extractPlatformJwtClaims(platformToken, null);
     if (!claims?.org_handle) {
         logger.error('Platform API token missing required claims', { operation: 'devportalLogin' });
         return res.status(503).json({ message: 'Authentication service error' });
     }
 
-    const scopes = (claims.scope || '').split(' ');
+    const scopes = claims.scopes;
     const adminRole = config.adminRole || 'admin';
     const subscriberRole = config.subscriberRole || 'Internal/subscriber';
     const isAdmin = scopes.some(s => s.endsWith('_manage'));

--- a/portals/developer-portal/src/middlewares/ensureAuthenticated.js
+++ b/portals/developer-portal/src/middlewares/ensureAuthenticated.js
@@ -41,13 +41,21 @@ function enforceSecuirty(scope) {
             if (!errors.isEmpty()) {
                 return res.status(400).json(util.getErrors(errors));
             }
-            // Config-auth users: authenticated with no token — allow through directly
+            // Local auth users: validate dp:* scope from platform JWT
             if (req.isAuthenticated() && req.user && req.user.isLocalAuth && !config.identityProvider?.clientId) {
-                return next();
+                const platformToken = req.user[constants.ACCESS_TOKEN];
+                if (!platformToken) return next();
+                let tokenScopes = [];
+                try {
+                    const payload = JSON.parse(
+                        Buffer.from(platformToken.split('.')[1], 'base64url').toString('utf8')
+                    );
+                    tokenScopes = String(payload.scope || '').split(' ').filter(Boolean);
+                } catch (_) {}
+                if (!scope || tokenScopes.includes(scope)) return next();
+                return util.handleError(res, new CustomError(403, constants.ERROR_CODE[403], constants.ERROR_MESSAGE.FORBIDDEN));
             }
             const token = accessTokenPresent(req);
-            const hasBasicAuth = !token && !config.identityProvider?.clientId &&
-                req.headers.authorization?.toLowerCase().startsWith('basic ');
             if (token) {
                 //check user belongs to organization
                 if (req.user && req.user[constants.ROLES.ORGANIZATION_CLAIM] !== req.user[constants.ORG_IDENTIFIER]) {
@@ -65,8 +73,6 @@ function enforceSecuirty(scope) {
                 //set user ID
                 const decodedAccessToken = jwt.decode(token);
                 req[constants.USER_ID] = decodedAccessToken[constants.USER_ID];
-            } else if (hasBasicAuth) {
-                validateAuthentication(scope)(req, res, next);
             } else if (config.advanced.apiKey.enabled) {
                 // Communcation with API KEY
                 if (req.headers.organization) {
@@ -287,10 +293,6 @@ function validateAuthentication(scope) {
         if (!errors.isEmpty()) {
             return res.status(400).json(util.getErrors(errors));
         }
-        // Config-auth users have no JWT to validate — allow through
-        if (req.isAuthenticated() && req.user && req.user.isLocalAuth && !config.identityProvider?.clientId) {
-            return next();
-        }
         let IDP, valid, scopes, orgId, response;
         if (req.params.orgName) {
             orgId = await adminDao.getOrgId(req.params.orgName);
@@ -300,7 +302,6 @@ function validateAuthentication(scope) {
         if (orgId) {
             response = await adminDao.getIdentityProvider(orgId);
             if (response.length !== 0) {
-                //login from super IDP
                 IDP = new IdentityProviderDTO(response[0].dataValues);
             } else {
                 IDP = config.identityProvider || {};
@@ -309,60 +310,36 @@ function validateAuthentication(scope) {
             IDP = config.identityProvider || {};
         }
 
-        let accessToken, basicHeader;
-        //if IDP present, fetch bearer token else use basic header
-        if (IDP.clientId !== "") {
-            if (req.isAuthenticated() && req.user) {
-                accessToken = req.user[constants.ACCESS_TOKEN];
-            } else {
-                accessToken = req.headers.authorization && req.headers.authorization.split(' ')[1];
-            }
-            //fetch certificate or JWKS URL
-            if (IDP.certificate) {
-                const pemKey = IDP.certificate;
-                const publicKey = await importX509(pemKey, 'RS256');
-                [valid, scopes] = await validateWithCert(accessToken, publicKey);
-            } else {
-                if (IDP.jwksURL) {
-                    [valid, scopes] = await validateWithJWKS(accessToken, IDP.jwksURL, req);
-                } else {
-                    valid = false;
-                }
-            }
-            if (!config.advanced.disableScopeValidation && valid) {
-                if (scopes.split(" ").includes(scope)) {
-                    return next();
-                } else {
-                    if (req.user) {
-                        return res.redirect('login');
-                    } else {
-                        return util.handleError(res, new CustomError(403, constants.ERROR_CODE[403], constants.ERROR_MESSAGE.FORBIDDEN));
-                    }
-                }
-            } else {
-                if (req.user) {
-                    return next();
-                } else {
-                    return util.handleError(res, new CustomError(401, constants.ERROR_CODE[401], constants.ERROR_MESSAGE.UNAUTHENTICATED));
-                }
-            }
+        let accessToken;
+        if (req.isAuthenticated() && req.user) {
+            accessToken = req.user[constants.ACCESS_TOKEN];
         } else {
-            if (req.isAuthenticated() && req.user) {
-                basicHeader = req.user[constants.BASIC_HEADER];
-            } else {
-                basicHeader = req.headers.authorization && req.headers.authorization.split(' ')[1];
-            }
-            valid = await validateBasicAuth(basicHeader);
-            if (valid) {
-                return next();
-            } else {
-                if (req.user) {
-                    return res.redirect('login');
-                } else {
-                    return util.handleError(res, new CustomError(401, constants.ERROR_CODE[401], constants.ERROR_MESSAGE.UNAUTHENTICATED));
-                }
-            }
+            accessToken = req.headers.authorization && req.headers.authorization.split(' ')[1];
         }
+
+        if (IDP.certificate) {
+            const pemKey = IDP.certificate;
+            const publicKey = await importX509(pemKey, 'RS256');
+            [valid, scopes] = await validateWithCert(accessToken, publicKey);
+        } else if (IDP.jwksURL) {
+            [valid, scopes] = await validateWithJWKS(accessToken, IDP.jwksURL, req);
+        } else {
+            valid = false;
+        }
+
+        if (valid) {
+            if (scopes.split(' ').includes(scope)) {
+                return next();
+            }
+            if (req.user) {
+                return res.redirect('login');
+            }
+            return util.handleError(res, new CustomError(403, constants.ERROR_CODE[403], constants.ERROR_MESSAGE.FORBIDDEN));
+        }
+        if (req.user) {
+            return res.redirect('login');
+        }
+        return util.handleError(res, new CustomError(401, constants.ERROR_CODE[401], constants.ERROR_MESSAGE.UNAUTHENTICATED));
     }
 }
 
@@ -428,21 +405,6 @@ async function refreshAccessToken(refreshToken) {
         });
         throw err;
     }
-}
-
-const validateBasicAuth = async (basicHeader) => {
-
-    let valid = false;
-    const base64Decoded = Buffer.from(basicHeader, 'base64').toString('utf-8');
-    const [username, password] = base64Decoded.split(':');
-    const users = config.defaultAuth?.users || [];
-    for (let user of users) {
-        if (username === user.username && password === user.password) {
-            valid = true;
-            break;
-        }
-    }
-    return valid;
 }
 
 const enforceMTLS = (req, res, next) => {

--- a/portals/developer-portal/src/middlewares/ensureAuthenticated.js
+++ b/portals/developer-portal/src/middlewares/ensureAuthenticated.js
@@ -44,7 +44,7 @@ function enforceSecuirty(scope) {
             // Local auth users: validate dp:* scope from platform JWT
             if (req.isAuthenticated() && req.user && req.user.isLocalAuth && !config.identityProvider?.clientId) {
                 const platformToken = req.user[constants.ACCESS_TOKEN];
-                if (!platformToken) return next();
+                if (!platformToken) return util.handleError(res, new CustomError(401, constants.ERROR_CODE[401], constants.ERROR_MESSAGE.UNAUTHENTICATED));
                 let tokenScopes = [];
                 try {
                     const payload = JSON.parse(
@@ -328,7 +328,7 @@ function validateAuthentication(scope) {
         }
 
         if (valid) {
-            if (scopes.split(' ').includes(scope)) {
+            if (String(scopes || '').split(' ').includes(scope)) {
                 return next();
             }
             if (req.user) {

--- a/portals/developer-portal/src/middlewares/ensureAuthenticated.js
+++ b/portals/developer-portal/src/middlewares/ensureAuthenticated.js
@@ -29,6 +29,7 @@ const jwt = require('jsonwebtoken');
 const axios = require('axios');
 const logger = require('../config/logger');
 const qs = require('qs');
+const { extractPlatformJwtClaims } = require('../utils/platformJwt');
 
 function enforceSecuirty(scope) {
     return async function (req, res, next) {
@@ -45,13 +46,7 @@ function enforceSecuirty(scope) {
             if (req.isAuthenticated() && req.user && req.user.isLocalAuth && !config.identityProvider?.clientId) {
                 const platformToken = req.user[constants.ACCESS_TOKEN];
                 if (!platformToken) return util.handleError(res, new CustomError(401, constants.ERROR_CODE[401], constants.ERROR_MESSAGE.UNAUTHENTICATED));
-                let tokenScopes = [];
-                try {
-                    const payload = JSON.parse(
-                        Buffer.from(platformToken.split('.')[1], 'base64url').toString('utf8')
-                    );
-                    tokenScopes = String(payload.scope || '').split(' ').filter(Boolean);
-                } catch (_) {}
+                const tokenScopes = extractPlatformJwtClaims(platformToken, null)?.scopes ?? [];
                 if (!scope || tokenScopes.includes(scope)) return next();
                 return util.handleError(res, new CustomError(403, constants.ERROR_CODE[403], constants.ERROR_MESSAGE.FORBIDDEN));
             }

--- a/portals/developer-portal/src/models/application.js
+++ b/portals/developer-portal/src/models/application.js
@@ -55,12 +55,6 @@ const Application = sequelize.define('DP_APPLICATION', {
     timestamps: false,
     tableName: 'DP_APPLICATION',
     returning: true,
-    indexes: [
-        {
-            unique: true,
-            fields: ['APP_ID', 'ORG_ID'],
-        },
-    ],
 });
 
 const ApplicationKeyMapping = sequelize.define('DP_APP_KEY_MAPPING', {

--- a/portals/developer-portal/src/models/application.js
+++ b/portals/developer-portal/src/models/application.js
@@ -54,17 +54,14 @@ const Application = sequelize.define('DP_APPLICATION', {
 }, {
     timestamps: false,
     tableName: 'DP_APPLICATION',
-    returning: true
-},
-    {
-        indexes: [
-            {
-                unique: true,
-                fields: ['APP_ID', 'ORG_ID']
-            }
-        ]
-    }
-);
+    returning: true,
+    indexes: [
+        {
+            unique: true,
+            fields: ['APP_ID', 'ORG_ID'],
+        },
+    ],
+});
 
 const ApplicationKeyMapping = sequelize.define('DP_APP_KEY_MAPPING', {
 

--- a/portals/developer-portal/src/openapi/middleware/auth.js
+++ b/portals/developer-portal/src/openapi/middleware/auth.js
@@ -148,13 +148,6 @@ async function verifyBearerToken(token, req) {
     return { valid: false, scopes: '' };
 }
 
-async function validateBasicAuth(basicHeader) {
-    const decoded = Buffer.from(basicHeader, 'base64').toString('utf-8');
-    const [username, password] = decoded.split(':');
-    const users = config.defaultAuth?.users || [];
-    return users.some(u => u.username === username && u.password === password);
-}
-
 function checkOrgMembership(req) {
     if (!req.user) return true;
     const tokenOrg = req.user[constants.ROLES.ORGANIZATION_CLAIM];
@@ -170,13 +163,23 @@ function checkOrgMembership(req) {
  */
 async function authResolver(req, res, next) {
     try {
-        // 1. Local config-auth users (no IdP configured) — pre-authorized
+        // 1. Local auth users (platform JWT in session, no IdP configured)
         if (req.isAuthenticated && req.isAuthenticated() &&
             req.user?.isLocalAuth && !config.identityProvider?.clientId) {
+            const platformToken = req.user[constants.ACCESS_TOKEN];
+            let scopes = [];
+            if (platformToken) {
+                try {
+                    const payload = JSON.parse(
+                        Buffer.from(platformToken.split('.')[1], 'base64url').toString('utf8')
+                    );
+                    scopes = String(payload.scope || '').split(' ').filter(Boolean);
+                } catch (_) {}
+            }
             req.auth = {
-                mode: 'local',
-                preauthorized: true,
-                scopes: [],
+                mode: 'platform-jwt',
+                preauthorized: false,
+                scopes,
                 userId: req.user[constants.USER_ID],
             };
             return next();
@@ -206,22 +209,7 @@ async function authResolver(req, res, next) {
             return next();
         }
 
-        // 3. Basic auth (no IdP configured path)
-        const authHeader = req.headers.authorization;
-        if (!config.identityProvider?.clientId &&
-            authHeader && authHeader.toLowerCase().startsWith('basic ')) {
-            const basicHeader = authHeader.split(' ')[1];
-            const ok = await validateBasicAuth(basicHeader);
-            if (ok) {
-                req.auth = { mode: 'basic', preauthorized: true, scopes: [] };
-                return next();
-            }
-            const err = new Error('Authentication required');
-            err.status = 401;
-            return next(err);
-        }
-
-        // 4. API key
+        // 3. API key
         if (config.advanced?.apiKey?.enabled) {
             const keyType = config.advanced.apiKey.keyType;
             if (keyType && config.advanced?.apiKey?.keyValue) {
@@ -236,7 +224,7 @@ async function authResolver(req, res, next) {
             }
         }
 
-        // 5. mTLS
+        // 4. mTLS
         if (typeof req.connection?.getPeerCertificate === 'function') {
             const cert = req.connection.getPeerCertificate(true);
             if (cert && Object.keys(cert).length > 0 && req.client?.authorized) {
@@ -248,7 +236,7 @@ async function authResolver(req, res, next) {
             }
         }
 
-        // 6. No usable credential — pass through as anonymous so the OpenAPI
+        // 5. No usable credential — pass through as anonymous so the OpenAPI
         // validator can enforce security on a per-operation basis. Operations
         // with `security: []` (public endpoints) will proceed; operations that
         // declare a security scheme will have their handler invoked by the
@@ -269,9 +257,6 @@ async function authResolver(req, res, next) {
  * OAuth2 security handler invoked by express-openapi-validator with the
  * scope list declared on the operation. Implements any-of semantics over
  * a single security requirement object, matching the OpenAPI spec.
- *
- * Honors `config.advanced.disableScopeValidation` — when true, scope
- * intersection is skipped (request only needs to be authenticated).
  */
 async function OAuth2Security(req /* , requiredScopes, schema */) {
     const requiredScopes = arguments[1] || [];
@@ -281,8 +266,7 @@ async function OAuth2Security(req /* , requiredScopes, schema */) {
         throw err;
     }
     if (req.auth.preauthorized) return true;
-    if (config.advanced?.disableScopeValidation) return true;
-    if (req.auth.mode !== 'oauth2') {
+    if (req.auth.mode !== 'oauth2' && req.auth.mode !== 'platform-jwt') {
         const err = new Error('Authentication required');
         err.status = 401;
         throw err;

--- a/portals/developer-portal/src/openapi/middleware/auth.js
+++ b/portals/developer-portal/src/openapi/middleware/auth.js
@@ -23,9 +23,10 @@
  *   authResolver  →  OpenAPI validator (calls OAuth2Security / apiKeyAuth)  →  handler
  *
  * `authResolver` runs once per /devportal request and resolves credentials in the
- * order local → bearer → basic → api key → mTLS). It populates `req.auth` with 
- * `{ mode, scopes, preauthorized, userId } but does NOT enforce scopes — that is the job of `OAuth2Security`, 
- * which the validator invokes with the operation-declared scope list.
+ * order: local session → bearer → api-key → mTLS. It populates `req.auth` with
+ * `{ mode, scopes, preauthorized, userId }` but does NOT enforce scopes — that is
+ * the job of `OAuth2Security`, which the validator invokes with the operation-declared
+ * scope list.
  *
  */
 
@@ -41,6 +42,20 @@ const IdentityProviderDTO = require('../../dto/identityProvider');
 const logger = require('../../config/logger');
 
 const DEFAULT_TOKEN_REFRESH_TIMEOUT_MS = 10000;
+
+function extractPlatformJwtClaims(token, jwtSecret) {
+    try {
+        const payload = jwtSecret
+            ? jwt.verify(token, jwtSecret, { algorithms: ['HS256'] })
+            : JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString('utf8'));
+        return {
+            scopes: String(payload.scope || '').split(' ').filter(Boolean),
+            sub: payload.sub || '',
+        };
+    } catch (_) {
+        return null;
+    }
+}
 
 function resolveTokenRefreshTimeoutMs() {
     const timeout = Number(config.identityProvider?.tokenRefreshTimeoutMs);
@@ -136,8 +151,11 @@ async function resolveOrgIdp(req) {
 async function verifyBearerToken(token, req) {
     const idp = await resolveOrgIdp(req);
     if (!idp || !idp.clientId) {
-        // No IdP configured — accept bearer presence (legacy parity), no scopes.
-        return { valid: true, scopes: '' };
+        // Local auth mode: verify Platform API JWT with shared secret when configured.
+        const jwtSecret = config.platformApi?.jwtSecret;
+        const claims = extractPlatformJwtClaims(token, jwtSecret || null);
+        if (jwtSecret && !claims) return { valid: false, scopes: '' };
+        return { valid: true, scopes: claims?.scopes?.join(' ') ?? '' };
     }
     if (idp.certificate) {
         return verifyWithCertificate(token, idp.certificate);

--- a/portals/developer-portal/src/openapi/middleware/auth.js
+++ b/portals/developer-portal/src/openapi/middleware/auth.js
@@ -185,19 +185,11 @@ async function authResolver(req, res, next) {
         if (req.isAuthenticated && req.isAuthenticated() &&
             req.user?.isLocalAuth && !config.identityProvider?.clientId) {
             const platformToken = req.user[constants.ACCESS_TOKEN];
-            let scopes = [];
-            if (platformToken) {
-                try {
-                    const payload = JSON.parse(
-                        Buffer.from(platformToken.split('.')[1], 'base64url').toString('utf8')
-                    );
-                    scopes = String(payload.scope || '').split(' ').filter(Boolean);
-                } catch (_) {}
-            }
+            const claims = platformToken ? extractPlatformJwtClaims(platformToken, null) : null;
             req.auth = {
                 mode: 'platform-jwt',
                 preauthorized: false,
-                scopes,
+                scopes: claims?.scopes ?? [],
                 userId: req.user[constants.USER_ID],
             };
             return next();

--- a/portals/developer-portal/src/openapi/middleware/auth.js
+++ b/portals/developer-portal/src/openapi/middleware/auth.js
@@ -40,22 +40,9 @@ const constants = require('../../utils/constants');
 const adminDao = require('../../dao/admin');
 const IdentityProviderDTO = require('../../dto/identityProvider');
 const logger = require('../../config/logger');
+const { extractPlatformJwtClaims } = require('../../utils/platformJwt');
 
 const DEFAULT_TOKEN_REFRESH_TIMEOUT_MS = 10000;
-
-function extractPlatformJwtClaims(token, jwtSecret) {
-    try {
-        const payload = jwtSecret
-            ? jwt.verify(token, jwtSecret, { algorithms: ['HS256'] })
-            : JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString('utf8'));
-        return {
-            scopes: String(payload.scope || '').split(' ').filter(Boolean),
-            sub: payload.sub || '',
-        };
-    } catch (_) {
-        return null;
-    }
-}
 
 function resolveTokenRefreshTimeoutMs() {
     const timeout = Number(config.identityProvider?.tokenRefreshTimeoutMs);

--- a/portals/developer-portal/src/services/seeder.js
+++ b/portals/developer-portal/src/services/seeder.js
@@ -109,7 +109,7 @@ async function seedDefaultOrg() {
     }
 
     try {
-        await adminDao.createProvider(orgId, { name: 'WSO2', providerURL: config.controlPlane.url });
+        await adminDao.createProvider(orgId, { name: 'WSO2', providerURL: 'https://wso2.com' });
     } catch (error) {
         if (!(error instanceof Sequelize.UniqueConstraintError)) {
             logger.error('Failed to seed provider', {

--- a/portals/developer-portal/src/utils/platformJwt.js
+++ b/portals/developer-portal/src/utils/platformJwt.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+const jwt = require('jsonwebtoken');
+
+/**
+ * Decode and optionally verify a Platform API JWT.
+ *
+ * When jwtSecret is provided the token is verified with HS256 (prevents
+ * tampered tokens from being accepted). Without a secret the payload is
+ * base64-decoded without signature verification — suitable for tokens that
+ * were just received directly from the Platform API over a trusted HTTPS
+ * connection.
+ *
+ * Returns the full JWT payload spread together with a parsed `scopes` array,
+ * or null if decoding / verification fails.
+ */
+function extractPlatformJwtClaims(token, jwtSecret) {
+    try {
+        const payload = jwtSecret
+            ? jwt.verify(token, jwtSecret, { algorithms: ['HS256'] })
+            : JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString('utf8'));
+        return {
+            ...payload,
+            scopes: String(payload.scope || '').split(' ').filter(Boolean),
+        };
+    } catch (_) {
+        return null;
+    }
+}
+
+module.exports = { extractPlatformJwtClaims };


### PR DESCRIPTION
## Purpose
$subject

## Goals
Using platform API for the local auth

## Approach
Added platform API to the distribution
Reused the platfrom API's file based auth in the devportal
successful login will return the JWT, and it will be stored in the devportal backend session

Removed support for basic auth for REST APIs. Users has to use the login ednpoint to get a token and use that with the RestAPIs.