### PR TITLE
Fix Build & push event-gateway-controller to temp registry

### DIFF
--- a/.github/workflows/jfrog-scan.yaml
+++ b/.github/workflows/jfrog-scan.yaml
@@ -118,18 +118,9 @@ jobs:
       # -------------------------
       - name: Build & push event-gateway-controller to temp registry
         run: |
-          cd gateway/gateway-controller && \
-          docker buildx build -f Dockerfile \
-            --build-context sdk=../../sdk \
-            --build-context sdk-core=../../sdk/core \
-            --build-context common=../../common \
-            --build-context build-manifest=.. \
-            --platform linux/amd64,linux/arm64 \
-            --build-arg VERSION=trivy \
-            --target production \
-            -t localhost:5000/event-gateway-controller:trivy \
-            --push \
-            .
+          make -C gateway/gateway-controller build-and-push-multiarch \
+            IMAGE_NAME=localhost:5000/event-gateway-controller \
+            VERSION=trivy
 
       - name: JFrog scan event-gateway-controller
         run: |


### PR DESCRIPTION
## Purpose
> $Subject - https://github.com/wso2/api-platform/actions/runs/26418498003/job/77767999887


**Fix**

Replace the raw `docker buildx build` command with `make -C gateway/gateway-controller build-and-push-multiarch`, matching the pattern used by every other step in this workflow. The Makefile already passes all required build contexts (`policies`, `target`, `sdk`, `sdk-core`, `common`, `build-manifest`) correctly.

The `policies` directory (`gateway/target/build/gateway-controller/policies`) is populated by the gateway-runtime step that runs earlier in the workflow via its `extract-policies` target.


Commit 0f8b59aeb (`refactor(gateway): source policy defs from gateway-builder output`) changed the Dockerfile to replace the checked-in `default-policies/` folder with a `COPY --from=policies . /app/default-policies` build context. This was added to the Makefile's `build-and-push-multiarch` correctly, but the `jfrog-scan.yaml` step was not updated.