### PR TITLE
Add platform-api and ai-workspace build and scan steps to workflows

### DIFF
--- a/.github/workflows/jfrog-scan.yaml
+++ b/.github/workflows/jfrog-scan.yaml
@@ -108,3 +108,31 @@ jobs:
         run: |
           docker pull localhost:5000/event-gateway-controller:trivy
           jf docker scan localhost:5000/event-gateway-controller:trivy
+
+      # -------------------------
+      # Platform API
+      # -------------------------
+      - name: Build & push platform-api to temp registry
+        run: |
+          make -C platform-api build-and-push-multiarch \
+            IMAGE_NAME=localhost:5000/platform-api \
+            VERSION=trivy
+
+      - name: JFrog scan platform-api
+        run: |
+          docker pull localhost:5000/platform-api:trivy
+          jf docker scan localhost:5000/platform-api:trivy
+
+      # -------------------------
+      # AI Workspace
+      # -------------------------
+      - name: Build & push ai-workspace to temp registry
+        run: |
+          make -C portals/ai-workspace build-and-push-multiarch \
+            IMAGE_NAME=localhost:5000/ai-workspace \
+            VERSION=trivy
+
+      - name: JFrog scan ai-workspace
+        run: |
+          docker pull localhost:5000/ai-workspace:trivy
+          jf docker scan localhost:5000/ai-workspace:trivy

--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -112,3 +112,31 @@ jobs:
           format: 'table'
           ignore-unfixed: true
           vuln-type: 'os,library'
+
+      - name: Build & push platform-api
+        run: |
+          make -C platform-api build-and-push-multiarch \
+          IMAGE_NAME=localhost:5000/platform-api \
+          VERSION=trivy
+
+      - name: Trivy scan platform-api
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'localhost:5000/platform-api:trivy'
+          format: 'table'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+
+      - name: Build & push ai-workspace
+        run: |
+          make -C portals/ai-workspace build-and-push-multiarch \
+          IMAGE_NAME=localhost:5000/ai-workspace \
+          VERSION=trivy
+
+      - name: Trivy scan ai-workspace
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'localhost:5000/ai-workspace:trivy'
+          format: 'table'
+          ignore-unfixed: true
+          vuln-type: 'os,library'


### PR DESCRIPTION
- Introduced build and push steps for platform-api and ai-workspace to the temporary registry in both jfrog-scan.yaml and trivy-scan.yaml.
- Added JFrog and Trivy scan steps for both services to enhance security checks.