### PR TITLE
ci: parallelize jfrog scan into per-image matrix with scan retry

### DIFF
--- a/.github/workflows/jfrog-scan.yaml
+++ b/.github/workflows/jfrog-scan.yaml
@@ -7,6 +7,25 @@ on:
 jobs:
   scan-images:
     runs-on: ubuntu-latest
+    # One job per image so a stall/failure on one image never aborts the others.
+    # fail-fast: false => every image is still built and scanned even if a sibling fails.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: gateway-runtime, make_dir: gateway/gateway-runtime }
+          - { name: gateway-controller, make_dir: gateway/gateway-controller }
+          - { name: gateway-builder, make_dir: gateway/gateway-builder }
+          - { name: platform-api, make_dir: platform-api }
+          - { name: ai-workspace, make_dir: portals/ai-workspace }
+          - { name: event-gateway-runtime, make_dir: event-gateway/gateway-runtime }
+          # event-gateway-controller is built from the gateway-controller Makefile target,
+          # tagged under its own image name.
+          - { name: event-gateway-controller, make_dir: gateway/gateway-controller }
+
+    # Hard ceiling for the whole job. The scan step has its own per-attempt timeout below,
+    # so this only guards against an unexpected hang in build/setup.
+    timeout-minutes: 60
 
     services:
       registry:
@@ -43,99 +62,45 @@ jobs:
           JF_URL: ${{ secrets.JF_URL }}
           JF_ACCESS_TOKEN: ${{ secrets.JF_ACCESS_TOKEN }}
 
-      # -------------------------
-      # Gateway Runtime (Router + Policy Engine)
-      # -------------------------
-      - name: Build & push gateway-runtime to temp registry
+      - name: Build & push ${{ matrix.name }} to temp registry
         run: |
-          make -C gateway/gateway-runtime build-and-push-multiarch \
-            IMAGE_NAME=localhost:5000/gateway-runtime \
+          make -C ${{ matrix.make_dir }} build-and-push-multiarch \
+            IMAGE_NAME=localhost:5000/${{ matrix.name }} \
             VERSION=trivy
 
-      - name: JFrog scan gateway-runtime
+      # The JFrog Xray SaaS backend periodically stalls on the SCA ("Get Dependencies
+      # Scan results") stage for large images. The client-side poll limit is hardcoded in
+      # jfrog-client-go at 45 min (540 attempts x 5s) with no flag/env override, so a stall
+      # otherwise burns ~46 min before failing. We cap each attempt with `timeout` so a stall
+      # fails fast, then retry a few times to absorb transient backend slowness.
+      - name: JFrog scan ${{ matrix.name }}
+        timeout-minutes: 45
         run: |
-          docker pull localhost:5000/gateway-runtime:trivy
-          jf docker scan localhost:5000/gateway-runtime:trivy
+          IMAGE="localhost:5000/${{ matrix.name }}:trivy"
+          docker pull "$IMAGE"
 
