### PR TITLE
Refactor workflows to include platform-api and ai-workspace build and scan steps

### DIFF
--- a/.github/workflows/jfrog-scan.yaml
+++ b/.github/workflows/jfrog-scan.yaml
@@ -71,6 +71,33 @@ jobs:
         run: |
           docker pull localhost:5000/gateway-builder:trivy
           jf docker scan localhost:5000/gateway-builder:trivy
+      # -------------------------
+      # Platform API
+      # -------------------------
+      - name: Build & push platform-api to temp registry
+        run: |
+          make -C platform-api build-and-push-multiarch \
+            IMAGE_NAME=localhost:5000/platform-api \
+            VERSION=trivy
+
+      - name: JFrog scan platform-api
+        run: |
+          docker pull localhost:5000/platform-api:trivy
+          jf docker scan localhost:5000/platform-api:trivy
+
+      # -------------------------
+      # AI Workspace
+      # -------------------------
+      - name: Build & push ai-workspace to temp registry
+        run: |
+          make -C portals/ai-workspace build-and-push-multiarch \
+            IMAGE_NAME=localhost:5000/ai-workspace \
+            VERSION=trivy
+
+      - name: JFrog scan ai-workspace
+        run: |
+          docker pull localhost:5000/ai-workspace:trivy
+          jf docker scan localhost:5000/ai-workspace:trivy
 
       # -------------------------
       # Event Gateway Runtime
@@ -108,31 +135,3 @@ jobs:
         run: |
           docker pull localhost:5000/event-gateway-controller:trivy
           jf docker scan localhost:5000/event-gateway-controller:trivy
-
-      # -------------------------
-      # Platform API
-      # -------------------------
-      - name: Build & push platform-api to temp registry
-        run: |
-          make -C platform-api build-and-push-multiarch \
-            IMAGE_NAME=localhost:5000/platform-api \
-            VERSION=trivy
-
-      - name: JFrog scan platform-api
-        run: |
-          docker pull localhost:5000/platform-api:trivy
-          jf docker scan localhost:5000/platform-api:trivy
-
-      # -------------------------
-      # AI Workspace
-      # -------------------------
-      - name: Build & push ai-workspace to temp registry
-        run: |
-          make -C portals/ai-workspace build-and-push-multiarch \
-            IMAGE_NAME=localhost:5000/ai-workspace \
-            VERSION=trivy
-
-      - name: JFrog scan ai-workspace
-        run: |
-          docker pull localhost:5000/ai-workspace:trivy
-          jf docker scan localhost:5000/ai-workspace:trivy

--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -112,31 +112,3 @@ jobs:
           format: 'table'
           ignore-unfixed: true
           vuln-type: 'os,library'
-
-      - name: Build & push platform-api
-        run: |
-          make -C platform-api build-and-push-multiarch \
-          IMAGE_NAME=localhost:5000/platform-api \
-          VERSION=trivy
-
-      - name: Trivy scan platform-api
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: 'localhost:5000/platform-api:trivy'
-          format: 'table'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-
-      - name: Build & push ai-workspace
-        run: |
-          make -C portals/ai-workspace build-and-push-multiarch \
-          IMAGE_NAME=localhost:5000/ai-workspace \
-          VERSION=trivy
-
-      - name: Trivy scan ai-workspace
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: 'localhost:5000/ai-workspace:trivy'
-          format: 'table'
-          ignore-unfixed: true
-          vuln-type: 'os,library'


### PR DESCRIPTION
- Added build and push steps for platform-api and ai-workspace to the temporary registry in jfrog-scan.yaml.
- Implemented JFrog scan steps for both services to enhance security checks.
- Removed redundant build and scan steps from trivy-scan.yaml.