-      # -------------------------
-      # Gateway Controller
-      # -------------------------
-      - name: Build & push gateway-controller to temp registry
-        run: |
-          make -C gateway/gateway-controller build-and-push-multiarch \
-            IMAGE_NAME=localhost:5000/gateway-controller \
-            VERSION=trivy
+          max_attempts=3
+          per_attempt_timeout=12m
+          attempt=1
+          while [ "$attempt" -le "$max_attempts" ]; do
+            echo "::group::jf docker scan attempt ${attempt}/${max_attempts} ($IMAGE)"
+            # `|| rc=$?` captures the real exit code (a bare `if` with no else resets $? to 0
+            # under set -e) without tripping set -e.
+            rc=0
+            timeout --kill-after=1m "$per_attempt_timeout" jf docker scan "$IMAGE" || rc=$?
+            echo "::endgroup::"
+            if [ "$rc" -eq 0 ]; then
+              echo "Scan succeeded on attempt ${attempt}"
+              exit 0
+            fi
+            if [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then
+              echo "Attempt ${attempt} hit the ${per_attempt_timeout} per-attempt timeout (backend stall)."
+            else
+              echo "Attempt ${attempt} failed with exit code ${rc}."
+            fi
+            attempt=$((attempt + 1))
+            [ "$attempt" -le "$max_attempts" ] && { echo "Retrying after 30s backoff..."; sleep 30; }
+          done
 
-      - name: JFrog scan gateway-controller
-        run: |
-          docker pull localhost:5000/gateway-controller:trivy
-          jf docker scan localhost:5000/gateway-controller:trivy
-
-      # -------------------------
-      # Gateway Builder
-      # -------------------------
-      - name: Build & push gateway-builder to temp registry
-        run: |
-          make -C gateway/gateway-builder build-and-push-multiarch \
-            IMAGE_NAME=localhost:5000/gateway-builder \
-            VERSION=trivy
-
-      - name: JFrog scan gateway-builder
-        run: |
-          docker pull localhost:5000/gateway-builder:trivy
-          jf docker scan localhost:5000/gateway-builder:trivy
-      # -------------------------
-      # Platform API
-      # -------------------------
-      - name: Build & push platform-api to temp registry
-        run: |
-          make -C platform-api build-and-push-multiarch \
-            IMAGE_NAME=localhost:5000/platform-api \
-            VERSION=trivy
-
-      - name: JFrog scan platform-api
-        run: |
-          docker pull localhost:5000/platform-api:trivy
-          jf docker scan localhost:5000/platform-api:trivy
-
-      # -------------------------
-      # AI Workspace
-      # -------------------------
-      - name: Build & push ai-workspace to temp registry
-        run: |
-          make -C portals/ai-workspace build-and-push-multiarch \
-            IMAGE_NAME=localhost:5000/ai-workspace \
-            VERSION=trivy
-
-      - name: JFrog scan ai-workspace
-        run: |
-          docker pull localhost:5000/ai-workspace:trivy
-          jf docker scan localhost:5000/ai-workspace:trivy
-
-      # -------------------------
-      # Event Gateway Runtime
-      # -------------------------
-      - name: Build & push event-gateway-runtime to temp registry
-        run: |
-          make -C event-gateway/gateway-runtime build-and-push-multiarch \
-            IMAGE_NAME=localhost:5000/event-gateway-runtime \
-            VERSION=trivy
-
-      - name: JFrog scan event-gateway-runtime
-        run: |
-          docker pull localhost:5000/event-gateway-runtime:trivy
-          jf docker scan localhost:5000/event-gateway-runtime:trivy
-
-      # -------------------------
-      # Event Gateway Controller
-      # -------------------------
-      - name: Build & push event-gateway-controller to temp registry
-        run: |
-          make -C gateway/gateway-controller build-and-push-multiarch \
-            IMAGE_NAME=localhost:5000/event-gateway-controller \
-            VERSION=trivy
-
-      - name: JFrog scan event-gateway-controller
-        run: |
-          docker pull localhost:5000/event-gateway-controller:trivy
-          jf docker scan localhost:5000/event-gateway-controller:trivy
+          echo "jf docker scan failed after ${max_attempts} attempts for $IMAGE"
+          exit 1


### PR DESCRIPTION
## Purpose

The nightly `Jfrog Scan` workflow has failed on essentially every run for weeks. Two compounding problems are responsible. First, all seven images were built and scanned in a single sequential job with fail-fast, so any one image's build error or scan stall aborted every image after it. Second, the JFrog Xray SaaS backend intermittently stalls on the SCA ("Get Dependencies Scan results") stage for large images, and the client-side poll limit is hardcoded in `jfrog-client-go` at 45 minutes (540 attempts × 5s) with no flag or env override — so a single stall burned ~46 minutes and then failed the whole workflow.

This is not a regression in the repo: the same `gateway-runtime` scan that timed out (>45 min) completed in ~21s on 2 May and ~3 min on 17–18 June. The trigger is backend latency on the SCA stage; image size only decides which image crosses the hardcoded ceiling first.

## Goals

Make the scan resilient to transient JFrog Xray backend slowness, and ensure every image is built and scanned independently so one image's failure no longer aborts the rest.

## Approach

- Split the single sequential job into a `matrix` of one job per image with `fail-fast: false`, so each image builds and scans independently and in parallel.
- Cap each `jf docker scan` attempt at 12m via `timeout` and retry up to 3× with a 30s backoff, so a backend stall fails fast (~37m worst case) instead of burning ~46m on the hardcoded client timeout.
- Add a 60m job-level ceiling as a safety guard against an unexpected hang in build/setup.
- Build all images (including `event-gateway-controller`) through the uniform `make ... build-and-push-multiarch` target, consistent with the recent event-gateway-controller build fix on main.

## User stories

N/A

## Documentation

N/A — CI-only change with no product or user-facing documentation impact.

## Automation tests

- Unit tests: N/A — CI workflow change. The embedded retry script was validated locally with `shellcheck` and exercised across the success, success-after-retry, persistent-timeout, and persistent-error paths.
- Integration tests: The workflow is its own test and can be validated via `workflow_dispatch` on the branch before merge.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — no source code change; GitHub Actions YAML only.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

N/A

## Test environment

GitHub Actions `ubuntu-latest` runner.