### PR TITLE
[PlatformAPI and UI] Add global policies support for LLM providers and proxies

### DIFF
--- a/.github/workflows/ai-workspace-pr-check.yml
+++ b/.github/workflows/ai-workspace-pr-check.yml
@@ -37,6 +37,20 @@ jobs:
         run: make build
         working-directory: portals/ai-workspace
 
+      # AI Workspace E2E depends on platform-api changes that ship in this PR but
+      # are not yet published to the registry. Build the platform-api image from
+      # source and pin the compose file to that freshly built snapshot so the
+      # stack runs the PR's code instead of the last published image.
+      - name: Build Platform API image (PR changes)
+        run: |
+          PLATFORM_API_VERSION="$(tr -d '[:space:]' < platform-api/VERSION)"
+          echo "Building platform-api:${PLATFORM_API_VERSION} from source"
+          make -C platform-api build VERSION="${PLATFORM_API_VERSION}"
+          echo "Pinning ai-workspace compose to platform-api:${PLATFORM_API_VERSION}"
+          sed -i.bak -E "s#image: .*/platform-api:.*#image: ghcr.io/wso2/api-platform/platform-api:${PLATFORM_API_VERSION}#" \
+            portals/ai-workspace/docker-compose.yaml
+          rm -f portals/ai-workspace/docker-compose.yaml.bak
+
       - name: Start quickstart stack
         run: docker compose up -d --wait
         working-directory: portals/ai-workspace

--- a/platform-api/src/api/generated.go
+++ b/platform-api/src/api/generated.go
@@ -1637,6 +1637,26 @@ type LLMPolicyPath struct {
 // LLMPolicyPathMethods defines model for LLMPolicyPath.Methods.
 type LLMPolicyPathMethods string
 
+// OperationPolicy defines model for OperationPolicy.
+type OperationPolicy struct {
+	// ExecutionCondition Condition under which the policy is executed
+	ExecutionCondition *string `json:"executionCondition,omitempty" yaml:"executionCondition,omitempty"`
+
+	Name  string                `binding:"required" json:"name" yaml:"name"`
+	Paths []OperationPolicyPath `binding:"required" json:"paths" yaml:"paths"`
+
+	Version string `binding:"required" json:"version" yaml:"version"`
+}
+
+// OperationPolicyPath defines model for OperationPolicyPath.
+type OperationPolicyPath struct {
+	Methods []string `binding:"required" json:"methods" yaml:"methods"`
+
+	// Params Policy parameters (key-value pairs specific to the policy)
+	Params map[string]interface{} `binding:"required" json:"params" yaml:"params"`
+	Path   string                 `binding:"required" json:"path" yaml:"path"`
+}
+
 // LLMProvider defines model for LLMProvider.
 type LLMProvider struct {
 	AccessControl LLMAccessControl `json:"accessControl" yaml:"accessControl"`
@@ -1665,7 +1685,13 @@ type LLMProvider struct {
 	// Openapi OpenAPI specification (JSON or YAML) for the provider endpoint
 	Openapi *string `json:"openapi,omitempty" yaml:"openapi,omitempty"`
 
-	// Policies List of policies applied only to this operation (overrides or adds to API-level policies)
+	// GlobalPolicies List of policies applied at the API level (shared rate-limit bucket across all operations)
+	GlobalPolicies *[]Policy `json:"globalPolicies,omitempty" yaml:"globalPolicies,omitempty"`
+
+	// OperationPolicies List of policies applied per operation (independent rate-limit bucket per resource)
+	OperationPolicies *[]OperationPolicy `json:"operationPolicies,omitempty" yaml:"operationPolicies,omitempty"`
+
+	// Policies Deprecated: use operationPolicies instead. List of policies applied only to this operation (overrides or adds to API-level policies)
 	Policies *[]LLMPolicy `json:"policies,omitempty" yaml:"policies,omitempty"`
 
 	// RateLimiting Rate limiting configuration for an LLM provider at provider and consumer levels.
@@ -1833,10 +1859,16 @@ type LLMProxy struct {
 	// Name Human-readable LLM proxy name (must be URL-friendly - only letters, numbers, spaces, hyphens, underscores, and dots allowed)
 	Name string `binding:"required" json:"name" yaml:"name"`
 
+	// GlobalPolicies List of policies applied at the API level (shared rate-limit bucket across all operations)
+	GlobalPolicies *[]Policy `json:"globalPolicies,omitempty" yaml:"globalPolicies,omitempty"`
+
+	// OperationPolicies List of policies applied per operation (independent rate-limit bucket per resource)
+	OperationPolicies *[]OperationPolicy `json:"operationPolicies,omitempty" yaml:"operationPolicies,omitempty"`
+
 	// Openapi OpenAPI specification (JSON or YAML) for the proxy endpoint
 	Openapi *string `json:"openapi,omitempty" yaml:"openapi,omitempty"`
 
-	// Policies List of policies applied only to this operation (overrides or adds to API-level policies)
+	// Policies Deprecated: use operationPolicies instead. List of policies applied only to this operation (overrides or adds to API-level policies)
 	Policies *[]LLMPolicy `json:"policies,omitempty" yaml:"policies,omitempty"`
 
 	// ProjectId UUID of the project this proxy belongs to

--- a/platform-api/src/internal/constants/constants.go
+++ b/platform-api/src/internal/constants/constants.go
@@ -146,15 +146,15 @@ const (
 // consumable by old gateways. New code should use GatewayApiVersion.
 const (
 	GatewayApiVersionV1Alpha1 = "gateway.api-platform.wso2.com/v1alpha1"
-	GatewayApiVersion         = "gateway.api-platform.wso2.com/v1alpha2"
+	GatewayApiVersion         = "gateway.api-platform.wso2.com/v1"
 )
 
 // Platform-api resource URL version. APIBasePath is the single source of truth for
 // the prefix every handler route group is mounted under. NOTE: this is a DIFFERENT
-// axis from GatewayApiVersion* (the gateway artifact apiVersion) — they share the
-// value "v1alpha2" but are governed independently.
+// axis from GatewayApiVersion* (the gateway artifact apiVersion) — the two are
+// governed independently and currently hold different values ("v0.9" vs "v1").
 const (
-    APIVersion  = "v1alpha2"
+    APIVersion  = "v0.9"
     APIBasePath = "/api/" + APIVersion
 )
 

--- a/platform-api/src/internal/constants/constants.go
+++ b/platform-api/src/internal/constants/constants.go
@@ -140,7 +140,18 @@ const (
 	MaxWebBrokerAPIsPerOrganization = 5
 )
 
-const GatewayApiVersion = "gateway.api-platform.wso2.com/v1alpha1"
+// GatewayApiVersionV1Alpha1 is the legacy artifact apiVersion for gateways < 1.2.0.
+// Use this only in down-convert paths (deploymenttransform) that must produce
+// artifacts consumable by old gateways. New code should use GatewayApiVersion.
+const GatewayApiVersionV1Alpha1 = "gateway.api-platform.wso2.com/v1alpha1"
+const GatewayApiVersion = "gateway.api-platform.wso2.com/v1alpha2"
+
+// APIVersion is the platform-api resource URL version segment, and APIBasePath is the
+// single source of truth for the prefix every handler route group is mounted under.
+// NOTE: this is a DIFFERENT axis from GatewayApiVersion* (the gateway artifact
+// apiVersion).
+const APIVersion = "v1alpha2"
+const APIBasePath = "/api/" + APIVersion
 
 // Custom Policy ManagedBy constants
 const (

--- a/platform-api/src/internal/constants/constants.go
+++ b/platform-api/src/internal/constants/constants.go
@@ -140,18 +140,23 @@ const (
 	MaxWebBrokerAPIsPerOrganization = 5
 )
 
-// GatewayApiVersionV1Alpha1 is the legacy artifact apiVersion for gateways < 1.2.0.
-// Use this only in down-convert paths (deploymenttransform) that must produce
-// artifacts consumable by old gateways. New code should use GatewayApiVersion.
-const GatewayApiVersionV1Alpha1 = "gateway.api-platform.wso2.com/v1alpha1"
-const GatewayApiVersion = "gateway.api-platform.wso2.com/v1alpha2"
+// Gateway artifact apiVersion (the `apiVersion:` field on deployment artifacts).
+// GatewayApiVersionV1Alpha1 is the legacy value for gateways < 1.2.0 — use it only
+// in down-convert paths (deploymenttransform) that must produce artifacts
+// consumable by old gateways. New code should use GatewayApiVersion.
+const (
+	GatewayApiVersionV1Alpha1 = "gateway.api-platform.wso2.com/v1alpha1"
+	GatewayApiVersion         = "gateway.api-platform.wso2.com/v1alpha2"
+)
 
-// APIVersion is the platform-api resource URL version segment, and APIBasePath is the
-// single source of truth for the prefix every handler route group is mounted under.
-// NOTE: this is a DIFFERENT axis from GatewayApiVersion* (the gateway artifact
-// apiVersion).
-const APIVersion = "v1alpha2"
-const APIBasePath = "/api/" + APIVersion
+// Platform-api resource URL version. APIBasePath is the single source of truth for
+// the prefix every handler route group is mounted under. NOTE: this is a DIFFERENT
+// axis from GatewayApiVersion* (the gateway artifact apiVersion) — they share the
+// value "v1alpha2" but are governed independently.
+const (
+    APIVersion  = "v1alpha2"
+    APIBasePath = "/api/" + APIVersion
+)
 
 // Custom Policy ManagedBy constants
 const (

--- a/platform-api/src/internal/deploymenttransform/policies.go
+++ b/platform-api/src/internal/deploymenttransform/policies.go
@@ -40,7 +40,7 @@ func init() {
 	// globalPolicies/operationPolicies. Flatten both new lists into the legacy
 	// policies field so those gateways can still consume the artifact.
 	defaultRegistry.Register(Transformation{
-		Name:        "policy-lists/downconvert-pre-1.2.0",
+		Name:        "policy-lists/downconvert-pre-1.2.0/llm-provider",
 		Kind:        constants.LLMProvider,
 		AppliesWhen: isOldGateway,
 		Apply: func(payload any) error {
@@ -60,7 +60,7 @@ func init() {
 	})
 
 	defaultRegistry.Register(Transformation{
-		Name:        "policy-lists/downconvert-pre-1.2.0",
+		Name:        "policy-lists/downconvert-pre-1.2.0/llm-proxy",
 		Kind:        constants.LLMProxy,
 		AppliesWhen: isOldGateway,
 		Apply: func(payload any) error {

--- a/platform-api/src/internal/deploymenttransform/policies.go
+++ b/platform-api/src/internal/deploymenttransform/policies.go
@@ -1,0 +1,141 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package deploymenttransform
+
+import (
+	"fmt"
+
+	"platform-api/src/api"
+	"platform-api/src/internal/constants"
+	"platform-api/src/internal/dto"
+)
+
+// Policy names used when ordering the down-converted legacy list.
+// These must stay in sync with service/llm_deployment.go's constants.
+const (
+	policyNameLLMCost              = "llm-cost"
+	policyNameLLMCostBasedRateLimit = "llm-cost-based-ratelimit"
+)
+
+func init() {
+	minVer := ParseVersion(MinSplitPoliciesVersion)
+	isOldGateway := func(target Version) bool { return !target.GTE(minVer) }
+
+	// policy-lists down-convert: gateways < 1.2.0 don't understand
+	// globalPolicies/operationPolicies. Flatten both new lists into the legacy
+	// policies field so those gateways can still consume the artifact.
+	defaultRegistry.Register(Transformation{
+		Name:        "policy-lists/downconvert-pre-1.2.0",
+		Kind:        constants.LLMProvider,
+		AppliesWhen: isOldGateway,
+		Apply: func(payload any) error {
+			artifact, ok := payload.(*dto.LLMProviderDeploymentYAML)
+			if !ok {
+				return fmt.Errorf("expected *dto.LLMProviderDeploymentYAML, got %T", payload)
+			}
+			downconvertPolicyLists(
+				artifact.Spec.GlobalPolicies, artifact.Spec.OperationPolicies,
+				&artifact.Spec.Policies,
+			)
+			artifact.Spec.GlobalPolicies = nil
+			artifact.Spec.OperationPolicies = nil
+			artifact.ApiVersion = constants.GatewayApiVersionV1Alpha1
+			return nil
+		},
+	})
+
+	defaultRegistry.Register(Transformation{
+		Name:        "policy-lists/downconvert-pre-1.2.0",
+		Kind:        constants.LLMProxy,
+		AppliesWhen: isOldGateway,
+		Apply: func(payload any) error {
+			artifact, ok := payload.(*dto.LLMProxyDeploymentYAML)
+			if !ok {
+				return fmt.Errorf("expected *dto.LLMProxyDeploymentYAML, got %T", payload)
+			}
+			downconvertPolicyLists(
+				artifact.Spec.GlobalPolicies, artifact.Spec.OperationPolicies,
+				&artifact.Spec.Policies,
+			)
+			artifact.Spec.GlobalPolicies = nil
+			artifact.Spec.OperationPolicies = nil
+			artifact.ApiVersion = constants.GatewayApiVersionV1Alpha1
+			return nil
+		},
+	})
+}
+
+// downconvertPolicyLists flattens globalPolicies and operationPolicies into the
+// legacy policies slice:
+//   - each global policy → a legacy entry with a single {path:"/*", methods:["*"]} path
+//   - each operation policy → a legacy entry with its paths copied 1:1
+//
+// The result is appended to *legacyPolicies (which may already contain
+// security/consumer entries the generator assembled), then re-ordered so that
+// llm-cost-based-ratelimit always precedes llm-cost.
+func downconvertPolicyLists(
+	globalPolicies []api.Policy,
+	operationPolicies []api.OperationPolicy,
+	legacyPolicies *[]api.LLMPolicy,
+) {
+	for _, gp := range globalPolicies {
+		params := map[string]interface{}{}
+		if gp.Params != nil {
+			params = *gp.Params
+		}
+		*legacyPolicies = append(*legacyPolicies, api.LLMPolicy{
+			Name:    gp.Name,
+			Version: gp.Version,
+			Paths:   []api.LLMPolicyPath{{Path: "/*", Methods: []api.LLMPolicyPathMethods{"*"}, Params: params}},
+		})
+	}
+	for _, op := range operationPolicies {
+		paths := make([]api.LLMPolicyPath, 0, len(op.Paths))
+		for _, pp := range op.Paths {
+			methods := make([]api.LLMPolicyPathMethods, 0, len(pp.Methods))
+			for _, m := range pp.Methods {
+				methods = append(methods, api.LLMPolicyPathMethods(m))
+			}
+			paths = append(paths, api.LLMPolicyPath{Path: pp.Path, Methods: methods, Params: pp.Params})
+		}
+		*legacyPolicies = append(*legacyPolicies, api.LLMPolicy{
+			Name:    op.Name,
+			Version: op.Version,
+			Paths:   paths,
+		})
+	}
+	*legacyPolicies = orderLegacyPolicies(*legacyPolicies)
+}
+
+// orderLegacyPolicies ensures llm-cost-based-ratelimit always precedes llm-cost
+// in the legacy policy list (llm-cost depends on the ratelimit policy running first).
+func orderLegacyPolicies(policies []api.LLMPolicy) []api.LLMPolicy {
+	costIdx, rateLimitIdx := -1, -1
+	for i, p := range policies {
+		switch p.Name {
+		case policyNameLLMCost:
+			costIdx = i
+		case policyNameLLMCostBasedRateLimit:
+			rateLimitIdx = i
+		}
+	}
+	if costIdx != -1 && rateLimitIdx != -1 && costIdx < rateLimitIdx {
+		policies[costIdx], policies[rateLimitIdx] = policies[rateLimitIdx], policies[costIdx]
+	}
+	return policies
+}

--- a/platform-api/src/internal/deploymenttransform/registry.go
+++ b/platform-api/src/internal/deploymenttransform/registry.go
@@ -1,0 +1,86 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+// Package deploymenttransform provides a generic, version-keyed registry for
+// adapting canonical deployment artifact specs to the capability of a target
+// gateway. Each registered Transformation is scoped to one artifact kind and
+// applied only when its AppliesWhen predicate matches the target gateway version.
+//
+// Generators produce the canonical (latest) artifact shape unconditionally.
+// The registry's Transform call, invoked in the deploy orchestration layer
+// before the artifact is marshalled and stored, rewrites the spec to whatever
+// shape the target gateway understands.
+//
+// New version-boundary conversions are registered once, in a package init(),
+// without touching the deploy services. The deploy services call only
+// Default().Transform(kind, target, &spec).
+package deploymenttransform
+
+import "fmt"
+
+// Transformation adapts a canonical deployment spec so a target gateway version
+// can consume it. Scoped to one artifact kind; applied only when AppliesWhen
+// returns true for the target Version.
+type Transformation struct {
+	// Name identifies the transformation in logs and error messages.
+	Name string
+	// Kind is the artifact kind this transformation applies to
+	// (e.g. constants.LLMProvider, constants.LLMProxy).
+	Kind string
+	// AppliesWhen returns true when this transformation must be applied for
+	// the given target gateway version.
+	AppliesWhen func(target Version) bool
+	// Apply mutates the payload (a *dto.*DeploymentSpec) in place.
+	Apply func(payload any) error
+}
+
+// Registry holds registered Transformations and applies them in order.
+type Registry struct {
+	transformations []Transformation
+}
+
+// Register adds a Transformation to the registry. Transformations are applied
+// in registration order, so order matters when multiple transformations target
+// the same kind and version range.
+func (r *Registry) Register(t Transformation) {
+	r.transformations = append(r.transformations, t)
+}
+
+// Transform runs every registered Transformation whose Kind matches and
+// AppliesWhen(target) is true, in registration order. An unknown kind or a
+// target version that matches no Transformation is a no-op — the canonical
+// payload passes through unchanged.
+func (r *Registry) Transform(kind string, target Version, payload any) error {
+	for _, t := range r.transformations {
+		if t.Kind == kind && t.AppliesWhen(target) {
+			if err := t.Apply(payload); err != nil {
+				return fmt.Errorf("deploymenttransform %q: %w", t.Name, err)
+			}
+		}
+	}
+	return nil
+}
+
+// defaultRegistry is the package-level registry, pre-loaded by init() calls
+// in other files of this package.
+var defaultRegistry = &Registry{}
+
+// Default returns the package-level Registry. All transformations registered
+// via init() are available here.
+func Default() *Registry {
+	return defaultRegistry
+}

--- a/platform-api/src/internal/deploymenttransform/transform_test.go
+++ b/platform-api/src/internal/deploymenttransform/transform_test.go
@@ -1,0 +1,207 @@
+package deploymenttransform
+
+import (
+	"testing"
+
+	"platform-api/src/api"
+	"platform-api/src/internal/constants"
+	"platform-api/src/internal/dto"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// ParseVersion / GTE
+// ---------------------------------------------------------------------------
+
+func TestParseVersion(t *testing.T) {
+	minVer := ParseVersion(MinSplitPoliciesVersion)
+	tests := []struct {
+		version string
+		wantGTE bool // whether ParseVersion(version).GTE(minVer)
+	}{
+		// Old / empty → treated as 1.0.0
+		{"", false},
+		{"1.0.0", false},
+		{"1.1.0", false},
+		{"v1.1.0", false},
+		{"1.1.9", false},
+		// Boundary — 1.2.x is new
+		{"1.2.0", true},
+		{"v1.2.0", true},
+		{"1.2.0-SNAPSHOT", true},
+		{"1.2.1", true},
+		{"1.3.0", true},
+		{"2.0.0", true},
+		// Unparseable → treated as 1.0.0 (old)
+		{"not-a-version", false},
+		{"abc", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			assert.Equal(t, tt.wantGTE, ParseVersion(tt.version).GTE(minVer))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helper spec builders
+// ---------------------------------------------------------------------------
+
+func newProviderArtifact(global []api.Policy, operation []api.OperationPolicy, legacy []api.LLMPolicy) *dto.LLMProviderDeploymentYAML {
+	return &dto.LLMProviderDeploymentYAML{
+		ApiVersion: constants.GatewayApiVersion,
+		Kind:       constants.LLMProvider,
+		Spec: dto.LLMProviderDeploymentSpec{
+			DisplayName:       "test",
+			GlobalPolicies:    global,
+			OperationPolicies: operation,
+			Policies:          legacy,
+		},
+	}
+}
+
+func newProxyArtifact(global []api.Policy, operation []api.OperationPolicy, legacy []api.LLMPolicy) *dto.LLMProxyDeploymentYAML {
+	return &dto.LLMProxyDeploymentYAML{
+		ApiVersion: constants.GatewayApiVersion,
+		Kind:       constants.LLMProxy,
+		Spec: dto.LLMProxyDeploymentSpec{
+			DisplayName:       "test",
+			GlobalPolicies:    global,
+			OperationPolicies: operation,
+			Policies:          legacy,
+		},
+	}
+}
+
+func sampleGlobal() []api.Policy {
+	return []api.Policy{{Name: "basic-ratelimit", Version: "v1", Params: &map[string]interface{}{"requests": 10}}}
+}
+
+func sampleOperation() []api.OperationPolicy {
+	return []api.OperationPolicy{{
+		Name:    "basic-ratelimit",
+		Version: "v1",
+		Paths:   []api.OperationPolicyPath{{Path: "/chat/completions", Methods: []string{"GET"}}},
+	}}
+}
+
+func sampleLegacy() []api.LLMPolicy {
+	return []api.LLMPolicy{{Name: "basic-ratelimit", Version: "v1",
+		Paths: []api.LLMPolicyPath{{Path: "/*", Methods: []api.LLMPolicyPathMethods{"*"}}}}}
+}
+
+// ---------------------------------------------------------------------------
+// Registry.Transform — new gateway (≥ 1.2.0): canonical spec passes through
+//
+// In normal operation the generator (Phase 8a) always produces the canonical
+// shape (globalPolicies + operationPolicies, policies=nil) before Transform is
+// called. Transform is a no-op for new gateways — it has no registered
+// Transformation for them — so the canonical payload is stored unchanged.
+// ---------------------------------------------------------------------------
+
+func TestTransform_Provider_NewGateway_CanonicalPassthrough(t *testing.T) {
+	artifact := newProviderArtifact(sampleGlobal(), sampleOperation(), nil)
+	err := Default().Transform(constants.LLMProvider, ParseVersion(MinSplitPoliciesVersion), artifact)
+	require.NoError(t, err)
+	// New gateway: no-op — canonical shape and apiVersion preserved as-is.
+	assert.Equal(t, constants.GatewayApiVersion, artifact.ApiVersion)
+	assert.Len(t, artifact.Spec.GlobalPolicies, 1)
+	assert.Len(t, artifact.Spec.OperationPolicies, 1)
+	assert.Nil(t, artifact.Spec.Policies)
+}
+
+func TestTransform_Proxy_NewGateway_CanonicalPassthrough(t *testing.T) {
+	artifact := newProxyArtifact(sampleGlobal(), sampleOperation(), nil)
+	err := Default().Transform(constants.LLMProxy, ParseVersion("1.2.0-SNAPSHOT"), artifact)
+	require.NoError(t, err)
+	assert.Equal(t, constants.GatewayApiVersion, artifact.ApiVersion)
+	assert.Len(t, artifact.Spec.GlobalPolicies, 1)
+	assert.Len(t, artifact.Spec.OperationPolicies, 1)
+	assert.Nil(t, artifact.Spec.Policies)
+}
+
+// ---------------------------------------------------------------------------
+// Registry.Transform — old gateway (< 1.2.0): flattens to legacy policies
+// ---------------------------------------------------------------------------
+
+func TestTransform_Provider_OldGateway_FlattensToLegacy(t *testing.T) {
+	artifact := newProviderArtifact(sampleGlobal(), sampleOperation(), nil)
+	err := Default().Transform(constants.LLMProvider, ParseVersion("1.1.0"), artifact)
+	require.NoError(t, err)
+	// Old gateway: apiVersion downgraded and policies flattened.
+	assert.Equal(t, constants.GatewayApiVersionV1Alpha1, artifact.ApiVersion)
+	assert.Nil(t, artifact.Spec.GlobalPolicies)
+	assert.Nil(t, artifact.Spec.OperationPolicies)
+	require.Len(t, artifact.Spec.Policies, 2)
+	// Global policy → legacy entry with path "/*", methods ["*"]
+	var wildcardEntry, chatEntry *api.LLMPolicy
+	for i := range artifact.Spec.Policies {
+		if len(artifact.Spec.Policies[i].Paths) > 0 && artifact.Spec.Policies[i].Paths[0].Path == "/*" {
+			wildcardEntry = &artifact.Spec.Policies[i]
+		} else {
+			chatEntry = &artifact.Spec.Policies[i]
+		}
+	}
+	require.NotNil(t, wildcardEntry, "global policy must produce a /* legacy entry")
+	assert.Equal(t, api.LLMPolicyPathMethods("*"), wildcardEntry.Paths[0].Methods[0])
+	require.NotNil(t, chatEntry, "operation policy must be preserved with its path")
+	assert.Equal(t, "/chat/completions", chatEntry.Paths[0].Path)
+}
+
+func TestTransform_Provider_EmptyVersion_TreatedAsOld(t *testing.T) {
+	// Empty version string → ParseVersion returns 1.0.0 → old gateway.
+	artifact := newProviderArtifact(sampleGlobal(), nil, nil)
+	err := Default().Transform(constants.LLMProvider, ParseVersion(""), artifact)
+	require.NoError(t, err)
+	assert.Equal(t, constants.GatewayApiVersionV1Alpha1, artifact.ApiVersion)
+	assert.Nil(t, artifact.Spec.GlobalPolicies)
+	require.Len(t, artifact.Spec.Policies, 1)
+	assert.Equal(t, "/*", artifact.Spec.Policies[0].Paths[0].Path)
+}
+
+func TestTransform_Provider_OldGateway_AppendedToExistingLegacy(t *testing.T) {
+	// If the spec already has legacy policies (e.g. security/consumer entries
+	// that are present when the old-gateway path is tested in isolation),
+	// down-convert appends to them then re-orders.
+	existing := sampleLegacy()
+	artifact := newProviderArtifact(sampleGlobal(), nil, existing)
+	err := Default().Transform(constants.LLMProvider, ParseVersion("1.0.0"), artifact)
+	require.NoError(t, err)
+	assert.Equal(t, constants.GatewayApiVersionV1Alpha1, artifact.ApiVersion)
+	assert.Nil(t, artifact.Spec.GlobalPolicies)
+	// existing (1) + global flattened (1) = 2
+	assert.Len(t, artifact.Spec.Policies, 2)
+}
+
+func TestTransform_Proxy_OldGateway_FlattensToLegacy(t *testing.T) {
+	artifact := newProxyArtifact(sampleGlobal(), nil, nil)
+	err := Default().Transform(constants.LLMProxy, ParseVersion("1.0.0"), artifact)
+	require.NoError(t, err)
+	assert.Equal(t, constants.GatewayApiVersionV1Alpha1, artifact.ApiVersion)
+	assert.Nil(t, artifact.Spec.GlobalPolicies)
+	require.Len(t, artifact.Spec.Policies, 1)
+	assert.Equal(t, "/*", artifact.Spec.Policies[0].Paths[0].Path)
+}
+
+// ---------------------------------------------------------------------------
+// Registry dispatch — no-op for unknown kind; type error for wrong payload
+// ---------------------------------------------------------------------------
+
+func TestTransform_UnknownKind_Noop(t *testing.T) {
+	artifact := newProviderArtifact(sampleGlobal(), nil, nil)
+	err := Default().Transform("UnknownKind", ParseVersion("1.0.0"), artifact)
+	require.NoError(t, err)
+	// Unknown kind: no-op — artifact unchanged.
+	assert.Equal(t, constants.GatewayApiVersion, artifact.ApiVersion)
+	assert.Len(t, artifact.Spec.GlobalPolicies, 1)
+}
+
+func TestTransform_WrongPayloadType_ReturnsError(t *testing.T) {
+	// Passing a *dto.LLMProviderDeploymentYAML where LLMProxy is expected
+	// triggers the type-assertion guard in Apply.
+	artifact := newProviderArtifact(sampleGlobal(), nil, nil)
+	err := Default().Transform(constants.LLMProxy, ParseVersion("1.0.0"), artifact)
+	assert.Error(t, err)
+}

--- a/platform-api/src/internal/deploymenttransform/version.go
+++ b/platform-api/src/internal/deploymenttransform/version.go
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package deploymenttransform
+
+import (
+	"strconv"
+	"strings"
+)
+
+// MinSplitPoliciesVersion is the first gateway release that understands
+// globalPolicies/operationPolicies. Use this constant in tests and call sites
+// instead of a raw string literal so a future version-boundary change is a
+// one-place edit.
+const MinSplitPoliciesVersion = "1.2.0"
+
+// Version is a parsed, comparable gateway semver. Empty or unparseable version
+// strings are treated as 1.0.0 — the implicit version for gateways that predate
+// version reporting.
+type Version struct {
+	Major, Minor, Patch int
+}
+
+// ParseVersion parses a gateway version string into a Version. Pre-release
+// suffixes (e.g. "-SNAPSHOT", "-RC1") and a leading "v" are stripped before
+// parsing. An empty or unparseable string returns Version{1, 0, 0}.
+func ParseVersion(s string) Version {
+	v := strings.TrimSpace(s)
+	if v == "" {
+		return Version{1, 0, 0}
+	}
+	// Strip pre-release suffix
+	if i := strings.IndexByte(v, '-'); i >= 0 {
+		v = v[:i]
+	}
+	// Strip leading "v"
+	v = strings.TrimPrefix(strings.ToLower(v), "v")
+	parts := strings.SplitN(v, ".", 3)
+	for len(parts) < 3 {
+		parts = append(parts, "0")
+	}
+	major, err1 := strconv.Atoi(parts[0])
+	minor, err2 := strconv.Atoi(parts[1])
+	patch, err3 := strconv.Atoi(parts[2])
+	if err1 != nil || err2 != nil || err3 != nil {
+		return Version{1, 0, 0} // unparseable → treat as oldest known
+	}
+	return Version{major, minor, patch}
+}
+
+// GTE reports whether v is greater than or equal to o.
+func (v Version) GTE(o Version) bool {
+	if v.Major != o.Major {
+		return v.Major > o.Major
+	}
+	if v.Minor != o.Minor {
+		return v.Minor > o.Minor
+	}
+	return v.Patch >= o.Patch
+}

--- a/platform-api/src/internal/dto/llm_deployment.go
+++ b/platform-api/src/internal/dto/llm_deployment.go
@@ -30,16 +30,16 @@ type LLMProviderDeploymentYAML struct {
 
 // LLMProviderDeploymentSpec represents the spec section for LLM provider deployments
 type LLMProviderDeploymentSpec struct {
-	DisplayName       string                  `yaml:"displayName"`
-	Version           string                  `yaml:"version"`
-	Context           string                  `yaml:"context,omitempty"`
-	VHost             string                  `yaml:"vhost,omitempty"`
-	Template          string                  `yaml:"template"`
-	Upstream          LLMUpstreamYAML         `yaml:"upstream"`
-	AccessControl     api.LLMAccessControl    `yaml:"accessControl"`
-	GlobalPolicies    []api.Policy            `yaml:"globalPolicies,omitempty"`
-	OperationPolicies []api.OperationPolicy   `yaml:"operationPolicies,omitempty"`
-	Policies          []api.LLMPolicy          `yaml:"policies,omitempty"`
+	DisplayName       string                `yaml:"displayName"`
+	Version           string                `yaml:"version"`
+	Context           string                `yaml:"context,omitempty"`
+	VHost             string                `yaml:"vhost,omitempty"`
+	Template          string                `yaml:"template"`
+	Upstream          LLMUpstreamYAML       `yaml:"upstream"`
+	AccessControl     api.LLMAccessControl  `yaml:"accessControl"`
+	GlobalPolicies    []api.Policy          `yaml:"globalPolicies,omitempty"`
+	OperationPolicies []api.OperationPolicy `yaml:"operationPolicies,omitempty"`
+	Policies          []api.LLMPolicy       `yaml:"policies,omitempty"`
 }
 
 // LLMUpstreamYAML represents the upstream configuration for LLM provider deployments
@@ -61,14 +61,14 @@ type LLMProxyDeploymentYAML struct {
 
 // LLMProxyDeploymentSpec represents the spec section for LLM proxy deployments
 type LLMProxyDeploymentSpec struct {
-	DisplayName       string                   `yaml:"displayName"`
-	Version           string                   `yaml:"version"`
-	Context           string                   `yaml:"context,omitempty"`
-	VHost             string                   `yaml:"vhost,omitempty"`
+	DisplayName       string                     `yaml:"displayName"`
+	Version           string                     `yaml:"version"`
+	Context           string                     `yaml:"context,omitempty"`
+	VHost             string                     `yaml:"vhost,omitempty"`
 	Provider          LLMProxyDeploymentProvider `yaml:"provider"`
-	GlobalPolicies    []api.Policy           `yaml:"globalPolicies,omitempty"`
-	OperationPolicies []api.OperationPolicy  `yaml:"operationPolicies,omitempty"`
-	Policies          []api.LLMPolicy          `yaml:"policies,omitempty"`
+	GlobalPolicies    []api.Policy               `yaml:"globalPolicies,omitempty"`
+	OperationPolicies []api.OperationPolicy      `yaml:"operationPolicies,omitempty"`
+	Policies          []api.LLMPolicy            `yaml:"policies,omitempty"`
 }
 
 type LLMProxyDeploymentProvider struct {

--- a/platform-api/src/internal/dto/llm_deployment.go
+++ b/platform-api/src/internal/dto/llm_deployment.go
@@ -30,14 +30,16 @@ type LLMProviderDeploymentYAML struct {
 
 // LLMProviderDeploymentSpec represents the spec section for LLM provider deployments
 type LLMProviderDeploymentSpec struct {
-	DisplayName   string           `yaml:"displayName"`
-	Version       string           `yaml:"version"`
-	Context       string           `yaml:"context,omitempty"`
-	VHost         string           `yaml:"vhost,omitempty"`
-	Template      string           `yaml:"template"`
-	Upstream      LLMUpstreamYAML  `yaml:"upstream"`
-	AccessControl api.LLMAccessControl `yaml:"accessControl"`
-	Policies      []api.LLMPolicy  `yaml:"policies,omitempty"`
+	DisplayName       string                  `yaml:"displayName"`
+	Version           string                  `yaml:"version"`
+	Context           string                  `yaml:"context,omitempty"`
+	VHost             string                  `yaml:"vhost,omitempty"`
+	Template          string                  `yaml:"template"`
+	Upstream          LLMUpstreamYAML         `yaml:"upstream"`
+	AccessControl     api.LLMAccessControl    `yaml:"accessControl"`
+	GlobalPolicies    []api.Policy            `yaml:"globalPolicies,omitempty"`
+	OperationPolicies []api.OperationPolicy   `yaml:"operationPolicies,omitempty"`
+	Policies          []api.LLMPolicy          `yaml:"policies,omitempty"`
 }
 
 // LLMUpstreamYAML represents the upstream configuration for LLM provider deployments
@@ -59,12 +61,14 @@ type LLMProxyDeploymentYAML struct {
 
 // LLMProxyDeploymentSpec represents the spec section for LLM proxy deployments
 type LLMProxyDeploymentSpec struct {
-	DisplayName string                     `yaml:"displayName"`
-	Version     string                     `yaml:"version"`
-	Context     string                     `yaml:"context,omitempty"`
-	VHost       string                     `yaml:"vhost,omitempty"`
-	Provider    LLMProxyDeploymentProvider `yaml:"provider"`
-	Policies    []api.LLMPolicy            `yaml:"policies,omitempty"`
+	DisplayName       string                   `yaml:"displayName"`
+	Version           string                   `yaml:"version"`
+	Context           string                   `yaml:"context,omitempty"`
+	VHost             string                   `yaml:"vhost,omitempty"`
+	Provider          LLMProxyDeploymentProvider `yaml:"provider"`
+	GlobalPolicies    []api.Policy           `yaml:"globalPolicies,omitempty"`
+	OperationPolicies []api.OperationPolicy  `yaml:"operationPolicies,omitempty"`
+	Policies          []api.LLMPolicy          `yaml:"policies,omitempty"`
 }
 
 type LLMProxyDeploymentProvider struct {

--- a/platform-api/src/internal/handler/api.go
+++ b/platform-api/src/internal/handler/api.go
@@ -48,7 +48,7 @@ func NewAPIHandler(apiService *service.APIService, slogger *slog.Logger) *APIHan
 	}
 }
 
-// CreateAPI handles POST /api/v1/rest-apis and creates a new API
+// CreateAPI handles POST /api/v1alpha2/rest-apis and creates a new API
 func (h *APIHandler) CreateAPI(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -168,7 +168,7 @@ func (h *APIHandler) CreateAPI(c *gin.Context) {
 	c.JSON(http.StatusCreated, apiResponse)
 }
 
-// GetAPI handles GET /api/v1/rest-apis/:apiId and retrieves an API by its handle
+// GetAPI handles GET /api/v1alpha2/rest-apis/:apiId and retrieves an API by its handle
 func (h *APIHandler) GetAPI(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -201,7 +201,7 @@ func (h *APIHandler) GetAPI(c *gin.Context) {
 	c.JSON(http.StatusOK, apiResponse)
 }
 
-// ListAPIs handles GET /api/v1/rest-apis and lists APIs for an organization filtered by project
+// ListAPIs handles GET /api/v1alpha2/rest-apis and lists APIs for an organization filtered by project
 func (h *APIHandler) ListAPIs(c *gin.Context) {
 	// Get organization from JWT token
 	orgId, exists := middleware.GetOrganizationFromContext(c)
@@ -319,7 +319,7 @@ func (h *APIHandler) UpdateAPI(c *gin.Context) {
 	c.JSON(http.StatusOK, apiResponse)
 }
 
-// DeleteAPI handles DELETE /api/v1/rest-apis/:apiId and deletes an API by its handle
+// DeleteAPI handles DELETE /api/v1alpha2/rest-apis/:apiId and deletes an API by its handle
 func (h *APIHandler) DeleteAPI(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -352,7 +352,7 @@ func (h *APIHandler) DeleteAPI(c *gin.Context) {
 	c.JSON(http.StatusNoContent, nil)
 }
 
-// AddGatewaysToAPI handles POST /api/v1/rest-apis/:apiId/gateways to associate gateways with an API
+// AddGatewaysToAPI handles POST /api/v1alpha2/rest-apis/:apiId/gateways to associate gateways with an API
 func (h *APIHandler) AddGatewaysToAPI(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -409,7 +409,7 @@ func (h *APIHandler) AddGatewaysToAPI(c *gin.Context) {
 	c.JSON(http.StatusOK, gatewaysResponse)
 }
 
-// GetAPIGateways handles GET /api/v1/rest-apis/:apiId/gateways to get gateways associated with an API including deployment details
+// GetAPIGateways handles GET /api/v1alpha2/rest-apis/:apiId/gateways to get gateways associated with an API including deployment details
 func (h *APIHandler) GetAPIGateways(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -442,7 +442,7 @@ func (h *APIHandler) GetAPIGateways(c *gin.Context) {
 	c.JSON(http.StatusOK, gatewaysResponse)
 }
 
-// PublishToDevPortal handles POST /api/v1/rest-apis/:apiId/publications
+// PublishToDevPortal handles POST /api/v1alpha2/rest-apis/:apiId/publications
 func (h *APIHandler) PublishToDevPortal(c *gin.Context) {
 	// Extract organization ID from context
 	orgID, exists := middleware.GetOrganizationFromContext(c)
@@ -487,7 +487,7 @@ func (h *APIHandler) PublishToDevPortal(c *gin.Context) {
 	})
 }
 
-// UnpublishFromDevPortal handles DELETE /api/v1/rest-apis/:apiId/publications/:devportalId
+// UnpublishFromDevPortal handles DELETE /api/v1alpha2/rest-apis/:apiId/publications/:devportalId
 func (h *APIHandler) UnpublishFromDevPortal(c *gin.Context) {
 	orgID, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -526,7 +526,7 @@ func (h *APIHandler) UnpublishFromDevPortal(c *gin.Context) {
 	})
 }
 
-// GetAPIPublications handles GET /api/v1/rest-apis/:apiId/publications
+// GetAPIPublications handles GET /api/v1alpha2/rest-apis/:apiId/publications
 //
 // This endpoint retrieves all DevPortals associated with an API including publication details.
 func (h *APIHandler) GetAPIPublications(c *gin.Context) {
@@ -567,7 +567,7 @@ func (h *APIHandler) GetAPIPublications(c *gin.Context) {
 	c.JSON(http.StatusOK, response)
 }
 
-// ImportAPIProject handles POST /api/v1/import/api-project
+// ImportAPIProject handles POST /api/v1alpha2/import/api-project
 func (h *APIHandler) ImportAPIProject(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -924,7 +924,7 @@ func (h *APIHandler) ImportOpenAPI(c *gin.Context) {
 	c.JSON(http.StatusCreated, apiResponse)
 }
 
-// ValidateAPI handles GET /api/v1/rest-apis?name=&version=
+// ValidateAPI handles GET /api/v1alpha2/rest-apis?name=&version=
 func (h *APIHandler) ValidateAPI(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -975,7 +975,7 @@ func (h *APIHandler) ValidateAPI(c *gin.Context) {
 // RegisterRoutes registers all API routes
 func (h *APIHandler) RegisterRoutes(r *gin.Engine) {
 	h.slogger.Debug("Registering REST API routes")
-	apiGroup := r.Group("/api/v1/rest-apis")
+	apiGroup := r.Group(constants.APIBasePath + "/rest-apis")
 	{
 		apiGroup.POST("", h.CreateAPI)
 		apiGroup.GET("", h.ListAPIs)
@@ -991,7 +991,7 @@ func (h *APIHandler) RegisterRoutes(r *gin.Engine) {
 		apiGroup.GET("/:apiId/publications", h.GetAPIPublications)
 
 	}
-	apiProjectsGroup := r.Group("/api/v1/api-projects")
+	apiProjectsGroup := r.Group(constants.APIBasePath + "/api-projects")
 	{
 		apiProjectsGroup.POST("/import", h.ImportAPIProject)
 		apiProjectsGroup.POST("/validate", h.ValidateAPIProject)

--- a/platform-api/src/internal/handler/api.go
+++ b/platform-api/src/internal/handler/api.go
@@ -567,7 +567,7 @@ func (h *APIHandler) GetAPIPublications(c *gin.Context) {
 	c.JSON(http.StatusOK, response)
 }
 
-// ImportAPIProject handles POST /api/v1alpha2/import/api-project
+// ImportAPIProject handles POST /api/v1alpha2/api-projects/import
 func (h *APIHandler) ImportAPIProject(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {

--- a/platform-api/src/internal/handler/api.go
+++ b/platform-api/src/internal/handler/api.go
@@ -48,7 +48,7 @@ func NewAPIHandler(apiService *service.APIService, slogger *slog.Logger) *APIHan
 	}
 }
 
-// CreateAPI handles POST /api/v1alpha2/rest-apis and creates a new API
+// CreateAPI handles POST /api/v0.9/rest-apis and creates a new API
 func (h *APIHandler) CreateAPI(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -168,7 +168,7 @@ func (h *APIHandler) CreateAPI(c *gin.Context) {
 	c.JSON(http.StatusCreated, apiResponse)
 }
 
-// GetAPI handles GET /api/v1alpha2/rest-apis/:apiId and retrieves an API by its handle
+// GetAPI handles GET /api/v0.9/rest-apis/:apiId and retrieves an API by its handle
 func (h *APIHandler) GetAPI(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -201,7 +201,7 @@ func (h *APIHandler) GetAPI(c *gin.Context) {
 	c.JSON(http.StatusOK, apiResponse)
 }
 
-// ListAPIs handles GET /api/v1alpha2/rest-apis and lists APIs for an organization filtered by project
+// ListAPIs handles GET /api/v0.9/rest-apis and lists APIs for an organization filtered by project
 func (h *APIHandler) ListAPIs(c *gin.Context) {
 	// Get organization from JWT token
 	orgId, exists := middleware.GetOrganizationFromContext(c)
@@ -319,7 +319,7 @@ func (h *APIHandler) UpdateAPI(c *gin.Context) {
 	c.JSON(http.StatusOK, apiResponse)
 }
 
-// DeleteAPI handles DELETE /api/v1alpha2/rest-apis/:apiId and deletes an API by its handle
+// DeleteAPI handles DELETE /api/v0.9/rest-apis/:apiId and deletes an API by its handle
 func (h *APIHandler) DeleteAPI(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -352,7 +352,7 @@ func (h *APIHandler) DeleteAPI(c *gin.Context) {
 	c.JSON(http.StatusNoContent, nil)
 }
 
-// AddGatewaysToAPI handles POST /api/v1alpha2/rest-apis/:apiId/gateways to associate gateways with an API
+// AddGatewaysToAPI handles POST /api/v0.9/rest-apis/:apiId/gateways to associate gateways with an API
 func (h *APIHandler) AddGatewaysToAPI(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -409,7 +409,7 @@ func (h *APIHandler) AddGatewaysToAPI(c *gin.Context) {
 	c.JSON(http.StatusOK, gatewaysResponse)
 }
 
-// GetAPIGateways handles GET /api/v1alpha2/rest-apis/:apiId/gateways to get gateways associated with an API including deployment details
+// GetAPIGateways handles GET /api/v0.9/rest-apis/:apiId/gateways to get gateways associated with an API including deployment details
 func (h *APIHandler) GetAPIGateways(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -442,7 +442,7 @@ func (h *APIHandler) GetAPIGateways(c *gin.Context) {
 	c.JSON(http.StatusOK, gatewaysResponse)
 }
 
-// PublishToDevPortal handles POST /api/v1alpha2/rest-apis/:apiId/publications
+// PublishToDevPortal handles POST /api/v0.9/rest-apis/:apiId/publications
 func (h *APIHandler) PublishToDevPortal(c *gin.Context) {
 	// Extract organization ID from context
 	orgID, exists := middleware.GetOrganizationFromContext(c)
@@ -487,7 +487,7 @@ func (h *APIHandler) PublishToDevPortal(c *gin.Context) {
 	})
 }
 
-// UnpublishFromDevPortal handles DELETE /api/v1alpha2/rest-apis/:apiId/publications/:devportalId
+// UnpublishFromDevPortal handles DELETE /api/v0.9/rest-apis/:apiId/publications/:devportalId
 func (h *APIHandler) UnpublishFromDevPortal(c *gin.Context) {
 	orgID, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -526,7 +526,7 @@ func (h *APIHandler) UnpublishFromDevPortal(c *gin.Context) {
 	})
 }
 
-// GetAPIPublications handles GET /api/v1alpha2/rest-apis/:apiId/publications
+// GetAPIPublications handles GET /api/v0.9/rest-apis/:apiId/publications
 //
 // This endpoint retrieves all DevPortals associated with an API including publication details.
 func (h *APIHandler) GetAPIPublications(c *gin.Context) {
@@ -567,7 +567,7 @@ func (h *APIHandler) GetAPIPublications(c *gin.Context) {
 	c.JSON(http.StatusOK, response)
 }
 
-// ImportAPIProject handles POST /api/v1alpha2/api-projects/import
+// ImportAPIProject handles POST /api/v0.9/api-projects/import
 func (h *APIHandler) ImportAPIProject(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -924,7 +924,7 @@ func (h *APIHandler) ImportOpenAPI(c *gin.Context) {
 	c.JSON(http.StatusCreated, apiResponse)
 }
 
-// ValidateAPI handles GET /api/v1alpha2/rest-apis?name=&version=
+// ValidateAPI handles GET /api/v0.9/rest-apis?name=&version=
 func (h *APIHandler) ValidateAPI(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {

--- a/platform-api/src/internal/handler/api_key.go
+++ b/platform-api/src/internal/handler/api_key.go
@@ -288,7 +288,7 @@ func (h *APIKeyHandler) RevokeAPIKey(c *gin.Context) {
 // RegisterRoutes registers API key routes with the router
 func (h *APIKeyHandler) RegisterRoutes(r *gin.Engine) {
 	h.slogger.Debug("Registering API key routes")
-	apiKeyGroup := r.Group("/api/v1/rest-apis/:apiId/api-keys")
+	apiKeyGroup := r.Group(constants.APIBasePath + "/rest-apis/:apiId/api-keys")
 	{
 		apiKeyGroup.POST("", h.CreateAPIKey)
 		apiKeyGroup.PUT("/:keyName", h.UpdateAPIKey)

--- a/platform-api/src/internal/handler/apikey_user.go
+++ b/platform-api/src/internal/handler/apikey_user.go
@@ -44,7 +44,7 @@ func NewAPIKeyUserHandler(apiKeyUserService *service.APIKeyUserService, slogger 
 	}
 }
 
-// ListUserAPIKeys handles GET /api/v1alpha2/me/api-keys
+// ListUserAPIKeys handles GET /api/v0.9/me/api-keys
 func (h *APIKeyUserHandler) ListUserAPIKeys(c *gin.Context) {
 	orgID, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {

--- a/platform-api/src/internal/handler/apikey_user.go
+++ b/platform-api/src/internal/handler/apikey_user.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"strings"
 
+	"platform-api/src/internal/constants"
 	"platform-api/src/internal/middleware"
 	"platform-api/src/internal/service"
 	"platform-api/src/internal/utils"
@@ -43,7 +44,7 @@ func NewAPIKeyUserHandler(apiKeyUserService *service.APIKeyUserService, slogger 
 	}
 }
 
-// ListUserAPIKeys handles GET /api/v1/me/api-keys
+// ListUserAPIKeys handles GET /api/v1alpha2/me/api-keys
 func (h *APIKeyUserHandler) ListUserAPIKeys(c *gin.Context) {
 	orgID, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -72,5 +73,5 @@ func (h *APIKeyUserHandler) ListUserAPIKeys(c *gin.Context) {
 
 // RegisterRoutes registers the user API key routes.
 func (h *APIKeyUserHandler) RegisterRoutes(r *gin.Engine) {
-	r.GET("/api/v1/me/api-keys", h.ListUserAPIKeys)
+	r.GET(constants.APIBasePath + "/me/api-keys", h.ListUserAPIKeys)
 }

--- a/platform-api/src/internal/handler/application.go
+++ b/platform-api/src/internal/handler/application.go
@@ -437,7 +437,7 @@ func (h *ApplicationHandler) RemoveApplicationAPIKey(c *gin.Context) {
 }
 
 func (h *ApplicationHandler) RegisterRoutes(r *gin.Engine) {
-	applicationGroup := r.Group("/api/v1/applications")
+	applicationGroup := r.Group(constants.APIBasePath + "/applications")
 	{
 		applicationGroup.GET("", h.ListApplications)
 		applicationGroup.POST("", h.CreateApplication)

--- a/platform-api/src/internal/handler/deployment.go
+++ b/platform-api/src/internal/handler/deployment.go
@@ -44,7 +44,7 @@ func NewDeploymentHandler(deploymentService *service.DeploymentService, slogger 
 	}
 }
 
-// DeployAPI handles POST /api/v1alpha2/apis/:apiId/deploy
+// DeployAPI handles POST /api/v1alpha2/rest-apis/:apiId/deployments
 // Creates a new immutable deployment artifact and deploys it to a gateway
 func (h *DeploymentHandler) DeployAPI(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
@@ -256,7 +256,7 @@ func (h *DeploymentHandler) RestoreDeployment(c *gin.Context) {
 	c.JSON(http.StatusOK, deployment)
 }
 
-// DeleteDeployment handles DELETE /api/v1alpha2/apis/:apiId/deployments/:deploymentId
+// DeleteDeployment handles DELETE /api/v1alpha2/rest-apis/:apiId/deployments/:deploymentId
 // Permanently deletes an undeployed deployment artifact
 func (h *DeploymentHandler) DeleteDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
@@ -305,7 +305,7 @@ func (h *DeploymentHandler) DeleteDeployment(c *gin.Context) {
 	c.JSON(http.StatusNoContent, nil)
 }
 
-// GetDeployment handles GET /api/v1alpha2/apis/:apiId/deployments/:deploymentId
+// GetDeployment handles GET /api/v1alpha2/rest-apis/:apiId/deployments/:deploymentId
 // Retrieves metadata for a specific deployment artifact
 func (h *DeploymentHandler) GetDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
@@ -350,7 +350,7 @@ func (h *DeploymentHandler) GetDeployment(c *gin.Context) {
 	c.JSON(http.StatusOK, deployment)
 }
 
-// GetDeployments handles GET /api/v1alpha2/apis/:apiId/deployments
+// GetDeployments handles GET /api/v1alpha2/rest-apis/:apiId/deployments
 // Retrieves all deployment records for an API with optional filters
 func (h *DeploymentHandler) GetDeployments(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)

--- a/platform-api/src/internal/handler/deployment.go
+++ b/platform-api/src/internal/handler/deployment.go
@@ -44,7 +44,7 @@ func NewDeploymentHandler(deploymentService *service.DeploymentService, slogger 
 	}
 }
 
-// DeployAPI handles POST /api/v1/apis/:apiId/deploy
+// DeployAPI handles POST /api/v1alpha2/apis/:apiId/deploy
 // Creates a new immutable deployment artifact and deploys it to a gateway
 func (h *DeploymentHandler) DeployAPI(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
@@ -130,7 +130,7 @@ func (h *DeploymentHandler) DeployAPI(c *gin.Context) {
 	c.JSON(http.StatusCreated, deployment)
 }
 
-// UndeployDeployment handles POST /api/v1/rest-apis/:apiId/deployments/:deploymentId/undeploy
+// UndeployDeployment handles POST /api/v1alpha2/rest-apis/:apiId/deployments/:deploymentId/undeploy
 func (h *DeploymentHandler) UndeployDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -198,7 +198,7 @@ func (h *DeploymentHandler) UndeployDeployment(c *gin.Context) {
 	c.JSON(http.StatusOK, deployment)
 }
 
-// RestoreDeployment handles POST /api/v1/rest-apis/:apiId/deployments/:deploymentId/restore
+// RestoreDeployment handles POST /api/v1alpha2/rest-apis/:apiId/deployments/:deploymentId/restore
 func (h *DeploymentHandler) RestoreDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -256,7 +256,7 @@ func (h *DeploymentHandler) RestoreDeployment(c *gin.Context) {
 	c.JSON(http.StatusOK, deployment)
 }
 
-// DeleteDeployment handles DELETE /api/v1/apis/:apiId/deployments/:deploymentId
+// DeleteDeployment handles DELETE /api/v1alpha2/apis/:apiId/deployments/:deploymentId
 // Permanently deletes an undeployed deployment artifact
 func (h *DeploymentHandler) DeleteDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
@@ -305,7 +305,7 @@ func (h *DeploymentHandler) DeleteDeployment(c *gin.Context) {
 	c.JSON(http.StatusNoContent, nil)
 }
 
-// GetDeployment handles GET /api/v1/apis/:apiId/deployments/:deploymentId
+// GetDeployment handles GET /api/v1alpha2/apis/:apiId/deployments/:deploymentId
 // Retrieves metadata for a specific deployment artifact
 func (h *DeploymentHandler) GetDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
@@ -350,7 +350,7 @@ func (h *DeploymentHandler) GetDeployment(c *gin.Context) {
 	c.JSON(http.StatusOK, deployment)
 }
 
-// GetDeployments handles GET /api/v1/apis/:apiId/deployments
+// GetDeployments handles GET /api/v1alpha2/apis/:apiId/deployments
 // Retrieves all deployment records for an API with optional filters
 func (h *DeploymentHandler) GetDeployments(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
@@ -405,7 +405,7 @@ func (h *DeploymentHandler) GetDeployments(c *gin.Context) {
 // RegisterRoutes registers all deployment-related routes
 func (h *DeploymentHandler) RegisterRoutes(r *gin.Engine) {
 	h.slogger.Debug("Registering deployment routes")
-	apiGroup := r.Group("/api/v1/rest-apis/:apiId")
+	apiGroup := r.Group(constants.APIBasePath + "/rest-apis/:apiId")
 	{
 		apiGroup.POST("/deployments", h.DeployAPI)
 		apiGroup.POST("/deployments/:deploymentId/undeploy", h.UndeployDeployment)

--- a/platform-api/src/internal/handler/deployment.go
+++ b/platform-api/src/internal/handler/deployment.go
@@ -44,7 +44,7 @@ func NewDeploymentHandler(deploymentService *service.DeploymentService, slogger 
 	}
 }
 
-// DeployAPI handles POST /api/v1alpha2/rest-apis/:apiId/deployments
+// DeployAPI handles POST /api/v0.9/rest-apis/:apiId/deployments
 // Creates a new immutable deployment artifact and deploys it to a gateway
 func (h *DeploymentHandler) DeployAPI(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
@@ -130,7 +130,7 @@ func (h *DeploymentHandler) DeployAPI(c *gin.Context) {
 	c.JSON(http.StatusCreated, deployment)
 }
 
-// UndeployDeployment handles POST /api/v1alpha2/rest-apis/:apiId/deployments/:deploymentId/undeploy
+// UndeployDeployment handles POST /api/v0.9/rest-apis/:apiId/deployments/:deploymentId/undeploy
 func (h *DeploymentHandler) UndeployDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -198,7 +198,7 @@ func (h *DeploymentHandler) UndeployDeployment(c *gin.Context) {
 	c.JSON(http.StatusOK, deployment)
 }
 
-// RestoreDeployment handles POST /api/v1alpha2/rest-apis/:apiId/deployments/:deploymentId/restore
+// RestoreDeployment handles POST /api/v0.9/rest-apis/:apiId/deployments/:deploymentId/restore
 func (h *DeploymentHandler) RestoreDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -256,7 +256,7 @@ func (h *DeploymentHandler) RestoreDeployment(c *gin.Context) {
 	c.JSON(http.StatusOK, deployment)
 }
 
-// DeleteDeployment handles DELETE /api/v1alpha2/rest-apis/:apiId/deployments/:deploymentId
+// DeleteDeployment handles DELETE /api/v0.9/rest-apis/:apiId/deployments/:deploymentId
 // Permanently deletes an undeployed deployment artifact
 func (h *DeploymentHandler) DeleteDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
@@ -305,7 +305,7 @@ func (h *DeploymentHandler) DeleteDeployment(c *gin.Context) {
 	c.JSON(http.StatusNoContent, nil)
 }
 
-// GetDeployment handles GET /api/v1alpha2/rest-apis/:apiId/deployments/:deploymentId
+// GetDeployment handles GET /api/v0.9/rest-apis/:apiId/deployments/:deploymentId
 // Retrieves metadata for a specific deployment artifact
 func (h *DeploymentHandler) GetDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
@@ -350,7 +350,7 @@ func (h *DeploymentHandler) GetDeployment(c *gin.Context) {
 	c.JSON(http.StatusOK, deployment)
 }
 
-// GetDeployments handles GET /api/v1alpha2/rest-apis/:apiId/deployments
+// GetDeployments handles GET /api/v0.9/rest-apis/:apiId/deployments
 // Retrieves all deployment records for an API with optional filters
 func (h *DeploymentHandler) GetDeployments(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)

--- a/platform-api/src/internal/handler/devportal.go
+++ b/platform-api/src/internal/handler/devportal.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"platform-api/src/api"
+	"platform-api/src/internal/constants"
 	"platform-api/src/internal/middleware"
 	"platform-api/src/internal/service"
 	"platform-api/src/internal/utils"
@@ -45,7 +46,7 @@ func NewDevPortalHandler(devPortalService *service.DevPortalService, logger *slo
 	}
 }
 
-// CreateDevPortal handles POST /api/v1/devportals
+// CreateDevPortal handles POST /api/v1alpha2/devportals
 func (h *DevPortalHandler) CreateDevPortal(c *gin.Context) {
 	// Extract organization ID from context
 	orgID, exists := middleware.GetOrganizationFromContext(c)
@@ -80,7 +81,7 @@ func (h *DevPortalHandler) CreateDevPortal(c *gin.Context) {
 	c.JSON(http.StatusCreated, response)
 }
 
-// GetDevPortal handles GET /api/v1/devportals/:devportalId
+// GetDevPortal handles GET /api/v1alpha2/devportals/:devportalId
 func (h *DevPortalHandler) GetDevPortal(c *gin.Context) {
 	// Extract organization ID from context
 	orgID, exists := middleware.GetOrganizationFromContext(c)
@@ -110,7 +111,7 @@ func (h *DevPortalHandler) GetDevPortal(c *gin.Context) {
 	c.JSON(http.StatusOK, response)
 }
 
-// ListDevPortals handles GET /api/v1/devportals
+// ListDevPortals handles GET /api/v1alpha2/devportals
 func (h *DevPortalHandler) ListDevPortals(c *gin.Context) {
 	// Extract organization ID from context
 	orgID, exists := middleware.GetOrganizationFromContext(c)
@@ -163,7 +164,7 @@ func (h *DevPortalHandler) ListDevPortals(c *gin.Context) {
 	c.JSON(http.StatusOK, response)
 }
 
-// UpdateDevPortal handles PUT /api/v1/devportals/:devportalId
+// UpdateDevPortal handles PUT /api/v1alpha2/devportals/:devportalId
 func (h *DevPortalHandler) UpdateDevPortal(c *gin.Context) {
 	// Extract organization ID from context
 	orgID, exists := middleware.GetOrganizationFromContext(c)
@@ -206,7 +207,7 @@ func (h *DevPortalHandler) UpdateDevPortal(c *gin.Context) {
 	c.JSON(http.StatusOK, response)
 }
 
-// DeleteDevPortal handles DELETE /api/v1/devportals/:devportalId
+// DeleteDevPortal handles DELETE /api/v1alpha2/devportals/:devportalId
 func (h *DevPortalHandler) DeleteDevPortal(c *gin.Context) {
 	// Extract organization ID from context
 	orgID, exists := middleware.GetOrganizationFromContext(c)
@@ -239,7 +240,7 @@ func (h *DevPortalHandler) DeleteDevPortal(c *gin.Context) {
 	c.JSON(http.StatusNoContent, nil)
 }
 
-// ActivateDevPortal handles POST /api/v1/devportals/:devportalId/activate
+// ActivateDevPortal handles POST /api/v1alpha2/devportals/:devportalId/activate
 func (h *DevPortalHandler) ActivateDevPortal(c *gin.Context) {
 	// Extract organization ID from context
 	orgID, exists := middleware.GetOrganizationFromContext(c)
@@ -277,7 +278,7 @@ func (h *DevPortalHandler) ActivateDevPortal(c *gin.Context) {
 	})
 }
 
-// DeactivateDevPortal handles POST /api/v1/devportals/:devportalId/deactivate
+// DeactivateDevPortal handles POST /api/v1alpha2/devportals/:devportalId/deactivate
 func (h *DevPortalHandler) DeactivateDevPortal(c *gin.Context) {
 	// Extract organization ID from context
 	orgID, exists := middleware.GetOrganizationFromContext(c)
@@ -315,7 +316,7 @@ func (h *DevPortalHandler) DeactivateDevPortal(c *gin.Context) {
 	})
 }
 
-// SetAsDefault handles POST /api/v1/devportals/:devportalId/set-default
+// SetAsDefault handles POST /api/v1alpha2/devportals/:devportalId/set-default
 func (h *DevPortalHandler) SetAsDefault(c *gin.Context) {
 	// Extract organization ID from context
 	orgID, exists := middleware.GetOrganizationFromContext(c)
@@ -373,7 +374,7 @@ func (h *DevPortalHandler) GetDefaultDevPortal(c *gin.Context) {
 // RegisterRoutes registers all DevPortal routes
 func (h *DevPortalHandler) RegisterRoutes(r *gin.Engine) {
 	h.logger.Debug("Registering DevPortal routes")
-	v1 := r.Group("/api/v1")
+	v1 := r.Group(constants.APIBasePath)
 	{
 		// DevPortal CRUD operations
 		v1.POST("/devportals", h.CreateDevPortal)

--- a/platform-api/src/internal/handler/devportal.go
+++ b/platform-api/src/internal/handler/devportal.go
@@ -46,7 +46,7 @@ func NewDevPortalHandler(devPortalService *service.DevPortalService, logger *slo
 	}
 }
 
-// CreateDevPortal handles POST /api/v1alpha2/devportals
+// CreateDevPortal handles POST /api/v0.9/devportals
 func (h *DevPortalHandler) CreateDevPortal(c *gin.Context) {
 	// Extract organization ID from context
 	orgID, exists := middleware.GetOrganizationFromContext(c)
@@ -81,7 +81,7 @@ func (h *DevPortalHandler) CreateDevPortal(c *gin.Context) {
 	c.JSON(http.StatusCreated, response)
 }
 
-// GetDevPortal handles GET /api/v1alpha2/devportals/:devportalId
+// GetDevPortal handles GET /api/v0.9/devportals/:devportalId
 func (h *DevPortalHandler) GetDevPortal(c *gin.Context) {
 	// Extract organization ID from context
 	orgID, exists := middleware.GetOrganizationFromContext(c)
@@ -111,7 +111,7 @@ func (h *DevPortalHandler) GetDevPortal(c *gin.Context) {
 	c.JSON(http.StatusOK, response)
 }
 
-// ListDevPortals handles GET /api/v1alpha2/devportals
+// ListDevPortals handles GET /api/v0.9/devportals
 func (h *DevPortalHandler) ListDevPortals(c *gin.Context) {
 	// Extract organization ID from context
 	orgID, exists := middleware.GetOrganizationFromContext(c)
@@ -164,7 +164,7 @@ func (h *DevPortalHandler) ListDevPortals(c *gin.Context) {
 	c.JSON(http.StatusOK, response)
 }
 
-// UpdateDevPortal handles PUT /api/v1alpha2/devportals/:devportalId
+// UpdateDevPortal handles PUT /api/v0.9/devportals/:devportalId
 func (h *DevPortalHandler) UpdateDevPortal(c *gin.Context) {
 	// Extract organization ID from context
 	orgID, exists := middleware.GetOrganizationFromContext(c)
@@ -207,7 +207,7 @@ func (h *DevPortalHandler) UpdateDevPortal(c *gin.Context) {
 	c.JSON(http.StatusOK, response)
 }
 
-// DeleteDevPortal handles DELETE /api/v1alpha2/devportals/:devportalId
+// DeleteDevPortal handles DELETE /api/v0.9/devportals/:devportalId
 func (h *DevPortalHandler) DeleteDevPortal(c *gin.Context) {
 	// Extract organization ID from context
 	orgID, exists := middleware.GetOrganizationFromContext(c)
@@ -240,7 +240,7 @@ func (h *DevPortalHandler) DeleteDevPortal(c *gin.Context) {
 	c.JSON(http.StatusNoContent, nil)
 }
 
-// ActivateDevPortal handles POST /api/v1alpha2/devportals/:devportalId/activate
+// ActivateDevPortal handles POST /api/v0.9/devportals/:devportalId/activate
 func (h *DevPortalHandler) ActivateDevPortal(c *gin.Context) {
 	// Extract organization ID from context
 	orgID, exists := middleware.GetOrganizationFromContext(c)
@@ -278,7 +278,7 @@ func (h *DevPortalHandler) ActivateDevPortal(c *gin.Context) {
 	})
 }
 
-// DeactivateDevPortal handles POST /api/v1alpha2/devportals/:devportalId/deactivate
+// DeactivateDevPortal handles POST /api/v0.9/devportals/:devportalId/deactivate
 func (h *DevPortalHandler) DeactivateDevPortal(c *gin.Context) {
 	// Extract organization ID from context
 	orgID, exists := middleware.GetOrganizationFromContext(c)
@@ -316,7 +316,7 @@ func (h *DevPortalHandler) DeactivateDevPortal(c *gin.Context) {
 	})
 }
 
-// SetAsDefault handles POST /api/v1alpha2/devportals/:devportalId/set-default
+// SetAsDefault handles POST /api/v0.9/devportals/:devportalId/set-default
 func (h *DevPortalHandler) SetAsDefault(c *gin.Context) {
 	// Extract organization ID from context
 	orgID, exists := middleware.GetOrganizationFromContext(c)

--- a/platform-api/src/internal/handler/gateway.go
+++ b/platform-api/src/internal/handler/gateway.go
@@ -60,7 +60,7 @@ type manifestSyncResponse struct {
 	Policies json.RawMessage `json:"policies,omitempty"`
 }
 
-// CreateGateway handles POST /api/v1alpha2/gateways
+// CreateGateway handles POST /api/v0.9/gateways
 func (h *GatewayHandler) CreateGateway(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -141,7 +141,7 @@ func (h *GatewayHandler) CreateGateway(c *gin.Context) {
 	c.JSON(http.StatusCreated, gateway)
 }
 
-// ListGateways handles GET /api/v1alpha2/gateways with constitution-compliant response
+// ListGateways handles GET /api/v0.9/gateways with constitution-compliant response
 func (h *GatewayHandler) ListGateways(c *gin.Context) {
 	organizationID, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -162,7 +162,7 @@ func (h *GatewayHandler) ListGateways(c *gin.Context) {
 	c.JSON(http.StatusOK, gateways)
 }
 
-// GetGateway handles GET /api/v1alpha2/gateways/:gatewayId
+// GetGateway handles GET /api/v0.9/gateways/:gatewayId
 func (h *GatewayHandler) GetGateway(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -237,7 +237,7 @@ func (h *GatewayHandler) GetGatewayStatus(c *gin.Context) {
 	c.JSON(http.StatusOK, status)
 }
 
-// UpdateGateway handles PUT /api/v1alpha2/gateways/:gatewayId
+// UpdateGateway handles PUT /api/v0.9/gateways/:gatewayId
 func (h *GatewayHandler) UpdateGateway(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -277,7 +277,7 @@ func (h *GatewayHandler) UpdateGateway(c *gin.Context) {
 	c.JSON(http.StatusOK, response)
 }
 
-// DeleteGateway handles DELETE /api/v1alpha2/gateways/:gatewayId
+// DeleteGateway handles DELETE /api/v0.9/gateways/:gatewayId
 func (h *GatewayHandler) DeleteGateway(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -328,7 +328,7 @@ func (h *GatewayHandler) DeleteGateway(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }
 
-// ListTokens handles GET /api/v1alpha2/gateways/:gatewayId/tokens
+// ListTokens handles GET /api/v0.9/gateways/:gatewayId/tokens
 func (h *GatewayHandler) ListTokens(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -363,7 +363,7 @@ func (h *GatewayHandler) ListTokens(c *gin.Context) {
 	c.JSON(http.StatusOK, tokens)
 }
 
-// RotateToken handles POST /api/v1alpha2/gateways/:gatewayId/tokens
+// RotateToken handles POST /api/v0.9/gateways/:gatewayId/tokens
 func (h *GatewayHandler) RotateToken(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -408,7 +408,7 @@ func (h *GatewayHandler) RotateToken(c *gin.Context) {
 	c.JSON(http.StatusCreated, response)
 }
 
-// RevokeToken handles DELETE /api/v1alpha2/gateways/:gatewayId/tokens/:tokenId
+// RevokeToken handles DELETE /api/v0.9/gateways/:gatewayId/tokens/:tokenId
 func (h *GatewayHandler) RevokeToken(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -450,7 +450,7 @@ func (h *GatewayHandler) RevokeToken(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "Token revoked successfully"})
 }
 
-// GetGatewayArtifacts handles GET /api/v1alpha2/gateways/{gatewayId}/live-proxy-artifacts
+// GetGatewayArtifacts handles GET /api/v0.9/gateways/{gatewayId}/live-proxy-artifacts
 func (h *GatewayHandler) GetGatewayArtifacts(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -495,7 +495,7 @@ func (h *GatewayHandler) GetGatewayArtifacts(c *gin.Context) {
 	c.JSON(http.StatusOK, artifactListResponse)
 }
 
-// GetGatewayManifest handles GET /api/v1alpha2/gateways/{gatewayId}/manifest
+// GetGatewayManifest handles GET /api/v0.9/gateways/{gatewayId}/manifest
 // Called by APIM to retrieve the manifest pushed by the gateway controller on connect.
 func (h *GatewayHandler) GetGatewayManifest(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
@@ -534,7 +534,7 @@ func (h *GatewayHandler) GetGatewayManifest(c *gin.Context) {
 	})
 }
 
-// SyncCustomPolicy handles POST /api/v1alpha2/gateway-custom-policies/sync
+// SyncCustomPolicy handles POST /api/v0.9/gateway-custom-policies/sync
 // It upserts a custom policy from the gateway's stored manifest into the gateway_custom_policies table.
 func (h *GatewayHandler) SyncCustomPolicy(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
@@ -582,7 +582,7 @@ func (h *GatewayHandler) SyncCustomPolicy(c *gin.Context) {
 	c.JSON(http.StatusOK, policy)
 }
 
-// GetCustomPolicy handles GET /api/v1alpha2/gateway-custom-policies/:customPolicyUuid/versions/:version
+// GetCustomPolicy handles GET /api/v0.9/gateway-custom-policies/:customPolicyUuid/versions/:version
 func (h *GatewayHandler) GetCustomPolicy(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -618,7 +618,7 @@ func (h *GatewayHandler) GetCustomPolicy(c *gin.Context) {
 	c.JSON(http.StatusOK, policy)
 }
 
-// DeleteCustomPolicy handles DELETE /api/v1alpha2/gateway-custom-policies/:customPolicyUuid/versions/:version
+// DeleteCustomPolicy handles DELETE /api/v0.9/gateway-custom-policies/:customPolicyUuid/versions/:version
 func (h *GatewayHandler) DeleteCustomPolicy(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -659,7 +659,7 @@ func (h *GatewayHandler) DeleteCustomPolicy(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }
 
-// ListCustomPolicies handles GET /api/v1alpha2/gateway-custom-policies
+// ListCustomPolicies handles GET /api/v0.9/gateway-custom-policies
 func (h *GatewayHandler) ListCustomPolicies(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {

--- a/platform-api/src/internal/handler/gateway.go
+++ b/platform-api/src/internal/handler/gateway.go
@@ -60,7 +60,7 @@ type manifestSyncResponse struct {
 	Policies json.RawMessage `json:"policies,omitempty"`
 }
 
-// CreateGateway handles POST /api/v1/gateways
+// CreateGateway handles POST /api/v1alpha2/gateways
 func (h *GatewayHandler) CreateGateway(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -141,7 +141,7 @@ func (h *GatewayHandler) CreateGateway(c *gin.Context) {
 	c.JSON(http.StatusCreated, gateway)
 }
 
-// ListGateways handles GET /api/v1/gateways with constitution-compliant response
+// ListGateways handles GET /api/v1alpha2/gateways with constitution-compliant response
 func (h *GatewayHandler) ListGateways(c *gin.Context) {
 	organizationID, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -162,7 +162,7 @@ func (h *GatewayHandler) ListGateways(c *gin.Context) {
 	c.JSON(http.StatusOK, gateways)
 }
 
-// GetGateway handles GET /api/v1/gateways/:gatewayId
+// GetGateway handles GET /api/v1alpha2/gateways/:gatewayId
 func (h *GatewayHandler) GetGateway(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -237,7 +237,7 @@ func (h *GatewayHandler) GetGatewayStatus(c *gin.Context) {
 	c.JSON(http.StatusOK, status)
 }
 
-// UpdateGateway handles PUT /api/v1/gateways/:gatewayId
+// UpdateGateway handles PUT /api/v1alpha2/gateways/:gatewayId
 func (h *GatewayHandler) UpdateGateway(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -277,7 +277,7 @@ func (h *GatewayHandler) UpdateGateway(c *gin.Context) {
 	c.JSON(http.StatusOK, response)
 }
 
-// DeleteGateway handles DELETE /api/v1/gateways/:gatewayId
+// DeleteGateway handles DELETE /api/v1alpha2/gateways/:gatewayId
 func (h *GatewayHandler) DeleteGateway(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -328,7 +328,7 @@ func (h *GatewayHandler) DeleteGateway(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }
 
-// ListTokens handles GET /api/v1/gateways/:gatewayId/tokens
+// ListTokens handles GET /api/v1alpha2/gateways/:gatewayId/tokens
 func (h *GatewayHandler) ListTokens(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -363,7 +363,7 @@ func (h *GatewayHandler) ListTokens(c *gin.Context) {
 	c.JSON(http.StatusOK, tokens)
 }
 
-// RotateToken handles POST /api/v1/gateways/:gatewayId/tokens
+// RotateToken handles POST /api/v1alpha2/gateways/:gatewayId/tokens
 func (h *GatewayHandler) RotateToken(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -408,7 +408,7 @@ func (h *GatewayHandler) RotateToken(c *gin.Context) {
 	c.JSON(http.StatusCreated, response)
 }
 
-// RevokeToken handles DELETE /api/v1/gateways/:gatewayId/tokens/:tokenId
+// RevokeToken handles DELETE /api/v1alpha2/gateways/:gatewayId/tokens/:tokenId
 func (h *GatewayHandler) RevokeToken(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -450,7 +450,7 @@ func (h *GatewayHandler) RevokeToken(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "Token revoked successfully"})
 }
 
-// GetGatewayArtifacts handles GET /api/v1/gateways/{gatewayId}/live-proxy-artifacts
+// GetGatewayArtifacts handles GET /api/v1alpha2/gateways/{gatewayId}/live-proxy-artifacts
 func (h *GatewayHandler) GetGatewayArtifacts(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -495,7 +495,7 @@ func (h *GatewayHandler) GetGatewayArtifacts(c *gin.Context) {
 	c.JSON(http.StatusOK, artifactListResponse)
 }
 
-// GetGatewayManifest handles GET /api/v1/gateways/{gatewayId}/manifest
+// GetGatewayManifest handles GET /api/v1alpha2/gateways/{gatewayId}/manifest
 // Called by APIM to retrieve the manifest pushed by the gateway controller on connect.
 func (h *GatewayHandler) GetGatewayManifest(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
@@ -534,7 +534,7 @@ func (h *GatewayHandler) GetGatewayManifest(c *gin.Context) {
 	})
 }
 
-// SyncCustomPolicy handles POST /api/v1/gateway-custom-policies/sync
+// SyncCustomPolicy handles POST /api/v1alpha2/gateway-custom-policies/sync
 // It upserts a custom policy from the gateway's stored manifest into the gateway_custom_policies table.
 func (h *GatewayHandler) SyncCustomPolicy(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
@@ -582,7 +582,7 @@ func (h *GatewayHandler) SyncCustomPolicy(c *gin.Context) {
 	c.JSON(http.StatusOK, policy)
 }
 
-// GetCustomPolicy handles GET /api/v1/gateway-custom-policies/:customPolicyUuid/versions/:version
+// GetCustomPolicy handles GET /api/v1alpha2/gateway-custom-policies/:customPolicyUuid/versions/:version
 func (h *GatewayHandler) GetCustomPolicy(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -618,7 +618,7 @@ func (h *GatewayHandler) GetCustomPolicy(c *gin.Context) {
 	c.JSON(http.StatusOK, policy)
 }
 
-// DeleteCustomPolicy handles DELETE /api/v1/gateway-custom-policies/:customPolicyUuid/versions/:version
+// DeleteCustomPolicy handles DELETE /api/v1alpha2/gateway-custom-policies/:customPolicyUuid/versions/:version
 func (h *GatewayHandler) DeleteCustomPolicy(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -659,7 +659,7 @@ func (h *GatewayHandler) DeleteCustomPolicy(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }
 
-// ListCustomPolicies handles GET /api/v1/gateway-custom-policies
+// ListCustomPolicies handles GET /api/v1alpha2/gateway-custom-policies
 func (h *GatewayHandler) ListCustomPolicies(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -682,7 +682,7 @@ func (h *GatewayHandler) ListCustomPolicies(c *gin.Context) {
 // RegisterRoutes registers gateway routes with the router
 func (h *GatewayHandler) RegisterRoutes(r *gin.Engine) {
 	h.slogger.Debug("Registering gateway routes")
-	gatewayGroup := r.Group("/api/v1/gateways")
+	gatewayGroup := r.Group(constants.APIBasePath + "/gateways")
 	{
 		gatewayGroup.POST("", h.CreateGateway)
 		gatewayGroup.GET("", h.ListGateways)
@@ -696,7 +696,7 @@ func (h *GatewayHandler) RegisterRoutes(r *gin.Engine) {
 		gatewayGroup.GET("/:gatewayId/manifest", h.GetGatewayManifest)
 	}
 
-	customPoliciesGroup := r.Group("/api/v1/gateway-custom-policies")
+	customPoliciesGroup := r.Group(constants.APIBasePath + "/gateway-custom-policies")
 	{
 		customPoliciesGroup.GET("", h.ListCustomPolicies)
 		customPoliciesGroup.POST("/sync", h.SyncCustomPolicy)

--- a/platform-api/src/internal/handler/git.go
+++ b/platform-api/src/internal/handler/git.go
@@ -21,6 +21,7 @@ import (
 	"log/slog"
 	"net/http"
 	"platform-api/src/api"
+	"platform-api/src/internal/constants"
 	"platform-api/src/internal/middleware"
 	"platform-api/src/internal/service"
 	"strings"
@@ -250,7 +251,7 @@ func (h *GitHandler) FetchRepoContent(c *gin.Context) {
 
 // RegisterRoutes registers Git-related routes
 func (h *GitHandler) RegisterRoutes(router *gin.Engine) {
-	gitRoutes := router.Group("/api/v1/git")
+	gitRoutes := router.Group(constants.APIBasePath + "/git")
 	{
 		gitRoutes.POST("/repo/fetch-branches", h.FetchRepoBranches)
 		gitRoutes.POST("/repo/branch/fetch-content", h.FetchRepoContent)

--- a/platform-api/src/internal/handler/llm.go
+++ b/platform-api/src/internal/handler/llm.go
@@ -50,7 +50,7 @@ func NewLLMHandler(
 }
 
 func (h *LLMHandler) RegisterRoutes(r *gin.Engine) {
-	v1 := r.Group("/api/v1")
+	v1 := r.Group(constants.APIBasePath)
 	{
 		// LLM Provider Templates
 		v1.POST("/llm-provider-templates", h.CreateLLMProviderTemplate)

--- a/platform-api/src/internal/handler/llm_apikey.go
+++ b/platform-api/src/internal/handler/llm_apikey.go
@@ -45,7 +45,7 @@ func NewLLMProviderAPIKeyHandler(apiKeyService *service.LLMProviderAPIKeyService
 	}
 }
 
-// ListAPIKeys handles GET /api/v1alpha2/llm-providers/{id}/api-keys
+// ListAPIKeys handles GET /api/v0.9/llm-providers/{id}/api-keys
 func (h *LLMProviderAPIKeyHandler) ListAPIKeys(c *gin.Context) {
 	orgID, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -79,7 +79,7 @@ func (h *LLMProviderAPIKeyHandler) ListAPIKeys(c *gin.Context) {
 	c.JSON(http.StatusOK, response)
 }
 
-// DeleteAPIKey handles DELETE /api/v1alpha2/llm-providers/{id}/api-keys/{keyName}
+// DeleteAPIKey handles DELETE /api/v0.9/llm-providers/{id}/api-keys/{keyName}
 func (h *LLMProviderAPIKeyHandler) DeleteAPIKey(c *gin.Context) {
 	orgID, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -131,7 +131,7 @@ func (h *LLMProviderAPIKeyHandler) DeleteAPIKey(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }
 
-// CreateAPIKey handles POST /api/v1alpha2/llm-providers/{id}/api-keys
+// CreateAPIKey handles POST /api/v0.9/llm-providers/{id}/api-keys
 func (h *LLMProviderAPIKeyHandler) CreateAPIKey(c *gin.Context) {
 	orgID, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {

--- a/platform-api/src/internal/handler/llm_apikey.go
+++ b/platform-api/src/internal/handler/llm_apikey.go
@@ -45,7 +45,7 @@ func NewLLMProviderAPIKeyHandler(apiKeyService *service.LLMProviderAPIKeyService
 	}
 }
 
-// ListAPIKeys handles GET /api/v1/llm-providers/{id}/api-keys
+// ListAPIKeys handles GET /api/v1alpha2/llm-providers/{id}/api-keys
 func (h *LLMProviderAPIKeyHandler) ListAPIKeys(c *gin.Context) {
 	orgID, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -79,7 +79,7 @@ func (h *LLMProviderAPIKeyHandler) ListAPIKeys(c *gin.Context) {
 	c.JSON(http.StatusOK, response)
 }
 
-// DeleteAPIKey handles DELETE /api/v1/llm-providers/{id}/api-keys/{keyName}
+// DeleteAPIKey handles DELETE /api/v1alpha2/llm-providers/{id}/api-keys/{keyName}
 func (h *LLMProviderAPIKeyHandler) DeleteAPIKey(c *gin.Context) {
 	orgID, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -103,7 +103,7 @@ func (h *LLMProviderAPIKeyHandler) DeleteAPIKey(c *gin.Context) {
 	}
 
 	callerUserID := c.GetHeader("x-user-id")
-	
+
 	err := h.apiKeyService.DeleteLLMProviderAPIKey(c.Request.Context(), providerID, orgID, callerUserID, keyName)
 	if err != nil {
 		if errors.Is(err, constants.ErrAPINotFound) {
@@ -131,7 +131,7 @@ func (h *LLMProviderAPIKeyHandler) DeleteAPIKey(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }
 
-// CreateAPIKey handles POST /api/v1/llm-providers/{id}/api-keys
+// CreateAPIKey handles POST /api/v1alpha2/llm-providers/{id}/api-keys
 func (h *LLMProviderAPIKeyHandler) CreateAPIKey(c *gin.Context) {
 	orgID, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -192,7 +192,7 @@ func (h *LLMProviderAPIKeyHandler) CreateAPIKey(c *gin.Context) {
 
 // RegisterRoutes registers LLM provider API key routes with the router
 func (h *LLMProviderAPIKeyHandler) RegisterRoutes(r *gin.Engine) {
-	apiKeyGroup := r.Group("/api/v1/llm-providers/:id/api-keys")
+	apiKeyGroup := r.Group(constants.APIBasePath + "/llm-providers/:id/api-keys")
 	{
 		apiKeyGroup.POST("", h.CreateAPIKey)
 		apiKeyGroup.GET("", h.ListAPIKeys)

--- a/platform-api/src/internal/handler/llm_deployment.go
+++ b/platform-api/src/internal/handler/llm_deployment.go
@@ -54,7 +54,7 @@ func NewLLMProxyDeploymentHandler(deploymentService *service.LLMProxyDeploymentS
 	return &LLMProxyDeploymentHandler{deploymentService: deploymentService, slogger: slogger}
 }
 
-// DeployLLMProvider handles POST /api/v1alpha2/llm-providers/:id/deployments
+// DeployLLMProvider handles POST /api/v0.9/llm-providers/:id/deployments
 func (h *LLMProviderDeploymentHandler) DeployLLMProvider(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -138,7 +138,7 @@ func (h *LLMProviderDeploymentHandler) DeployLLMProvider(c *gin.Context) {
 	c.JSON(http.StatusCreated, deployment)
 }
 
-// UndeployLLMProviderDeployment handles POST /api/v1alpha2/llm-providers/:id/deployments/:deploymentId/undeploy
+// UndeployLLMProviderDeployment handles POST /api/v0.9/llm-providers/:id/deployments/:deploymentId/undeploy
 func (h *LLMProviderDeploymentHandler) UndeployLLMProviderDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -189,7 +189,7 @@ func (h *LLMProviderDeploymentHandler) UndeployLLMProviderDeployment(c *gin.Cont
 	c.JSON(http.StatusOK, deployment)
 }
 
-// RestoreLLMProviderDeployment handles POST /api/v1alpha2/llm-providers/:id/deployments/:deploymentId/restore
+// RestoreLLMProviderDeployment handles POST /api/v0.9/llm-providers/:id/deployments/:deploymentId/restore
 func (h *LLMProviderDeploymentHandler) RestoreLLMProviderDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -240,7 +240,7 @@ func (h *LLMProviderDeploymentHandler) RestoreLLMProviderDeployment(c *gin.Conte
 	c.JSON(http.StatusOK, deployment)
 }
 
-// DeleteLLMProviderDeployment handles DELETE /api/v1alpha2/llm-providers/:id/deployments/:deploymentId
+// DeleteLLMProviderDeployment handles DELETE /api/v0.9/llm-providers/:id/deployments/:deploymentId
 func (h *LLMProviderDeploymentHandler) DeleteLLMProviderDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -288,7 +288,7 @@ func (h *LLMProviderDeploymentHandler) DeleteLLMProviderDeployment(c *gin.Contex
 	c.JSON(http.StatusNoContent, nil)
 }
 
-// GetLLMProviderDeployment handles GET /api/v1alpha2/llm-providers/:id/deployments/:deploymentId
+// GetLLMProviderDeployment handles GET /api/v0.9/llm-providers/:id/deployments/:deploymentId
 func (h *LLMProviderDeploymentHandler) GetLLMProviderDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -333,7 +333,7 @@ func (h *LLMProviderDeploymentHandler) GetLLMProviderDeployment(c *gin.Context) 
 	c.JSON(http.StatusOK, deployment)
 }
 
-// GetLLMProviderDeployments handles GET /api/v1alpha2/llm-providers/:id/deployments
+// GetLLMProviderDeployments handles GET /api/v0.9/llm-providers/:id/deployments
 func (h *LLMProviderDeploymentHandler) GetLLMProviderDeployments(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -400,7 +400,7 @@ func (h *LLMProviderDeploymentHandler) RegisterRoutes(r *gin.Engine) {
 	}
 }
 
-// DeployLLMProxy handles POST /api/v1alpha2/llm-proxies/:id/deployments
+// DeployLLMProxy handles POST /api/v0.9/llm-proxies/:id/deployments
 func (h *LLMProxyDeploymentHandler) DeployLLMProxy(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -480,7 +480,7 @@ func (h *LLMProxyDeploymentHandler) DeployLLMProxy(c *gin.Context) {
 	c.JSON(http.StatusCreated, deployment)
 }
 
-// UndeployLLMProxyDeployment handles POST /api/v1alpha2/llm-proxies/:id/deployments/:deploymentId/undeploy
+// UndeployLLMProxyDeployment handles POST /api/v0.9/llm-proxies/:id/deployments/:deploymentId/undeploy
 func (h *LLMProxyDeploymentHandler) UndeployLLMProxyDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -531,7 +531,7 @@ func (h *LLMProxyDeploymentHandler) UndeployLLMProxyDeployment(c *gin.Context) {
 	c.JSON(http.StatusOK, deployment)
 }
 
-// RestoreLLMProxyDeployment handles POST /api/v1alpha2/llm-proxies/:id/deployments/:deploymentId/restore
+// RestoreLLMProxyDeployment handles POST /api/v0.9/llm-proxies/:id/deployments/:deploymentId/restore
 func (h *LLMProxyDeploymentHandler) RestoreLLMProxyDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -582,7 +582,7 @@ func (h *LLMProxyDeploymentHandler) RestoreLLMProxyDeployment(c *gin.Context) {
 	c.JSON(http.StatusOK, deployment)
 }
 
-// DeleteLLMProxyDeployment handles DELETE /api/v1alpha2/llm-proxies/:id/deployments/:deploymentId
+// DeleteLLMProxyDeployment handles DELETE /api/v0.9/llm-proxies/:id/deployments/:deploymentId
 func (h *LLMProxyDeploymentHandler) DeleteLLMProxyDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -630,7 +630,7 @@ func (h *LLMProxyDeploymentHandler) DeleteLLMProxyDeployment(c *gin.Context) {
 	c.JSON(http.StatusNoContent, nil)
 }
 
-// GetLLMProxyDeployment handles GET /api/v1alpha2/llm-proxies/:id/deployments/:deploymentId
+// GetLLMProxyDeployment handles GET /api/v0.9/llm-proxies/:id/deployments/:deploymentId
 func (h *LLMProxyDeploymentHandler) GetLLMProxyDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -675,7 +675,7 @@ func (h *LLMProxyDeploymentHandler) GetLLMProxyDeployment(c *gin.Context) {
 	c.JSON(http.StatusOK, deployment)
 }
 
-// GetLLMProxyDeployments handles GET /api/v1alpha2/llm-proxies/:id/deployments
+// GetLLMProxyDeployments handles GET /api/v0.9/llm-proxies/:id/deployments
 func (h *LLMProxyDeploymentHandler) GetLLMProxyDeployments(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {

--- a/platform-api/src/internal/handler/llm_deployment.go
+++ b/platform-api/src/internal/handler/llm_deployment.go
@@ -54,7 +54,7 @@ func NewLLMProxyDeploymentHandler(deploymentService *service.LLMProxyDeploymentS
 	return &LLMProxyDeploymentHandler{deploymentService: deploymentService, slogger: slogger}
 }
 
-// DeployLLMProvider handles POST /api/v1/llm-providers/:id/deployments
+// DeployLLMProvider handles POST /api/v1alpha2/llm-providers/:id/deployments
 func (h *LLMProviderDeploymentHandler) DeployLLMProvider(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -138,7 +138,7 @@ func (h *LLMProviderDeploymentHandler) DeployLLMProvider(c *gin.Context) {
 	c.JSON(http.StatusCreated, deployment)
 }
 
-// UndeployLLMProviderDeployment handles POST /api/v1/llm-providers/:id/deployments/:deploymentId/undeploy
+// UndeployLLMProviderDeployment handles POST /api/v1alpha2/llm-providers/:id/deployments/:deploymentId/undeploy
 func (h *LLMProviderDeploymentHandler) UndeployLLMProviderDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -189,7 +189,7 @@ func (h *LLMProviderDeploymentHandler) UndeployLLMProviderDeployment(c *gin.Cont
 	c.JSON(http.StatusOK, deployment)
 }
 
-// RestoreLLMProviderDeployment handles POST /api/v1/llm-providers/:id/deployments/:deploymentId/restore
+// RestoreLLMProviderDeployment handles POST /api/v1alpha2/llm-providers/:id/deployments/:deploymentId/restore
 func (h *LLMProviderDeploymentHandler) RestoreLLMProviderDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -240,7 +240,7 @@ func (h *LLMProviderDeploymentHandler) RestoreLLMProviderDeployment(c *gin.Conte
 	c.JSON(http.StatusOK, deployment)
 }
 
-// DeleteLLMProviderDeployment handles DELETE /api/v1/llm-providers/:id/deployments/:deploymentId
+// DeleteLLMProviderDeployment handles DELETE /api/v1alpha2/llm-providers/:id/deployments/:deploymentId
 func (h *LLMProviderDeploymentHandler) DeleteLLMProviderDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -288,7 +288,7 @@ func (h *LLMProviderDeploymentHandler) DeleteLLMProviderDeployment(c *gin.Contex
 	c.JSON(http.StatusNoContent, nil)
 }
 
-// GetLLMProviderDeployment handles GET /api/v1/llm-providers/:id/deployments/:deploymentId
+// GetLLMProviderDeployment handles GET /api/v1alpha2/llm-providers/:id/deployments/:deploymentId
 func (h *LLMProviderDeploymentHandler) GetLLMProviderDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -333,7 +333,7 @@ func (h *LLMProviderDeploymentHandler) GetLLMProviderDeployment(c *gin.Context) 
 	c.JSON(http.StatusOK, deployment)
 }
 
-// GetLLMProviderDeployments handles GET /api/v1/llm-providers/:id/deployments
+// GetLLMProviderDeployments handles GET /api/v1alpha2/llm-providers/:id/deployments
 func (h *LLMProviderDeploymentHandler) GetLLMProviderDeployments(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -389,7 +389,7 @@ func (h *LLMProviderDeploymentHandler) GetLLMProviderDeployments(c *gin.Context)
 
 // RegisterRoutes registers all LLM provider deployment-related routes
 func (h *LLMProviderDeploymentHandler) RegisterRoutes(r *gin.Engine) {
-	providerGroup := r.Group("/api/v1/llm-providers/:id")
+	providerGroup := r.Group(constants.APIBasePath + "/llm-providers/:id")
 	{
 		providerGroup.POST("/deployments", h.DeployLLMProvider)
 		providerGroup.POST("/deployments/:deploymentId/undeploy", h.UndeployLLMProviderDeployment)
@@ -400,7 +400,7 @@ func (h *LLMProviderDeploymentHandler) RegisterRoutes(r *gin.Engine) {
 	}
 }
 
-// DeployLLMProxy handles POST /api/v1/llm-proxies/:id/deployments
+// DeployLLMProxy handles POST /api/v1alpha2/llm-proxies/:id/deployments
 func (h *LLMProxyDeploymentHandler) DeployLLMProxy(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -480,7 +480,7 @@ func (h *LLMProxyDeploymentHandler) DeployLLMProxy(c *gin.Context) {
 	c.JSON(http.StatusCreated, deployment)
 }
 
-// UndeployLLMProxyDeployment handles POST /api/v1/llm-proxies/:id/deployments/:deploymentId/undeploy
+// UndeployLLMProxyDeployment handles POST /api/v1alpha2/llm-proxies/:id/deployments/:deploymentId/undeploy
 func (h *LLMProxyDeploymentHandler) UndeployLLMProxyDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -531,7 +531,7 @@ func (h *LLMProxyDeploymentHandler) UndeployLLMProxyDeployment(c *gin.Context) {
 	c.JSON(http.StatusOK, deployment)
 }
 
-// RestoreLLMProxyDeployment handles POST /api/v1/llm-proxies/:id/deployments/:deploymentId/restore
+// RestoreLLMProxyDeployment handles POST /api/v1alpha2/llm-proxies/:id/deployments/:deploymentId/restore
 func (h *LLMProxyDeploymentHandler) RestoreLLMProxyDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -582,7 +582,7 @@ func (h *LLMProxyDeploymentHandler) RestoreLLMProxyDeployment(c *gin.Context) {
 	c.JSON(http.StatusOK, deployment)
 }
 
-// DeleteLLMProxyDeployment handles DELETE /api/v1/llm-proxies/:id/deployments/:deploymentId
+// DeleteLLMProxyDeployment handles DELETE /api/v1alpha2/llm-proxies/:id/deployments/:deploymentId
 func (h *LLMProxyDeploymentHandler) DeleteLLMProxyDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -630,7 +630,7 @@ func (h *LLMProxyDeploymentHandler) DeleteLLMProxyDeployment(c *gin.Context) {
 	c.JSON(http.StatusNoContent, nil)
 }
 
-// GetLLMProxyDeployment handles GET /api/v1/llm-proxies/:id/deployments/:deploymentId
+// GetLLMProxyDeployment handles GET /api/v1alpha2/llm-proxies/:id/deployments/:deploymentId
 func (h *LLMProxyDeploymentHandler) GetLLMProxyDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -675,7 +675,7 @@ func (h *LLMProxyDeploymentHandler) GetLLMProxyDeployment(c *gin.Context) {
 	c.JSON(http.StatusOK, deployment)
 }
 
-// GetLLMProxyDeployments handles GET /api/v1/llm-proxies/:id/deployments
+// GetLLMProxyDeployments handles GET /api/v1alpha2/llm-proxies/:id/deployments
 func (h *LLMProxyDeploymentHandler) GetLLMProxyDeployments(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -731,7 +731,7 @@ func (h *LLMProxyDeploymentHandler) GetLLMProxyDeployments(c *gin.Context) {
 
 // RegisterRoutes registers all LLM proxy deployment-related routes
 func (h *LLMProxyDeploymentHandler) RegisterRoutes(r *gin.Engine) {
-	proxyGroup := r.Group("/api/v1/llm-proxies/:id")
+	proxyGroup := r.Group(constants.APIBasePath + "/llm-proxies/:id")
 	{
 		proxyGroup.POST("/deployments", h.DeployLLMProxy)
 		proxyGroup.POST("/deployments/:deploymentId/undeploy", h.UndeployLLMProxyDeployment)

--- a/platform-api/src/internal/handler/llm_proxy_apikey.go
+++ b/platform-api/src/internal/handler/llm_proxy_apikey.go
@@ -45,7 +45,7 @@ func NewLLMProxyAPIKeyHandler(apiKeyService *service.LLMProxyAPIKeyService, slog
 	}
 }
 
-// ListAPIKeys handles GET /api/v1alpha2/llm-proxies/{id}/api-keys
+// ListAPIKeys handles GET /api/v0.9/llm-proxies/{id}/api-keys
 func (h *LLMProxyAPIKeyHandler) ListAPIKeys(c *gin.Context) {
 	orgID, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -79,7 +79,7 @@ func (h *LLMProxyAPIKeyHandler) ListAPIKeys(c *gin.Context) {
 	c.JSON(http.StatusOK, response)
 }
 
-// DeleteAPIKey handles DELETE /api/v1alpha2/llm-proxies/{id}/api-keys/{keyName}
+// DeleteAPIKey handles DELETE /api/v0.9/llm-proxies/{id}/api-keys/{keyName}
 func (h *LLMProxyAPIKeyHandler) DeleteAPIKey(c *gin.Context) {
 	orgID, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -131,7 +131,7 @@ func (h *LLMProxyAPIKeyHandler) DeleteAPIKey(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }
 
-// CreateAPIKey handles POST /api/v1alpha2/llm-proxies/{id}/api-keys
+// CreateAPIKey handles POST /api/v0.9/llm-proxies/{id}/api-keys
 func (h *LLMProxyAPIKeyHandler) CreateAPIKey(c *gin.Context) {
 	orgID, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {

--- a/platform-api/src/internal/handler/llm_proxy_apikey.go
+++ b/platform-api/src/internal/handler/llm_proxy_apikey.go
@@ -45,7 +45,7 @@ func NewLLMProxyAPIKeyHandler(apiKeyService *service.LLMProxyAPIKeyService, slog
 	}
 }
 
-// ListAPIKeys handles GET /api/v1/llm-proxies/{id}/api-keys
+// ListAPIKeys handles GET /api/v1alpha2/llm-proxies/{id}/api-keys
 func (h *LLMProxyAPIKeyHandler) ListAPIKeys(c *gin.Context) {
 	orgID, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -79,7 +79,7 @@ func (h *LLMProxyAPIKeyHandler) ListAPIKeys(c *gin.Context) {
 	c.JSON(http.StatusOK, response)
 }
 
-// DeleteAPIKey handles DELETE /api/v1/llm-proxies/{id}/api-keys/{keyName}
+// DeleteAPIKey handles DELETE /api/v1alpha2/llm-proxies/{id}/api-keys/{keyName}
 func (h *LLMProxyAPIKeyHandler) DeleteAPIKey(c *gin.Context) {
 	orgID, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -131,7 +131,7 @@ func (h *LLMProxyAPIKeyHandler) DeleteAPIKey(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }
 
-// CreateAPIKey handles POST /api/v1/llm-proxies/{id}/api-keys
+// CreateAPIKey handles POST /api/v1alpha2/llm-proxies/{id}/api-keys
 func (h *LLMProxyAPIKeyHandler) CreateAPIKey(c *gin.Context) {
 	orgID, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -192,7 +192,7 @@ func (h *LLMProxyAPIKeyHandler) CreateAPIKey(c *gin.Context) {
 
 // RegisterRoutes registers LLM proxy API key routes with the router
 func (h *LLMProxyAPIKeyHandler) RegisterRoutes(r *gin.Engine) {
-	apiKeyGroup := r.Group("/api/v1/llm-proxies/:id/api-keys")
+	apiKeyGroup := r.Group(constants.APIBasePath + "/llm-proxies/:id/api-keys")
 	{
 		apiKeyGroup.POST("", h.CreateAPIKey)
 		apiKeyGroup.GET("", h.ListAPIKeys)

--- a/platform-api/src/internal/handler/mcp.go
+++ b/platform-api/src/internal/handler/mcp.go
@@ -57,7 +57,7 @@ func (h *MCPProxyHandler) RegisterRoutes(r *gin.Engine) {
 	}
 }
 
-// CreateMCPProxy handles POST /api/v1alpha2/mcp-proxies
+// CreateMCPProxy handles POST /api/v0.9/mcp-proxies
 func (h *MCPProxyHandler) CreateMCPProxy(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -88,7 +88,7 @@ func (h *MCPProxyHandler) CreateMCPProxy(c *gin.Context) {
 	c.JSON(http.StatusCreated, resp)
 }
 
-// ListMCPProxies handles GET /api/v1alpha2/mcp-proxies
+// ListMCPProxies handles GET /api/v0.9/mcp-proxies
 func (h *MCPProxyHandler) ListMCPProxies(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -130,7 +130,7 @@ func (h *MCPProxyHandler) ListMCPProxies(c *gin.Context) {
 	c.JSON(http.StatusOK, resp)
 }
 
-// GetMCPProxy handles GET /api/v1alpha2/mcp-proxies/:id
+// GetMCPProxy handles GET /api/v0.9/mcp-proxies/:id
 func (h *MCPProxyHandler) GetMCPProxy(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -149,7 +149,7 @@ func (h *MCPProxyHandler) GetMCPProxy(c *gin.Context) {
 	c.JSON(http.StatusOK, resp)
 }
 
-// UpdateMCPProxy handles PUT /api/v1alpha2/mcp-proxies/:id
+// UpdateMCPProxy handles PUT /api/v0.9/mcp-proxies/:id
 func (h *MCPProxyHandler) UpdateMCPProxy(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -175,7 +175,7 @@ func (h *MCPProxyHandler) UpdateMCPProxy(c *gin.Context) {
 	c.JSON(http.StatusOK, resp)
 }
 
-// DeleteMCPProxy handles DELETE /api/v1alpha2/mcp-proxies/:id
+// DeleteMCPProxy handles DELETE /api/v0.9/mcp-proxies/:id
 func (h *MCPProxyHandler) DeleteMCPProxy(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -193,7 +193,7 @@ func (h *MCPProxyHandler) DeleteMCPProxy(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }
 
-// FetchMCPProxyServerInfo handles POST /api/v1alpha2/mcp-proxies/fetch-server-info
+// FetchMCPProxyServerInfo handles POST /api/v0.9/mcp-proxies/fetch-server-info
 func (h *MCPProxyHandler) FetchMCPProxyServerInfo(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {

--- a/platform-api/src/internal/handler/mcp.go
+++ b/platform-api/src/internal/handler/mcp.go
@@ -46,7 +46,7 @@ func NewMCPProxyHandler(service *service.MCPProxyService, slogger *slog.Logger) 
 }
 
 func (h *MCPProxyHandler) RegisterRoutes(r *gin.Engine) {
-	v1 := r.Group("/api/v1")
+	v1 := r.Group(constants.APIBasePath)
 	{
 		v1.POST("/mcp-proxies", h.CreateMCPProxy)
 		v1.GET("/mcp-proxies", h.ListMCPProxies)
@@ -57,7 +57,7 @@ func (h *MCPProxyHandler) RegisterRoutes(r *gin.Engine) {
 	}
 }
 
-// CreateMCPProxy handles POST /api/v1/mcp-proxies
+// CreateMCPProxy handles POST /api/v1alpha2/mcp-proxies
 func (h *MCPProxyHandler) CreateMCPProxy(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -88,7 +88,7 @@ func (h *MCPProxyHandler) CreateMCPProxy(c *gin.Context) {
 	c.JSON(http.StatusCreated, resp)
 }
 
-// ListMCPProxies handles GET /api/v1/mcp-proxies
+// ListMCPProxies handles GET /api/v1alpha2/mcp-proxies
 func (h *MCPProxyHandler) ListMCPProxies(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -130,7 +130,7 @@ func (h *MCPProxyHandler) ListMCPProxies(c *gin.Context) {
 	c.JSON(http.StatusOK, resp)
 }
 
-// GetMCPProxy handles GET /api/v1/mcp-proxies/:id
+// GetMCPProxy handles GET /api/v1alpha2/mcp-proxies/:id
 func (h *MCPProxyHandler) GetMCPProxy(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -149,7 +149,7 @@ func (h *MCPProxyHandler) GetMCPProxy(c *gin.Context) {
 	c.JSON(http.StatusOK, resp)
 }
 
-// UpdateMCPProxy handles PUT /api/v1/mcp-proxies/:id
+// UpdateMCPProxy handles PUT /api/v1alpha2/mcp-proxies/:id
 func (h *MCPProxyHandler) UpdateMCPProxy(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -175,7 +175,7 @@ func (h *MCPProxyHandler) UpdateMCPProxy(c *gin.Context) {
 	c.JSON(http.StatusOK, resp)
 }
 
-// DeleteMCPProxy handles DELETE /api/v1/mcp-proxies/:id
+// DeleteMCPProxy handles DELETE /api/v1alpha2/mcp-proxies/:id
 func (h *MCPProxyHandler) DeleteMCPProxy(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -193,7 +193,7 @@ func (h *MCPProxyHandler) DeleteMCPProxy(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }
 
-// FetchMCPProxyServerInfo handles POST /api/v1/mcp-proxies/fetch-server-info
+// FetchMCPProxyServerInfo handles POST /api/v1alpha2/mcp-proxies/fetch-server-info
 func (h *MCPProxyHandler) FetchMCPProxyServerInfo(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {

--- a/platform-api/src/internal/handler/mcp_deployment.go
+++ b/platform-api/src/internal/handler/mcp_deployment.go
@@ -50,7 +50,7 @@ func NewMCPProxyDeploymentHandler(deploymentService *service.MCPDeploymentServic
 
 // RegisterRoutes registers all MCP proxy deployment-related routes
 func (h *MCPProxyDeploymentHandler) RegisterRoutes(r *gin.Engine) {
-	proxyGroup := r.Group("/api/v1/mcp-proxies/:id")
+	proxyGroup := r.Group(constants.APIBasePath + "/mcp-proxies/:id")
 	{
 		proxyGroup.POST("/deployments", h.DeployMCPProxy)
 		proxyGroup.POST("/deployments/:deploymentId/undeploy", h.UndeployMCPProxyDeployment)
@@ -61,7 +61,7 @@ func (h *MCPProxyDeploymentHandler) RegisterRoutes(r *gin.Engine) {
 	}
 }
 
-// DeployMCPProxy handles POST /api/v1/mcp-proxies/:id/deployments
+// DeployMCPProxy handles POST /api/v1alpha2/mcp-proxies/:id/deployments
 func (h *MCPProxyDeploymentHandler) DeployMCPProxy(c *gin.Context) {
 	orgId, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -141,7 +141,7 @@ func (h *MCPProxyDeploymentHandler) DeployMCPProxy(c *gin.Context) {
 	c.JSON(http.StatusCreated, deployment)
 }
 
-// UndeployMCPProxyDeployment handles POST /api/v1/mcp-proxies/:id/deployments/:deploymentId/undeploy
+// UndeployMCPProxyDeployment handles POST /api/v1alpha2/mcp-proxies/:id/deployments/:deploymentId/undeploy
 func (h *MCPProxyDeploymentHandler) UndeployMCPProxyDeployment(c *gin.Context) {
 	orgId, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -203,7 +203,7 @@ func (h *MCPProxyDeploymentHandler) UndeployMCPProxyDeployment(c *gin.Context) {
 	c.JSON(http.StatusOK, deployment)
 }
 
-// RestoreMCPProxyDeployment handles POST /api/v1/mcp-proxies/:id/deployments/:deploymentId/restore
+// RestoreMCPProxyDeployment handles POST /api/v1alpha2/mcp-proxies/:id/deployments/:deploymentId/restore
 func (h *MCPProxyDeploymentHandler) RestoreMCPProxyDeployment(c *gin.Context) {
 	orgId, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -265,7 +265,7 @@ func (h *MCPProxyDeploymentHandler) RestoreMCPProxyDeployment(c *gin.Context) {
 	c.JSON(http.StatusOK, deployment)
 }
 
-// DeleteMCPProxyDeployment handles DELETE /api/v1/mcp-proxies/:id/deployments/:deploymentId
+// DeleteMCPProxyDeployment handles DELETE /api/v1alpha2/mcp-proxies/:id/deployments/:deploymentId
 func (h *MCPProxyDeploymentHandler) DeleteMCPProxyDeployment(c *gin.Context) {
 	orgId, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -313,7 +313,7 @@ func (h *MCPProxyDeploymentHandler) DeleteMCPProxyDeployment(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }
 
-// GetMCPProxyDeployment handles GET /api/v1/mcp-proxies/:id/deployments/:deploymentId
+// GetMCPProxyDeployment handles GET /api/v1alpha2/mcp-proxies/:id/deployments/:deploymentId
 func (h *MCPProxyDeploymentHandler) GetMCPProxyDeployment(c *gin.Context) {
 	orgId, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -358,7 +358,7 @@ func (h *MCPProxyDeploymentHandler) GetMCPProxyDeployment(c *gin.Context) {
 	c.JSON(http.StatusOK, deployment)
 }
 
-// GetMCPProxyDeployments handles GET /api/v1/mcp-proxies/:id/deployments
+// GetMCPProxyDeployments handles GET /api/v1alpha2/mcp-proxies/:id/deployments
 func (h *MCPProxyDeploymentHandler) GetMCPProxyDeployments(c *gin.Context) {
 	orgId, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {

--- a/platform-api/src/internal/handler/mcp_deployment.go
+++ b/platform-api/src/internal/handler/mcp_deployment.go
@@ -61,7 +61,7 @@ func (h *MCPProxyDeploymentHandler) RegisterRoutes(r *gin.Engine) {
 	}
 }
 
-// DeployMCPProxy handles POST /api/v1alpha2/mcp-proxies/:id/deployments
+// DeployMCPProxy handles POST /api/v0.9/mcp-proxies/:id/deployments
 func (h *MCPProxyDeploymentHandler) DeployMCPProxy(c *gin.Context) {
 	orgId, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -141,7 +141,7 @@ func (h *MCPProxyDeploymentHandler) DeployMCPProxy(c *gin.Context) {
 	c.JSON(http.StatusCreated, deployment)
 }
 
-// UndeployMCPProxyDeployment handles POST /api/v1alpha2/mcp-proxies/:id/deployments/:deploymentId/undeploy
+// UndeployMCPProxyDeployment handles POST /api/v0.9/mcp-proxies/:id/deployments/:deploymentId/undeploy
 func (h *MCPProxyDeploymentHandler) UndeployMCPProxyDeployment(c *gin.Context) {
 	orgId, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -203,7 +203,7 @@ func (h *MCPProxyDeploymentHandler) UndeployMCPProxyDeployment(c *gin.Context) {
 	c.JSON(http.StatusOK, deployment)
 }
 
-// RestoreMCPProxyDeployment handles POST /api/v1alpha2/mcp-proxies/:id/deployments/:deploymentId/restore
+// RestoreMCPProxyDeployment handles POST /api/v0.9/mcp-proxies/:id/deployments/:deploymentId/restore
 func (h *MCPProxyDeploymentHandler) RestoreMCPProxyDeployment(c *gin.Context) {
 	orgId, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -265,7 +265,7 @@ func (h *MCPProxyDeploymentHandler) RestoreMCPProxyDeployment(c *gin.Context) {
 	c.JSON(http.StatusOK, deployment)
 }
 
-// DeleteMCPProxyDeployment handles DELETE /api/v1alpha2/mcp-proxies/:id/deployments/:deploymentId
+// DeleteMCPProxyDeployment handles DELETE /api/v0.9/mcp-proxies/:id/deployments/:deploymentId
 func (h *MCPProxyDeploymentHandler) DeleteMCPProxyDeployment(c *gin.Context) {
 	orgId, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -313,7 +313,7 @@ func (h *MCPProxyDeploymentHandler) DeleteMCPProxyDeployment(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }
 
-// GetMCPProxyDeployment handles GET /api/v1alpha2/mcp-proxies/:id/deployments/:deploymentId
+// GetMCPProxyDeployment handles GET /api/v0.9/mcp-proxies/:id/deployments/:deploymentId
 func (h *MCPProxyDeploymentHandler) GetMCPProxyDeployment(c *gin.Context) {
 	orgId, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -358,7 +358,7 @@ func (h *MCPProxyDeploymentHandler) GetMCPProxyDeployment(c *gin.Context) {
 	c.JSON(http.StatusOK, deployment)
 }
 
-// GetMCPProxyDeployments handles GET /api/v1alpha2/mcp-proxies/:id/deployments
+// GetMCPProxyDeployments handles GET /api/v0.9/mcp-proxies/:id/deployments
 func (h *MCPProxyDeploymentHandler) GetMCPProxyDeployments(c *gin.Context) {
 	orgId, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {

--- a/platform-api/src/internal/handler/organization.go
+++ b/platform-api/src/internal/handler/organization.go
@@ -46,7 +46,7 @@ func NewOrganizationHandler(orgService *service.OrganizationService, orgCreation
 	}
 }
 
-// RegisterOrganization handles POST /api/v1alpha2/organizations
+// RegisterOrganization handles POST /api/v0.9/organizations
 func (h *OrganizationHandler) RegisterOrganization(c *gin.Context) {
 	var req api.Organization
 
@@ -101,7 +101,7 @@ func (h *OrganizationHandler) RegisterOrganization(c *gin.Context) {
 	c.JSON(http.StatusCreated, org)
 }
 
-// HeadOrganizationByUuid handles HEAD /api/v1alpha2/organizations/{organizationId}
+// HeadOrganizationByUuid handles HEAD /api/v0.9/organizations/{organizationId}
 func (h *OrganizationHandler) HeadOrganizationByUuid(c *gin.Context) {
 	organizationIdFromContext, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -132,7 +132,7 @@ func (h *OrganizationHandler) HeadOrganizationByUuid(c *gin.Context) {
 	c.Status(http.StatusOK)
 }
 
-// GetOrganizationByUUID handles GET /api/v1alpha2/organizations/{organizationId}
+// GetOrganizationByUUID handles GET /api/v0.9/organizations/{organizationId}
 func (h *OrganizationHandler) GetOrganizationByUUID(c *gin.Context) {
 	orgID := c.Param("organizationId")
 
@@ -152,7 +152,7 @@ func (h *OrganizationHandler) GetOrganizationByUUID(c *gin.Context) {
 	c.JSON(http.StatusOK, org)
 }
 
-// GetOrganization handles GET /api/v1alpha2/organizations
+// GetOrganization handles GET /api/v0.9/organizations
 func (h *OrganizationHandler) GetOrganization(c *gin.Context) {
 	orgID, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -182,7 +182,7 @@ func (h *OrganizationHandler) GetOrganization(c *gin.Context) {
 	c.JSON(http.StatusOK, org)
 }
 
-// GetOrganizationSubscription handles GET /api/v1alpha2/organizations/:organizationId/subscription
+// GetOrganizationSubscription handles GET /api/v0.9/organizations/:organizationId/subscription
 func (h *OrganizationHandler) GetOrganizationSubscription(c *gin.Context) {
 	organizationIdFromContext, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {

--- a/platform-api/src/internal/handler/organization.go
+++ b/platform-api/src/internal/handler/organization.go
@@ -33,20 +33,20 @@ import (
 )
 
 type OrganizationHandler struct {
-	orgService             *service.OrganizationService
+	orgService              *service.OrganizationService
 	orgCreationRequiresAuth bool
-	slogger                *slog.Logger
+	slogger                 *slog.Logger
 }
 
 func NewOrganizationHandler(orgService *service.OrganizationService, orgCreationRequiresAuth bool, slogger *slog.Logger) *OrganizationHandler {
 	return &OrganizationHandler{
-		orgService:             orgService,
+		orgService:              orgService,
 		orgCreationRequiresAuth: orgCreationRequiresAuth,
-		slogger:                slogger,
+		slogger:                 slogger,
 	}
 }
 
-// RegisterOrganization handles POST /api/v1/organizations
+// RegisterOrganization handles POST /api/v1alpha2/organizations
 func (h *OrganizationHandler) RegisterOrganization(c *gin.Context) {
 	var req api.Organization
 
@@ -101,7 +101,7 @@ func (h *OrganizationHandler) RegisterOrganization(c *gin.Context) {
 	c.JSON(http.StatusCreated, org)
 }
 
-// HeadOrganizationByUuid handles HEAD /api/v1/organizations/{organizationId}
+// HeadOrganizationByUuid handles HEAD /api/v1alpha2/organizations/{organizationId}
 func (h *OrganizationHandler) HeadOrganizationByUuid(c *gin.Context) {
 	organizationIdFromContext, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -132,7 +132,7 @@ func (h *OrganizationHandler) HeadOrganizationByUuid(c *gin.Context) {
 	c.Status(http.StatusOK)
 }
 
-// GetOrganizationByUUID handles GET /api/v1/organizations/{organizationId}
+// GetOrganizationByUUID handles GET /api/v1alpha2/organizations/{organizationId}
 func (h *OrganizationHandler) GetOrganizationByUUID(c *gin.Context) {
 	orgID := c.Param("organizationId")
 
@@ -152,7 +152,7 @@ func (h *OrganizationHandler) GetOrganizationByUUID(c *gin.Context) {
 	c.JSON(http.StatusOK, org)
 }
 
-// GetOrganization handles GET /api/v1/organizations
+// GetOrganization handles GET /api/v1alpha2/organizations
 func (h *OrganizationHandler) GetOrganization(c *gin.Context) {
 	orgID, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -182,7 +182,7 @@ func (h *OrganizationHandler) GetOrganization(c *gin.Context) {
 	c.JSON(http.StatusOK, org)
 }
 
-// GetOrganizationSubscription handles GET /api/v1/organizations/:organizationId/subscription
+// GetOrganizationSubscription handles GET /api/v1alpha2/organizations/:organizationId/subscription
 func (h *OrganizationHandler) GetOrganizationSubscription(c *gin.Context) {
 	organizationIdFromContext, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -224,12 +224,12 @@ func (h *OrganizationHandler) GetOrganizationSubscription(c *gin.Context) {
 // The org creation POST is only registered here when OrgCreationRequiresAuth is false.
 func (h *OrganizationHandler) RegisterPublicRoutes(r *gin.Engine) {
 	if !h.orgCreationRequiresAuth {
-		r.POST("/api/v1/organizations", h.RegisterOrganization)
+		r.POST(constants.APIBasePath + "/organizations", h.RegisterOrganization)
 	}
 }
 
 func (h *OrganizationHandler) RegisterRoutes(r *gin.Engine) {
-	orgGroup := r.Group("/api/v1/organizations")
+	orgGroup := r.Group(constants.APIBasePath + "/organizations")
 	{
 		// When auth is required, POST is registered here — behind the auth middleware.
 		if h.orgCreationRequiresAuth {

--- a/platform-api/src/internal/handler/project.go
+++ b/platform-api/src/internal/handler/project.go
@@ -42,7 +42,7 @@ func NewProjectHandler(projectService *service.ProjectService, slogger *slog.Log
 	}
 }
 
-// CreateProject handles POST /api/v1alpha2/projects
+// CreateProject handles POST /api/v0.9/projects
 func (h *ProjectHandler) CreateProject(c *gin.Context) {
 	organizationID, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -90,7 +90,7 @@ func (h *ProjectHandler) CreateProject(c *gin.Context) {
 	c.JSON(http.StatusCreated, project)
 }
 
-// GetProject handles GET /api/v1alpha2/projects/:projectId
+// GetProject handles GET /api/v0.9/projects/:projectId
 func (h *ProjectHandler) GetProject(c *gin.Context) {
 	orgID, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -122,7 +122,7 @@ func (h *ProjectHandler) GetProject(c *gin.Context) {
 	c.JSON(http.StatusOK, project)
 }
 
-// ListProjects handles GET /api/v1alpha2/projects
+// ListProjects handles GET /api/v0.9/projects
 func (h *ProjectHandler) ListProjects(c *gin.Context) {
 	orgID, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -156,7 +156,7 @@ func (h *ProjectHandler) ListProjects(c *gin.Context) {
 	})
 }
 
-// UpdateProject handles PUT /api/v1alpha2/projects/:projectId
+// UpdateProject handles PUT /api/v0.9/projects/:projectId
 func (h *ProjectHandler) UpdateProject(c *gin.Context) {
 	orgID, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -199,7 +199,7 @@ func (h *ProjectHandler) UpdateProject(c *gin.Context) {
 	c.JSON(http.StatusOK, project)
 }
 
-// DeleteProject handles DELETE /api/v1alpha2/projects/:projectId
+// DeleteProject handles DELETE /api/v0.9/projects/:projectId
 func (h *ProjectHandler) DeleteProject(c *gin.Context) {
 	orgID, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {

--- a/platform-api/src/internal/handler/project.go
+++ b/platform-api/src/internal/handler/project.go
@@ -42,7 +42,7 @@ func NewProjectHandler(projectService *service.ProjectService, slogger *slog.Log
 	}
 }
 
-// CreateProject handles POST /api/v1/projects
+// CreateProject handles POST /api/v1alpha2/projects
 func (h *ProjectHandler) CreateProject(c *gin.Context) {
 	organizationID, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -90,7 +90,7 @@ func (h *ProjectHandler) CreateProject(c *gin.Context) {
 	c.JSON(http.StatusCreated, project)
 }
 
-// GetProject handles GET /api/v1/projects/:projectId
+// GetProject handles GET /api/v1alpha2/projects/:projectId
 func (h *ProjectHandler) GetProject(c *gin.Context) {
 	orgID, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -122,7 +122,7 @@ func (h *ProjectHandler) GetProject(c *gin.Context) {
 	c.JSON(http.StatusOK, project)
 }
 
-// ListProjects handles GET /api/v1/projects
+// ListProjects handles GET /api/v1alpha2/projects
 func (h *ProjectHandler) ListProjects(c *gin.Context) {
 	orgID, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -156,7 +156,7 @@ func (h *ProjectHandler) ListProjects(c *gin.Context) {
 	})
 }
 
-// UpdateProject handles PUT /api/v1/projects/:projectId
+// UpdateProject handles PUT /api/v1alpha2/projects/:projectId
 func (h *ProjectHandler) UpdateProject(c *gin.Context) {
 	orgID, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -199,7 +199,7 @@ func (h *ProjectHandler) UpdateProject(c *gin.Context) {
 	c.JSON(http.StatusOK, project)
 }
 
-// DeleteProject handles DELETE /api/v1/projects/:projectId
+// DeleteProject handles DELETE /api/v1alpha2/projects/:projectId
 func (h *ProjectHandler) DeleteProject(c *gin.Context) {
 	orgID, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -247,7 +247,7 @@ func (h *ProjectHandler) DeleteProject(c *gin.Context) {
 }
 
 func (h *ProjectHandler) RegisterRoutes(r *gin.Engine) {
-	projectGroup := r.Group("/api/v1/projects")
+	projectGroup := r.Group(constants.APIBasePath + "/projects")
 	{
 		projectGroup.GET("", h.ListProjects)
 		projectGroup.POST("", h.CreateProject)

--- a/platform-api/src/internal/handler/subscription_handler.go
+++ b/platform-api/src/internal/handler/subscription_handler.go
@@ -52,7 +52,7 @@ func NewSubscriptionHandler(subscriptionService *service.SubscriptionService, su
 	}
 }
 
-// CreateSubscriptionRequest is the body for POST /api/v1/subscriptions
+// CreateSubscriptionRequest is the body for POST /api/v1alpha2/subscriptions
 type CreateSubscriptionRequest struct {
 	APIID              string  `json:"apiId" binding:"required"`
 	SubscriberID       string  `json:"subscriberId" binding:"required"`
@@ -61,12 +61,12 @@ type CreateSubscriptionRequest struct {
 	Status             string  `json:"status,omitempty"`
 }
 
-// UpdateSubscriptionRequest is the body for PUT /api/v1/subscriptions/:subscriptionId
+// UpdateSubscriptionRequest is the body for PUT /api/v1alpha2/subscriptions/:subscriptionId
 type UpdateSubscriptionRequest struct {
 	Status string `json:"status,omitempty"`
 }
 
-// CreateSubscription handles POST /api/v1/subscriptions
+// CreateSubscription handles POST /api/v1alpha2/subscriptions
 func (h *SubscriptionHandler) CreateSubscription(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -112,7 +112,7 @@ func (h *SubscriptionHandler) CreateSubscription(c *gin.Context) {
 	c.JSON(http.StatusCreated, h.toSubscriptionResponse(sub, orgId))
 }
 
-// ListSubscriptions handles GET /api/v1/subscriptions
+// ListSubscriptions handles GET /api/v1alpha2/subscriptions
 func (h *SubscriptionHandler) ListSubscriptions(c *gin.Context) {
 	apiId := c.Query("apiId")
 	subscriberID := c.Query("subscriberId")
@@ -214,7 +214,7 @@ func (h *SubscriptionHandler) ListSubscriptions(c *gin.Context) {
 	})
 }
 
-// GetSubscription handles GET /api/v1/subscriptions/:subscriptionId
+// GetSubscription handles GET /api/v1alpha2/subscriptions/:subscriptionId
 func (h *SubscriptionHandler) GetSubscription(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -240,7 +240,7 @@ func (h *SubscriptionHandler) GetSubscription(c *gin.Context) {
 	c.JSON(http.StatusOK, h.toSubscriptionResponse(sub, orgId))
 }
 
-// UpdateSubscription handles PUT /api/v1/subscriptions/:subscriptionId
+// UpdateSubscription handles PUT /api/v1alpha2/subscriptions/:subscriptionId
 func (h *SubscriptionHandler) UpdateSubscription(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -285,7 +285,7 @@ func (h *SubscriptionHandler) UpdateSubscription(c *gin.Context) {
 	c.JSON(http.StatusOK, h.toSubscriptionResponse(sub, orgId))
 }
 
-// DeleteSubscription handles DELETE /api/v1/subscriptions/:subscriptionId
+// DeleteSubscription handles DELETE /api/v1alpha2/subscriptions/:subscriptionId
 func (h *SubscriptionHandler) DeleteSubscription(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -330,7 +330,7 @@ func requireSubscriptionSubscriberQuery(c *gin.Context) (string, bool) {
 }
 
 func (h *SubscriptionHandler) RegisterRoutes(r *gin.Engine) {
-	subGroup := r.Group("/api/v1/subscriptions")
+	subGroup := r.Group(constants.APIBasePath + "/subscriptions")
 	{
 		subGroup.POST("", h.CreateSubscription)
 		subGroup.GET("", h.ListSubscriptions)

--- a/platform-api/src/internal/handler/subscription_handler.go
+++ b/platform-api/src/internal/handler/subscription_handler.go
@@ -52,7 +52,7 @@ func NewSubscriptionHandler(subscriptionService *service.SubscriptionService, su
 	}
 }
 
-// CreateSubscriptionRequest is the body for POST /api/v1alpha2/subscriptions
+// CreateSubscriptionRequest is the body for POST /api/v0.9/subscriptions
 type CreateSubscriptionRequest struct {
 	APIID              string  `json:"apiId" binding:"required"`
 	SubscriberID       string  `json:"subscriberId" binding:"required"`
@@ -61,12 +61,12 @@ type CreateSubscriptionRequest struct {
 	Status             string  `json:"status,omitempty"`
 }
 
-// UpdateSubscriptionRequest is the body for PUT /api/v1alpha2/subscriptions/:subscriptionId
+// UpdateSubscriptionRequest is the body for PUT /api/v0.9/subscriptions/:subscriptionId
 type UpdateSubscriptionRequest struct {
 	Status string `json:"status,omitempty"`
 }
 
-// CreateSubscription handles POST /api/v1alpha2/subscriptions
+// CreateSubscription handles POST /api/v0.9/subscriptions
 func (h *SubscriptionHandler) CreateSubscription(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -112,7 +112,7 @@ func (h *SubscriptionHandler) CreateSubscription(c *gin.Context) {
 	c.JSON(http.StatusCreated, h.toSubscriptionResponse(sub, orgId))
 }
 
-// ListSubscriptions handles GET /api/v1alpha2/subscriptions
+// ListSubscriptions handles GET /api/v0.9/subscriptions
 func (h *SubscriptionHandler) ListSubscriptions(c *gin.Context) {
 	apiId := c.Query("apiId")
 	subscriberID := c.Query("subscriberId")
@@ -214,7 +214,7 @@ func (h *SubscriptionHandler) ListSubscriptions(c *gin.Context) {
 	})
 }
 
-// GetSubscription handles GET /api/v1alpha2/subscriptions/:subscriptionId
+// GetSubscription handles GET /api/v0.9/subscriptions/:subscriptionId
 func (h *SubscriptionHandler) GetSubscription(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -240,7 +240,7 @@ func (h *SubscriptionHandler) GetSubscription(c *gin.Context) {
 	c.JSON(http.StatusOK, h.toSubscriptionResponse(sub, orgId))
 }
 
-// UpdateSubscription handles PUT /api/v1alpha2/subscriptions/:subscriptionId
+// UpdateSubscription handles PUT /api/v0.9/subscriptions/:subscriptionId
 func (h *SubscriptionHandler) UpdateSubscription(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -285,7 +285,7 @@ func (h *SubscriptionHandler) UpdateSubscription(c *gin.Context) {
 	c.JSON(http.StatusOK, h.toSubscriptionResponse(sub, orgId))
 }
 
-// DeleteSubscription handles DELETE /api/v1alpha2/subscriptions/:subscriptionId
+// DeleteSubscription handles DELETE /api/v0.9/subscriptions/:subscriptionId
 func (h *SubscriptionHandler) DeleteSubscription(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {

--- a/platform-api/src/internal/handler/subscription_plan_handler.go
+++ b/platform-api/src/internal/handler/subscription_plan_handler.go
@@ -69,7 +69,7 @@ func validateThrottleLimitPair(count *int, unit *string) string {
 	return ""
 }
 
-// CreateSubscriptionPlanRequest is the body for POST /api/v1alpha2/subscription-plans
+// CreateSubscriptionPlanRequest is the body for POST /api/v0.9/subscription-plans
 type CreateSubscriptionPlanRequest struct {
 	PlanName           string  `json:"planName" binding:"required"`
 	BillingPlan        string  `json:"billingPlan,omitempty"`
@@ -80,7 +80,7 @@ type CreateSubscriptionPlanRequest struct {
 	Status             string  `json:"status,omitempty"`
 }
 
-// UpdateSubscriptionPlanRequest is the body for PUT /api/v1alpha2/subscription-plans/:planId
+// UpdateSubscriptionPlanRequest is the body for PUT /api/v0.9/subscription-plans/:planId
 // All fields use pointers for patch semantics: nil = omitted, non-nil = set (including clear-to-empty).
 type UpdateSubscriptionPlanRequest struct {
 	PlanName           *string `json:"planName,omitempty"`
@@ -92,7 +92,7 @@ type UpdateSubscriptionPlanRequest struct {
 	Status             *string `json:"status,omitempty"`
 }
 
-// CreateSubscriptionPlan handles POST /api/v1alpha2/subscription-plans
+// CreateSubscriptionPlan handles POST /api/v0.9/subscription-plans
 func (h *SubscriptionPlanHandler) CreateSubscriptionPlan(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -158,7 +158,7 @@ func (h *SubscriptionPlanHandler) CreateSubscriptionPlan(c *gin.Context) {
 	c.JSON(http.StatusCreated, toSubscriptionPlanResponse(created))
 }
 
-// ListSubscriptionPlans handles GET /api/v1alpha2/subscription-plans
+// ListSubscriptionPlans handles GET /api/v0.9/subscription-plans
 func (h *SubscriptionPlanHandler) ListSubscriptionPlans(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -193,7 +193,7 @@ func (h *SubscriptionPlanHandler) ListSubscriptionPlans(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"subscriptionPlans": items, "count": len(items)})
 }
 
-// GetSubscriptionPlan handles GET /api/v1alpha2/subscription-plans/:planId
+// GetSubscriptionPlan handles GET /api/v0.9/subscription-plans/:planId
 func (h *SubscriptionPlanHandler) GetSubscriptionPlan(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -220,7 +220,7 @@ func (h *SubscriptionPlanHandler) GetSubscriptionPlan(c *gin.Context) {
 	c.JSON(http.StatusOK, toSubscriptionPlanResponse(plan))
 }
 
-// UpdateSubscriptionPlan handles PUT /api/v1alpha2/subscription-plans/:planId
+// UpdateSubscriptionPlan handles PUT /api/v0.9/subscription-plans/:planId
 func (h *SubscriptionPlanHandler) UpdateSubscriptionPlan(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -295,7 +295,7 @@ func (h *SubscriptionPlanHandler) UpdateSubscriptionPlan(c *gin.Context) {
 	c.JSON(http.StatusOK, toSubscriptionPlanResponse(updated))
 }
 
-// DeleteSubscriptionPlan handles DELETE /api/v1alpha2/subscription-plans/:planId
+// DeleteSubscriptionPlan handles DELETE /api/v0.9/subscription-plans/:planId
 func (h *SubscriptionPlanHandler) DeleteSubscriptionPlan(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {

--- a/platform-api/src/internal/handler/subscription_plan_handler.go
+++ b/platform-api/src/internal/handler/subscription_plan_handler.go
@@ -69,7 +69,7 @@ func validateThrottleLimitPair(count *int, unit *string) string {
 	return ""
 }
 
-// CreateSubscriptionPlanRequest is the body for POST /api/v1/subscription-plans
+// CreateSubscriptionPlanRequest is the body for POST /api/v1alpha2/subscription-plans
 type CreateSubscriptionPlanRequest struct {
 	PlanName           string  `json:"planName" binding:"required"`
 	BillingPlan        string  `json:"billingPlan,omitempty"`
@@ -80,7 +80,7 @@ type CreateSubscriptionPlanRequest struct {
 	Status             string  `json:"status,omitempty"`
 }
 
-// UpdateSubscriptionPlanRequest is the body for PUT /api/v1/subscription-plans/:planId
+// UpdateSubscriptionPlanRequest is the body for PUT /api/v1alpha2/subscription-plans/:planId
 // All fields use pointers for patch semantics: nil = omitted, non-nil = set (including clear-to-empty).
 type UpdateSubscriptionPlanRequest struct {
 	PlanName           *string `json:"planName,omitempty"`
@@ -92,7 +92,7 @@ type UpdateSubscriptionPlanRequest struct {
 	Status             *string `json:"status,omitempty"`
 }
 
-// CreateSubscriptionPlan handles POST /api/v1/subscription-plans
+// CreateSubscriptionPlan handles POST /api/v1alpha2/subscription-plans
 func (h *SubscriptionPlanHandler) CreateSubscriptionPlan(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -158,7 +158,7 @@ func (h *SubscriptionPlanHandler) CreateSubscriptionPlan(c *gin.Context) {
 	c.JSON(http.StatusCreated, toSubscriptionPlanResponse(created))
 }
 
-// ListSubscriptionPlans handles GET /api/v1/subscription-plans
+// ListSubscriptionPlans handles GET /api/v1alpha2/subscription-plans
 func (h *SubscriptionPlanHandler) ListSubscriptionPlans(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -193,7 +193,7 @@ func (h *SubscriptionPlanHandler) ListSubscriptionPlans(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"subscriptionPlans": items, "count": len(items)})
 }
 
-// GetSubscriptionPlan handles GET /api/v1/subscription-plans/:planId
+// GetSubscriptionPlan handles GET /api/v1alpha2/subscription-plans/:planId
 func (h *SubscriptionPlanHandler) GetSubscriptionPlan(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -220,7 +220,7 @@ func (h *SubscriptionPlanHandler) GetSubscriptionPlan(c *gin.Context) {
 	c.JSON(http.StatusOK, toSubscriptionPlanResponse(plan))
 }
 
-// UpdateSubscriptionPlan handles PUT /api/v1/subscription-plans/:planId
+// UpdateSubscriptionPlan handles PUT /api/v1alpha2/subscription-plans/:planId
 func (h *SubscriptionPlanHandler) UpdateSubscriptionPlan(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -295,7 +295,7 @@ func (h *SubscriptionPlanHandler) UpdateSubscriptionPlan(c *gin.Context) {
 	c.JSON(http.StatusOK, toSubscriptionPlanResponse(updated))
 }
 
-// DeleteSubscriptionPlan handles DELETE /api/v1/subscription-plans/:planId
+// DeleteSubscriptionPlan handles DELETE /api/v1alpha2/subscription-plans/:planId
 func (h *SubscriptionPlanHandler) DeleteSubscriptionPlan(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -324,7 +324,7 @@ func (h *SubscriptionPlanHandler) DeleteSubscriptionPlan(c *gin.Context) {
 
 // RegisterRoutes registers subscription plan routes
 func (h *SubscriptionPlanHandler) RegisterRoutes(r *gin.Engine) {
-	group := r.Group("/api/v1/subscription-plans")
+	group := r.Group(constants.APIBasePath + "/subscription-plans")
 	{
 		group.POST("", h.CreateSubscriptionPlan)
 		group.GET("", h.ListSubscriptionPlans)

--- a/platform-api/src/internal/handler/webbroker_api.go
+++ b/platform-api/src/internal/handler/webbroker_api.go
@@ -51,7 +51,7 @@ func NewWebBrokerAPIHandler(webbrokerAPIService *service.WebBrokerAPIService, sl
 
 // RegisterRoutes registers WebBroker API routes
 func (h *WebBrokerAPIHandler) RegisterRoutes(r *gin.Engine) {
-	v1 := r.Group("/api/v1")
+	v1 := r.Group(constants.APIBasePath)
 	{
 		v1.POST("/webbroker-apis", h.CreateWebBrokerAPI)
 		v1.GET("/webbroker-apis", h.ListWebBrokerAPIs)
@@ -63,7 +63,7 @@ func (h *WebBrokerAPIHandler) RegisterRoutes(r *gin.Engine) {
 	}
 }
 
-// CreateWebBrokerAPI handles POST /api/v1/webbroker-apis
+// CreateWebBrokerAPI handles POST /api/v1alpha2/webbroker-apis
 func (h *WebBrokerAPIHandler) CreateWebBrokerAPI(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -89,7 +89,7 @@ func (h *WebBrokerAPIHandler) CreateWebBrokerAPI(c *gin.Context) {
 	c.JSON(http.StatusCreated, resp)
 }
 
-// ListWebBrokerAPIs handles GET /api/v1/webbroker-apis
+// ListWebBrokerAPIs handles GET /api/v1alpha2/webbroker-apis
 func (h *WebBrokerAPIHandler) ListWebBrokerAPIs(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -124,7 +124,7 @@ func (h *WebBrokerAPIHandler) ListWebBrokerAPIs(c *gin.Context) {
 	c.JSON(http.StatusOK, resp)
 }
 
-// GetWebBrokerAPI handles GET /api/v1/webbroker-apis/:apiId
+// GetWebBrokerAPI handles GET /api/v1alpha2/webbroker-apis/:apiId
 func (h *WebBrokerAPIHandler) GetWebBrokerAPI(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -142,7 +142,7 @@ func (h *WebBrokerAPIHandler) GetWebBrokerAPI(c *gin.Context) {
 	c.JSON(http.StatusOK, resp)
 }
 
-// UpdateWebBrokerAPI handles PUT /api/v1/webbroker-apis/:apiId
+// UpdateWebBrokerAPI handles PUT /api/v1alpha2/webbroker-apis/:apiId
 func (h *WebBrokerAPIHandler) UpdateWebBrokerAPI(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -168,7 +168,7 @@ func (h *WebBrokerAPIHandler) UpdateWebBrokerAPI(c *gin.Context) {
 	c.JSON(http.StatusOK, resp)
 }
 
-// DeleteWebBrokerAPI handles DELETE /api/v1/webbroker-apis/:apiId
+// DeleteWebBrokerAPI handles DELETE /api/v1alpha2/webbroker-apis/:apiId
 func (h *WebBrokerAPIHandler) DeleteWebBrokerAPI(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {

--- a/platform-api/src/internal/handler/webbroker_api.go
+++ b/platform-api/src/internal/handler/webbroker_api.go
@@ -63,7 +63,7 @@ func (h *WebBrokerAPIHandler) RegisterRoutes(r *gin.Engine) {
 	}
 }
 
-// CreateWebBrokerAPI handles POST /api/v1alpha2/webbroker-apis
+// CreateWebBrokerAPI handles POST /api/v0.9/webbroker-apis
 func (h *WebBrokerAPIHandler) CreateWebBrokerAPI(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -89,7 +89,7 @@ func (h *WebBrokerAPIHandler) CreateWebBrokerAPI(c *gin.Context) {
 	c.JSON(http.StatusCreated, resp)
 }
 
-// ListWebBrokerAPIs handles GET /api/v1alpha2/webbroker-apis
+// ListWebBrokerAPIs handles GET /api/v0.9/webbroker-apis
 func (h *WebBrokerAPIHandler) ListWebBrokerAPIs(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -124,7 +124,7 @@ func (h *WebBrokerAPIHandler) ListWebBrokerAPIs(c *gin.Context) {
 	c.JSON(http.StatusOK, resp)
 }
 
-// GetWebBrokerAPI handles GET /api/v1alpha2/webbroker-apis/:apiId
+// GetWebBrokerAPI handles GET /api/v0.9/webbroker-apis/:apiId
 func (h *WebBrokerAPIHandler) GetWebBrokerAPI(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -142,7 +142,7 @@ func (h *WebBrokerAPIHandler) GetWebBrokerAPI(c *gin.Context) {
 	c.JSON(http.StatusOK, resp)
 }
 
-// UpdateWebBrokerAPI handles PUT /api/v1alpha2/webbroker-apis/:apiId
+// UpdateWebBrokerAPI handles PUT /api/v0.9/webbroker-apis/:apiId
 func (h *WebBrokerAPIHandler) UpdateWebBrokerAPI(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -168,7 +168,7 @@ func (h *WebBrokerAPIHandler) UpdateWebBrokerAPI(c *gin.Context) {
 	c.JSON(http.StatusOK, resp)
 }
 
-// DeleteWebBrokerAPI handles DELETE /api/v1alpha2/webbroker-apis/:apiId
+// DeleteWebBrokerAPI handles DELETE /api/v0.9/webbroker-apis/:apiId
 func (h *WebBrokerAPIHandler) DeleteWebBrokerAPI(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {

--- a/platform-api/src/internal/handler/webbroker_api_deployment.go
+++ b/platform-api/src/internal/handler/webbroker_api_deployment.go
@@ -50,7 +50,7 @@ func NewWebBrokerAPIDeploymentHandler(webbrokerAPIDeploymentService *service.Web
 
 // RegisterRoutes registers WebBroker API deployment routes
 func (h *WebBrokerAPIDeploymentHandler) RegisterRoutes(r *gin.Engine) {
-	g := r.Group("/api/v1/webbroker-apis/:apiId")
+	g := r.Group(constants.APIBasePath + "/webbroker-apis/:apiId")
 	{
 		g.POST("/deployments", h.DeployWebBrokerAPI)
 		g.POST("/deployments/:deploymentId/undeploy", h.UndeployDeployment)
@@ -61,7 +61,7 @@ func (h *WebBrokerAPIDeploymentHandler) RegisterRoutes(r *gin.Engine) {
 	}
 }
 
-// DeployWebBrokerAPI handles POST /api/v1/webbroker-apis/:apiId/deployments
+// DeployWebBrokerAPI handles POST /api/v1alpha2/webbroker-apis/:apiId/deployments
 func (h *WebBrokerAPIDeploymentHandler) DeployWebBrokerAPI(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -103,7 +103,7 @@ func (h *WebBrokerAPIDeploymentHandler) DeployWebBrokerAPI(c *gin.Context) {
 	c.JSON(http.StatusCreated, deployment)
 }
 
-// UndeployDeployment handles POST /api/v1/webbroker-apis/:apiId/deployments/:deploymentId/undeploy
+// UndeployDeployment handles POST /api/v1alpha2/webbroker-apis/:apiId/deployments/:deploymentId/undeploy
 func (h *WebBrokerAPIDeploymentHandler) UndeployDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -132,7 +132,7 @@ func (h *WebBrokerAPIDeploymentHandler) UndeployDeployment(c *gin.Context) {
 	c.JSON(http.StatusOK, deployment)
 }
 
-// RestoreDeployment handles POST /api/v1/webbroker-apis/:apiId/deployments/:deploymentId/restore
+// RestoreDeployment handles POST /api/v1alpha2/webbroker-apis/:apiId/deployments/:deploymentId/restore
 func (h *WebBrokerAPIDeploymentHandler) RestoreDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -161,7 +161,7 @@ func (h *WebBrokerAPIDeploymentHandler) RestoreDeployment(c *gin.Context) {
 	c.JSON(http.StatusOK, deployment)
 }
 
-// GetDeployments handles GET /api/v1/webbroker-apis/:apiId/deployments
+// GetDeployments handles GET /api/v1alpha2/webbroker-apis/:apiId/deployments
 func (h *WebBrokerAPIDeploymentHandler) GetDeployments(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -198,7 +198,7 @@ func (h *WebBrokerAPIDeploymentHandler) GetDeployments(c *gin.Context) {
 	c.JSON(http.StatusOK, deployments)
 }
 
-// GetDeployment handles GET /api/v1/webbroker-apis/:apiId/deployments/:deploymentId
+// GetDeployment handles GET /api/v1alpha2/webbroker-apis/:apiId/deployments/:deploymentId
 func (h *WebBrokerAPIDeploymentHandler) GetDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -218,7 +218,7 @@ func (h *WebBrokerAPIDeploymentHandler) GetDeployment(c *gin.Context) {
 	c.JSON(http.StatusOK, deployment)
 }
 
-// DeleteDeployment handles DELETE /api/v1/webbroker-apis/:apiId/deployments/:deploymentId
+// DeleteDeployment handles DELETE /api/v1alpha2/webbroker-apis/:apiId/deployments/:deploymentId
 func (h *WebBrokerAPIDeploymentHandler) DeleteDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {

--- a/platform-api/src/internal/handler/webbroker_api_deployment.go
+++ b/platform-api/src/internal/handler/webbroker_api_deployment.go
@@ -61,7 +61,7 @@ func (h *WebBrokerAPIDeploymentHandler) RegisterRoutes(r *gin.Engine) {
 	}
 }
 
-// DeployWebBrokerAPI handles POST /api/v1alpha2/webbroker-apis/:apiId/deployments
+// DeployWebBrokerAPI handles POST /api/v0.9/webbroker-apis/:apiId/deployments
 func (h *WebBrokerAPIDeploymentHandler) DeployWebBrokerAPI(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -103,7 +103,7 @@ func (h *WebBrokerAPIDeploymentHandler) DeployWebBrokerAPI(c *gin.Context) {
 	c.JSON(http.StatusCreated, deployment)
 }
 
-// UndeployDeployment handles POST /api/v1alpha2/webbroker-apis/:apiId/deployments/:deploymentId/undeploy
+// UndeployDeployment handles POST /api/v0.9/webbroker-apis/:apiId/deployments/:deploymentId/undeploy
 func (h *WebBrokerAPIDeploymentHandler) UndeployDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -132,7 +132,7 @@ func (h *WebBrokerAPIDeploymentHandler) UndeployDeployment(c *gin.Context) {
 	c.JSON(http.StatusOK, deployment)
 }
 
-// RestoreDeployment handles POST /api/v1alpha2/webbroker-apis/:apiId/deployments/:deploymentId/restore
+// RestoreDeployment handles POST /api/v0.9/webbroker-apis/:apiId/deployments/:deploymentId/restore
 func (h *WebBrokerAPIDeploymentHandler) RestoreDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -161,7 +161,7 @@ func (h *WebBrokerAPIDeploymentHandler) RestoreDeployment(c *gin.Context) {
 	c.JSON(http.StatusOK, deployment)
 }
 
-// GetDeployments handles GET /api/v1alpha2/webbroker-apis/:apiId/deployments
+// GetDeployments handles GET /api/v0.9/webbroker-apis/:apiId/deployments
 func (h *WebBrokerAPIDeploymentHandler) GetDeployments(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -198,7 +198,7 @@ func (h *WebBrokerAPIDeploymentHandler) GetDeployments(c *gin.Context) {
 	c.JSON(http.StatusOK, deployments)
 }
 
-// GetDeployment handles GET /api/v1alpha2/webbroker-apis/:apiId/deployments/:deploymentId
+// GetDeployment handles GET /api/v0.9/webbroker-apis/:apiId/deployments/:deploymentId
 func (h *WebBrokerAPIDeploymentHandler) GetDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -218,7 +218,7 @@ func (h *WebBrokerAPIDeploymentHandler) GetDeployment(c *gin.Context) {
 	c.JSON(http.StatusOK, deployment)
 }
 
-// DeleteDeployment handles DELETE /api/v1alpha2/webbroker-apis/:apiId/deployments/:deploymentId
+// DeleteDeployment handles DELETE /api/v0.9/webbroker-apis/:apiId/deployments/:deploymentId
 func (h *WebBrokerAPIDeploymentHandler) DeleteDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {

--- a/platform-api/src/internal/handler/webbroker_apikey.go
+++ b/platform-api/src/internal/handler/webbroker_apikey.go
@@ -52,7 +52,7 @@ func NewWebBrokerAPIKeyHandler(webbrokerAPIService *service.WebBrokerAPIService,
 
 // RegisterRoutes registers WebBroker API key routes
 func (h *WebBrokerAPIKeyHandler) RegisterRoutes(r *gin.Engine) {
-	v1 := r.Group("/api/v1/webbroker-apis/:apiId/api-keys")
+	v1 := r.Group(constants.APIBasePath + "/webbroker-apis/:apiId/api-keys")
 	{
 		v1.POST("", h.CreateAPIKey)
 		v1.PUT("/:keyName", h.UpdateAPIKey)
@@ -60,7 +60,7 @@ func (h *WebBrokerAPIKeyHandler) RegisterRoutes(r *gin.Engine) {
 	}
 }
 
-// CreateAPIKey handles POST /api/v1/webbroker-apis/:apiId/api-keys
+// CreateAPIKey handles POST /api/v1alpha2/webbroker-apis/:apiId/api-keys
 func (h *WebBrokerAPIKeyHandler) CreateAPIKey(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -134,7 +134,7 @@ func (h *WebBrokerAPIKeyHandler) CreateAPIKey(c *gin.Context) {
 	})
 }
 
-// UpdateAPIKey handles PUT /api/v1/webbroker-apis/:apiId/api-keys/:keyName
+// UpdateAPIKey handles PUT /api/v1alpha2/webbroker-apis/:apiId/api-keys/:keyName
 func (h *WebBrokerAPIKeyHandler) UpdateAPIKey(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -204,7 +204,7 @@ func (h *WebBrokerAPIKeyHandler) UpdateAPIKey(c *gin.Context) {
 	})
 }
 
-// DeleteAPIKey handles DELETE /api/v1/webbroker-apis/:apiId/api-keys/:keyName
+// DeleteAPIKey handles DELETE /api/v1alpha2/webbroker-apis/:apiId/api-keys/:keyName
 func (h *WebBrokerAPIKeyHandler) DeleteAPIKey(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {

--- a/platform-api/src/internal/handler/webbroker_apikey.go
+++ b/platform-api/src/internal/handler/webbroker_apikey.go
@@ -60,7 +60,7 @@ func (h *WebBrokerAPIKeyHandler) RegisterRoutes(r *gin.Engine) {
 	}
 }
 
-// CreateAPIKey handles POST /api/v1alpha2/webbroker-apis/:apiId/api-keys
+// CreateAPIKey handles POST /api/v0.9/webbroker-apis/:apiId/api-keys
 func (h *WebBrokerAPIKeyHandler) CreateAPIKey(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -134,7 +134,7 @@ func (h *WebBrokerAPIKeyHandler) CreateAPIKey(c *gin.Context) {
 	})
 }
 
-// UpdateAPIKey handles PUT /api/v1alpha2/webbroker-apis/:apiId/api-keys/:keyName
+// UpdateAPIKey handles PUT /api/v0.9/webbroker-apis/:apiId/api-keys/:keyName
 func (h *WebBrokerAPIKeyHandler) UpdateAPIKey(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -204,7 +204,7 @@ func (h *WebBrokerAPIKeyHandler) UpdateAPIKey(c *gin.Context) {
 	})
 }
 
-// DeleteAPIKey handles DELETE /api/v1alpha2/webbroker-apis/:apiId/api-keys/:keyName
+// DeleteAPIKey handles DELETE /api/v0.9/webbroker-apis/:apiId/api-keys/:keyName
 func (h *WebBrokerAPIKeyHandler) DeleteAPIKey(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {

--- a/platform-api/src/internal/handler/websub_api.go
+++ b/platform-api/src/internal/handler/websub_api.go
@@ -51,7 +51,7 @@ func NewWebSubAPIHandler(websubAPIService *service.WebSubAPIService, slogger *sl
 
 // RegisterRoutes registers WebSub API routes
 func (h *WebSubAPIHandler) RegisterRoutes(r *gin.Engine) {
-	v1 := r.Group("/api/v1")
+	v1 := r.Group(constants.APIBasePath)
 	{
 		v1.POST("/websub-apis", h.CreateWebSubAPI)
 		v1.GET("/websub-apis", h.ListWebSubAPIs)
@@ -63,7 +63,7 @@ func (h *WebSubAPIHandler) RegisterRoutes(r *gin.Engine) {
 	}
 }
 
-// CreateWebSubAPI handles POST /api/v1/websub-apis
+// CreateWebSubAPI handles POST /api/v1alpha2/websub-apis
 func (h *WebSubAPIHandler) CreateWebSubAPI(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -89,7 +89,7 @@ func (h *WebSubAPIHandler) CreateWebSubAPI(c *gin.Context) {
 	c.JSON(http.StatusCreated, resp)
 }
 
-// ListWebSubAPIs handles GET /api/v1/websub-apis
+// ListWebSubAPIs handles GET /api/v1alpha2/websub-apis
 func (h *WebSubAPIHandler) ListWebSubAPIs(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -124,7 +124,7 @@ func (h *WebSubAPIHandler) ListWebSubAPIs(c *gin.Context) {
 	c.JSON(http.StatusOK, resp)
 }
 
-// GetWebSubAPI handles GET /api/v1/websub-apis/:apiId
+// GetWebSubAPI handles GET /api/v1alpha2/websub-apis/:apiId
 func (h *WebSubAPIHandler) GetWebSubAPI(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -142,7 +142,7 @@ func (h *WebSubAPIHandler) GetWebSubAPI(c *gin.Context) {
 	c.JSON(http.StatusOK, resp)
 }
 
-// UpdateWebSubAPI handles PUT /api/v1/websub-apis/:apiId
+// UpdateWebSubAPI handles PUT /api/v1alpha2/websub-apis/:apiId
 func (h *WebSubAPIHandler) UpdateWebSubAPI(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -168,7 +168,7 @@ func (h *WebSubAPIHandler) UpdateWebSubAPI(c *gin.Context) {
 	c.JSON(http.StatusOK, resp)
 }
 
-// DeleteWebSubAPI handles DELETE /api/v1/websub-apis/:apiId
+// DeleteWebSubAPI handles DELETE /api/v1alpha2/websub-apis/:apiId
 func (h *WebSubAPIHandler) DeleteWebSubAPI(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {

--- a/platform-api/src/internal/handler/websub_api.go
+++ b/platform-api/src/internal/handler/websub_api.go
@@ -63,7 +63,7 @@ func (h *WebSubAPIHandler) RegisterRoutes(r *gin.Engine) {
 	}
 }
 
-// CreateWebSubAPI handles POST /api/v1alpha2/websub-apis
+// CreateWebSubAPI handles POST /api/v0.9/websub-apis
 func (h *WebSubAPIHandler) CreateWebSubAPI(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -89,7 +89,7 @@ func (h *WebSubAPIHandler) CreateWebSubAPI(c *gin.Context) {
 	c.JSON(http.StatusCreated, resp)
 }
 
-// ListWebSubAPIs handles GET /api/v1alpha2/websub-apis
+// ListWebSubAPIs handles GET /api/v0.9/websub-apis
 func (h *WebSubAPIHandler) ListWebSubAPIs(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -124,7 +124,7 @@ func (h *WebSubAPIHandler) ListWebSubAPIs(c *gin.Context) {
 	c.JSON(http.StatusOK, resp)
 }
 
-// GetWebSubAPI handles GET /api/v1alpha2/websub-apis/:apiId
+// GetWebSubAPI handles GET /api/v0.9/websub-apis/:apiId
 func (h *WebSubAPIHandler) GetWebSubAPI(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -142,7 +142,7 @@ func (h *WebSubAPIHandler) GetWebSubAPI(c *gin.Context) {
 	c.JSON(http.StatusOK, resp)
 }
 
-// UpdateWebSubAPI handles PUT /api/v1alpha2/websub-apis/:apiId
+// UpdateWebSubAPI handles PUT /api/v0.9/websub-apis/:apiId
 func (h *WebSubAPIHandler) UpdateWebSubAPI(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -168,7 +168,7 @@ func (h *WebSubAPIHandler) UpdateWebSubAPI(c *gin.Context) {
 	c.JSON(http.StatusOK, resp)
 }
 
-// DeleteWebSubAPI handles DELETE /api/v1alpha2/websub-apis/:apiId
+// DeleteWebSubAPI handles DELETE /api/v0.9/websub-apis/:apiId
 func (h *WebSubAPIHandler) DeleteWebSubAPI(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {

--- a/platform-api/src/internal/handler/websub_api_deployment.go
+++ b/platform-api/src/internal/handler/websub_api_deployment.go
@@ -50,7 +50,7 @@ func NewWebSubAPIDeploymentHandler(websubAPIDeploymentService *service.WebSubAPI
 
 // RegisterRoutes registers WebSub API deployment routes
 func (h *WebSubAPIDeploymentHandler) RegisterRoutes(r *gin.Engine) {
-	g := r.Group("/api/v1/websub-apis/:apiId")
+	g := r.Group(constants.APIBasePath + "/websub-apis/:apiId")
 	{
 		g.POST("/deployments", h.DeployWebSubAPI)
 		g.POST("/deployments/:deploymentId/undeploy", h.UndeployDeployment)
@@ -61,7 +61,7 @@ func (h *WebSubAPIDeploymentHandler) RegisterRoutes(r *gin.Engine) {
 	}
 }
 
-// DeployWebSubAPI handles POST /api/v1/websub-apis/:apiId/deployments
+// DeployWebSubAPI handles POST /api/v1alpha2/websub-apis/:apiId/deployments
 func (h *WebSubAPIDeploymentHandler) DeployWebSubAPI(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -103,7 +103,7 @@ func (h *WebSubAPIDeploymentHandler) DeployWebSubAPI(c *gin.Context) {
 	c.JSON(http.StatusCreated, deployment)
 }
 
-// UndeployDeployment handles POST /api/v1/websub-apis/:apiId/deployments/:deploymentId/undeploy
+// UndeployDeployment handles POST /api/v1alpha2/websub-apis/:apiId/deployments/:deploymentId/undeploy
 func (h *WebSubAPIDeploymentHandler) UndeployDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -132,7 +132,7 @@ func (h *WebSubAPIDeploymentHandler) UndeployDeployment(c *gin.Context) {
 	c.JSON(http.StatusOK, deployment)
 }
 
-// RestoreDeployment handles POST /api/v1/websub-apis/:apiId/deployments/:deploymentId/restore
+// RestoreDeployment handles POST /api/v1alpha2/websub-apis/:apiId/deployments/:deploymentId/restore
 func (h *WebSubAPIDeploymentHandler) RestoreDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -161,7 +161,7 @@ func (h *WebSubAPIDeploymentHandler) RestoreDeployment(c *gin.Context) {
 	c.JSON(http.StatusOK, deployment)
 }
 
-// GetDeployments handles GET /api/v1/websub-apis/:apiId/deployments
+// GetDeployments handles GET /api/v1alpha2/websub-apis/:apiId/deployments
 func (h *WebSubAPIDeploymentHandler) GetDeployments(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -198,7 +198,7 @@ func (h *WebSubAPIDeploymentHandler) GetDeployments(c *gin.Context) {
 	c.JSON(http.StatusOK, deployments)
 }
 
-// GetDeployment handles GET /api/v1/websub-apis/:apiId/deployments/:deploymentId
+// GetDeployment handles GET /api/v1alpha2/websub-apis/:apiId/deployments/:deploymentId
 func (h *WebSubAPIDeploymentHandler) GetDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -218,7 +218,7 @@ func (h *WebSubAPIDeploymentHandler) GetDeployment(c *gin.Context) {
 	c.JSON(http.StatusOK, deployment)
 }
 
-// DeleteDeployment handles DELETE /api/v1/websub-apis/:apiId/deployments/:deploymentId
+// DeleteDeployment handles DELETE /api/v1alpha2/websub-apis/:apiId/deployments/:deploymentId
 func (h *WebSubAPIDeploymentHandler) DeleteDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {

--- a/platform-api/src/internal/handler/websub_api_deployment.go
+++ b/platform-api/src/internal/handler/websub_api_deployment.go
@@ -61,7 +61,7 @@ func (h *WebSubAPIDeploymentHandler) RegisterRoutes(r *gin.Engine) {
 	}
 }
 
-// DeployWebSubAPI handles POST /api/v1alpha2/websub-apis/:apiId/deployments
+// DeployWebSubAPI handles POST /api/v0.9/websub-apis/:apiId/deployments
 func (h *WebSubAPIDeploymentHandler) DeployWebSubAPI(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -103,7 +103,7 @@ func (h *WebSubAPIDeploymentHandler) DeployWebSubAPI(c *gin.Context) {
 	c.JSON(http.StatusCreated, deployment)
 }
 
-// UndeployDeployment handles POST /api/v1alpha2/websub-apis/:apiId/deployments/:deploymentId/undeploy
+// UndeployDeployment handles POST /api/v0.9/websub-apis/:apiId/deployments/:deploymentId/undeploy
 func (h *WebSubAPIDeploymentHandler) UndeployDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -132,7 +132,7 @@ func (h *WebSubAPIDeploymentHandler) UndeployDeployment(c *gin.Context) {
 	c.JSON(http.StatusOK, deployment)
 }
 
-// RestoreDeployment handles POST /api/v1alpha2/websub-apis/:apiId/deployments/:deploymentId/restore
+// RestoreDeployment handles POST /api/v0.9/websub-apis/:apiId/deployments/:deploymentId/restore
 func (h *WebSubAPIDeploymentHandler) RestoreDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -161,7 +161,7 @@ func (h *WebSubAPIDeploymentHandler) RestoreDeployment(c *gin.Context) {
 	c.JSON(http.StatusOK, deployment)
 }
 
-// GetDeployments handles GET /api/v1alpha2/websub-apis/:apiId/deployments
+// GetDeployments handles GET /api/v0.9/websub-apis/:apiId/deployments
 func (h *WebSubAPIDeploymentHandler) GetDeployments(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -198,7 +198,7 @@ func (h *WebSubAPIDeploymentHandler) GetDeployments(c *gin.Context) {
 	c.JSON(http.StatusOK, deployments)
 }
 
-// GetDeployment handles GET /api/v1alpha2/websub-apis/:apiId/deployments/:deploymentId
+// GetDeployment handles GET /api/v0.9/websub-apis/:apiId/deployments/:deploymentId
 func (h *WebSubAPIDeploymentHandler) GetDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {
@@ -218,7 +218,7 @@ func (h *WebSubAPIDeploymentHandler) GetDeployment(c *gin.Context) {
 	c.JSON(http.StatusOK, deployment)
 }
 
-// DeleteDeployment handles DELETE /api/v1alpha2/websub-apis/:apiId/deployments/:deploymentId
+// DeleteDeployment handles DELETE /api/v0.9/websub-apis/:apiId/deployments/:deploymentId
 func (h *WebSubAPIDeploymentHandler) DeleteDeployment(c *gin.Context) {
 	orgId, exists := middleware.GetOrganizationFromContext(c)
 	if !exists {

--- a/platform-api/src/internal/handler/websub_apikey.go
+++ b/platform-api/src/internal/handler/websub_apikey.go
@@ -52,7 +52,7 @@ func NewWebSubAPIKeyHandler(websubAPIService *service.WebSubAPIService, apiKeySe
 
 // RegisterRoutes registers WebSub API key routes
 func (h *WebSubAPIKeyHandler) RegisterRoutes(r *gin.Engine) {
-	v1 := r.Group("/api/v1/websub-apis/:apiId/api-keys")
+	v1 := r.Group(constants.APIBasePath + "/websub-apis/:apiId/api-keys")
 	{
 		v1.POST("", h.CreateAPIKey)
 		v1.PUT("/:keyName", h.UpdateAPIKey)
@@ -60,7 +60,7 @@ func (h *WebSubAPIKeyHandler) RegisterRoutes(r *gin.Engine) {
 	}
 }
 
-// CreateAPIKey handles POST /api/v1/websub-apis/:apiId/api-keys
+// CreateAPIKey handles POST /api/v1alpha2/websub-apis/:apiId/api-keys
 func (h *WebSubAPIKeyHandler) CreateAPIKey(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -134,7 +134,7 @@ func (h *WebSubAPIKeyHandler) CreateAPIKey(c *gin.Context) {
 	})
 }
 
-// UpdateAPIKey handles PUT /api/v1/websub-apis/:apiId/api-keys/:keyName
+// UpdateAPIKey handles PUT /api/v1alpha2/websub-apis/:apiId/api-keys/:keyName
 func (h *WebSubAPIKeyHandler) UpdateAPIKey(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -205,7 +205,7 @@ func (h *WebSubAPIKeyHandler) UpdateAPIKey(c *gin.Context) {
 	})
 }
 
-// DeleteAPIKey handles DELETE /api/v1/websub-apis/:apiId/api-keys/:keyName
+// DeleteAPIKey handles DELETE /api/v1alpha2/websub-apis/:apiId/api-keys/:keyName
 func (h *WebSubAPIKeyHandler) DeleteAPIKey(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {

--- a/platform-api/src/internal/handler/websub_apikey.go
+++ b/platform-api/src/internal/handler/websub_apikey.go
@@ -60,7 +60,7 @@ func (h *WebSubAPIKeyHandler) RegisterRoutes(r *gin.Engine) {
 	}
 }
 
-// CreateAPIKey handles POST /api/v1alpha2/websub-apis/:apiId/api-keys
+// CreateAPIKey handles POST /api/v0.9/websub-apis/:apiId/api-keys
 func (h *WebSubAPIKeyHandler) CreateAPIKey(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -134,7 +134,7 @@ func (h *WebSubAPIKeyHandler) CreateAPIKey(c *gin.Context) {
 	})
 }
 
-// UpdateAPIKey handles PUT /api/v1alpha2/websub-apis/:apiId/api-keys/:keyName
+// UpdateAPIKey handles PUT /api/v0.9/websub-apis/:apiId/api-keys/:keyName
 func (h *WebSubAPIKeyHandler) UpdateAPIKey(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -205,7 +205,7 @@ func (h *WebSubAPIKeyHandler) UpdateAPIKey(c *gin.Context) {
 	})
 }
 
-// DeleteAPIKey handles DELETE /api/v1alpha2/websub-apis/:apiId/api-keys/:keyName
+// DeleteAPIKey handles DELETE /api/v0.9/websub-apis/:apiId/api-keys/:keyName
 func (h *WebSubAPIKeyHandler) DeleteAPIKey(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {

--- a/platform-api/src/internal/middleware/openapi_scope_registry_test.go
+++ b/platform-api/src/internal/middleware/openapi_scope_registry_test.go
@@ -8,7 +8,7 @@ import (
 const testSpec = `
 openapi: 3.1.1
 servers:
-  - url: https://localhost:9243/api/v1
+  - url: https://localhost:9243/api/v1alpha2
 paths:
   /projects:
     post:
@@ -57,9 +57,9 @@ func TestLoadScopeRegistry(t *testing.T) {
 		wantFound  bool
 		wantScopes []string
 	}{
-		{"POST", "/api/v1/projects", true, []string{"ap:project:create", "ap:project:manage"}},
-		{"GET", "/api/v1/projects/:projectId", true, []string{"ap:project:read", "ap:project:manage"}},
-		{"POST", "/api/v1/organizations", false, nil},
+		{"POST", "/api/v1alpha2/projects", true, []string{"ap:project:create", "ap:project:manage"}},
+		{"GET", "/api/v1alpha2/projects/:projectId", true, []string{"ap:project:read", "ap:project:manage"}},
+		{"POST", "/api/v1alpha2/organizations", false, nil},
 	}
 	for _, tc := range tests {
 		scopes, found := reg.Lookup(tc.method, tc.path)

--- a/platform-api/src/internal/middleware/openapi_scope_registry_test.go
+++ b/platform-api/src/internal/middleware/openapi_scope_registry_test.go
@@ -8,7 +8,7 @@ import (
 const testSpec = `
 openapi: 3.1.1
 servers:
-  - url: https://localhost:9243/api/v1alpha2
+  - url: https://localhost:9243/api/v0.9
 paths:
   /projects:
     post:
@@ -57,9 +57,9 @@ func TestLoadScopeRegistry(t *testing.T) {
 		wantFound  bool
 		wantScopes []string
 	}{
-		{"POST", "/api/v1alpha2/projects", true, []string{"ap:project:create", "ap:project:manage"}},
-		{"GET", "/api/v1alpha2/projects/:projectId", true, []string{"ap:project:read", "ap:project:manage"}},
-		{"POST", "/api/v1alpha2/organizations", false, nil},
+		{"POST", "/api/v0.9/projects", true, []string{"ap:project:create", "ap:project:manage"}},
+		{"GET", "/api/v0.9/projects/:projectId", true, []string{"ap:project:read", "ap:project:manage"}},
+		{"POST", "/api/v0.9/organizations", false, nil},
 	}
 	for _, tc := range tests {
 		scopes, found := reg.Lookup(tc.method, tc.path)

--- a/platform-api/src/internal/model/llm.go
+++ b/platform-api/src/internal/model/llm.go
@@ -159,22 +159,22 @@ type LLMProviderTemplateResourceMappings struct {
 }
 
 type LLMProviderTemplate struct {
-	UUID             string                       `json:"uuid" db:"uuid"`
-	OrganizationUUID string                       `json:"organizationId" db:"organization_uuid"`
-	ID               string                       `json:"id" db:"handle"`
-	Name             string                       `json:"name" db:"name"`
-	Description      string                       `json:"description,omitempty" db:"description"`
-	CreatedBy        string                       `json:"createdBy,omitempty" db:"created_by"`
-	Metadata         *LLMProviderTemplateMetadata `json:"metadata,omitempty" db:"-"`
-	PromptTokens     *ExtractionIdentifier        `json:"promptTokens,omitempty" db:"-"`
-	CompletionTokens *ExtractionIdentifier        `json:"completionTokens,omitempty" db:"-"`
-	TotalTokens      *ExtractionIdentifier        `json:"totalTokens,omitempty" db:"-"`
-	RemainingTokens  *ExtractionIdentifier        `json:"remainingTokens,omitempty" db:"-"`
-	RequestModel     *ExtractionIdentifier        `json:"requestModel,omitempty" db:"-"`
-	ResponseModel    *ExtractionIdentifier        `json:"responseModel,omitempty" db:"-"`
+	UUID             string                               `json:"uuid" db:"uuid"`
+	OrganizationUUID string                               `json:"organizationId" db:"organization_uuid"`
+	ID               string                               `json:"id" db:"handle"`
+	Name             string                               `json:"name" db:"name"`
+	Description      string                               `json:"description,omitempty" db:"description"`
+	CreatedBy        string                               `json:"createdBy,omitempty" db:"created_by"`
+	Metadata         *LLMProviderTemplateMetadata         `json:"metadata,omitempty" db:"-"`
+	PromptTokens     *ExtractionIdentifier                `json:"promptTokens,omitempty" db:"-"`
+	CompletionTokens *ExtractionIdentifier                `json:"completionTokens,omitempty" db:"-"`
+	TotalTokens      *ExtractionIdentifier                `json:"totalTokens,omitempty" db:"-"`
+	RemainingTokens  *ExtractionIdentifier                `json:"remainingTokens,omitempty" db:"-"`
+	RequestModel     *ExtractionIdentifier                `json:"requestModel,omitempty" db:"-"`
+	ResponseModel    *ExtractionIdentifier                `json:"responseModel,omitempty" db:"-"`
 	ResourceMappings *LLMProviderTemplateResourceMappings `json:"resourceMappings,omitempty" db:"-"`
-	CreatedAt        time.Time                    `json:"createdAt" db:"created_at"`
-	UpdatedAt        time.Time                    `json:"updatedAt" db:"updated_at"`
+	CreatedAt        time.Time                            `json:"createdAt" db:"created_at"`
+	UpdatedAt        time.Time                            `json:"updatedAt" db:"updated_at"`
 }
 
 // LLMProvider represents an LLM provider entity
@@ -196,18 +196,18 @@ type LLMProvider struct {
 }
 
 type LLMProviderConfig struct {
-	Name          string                 `json:"name,omitempty" db:"-"`
-	Version       string                 `json:"version,omitempty" db:"-"`
-	Context       *string                `json:"context,omitempty" db:"-"`
-	VHost         *string                `json:"vhost,omitempty" db:"-"`
-	Template      string                 `json:"template,omitempty" db:"-"`
-	Upstream      *UpstreamConfig        `json:"upstream,omitempty" db:"-"`
-	AccessControl *LLMAccessControl      `json:"accessControl,omitempty" db:"-"`
-	RateLimiting  *LLMRateLimitingConfig `json:"rateLimiting,omitempty" db:"-"`
-	GlobalPolicies    []GlobalPolicy    `json:"globalPolicies,omitempty" db:"-"`
-	OperationPolicies []OperationPolicy `json:"operationPolicies,omitempty" db:"-"`
-	Policies          []LLMPolicy       `json:"policies,omitempty" db:"-"`
-	Security          *SecurityConfig   `json:"security,omitempty" db:"-"`
+	Name              string                 `json:"name,omitempty" db:"-"`
+	Version           string                 `json:"version,omitempty" db:"-"`
+	Context           *string                `json:"context,omitempty" db:"-"`
+	VHost             *string                `json:"vhost,omitempty" db:"-"`
+	Template          string                 `json:"template,omitempty" db:"-"`
+	Upstream          *UpstreamConfig        `json:"upstream,omitempty" db:"-"`
+	AccessControl     *LLMAccessControl      `json:"accessControl,omitempty" db:"-"`
+	RateLimiting      *LLMRateLimitingConfig `json:"rateLimiting,omitempty" db:"-"`
+	GlobalPolicies    []GlobalPolicy         `json:"globalPolicies,omitempty" db:"-"`
+	OperationPolicies []OperationPolicy      `json:"operationPolicies,omitempty" db:"-"`
+	Policies          []LLMPolicy            `json:"policies,omitempty" db:"-"`
+	Security          *SecurityConfig        `json:"security,omitempty" db:"-"`
 }
 
 // LLMProxy represents an LLM proxy entity
@@ -229,12 +229,12 @@ type LLMProxy struct {
 }
 
 type LLMProxyConfig struct {
-	Name         string          `json:"name,omitempty" db:"-"`
-	Version      string          `json:"version,omitempty" db:"-"`
-	Context      *string         `json:"context,omitempty" db:"-"`
-	Vhost        *string         `json:"vhost,omitempty" db:"-"`
-	Provider     string          `json:"provider,omitempty" db:"-"`
-	UpstreamAuth *UpstreamAuth   `json:"upstreamAuth,omitempty" db:"-"`
+	Name              string            `json:"name,omitempty" db:"-"`
+	Version           string            `json:"version,omitempty" db:"-"`
+	Context           *string           `json:"context,omitempty" db:"-"`
+	Vhost             *string           `json:"vhost,omitempty" db:"-"`
+	Provider          string            `json:"provider,omitempty" db:"-"`
+	UpstreamAuth      *UpstreamAuth     `json:"upstreamAuth,omitempty" db:"-"`
 	GlobalPolicies    []GlobalPolicy    `json:"globalPolicies,omitempty" db:"-"`
 	OperationPolicies []OperationPolicy `json:"operationPolicies,omitempty" db:"-"`
 	Policies          []LLMPolicy       `json:"policies,omitempty" db:"-"`

--- a/platform-api/src/internal/model/llm.go
+++ b/platform-api/src/internal/model/llm.go
@@ -58,6 +58,26 @@ type LLMPolicy struct {
 	Paths   []LLMPolicyPath `json:"paths" db:"-"`
 }
 
+type GlobalPolicy struct {
+	Name               string                 `json:"name" db:"-"`
+	Version            string                 `json:"version" db:"-"`
+	ExecutionCondition string                 `json:"executionCondition,omitempty" db:"-"`
+	Params             map[string]interface{} `json:"params,omitempty" db:"-"`
+}
+
+type OperationPolicyPath struct {
+	Path    string                 `json:"path" db:"-"`
+	Methods []string               `json:"methods" db:"-"`
+	Params  map[string]interface{} `json:"params" db:"-"`
+}
+
+type OperationPolicy struct {
+	Name               string                `json:"name" db:"-"`
+	Version            string                `json:"version" db:"-"`
+	ExecutionCondition string                `json:"executionCondition,omitempty" db:"-"`
+	Paths              []OperationPolicyPath `json:"paths" db:"-"`
+}
+
 type RateLimitingLimitConfig struct {
 	Request *RequestRateLimit `json:"request,omitempty" db:"-"`
 	Token   *TokenRateLimit   `json:"token,omitempty" db:"-"`
@@ -184,8 +204,10 @@ type LLMProviderConfig struct {
 	Upstream      *UpstreamConfig        `json:"upstream,omitempty" db:"-"`
 	AccessControl *LLMAccessControl      `json:"accessControl,omitempty" db:"-"`
 	RateLimiting  *LLMRateLimitingConfig `json:"rateLimiting,omitempty" db:"-"`
-	Policies      []LLMPolicy            `json:"policies,omitempty" db:"-"`
-	Security      *SecurityConfig        `json:"security,omitempty" db:"-"`
+	GlobalPolicies    []GlobalPolicy    `json:"globalPolicies,omitempty" db:"-"`
+	OperationPolicies []OperationPolicy `json:"operationPolicies,omitempty" db:"-"`
+	Policies          []LLMPolicy       `json:"policies,omitempty" db:"-"`
+	Security          *SecurityConfig   `json:"security,omitempty" db:"-"`
 }
 
 // LLMProxy represents an LLM proxy entity
@@ -213,8 +235,10 @@ type LLMProxyConfig struct {
 	Vhost        *string         `json:"vhost,omitempty" db:"-"`
 	Provider     string          `json:"provider,omitempty" db:"-"`
 	UpstreamAuth *UpstreamAuth   `json:"upstreamAuth,omitempty" db:"-"`
-	Policies     []LLMPolicy     `json:"policies,omitempty" db:"-"`
-	Security     *SecurityConfig `json:"security,omitempty" db:"-"`
+	GlobalPolicies    []GlobalPolicy    `json:"globalPolicies,omitempty" db:"-"`
+	OperationPolicies []OperationPolicy `json:"operationPolicies,omitempty" db:"-"`
+	Policies          []LLMPolicy       `json:"policies,omitempty" db:"-"`
+	Security          *SecurityConfig   `json:"security,omitempty" db:"-"`
 }
 
 type SecurityConfig struct {

--- a/platform-api/src/internal/repository/gateway.go
+++ b/platform-api/src/internal/repository/gateway.go
@@ -428,6 +428,13 @@ func (r *GatewayRepo) UpdateGatewayManifest(gatewayID string, manifest []byte) e
 	return err
 }
 
+// UpdateGatewayVersion persists the version string reported by the gateway controller on manifest push.
+func (r *GatewayRepo) UpdateGatewayVersion(gatewayID, version string) error {
+	query := `UPDATE gateways SET version = ?, updated_at = ? WHERE uuid = ?`
+	_, err := r.db.Exec(r.db.Rebind(query), version, time.Now(), gatewayID)
+	return err
+}
+
 // GetGatewayManifest returns the raw manifest JSON stored for the gateway.
 // Returns nil data (no error) if the gateway exists but has no manifest yet.
 // Returns an error if the gateway row does not exist.

--- a/platform-api/src/internal/repository/interfaces.go
+++ b/platform-api/src/internal/repository/interfaces.go
@@ -165,6 +165,9 @@ type GatewayRepository interface {
 	// Manifest operations
 	UpdateGatewayManifest(gatewayID string, manifest []byte) error
 	GetGatewayManifest(gatewayID string) ([]byte, error)
+
+	// Version update — persists the version reported by the gateway controller on connect.
+	UpdateGatewayVersion(gatewayID, version string) error
 }
 
 // DevPortalRepository interface for DevPortal-related database operations

--- a/platform-api/src/internal/service/deployment_test.go
+++ b/platform-api/src/internal/service/deployment_test.go
@@ -1873,7 +1873,7 @@ func TestApplyStructOverrides(t *testing.T) {
 }
 
 func TestApplyDeploymentOverrides(t *testing.T) {
-	baseYAML := `apiVersion: gateway.api-platform.wso2.com/v1alpha2
+	baseYAML := `apiVersion: gateway.api-platform.wso2.com/v1
 kind: RestApi
 metadata:
   name: test-api

--- a/platform-api/src/internal/service/deployment_test.go
+++ b/platform-api/src/internal/service/deployment_test.go
@@ -1873,7 +1873,7 @@ func TestApplyStructOverrides(t *testing.T) {
 }
 
 func TestApplyDeploymentOverrides(t *testing.T) {
-	baseYAML := `apiVersion: gateway.api-platform.wso2.com/v1alpha1
+	baseYAML := `apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: RestApi
 metadata:
   name: test-api

--- a/platform-api/src/internal/service/gateway.go
+++ b/platform-api/src/internal/service/gateway.go
@@ -257,6 +257,12 @@ func (s *GatewayService) ReceiveGatewayManifest(orgID, gatewayID, gatewayVersion
 		return fmt.Errorf("failed to store gateway manifest: %w", err)
 	}
 
+	// Persist the version the controller reported so the deploy transform uses the
+	// live gateway version rather than the stale value stored at registration time.
+	if err := s.gatewayRepo.UpdateGatewayVersion(gatewayID, reported); err != nil {
+		return fmt.Errorf("failed to update gateway version: %w", err)
+	}
+
 	customerCount := 0
 	for _, p := range policies {
 		if p.ManagedBy == constants.PolicyManagedByCustomer {

--- a/platform-api/src/internal/service/llm.go
+++ b/platform-api/src/internal/service/llm.go
@@ -338,15 +338,18 @@ func (s *LLMProviderService) Create(orgUUID, createdBy string, req *api.LLMProvi
 		ModelProviders:   mapModelProvidersAPI(req.ModelProviders),
 		Status:           llmStatusPending,
 		Configuration: model.LLMProviderConfig{
-			Context:       &contextValue,
-			VHost:         req.Vhost,
-			Upstream:      mapUpstreamAPIToModel(req.Upstream),
-			AccessControl: mapAccessControlAPI(&req.AccessControl),
-			RateLimiting:  mapRateLimitingAPIToModel(req.RateLimiting),
-			Policies:      mapPoliciesAPIToModel(req.Policies),
-			Security:      mapSecurityAPIToModel(req.Security),
+			Context:           &contextValue,
+			VHost:             req.Vhost,
+			Upstream:          mapUpstreamAPIToModel(req.Upstream),
+			AccessControl:     mapAccessControlAPI(&req.AccessControl),
+			RateLimiting:      mapRateLimitingAPIToModel(req.RateLimiting),
+			GlobalPolicies:    mapGlobalPoliciesAPIToModel(req.GlobalPolicies),
+			OperationPolicies: mapOperationPoliciesAPIToModel(req.OperationPolicies),
+			Policies:          mapPoliciesAPIToModel(req.Policies),
+			Security:          mapSecurityAPIToModel(req.Security),
 		},
 	}
+	migrateLegacyProviderPoliciesInPlace(&m.Configuration)
 
 	if err := s.repo.Create(m); err != nil {
 		if isSQLiteUniqueConstraint(err) {
@@ -491,15 +494,18 @@ func (s *LLMProviderService) Update(orgUUID, handle string, req *api.LLMProvider
 		ModelProviders:   mapModelProvidersAPI(req.ModelProviders),
 		Status:           llmStatusPending,
 		Configuration: model.LLMProviderConfig{
-			Context:       &contextValue,
-			VHost:         req.Vhost,
-			Upstream:      mapUpstreamAPIToModel(req.Upstream),
-			AccessControl: mapAccessControlAPI(&req.AccessControl),
-			RateLimiting:  mapRateLimitingAPIToModel(req.RateLimiting),
-			Policies:      mapPoliciesAPIToModel(req.Policies),
-			Security:      mapSecurityAPIToModel(req.Security),
+			Context:           &contextValue,
+			VHost:             req.Vhost,
+			Upstream:          mapUpstreamAPIToModel(req.Upstream),
+			AccessControl:     mapAccessControlAPI(&req.AccessControl),
+			RateLimiting:      mapRateLimitingAPIToModel(req.RateLimiting),
+			GlobalPolicies:    mapGlobalPoliciesAPIToModel(req.GlobalPolicies),
+			OperationPolicies: mapOperationPoliciesAPIToModel(req.OperationPolicies),
+			Policies:          mapPoliciesAPIToModel(req.Policies),
+			Security:          mapSecurityAPIToModel(req.Security),
 		},
 	}
+	migrateLegacyProviderPoliciesInPlace(&m.Configuration)
 
 	// Preserve stored upstream auth credential only when auth object is provided with an empty value.
 	// If auth object is omitted, treat it as explicit removal and clear stored auth.
@@ -630,14 +636,17 @@ func (s *LLMProxyService) Create(orgUUID, createdBy string, req *api.LLMProxy) (
 		OpenAPISpec:      utils.ValueOrEmpty(req.Openapi),
 		Status:           llmStatusPending,
 		Configuration: model.LLMProxyConfig{
-			Context:      &contextValue,
-			Vhost:        req.Vhost,
-			Provider:     req.Provider.Id,
-			UpstreamAuth: mapUpstreamAuthAPIToModel(req.Provider.Auth),
-			Policies:     mapPoliciesAPIToModel(req.Policies),
-			Security:     mapSecurityAPIToModel(req.Security),
+			Context:           &contextValue,
+			Vhost:             req.Vhost,
+			Provider:          req.Provider.Id,
+			UpstreamAuth:      mapUpstreamAuthAPIToModel(req.Provider.Auth),
+			GlobalPolicies:    mapGlobalPoliciesAPIToModel(req.GlobalPolicies),
+			OperationPolicies: mapOperationPoliciesAPIToModel(req.OperationPolicies),
+			Policies:          mapPoliciesAPIToModel(req.Policies),
+			Security:          mapSecurityAPIToModel(req.Security),
 		},
 	}
+	migrateLegacyProxyPoliciesInPlace(&m.Configuration)
 
 	if err := s.repo.Create(m); err != nil {
 		if isSQLiteUniqueConstraint(err) {
@@ -842,14 +851,17 @@ func (s *LLMProxyService) Update(orgUUID, handle string, req *api.LLMProxy) (*ap
 		OpenAPISpec:      utils.ValueOrEmpty(req.Openapi),
 		Status:           llmStatusPending,
 		Configuration: model.LLMProxyConfig{
-			Context:      &contextValue,
-			Vhost:        req.Vhost,
-			Provider:     req.Provider.Id,
-			UpstreamAuth: mapUpstreamAuthAPIToModel(req.Provider.Auth),
-			Policies:     mapPoliciesAPIToModel(req.Policies),
-			Security:     mapSecurityAPIToModel(req.Security),
+			Context:           &contextValue,
+			Vhost:             req.Vhost,
+			Provider:          req.Provider.Id,
+			UpstreamAuth:      mapUpstreamAuthAPIToModel(req.Provider.Auth),
+			GlobalPolicies:    mapGlobalPoliciesAPIToModel(req.GlobalPolicies),
+			OperationPolicies: mapOperationPoliciesAPIToModel(req.OperationPolicies),
+			Policies:          mapPoliciesAPIToModel(req.Policies),
+			Security:          mapSecurityAPIToModel(req.Security),
 		},
 	}
+	migrateLegacyProxyPoliciesInPlace(&m.Configuration)
 
 	// Preserve stored upstream auth credential when not supplied in update payload
 	m.Configuration.UpstreamAuth = preserveUpstreamAuthCredential(existing.Configuration.UpstreamAuth, m.Configuration.UpstreamAuth)
@@ -1031,6 +1043,185 @@ func mapPoliciesAPIToModel(in *[]api.LLMPolicy) []model.LLMPolicy {
 		out = append(out, model.LLMPolicy{Name: p.Name, Version: p.Version, Paths: paths})
 	}
 	return out
+}
+
+func mapGlobalPoliciesAPIToModel(in *[]api.Policy) []model.GlobalPolicy {
+	if in == nil || len(*in) == 0 {
+		return nil
+	}
+	out := make([]model.GlobalPolicy, 0, len(*in))
+	for _, p := range *in {
+		ec := ""
+		if p.ExecutionCondition != nil {
+			ec = *p.ExecutionCondition
+		}
+		var params map[string]interface{}
+		if p.Params != nil {
+			params = *p.Params
+		}
+		out = append(out, model.GlobalPolicy{Name: p.Name, Version: p.Version, ExecutionCondition: ec, Params: params})
+	}
+	return out
+}
+
+func mapOperationPoliciesAPIToModel(in *[]api.OperationPolicy) []model.OperationPolicy {
+	if in == nil || len(*in) == 0 {
+		return nil
+	}
+	out := make([]model.OperationPolicy, 0, len(*in))
+	for _, p := range *in {
+		ec := ""
+		if p.ExecutionCondition != nil {
+			ec = *p.ExecutionCondition
+		}
+		paths := make([]model.OperationPolicyPath, 0, len(p.Paths))
+		for _, pp := range p.Paths {
+			paths = append(paths, model.OperationPolicyPath{Path: pp.Path, Methods: pp.Methods, Params: pp.Params})
+		}
+		out = append(out, model.OperationPolicy{Name: p.Name, Version: p.Version, ExecutionCondition: ec, Paths: paths})
+	}
+	return out
+}
+
+func mapGlobalPoliciesModelToAPI(in []model.GlobalPolicy) *[]api.Policy {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]api.Policy, 0, len(in))
+	for _, p := range in {
+		entry := api.Policy{Name: p.Name, Version: p.Version}
+		if p.ExecutionCondition != "" {
+			entry.ExecutionCondition = &p.ExecutionCondition
+		}
+		if p.Params != nil {
+			params := p.Params
+			entry.Params = &params
+		}
+		out = append(out, entry)
+	}
+	return &out
+}
+
+func mapOperationPoliciesModelToAPI(in []model.OperationPolicy) *[]api.OperationPolicy {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]api.OperationPolicy, 0, len(in))
+	for _, p := range in {
+		paths := make([]api.OperationPolicyPath, 0, len(p.Paths))
+		for _, pp := range p.Paths {
+			paths = append(paths, api.OperationPolicyPath{Path: pp.Path, Methods: pp.Methods, Params: pp.Params})
+		}
+		entry := api.OperationPolicy{Name: p.Name, Version: p.Version, Paths: paths}
+		if p.ExecutionCondition != "" {
+			entry.ExecutionCondition = &p.ExecutionCondition
+		}
+		out = append(out, entry)
+	}
+	return &out
+}
+
+// migrateLegacyProviderPoliciesInPlace folds any legacy `policies` entries into
+// globalPolicies / operationPolicies, then clears `policies`.
+// Rules:
+//   - a path entry with path == "/*" AND methods == ["*"] → GlobalPolicy (deduped by name)
+//   - any other path entry                                → OperationPolicy path (merged by name)
+//
+// Empty or nil Policies → no-op.
+func migrateLegacyProviderPoliciesInPlace(cfg *model.LLMProviderConfig) {
+	migrateLegacyPolicies(&cfg.GlobalPolicies, &cfg.OperationPolicies, cfg.Policies)
+	cfg.Policies = nil
+}
+
+// migrateLegacyProxyPoliciesInPlace is the proxy-config counterpart.
+func migrateLegacyProxyPoliciesInPlace(cfg *model.LLMProxyConfig) {
+	migrateLegacyPolicies(&cfg.GlobalPolicies, &cfg.OperationPolicies, cfg.Policies)
+	cfg.Policies = nil
+}
+
+// migrateLegacyPolicies is the shared migration kernel.
+func migrateLegacyPolicies(globalPolicies *[]model.GlobalPolicy, operationPolicies *[]model.OperationPolicy, legacyPolicies []model.LLMPolicy) {
+	for _, p := range legacyPolicies {
+		for _, pe := range p.Paths {
+			if pe.Path == "/*" && isWildcardOnlyMethods(pe.Methods) {
+				if !hasGlobalPolicyByName(*globalPolicies, p.Name) {
+					*globalPolicies = append(*globalPolicies, model.GlobalPolicy{
+						Name:    p.Name,
+						Version: p.Version,
+						Params:  pe.Params,
+					})
+				}
+			} else {
+				appendLegacyOperationPath(operationPolicies, p.Name, p.Version, model.OperationPolicyPath{
+					Path:    pe.Path,
+					Methods: pe.Methods,
+					Params:  pe.Params,
+				})
+			}
+		}
+	}
+}
+
+// isWildcardOnlyMethods reports whether methods is exactly ["*"].
+func isWildcardOnlyMethods(methods []string) bool {
+	return len(methods) == 1 && methods[0] == "*"
+}
+
+// hasGlobalPolicyByName reports whether a GlobalPolicy with the given name already exists.
+func hasGlobalPolicyByName(policies []model.GlobalPolicy, name string) bool {
+	for _, p := range policies {
+		if p.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// appendLegacyOperationPath merges a path entry into an existing OperationPolicy of the same
+// name+version, or appends a new OperationPolicy if none exists.
+func appendLegacyOperationPath(policies *[]model.OperationPolicy, name, version string, path model.OperationPolicyPath) {
+	for i := range *policies {
+		if (*policies)[i].Name == name {
+			(*policies)[i].Paths = append((*policies)[i].Paths, path)
+			return
+		}
+	}
+	*policies = append(*policies, model.OperationPolicy{
+		Name:    name,
+		Version: version,
+		Paths:   []model.OperationPolicyPath{path},
+	})
+}
+
+// splitLegacyPoliciesForRead converts a stored legacy policies list into the two
+// canonical lists for read responses, using the same rule as the save-time migration:
+//   - path "/*" + methods ["*"] → GlobalPolicy (shared api-level bucket)
+//   - any other path            → OperationPolicy (per-path bucket)
+//
+// Called only when both new lists are empty and the legacy list is non-empty.
+func splitLegacyPoliciesForRead(legacy []model.LLMPolicy) ([]model.GlobalPolicy, []model.OperationPolicy) {
+	var global []model.GlobalPolicy
+	var operation []model.OperationPolicy
+	for _, p := range legacy {
+		for _, pe := range p.Paths {
+			if pe.Path == "/*" && isWildcardOnlyMethods(pe.Methods) {
+				if !hasGlobalPolicyByName(global, p.Name) {
+					global = append(global, model.GlobalPolicy{
+						Name:    p.Name,
+						Version: p.Version,
+						Params:  pe.Params,
+					})
+				}
+			} else {
+				appendLegacyOperationPath(&operation, p.Name, p.Version, model.OperationPolicyPath{
+					Path:    pe.Path,
+					Methods: pe.Methods,
+					Params:  pe.Params,
+				})
+			}
+		}
+	}
+	return global, operation
 }
 
 func mapUpstreamAuthAPIToModel(in *api.UpstreamAuth) *model.UpstreamAuth {
@@ -1502,10 +1693,21 @@ func mapProviderModelToAPI(m *model.LLMProvider, templateHandle string) *api.LLM
 		ac.Exceptions = &exc
 	}
 
-	policies := mapPoliciesModelToAPI(m.Configuration.Policies)
-	if policies == nil {
-		empty := []api.LLMPolicy{}
-		policies = &empty
+	globalPolicyCfg := m.Configuration.GlobalPolicies
+	operationPolicyCfg := m.Configuration.OperationPolicies
+	// For legacy rows stored before v1alpha2 migration: split policies on read.
+	if len(globalPolicyCfg) == 0 && len(operationPolicyCfg) == 0 && len(m.Configuration.Policies) > 0 {
+		globalPolicyCfg, operationPolicyCfg = splitLegacyPoliciesForRead(m.Configuration.Policies)
+	}
+	globalPolicies := mapGlobalPoliciesModelToAPI(globalPolicyCfg)
+	if globalPolicies == nil {
+		empty := []api.Policy{}
+		globalPolicies = &empty
+	}
+	operationPolicies := mapOperationPoliciesModelToAPI(operationPolicyCfg)
+	if operationPolicies == nil {
+		empty := []api.OperationPolicy{}
+		operationPolicies = &empty
 	}
 
 	modelProviders := mapModelProvidersModelToAPI(m.ModelProviders)
@@ -1525,11 +1727,13 @@ func mapProviderModelToAPI(m *model.LLMProvider, templateHandle string) *api.LLM
 		Template:       templateHandle,
 		Openapi:        utils.StringPtrIfNotEmpty(m.OpenAPISpec),
 		ModelProviders: modelProviders,
-		RateLimiting:   mapRateLimitingModelToAPI(m.Configuration.RateLimiting),
-		Upstream:       upstream,
-		AccessControl:  ac,
-		Policies:       policies,
-		Security:       mapSecurityModelToAPI(m.Configuration.Security),
+		RateLimiting:      mapRateLimitingModelToAPI(m.Configuration.RateLimiting),
+		Upstream:          upstream,
+		AccessControl:     ac,
+		GlobalPolicies:    globalPolicies,
+		OperationPolicies: operationPolicies,
+		Policies:          nil,
+		Security:          mapSecurityModelToAPI(m.Configuration.Security),
 		CreatedAt:      utils.TimePtr(m.CreatedAt),
 		UpdatedAt:      utils.TimePtr(m.UpdatedAt),
 	}
@@ -1820,10 +2024,21 @@ func mapProxyModelToAPI(m *model.LLMProxy) *api.LLMProxy {
 		v := *m.Configuration.Vhost
 		vhostValue = &v
 	}
-	policies := mapPoliciesModelToAPI(m.Configuration.Policies)
-	if policies == nil {
-		empty := []api.LLMPolicy{}
-		policies = &empty
+	globalPolicyCfgProxy := m.Configuration.GlobalPolicies
+	operationPolicyCfgProxy := m.Configuration.OperationPolicies
+	// For legacy rows stored before v1alpha2 migration: split policies on read.
+	if len(globalPolicyCfgProxy) == 0 && len(operationPolicyCfgProxy) == 0 && len(m.Configuration.Policies) > 0 {
+		globalPolicyCfgProxy, operationPolicyCfgProxy = splitLegacyPoliciesForRead(m.Configuration.Policies)
+	}
+	globalPoliciesProxy := mapGlobalPoliciesModelToAPI(globalPolicyCfgProxy)
+	if globalPoliciesProxy == nil {
+		empty := []api.Policy{}
+		globalPoliciesProxy = &empty
+	}
+	operationPoliciesProxy := mapOperationPoliciesModelToAPI(operationPolicyCfgProxy)
+	if operationPoliciesProxy == nil {
+		empty := []api.OperationPolicy{}
+		operationPoliciesProxy = &empty
 	}
 	createdAt := utils.TimePtr(m.CreatedAt)
 	updatedAt := utils.TimePtr(m.UpdatedAt)
@@ -1857,25 +2072,9 @@ func mapProxyModelToAPI(m *model.LLMProxy) *api.LLMProxy {
 			Value:  nil, // Redact auth credential value
 		}
 	}
-	if len(m.Configuration.Policies) > 0 {
-		policyList := make([]api.LLMPolicy, 0, len(m.Configuration.Policies))
-		for _, p := range m.Configuration.Policies {
-			paths := make([]api.LLMPolicyPath, 0, len(p.Paths))
-			for _, pp := range p.Paths {
-				methods := make([]api.LLMPolicyPathMethods, 0, len(pp.Methods))
-				for _, m := range pp.Methods {
-					methods = append(methods, api.LLMPolicyPathMethods(m))
-				}
-				paths = append(paths, api.LLMPolicyPath{Path: pp.Path, Methods: methods, Params: pp.Params})
-			}
-			policyList = append(policyList, api.LLMPolicy{Name: p.Name, Version: p.Version, Paths: paths})
-		}
-		out.Policies = &policyList
-	}
-	if out.Policies == nil {
-		empty := []api.LLMPolicy{}
-		out.Policies = &empty
-	}
+	out.GlobalPolicies = globalPoliciesProxy
+	out.OperationPolicies = operationPoliciesProxy
+	out.Policies = nil
 	return out
 }
 

--- a/platform-api/src/internal/service/llm.go
+++ b/platform-api/src/internal/service/llm.go
@@ -1181,7 +1181,7 @@ func hasGlobalPolicyByName(policies []model.GlobalPolicy, name string) bool {
 // name+version, or appends a new OperationPolicy if none exists.
 func appendLegacyOperationPath(policies *[]model.OperationPolicy, name, version string, path model.OperationPolicyPath) {
 	for i := range *policies {
-		if (*policies)[i].Name == name {
+		if (*policies)[i].Name == name && (*policies)[i].Version == version {
 			(*policies)[i].Paths = append((*policies)[i].Paths, path)
 			return
 		}

--- a/platform-api/src/internal/service/llm_deployment.go
+++ b/platform-api/src/internal/service/llm_deployment.go
@@ -38,7 +38,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// TODO: Temporary
+// Policy names referenced during LLM deployment artifact generation, migration,
+// and version-aware downconversion.
 const (
 	tokenBasedRateLimitPolicyName   = "token-based-ratelimit"
 	advancedRateLimitPolicyName     = "advanced-ratelimit"
@@ -1300,7 +1301,7 @@ func (s *LLMProxyDeploymentService) DeployLLMProxy(proxyID string, req *api.Depl
 		initialStatus, string(model.DeploymentStatusDeployed),
 		&performedAt, "",
 	); err != nil {
-		s.slogger.Warn("Failed to set deployment status for LLM proxy", "error", err)
+		return nil, fmt.Errorf("failed to set deployment status for LLM proxy: %w", err)
 	}
 
 	// Broadcast LLM proxy deployment event to gateway
@@ -1641,6 +1642,9 @@ func generateLLMProxyDeploymentYAML(proxy *model.LLMProxy) (dto.LLMProxyDeployme
 
 	// Carry through user-set globalPolicies from the model
 	for _, p := range proxy.Configuration.GlobalPolicies {
+		if hasGlobalPolicy(proxyGlobalPolicies, p.Name) {
+			continue
+		}
 		params := p.Params
 		if p.Name == advancedRateLimitPolicyName && params != nil {
 			params = withGlobalAdvancedRatelimitKeyExtraction(params)
@@ -1770,9 +1774,14 @@ func orderLLMPolicies(policies []api.LLMPolicy) []api.LLMPolicy {
 }
 
 // withGlobalAdvancedRatelimitKeyExtraction returns a copy of params with
-// keyExtraction set to [{type:"apiname"}] if not already present. This ensures
-// that advanced-ratelimit in globalPolicies uses a shared API-level counter
-// rather than the default per-route (routename) bucket.
+// keyExtraction defaulted to [{type:"apiname"}] when the caller did not set one.
+// advanced-ratelimit defaults to a per-route (routename) key; in globalPolicies
+// that would create one bucket per operation, so an apiname key is injected to
+// give a single shared API-level counter.
+//
+// An explicit keyExtraction is intentionally preserved untouched: a user who sets
+// it (e.g. a per-consumer header key, or routename on purpose) has made a
+// deliberate choice that this default must not override.
 func withGlobalAdvancedRatelimitKeyExtraction(params map[string]interface{}) map[string]interface{} {
 	if _, ok := params["keyExtraction"]; ok {
 		return params

--- a/platform-api/src/internal/service/llm_deployment.go
+++ b/platform-api/src/internal/service/llm_deployment.go
@@ -28,6 +28,7 @@ import (
 	"platform-api/src/api"
 	"platform-api/src/config"
 	"platform-api/src/internal/constants"
+	"platform-api/src/internal/deploymenttransform"
 	"platform-api/src/internal/dto"
 	"platform-api/src/internal/model"
 	"platform-api/src/internal/repository"
@@ -165,11 +166,23 @@ func (s *LLMProviderDeploymentService) DeployLLMProvider(providerID string, req 
 		if err != nil {
 			return nil, err
 		}
-		providerYaml, err := generateLLMProviderDeploymentYAML(provider, tplHandle)
+		providerDeployment, err := generateLLMProviderDeploymentYAML(provider, tplHandle)
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate LLM provider deployment YAML: %w", err)
 		}
-		contentBytes = []byte(providerYaml)
+		target := deploymenttransform.ParseVersion(gateway.Version)
+		if err := deploymenttransform.Default().Transform(
+			constants.LLMProvider,
+			target,
+			&providerDeployment,
+		); err != nil {
+			return nil, fmt.Errorf("failed to transform LLM provider deployment for gateway %s: %w", gateway.Version, err)
+		}
+		providerYamlBytes, marshalErr := yaml.Marshal(providerDeployment)
+		if marshalErr != nil {
+			return nil, fmt.Errorf("failed to marshal LLM provider deployment YAML: %w", marshalErr)
+		}
+		contentBytes = providerYamlBytes
 	} else {
 		// Use existing deployment as base
 		baseDeployment, err := s.deploymentRepo.GetWithContent(req.Base, provider.UUID, orgUUID)
@@ -531,19 +544,19 @@ func (s *LLMProviderDeploymentService) getTemplateHandle(templateUUID, orgUUID s
 	return tpl.ID, nil
 }
 
-func generateLLMProviderDeploymentYAML(provider *model.LLMProvider, templateHandle string) (string, error) {
+func generateLLMProviderDeploymentYAML(provider *model.LLMProvider, templateHandle string) (dto.LLMProviderDeploymentYAML, error) {
 	if provider == nil {
-		return "", errors.New("provider is required")
+		return dto.LLMProviderDeploymentYAML{}, errors.New("provider is required")
 	}
 	if templateHandle == "" {
-		return "", errors.New("template handle is required")
+		return dto.LLMProviderDeploymentYAML{}, errors.New("template handle is required")
 	}
 	if provider.Configuration.Upstream == nil || provider.Configuration.Upstream.Main == nil {
-		return "", constants.ErrInvalidInput
+		return dto.LLMProviderDeploymentYAML{}, constants.ErrInvalidInput
 	}
 	main := provider.Configuration.Upstream.Main
 	if main.URL == "" && main.Ref == "" {
-		return "", constants.ErrInvalidInput
+		return dto.LLMProviderDeploymentYAML{}, constants.ErrInvalidInput
 	}
 
 	contextValue := "/"
@@ -571,7 +584,9 @@ func generateLLMProviderDeploymentYAML(provider *model.LLMProvider, templateHand
 		}
 	}
 
-	policies := make([]api.LLMPolicy, 0, len(provider.Configuration.Policies))
+	var globalPolicies []api.Policy
+	var operationPolicies []api.OperationPolicy
+	policies := make([]api.LLMPolicy, 0)
 
 	// Transform security config
 	security := provider.Configuration.Security
@@ -579,21 +594,18 @@ func generateLLMProviderDeploymentYAML(provider *model.LLMProvider, templateHand
 		if security.APIKey != nil && isBoolTrue(security.APIKey.Enabled) {
 			key := strings.TrimSpace(security.APIKey.Key)
 			if key == "" {
-				return "", fmt.Errorf("invalid api key security configuration: key is required")
+				return dto.LLMProviderDeploymentYAML{}, fmt.Errorf("invalid api key security configuration: key is required")
 			}
 
 			in := strings.ToLower(strings.TrimSpace(security.APIKey.In))
 			if in != "header" && in != "query" {
-				return "", fmt.Errorf("invalid api key security configuration: in must be 'header' or 'query', got %q", security.APIKey.In)
+				return dto.LLMProviderDeploymentYAML{}, fmt.Errorf("invalid api key security configuration: in must be 'header' or 'query', got %q", security.APIKey.In)
 			}
 
-			addOrAppendPolicyPath(&policies, apiKeyAuthPolicyName, "", api.LLMPolicyPath{
-				Path:    "/*",
-				Methods: []api.LLMPolicyPathMethods{"*"},
-				Params: map[string]interface{}{
-					"key": key,
-					"in":  in,
-				},
+			params := map[string]interface{}{"key": key, "in": in}
+			globalPolicies = append(globalPolicies, api.Policy{
+				Name:   apiKeyAuthPolicyName,
+				Params: &params,
 			})
 		}
 	}
@@ -607,159 +619,94 @@ func generateLLMProviderDeploymentYAML(provider *model.LLMProvider, templateHand
 		if providerLevel != nil {
 			// Priority to global rate limit configuration if both global and resource-wise are present
 			if providerLevel.Global != nil {
-				// Step 2.1 Handle global rate limiting
-				// TODO: Confirm with gateway interpret this as a global policy
+				// Step 2.1 Handle global rate limiting — emits to globalPolicies (shared api-level bucket)
 				if providerLevel.Global.Token != nil && providerLevel.Global.Token.Enabled {
 					tokenLimit := providerLevel.Global.Token
 					duration, err := formatRateLimitDuration(tokenLimit.Reset.Duration, tokenLimit.Reset.Unit)
 					if err != nil {
-						return "", fmt.Errorf("invalid token reset window: %w", err)
+						return dto.LLMProviderDeploymentYAML{}, fmt.Errorf("invalid token reset window: %w", err)
 					}
-					policies = append(policies, api.LLMPolicy{
-						// TODO: This should be taken from config
-						Name:    tokenBasedRateLimitPolicyName,
-						Version: "",
-						Paths: []api.LLMPolicyPath{
-							{
-								Path:    "/*",
-								Methods: []api.LLMPolicyPathMethods{"*"},
-								Params: map[string]interface{}{
-									"totalTokenLimits": []map[string]interface{}{
-										{
-											"count":    tokenLimit.Count,
-											"duration": duration,
-										},
-									},
-								},
-							},
+					params := map[string]interface{}{
+						"totalTokenLimits": []map[string]interface{}{
+							{"count": tokenLimit.Count, "duration": duration},
 						},
-					})
+					}
+					globalPolicies = append(globalPolicies, api.Policy{Name: tokenBasedRateLimitPolicyName, Version: "", Params: &params})
 				}
 				if providerLevel.Global.Request != nil && providerLevel.Global.Request.Enabled {
 					requestLimit := providerLevel.Global.Request
 					duration, err := formatRateLimitDuration(requestLimit.Reset.Duration, requestLimit.Reset.Unit)
 					if err != nil {
-						return "", fmt.Errorf("invalid request reset window: %w", err)
+						return dto.LLMProviderDeploymentYAML{}, fmt.Errorf("invalid request reset window: %w", err)
 					}
-					policies = append(policies, api.LLMPolicy{
-						// TODO: This should be taken from config
-						Name:    advancedRateLimitPolicyName,
-						Version: "",
-						Paths: []api.LLMPolicyPath{
+					params := map[string]interface{}{
+						"quotas": []map[string]interface{}{
 							{
-								Path:    "/*",
-								Methods: []api.LLMPolicyPathMethods{"*"},
-								Params: map[string]interface{}{
-									// TODO: Is this correct?
-									// TODO: Is `algorithm` and `backend` not available?
-									"quotas": []map[string]interface{}{
-										{
-											"name": "request-limit",
-											"limits": []map[string]interface{}{
-												{
-													"limit":    requestLimit.Count,
-													"duration": duration,
-												},
-											},
-										},
-									},
+								"name": "request-limit",
+								"limits": []map[string]interface{}{
+									{"limit": requestLimit.Count, "duration": duration},
 								},
 							},
 						},
-					})
+						"keyExtraction": []map[string]interface{}{
+							{"type": "apiname"},
+						},
+					}
+					globalPolicies = append(globalPolicies, api.Policy{Name: advancedRateLimitPolicyName, Version: "", Params: &params})
 				}
 				if providerLevel.Global.Cost != nil && providerLevel.Global.Cost.Enabled {
 					costLimit := providerLevel.Global.Cost
 					duration, err := formatRateLimitDuration(costLimit.Reset.Duration, costLimit.Reset.Unit)
 					if err != nil {
-						return "", fmt.Errorf("invalid cost reset window: %w", err)
+						return dto.LLMProviderDeploymentYAML{}, fmt.Errorf("invalid cost reset window: %w", err)
 					}
-					policies = append(policies, api.LLMPolicy{
-						Name:    llmCostBasedRateLimitPolicyName,
-						Version: "",
-						Paths: []api.LLMPolicyPath{
-							{
-								Path:    "/*",
-								Methods: []api.LLMPolicyPathMethods{"*"},
-								Params: map[string]interface{}{
-									"budgetLimits": []map[string]interface{}{
-										{"amount": costLimit.Amount, "duration": duration},
-									},
-								},
-							},
+					costParams := map[string]interface{}{
+						"budgetLimits": []map[string]interface{}{
+							{"amount": costLimit.Amount, "duration": duration},
 						},
-					})
-					if !hasPolicy(policies, llmCostPolicyName) {
-						policies = append(policies, api.LLMPolicy{
-							Name:    llmCostPolicyName,
-							Version: "",
-							Paths: []api.LLMPolicyPath{
-								{
-									Path:    "/*",
-									Methods: []api.LLMPolicyPathMethods{"*"},
-									Params:  map[string]interface{}{},
-								},
-							},
-						})
+					}
+					globalPolicies = append(globalPolicies, api.Policy{Name: llmCostBasedRateLimitPolicyName, Version: "", Params: &costParams})
+					if !hasGlobalPolicy(globalPolicies, llmCostPolicyName) {
+						emptyParams := map[string]interface{}{}
+						globalPolicies = append(globalPolicies, api.Policy{Name: llmCostPolicyName, Version: "", Params: &emptyParams})
 					}
 				}
 			} else if providerLevel.ResourceWise != nil {
-				// Step 2.2 Handle resource-wise rate limiting
+				// Step 2.2 Handle resource-wise rate limiting — emits to operationPolicies (per-path buckets)
 				defaultLimit := &providerLevel.ResourceWise.Default
 
-				// Step 2.2.1 Default resource-wise rate limit
+				// Step 2.2.1 Default resource-wise rate limit (path: /* catches all unmatched paths)
 				if defaultLimit.Token != nil && defaultLimit.Token.Enabled {
 					tokenLimit := defaultLimit.Token
 					duration, err := formatRateLimitDuration(tokenLimit.Reset.Duration, tokenLimit.Reset.Unit)
 					if err != nil {
-						return "", fmt.Errorf("invalid token reset window: %w", err)
+						return dto.LLMProviderDeploymentYAML{}, fmt.Errorf("invalid token reset window: %w", err)
 					}
-					policies = append(policies, api.LLMPolicy{
-						// TODO: This should be taken from config
-						Name:    tokenBasedRateLimitPolicyName,
-						Version: "",
-						Paths: []api.LLMPolicyPath{
-							{
-								Path:    "/*",
-								Methods: []api.LLMPolicyPathMethods{"*"},
-								Params: map[string]interface{}{
-									"totalTokenLimits": []map[string]interface{}{
-										{
-											"count":    tokenLimit.Count,
-											"duration": duration,
-										},
-									},
-								},
+					addOrAppendOperationPolicyPath(&operationPolicies, tokenBasedRateLimitPolicyName, "", api.OperationPolicyPath{
+						Path:    "/*",
+						Methods: []string{"*"},
+						Params: map[string]interface{}{
+							"totalTokenLimits": []map[string]interface{}{
+								{"count": tokenLimit.Count, "duration": duration},
 							},
 						},
 					})
 				}
-
 				if defaultLimit.Request != nil && defaultLimit.Request.Enabled {
 					requestLimit := defaultLimit.Request
 					duration, err := formatRateLimitDuration(requestLimit.Reset.Duration, requestLimit.Reset.Unit)
 					if err != nil {
-						return "", fmt.Errorf("invalid request reset window: %w", err)
+						return dto.LLMProviderDeploymentYAML{}, fmt.Errorf("invalid request reset window: %w", err)
 					}
-					policies = append(policies, api.LLMPolicy{
-						// TODO: This should be taken from config
-						Name:    advancedRateLimitPolicyName,
-						Version: "",
-						Paths: []api.LLMPolicyPath{
-							{
-								Path:    "/*",
-								Methods: []api.LLMPolicyPathMethods{"*"},
-								Params: map[string]interface{}{
-									"quotas": []map[string]interface{}{
-										{
-											"name": "request-limit",
-											"limits": []map[string]interface{}{
-												{
-													"limit":    requestLimit.Count,
-													"duration": duration,
-												},
-											},
-										},
+					addOrAppendOperationPolicyPath(&operationPolicies, advancedRateLimitPolicyName, "", api.OperationPolicyPath{
+						Path:    "/*",
+						Methods: []string{"*"},
+						Params: map[string]interface{}{
+							"quotas": []map[string]interface{}{
+								{
+									"name": "request-limit",
+									"limits": []map[string]interface{}{
+										{"limit": requestLimit.Count, "duration": duration},
 									},
 								},
 							},
@@ -770,52 +717,39 @@ func generateLLMProviderDeploymentYAML(provider *model.LLMProvider, templateHand
 					costLimit := defaultLimit.Cost
 					duration, err := formatRateLimitDuration(costLimit.Reset.Duration, costLimit.Reset.Unit)
 					if err != nil {
-						return "", fmt.Errorf("invalid cost reset window: %w", err)
+						return dto.LLMProviderDeploymentYAML{}, fmt.Errorf("invalid cost reset window: %w", err)
 					}
-					policies = append(policies, api.LLMPolicy{
-						Name:    llmCostBasedRateLimitPolicyName,
-						Version: "",
-						Paths: []api.LLMPolicyPath{
-							{
-								Path:    "/*",
-								Methods: []api.LLMPolicyPathMethods{"*"},
-								Params: map[string]interface{}{
-									"budgetLimits": []map[string]interface{}{
-										{"amount": costLimit.Amount, "duration": duration},
-									},
-								},
+					addOrAppendOperationPolicyPath(&operationPolicies, llmCostBasedRateLimitPolicyName, "", api.OperationPolicyPath{
+						Path:    "/*",
+						Methods: []string{"*"},
+						Params: map[string]interface{}{
+							"budgetLimits": []map[string]interface{}{
+								{"amount": costLimit.Amount, "duration": duration},
 							},
 						},
 					})
-					if !hasPolicy(policies, llmCostPolicyName) {
-						policies = append(policies, api.LLMPolicy{
-							Name:    llmCostPolicyName,
-							Version: "",
-							Paths: []api.LLMPolicyPath{
-								{Path: "/*", Methods: []api.LLMPolicyPathMethods{"*"}, Params: map[string]interface{}{}},
-							},
+					if !hasOperationPolicy(operationPolicies, llmCostPolicyName) {
+						operationPolicies = append(operationPolicies, api.OperationPolicy{
+							Name:  llmCostPolicyName,
+							Paths: []api.OperationPolicyPath{{Path: "/*", Methods: []string{"*"}, Params: map[string]interface{}{}}},
 						})
 					}
 				}
 
-				// Step 2.2.2 Resource-wise rate limit
+				// Step 2.2.2 Resource-wise rate limit (per specific resource path)
 				for _, r := range providerLevel.ResourceWise.Resources {
 					if r.Limit.Token != nil && r.Limit.Token.Enabled {
 						tokenLimit := r.Limit.Token
 						duration, err := formatRateLimitDuration(tokenLimit.Reset.Duration, tokenLimit.Reset.Unit)
 						if err != nil {
-							return "", fmt.Errorf("invalid token reset window for resource %s: %w", r.Resource, err)
+							return dto.LLMProviderDeploymentYAML{}, fmt.Errorf("invalid token reset window for resource %s: %w", r.Resource, err)
 						}
-						// TODO: the methods should be coming as input
-						addOrAppendPolicyPath(&policies, tokenBasedRateLimitPolicyName, "", api.LLMPolicyPath{
+						addOrAppendOperationPolicyPath(&operationPolicies, tokenBasedRateLimitPolicyName, "", api.OperationPolicyPath{
 							Path:    r.Resource,
-							Methods: []api.LLMPolicyPathMethods{"*"},
+							Methods: []string{"*"},
 							Params: map[string]interface{}{
 								"totalTokenLimits": []map[string]interface{}{
-									{
-										"count":    tokenLimit.Count,
-										"duration": duration,
-									},
+									{"count": tokenLimit.Count, "duration": duration},
 								},
 							},
 						})
@@ -824,21 +758,17 @@ func generateLLMProviderDeploymentYAML(provider *model.LLMProvider, templateHand
 						requestLimit := r.Limit.Request
 						duration, err := formatRateLimitDuration(requestLimit.Reset.Duration, requestLimit.Reset.Unit)
 						if err != nil {
-							return "", fmt.Errorf("invalid request reset window for resource %s: %w", r.Resource, err)
+							return dto.LLMProviderDeploymentYAML{}, fmt.Errorf("invalid request reset window for resource %s: %w", r.Resource, err)
 						}
-						// TODO: the methods should be coming as input
-						addOrAppendPolicyPath(&policies, advancedRateLimitPolicyName, "", api.LLMPolicyPath{
+						addOrAppendOperationPolicyPath(&operationPolicies, advancedRateLimitPolicyName, "", api.OperationPolicyPath{
 							Path:    r.Resource,
-							Methods: []api.LLMPolicyPathMethods{"*"},
+							Methods: []string{"*"},
 							Params: map[string]interface{}{
 								"quotas": []map[string]interface{}{
 									{
 										"name": "request-limit",
 										"limits": []map[string]interface{}{
-											{
-												"limit":    requestLimit.Count,
-												"duration": duration,
-											},
+											{"limit": requestLimit.Count, "duration": duration},
 										},
 									},
 								},
@@ -849,28 +779,21 @@ func generateLLMProviderDeploymentYAML(provider *model.LLMProvider, templateHand
 						costLimit := r.Limit.Cost
 						duration, err := formatRateLimitDuration(costLimit.Reset.Duration, costLimit.Reset.Unit)
 						if err != nil {
-							return "", fmt.Errorf("invalid cost reset window for resource %s: %w", r.Resource, err)
+							return dto.LLMProviderDeploymentYAML{}, fmt.Errorf("invalid cost reset window for resource %s: %w", r.Resource, err)
 						}
-						addOrAppendPolicyPath(&policies, llmCostBasedRateLimitPolicyName, "", api.LLMPolicyPath{
+						addOrAppendOperationPolicyPath(&operationPolicies, llmCostBasedRateLimitPolicyName, "", api.OperationPolicyPath{
 							Path:    r.Resource,
-							Methods: []api.LLMPolicyPathMethods{"*"},
+							Methods: []string{"*"},
 							Params: map[string]interface{}{
 								"budgetLimits": []map[string]interface{}{
 									{"amount": costLimit.Amount, "duration": duration},
 								},
 							},
 						})
-						if !hasPolicy(policies, llmCostPolicyName) {
-							policies = append(policies, api.LLMPolicy{
-								Name:    llmCostPolicyName,
-								Version: "",
-								Paths: []api.LLMPolicyPath{
-									{
-										Path:    "/*",
-										Methods: []api.LLMPolicyPathMethods{"*"},
-										Params:  map[string]interface{}{},
-									},
-								},
+						if !hasOperationPolicy(operationPolicies, llmCostPolicyName) {
+							operationPolicies = append(operationPolicies, api.OperationPolicy{
+								Name:  llmCostPolicyName,
+								Paths: []api.OperationPolicyPath{{Path: "/*", Methods: []string{"*"}, Params: map[string]interface{}{}}},
 							})
 						}
 					}
@@ -886,7 +809,7 @@ func generateLLMProviderDeploymentYAML(provider *model.LLMProvider, templateHand
 					tokenLimit := consumerLevel.Global.Token
 					duration, err := formatRateLimitDuration(tokenLimit.Reset.Duration, tokenLimit.Reset.Unit)
 					if err != nil {
-						return "", fmt.Errorf("invalid consumer token reset window: %w", err)
+						return dto.LLMProviderDeploymentYAML{}, fmt.Errorf("invalid consumer token reset window: %w", err)
 					}
 					policies = append(policies, api.LLMPolicy{
 						Name:    tokenBasedRateLimitPolicyName,
@@ -912,7 +835,7 @@ func generateLLMProviderDeploymentYAML(provider *model.LLMProvider, templateHand
 					requestLimit := consumerLevel.Global.Request
 					duration, err := formatRateLimitDuration(requestLimit.Reset.Duration, requestLimit.Reset.Unit)
 					if err != nil {
-						return "", fmt.Errorf("invalid consumer request reset window: %w", err)
+						return dto.LLMProviderDeploymentYAML{}, fmt.Errorf("invalid consumer request reset window: %w", err)
 					}
 					policies = append(policies, api.LLMPolicy{
 						Name:    advancedRateLimitPolicyName,
@@ -946,7 +869,7 @@ func generateLLMProviderDeploymentYAML(provider *model.LLMProvider, templateHand
 					costLimit := consumerLevel.Global.Cost
 					duration, err := formatRateLimitDuration(costLimit.Reset.Duration, costLimit.Reset.Unit)
 					if err != nil {
-						return "", fmt.Errorf("invalid consumer cost reset window: %w", err)
+						return dto.LLMProviderDeploymentYAML{}, fmt.Errorf("invalid consumer cost reset window: %w", err)
 					}
 					policies = append(policies, api.LLMPolicy{
 						Name:    llmCostBasedRateLimitPolicyName,
@@ -964,7 +887,7 @@ func generateLLMProviderDeploymentYAML(provider *model.LLMProvider, templateHand
 							},
 						},
 					})
-					if !hasPolicy(policies, llmCostPolicyName) {
+					if !hasPolicy(policies, llmCostPolicyName) && !hasGlobalPolicy(globalPolicies, llmCostPolicyName) {
 						policies = append(policies, api.LLMPolicy{
 							Name:    llmCostPolicyName,
 							Version: "",
@@ -984,7 +907,7 @@ func generateLLMProviderDeploymentYAML(provider *model.LLMProvider, templateHand
 						tokenLimit := r.Limit.Token
 						duration, err := formatRateLimitDuration(tokenLimit.Reset.Duration, tokenLimit.Reset.Unit)
 						if err != nil {
-							return "", fmt.Errorf("invalid consumer token reset window for resource %s: %w", r.Resource, err)
+							return dto.LLMProviderDeploymentYAML{}, fmt.Errorf("invalid consumer token reset window for resource %s: %w", r.Resource, err)
 						}
 						addOrAppendPolicyPath(&policies, tokenBasedRateLimitPolicyName, "", api.LLMPolicyPath{
 							Path:    r.Resource,
@@ -1004,7 +927,7 @@ func generateLLMProviderDeploymentYAML(provider *model.LLMProvider, templateHand
 						requestLimit := r.Limit.Request
 						duration, err := formatRateLimitDuration(requestLimit.Reset.Duration, requestLimit.Reset.Unit)
 						if err != nil {
-							return "", fmt.Errorf("invalid consumer request reset window for resource %s: %w", r.Resource, err)
+							return dto.LLMProviderDeploymentYAML{}, fmt.Errorf("invalid consumer request reset window for resource %s: %w", r.Resource, err)
 						}
 						addOrAppendPolicyPath(&policies, advancedRateLimitPolicyName, "", api.LLMPolicyPath{
 							Path:    r.Resource,
@@ -1032,7 +955,7 @@ func generateLLMProviderDeploymentYAML(provider *model.LLMProvider, templateHand
 						costLimit := r.Limit.Cost
 						duration, err := formatRateLimitDuration(costLimit.Reset.Duration, costLimit.Reset.Unit)
 						if err != nil {
-							return "", fmt.Errorf("invalid consumer cost reset window for resource %s: %w", r.Resource, err)
+							return dto.LLMProviderDeploymentYAML{}, fmt.Errorf("invalid consumer cost reset window for resource %s: %w", r.Resource, err)
 						}
 						addOrAppendPolicyPath(&policies, llmCostBasedRateLimitPolicyName, "", api.LLMPolicyPath{
 							Path:    r.Resource,
@@ -1044,7 +967,7 @@ func generateLLMProviderDeploymentYAML(provider *model.LLMProvider, templateHand
 								"consumerBased": true,
 							},
 						})
-						if !hasPolicy(policies, llmCostPolicyName) {
+						if !hasPolicy(policies, llmCostPolicyName) && !hasGlobalPolicy(globalPolicies, llmCostPolicyName) {
 							policies = append(policies, api.LLMPolicy{
 								Name:    llmCostPolicyName,
 								Version: "",
@@ -1063,10 +986,43 @@ func generateLLMProviderDeploymentYAML(provider *model.LLMProvider, templateHand
 		}
 	}
 
+	// Carry through user-set globalPolicies from the model (e.g. guardrails set via UI/API)
+	for _, p := range provider.Configuration.GlobalPolicies {
+		if hasGlobalPolicy(globalPolicies, p.Name) {
+			continue
+		}
+		params := p.Params
+		if p.Name == advancedRateLimitPolicyName && params != nil {
+			params = withGlobalAdvancedRatelimitKeyExtraction(params)
+		}
+		entry := api.Policy{Name: p.Name, Version: normalizePolicyVersionToMajor(p.Version)}
+		if p.ExecutionCondition != "" {
+			entry.ExecutionCondition = &p.ExecutionCondition
+		}
+		if params != nil {
+			entry.Params = &params
+		}
+		globalPolicies = append(globalPolicies, entry)
+	}
+
+	// Carry through user-set operationPolicies from the model
+	for _, p := range provider.Configuration.OperationPolicies {
+		paths := make([]api.OperationPolicyPath, 0, len(p.Paths))
+		for _, pp := range p.Paths {
+			paths = append(paths, api.OperationPolicyPath{Path: pp.Path, Methods: pp.Methods, Params: pp.Params})
+		}
+		entry := api.OperationPolicy{Name: p.Name, Version: normalizePolicyVersionToMajor(p.Version), Paths: paths}
+		if p.ExecutionCondition != "" {
+			entry.ExecutionCondition = &p.ExecutionCondition
+		}
+		operationPolicies = append(operationPolicies, entry)
+	}
+
+	// Carry through deprecated policies field
 	for _, p := range provider.Configuration.Policies {
 		// llm-cost is a parameterless tracker policy that the frontend attaches by default.
 		// Skip it here if the rate limiting block already added it to avoid duplication.
-		if p.Name == llmCostPolicyName && hasPolicy(policies, llmCostPolicyName) {
+		if p.Name == llmCostPolicyName && (hasGlobalPolicy(globalPolicies, llmCostPolicyName) || hasPolicy(policies, llmCostPolicyName)) {
 			continue
 		}
 		paths := make([]api.LLMPolicyPath, 0, len(p.Paths))
@@ -1080,6 +1036,8 @@ func generateLLMProviderDeploymentYAML(provider *model.LLMProvider, templateHand
 		policies = append(policies, api.LLMPolicy{Name: p.Name, Version: normalizePolicyVersionToMajor(p.Version), Paths: paths})
 	}
 
+	globalPolicies = orderLLMGlobalPolicies(globalPolicies)
+	operationPolicies = orderLLMOperationPolicies(operationPolicies)
 	policies = orderLLMPolicies(policies)
 
 	upstream := dto.LLMUpstreamYAML{URL: main.URL, Ref: main.Ref}
@@ -1088,29 +1046,46 @@ func generateLLMProviderDeploymentYAML(provider *model.LLMProvider, templateHand
 	}
 
 	providerDeployment := dto.LLMProviderDeploymentYAML{
-		ApiVersion: "gateway.api-platform.wso2.com/v1alpha1",
+		ApiVersion: constants.GatewayApiVersion,
 		Kind:       constants.LLMProvider,
 		Metadata: dto.DeploymentMetadata{
 			Name: provider.ID,
 		},
 		Spec: dto.LLMProviderDeploymentSpec{
-			DisplayName:   provider.Name,
-			Version:       provider.Version,
-			Context:       contextValue,
-			VHost:         vhostValue,
-			Template:      templateHandle,
-			Upstream:      upstream,
-			AccessControl: accessControl,
-			Policies:      policies,
+			DisplayName:       provider.Name,
+			Version:           provider.Version,
+			Context:           contextValue,
+			VHost:             vhostValue,
+			Template:          templateHandle,
+			Upstream:          upstream,
+			AccessControl:     accessControl,
+			GlobalPolicies:    globalPolicies,
+			OperationPolicies: operationPolicies,
+			Policies:          policies,
 		},
 	}
 
-	yamlBytes, err := yaml.Marshal(providerDeployment)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal LLM provider to YAML: %w", err)
+	// Promote any legacy policies assembled by the generator (security api-key-auth,
+	// consumer-level rate limits) into operationPolicies — the canonical latest format.
+	// The deploy orchestration layer applies version-aware transformation afterward.
+	for _, p := range providerDeployment.Spec.Policies {
+		paths := make([]api.OperationPolicyPath, 0, len(p.Paths))
+		for _, pp := range p.Paths {
+			methods := make([]string, 0, len(pp.Methods))
+			for _, m := range pp.Methods {
+				methods = append(methods, string(m))
+			}
+			paths = append(paths, api.OperationPolicyPath{Path: pp.Path, Methods: methods, Params: pp.Params})
+		}
+		providerDeployment.Spec.OperationPolicies = append(providerDeployment.Spec.OperationPolicies, api.OperationPolicy{
+			Name:    p.Name,
+			Version: p.Version,
+			Paths:   paths,
+		})
 	}
+	providerDeployment.Spec.Policies = nil
 
-	return string(yamlBytes), nil
+	return providerDeployment, nil
 }
 
 func formatRateLimitDuration(duration int, unit string) (string, error) {
@@ -1257,11 +1232,23 @@ func (s *LLMProxyDeploymentService) DeployLLMProxy(proxyID string, req *api.Depl
 
 	// Determine the source: "current" or existing deployment
 	if req.Base == "current" {
-		proxyYaml, err := generateLLMProxyDeploymentYAML(proxy)
+		proxyDeployment, err := generateLLMProxyDeploymentYAML(proxy)
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate LLM proxy deployment YAML: %w", err)
 		}
-		contentBytes = []byte(proxyYaml)
+		target := deploymenttransform.ParseVersion(gateway.Version)
+		if err := deploymenttransform.Default().Transform(
+			constants.LLMProxy,
+			target,
+			&proxyDeployment,
+		); err != nil {
+			return nil, fmt.Errorf("failed to transform LLM proxy deployment for gateway %s: %w", gateway.Version, err)
+		}
+		proxyYamlBytes, marshalErr := yaml.Marshal(proxyDeployment)
+		if marshalErr != nil {
+			return nil, fmt.Errorf("failed to marshal LLM proxy deployment YAML: %w", marshalErr)
+		}
+		contentBytes = proxyYamlBytes
 	} else {
 		// Use existing deployment as base
 		baseDeployment, err := s.deploymentRepo.GetWithContent(req.Base, proxy.UUID, orgUUID)
@@ -1609,12 +1596,12 @@ func (s *LLMProxyDeploymentService) GetLLMProxyDeployment(proxyID, deploymentID,
 	)
 }
 
-func generateLLMProxyDeploymentYAML(proxy *model.LLMProxy) (string, error) {
+func generateLLMProxyDeploymentYAML(proxy *model.LLMProxy) (dto.LLMProxyDeploymentYAML, error) {
 	if proxy == nil {
-		return "", errors.New("proxy is required")
+		return dto.LLMProxyDeploymentYAML{}, errors.New("proxy is required")
 	}
 	if proxy.Configuration.Provider == "" {
-		return "", constants.ErrInvalidInput
+		return dto.LLMProxyDeploymentYAML{}, constants.ErrInvalidInput
 	}
 
 	contextValue := "/"
@@ -1626,7 +1613,9 @@ func generateLLMProxyDeploymentYAML(proxy *model.LLMProxy) (string, error) {
 		vhostValue = *proxy.Configuration.Vhost
 	}
 
-	policies := make([]api.LLMPolicy, 0, len(proxy.Configuration.Policies))
+	var proxyGlobalPolicies []api.Policy
+	var proxyOperationPolicies []api.OperationPolicy
+	proxyPolicies := make([]api.LLMPolicy, 0)
 
 	// Transform security config
 	security := proxy.Configuration.Security
@@ -1634,25 +1623,52 @@ func generateLLMProxyDeploymentYAML(proxy *model.LLMProxy) (string, error) {
 		if security.APIKey != nil && isBoolTrue(security.APIKey.Enabled) {
 			key := strings.TrimSpace(security.APIKey.Key)
 			if key == "" {
-				return "", fmt.Errorf("invalid api key security configuration: key is required")
+				return dto.LLMProxyDeploymentYAML{}, fmt.Errorf("invalid api key security configuration: key is required")
 			}
 
 			in := strings.ToLower(strings.TrimSpace(security.APIKey.In))
 			if in != "header" && in != "query" {
-				return "", fmt.Errorf("invalid api key security configuration: in must be 'header' or 'query', got %q", security.APIKey.In)
+				return dto.LLMProxyDeploymentYAML{}, fmt.Errorf("invalid api key security configuration: in must be 'header' or 'query', got %q", security.APIKey.In)
 			}
 
-			addOrAppendPolicyPath(&policies, apiKeyAuthPolicyName, "", api.LLMPolicyPath{
-				Path:    "/*",
-				Methods: []api.LLMPolicyPathMethods{"*"},
-				Params: map[string]interface{}{
-					"key": key,
-					"in":  in,
-				},
+			params := map[string]interface{}{"key": key, "in": in}
+			proxyGlobalPolicies = append(proxyGlobalPolicies, api.Policy{
+				Name:   apiKeyAuthPolicyName,
+				Params: &params,
 			})
 		}
 	}
 
+	// Carry through user-set globalPolicies from the model
+	for _, p := range proxy.Configuration.GlobalPolicies {
+		params := p.Params
+		if p.Name == advancedRateLimitPolicyName && params != nil {
+			params = withGlobalAdvancedRatelimitKeyExtraction(params)
+		}
+		entry := api.Policy{Name: p.Name, Version: normalizePolicyVersionToMajor(p.Version)}
+		if p.ExecutionCondition != "" {
+			entry.ExecutionCondition = &p.ExecutionCondition
+		}
+		if params != nil {
+			entry.Params = &params
+		}
+		proxyGlobalPolicies = append(proxyGlobalPolicies, entry)
+	}
+
+	// Carry through user-set operationPolicies from the model
+	for _, p := range proxy.Configuration.OperationPolicies {
+		paths := make([]api.OperationPolicyPath, 0, len(p.Paths))
+		for _, pp := range p.Paths {
+			paths = append(paths, api.OperationPolicyPath{Path: pp.Path, Methods: pp.Methods, Params: pp.Params})
+		}
+		entry := api.OperationPolicy{Name: p.Name, Version: normalizePolicyVersionToMajor(p.Version), Paths: paths}
+		if p.ExecutionCondition != "" {
+			entry.ExecutionCondition = &p.ExecutionCondition
+		}
+		proxyOperationPolicies = append(proxyOperationPolicies, entry)
+	}
+
+	// Carry through deprecated policies field
 	for _, p := range proxy.Configuration.Policies {
 		paths := make([]api.LLMPolicyPath, 0, len(p.Paths))
 		for _, pp := range p.Paths {
@@ -1662,13 +1678,13 @@ func generateLLMProxyDeploymentYAML(proxy *model.LLMProxy) (string, error) {
 			}
 			paths = append(paths, api.LLMPolicyPath{Path: pp.Path, Methods: methods, Params: pp.Params})
 		}
-		policies = append(policies, api.LLMPolicy{Name: p.Name, Version: normalizePolicyVersionToMajor(p.Version), Paths: paths})
+		proxyPolicies = append(proxyPolicies, api.LLMPolicy{Name: p.Name, Version: normalizePolicyVersionToMajor(p.Version), Paths: paths})
 	}
 
-	policies = orderLLMPolicies(policies)
+	proxyPolicies = orderLLMPolicies(proxyPolicies)
 
 	proxyDeployment := dto.LLMProxyDeploymentYAML{
-		ApiVersion: "gateway.api-platform.wso2.com/v1alpha1",
+		ApiVersion: constants.GatewayApiVersion,
 		Kind:       constants.LLMProxy,
 		Metadata: dto.DeploymentMetadata{
 			Name: proxy.ID,
@@ -1681,7 +1697,9 @@ func generateLLMProxyDeploymentYAML(proxy *model.LLMProxy) (string, error) {
 			Provider: dto.LLMProxyDeploymentProvider{
 				ID: proxy.Configuration.Provider,
 			},
-			Policies: policies,
+			GlobalPolicies:    proxyGlobalPolicies,
+			OperationPolicies: proxyOperationPolicies,
+			Policies:          proxyPolicies,
 		},
 	}
 
@@ -1689,12 +1707,25 @@ func generateLLMProxyDeploymentYAML(proxy *model.LLMProxy) (string, error) {
 		proxyDeployment.Spec.Provider.Auth = mapModelUpstreamAuthToAPI(proxy.Configuration.UpstreamAuth)
 	}
 
-	yamlBytes, err := yaml.Marshal(proxyDeployment)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal LLM proxy to YAML: %w", err)
+	// Promote any legacy policies assembled by the generator into operationPolicies.
+	for _, p := range proxyDeployment.Spec.Policies {
+		paths := make([]api.OperationPolicyPath, 0, len(p.Paths))
+		for _, pp := range p.Paths {
+			methods := make([]string, 0, len(pp.Methods))
+			for _, m := range pp.Methods {
+				methods = append(methods, string(m))
+			}
+			paths = append(paths, api.OperationPolicyPath{Path: pp.Path, Methods: methods, Params: pp.Params})
+		}
+		proxyDeployment.Spec.OperationPolicies = append(proxyDeployment.Spec.OperationPolicies, api.OperationPolicy{
+			Name:    p.Name,
+			Version: p.Version,
+			Paths:   paths,
+		})
 	}
+	proxyDeployment.Spec.Policies = nil
 
-	return string(yamlBytes), nil
+	return proxyDeployment, nil
 }
 
 // mapModelAuthToAPI converts model.UpstreamAuth to api.UpstreamAuth with pointer fields
@@ -1736,4 +1767,91 @@ func orderLLMPolicies(policies []api.LLMPolicy) []api.LLMPolicy {
 		policies[costIdx], policies[rateLimitIdx] = policies[rateLimitIdx], policies[costIdx]
 	}
 	return policies
+}
+
+// withGlobalAdvancedRatelimitKeyExtraction returns a copy of params with
+// keyExtraction set to [{type:"apiname"}] if not already present. This ensures
+// that advanced-ratelimit in globalPolicies uses a shared API-level counter
+// rather than the default per-route (routename) bucket.
+func withGlobalAdvancedRatelimitKeyExtraction(params map[string]interface{}) map[string]interface{} {
+	if _, ok := params["keyExtraction"]; ok {
+		return params
+	}
+	out := make(map[string]interface{}, len(params)+1)
+	for k, v := range params {
+		out[k] = v
+	}
+	out["keyExtraction"] = []map[string]interface{}{{"type": "apiname"}}
+	return out
+}
+
+// orderLLMGlobalPolicies ensures llm-cost-based-ratelimit precedes llm-cost in the global policy list.
+func orderLLMGlobalPolicies(policies []api.Policy) []api.Policy {
+	costIdx := -1
+	rateLimitIdx := -1
+	for i, p := range policies {
+		switch p.Name {
+		case llmCostPolicyName:
+			costIdx = i
+		case llmCostBasedRateLimitPolicyName:
+			rateLimitIdx = i
+		}
+	}
+	if costIdx != -1 && rateLimitIdx != -1 && costIdx < rateLimitIdx {
+		policies[costIdx], policies[rateLimitIdx] = policies[rateLimitIdx], policies[costIdx]
+	}
+	return policies
+}
+
+// orderLLMOperationPolicies ensures llm-cost-based-ratelimit precedes llm-cost in the operation policy list.
+func orderLLMOperationPolicies(policies []api.OperationPolicy) []api.OperationPolicy {
+	costIdx := -1
+	rateLimitIdx := -1
+	for i, p := range policies {
+		switch p.Name {
+		case llmCostPolicyName:
+			costIdx = i
+		case llmCostBasedRateLimitPolicyName:
+			rateLimitIdx = i
+		}
+	}
+	if costIdx != -1 && rateLimitIdx != -1 && costIdx < rateLimitIdx {
+		policies[costIdx], policies[rateLimitIdx] = policies[rateLimitIdx], policies[costIdx]
+	}
+	return policies
+}
+
+func hasGlobalPolicy(policies []api.Policy, name string) bool {
+	for _, p := range policies {
+		if p.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func hasOperationPolicy(policies []api.OperationPolicy, name string) bool {
+	for _, p := range policies {
+		if p.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// addOrAppendOperationPolicyPath adds a path to an existing OperationPolicy entry with the
+// given name, or appends a new entry if none exists.
+func addOrAppendOperationPolicyPath(policies *[]api.OperationPolicy, name, version string, path api.OperationPolicyPath) {
+	for i := range *policies {
+		if (*policies)[i].Name == name && (*policies)[i].Version == version {
+			for _, existing := range (*policies)[i].Paths {
+				if existing.Path == path.Path {
+					return // already present, skip
+				}
+			}
+			(*policies)[i].Paths = append((*policies)[i].Paths, path)
+			return
+		}
+	}
+	*policies = append(*policies, api.OperationPolicy{Name: name, Version: version, Paths: []api.OperationPolicyPath{path}})
 }

--- a/platform-api/src/internal/service/llm_deployment_test.go
+++ b/platform-api/src/internal/service/llm_deployment_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"platform-api/src/internal/model"
+	"gopkg.in/yaml.v3"
 )
 
 func TestMapModelAuthToAPI_NormalizesApiKeyType(t *testing.T) {
@@ -65,24 +66,26 @@ func TestGenerateYAML_ConsumerRequestLimit(t *testing.T) {
 		},
 	}
 
-	yaml, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
+	yamlArtifact, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	yamlBytes, _ := yaml.Marshal(yamlArtifact)
+	yamlStr := string(yamlBytes)
 
-	if !strings.Contains(yaml, "advanced-ratelimit") {
+	if !strings.Contains(yamlStr, "advanced-ratelimit") {
 		t.Error("expected advanced-ratelimit policy in generated YAML")
 	}
 	// Consumer-scoped: key extraction must include x-wso2-application-id
-	if !strings.Contains(yaml, "x-wso2-application-id") {
+	if !strings.Contains(yamlStr, "x-wso2-application-id") {
 		t.Error("expected x-wso2-application-id in key extraction for consumer request limit")
 	}
 	// Should NOT have a backend (non-consumer) advanced-ratelimit entry
-	if strings.Count(yaml, "advanced-ratelimit") > 1 {
+	if strings.Count(yamlStr, "advanced-ratelimit") > 1 {
 		t.Error("expected only one advanced-ratelimit policy (consumer), got more than one")
 	}
 
-	t.Logf("Generated YAML:\n%s", yaml)
+	t.Logf("Generated YAML:\n%s", yamlStr)
 }
 
 // TestGenerateYAML_ConsumerTokenLimit verifies that a consumer token limit
@@ -101,19 +104,21 @@ func TestGenerateYAML_ConsumerTokenLimit(t *testing.T) {
 		},
 	}
 
-	yaml, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
+	yamlArtifact, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	yamlBytes, _ := yaml.Marshal(yamlArtifact)
+	yamlStr := string(yamlBytes)
 
-	if !strings.Contains(yaml, "consumerBased: true") {
+	if !strings.Contains(yamlStr, "consumerBased: true") {
 		t.Error("expected consumerBased: true in generated YAML")
 	}
-	if !strings.Contains(yaml, "token-based-ratelimit") {
+	if !strings.Contains(yamlStr, "token-based-ratelimit") {
 		t.Error("expected token-based-ratelimit policy in generated YAML")
 	}
 
-	t.Logf("Generated YAML:\n%s", yaml)
+	t.Logf("Generated YAML:\n%s", yamlStr)
 }
 
 // TestGenerateYAML_ConsumerCostLimit verifies that a consumer cost limit
@@ -131,19 +136,21 @@ func TestGenerateYAML_ConsumerCostLimit(t *testing.T) {
 		},
 	}
 
-	yaml, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
+	yamlArtifact, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	yamlBytes, _ := yaml.Marshal(yamlArtifact)
+	yamlStr := string(yamlBytes)
 
-	if !strings.Contains(yaml, "consumerBased: true") {
+	if !strings.Contains(yamlStr, "consumerBased: true") {
 		t.Error("expected consumerBased: true in generated YAML")
 	}
-	if !strings.Contains(yaml, "llm-cost-based-ratelimit") {
+	if !strings.Contains(yamlStr, "llm-cost-based-ratelimit") {
 		t.Error("expected llm-cost-based-ratelimit policy in generated YAML")
 	}
 
-	t.Logf("Generated YAML:\n%s", yaml)
+	t.Logf("Generated YAML:\n%s", yamlStr)
 }
 
 // TestGenerateYAML_BothBackendAndConsumerLimits verifies that when both a backend
@@ -172,21 +179,23 @@ func TestGenerateYAML_BothBackendAndConsumerLimits(t *testing.T) {
 		},
 	}
 
-	yaml, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
+	yamlArtifact, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	yamlBytes, _ := yaml.Marshal(yamlArtifact)
+	yamlStr := string(yamlBytes)
 
 	// Should have two token-based-ratelimit policies
-	if strings.Count(yaml, "token-based-ratelimit") < 2 {
-		t.Errorf("expected two token-based-ratelimit entries, got:\n%s", yaml)
+	if strings.Count(yamlStr, "token-based-ratelimit") < 2 {
+		t.Errorf("expected two token-based-ratelimit entries, got:\n%s", yamlStr)
 	}
 	// One must be consumer-based
-	if !strings.Contains(yaml, "consumerBased: true") {
+	if !strings.Contains(yamlStr, "consumerBased: true") {
 		t.Error("expected consumerBased: true in generated YAML")
 	}
 
-	t.Logf("Generated YAML:\n%s", yaml)
+	t.Logf("Generated YAML:\n%s", yamlStr)
 }
 
 // ---------------------------------------------------------------------------
@@ -204,17 +213,19 @@ func TestGenerateYAML_BackendOnlyTokenLimit(t *testing.T) {
 			},
 		},
 	}
-	yaml, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
+	yamlArtifact, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(yaml, "token-based-ratelimit") {
+	yamlBytes, _ := yaml.Marshal(yamlArtifact)
+	yamlStr := string(yamlBytes)
+	if !strings.Contains(yamlStr, "token-based-ratelimit") {
 		t.Error("expected token-based-ratelimit in generated YAML")
 	}
-	if strings.Contains(yaml, "consumerBased") {
+	if strings.Contains(yamlStr, "consumerBased") {
 		t.Error("expected no consumerBased for backend-only limit")
 	}
-	t.Logf("Generated YAML:\n%s", yaml)
+	t.Logf("Generated YAML:\n%s", yamlStr)
 }
 
 // TestGenerateYAML_BackendOnlyRequestLimit verifies that a backend-only request limit
@@ -229,23 +240,25 @@ func TestGenerateYAML_BackendOnlyRequestLimit(t *testing.T) {
 			},
 		},
 	}
-	yaml, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
+	yamlArtifact, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(yaml, "advanced-ratelimit") {
+	yamlBytes, _ := yaml.Marshal(yamlArtifact)
+	yamlStr := string(yamlBytes)
+	if !strings.Contains(yamlStr, "advanced-ratelimit") {
 		t.Error("expected advanced-ratelimit in generated YAML")
 	}
-	if strings.Contains(yaml, "x-wso2-application-id") {
+	if strings.Contains(yamlStr, "x-wso2-application-id") {
 		t.Error("expected no x-wso2-application-id for backend-only request limit")
 	}
-	if !strings.Contains(yaml, "request-limit") {
+	if !strings.Contains(yamlStr, "request-limit") {
 		t.Error("expected quota name 'request-limit' in generated YAML")
 	}
-	if strings.Contains(yaml, "consumer-request-limit") {
+	if strings.Contains(yamlStr, "consumer-request-limit") {
 		t.Error("expected no 'consumer-request-limit' for backend-only request limit")
 	}
-	t.Logf("Generated YAML:\n%s", yaml)
+	t.Logf("Generated YAML:\n%s", yamlStr)
 }
 
 // TestGenerateYAML_BackendOnlyCostLimit verifies that a backend-only cost limit
@@ -258,20 +271,22 @@ func TestGenerateYAML_BackendOnlyCostLimit(t *testing.T) {
 			},
 		},
 	}
-	yaml, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
+	yamlArtifact, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(yaml, "llm-cost-based-ratelimit") {
+	yamlBytes, _ := yaml.Marshal(yamlArtifact)
+	yamlStr := string(yamlBytes)
+	if !strings.Contains(yamlStr, "llm-cost-based-ratelimit") {
 		t.Error("expected llm-cost-based-ratelimit in generated YAML")
 	}
-	if strings.Contains(yaml, "consumerBased") {
+	if strings.Contains(yamlStr, "consumerBased") {
 		t.Error("expected no consumerBased for backend-only cost limit")
 	}
-	if strings.Count(yaml, "llm-cost") < 2 {
+	if strings.Count(yamlStr, "llm-cost") < 2 {
 		t.Error("expected llm-cost policy alongside llm-cost-based-ratelimit")
 	}
-	t.Logf("Generated YAML:\n%s", yaml)
+	t.Logf("Generated YAML:\n%s", yamlStr)
 }
 
 func TestGenerateYAML_BackendResourceWiseDefaultCostLimit(t *testing.T) {
@@ -284,20 +299,22 @@ func TestGenerateYAML_BackendResourceWiseDefaultCostLimit(t *testing.T) {
 			},
 		},
 	}
-	yaml, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
+	yamlArtifact, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(yaml, "llm-cost-based-ratelimit") {
+	yamlBytes, _ := yaml.Marshal(yamlArtifact)
+	yamlStr := string(yamlBytes)
+	if !strings.Contains(yamlStr, "llm-cost-based-ratelimit") {
 		t.Error("expected llm-cost-based-ratelimit in generated YAML")
 	}
-	if !strings.Contains(yaml, "budgetLimits") {
+	if !strings.Contains(yamlStr, "budgetLimits") {
 		t.Error("expected budgetLimits in generated YAML")
 	}
-	if strings.Contains(yaml, "consumerBased") {
+	if strings.Contains(yamlStr, "consumerBased") {
 		t.Error("expected no consumerBased for backend-only cost limit")
 	}
-	t.Logf("Generated YAML:\n%s", yaml)
+	t.Logf("Generated YAML:\n%s", yamlStr)
 }
 
 func TestGenerateYAML_BackendPerResourceCostLimit(t *testing.T) {
@@ -316,23 +333,25 @@ func TestGenerateYAML_BackendPerResourceCostLimit(t *testing.T) {
 			},
 		},
 	}
-	yaml, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
+	yamlArtifact, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(yaml, "llm-cost-based-ratelimit") {
+	yamlBytes, _ := yaml.Marshal(yamlArtifact)
+	yamlStr := string(yamlBytes)
+	if !strings.Contains(yamlStr, "llm-cost-based-ratelimit") {
 		t.Error("expected llm-cost-based-ratelimit in generated YAML")
 	}
-	if !strings.Contains(yaml, "budgetLimits") {
+	if !strings.Contains(yamlStr, "budgetLimits") {
 		t.Error("expected budgetLimits in generated YAML")
 	}
-	if !strings.Contains(yaml, "/v1/messages") {
+	if !strings.Contains(yamlStr, "/v1/messages") {
 		t.Error("expected resource path /v1/messages in generated YAML")
 	}
-	if strings.Contains(yaml, "consumerBased") {
+	if strings.Contains(yamlStr, "consumerBased") {
 		t.Error("expected no consumerBased for backend-only cost limit")
 	}
-	t.Logf("Generated YAML:\n%s", yaml)
+	t.Logf("Generated YAML:\n%s", yamlStr)
 }
 
 // ---------------------------------------------------------------------------
@@ -356,20 +375,22 @@ func TestGenerateYAML_BothBackendAndConsumerRequestLimits(t *testing.T) {
 			},
 		},
 	}
-	yaml, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
+	yamlArtifact, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if strings.Count(yaml, "advanced-ratelimit") < 2 {
+	yamlBytes, _ := yaml.Marshal(yamlArtifact)
+	yamlStr := string(yamlBytes)
+	if strings.Count(yamlStr, "advanced-ratelimit") < 2 {
 		t.Error("expected two advanced-ratelimit policies (one backend, one consumer)")
 	}
-	if !strings.Contains(yaml, "consumer-request-limit") {
+	if !strings.Contains(yamlStr, "consumer-request-limit") {
 		t.Error("expected 'consumer-request-limit' quota name for consumer policy")
 	}
-	if !strings.Contains(yaml, "x-wso2-application-id") {
+	if !strings.Contains(yamlStr, "x-wso2-application-id") {
 		t.Error("expected x-wso2-application-id in consumer policy key extraction")
 	}
-	t.Logf("Generated YAML:\n%s", yaml)
+	t.Logf("Generated YAML:\n%s", yamlStr)
 }
 
 // TestGenerateYAML_BothBackendAndConsumerCostLimits verifies that backend and consumer
@@ -388,21 +409,23 @@ func TestGenerateYAML_BothBackendAndConsumerCostLimits(t *testing.T) {
 			},
 		},
 	}
-	yaml, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
+	yamlArtifact, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if strings.Count(yaml, "llm-cost-based-ratelimit") < 2 {
+	yamlBytes, _ := yaml.Marshal(yamlArtifact)
+	yamlStr := string(yamlBytes)
+	if strings.Count(yamlStr, "llm-cost-based-ratelimit") < 2 {
 		t.Error("expected two llm-cost-based-ratelimit policies (backend + consumer)")
 	}
-	if !strings.Contains(yaml, "consumerBased: true") {
+	if !strings.Contains(yamlStr, "consumerBased: true") {
 		t.Error("expected consumerBased: true on consumer cost policy")
 	}
 	// llm-cost must appear exactly once — hasPolicy check prevents duplication
-	if strings.Count(yaml, "name: llm-cost\n") != 1 {
-		t.Errorf("expected exactly one llm-cost policy, got:\n%s", yaml)
+	if strings.Count(yamlStr, "name: llm-cost\n") != 1 {
+		t.Errorf("expected exactly one llm-cost policy, got:\n%s", yamlStr)
 	}
-	t.Logf("Generated YAML:\n%s", yaml)
+	t.Logf("Generated YAML:\n%s", yamlStr)
 }
 
 // ---------------------------------------------------------------------------
@@ -421,17 +444,19 @@ func TestGenerateYAML_DisabledLimitIsSkipped(t *testing.T) {
 			},
 		},
 	}
-	yaml, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
+	yamlArtifact, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if strings.Contains(yaml, "token-based-ratelimit") {
+	yamlBytes, _ := yaml.Marshal(yamlArtifact)
+	yamlStr := string(yamlBytes)
+	if strings.Contains(yamlStr, "token-based-ratelimit") {
 		t.Error("expected no token-based-ratelimit for disabled token limit")
 	}
-	if strings.Contains(yaml, "llm-cost-based-ratelimit") {
+	if strings.Contains(yamlStr, "llm-cost-based-ratelimit") {
 		t.Error("expected no llm-cost-based-ratelimit for disabled cost limit")
 	}
-	t.Logf("Generated YAML:\n%s", yaml)
+	t.Logf("Generated YAML:\n%s", yamlStr)
 }
 
 // TestGenerateYAML_AllThreeConsumerLimits verifies the full UI scenario from the
@@ -463,10 +488,12 @@ func TestGenerateYAML_AllThreeConsumerLimits(t *testing.T) {
 		},
 	}
 
-	yaml, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
+	yamlArtifact, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	yamlBytes, _ := yaml.Marshal(yamlArtifact)
+	yamlStr := string(yamlBytes)
 
 	checks := []string{
 		"advanced-ratelimit",
@@ -475,12 +502,12 @@ func TestGenerateYAML_AllThreeConsumerLimits(t *testing.T) {
 		"consumerBased: true",
 	}
 	for _, want := range checks {
-		if !strings.Contains(yaml, want) {
+		if !strings.Contains(yamlStr, want) {
 			t.Errorf("expected %q in generated YAML", want)
 		}
 	}
 
-	t.Logf("Generated YAML:\n%s", yaml)
+	t.Logf("Generated YAML:\n%s", yamlStr)
 }
 
 // ---------------------------------------------------------------------------
@@ -516,15 +543,17 @@ func TestGenerateYAML_LLMCostNotDuplicatedWithProviderCostLimit(t *testing.T) {
 		},
 	}
 
-	yaml, err := generateLLMProviderDeploymentYAML(providerWithCostRLAndDefaultPolicies(rl), "anthropic")
+	yamlArtifact, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	yamlBytes, _ := yaml.Marshal(yamlArtifact)
+	yamlStr := string(yamlBytes)
 
-	if strings.Count(yaml, "name: llm-cost\n") != 1 {
-		t.Errorf("expected exactly one llm-cost policy, got:\n%s", yaml)
+	if strings.Count(yamlStr, "name: llm-cost\n") != 1 {
+		t.Errorf("expected exactly one llm-cost policy, got:\n%s", yamlStr)
 	}
-	t.Logf("Generated YAML:\n%s", yaml)
+	t.Logf("Generated YAML:\n%s", yamlStr)
 }
 
 // TestGenerateYAML_LLMCostNotDuplicatedWithConsumerCostLimit verifies the same
@@ -538,15 +567,17 @@ func TestGenerateYAML_LLMCostNotDuplicatedWithConsumerCostLimit(t *testing.T) {
 		},
 	}
 
-	yaml, err := generateLLMProviderDeploymentYAML(providerWithCostRLAndDefaultPolicies(rl), "anthropic")
+	yamlArtifact, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	yamlBytes, _ := yaml.Marshal(yamlArtifact)
+	yamlStr := string(yamlBytes)
 
-	if strings.Count(yaml, "name: llm-cost\n") != 1 {
-		t.Errorf("expected exactly one llm-cost policy, got:\n%s", yaml)
+	if strings.Count(yamlStr, "name: llm-cost\n") != 1 {
+		t.Errorf("expected exactly one llm-cost policy, got:\n%s", yamlStr)
 	}
-	t.Logf("Generated YAML:\n%s", yaml)
+	t.Logf("Generated YAML:\n%s", yamlStr)
 }
 
 // TestGenerateYAML_LLMCostNotDuplicatedWithBothProviderAndConsumerCostLimits verifies
@@ -566,33 +597,43 @@ func TestGenerateYAML_LLMCostNotDuplicatedWithBothProviderAndConsumerCostLimits(
 		},
 	}
 
-	yaml, err := generateLLMProviderDeploymentYAML(providerWithCostRLAndDefaultPolicies(rl), "anthropic")
+	yamlArtifact, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	yamlBytes, _ := yaml.Marshal(yamlArtifact)
+	yamlStr := string(yamlBytes)
 
-	if strings.Count(yaml, "name: llm-cost\n") != 1 {
-		t.Errorf("expected exactly one llm-cost policy, got:\n%s", yaml)
+	if strings.Count(yamlStr, "name: llm-cost\n") != 1 {
+		t.Errorf("expected exactly one llm-cost policy, got:\n%s", yamlStr)
 	}
-	if strings.Count(yaml, "llm-cost-based-ratelimit") < 2 {
-		t.Errorf("expected two llm-cost-based-ratelimit policies (backend + consumer), got:\n%s", yaml)
+	if strings.Count(yamlStr, "llm-cost-based-ratelimit") < 2 {
+		t.Errorf("expected two llm-cost-based-ratelimit policies (backend + consumer), got:\n%s", yamlStr)
 	}
-	t.Logf("Generated YAML:\n%s", yaml)
+	t.Logf("Generated YAML:\n%s", yamlStr)
 }
 
 // TestGenerateYAML_LLMCostKeptWhenNoCostRLConfigured verifies that when no cost-based
 // rate limit is configured, the llm-cost policy from Configuration.Policies is still
 // included in the output (it should only be skipped if already added by the RL block).
 func TestGenerateYAML_LLMCostKeptWhenNoCostRLConfigured(t *testing.T) {
-	yaml, err := generateLLMProviderDeploymentYAML(providerWithCostRLAndDefaultPolicies(nil), "anthropic")
+	p := providerWithConsumerLimits(nil)
+	p.Configuration.Policies = []model.LLMPolicy{
+		{Name: "llm-cost", Version: "v1", Paths: []model.LLMPolicyPath{
+			{Path: "/*", Methods: []string{"*"}, Params: map[string]interface{}{}},
+		}},
+	}
+	yamlArtifact, err := generateLLMProviderDeploymentYAML(p, "anthropic")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	yamlBytes, _ := yaml.Marshal(yamlArtifact)
+	yamlStr := string(yamlBytes)
 
-	if strings.Count(yaml, "name: llm-cost\n") != 1 {
-		t.Errorf("expected exactly one llm-cost policy when no RL is configured, got:\n%s", yaml)
+	if strings.Count(yamlStr, "name: llm-cost\n") != 1 {
+		t.Errorf("expected exactly one llm-cost policy when no RL is configured, got:\n%s", yamlStr)
 	}
-	t.Logf("Generated YAML:\n%s", yaml)
+	t.Logf("Generated YAML:\n%s", yamlStr)
 }
 
 // TestGenerateYAML_OtherCustomPoliciesNotDeduplicated verifies that the llm-cost
@@ -613,13 +654,15 @@ func TestGenerateYAML_OtherCustomPoliciesNotDeduplicated(t *testing.T) {
 		},
 	}
 
-	yaml, err := generateLLMProviderDeploymentYAML(p, "anthropic")
+	yamlArtifact, err := generateLLMProviderDeploymentYAML(p, "anthropic")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	yamlBytes, _ := yaml.Marshal(yamlArtifact)
+	yamlStr := string(yamlBytes)
 
-	if strings.Count(yaml, "name: my-guardrail") < 2 {
-		t.Errorf("expected both my-guardrail entries to be present, got:\n%s", yaml)
+	if strings.Count(yamlStr, "name: my-guardrail") < 2 {
+		t.Errorf("expected both my-guardrail entries to be present, got:\n%s", yamlStr)
 	}
-	t.Logf("Generated YAML:\n%s", yaml)
+	t.Logf("Generated YAML:\n%s", yamlStr)
 }

--- a/platform-api/src/internal/service/llm_policy_migration_test.go
+++ b/platform-api/src/internal/service/llm_policy_migration_test.go
@@ -1,0 +1,139 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package service
+
+import (
+	"testing"
+
+	"platform-api/src/internal/model"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// gatewaySupportsSplitPolicies
+// ---------------------------------------------------------------------------
+
+func TestMigrateLegacyProviderPoliciesInPlace_NoLegacy(t *testing.T) {
+	cfg := &model.LLMProviderConfig{
+		GlobalPolicies:    []model.GlobalPolicy{{Name: "existing-global", Version: "v1"}},
+		OperationPolicies: []model.OperationPolicy{},
+		Policies:          nil,
+	}
+	migrateLegacyProviderPoliciesInPlace(cfg)
+	assert.Len(t, cfg.GlobalPolicies, 1)
+	assert.Empty(t, cfg.OperationPolicies)
+	assert.Nil(t, cfg.Policies)
+}
+
+func TestMigrateLegacyProviderPoliciesInPlace_WildcardGlobal(t *testing.T) {
+	cfg := &model.LLMProviderConfig{
+		Policies: []model.LLMPolicy{
+			{
+				Name:    "basic-ratelimit",
+				Version: "v1",
+				Paths: []model.LLMPolicyPath{
+					{Path: "/*", Methods: []string{"*"}, Params: map[string]interface{}{"requests": 10}},
+				},
+			},
+		},
+	}
+	migrateLegacyProviderPoliciesInPlace(cfg)
+	require.Len(t, cfg.GlobalPolicies, 1)
+	assert.Equal(t, "basic-ratelimit", cfg.GlobalPolicies[0].Name)
+	assert.Equal(t, map[string]interface{}{"requests": 10}, cfg.GlobalPolicies[0].Params)
+	assert.Empty(t, cfg.OperationPolicies)
+	assert.Nil(t, cfg.Policies)
+}
+
+func TestMigrateLegacyProviderPoliciesInPlace_SpecificPathBecomesOperation(t *testing.T) {
+	cfg := &model.LLMProviderConfig{
+		Policies: []model.LLMPolicy{
+			{
+				Name:    "basic-ratelimit",
+				Version: "v1",
+				Paths: []model.LLMPolicyPath{
+					{Path: "/chat/completions", Methods: []string{"GET"}, Params: map[string]interface{}{"requests": 5}},
+				},
+			},
+		},
+	}
+	migrateLegacyProviderPoliciesInPlace(cfg)
+	assert.Empty(t, cfg.GlobalPolicies)
+	require.Len(t, cfg.OperationPolicies, 1)
+	assert.Equal(t, "basic-ratelimit", cfg.OperationPolicies[0].Name)
+	require.Len(t, cfg.OperationPolicies[0].Paths, 1)
+	assert.Equal(t, "/chat/completions", cfg.OperationPolicies[0].Paths[0].Path)
+	assert.Nil(t, cfg.Policies)
+}
+
+func TestMigrateLegacyProviderPoliciesInPlace_MixedPaths(t *testing.T) {
+	// One policy with /*+["*"] path AND a specific path: the /* → global, the other → operation.
+	cfg := &model.LLMProviderConfig{
+		Policies: []model.LLMPolicy{
+			{
+				Name:    "basic-ratelimit",
+				Version: "v1",
+				Paths: []model.LLMPolicyPath{
+					{Path: "/*", Methods: []string{"*"}, Params: map[string]interface{}{"requests": 20}},
+					{Path: "/chat/completions", Methods: []string{"POST"}, Params: map[string]interface{}{"requests": 5}},
+				},
+			},
+		},
+	}
+	migrateLegacyProviderPoliciesInPlace(cfg)
+	require.Len(t, cfg.GlobalPolicies, 1)
+	assert.Equal(t, "basic-ratelimit", cfg.GlobalPolicies[0].Name)
+	require.Len(t, cfg.OperationPolicies, 1)
+	assert.Equal(t, "basic-ratelimit", cfg.OperationPolicies[0].Name)
+	require.Len(t, cfg.OperationPolicies[0].Paths, 1)
+	assert.Equal(t, "/chat/completions", cfg.OperationPolicies[0].Paths[0].Path)
+}
+
+func TestMigrateLegacyProviderPoliciesInPlace_WildcardMethodSpecificPath_StaysOperation(t *testing.T) {
+	// /* with specific methods (not ["*"]) must NOT become global.
+	cfg := &model.LLMProviderConfig{
+		Policies: []model.LLMPolicy{
+			{Name: "basic-ratelimit", Version: "v1", Paths: []model.LLMPolicyPath{
+				{Path: "/*", Methods: []string{"POST"}, Params: nil},
+			}},
+		},
+	}
+	migrateLegacyProviderPoliciesInPlace(cfg)
+	assert.Empty(t, cfg.GlobalPolicies)
+	require.Len(t, cfg.OperationPolicies, 1)
+}
+
+func TestMigrateLegacyProviderPoliciesInPlace_DedupsGlobalByName(t *testing.T) {
+	// If globalPolicies already has a policy of the same name, don't add a duplicate.
+	cfg := &model.LLMProviderConfig{
+		GlobalPolicies: []model.GlobalPolicy{{Name: "basic-ratelimit", Version: "v1"}},
+		Policies: []model.LLMPolicy{
+			{Name: "basic-ratelimit", Version: "v1", Paths: []model.LLMPolicyPath{
+				{Path: "/*", Methods: []string{"*"}, Params: nil},
+			}},
+		},
+	}
+	migrateLegacyProviderPoliciesInPlace(cfg)
+	assert.Len(t, cfg.GlobalPolicies, 1) // still just one
+}
+
+// ---------------------------------------------------------------------------
+// applyVersionAwareProviderPolicyTransform
+// ---------------------------------------------------------------------------

--- a/platform-api/src/internal/service/llm_test.go
+++ b/platform-api/src/internal/service/llm_test.go
@@ -16,6 +16,23 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// roundTripYAML marshals a dto artifact to YAML and back, normalising all
+// typed slices (e.g. []map[string]interface{}) to []interface{} the way a real
+// YAML round-trip does. Tests that inspect nested policy params use this to
+// keep their type assertions consistent with pre-Phase-8 behaviour.
+func roundTripYAML(t *testing.T, artifact dto.LLMProviderDeploymentYAML) dto.LLMProviderDeploymentYAML {
+	t.Helper()
+	b, err := yaml.Marshal(artifact)
+	if err != nil {
+		t.Fatalf("roundTripYAML marshal: %v", err)
+	}
+	var out dto.LLMProviderDeploymentYAML
+	if err := yaml.Unmarshal(b, &out); err != nil {
+		t.Fatalf("roundTripYAML unmarshal: %v", err)
+	}
+	return out
+}
+
 func TestMapTemplateResourceMappingAPI_RejectsEmptyResource(t *testing.T) {
 	mapped, err := mapTemplateResourceMappingAPI(&api.LLMProviderTemplateResourceMapping{Resource: "   "})
 	if err == nil {
@@ -316,15 +333,11 @@ func TestGenerateLLMProviderDeploymentYAML_WithSecurityAPIKeyPolicy(t *testing.T
 		},
 	}
 
-	yamlStr, err := generateLLMProviderDeploymentYAML(provider, "openai")
+	out, err := generateLLMProviderDeploymentYAML(provider, "openai")
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
 
-	var out dto.LLMProviderDeploymentYAML
-	if err := yaml.Unmarshal([]byte(yamlStr), &out); err != nil {
-		t.Fatalf("failed to unmarshal generated yaml: %v", err)
-	}
 
 	if out.Metadata.Name != "tt" {
 		t.Fatalf("expected metadata name tt, got: %s", out.Metadata.Name)
@@ -358,33 +371,28 @@ func TestGenerateLLMProviderDeploymentYAML_WithSecurityAPIKeyPolicy(t *testing.T
 		t.Fatalf("expected access control mode allow_all, got: %s", out.Spec.AccessControl.Mode)
 	}
 
-	if len(out.Spec.Policies) != 1 {
-		t.Fatalf("expected 1 policy, got: %d", len(out.Spec.Policies))
+	if len(out.Spec.OperationPolicies) != 0 {
+		t.Fatalf("expected 0 operation policies, got: %d", len(out.Spec.OperationPolicies))
+	}
+	if len(out.Spec.GlobalPolicies) != 1 {
+		t.Fatalf("expected 1 global policy, got: %d", len(out.Spec.GlobalPolicies))
 	}
 
-	policy := out.Spec.Policies[0]
+	policy := out.Spec.GlobalPolicies[0]
 	if policy.Name != "api-key-auth" {
 		t.Fatalf("expected policy name api-key-auth, got: %s", policy.Name)
 	}
 	if policy.Version != "" {
 		t.Fatalf("expected policy version empty, got: %s", policy.Version)
 	}
-	if len(policy.Paths) != 1 {
-		t.Fatalf("expected 1 policy path, got: %d", len(policy.Paths))
+	if policy.Params == nil {
+		t.Fatalf("expected policy params to be present")
 	}
-
-	path := policy.Paths[0]
-	if path.Path != "/*" {
-		t.Fatalf("expected policy path /*, got: %s", path.Path)
+	if (*policy.Params)["key"] != "X-API-Key" {
+		t.Fatalf("expected params.key X-API-Key, got: %#v", (*policy.Params)["key"])
 	}
-	if len(path.Methods) != 1 || path.Methods[0] != "*" {
-		t.Fatalf("expected methods [*], got: %#v", path.Methods)
-	}
-	if path.Params["key"] != "X-API-Key" {
-		t.Fatalf("expected params.key X-API-Key, got: %#v", path.Params["key"])
-	}
-	if path.Params["in"] != "header" {
-		t.Fatalf("expected params.in header, got: %#v", path.Params["in"])
+	if (*policy.Params)["in"] != "header" {
+		t.Fatalf("expected params.in header, got: %#v", (*policy.Params)["in"])
 	}
 }
 
@@ -450,29 +458,28 @@ func TestGenerateLLMProviderDeploymentYAML_WithSecurityAndAdditionalPolicy(t *te
 		},
 	}
 
-	yamlStr, err := generateLLMProviderDeploymentYAML(provider, "openai")
+	out, err := generateLLMProviderDeploymentYAML(provider, "openai")
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
 
-	var out dto.LLMProviderDeploymentYAML
-	if err := yaml.Unmarshal([]byte(yamlStr), &out); err != nil {
-		t.Fatalf("failed to unmarshal generated yaml: %v", err)
+
+	if len(out.Spec.OperationPolicies) != 1 {
+		t.Fatalf("expected 1 operation policy, got: %d", len(out.Spec.OperationPolicies))
+	}
+	if len(out.Spec.GlobalPolicies) != 1 {
+		t.Fatalf("expected 1 global policy, got: %d", len(out.Spec.GlobalPolicies))
 	}
 
-	if len(out.Spec.Policies) != 2 {
-		t.Fatalf("expected 2 policies, got: %d", len(out.Spec.Policies))
+	apiKeyPolicy := out.Spec.GlobalPolicies[0]
+	if apiKeyPolicy.Name != "api-key-auth" {
+		t.Fatalf("expected api-key-auth global policy, got: %s", apiKeyPolicy.Name)
+	}
+	if apiKeyPolicy.Params == nil || (*apiKeyPolicy.Params)["key"] != "X-API-Key" {
+		t.Fatalf("expected api-key-auth params.key X-API-Key")
 	}
 
-	apiKeyPolicy := findPolicy(out.Spec.Policies, "api-key-auth", "")
-	if apiKeyPolicy == nil {
-		t.Fatalf("expected api-key-auth policy to exist")
-	}
-	if len(apiKeyPolicy.Paths) != 1 || apiKeyPolicy.Paths[0].Path != "/*" {
-		t.Fatalf("expected api-key-auth path /*")
-	}
-
-	guardrailPolicy := findPolicy(out.Spec.Policies, "word-count-guardrail", "v0")
+	guardrailPolicy := findOperationPolicy(out.Spec.OperationPolicies, "word-count-guardrail")
 	if guardrailPolicy == nil {
 		t.Fatalf("expected word-count-guardrail policy to exist")
 	}
@@ -535,21 +542,26 @@ func TestGenerateLLMProviderDeploymentYAML_NormalizesPolicyVersionToMajor(t *tes
 		},
 	}
 
-	yamlStr, err := generateLLMProviderDeploymentYAML(provider, "openai")
+	out, err := generateLLMProviderDeploymentYAML(provider, "openai")
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
 
-	var out dto.LLMProviderDeploymentYAML
-	if err := yaml.Unmarshal([]byte(yamlStr), &out); err != nil {
-		t.Fatalf("failed to unmarshal generated yaml: %v", err)
+
+	policyA := findOperationPolicy(out.Spec.OperationPolicies, "policy-a")
+	if policyA == nil {
+		t.Fatalf("expected policy-a to be present")
+	}
+	if policyA.Version != "v0" {
+		t.Fatalf("expected policy-a version to be normalized to v0, got: %s", policyA.Version)
 	}
 
-	if findPolicy(out.Spec.Policies, "policy-a", "v0") == nil {
-		t.Fatalf("expected policy-a version to be normalized to v0")
+	policyB := findOperationPolicy(out.Spec.OperationPolicies, "policy-b")
+	if policyB == nil {
+		t.Fatalf("expected policy-b to be present")
 	}
-	if findPolicy(out.Spec.Policies, "policy-b", "v10") == nil {
-		t.Fatalf("expected policy-b version to be normalized to v10")
+	if policyB.Version != "v10" {
+		t.Fatalf("expected policy-b version to be normalized to v10, got: %s", policyB.Version)
 	}
 }
 
@@ -589,34 +601,27 @@ func TestGenerateLLMProviderDeploymentYAML_WithProviderGlobalRateLimit(t *testin
 		},
 	}
 
-	yamlStr, err := generateLLMProviderDeploymentYAML(provider, "openai")
+	out, err := generateLLMProviderDeploymentYAML(provider, "openai")
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
+	out = roundTripYAML(t, out)
 
-	var out dto.LLMProviderDeploymentYAML
-	if err := yaml.Unmarshal([]byte(yamlStr), &out); err != nil {
-		t.Fatalf("failed to unmarshal generated yaml: %v", err)
+
+	if len(out.Spec.GlobalPolicies) != 2 {
+		t.Fatalf("expected 2 global policies, got: %d", len(out.Spec.GlobalPolicies))
 	}
 
-	if len(out.Spec.Policies) != 2 {
-		t.Fatalf("expected 2 policies, got: %d", len(out.Spec.Policies))
-	}
-
-	tokenPolicy := findPolicy(out.Spec.Policies, "token-based-ratelimit", "")
+	tokenPolicy := findGlobalPolicy(out.Spec.GlobalPolicies, "token-based-ratelimit")
 	if tokenPolicy == nil {
-		t.Fatalf("expected token-based-ratelimit policy to exist")
+		t.Fatalf("expected token-based-ratelimit global policy to exist")
 	}
-	if len(tokenPolicy.Paths) != 1 {
-		t.Fatalf("expected token policy to have 1 path, got: %d", len(tokenPolicy.Paths))
+	if tokenPolicy.Params == nil {
+		t.Fatalf("expected token policy to have params")
 	}
-	tokenPath := tokenPolicy.Paths[0]
-	if tokenPath.Path != "/*" {
-		t.Fatalf("expected token policy path /*, got: %s", tokenPath.Path)
-	}
-	totalTokenLimits, ok := tokenPath.Params["totalTokenLimits"].([]interface{})
+	totalTokenLimits, ok := (*tokenPolicy.Params)["totalTokenLimits"].([]interface{})
 	if !ok || len(totalTokenLimits) != 1 {
-		t.Fatalf("expected totalTokenLimits with one entry, got: %#v", tokenPath.Params["totalTokenLimits"])
+		t.Fatalf("expected totalTokenLimits with one entry, got: %#v", (*tokenPolicy.Params)["totalTokenLimits"])
 	}
 	firstTokenLimit, ok := totalTokenLimits[0].(map[string]interface{})
 	if !ok {
@@ -629,20 +634,16 @@ func TestGenerateLLMProviderDeploymentYAML_WithProviderGlobalRateLimit(t *testin
 		t.Fatalf("expected token duration 1h, got: %#v", firstTokenLimit["duration"])
 	}
 
-	requestPolicy := findPolicy(out.Spec.Policies, "advanced-ratelimit", "")
+	requestPolicy := findGlobalPolicy(out.Spec.GlobalPolicies, "advanced-ratelimit")
 	if requestPolicy == nil {
-		t.Fatalf("expected advanced-ratelimit policy to exist")
+		t.Fatalf("expected advanced-ratelimit global policy to exist")
 	}
-	if len(requestPolicy.Paths) != 1 {
-		t.Fatalf("expected request policy to have 1 path, got: %d", len(requestPolicy.Paths))
+	if requestPolicy.Params == nil {
+		t.Fatalf("expected request policy to have params")
 	}
-	requestPath := requestPolicy.Paths[0]
-	if requestPath.Path != "/*" {
-		t.Fatalf("expected request policy path /*, got: %s", requestPath.Path)
-	}
-	quotas, ok := requestPath.Params["quotas"].([]interface{})
+	quotas, ok := (*requestPolicy.Params)["quotas"].([]interface{})
 	if !ok || len(quotas) != 1 {
-		t.Fatalf("expected quotas with one entry, got: %#v", requestPath.Params["quotas"])
+		t.Fatalf("expected quotas with one entry, got: %#v", (*requestPolicy.Params)["quotas"])
 	}
 	firstQuota, ok := quotas[0].(map[string]interface{})
 	if !ok {
@@ -719,55 +720,52 @@ func TestGenerateLLMProviderDeploymentYAML_WithProviderResourceWiseRateLimit(t *
 		},
 	}
 
-	yamlStr, err := generateLLMProviderDeploymentYAML(provider, "openai")
+	out, err := generateLLMProviderDeploymentYAML(provider, "openai")
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
+	out = roundTripYAML(t, out)
 
-	var out dto.LLMProviderDeploymentYAML
-	if err := yaml.Unmarshal([]byte(yamlStr), &out); err != nil {
-		t.Fatalf("failed to unmarshal generated yaml: %v", err)
+
+	if len(out.Spec.OperationPolicies) != 2 {
+		t.Fatalf("expected 2 operation policies, got: %d", len(out.Spec.OperationPolicies))
 	}
 
-	if len(out.Spec.Policies) != 2 {
-		t.Fatalf("expected 2 policies, got: %d", len(out.Spec.Policies))
-	}
-
-	tokenPolicy := findPolicy(out.Spec.Policies, "token-based-ratelimit", "")
+	tokenPolicy := findOperationPolicy(out.Spec.OperationPolicies, "token-based-ratelimit")
 	if tokenPolicy == nil {
-		t.Fatalf("expected token-based-ratelimit policy to exist")
+		t.Fatalf("expected token-based-ratelimit operation policy to exist")
 	}
 	if len(tokenPolicy.Paths) != 2 {
 		t.Fatalf("expected 2 token policy paths, got: %d", len(tokenPolicy.Paths))
 	}
 
-	assistantsTokenPath := findPath(tokenPolicy, "/assistants")
+	assistantsTokenPath := findOperationPath(tokenPolicy, "/assistants")
 	if assistantsTokenPath == nil {
 		t.Fatalf("expected token policy path /assistants")
 	}
-	audioTokenPath := findPath(tokenPolicy, "/audio/speech")
+	audioTokenPath := findOperationPath(tokenPolicy, "/audio/speech")
 	if audioTokenPath == nil {
 		t.Fatalf("expected token policy path /audio/speech")
 	}
 
-	requestPolicy := findPolicy(out.Spec.Policies, "advanced-ratelimit", "")
+	requestPolicy := findOperationPolicy(out.Spec.OperationPolicies, "advanced-ratelimit")
 	if requestPolicy == nil {
-		t.Fatalf("expected advanced-ratelimit policy to exist")
+		t.Fatalf("expected advanced-ratelimit operation policy to exist")
 	}
 	if len(requestPolicy.Paths) != 2 {
 		t.Fatalf("expected 2 request policy paths, got: %d", len(requestPolicy.Paths))
 	}
 
-	assistantsRequestPath := findPath(requestPolicy, "/assistants")
+	assistantsRequestPath := findOperationPath(requestPolicy, "/assistants")
 	if assistantsRequestPath == nil {
 		t.Fatalf("expected request policy path /assistants")
 	}
-	audioRequestPath := findPath(requestPolicy, "/audio/speech")
+	audioRequestPath := findOperationPath(requestPolicy, "/audio/speech")
 	if audioRequestPath == nil {
 		t.Fatalf("expected request policy path /audio/speech")
 	}
 
-	for _, p := range []*api.LLMPolicyPath{assistantsTokenPath, audioTokenPath} {
+	for _, p := range []*api.OperationPolicyPath{assistantsTokenPath, audioTokenPath} {
 		totalTokenLimits, ok := p.Params["totalTokenLimits"].([]interface{})
 		if !ok || len(totalTokenLimits) != 1 {
 			t.Fatalf("expected totalTokenLimits with one entry, got: %#v", p.Params["totalTokenLimits"])
@@ -784,7 +782,7 @@ func TestGenerateLLMProviderDeploymentYAML_WithProviderResourceWiseRateLimit(t *
 		}
 	}
 
-	for _, p := range []*api.LLMPolicyPath{assistantsRequestPath, audioRequestPath} {
+	for _, p := range []*api.OperationPolicyPath{assistantsRequestPath, audioRequestPath} {
 		quotas, ok := p.Params["quotas"].([]interface{})
 		if !ok || len(quotas) != 1 {
 			t.Fatalf("expected quotas with one entry, got: %#v", p.Params["quotas"])
@@ -865,41 +863,38 @@ func TestGenerateLLMProviderDeploymentYAML_WithProviderResourceWiseRateLimitAndD
 		},
 	}
 
-	yamlStr, err := generateLLMProviderDeploymentYAML(provider, "openai")
+	out, err := generateLLMProviderDeploymentYAML(provider, "openai")
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
+	out = roundTripYAML(t, out)
 
-	var out dto.LLMProviderDeploymentYAML
-	if err := yaml.Unmarshal([]byte(yamlStr), &out); err != nil {
-		t.Fatalf("failed to unmarshal generated yaml: %v", err)
+
+	if len(out.Spec.OperationPolicies) != 2 {
+		t.Fatalf("expected 2 operation policies, got: %d", len(out.Spec.OperationPolicies))
 	}
 
-	if len(out.Spec.Policies) != 2 {
-		t.Fatalf("expected 2 policies, got: %d", len(out.Spec.Policies))
-	}
-
-	tokenPolicy := findPolicy(out.Spec.Policies, "token-based-ratelimit", "")
+	tokenPolicy := findOperationPolicy(out.Spec.OperationPolicies, "token-based-ratelimit")
 	if tokenPolicy == nil {
-		t.Fatalf("expected token-based-ratelimit policy to exist")
+		t.Fatalf("expected token-based-ratelimit operation policy to exist")
 	}
 	if len(tokenPolicy.Paths) != 3 {
 		t.Fatalf("expected 3 token policy paths (default + 2 unique resources), got: %d", len(tokenPolicy.Paths))
 	}
 
-	requestPolicy := findPolicy(out.Spec.Policies, "advanced-ratelimit", "")
+	requestPolicy := findOperationPolicy(out.Spec.OperationPolicies, "advanced-ratelimit")
 	if requestPolicy == nil {
-		t.Fatalf("expected advanced-ratelimit policy to exist")
+		t.Fatalf("expected advanced-ratelimit operation policy to exist")
 	}
 	if len(requestPolicy.Paths) != 3 {
 		t.Fatalf("expected 3 request policy paths (default + 2 unique resources), got: %d", len(requestPolicy.Paths))
 	}
 
 	for _, p := range []string{"/*", "/assistants", "/audio/speech"} {
-		if findPath(tokenPolicy, p) == nil {
+		if findOperationPath(tokenPolicy, p) == nil {
 			t.Fatalf("expected token policy path %s", p)
 		}
-		if findPath(requestPolicy, p) == nil {
+		if findOperationPath(requestPolicy, p) == nil {
 			t.Fatalf("expected request policy path %s", p)
 		}
 	}
@@ -941,16 +936,25 @@ func TestGenerateLLMProviderDeploymentYAML_WithProviderResourceWiseRateLimitAndD
 	}
 }
 
-func findPolicy(policies []api.LLMPolicy, name, version string) *api.LLMPolicy {
+func findGlobalPolicy(policies []api.Policy, name string) *api.Policy {
 	for i := range policies {
-		if policies[i].Name == name && policies[i].Version == version {
+		if policies[i].Name == name {
 			return &policies[i]
 		}
 	}
 	return nil
 }
 
-func findPath(policy *api.LLMPolicy, path string) *api.LLMPolicyPath {
+func findOperationPolicy(policies []api.OperationPolicy, name string) *api.OperationPolicy {
+	for i := range policies {
+		if policies[i].Name == name {
+			return &policies[i]
+		}
+	}
+	return nil
+}
+
+func findOperationPath(policy *api.OperationPolicy, path string) *api.OperationPolicyPath {
 	if policy == nil {
 		return nil
 	}
@@ -1143,6 +1147,82 @@ func TestLLMProviderServiceCreateAllowsAggregatorTemplate(t *testing.T) {
 	}
 	if providerRepo.created == nil || providerRepo.created.TemplateUUID != "tpl-agg" {
 		t.Fatalf("expected created provider to reference aggregator template UUID")
+	}
+}
+
+// TestLLMProviderServiceCreateMigratesLegacyPolicies verifies Phase 10 save-time
+// migration: a provider created with the deprecated `policies` list has it split into
+// globalPolicies (for path "/*" + methods ["*"]) and operationPolicies (all other paths).
+// After save, `policies` is cleared in the stored config.
+func TestLLMProviderServiceCreateMigratesLegacyPolicies(t *testing.T) {
+	now := time.Now()
+	providerRepo := &mockLLMProviderRepo{}
+	providerRepo.getByIDFunc = func(providerID, orgUUID string) (*model.LLMProvider, error) {
+		if providerRepo.created == nil {
+			return nil, nil
+		}
+		created := *providerRepo.created
+		created.UUID = "prov-uuid"
+		created.CreatedAt = now
+		created.UpdatedAt = now
+		return &created, nil
+	}
+	templateRepo := &mockLLMTemplateRepo{
+		getByIDFunc: func(templateID, orgUUID string) (*model.LLMProviderTemplate, error) {
+			return &model.LLMProviderTemplate{UUID: "tpl-openai", ID: "openai", CreatedAt: now, UpdatedAt: now}, nil
+		},
+	}
+	orgRepo := &mockOrganizationRepo{org: &model.Organization{ID: "org-1"}}
+	service := NewLLMProviderService(providerRepo, templateRepo, orgRepo, nil, nil, nil, nil, slog.Default())
+
+	request := validProviderRequest("openai")
+	request.Policies = &[]api.LLMPolicy{
+		// path "/*" + methods ["*"] → globalPolicies
+		{
+			Name:    "basic-ratelimit",
+			Version: "v1",
+			Paths: []api.LLMPolicyPath{
+				{Path: "/*", Methods: []api.LLMPolicyPathMethods{"*"}, Params: map[string]interface{}{"requests": 10}},
+			},
+		},
+		// specific path → operationPolicies
+		{
+			Name:    "token-ratelimit",
+			Version: "v1",
+			Paths: []api.LLMPolicyPath{
+				{Path: "/chat/completions", Methods: []api.LLMPolicyPathMethods{"POST"}, Params: map[string]interface{}{"tokens": 1000}},
+			},
+		},
+	}
+
+	if _, err := service.Create("org-1", "alice", request); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if providerRepo.created == nil {
+		t.Fatal("expected provider to be created")
+	}
+	cfg := providerRepo.created.Configuration
+
+	// Deprecated list cleared after migration.
+	if len(cfg.Policies) != 0 {
+		t.Fatalf("expected policies cleared after migration, got: %d", len(cfg.Policies))
+	}
+	// "/*" + ["*"] → globalPolicies
+	if len(cfg.GlobalPolicies) != 1 {
+		t.Fatalf("expected 1 globalPolicy, got: %d", len(cfg.GlobalPolicies))
+	}
+	if cfg.GlobalPolicies[0].Name != "basic-ratelimit" {
+		t.Fatalf("expected globalPolicy name basic-ratelimit, got: %s", cfg.GlobalPolicies[0].Name)
+	}
+	// specific path → operationPolicies
+	if len(cfg.OperationPolicies) != 1 {
+		t.Fatalf("expected 1 operationPolicy, got: %d", len(cfg.OperationPolicies))
+	}
+	if cfg.OperationPolicies[0].Name != "token-ratelimit" {
+		t.Fatalf("expected operationPolicy name token-ratelimit, got: %s", cfg.OperationPolicies[0].Name)
+	}
+	if len(cfg.OperationPolicies[0].Paths) != 1 || cfg.OperationPolicies[0].Paths[0].Path != "/chat/completions" {
+		t.Fatalf("expected operationPolicy path /chat/completions, got: %+v", cfg.OperationPolicies[0].Paths)
 	}
 }
 

--- a/platform-api/src/internal/utils/api.go
+++ b/platform-api/src/internal/utils/api.go
@@ -548,7 +548,7 @@ func (u *APIUtil) BuildAPIDeploymentYAML(apiModel *model.API) (*dto.APIDeploymen
 	}
 
 	return &dto.APIDeploymentYAML{
-		ApiVersion: "gateway.api-platform.wso2.com/v1alpha1",
+		ApiVersion: constants.GatewayApiVersion,
 		Kind:       apiType,
 		Metadata: dto.DeploymentMetadata{
 			Name: apiModel.Handle,

--- a/platform-api/src/internal/utils/api_test.go
+++ b/platform-api/src/internal/utils/api_test.go
@@ -637,7 +637,7 @@ func TestBuildAPIDeploymentYAML(t *testing.T) {
 	}
 
 	// Verify key struct fields
-	if deploymentStruct.ApiVersion != "gateway.api-platform.wso2.com/v1alpha1" {
+	if deploymentStruct.ApiVersion != "gateway.api-platform.wso2.com/v1alpha2" {
 		t.Errorf("ApiVersion = %q", deploymentStruct.ApiVersion)
 	}
 	if deploymentStruct.Kind != constants.RestApi {

--- a/platform-api/src/internal/utils/api_test.go
+++ b/platform-api/src/internal/utils/api_test.go
@@ -637,7 +637,7 @@ func TestBuildAPIDeploymentYAML(t *testing.T) {
 	}
 
 	// Verify key struct fields
-	if deploymentStruct.ApiVersion != "gateway.api-platform.wso2.com/v1alpha2" {
+	if deploymentStruct.ApiVersion != "gateway.api-platform.wso2.com/v1" {
 		t.Errorf("ApiVersion = %q", deploymentStruct.ApiVersion)
 	}
 	if deploymentStruct.Kind != constants.RestApi {

--- a/platform-api/src/resources/default-llm-provider-templates/anthropic-template.yaml
+++ b/platform-api/src/resources/default-llm-provider-templates/anthropic-template.yaml
@@ -16,7 +16,7 @@
 # under the License.
 # --------------------------------------------------------------------
 
-apiVersion: gateway.api-platform.wso2.com/v1alpha2
+apiVersion: gateway.api-platform.wso2.com/v1
 kind: LlmProviderTemplate
 metadata:
   name: anthropic

--- a/platform-api/src/resources/default-llm-provider-templates/anthropic-template.yaml
+++ b/platform-api/src/resources/default-llm-provider-templates/anthropic-template.yaml
@@ -16,7 +16,7 @@
 # under the License.
 # --------------------------------------------------------------------
 
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProviderTemplate
 metadata:
   name: anthropic

--- a/platform-api/src/resources/default-llm-provider-templates/awsbedrock-template.yaml
+++ b/platform-api/src/resources/default-llm-provider-templates/awsbedrock-template.yaml
@@ -16,7 +16,7 @@
 # under the License.
 # --------------------------------------------------------------------
 
-apiVersion: gateway.api-platform.wso2.com/v1alpha2
+apiVersion: gateway.api-platform.wso2.com/v1
 kind: LlmProviderTemplate
 metadata:
   name: awsbedrock

--- a/platform-api/src/resources/default-llm-provider-templates/awsbedrock-template.yaml
+++ b/platform-api/src/resources/default-llm-provider-templates/awsbedrock-template.yaml
@@ -16,7 +16,7 @@
 # under the License.
 # --------------------------------------------------------------------
 
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProviderTemplate
 metadata:
   name: awsbedrock

--- a/platform-api/src/resources/default-llm-provider-templates/azureaifoundry-template.yaml
+++ b/platform-api/src/resources/default-llm-provider-templates/azureaifoundry-template.yaml
@@ -16,7 +16,7 @@
 # under the License.
 # --------------------------------------------------------------------
 
-apiVersion: gateway.api-platform.wso2.com/v1alpha2
+apiVersion: gateway.api-platform.wso2.com/v1
 kind: LlmProviderTemplate
 metadata:
   name: azureai-foundry

--- a/platform-api/src/resources/default-llm-provider-templates/azureaifoundry-template.yaml
+++ b/platform-api/src/resources/default-llm-provider-templates/azureaifoundry-template.yaml
@@ -16,7 +16,7 @@
 # under the License.
 # --------------------------------------------------------------------
 
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProviderTemplate
 metadata:
   name: azureai-foundry

--- a/platform-api/src/resources/default-llm-provider-templates/azureopenai-template.yaml
+++ b/platform-api/src/resources/default-llm-provider-templates/azureopenai-template.yaml
@@ -16,7 +16,7 @@
 # under the License.
 # --------------------------------------------------------------------
 
-apiVersion: gateway.api-platform.wso2.com/v1alpha2
+apiVersion: gateway.api-platform.wso2.com/v1
 kind: LlmProviderTemplate
 metadata:
   name: azure-openai

--- a/platform-api/src/resources/default-llm-provider-templates/azureopenai-template.yaml
+++ b/platform-api/src/resources/default-llm-provider-templates/azureopenai-template.yaml
@@ -16,7 +16,7 @@
 # under the License.
 # --------------------------------------------------------------------
 
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProviderTemplate
 metadata:
   name: azure-openai

--- a/platform-api/src/resources/default-llm-provider-templates/gemini-template.yaml
+++ b/platform-api/src/resources/default-llm-provider-templates/gemini-template.yaml
@@ -16,7 +16,7 @@
 # under the License.
 # --------------------------------------------------------------------
 
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProviderTemplate
 metadata:
   name: gemini

--- a/platform-api/src/resources/default-llm-provider-templates/gemini-template.yaml
+++ b/platform-api/src/resources/default-llm-provider-templates/gemini-template.yaml
@@ -16,7 +16,7 @@
 # under the License.
 # --------------------------------------------------------------------
 
-apiVersion: gateway.api-platform.wso2.com/v1alpha2
+apiVersion: gateway.api-platform.wso2.com/v1
 kind: LlmProviderTemplate
 metadata:
   name: gemini

--- a/platform-api/src/resources/default-llm-provider-templates/mistral-template.yaml
+++ b/platform-api/src/resources/default-llm-provider-templates/mistral-template.yaml
@@ -16,7 +16,7 @@
 # under the License.
 # --------------------------------------------------------------------
 
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProviderTemplate
 metadata:
   name: mistralai

--- a/platform-api/src/resources/default-llm-provider-templates/mistral-template.yaml
+++ b/platform-api/src/resources/default-llm-provider-templates/mistral-template.yaml
@@ -16,7 +16,7 @@
 # under the License.
 # --------------------------------------------------------------------
 
-apiVersion: gateway.api-platform.wso2.com/v1alpha2
+apiVersion: gateway.api-platform.wso2.com/v1
 kind: LlmProviderTemplate
 metadata:
   name: mistralai

--- a/platform-api/src/resources/default-llm-provider-templates/openai-template.yaml
+++ b/platform-api/src/resources/default-llm-provider-templates/openai-template.yaml
@@ -16,7 +16,7 @@
 # under the License.
 # --------------------------------------------------------------------
 
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProviderTemplate
 metadata:
   name: openai

--- a/platform-api/src/resources/default-llm-provider-templates/openai-template.yaml
+++ b/platform-api/src/resources/default-llm-provider-templates/openai-template.yaml
@@ -16,7 +16,7 @@
 # under the License.
 # --------------------------------------------------------------------
 
-apiVersion: gateway.api-platform.wso2.com/v1alpha2
+apiVersion: gateway.api-platform.wso2.com/v1
 kind: LlmProviderTemplate
 metadata:
   name: openai

--- a/platform-api/src/resources/openapi.yaml
+++ b/platform-api/src/resources/openapi.yaml
@@ -25,7 +25,7 @@ info:
     Authorization is enforced via OAuth2 scopes carried in the JWT. Both read (GET) and write
     operations require specific scopes declared in the `security` field of each operation.
 
-  version: 1.0.0
+  version: v1alpha2
   contact:
     name: WSO2 API Platform Team
   license:
@@ -33,9 +33,9 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0.html
 
 servers:
-  - url: https://localhost:9243/api/v1
+  - url: https://localhost:9243/api/v1alpha2
     description: Development server (HTTPS)
-  - url: https://api.platform.com/api/v1
+  - url: https://api.platform.com/api/v1alpha2
     description: Production server
 
 security:
@@ -10003,6 +10003,47 @@ components:
           description: JSON Schema describing the parameters accepted by this policy. This itself is a JSON Schema document.
           additionalProperties: true
 
+    OperationPolicy:
+      type: object
+      required:
+        - name
+        - version
+        - paths
+      properties:
+        name:
+          type: string
+          example: token-based-ratelimit
+        version:
+          type: string
+          example: v1
+        executionCondition:
+          type: string
+          description: Optional per-request CEL expression controlling whether the policy runs
+        paths:
+          type: array
+          items:
+            $ref: '#/components/schemas/OperationPolicyPath'
+
+    OperationPolicyPath:
+      type: object
+      required:
+        - path
+        - methods
+        - params
+      properties:
+        path:
+          type: string
+          example: /chat/completions
+        methods:
+          type: array
+          items:
+            type: string
+            description: "HTTP method: GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD, or * for all"
+        params:
+          type: object
+          description: Policy parameters
+          additionalProperties: true
+
     LLMRateLimitingConfig:
       type: object
       description: Rate limiting configuration for an LLM provider at provider and consumer levels.
@@ -10263,9 +10304,20 @@ components:
           $ref: '#/components/schemas/LLMAccessControl'
         rateLimiting:
           $ref: '#/components/schemas/LLMRateLimitingConfig'
-        policies:
+        globalPolicies:
           type: array
-          description: List of policies applied only to this operation (overrides or adds to API-level policies)
+          description: Global (api-level) policies applied across ALL operations as one shared scope, evaluated before operation-level policies.
+          items:
+            $ref: "#/components/schemas/Policy"
+        operationPolicies:
+          type: array
+          description: Operation-level policies scoped to specific paths/methods, evaluated after global policies.
+          items:
+            $ref: "#/components/schemas/OperationPolicy"
+        policies:
+          deprecated: true
+          type: array
+          description: DEPRECATED - use operationPolicies. Still honoured (treated identically to operationPolicies).
           items:
             $ref: "#/components/schemas/LLMPolicy"
         security:
@@ -10442,9 +10494,20 @@ components:
               title: Proxy API
               version: v1.0
             paths: {}
-        policies:
+        globalPolicies:
           type: array
-          description: List of policies applied only to this operation (overrides or adds to API-level policies)
+          description: Global (api-level) policies applied across ALL operations as one shared scope, evaluated before operation-level policies.
+          items:
+            $ref: "#/components/schemas/Policy"
+        operationPolicies:
+          type: array
+          description: Operation-level policies scoped to specific paths/methods, evaluated after global policies.
+          items:
+            $ref: "#/components/schemas/OperationPolicy"
+        policies:
+          deprecated: true
+          type: array
+          description: DEPRECATED - use operationPolicies. Still honoured (treated identically to operationPolicies).
           items:
             $ref: "#/components/schemas/LLMPolicy"
         security:

--- a/platform-api/src/resources/openapi.yaml
+++ b/platform-api/src/resources/openapi.yaml
@@ -25,7 +25,7 @@ info:
     Authorization is enforced via OAuth2 scopes carried in the JWT. Both read (GET) and write
     operations require specific scopes declared in the `security` field of each operation.
 
-  version: v1alpha2
+  version: 0.9.0
   contact:
     name: WSO2 API Platform Team
   license:
@@ -33,9 +33,9 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0.html
 
 servers:
-  - url: https://localhost:9243/api/v1alpha2
+  - url: https://localhost:9243/api/v0.9
     description: Development server (HTTPS)
-  - url: https://api.platform.com/api/v1alpha2
+  - url: https://api.platform.com/api/v0.9
     description: Production server
 
 security:

--- a/platform-api/src/resources/openapi.yaml
+++ b/platform-api/src/resources/openapi.yaml
@@ -10038,6 +10038,7 @@ components:
           type: array
           items:
             type: string
+            enum: [ GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD, "*" ]
             description: "HTTP method: GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD, or * for all"
         params:
           type: object

--- a/portals/ai-workspace/configs/config-platform-api-template.toml
+++ b/portals/ai-workspace/configs/config-platform-api-template.toml
@@ -33,7 +33,7 @@ port      = "9243"   # HTTP/HTTPS listen port for Platform API
 # Set to false only to temporarily bypass during development.
 enable_scope_validation = true
 
-# Controls authentication for POST /api/v1/organizations.
+# Controls authentication for POST /api/v0.9/organizations.
 # When true, the endpoint requires both a valid Bearer JWT and the
 # ap:organization:manage scope; requests without that scope are rejected.
 # Default: false (public) — preserves backwards-compatible behaviour for existing deployments.

--- a/portals/ai-workspace/configs/config-platform-api.toml
+++ b/portals/ai-workspace/configs/config-platform-api.toml
@@ -25,7 +25,7 @@ port      = "9243"
 
 # Validate OAuth2 scopes on incoming requests.
 enable_scope_validation = true
-# Controls authentication for POST /api/v1/organizations.
+# Controls authentication for POST /api/v0.9/organizations.
 # When true, the endpoint requires both a valid Bearer JWT and the
 # ap:organization:manage scope; requests without that scope are rejected.
 org_creation_requires_auth = true

--- a/portals/ai-workspace/configs/config-template.toml
+++ b/portals/ai-workspace/configs/config-template.toml
@@ -40,9 +40,9 @@ auth_mode = "basic"
 # oidc_org_handle_claim = "org_handle"
 
 # Platform API base URL — used by the UI to make API calls (may be a relative
-# path when nginx proxying is in use, e.g. /api-proxy/api/v1).
-# Defaults to https://localhost:9243/api/v1 if unset.
-platform_api_base_url = "https://localhost:9243/api/v1"
+# path when nginx proxying is in use, e.g. /api-proxy/api/v0.9).
+# Defaults to https://localhost:9243/api/v0.9 if unset.
+platform_api_base_url = "https://localhost:9243/api/v0.9"
 
 # Control-plane host — the host:port that deployed gateways use to reach
 # the Platform API. Shown in gateway setup instructions (keys.env, helm values).

--- a/portals/ai-workspace/configs/config.toml
+++ b/portals/ai-workspace/configs/config.toml
@@ -20,7 +20,7 @@ domain = "localhost:5380"
 auth_mode = "basic"
 
 # Platform API base URL — used by the UI to make API calls.
-platform_api_base_url = "https://localhost:9243/api/v1"
+platform_api_base_url = "https://localhost:9243/api/v0.9"
 
 # Control-plane host — the externally reachable address gateways use to reach
 # the Platform API. Shown in gateway setup instructions (keys.env, helm values).

--- a/portals/ai-workspace/cypress/e2e/001-providers/001-provider-and-proxy.cy.js
+++ b/portals/ai-workspace/cypress/e2e/001-providers/001-provider-and-proxy.cy.js
@@ -48,7 +48,7 @@ describe('AI Workspace - OpenAI provider and proxy lifecycle', () => {
         expect(authToken).to.not.equal('');
 
         return cy.request({
-          url: '/api-proxy/api/v1/organizations',
+          url: '/api-proxy/api/v0.9/organizations',
           headers: {
             Authorization: `Bearer ${authToken}`,
           },
@@ -185,7 +185,7 @@ describe('AI Workspace - OpenAI provider and proxy lifecycle', () => {
 
 function deleteLinkedProxies(authToken, organizationId, providerId) {
   return requestWithAuth(authToken, {
-    url: `/api-proxy/api/v1/llm-providers/${encodeURIComponent(providerId)}/llm-proxies?organizationId=${encodeURIComponent(organizationId)}`,
+    url: `/api-proxy/api/v0.9/llm-providers/${encodeURIComponent(providerId)}/llm-proxies?organizationId=${encodeURIComponent(organizationId)}`,
     failOnStatusCode: false,
   }).then((response) => {
     expect(response.status).to.be.oneOf([200, 404]);
@@ -202,7 +202,7 @@ function deleteLinkedProxies(authToken, organizationId, providerId) {
     return cy.wrap(proxies).each((proxy) =>
       requestWithAuth(authToken, {
         method: 'DELETE',
-        url: `/api-proxy/api/v1/llm-proxies/${encodeURIComponent(proxy.id)}?organizationId=${encodeURIComponent(organizationId)}`,
+        url: `/api-proxy/api/v0.9/llm-proxies/${encodeURIComponent(proxy.id)}?organizationId=${encodeURIComponent(organizationId)}`,
         failOnStatusCode: false,
       }).then((deleteResponse) => {
         expect(deleteResponse.status).to.be.oneOf([200, 204, 404]);
@@ -213,7 +213,7 @@ function deleteLinkedProxies(authToken, organizationId, providerId) {
 
 function deleteProjectByName(authToken, targetProjectName, fallbackProjectName) {
   return requestWithAuth(authToken, {
-    url: '/api-proxy/api/v1/projects',
+    url: '/api-proxy/api/v0.9/projects',
   }).then((response) => {
     expect(response.status).to.eq(200);
 
@@ -239,7 +239,7 @@ function deleteProjectByName(authToken, targetProjectName, fallbackProjectName) 
 function ensureFallbackProject(authToken, fallbackProjectName) {
   return requestWithAuth(authToken, {
     method: 'POST',
-    url: '/api-proxy/api/v1/projects',
+    url: '/api-proxy/api/v0.9/projects',
     body: {
       name: fallbackProjectName,
       description: 'Reserved project to satisfy E2E cleanup invariants.',
@@ -253,7 +253,7 @@ function ensureFallbackProject(authToken, fallbackProjectName) {
 function deleteProject(authToken, projectId) {
   return requestWithAuth(authToken, {
     method: 'DELETE',
-    url: `/api-proxy/api/v1/projects/${encodeURIComponent(projectId)}`,
+    url: `/api-proxy/api/v0.9/projects/${encodeURIComponent(projectId)}`,
     failOnStatusCode: false,
   }).then((response) => {
     expect(response.status).to.be.oneOf([200, 204, 404]);
@@ -263,7 +263,7 @@ function deleteProject(authToken, projectId) {
 function deleteProvider(authToken, organizationId, providerId) {
   return requestWithAuth(authToken, {
     method: 'DELETE',
-    url: `/api-proxy/api/v1/llm-providers/${encodeURIComponent(providerId)}?organizationId=${encodeURIComponent(organizationId)}`,
+    url: `/api-proxy/api/v0.9/llm-providers/${encodeURIComponent(providerId)}?organizationId=${encodeURIComponent(organizationId)}`,
     failOnStatusCode: false,
   }).then((response) => {
     expect(response.status).to.be.oneOf([200, 204, 404]);

--- a/portals/ai-workspace/docker-compose.yaml
+++ b/portals/ai-workspace/docker-compose.yaml
@@ -82,7 +82,7 @@ services:
       # Route all Platform API calls through nginx (/api-proxy/ → platform-api:9243/).
       # Relative paths avoid direct browser-to-platform-api connections and
       # sidestep self-signed TLS certificate issues.
-      - VITE_PLATFORM_API_BASE_URL=/api-proxy/api/v1
+      - VITE_PLATFORM_API_BASE_URL=/api-proxy/api/v0.9
       - VITE_PORTAL_API_BASE_URL=/api-proxy/api/portal/v1
     volumes:
       - ./configs/config.toml:/etc/ai-workspace/config.toml:ro

--- a/portals/ai-workspace/src/apis/platformApis.ts
+++ b/portals/ai-workspace/src/apis/platformApis.ts
@@ -28,7 +28,7 @@ import { logger } from '../utils/logger';
  * Organization schema from the Platform API.
  *
  * curl reference:
- *   POST https://localhost:9243/api/v1/organizations
+ *   POST https://localhost:9243/api/v0.9/organizations
  *   -H 'Authorization: Bearer <token>'
  *   -H 'accept: application/json' -H 'content-type: application/json'
  *   --data-raw '{"id":"<uuid>","name":"<name>","handle":"<handle>","region":"us"}'

--- a/portals/ai-workspace/src/clients/choreoApiClient.ts
+++ b/portals/ai-workspace/src/clients/choreoApiClient.ts
@@ -20,7 +20,7 @@
 // Platform API Client
 // ----------------------------------------------------------------------------
 // Replaces the Asgardeo-backed httpRequest with native fetch.
-// All calls go to PLATFORM_API_BASE_URL (default: https://localhost:9243/api/v1).
+// All calls go to PLATFORM_API_BASE_URL (default: https://localhost:9243/api/v0.9).
 //
 // Token storage:
 //   localStorage.setItem('platform_auth_token', '<your-token>')

--- a/portals/ai-workspace/src/config.env.ts
+++ b/portals/ai-workspace/src/config.env.ts
@@ -156,7 +156,7 @@ export const POLICY_HUB_WEB_URL = getEnvOrDefault(
 // only if calling the platform API directly.
 export const PLATFORM_API_BASE_URL = getEnvOrDefault(
   'VITE_PLATFORM_API_BASE_URL',
-  '/api-proxy/api/v1'
+  '/api-proxy/api/v0.9'
 );
 
 // Control-plane host shown in gateway setup instructions (host:port).

--- a/portals/ai-workspace/src/contexts/ChoreoUserContext.tsx
+++ b/portals/ai-workspace/src/contexts/ChoreoUserContext.tsx
@@ -20,7 +20,7 @@
 // ChoreoUserContext — Platform API (standalone) version
 // ----------------------------------------------------------------------------
 // Asgardeo authentication has been removed. All org data comes from the
-// Platform API (https://localhost:9243/api/v1).
+// Platform API (https://localhost:9243/api/v0.9).
 // Token exchange and IDP-specific logic are no-ops.
 // ============================================================================
 

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyGuardrailsTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyGuardrailsTab.tsx
@@ -173,6 +173,7 @@ export default function LLMProxyGuardrailsTab() {
   const [editingTarget, setEditingTarget] = useState<{
     policyIndex: number;
     pathIndex: number | null;
+    source: 'global' | 'operation' | 'legacy';
   } | null>(null);
   const [selectedCategories, setSelectedCategories] = useState<string[]>(['AI']);
   const [drawerGuardrails, setDrawerGuardrails] = useState<typeof availableGuardrails>([]);
@@ -227,43 +228,68 @@ export default function LLMProxyGuardrailsTab() {
   const getDisplayName = (policyName: string): string =>
     displayNameMap[policyName] || policyName;
 
-  const globalGuardrails = useMemo(
-    () =>
-      policies.flatMap((policy, policyIndex) => {
-        const version = policy.version
-          ? `v${policy.version.split('.')[0]}`
-          : 'v0';
-        const displayName = getDisplayName(policy.name);
-        if (!policy.paths || policy.paths.length === 0) {
-          return [
-            {
-              id: `${policy.name}-${version}-${policyIndex}-default`,
+  const globalGuardrails = useMemo(() => {
+    const items: Array<{
+      id: string;
+      name: string;
+      displayName: string;
+      version: string;
+      source: 'global' | 'legacy';
+      policyIndex: number;
+      pathIndex: number | null;
+    }> = [];
+
+    // New globalPolicies list
+    (proxy?.globalPolicies ?? []).forEach((policy, policyIndex) => {
+      const version = policy.version
+        ? `v${policy.version.replace(/^v/, '').split('.')[0]}`
+        : 'v0';
+      items.push({
+        id: `global-${policy.name}-${version}-${policyIndex}`,
+        name: policy.name,
+        displayName: getDisplayName(policy.name),
+        version,
+        source: 'global',
+        policyIndex,
+        pathIndex: null,
+      });
+    });
+
+    // Legacy policies with path === '/*'
+    policies.forEach((policy, policyIndex) => {
+      const version = policy.version
+        ? `v${policy.version.split('.')[0]}`
+        : 'v0';
+      const displayName = getDisplayName(policy.name);
+      if (!policy.paths || policy.paths.length === 0) {
+        items.push({
+          id: `legacy-${policy.name}-${version}-${policyIndex}-default`,
+          name: policy.name,
+          displayName,
+          version,
+          source: 'legacy',
+          policyIndex,
+          pathIndex: null,
+        });
+      } else {
+        policy.paths.forEach((pathConfig, pathIndex) => {
+          if (pathConfig.path === '/*') {
+            items.push({
+              id: `legacy-${policy.name}-${version}-${policyIndex}-${pathIndex}`,
               name: policy.name,
               displayName,
               version,
+              source: 'legacy',
               policyIndex,
-              pathIndex: null as number | null,
-            },
-          ];
-        }
+              pathIndex,
+            });
+          }
+        });
+      }
+    });
 
-        return policy.paths.flatMap((pathConfig, pathIndex) =>
-          pathConfig.path === '/*'
-            ? [
-                {
-                  id: `${policy.name}-${version}-${policyIndex}-${pathIndex}`,
-                  name: policy.name,
-                  displayName,
-                  version,
-                  policyIndex,
-                  pathIndex,
-                },
-              ]
-            : []
-        );
-      }),
-    [policies, displayNameMap]
-  );
+    return items;
+  }, [proxy?.globalPolicies, policies, displayNameMap]);
 
   const resources = useMemo(
     () => parseOpenApiText(proxy?.openapi || ''),
@@ -294,17 +320,38 @@ export default function LLMProxyGuardrailsTab() {
   const handleEditGuardrailPill = (
     policyIndex: number,
     pathIndex: number | null,
-    scope: DrawerContext
+    scope: DrawerContext,
+    source: 'global' | 'operation' | 'legacy'
   ) => {
-    const policy = policies[policyIndex];
-    if (!policy) return;
+    let policyName: string;
+    let existingParams: ParameterValues = {};
 
-    const existingParams =
-      pathIndex !== null ? policy.paths?.[pathIndex]?.params ?? {} : {};
+    if (source === 'global') {
+      const policy = (proxy?.globalPolicies ?? [])[policyIndex];
+      if (!policy) return;
+      policyName = policy.name;
+      existingParams = (policy.params as ParameterValues) ?? {};
+    } else if (source === 'operation') {
+      const policy = (proxy?.operationPolicies ?? [])[policyIndex];
+      if (!policy) return;
+      policyName = policy.name;
+      existingParams =
+        pathIndex !== null
+          ? ((policy.paths[pathIndex]?.params as ParameterValues) ?? {})
+          : {};
+    } else {
+      const policy = policies[policyIndex];
+      if (!policy) return;
+      policyName = policy.name;
+      existingParams =
+        pathIndex !== null
+          ? ((policy.paths?.[pathIndex]?.params as ParameterValues) ?? {})
+          : {};
+    }
 
-    setEditingTarget({ policyIndex, pathIndex });
+    setEditingTarget({ policyIndex, pathIndex, source });
     setDrawerContext(scope);
-    setSelectedGuardrail(policy.name);
+    setSelectedGuardrail(policyName);
     setGuardrailSettings(existingParams);
     setIsDetailView(true);
     setPolicyDefinition(null);
@@ -312,7 +359,7 @@ export default function LLMProxyGuardrailsTab() {
     setDrawerOpen(true);
 
     const guardrailMeta = availableGuardrails.find(
-      (g) => g.name === policy.name
+      (g) => g.name === policyName
     );
     if (!guardrailMeta?.version) {
       setDefinitionError('No version available for this guardrail.');
@@ -391,63 +438,105 @@ export default function LLMProxyGuardrailsTab() {
   const handlePolicySubmit = async (params: ParameterValues) => {
     if (!proxy || !selectedGuardrailPolicy) return;
 
-    const updatedPolicies = (() => {
-      // Edit mode: update existing policy path params
-      if (editingTarget) {
-        const { policyIndex, pathIndex } = editingTarget;
-        const updated = [...policies];
-        const existing = updated[policyIndex];
-        if (!existing) return policies;
-
-        if (pathIndex !== null) {
-          const existingPaths = [...(existing.paths ?? [])];
-          existingPaths[pathIndex] = {
-            ...existingPaths[pathIndex],
-            params,
-          };
-          updated[policyIndex] = { ...existing, paths: existingPaths };
-        }
-        return updated;
+    if (editingTarget) {
+      const { policyIndex, pathIndex, source } = editingTarget;
+      if (source === 'global') {
+        setLocalProxy((prev) => {
+          if (!prev) return prev;
+          const globalPolicies = [...(prev.globalPolicies ?? [])];
+          globalPolicies[policyIndex] = { ...globalPolicies[policyIndex], params };
+          return { ...prev, globalPolicies };
+        });
+      } else if (source === 'operation') {
+        setLocalProxy((prev) => {
+          if (!prev) return prev;
+          const operationPolicies = [...(prev.operationPolicies ?? [])];
+          const existing = operationPolicies[policyIndex];
+          const paths = [...existing.paths];
+          if (pathIndex !== null) {
+            paths[pathIndex] = { ...paths[pathIndex], params };
+          }
+          operationPolicies[policyIndex] = { ...existing, paths };
+          return { ...prev, operationPolicies };
+        });
+      } else {
+        // legacy
+        setLocalProxy((prev) => {
+          if (!prev) return prev;
+          const updated = [...(prev.policies ?? [])];
+          const existing = updated[policyIndex];
+          if (!existing) return prev;
+          if (pathIndex !== null) {
+            const existingPaths = [...(existing.paths ?? [])];
+            existingPaths[pathIndex] = { ...existingPaths[pathIndex], params };
+            updated[policyIndex] = { ...existing, paths: existingPaths };
+          }
+          return { ...prev, policies: updated };
+        });
       }
-
-      // Add mode: add new policy path
-      const nextPath = buildPolicyPath(params);
-      const existingIndex = policies.findIndex(
-        (p) =>
-          p.name === selectedGuardrailPolicy.name &&
-          p.version === selectedGuardrailVersion
-      );
-
-      if (existingIndex === -1) {
-        return [
-          ...policies,
-          {
+    } else if (drawerContext.scope === 'global') {
+      // Add mode — global scope → globalPolicies
+      setLocalProxy((prev) => {
+        if (!prev) return prev;
+        const globalPolicies = [...(prev.globalPolicies ?? [])];
+        const existingIndex = globalPolicies.findIndex(
+          (p) =>
+            p.name === selectedGuardrailPolicy.name &&
+            p.version === selectedGuardrailVersion
+        );
+        if (existingIndex === -1) {
+          globalPolicies.push({
             name: selectedGuardrailPolicy.name,
             version: selectedGuardrailVersion,
-            paths: [nextPath],
-          },
-        ];
-      }
-
-      const existing = policies[existingIndex];
-      const existingPaths = existing.paths ?? [];
-
-      const updated = [...policies];
-      updated[existingIndex] = {
-        ...existing,
-        paths: [...existingPaths, nextPath],
-      };
-      return updated;
-    })();
-
-    setLocalProxy((prev) =>
-      prev
-        ? {
-            ...prev,
-            policies: updatedPolicies,
+            params,
+          });
+        } else {
+          globalPolicies[existingIndex] = {
+            ...globalPolicies[existingIndex],
+            params,
+          };
+        }
+        return { ...prev, globalPolicies };
+      });
+    } else {
+      // Add mode — resource scope → operationPolicies
+      const resourcePath = drawerContext.path;
+      const resourceMethod = drawerContext.method;
+      const newPathEntry = { path: resourcePath, methods: [resourceMethod], params };
+      setLocalProxy((prev) => {
+        if (!prev) return prev;
+        const operationPolicies = [...(prev.operationPolicies ?? [])];
+        const existingPolicyIndex = operationPolicies.findIndex(
+          (p) =>
+            p.name === selectedGuardrailPolicy.name &&
+            p.version === selectedGuardrailVersion
+        );
+        if (existingPolicyIndex === -1) {
+          operationPolicies.push({
+            name: selectedGuardrailPolicy.name,
+            version: selectedGuardrailVersion,
+            paths: [newPathEntry],
+          });
+        } else {
+          const existing = operationPolicies[existingPolicyIndex];
+          const alreadyHasPath = existing.paths.some(
+            (p) =>
+              p.path === resourcePath &&
+              p.methods
+                .map((m) => m.toUpperCase())
+                .includes(resourceMethod.toUpperCase())
+          );
+          if (!alreadyHasPath) {
+            operationPolicies[existingPolicyIndex] = {
+              ...existing,
+              paths: [...existing.paths, newPathEntry],
+            };
           }
-        : prev
-    );
+        }
+        return { ...prev, operationPolicies };
+      });
+    }
+
     setGuardrailSettings(params);
     setDrawerOpen(false);
     setIsDetailView(false);
@@ -455,33 +544,52 @@ export default function LLMProxyGuardrailsTab() {
 
   const handleRemoveAppliedGuardrail = (
     policyIndex: number,
-    pathIndex: number | null
+    pathIndex: number | null,
+    source: 'global' | 'operation' | 'legacy'
   ) => {
-    setLocalProxy((prev) => {
-      if (!prev) return prev;
-      const existingPolicies = prev.policies ?? [];
-
-      const updatedPolicies = existingPolicies.flatMap((policy, index) => {
-        if (index !== policyIndex) return [policy];
-
-        if (pathIndex === null) {
-          return [];
-        }
-
-        const existingPaths = policy.paths ?? [];
-        const nextPaths = existingPaths.filter((_, idx) => idx !== pathIndex);
-        if (nextPaths.length === 0) {
-          return [];
-        }
-
-        return [{ ...policy, paths: nextPaths }];
+    if (source === 'global') {
+      setLocalProxy((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          globalPolicies: (prev.globalPolicies ?? []).filter(
+            (_, idx) => idx !== policyIndex
+          ),
+        };
       });
-
-      return {
-        ...prev,
-        policies: updatedPolicies,
-      };
-    });
+    } else if (source === 'operation') {
+      setLocalProxy((prev) => {
+        if (!prev) return prev;
+        const operationPolicies = [...(prev.operationPolicies ?? [])];
+        const existing = operationPolicies[policyIndex];
+        if (pathIndex !== null) {
+          const paths = existing.paths.filter((_, idx) => idx !== pathIndex);
+          if (paths.length === 0) {
+            operationPolicies.splice(policyIndex, 1);
+          } else {
+            operationPolicies[policyIndex] = { ...existing, paths };
+          }
+        } else {
+          operationPolicies.splice(policyIndex, 1);
+        }
+        return { ...prev, operationPolicies };
+      });
+    } else {
+      // legacy
+      setLocalProxy((prev) => {
+        if (!prev) return prev;
+        const existingPolicies = prev.policies ?? [];
+        const updatedPolicies = existingPolicies.flatMap((policy, index) => {
+          if (index !== policyIndex) return [policy];
+          if (pathIndex === null) return [];
+          const existingPaths = policy.paths ?? [];
+          const nextPaths = existingPaths.filter((_, idx) => idx !== pathIndex);
+          if (nextPaths.length === 0) return [];
+          return [{ ...policy, paths: nextPaths }];
+        });
+        return { ...prev, policies: updatedPolicies };
+      });
+    }
   };
 
   // ── Render ──────────────────────────────────────────────────────────────
@@ -537,10 +645,10 @@ export default function LLMProxyGuardrailsTab() {
                 onClick={() =>
                   handleEditGuardrailPill(g.policyIndex, g.pathIndex, {
                     scope: 'global',
-                  })
+                  }, g.source)
                 }
                 onRemove={() =>
-                  void handleRemoveAppliedGuardrail(g.policyIndex, g.pathIndex)
+                  void handleRemoveAppliedGuardrail(g.policyIndex, g.pathIndex, g.source)
                 }
               />
             ))}
@@ -637,6 +745,9 @@ export default function LLMProxyGuardrailsTab() {
               <Stack spacing={1.25}>
                 {(() => {
                   const hasResourcePolicy = (resource: ResourceItem) =>
+                    (proxy?.operationPolicies ?? []).some((policy) =>
+                      policy.paths.some((pc) => matchesResource(pc, resource))
+                    ) ||
                     policies.some((policy) =>
                       (policy.paths ?? []).some(
                         (pc) =>
@@ -692,9 +803,31 @@ export default function LLMProxyGuardrailsTab() {
                         name: string;
                         displayName: string;
                         version: string;
+                        source: 'operation' | 'legacy';
                         policyIndex: number;
                         pathIndex: number;
                       }> = [];
+                      // New operationPolicies
+                      (proxy?.operationPolicies ?? []).forEach(
+                        (policy, policyIndex) => {
+                          policy.paths.forEach((pc, pathIndex) => {
+                            if (!matchesResource(pc, resource)) return;
+                            const version = policy.version
+                              ? `v${policy.version.replace(/^v/, '').split('.')[0]}`
+                              : 'v0';
+                            items.push({
+                              id: `op-${policy.name}-${version}-${policyIndex}-${pathIndex}`,
+                              name: policy.name,
+                              displayName: getDisplayName(policy.name),
+                              version,
+                              source: 'operation',
+                              policyIndex,
+                              pathIndex,
+                            });
+                          });
+                        }
+                      );
+                      // Legacy policies
                       policies.forEach((policy, policyIndex) => {
                         (policy.paths ?? []).forEach((pc, pathIndex) => {
                           if (pc.path === '/*') return;
@@ -702,12 +835,12 @@ export default function LLMProxyGuardrailsTab() {
                           const version = policy.version
                             ? `v${policy.version.split('.')[0]}`
                             : 'v0';
-                          const displayName = getDisplayName(policy.name);
                           items.push({
-                            id: `${policy.name}-${version}-${policyIndex}-${pathIndex}`,
+                            id: `legacy-${policy.name}-${version}-${policyIndex}-${pathIndex}`,
                             name: policy.name,
-                            displayName,
+                            displayName: getDisplayName(policy.name),
                             version,
+                            source: 'legacy',
                             policyIndex,
                             pathIndex,
                           });
@@ -818,13 +951,15 @@ export default function LLMProxyGuardrailsTab() {
                                                 scope: 'resource',
                                                 method,
                                                 path: resource.path,
-                                              }
+                                              },
+                                              g.source
                                             )
                                           }
                                           onRemove={() =>
                                             void handleRemoveAppliedGuardrail(
                                               g.policyIndex,
-                                              g.pathIndex
+                                              g.pathIndex,
+                                              g.source
                                             )
                                           }
                                         />

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderGuardrailsTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderGuardrailsTab.tsx
@@ -187,6 +187,7 @@ export default function ServiceProviderGuardrailsTab() {
   const [editingTarget, setEditingTarget] = useState<{
     policyIndex: number;
     pathIndex: number | null;
+    source: 'global' | 'operation' | 'legacy';
   } | null>(null);
   const [selectedCategories, setSelectedCategories] = useState<string[]>(['AI']);
   const [drawerGuardrails, setDrawerGuardrails] = useState<typeof availableGuardrails>([]);
@@ -241,43 +242,68 @@ export default function ServiceProviderGuardrailsTab() {
   const getDisplayName = (policyName: string): string =>
     displayNameMap[policyName] || policyName;
 
-  const globalGuardrails = useMemo(
-    () =>
-      policies.flatMap((policy, policyIndex) => {
-        const version = policy.version
-          ? `v${policy.version.replace(/^v/, '').split('.')[0]}`
-          : 'v0';
-        const displayName = getDisplayName(policy.name);
-        if (!policy.paths || policy.paths.length === 0) {
-          return [
-            {
-              id: `${policy.name}-${version}-${policyIndex}-default`,
+  const globalGuardrails = useMemo(() => {
+    const items: Array<{
+      id: string;
+      name: string;
+      displayName: string;
+      version: string;
+      source: 'global' | 'legacy';
+      policyIndex: number;
+      pathIndex: number | null;
+    }> = [];
+
+    // New globalPolicies list
+    (provider?.globalPolicies ?? []).forEach((policy, policyIndex) => {
+      const version = policy.version
+        ? `v${policy.version.replace(/^v/, '').split('.')[0]}`
+        : 'v0';
+      items.push({
+        id: `global-${policy.name}-${version}-${policyIndex}`,
+        name: policy.name,
+        displayName: getDisplayName(policy.name),
+        version,
+        source: 'global',
+        policyIndex,
+        pathIndex: null,
+      });
+    });
+
+    // Legacy policies with path === '/*'
+    policies.forEach((policy, policyIndex) => {
+      const version = policy.version
+        ? `v${policy.version.replace(/^v/, '').split('.')[0]}`
+        : 'v0';
+      const displayName = getDisplayName(policy.name);
+      if (!policy.paths || policy.paths.length === 0) {
+        items.push({
+          id: `legacy-${policy.name}-${version}-${policyIndex}-default`,
+          name: policy.name,
+          displayName,
+          version,
+          source: 'legacy',
+          policyIndex,
+          pathIndex: null,
+        });
+      } else {
+        policy.paths.forEach((pathConfig, pathIndex) => {
+          if (pathConfig.path === '/*') {
+            items.push({
+              id: `legacy-${policy.name}-${version}-${policyIndex}-${pathIndex}`,
               name: policy.name,
               displayName,
               version,
+              source: 'legacy',
               policyIndex,
-              pathIndex: null as number | null,
-            },
-          ];
-        }
+              pathIndex,
+            });
+          }
+        });
+      }
+    });
 
-        return policy.paths.flatMap((pathConfig, pathIndex) =>
-          pathConfig.path === '/*'
-            ? [
-                {
-                  id: `${policy.name}-${version}-${policyIndex}-${pathIndex}`,
-                  name: policy.name,
-                  displayName,
-                  version,
-                  policyIndex,
-                  pathIndex,
-                },
-              ]
-            : []
-        );
-      }),
-    [policies, displayNameMap]
-  );
+    return items;
+  }, [provider?.globalPolicies, policies, displayNameMap]);
 
   const resources = useMemo(
     () => parseOpenApiText(provider?.openapi || '', provider?.accessControl),
@@ -306,17 +332,38 @@ export default function ServiceProviderGuardrailsTab() {
   const handleEditGuardrailPill = (
     policyIndex: number,
     pathIndex: number | null,
-    scope: DrawerContext
+    scope: DrawerContext,
+    source: 'global' | 'operation' | 'legacy'
   ) => {
-    const policy = policies[policyIndex];
-    if (!policy) return;
+    let policyName: string;
+    let existingParams: ParameterValues = {};
 
-    const existingParams =
-      pathIndex !== null ? policy.paths?.[pathIndex]?.params ?? {} : {};
+    if (source === 'global') {
+      const policy = (provider?.globalPolicies ?? [])[policyIndex];
+      if (!policy) return;
+      policyName = policy.name;
+      existingParams = (policy.params as ParameterValues) ?? {};
+    } else if (source === 'operation') {
+      const policy = (provider?.operationPolicies ?? [])[policyIndex];
+      if (!policy) return;
+      policyName = policy.name;
+      existingParams =
+        pathIndex !== null
+          ? ((policy.paths[pathIndex]?.params as ParameterValues) ?? {})
+          : {};
+    } else {
+      const policy = policies[policyIndex];
+      if (!policy) return;
+      policyName = policy.name;
+      existingParams =
+        pathIndex !== null
+          ? ((policy.paths?.[pathIndex]?.params as ParameterValues) ?? {})
+          : {};
+    }
 
-    setEditingTarget({ policyIndex, pathIndex });
+    setEditingTarget({ policyIndex, pathIndex, source });
     setDrawerContext(scope);
-    setSelectedGuardrail(policy.name);
+    setSelectedGuardrail(policyName);
     setGuardrailSettings(existingParams);
     setIsDetailView(true);
     setPolicyDefinition(null);
@@ -324,7 +371,7 @@ export default function ServiceProviderGuardrailsTab() {
     setDrawerOpen(true);
 
     const guardrailMeta = availableGuardrails.find(
-      (g) => g.name === policy.name
+      (g) => g.name === policyName
     );
     if (!guardrailMeta?.version) {
       setDefinitionError('No version available for this guardrail.');
@@ -413,62 +460,93 @@ export default function ServiceProviderGuardrailsTab() {
       ...updatePayload
     } = provider;
 
-    const updatedPolicies = (() => {
-      // Edit mode: update existing policy path params
-      if (editingTarget) {
-        const { policyIndex, pathIndex } = editingTarget;
-        const updated = [...policies];
-        const existing = updated[policyIndex];
-        if (!existing) return policies;
-
-        if (pathIndex !== null) {
-          const existingPaths = [...(existing.paths ?? [])];
-          existingPaths[pathIndex] = {
-            ...existingPaths[pathIndex],
-            params,
-          };
-          updated[policyIndex] = { ...existing, paths: existingPaths };
-        }
-        return updated;
-      }
-
-      // Add mode: add new policy path
-      const nextPath = buildPolicyPath(params);
-      const existingIndex = policies.findIndex(
-        (policy) =>
-          policy.name === selectedGuardrailPolicy.name &&
-          policy.version === selectedGuardrailVersion
-      );
-
-      if (existingIndex === -1) {
-        return [
-          ...policies,
-          {
-            name: selectedGuardrailPolicy.name,
-            version: selectedGuardrailVersion,
-            paths: [nextPath],
-          },
-        ];
-      }
-
-      const existing = policies[existingIndex];
-      const existingPaths = existing.paths ?? [];
-
-      const updated = [...policies];
-      updated[existingIndex] = {
-        ...existing,
-        paths: [...existingPaths, nextPath],
-      };
-      return updated;
-    })();
-
     const isEditing = !!editingTarget;
 
     try {
-      await updateProvider({
-        ...updatePayload,
-        policies: updatedPolicies,
-      });
+      if (editingTarget) {
+        const { policyIndex, pathIndex, source } = editingTarget;
+        if (source === 'global') {
+          const globalPolicies = [...(provider.globalPolicies ?? [])];
+          globalPolicies[policyIndex] = { ...globalPolicies[policyIndex], params };
+          await updateProvider({ ...updatePayload, globalPolicies });
+        } else if (source === 'operation') {
+          const operationPolicies = [...(provider.operationPolicies ?? [])];
+          const existing = operationPolicies[policyIndex];
+          const paths = [...existing.paths];
+          if (pathIndex !== null) {
+            paths[pathIndex] = { ...paths[pathIndex], params };
+          }
+          operationPolicies[policyIndex] = { ...existing, paths };
+          await updateProvider({ ...updatePayload, operationPolicies });
+        } else {
+          // legacy
+          const updated = [...policies];
+          const existing = updated[policyIndex];
+          if (!existing) return;
+          if (pathIndex !== null) {
+            const existingPaths = [...(existing.paths ?? [])];
+            existingPaths[pathIndex] = { ...existingPaths[pathIndex], params };
+            updated[policyIndex] = { ...existing, paths: existingPaths };
+          }
+          await updateProvider({ ...updatePayload, policies: updated });
+        }
+      } else if (drawerContext.scope === 'global') {
+        // Add mode — global scope → globalPolicies
+        const globalPolicies = [...(provider.globalPolicies ?? [])];
+        const existingIndex = globalPolicies.findIndex(
+          (p) =>
+            p.name === selectedGuardrailPolicy.name &&
+            p.version === selectedGuardrailVersion
+        );
+        if (existingIndex === -1) {
+          globalPolicies.push({
+            name: selectedGuardrailPolicy.name,
+            version: selectedGuardrailVersion,
+            params,
+          });
+        } else {
+          globalPolicies[existingIndex] = {
+            ...globalPolicies[existingIndex],
+            params,
+          };
+        }
+        await updateProvider({ ...updatePayload, globalPolicies });
+      } else {
+        // Add mode — resource scope → operationPolicies
+        const operationPolicies = [...(provider.operationPolicies ?? [])];
+        const resourcePath = drawerContext.path;
+        const resourceMethod = drawerContext.method;
+        const newPathEntry = { path: resourcePath, methods: [resourceMethod], params };
+        const existingPolicyIndex = operationPolicies.findIndex(
+          (p) =>
+            p.name === selectedGuardrailPolicy.name &&
+            p.version === selectedGuardrailVersion
+        );
+        if (existingPolicyIndex === -1) {
+          operationPolicies.push({
+            name: selectedGuardrailPolicy.name,
+            version: selectedGuardrailVersion,
+            paths: [newPathEntry],
+          });
+        } else {
+          const existing = operationPolicies[existingPolicyIndex];
+          const alreadyHasPath = existing.paths.some(
+            (p) =>
+              p.path === resourcePath &&
+              p.methods
+                .map((m) => m.toUpperCase())
+                .includes(resourceMethod.toUpperCase())
+          );
+          if (!alreadyHasPath) {
+            operationPolicies[existingPolicyIndex] = {
+              ...existing,
+              paths: [...existing.paths, newPathEntry],
+            };
+          }
+        }
+        await updateProvider({ ...updatePayload, operationPolicies });
+      }
+
       setGuardrailSettings(params);
       if (!isDraftMode) {
         showSnackbar(
@@ -495,7 +573,8 @@ export default function ServiceProviderGuardrailsTab() {
 
   const handleRemoveAppliedGuardrail = async (
     policyIndex: number,
-    pathIndex: number | null
+    pathIndex: number | null,
+    source: 'global' | 'operation' | 'legacy'
   ) => {
     if (!provider || isLoading || error) return;
 
@@ -508,27 +587,39 @@ export default function ServiceProviderGuardrailsTab() {
       ...updatePayload
     } = provider;
 
-    const updatedPolicies = policies.flatMap((policy, index) => {
-      if (index !== policyIndex) return [policy];
-
-      if (pathIndex === null) {
-        return [];
-      }
-
-      const existingPaths = policy.paths ?? [];
-      const nextPaths = existingPaths.filter((_, idx) => idx !== pathIndex);
-      if (nextPaths.length === 0) {
-        return [];
-      }
-
-      return [{ ...policy, paths: nextPaths }];
-    });
-
     try {
-      await updateProvider({
-        ...updatePayload,
-        policies: updatedPolicies,
-      });
+      if (source === 'global') {
+        const globalPolicies = (provider.globalPolicies ?? []).filter(
+          (_, idx) => idx !== policyIndex
+        );
+        await updateProvider({ ...updatePayload, globalPolicies });
+      } else if (source === 'operation') {
+        const operationPolicies = [...(provider.operationPolicies ?? [])];
+        const existing = operationPolicies[policyIndex];
+        if (pathIndex !== null) {
+          const paths = existing.paths.filter((_, idx) => idx !== pathIndex);
+          if (paths.length === 0) {
+            operationPolicies.splice(policyIndex, 1);
+          } else {
+            operationPolicies[policyIndex] = { ...existing, paths };
+          }
+        } else {
+          operationPolicies.splice(policyIndex, 1);
+        }
+        await updateProvider({ ...updatePayload, operationPolicies });
+      } else {
+        // legacy
+        const updatedPolicies = policies.flatMap((policy, index) => {
+          if (index !== policyIndex) return [policy];
+          if (pathIndex === null) return [];
+          const existingPaths = policy.paths ?? [];
+          const nextPaths = existingPaths.filter((_, idx) => idx !== pathIndex);
+          if (nextPaths.length === 0) return [];
+          return [{ ...policy, paths: nextPaths }];
+        });
+        await updateProvider({ ...updatePayload, policies: updatedPolicies });
+      }
+
       if (!isDraftMode) {
         showSnackbar('Guardrail removed successfully.', 'success');
       }
@@ -598,10 +689,10 @@ export default function ServiceProviderGuardrailsTab() {
                 onClick={() =>
                   handleEditGuardrailPill(g.policyIndex, g.pathIndex, {
                     scope: 'global',
-                  })
+                  }, g.source)
                 }
                 onRemove={() =>
-                  void handleRemoveAppliedGuardrail(g.policyIndex, g.pathIndex)
+                  void handleRemoveAppliedGuardrail(g.policyIndex, g.pathIndex, g.source)
                 }
               />
             ))}
@@ -686,6 +777,9 @@ export default function ServiceProviderGuardrailsTab() {
             <Stack spacing={1.25}>
               {(() => {
                 const hasResourcePolicy = (resource: ResourceItem) =>
+                  (provider?.operationPolicies ?? []).some((policy) =>
+                    policy.paths.some((pc) => matchesResource(pc, resource))
+                  ) ||
                   policies.some((policy) =>
                     (policy.paths ?? []).some(
                       (pc) => pc.path !== '/*' && matchesResource(pc, resource)
@@ -739,9 +833,31 @@ export default function ServiceProviderGuardrailsTab() {
                       name: string;
                       displayName: string;
                       version: string;
+                      source: 'operation' | 'legacy';
                       policyIndex: number;
                       pathIndex: number;
                     }> = [];
+                    // New operationPolicies
+                    (provider?.operationPolicies ?? []).forEach(
+                      (policy, policyIndex) => {
+                        policy.paths.forEach((pathConfig, pathIndex) => {
+                          if (!matchesResource(pathConfig, resource)) return;
+                          const version = policy.version
+                            ? `v${policy.version.replace(/^v/, '').split('.')[0]}`
+                            : 'v0';
+                          items.push({
+                            id: `op-${policy.name}-${version}-${policyIndex}-${pathIndex}`,
+                            name: policy.name,
+                            displayName: getDisplayName(policy.name),
+                            version,
+                            source: 'operation',
+                            policyIndex,
+                            pathIndex,
+                          });
+                        });
+                      }
+                    );
+                    // Legacy policies
                     policies.forEach((policy, policyIndex) => {
                       (policy.paths ?? []).forEach((pathConfig, pathIndex) => {
                         if (pathConfig.path === '/*') return;
@@ -749,12 +865,12 @@ export default function ServiceProviderGuardrailsTab() {
                         const version = policy.version
                           ? `v${policy.version.replace(/^v/, '').split('.')[0]}`
                           : 'v0';
-                        const displayName = getDisplayName(policy.name);
                         items.push({
-                          id: `${policy.name}-${version}-${policyIndex}-${pathIndex}`,
+                          id: `legacy-${policy.name}-${version}-${policyIndex}-${pathIndex}`,
                           name: policy.name,
-                          displayName,
+                          displayName: getDisplayName(policy.name),
                           version,
+                          source: 'legacy',
                           policyIndex,
                           pathIndex,
                         });
@@ -856,13 +972,15 @@ export default function ServiceProviderGuardrailsTab() {
                                               scope: 'resource',
                                               method,
                                               path: resource.path,
-                                            }
+                                            },
+                                            guardrail.source
                                           )
                                         }
                                         onRemove={() =>
                                           void handleRemoveAppliedGuardrail(
                                             guardrail.policyIndex,
-                                            guardrail.pathIndex
+                                            guardrail.pathIndex,
+                                            guardrail.source
                                           )
                                         }
                                       />

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderNew.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderNew.tsx
@@ -331,27 +331,15 @@ export default function ServiceProviderNew() {
         template: selectedTemplateId,
         openapi: openapiSpec,
         upstream,
-        policies: [
+        globalPolicies: [
           ...(selectedTemplateId !== 'azure-openai' &&
           selectedTemplateId !== 'azureai-foundry'
-            ? [
-                {
-                  name: 'llm-cost',
-                  version: 'v1',
-                  paths: [{ path: '/*', methods: ['*'], params: {} }],
-                },
-              ]
+            ? [{ name: 'llm-cost', version: 'v1', params: {} }]
             : []),
           ...guardrails.map((guardrail) => ({
             name: guardrail.name,
             version: guardrail.version,
-            paths: [
-              {
-                path: '/*',
-                methods: ['*'],
-                params: guardrail.settings ?? {},
-              },
-            ],
+            params: guardrail.settings ?? {},
           })),
         ],
         accessControl: {

--- a/portals/ai-workspace/src/utils/types.ts
+++ b/portals/ai-workspace/src/utils/types.ts
@@ -315,6 +315,26 @@ export interface Policy {
 }
 
 /**
+ * Global (api-level) policy — no path binding
+ */
+export interface GlobalPolicy {
+  name: string;
+  version: string;
+  executionCondition?: string;
+  params?: Record<string, unknown>;
+}
+
+/**
+ * Operation policy — path-bound
+ */
+export interface OperationPolicy {
+  name: string;
+  version: string;
+  executionCondition?: string;
+  paths: PolicyPath[];
+}
+
+/**
  * API Key security configuration
  */
 export interface ApiKeySecurity {
@@ -374,6 +394,8 @@ export interface LLMProvider {
   upstream?: Upstream;
   accessControl?: AccessControl;
   rateLimiting?: RateLimiting;
+  globalPolicies?: GlobalPolicy[];
+  operationPolicies?: OperationPolicy[];
   policies?: Policy[];
   security?: SecurityConfig;
   status?: 'Active' | 'Degraded' | 'Paused' | string;
@@ -397,6 +419,8 @@ export interface CreateLLMProviderRequest {
   modelProviders?: ModelProvider[];
   upstream: Upstream;
   accessControl: AccessControl;
+  globalPolicies?: GlobalPolicy[];
+  operationPolicies?: OperationPolicy[];
   policies?: Policy[];
   openapi?: string;
 }
@@ -550,6 +574,8 @@ export interface Proxy {
   vhost?: string;
   provider?: string | ProxyProviderConfig;
   openapi?: string;
+  globalPolicies?: GlobalPolicy[];
+  operationPolicies?: OperationPolicy[];
   policies?: Policy[];
   security?: ProxySecurityConfig;
   createdAt?: string;
@@ -591,6 +617,8 @@ export interface CreateProxyRequest {
   vhost?: string;
   provider: ProxyProviderConfig;
   openapi: string;
+  globalPolicies?: GlobalPolicy[];
+  operationPolicies?: OperationPolicy[];
   policies: Policy[];
   security: ProxySecurityConfig;
 }

--- a/portals/management-portal/src/hooks/GithubAPICreation.ts
+++ b/portals/management-portal/src/hooks/GithubAPICreation.ts
@@ -114,7 +114,7 @@ export const useGithubAPICreation = () => {
       provider: GitProvider = "github",
       opts?: { signal?: AbortSignal }
     ): Promise<GitBranch[]> => {
-      const res = await authedFetch(`/api/v1/git/repo/fetch-branches`, {
+      const res = await authedFetch(`/api/v0.9/git/repo/fetch-branches`, {
         method: "POST",
         body: JSON.stringify({ repoUrl, provider }),
         signal: opts?.signal,
@@ -136,7 +136,7 @@ export const useGithubAPICreation = () => {
       branch: string,
       opts?: { signal?: AbortSignal }
     ): Promise<GitFetchContentResponse> => {
-      const res = await authedFetch(`/api/v1/git/repo/branch/fetch-content`, {
+      const res = await authedFetch(`/api/v0.9/git/repo/branch/fetch-content`, {
         method: "POST",
         body: JSON.stringify({ repoUrl, provider, branch }),
         signal: opts?.signal,
@@ -152,13 +152,13 @@ export const useGithubAPICreation = () => {
     []
   );
 
-  /** POST: /api/v1/api-projects/import */
+  /** POST: /api/v0.9/api-projects/import */
   const importApiProject = useCallback(
     async (
       payload: ImportApiProjectRequest,
       opts?: { signal?: AbortSignal }
     ): Promise<ApiSummary> => {
-      const res = await authedFetch(`/api/v1/api-projects/import`, {
+      const res = await authedFetch(`/api/v0.9/api-projects/import`, {
         method: "POST",
         body: JSON.stringify(payload),
         signal: opts?.signal,

--- a/portals/management-portal/src/hooks/apiPublish.ts
+++ b/portals/management-portal/src/hooks/apiPublish.ts
@@ -78,7 +78,7 @@ const normalizePublication = (item: any): ApiPublicationWithPortal => ({
 export const useApiPublishApi = () => {
   const fetchPublications = useCallback(async (apiId: string): Promise<ApiPublicationWithPortal[]> => {
     const { token, baseUrl } = getApiConfig();
-    const response = await fetch(`${baseUrl}/api/v1/apis/${apiId}/publications`, {
+    const response = await fetch(`${baseUrl}/api/v0.9/apis/${apiId}/publications`, {
       method: "GET",
       headers: { Authorization: `Bearer ${token}` },
     });
@@ -95,7 +95,7 @@ export const useApiPublishApi = () => {
   const publishApiToDevPortal = useCallback(async (apiId: string, payload: ApiPublishPayload): Promise<PublishResponse> => {
     const { token, baseUrl } = getApiConfig();
 
-    const response = await fetch(`${baseUrl}/api/v1/rest-apis/${apiId}/publications`, {
+    const response = await fetch(`${baseUrl}/api/v0.9/rest-apis/${apiId}/publications`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${token}`,
@@ -116,7 +116,7 @@ export const useApiPublishApi = () => {
   const unpublishApiFromDevPortal = useCallback(async (apiId: string, devPortalId: string): Promise<UnpublishResponse> => {
     const { token, baseUrl } = getApiConfig();
 
-    const response = await fetch(`${baseUrl}/api/v1/rest-apis/${apiId}/publications/${devPortalId}`, {
+    const response = await fetch(`${baseUrl}/api/v0.9/rest-apis/${apiId}/publications/${devPortalId}`, {
       method: "DELETE",
       headers: {
         Authorization: `Bearer ${token}`,

--- a/portals/management-portal/src/hooks/apis.ts
+++ b/portals/management-portal/src/hooks/apis.ts
@@ -177,7 +177,7 @@ export const useApisApi = () => {
         body.contract = contract;
       }
 
-      const response = await fetch(`${baseUrl}/api/v1/apis`, {
+      const response = await fetch(`${baseUrl}/api/v0.9/apis`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -200,9 +200,9 @@ export const useApisApi = () => {
   );
 
   /**
-   * Fetch from /api/v1/apis with optional projectId filter:
-   * - /api/v1/apis                 => all APIs in org
-   * - /api/v1/apis?projectId=....  => APIs for a specific project
+   * Fetch from /api/v0.9/apis with optional projectId filter:
+   * - /api/v0.9/apis                 => all APIs in org
+   * - /api/v0.9/apis?projectId=....  => APIs for a specific project
    */
   const fetchProjectApis = useCallback(
     async (projectId: string): Promise<ApiSummary[]> => {
@@ -210,8 +210,8 @@ export const useApisApi = () => {
 
       const url =
         projectId && projectId.length > 0
-          ? `${baseUrl}/api/v1/apis?projectId=${encodeURIComponent(projectId)}`
-          : `${baseUrl}/api/v1/apis`;
+          ? `${baseUrl}/api/v0.9/apis?projectId=${encodeURIComponent(projectId)}`
+          : `${baseUrl}/api/v0.9/apis`;
 
       const response = await fetch(url, {
         method: "GET",
@@ -251,7 +251,7 @@ export const useApisApi = () => {
   const fetchApi = useCallback(async (apiId: string): Promise<ApiSummary> => {
     const { token, baseUrl } = getApiConfig();
 
-    const response = await fetch(`${baseUrl}/api/v1/apis/${apiId}`, {
+    const response = await fetch(`${baseUrl}/api/v0.9/apis/${apiId}`, {
       method: "GET",
       headers: {
         Authorization: `Bearer ${token}`,
@@ -272,7 +272,7 @@ export const useApisApi = () => {
   const deleteApi = useCallback(async (apiId: string): Promise<void> => {
     const { token, baseUrl } = getApiConfig();
 
-    const response = await fetch(`${baseUrl}/api/v1/apis/${apiId}`, {
+    const response = await fetch(`${baseUrl}/api/v0.9/apis/${apiId}`, {
       method: "DELETE",
       headers: {
         Authorization: `Bearer ${token}`,
@@ -293,7 +293,7 @@ export const useApisApi = () => {
       const { token, baseUrl } = getApiConfig();
 
       const response = await fetch(
-        `${baseUrl}/api/v1/apis/${encodeURIComponent(apiId)}/gateways`,
+        `${baseUrl}/api/v0.9/apis/${encodeURIComponent(apiId)}/gateways`,
         {
           method: "GET",
           headers: { Authorization: `Bearer ${token}` },
@@ -339,7 +339,7 @@ export const useApisApi = () => {
         formData.append("definition", payload.definition);
       }
 
-      const res = await fetch(`${baseUrl}/api/v1/import/open-api`, {
+      const res = await fetch(`${baseUrl}/api/v0.9/import/open-api`, {
         method: "POST",
         headers: {
           Authorization: `Bearer ${token}`,
@@ -380,7 +380,7 @@ export const useApisApi = () => {
       const payload = gatewayIds.map((gatewayId) => ({ gatewayId }));
 
       const response = await fetch(
-        `${baseUrl}/api/v1/apis/${encodeURIComponent(apiId)}/gateways`,
+        `${baseUrl}/api/v0.9/apis/${encodeURIComponent(apiId)}/gateways`,
         {
           method: "POST",
           headers: {

--- a/portals/management-portal/src/hooks/deployments.ts
+++ b/portals/management-portal/src/hooks/deployments.ts
@@ -58,7 +58,7 @@ export const useDeploymentsApi = () => {
       targets: DeployTargetRequest[]
     ): Promise<DeployRevisionResponse> => {
       const { token, baseUrl } = getApiConfig();
-      const url = `${baseUrl}/api/v1/apis/${encodeURIComponent(
+      const url = `${baseUrl}/api/v0.9/apis/${encodeURIComponent(
         apiId
       )}/deploy-revision?revisionId=${encodeURIComponent(String(revisionId))}`;
 
@@ -91,7 +91,7 @@ export const useDeploymentsApi = () => {
   const fetchApiDeployments = useCallback(
     async (apiId: string): Promise<ApiDeploymentRecord[]> => {
       const { token, baseUrl } = getApiConfig();
-      const url = `${baseUrl}/api/v1/apis/${encodeURIComponent(apiId)}/deployments`;
+      const url = `${baseUrl}/api/v0.9/apis/${encodeURIComponent(apiId)}/deployments`;
 
       const res = await fetch(url, {
         method: "GET",

--- a/portals/management-portal/src/hooks/devportals.ts
+++ b/portals/management-portal/src/hooks/devportals.ts
@@ -54,7 +54,7 @@ export const useDevPortalsApi = () => {
   const fetchDevPortals = useCallback(async (): Promise<Portal[]> => {
     const { token, baseUrl } = getApiConfig();
 
-    const response = await fetch(`${baseUrl}/api/v1/devportals`, {
+    const response = await fetch(`${baseUrl}/api/v0.9/devportals`, {
       method: "GET",
       headers: {
         Authorization: `Bearer ${token}`,
@@ -77,7 +77,7 @@ export const useDevPortalsApi = () => {
     async (uuid: string): Promise<Portal> => {
       const { token, baseUrl } = getApiConfig();
 
-      const response = await fetch(`${baseUrl}/api/v1/devportals/${uuid}`, {
+      const response = await fetch(`${baseUrl}/api/v0.9/devportals/${uuid}`, {
         method: "GET",
         headers: {
           Authorization: `Bearer ${token}`,
@@ -101,7 +101,7 @@ export const useDevPortalsApi = () => {
     async (payload: CreatePortalPayload): Promise<Portal> => {
       const { token, baseUrl } = getApiConfig();
 
-      const response = await fetch(`${baseUrl}/api/v1/devportals`, {
+      const response = await fetch(`${baseUrl}/api/v0.9/devportals`, {
         method: "POST",
         headers: {
           Authorization: `Bearer ${token}`,
@@ -130,7 +130,7 @@ export const useDevPortalsApi = () => {
     ): Promise<DevPortalAPIModel> => {
       const { token, baseUrl } = getApiConfig();
 
-      const response = await fetch(`${baseUrl}/api/v1/devportals/${uuid}`, {
+      const response = await fetch(`${baseUrl}/api/v0.9/devportals/${uuid}`, {
         method: "PUT",
         headers: {
           Authorization: `Bearer ${token}`,
@@ -156,7 +156,7 @@ export const useDevPortalsApi = () => {
     async (uuid: string): Promise<void> => {
       const { token, baseUrl } = getApiConfig();
 
-      const response = await fetch(`${baseUrl}/api/v1/devportals/${uuid}`, {
+      const response = await fetch(`${baseUrl}/api/v0.9/devportals/${uuid}`, {
         method: "DELETE",
         headers: {
           Authorization: `Bearer ${token}`,
@@ -178,7 +178,7 @@ export const useDevPortalsApi = () => {
   const activateDevPortal = useCallback(async (uuid: string): Promise<void> => {
     const { token, baseUrl } = getApiConfig();
 
-    const response = await fetch(`${baseUrl}/api/v1/devportals/${uuid}/activate`, {
+    const response = await fetch(`${baseUrl}/api/v0.9/devportals/${uuid}/activate`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${token}`,

--- a/portals/management-portal/src/hooks/gateways.ts
+++ b/portals/management-portal/src/hooks/gateways.ts
@@ -77,7 +77,7 @@ export const useGatewaysApi = () => {
   const createGateway = useCallback(
     async (payload: CreateGatewayPayload): Promise<Gateway> => {
       const { token, baseUrl } = getApiConfig();
-      const response = await fetch(`${baseUrl}/api/v1/gateways`, {
+      const response = await fetch(`${baseUrl}/api/v0.9/gateways`, {
         method: "POST",
         headers: {
           Authorization: `Bearer ${token}`,
@@ -109,7 +109,7 @@ export const useGatewaysApi = () => {
   const fetchGateways = useCallback(async (): Promise<Gateway[]> => {
     const { token, baseUrl } = getApiConfig();
 
-    const response = await fetch(`${baseUrl}/api/v1/gateways`, {
+    const response = await fetch(`${baseUrl}/api/v0.9/gateways`, {
       method: "GET",
       headers: {
         Authorization: `Bearer ${token}`,
@@ -131,7 +131,7 @@ export const useGatewaysApi = () => {
     async (gatewayId: string): Promise<Gateway> => {
       const { token, baseUrl } = getApiConfig();
 
-      const response = await fetch(`${baseUrl}/api/v1/gateways/${gatewayId}`, {
+      const response = await fetch(`${baseUrl}/api/v0.9/gateways/${gatewayId}`, {
         method: "GET",
         headers: {
           Authorization: `Bearer ${token}`,
@@ -155,7 +155,7 @@ export const useGatewaysApi = () => {
     async (gatewayId: string): Promise<void> => {
       const { token, baseUrl } = getApiConfig();
 
-      const response = await fetch(`${baseUrl}/api/v1/gateways/${gatewayId}`, {
+      const response = await fetch(`${baseUrl}/api/v0.9/gateways/${gatewayId}`, {
         method: "DELETE",
         headers: {
           Authorization: `Bearer ${token}`,
@@ -178,7 +178,7 @@ export const useGatewaysApi = () => {
       const { token, baseUrl } = getApiConfig();
 
       const response = await fetch(
-        `${baseUrl}/api/v1/gateways/${payload.gatewayId}`,
+        `${baseUrl}/api/v0.9/gateways/${payload.gatewayId}`,
         {
           method: "DELETE",
           headers: {
@@ -204,7 +204,7 @@ export const useGatewaysApi = () => {
       const { token, baseUrl } = getApiConfig();
 
       const response = await fetch(
-        `${baseUrl}/api/v1/gateways/${gatewayId}/tokens`,
+        `${baseUrl}/api/v0.9/gateways/${gatewayId}/tokens`,
         {
           method: "POST",
           headers: {
@@ -230,7 +230,7 @@ export const useGatewaysApi = () => {
   const fetchGatewayStatuses = useCallback(
     async (gatewayId?: string): Promise<GatewayStatus[]> => {
       const { token, baseUrl } = getApiConfig();
-      const url = new URL(`${baseUrl}/api/v1/gateways`);
+      const url = new URL(`${baseUrl}/api/v0.9/gateways`);
       if (gatewayId) url.searchParams.set("gatewayId", gatewayId);
 
       const response = await fetch(url.toString(), {

--- a/portals/management-portal/src/hooks/orgs.tsx
+++ b/portals/management-portal/src/hooks/orgs.tsx
@@ -41,7 +41,7 @@ export const useCreateOrganization = () => {
         ...overrides,
       };
 
-      const response = await fetch(`${baseUrl}/api/v1/organizations`, {
+      const response = await fetch(`${baseUrl}/api/v0.9/organizations`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -113,7 +113,7 @@ export const useOrganizationsApi = () => {
   const fetchOrganizations = useCallback(async (): Promise<OrganizationResponse[]> => {
     const { token, baseUrl } = getApiConfig();
 
-    const response = await fetch(`${baseUrl}/api/v1/organizations`, {
+    const response = await fetch(`${baseUrl}/api/v0.9/organizations`, {
       method: "GET",
       headers: {
         Authorization: `Bearer ${token}`,

--- a/portals/management-portal/src/hooks/projects.ts
+++ b/portals/management-portal/src/hooks/projects.ts
@@ -26,7 +26,7 @@ export const useProjectsApi = () => {
     ): Promise<Project> => {
       const { token, baseUrl } = getApiConfig();
 
-      const response = await fetch(`${baseUrl}/api/v1/projects`, {
+      const response = await fetch(`${baseUrl}/api/v0.9/projects`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -51,7 +51,7 @@ export const useProjectsApi = () => {
   const fetchProject = useCallback(async (projectId: string): Promise<Project> => {
     const { token, baseUrl } = getApiConfig();
 
-    const response = await fetch(`${baseUrl}/api/v1/projects/${projectId}`, {
+    const response = await fetch(`${baseUrl}/api/v0.9/projects/${projectId}`, {
       method: "GET",
       headers: {
         Authorization: `Bearer ${token}`,
@@ -73,7 +73,7 @@ export const useProjectsApi = () => {
     async (): Promise<Project[]> => {
       const { token, baseUrl } = getApiConfig();
 
-      const response = await fetch(`${baseUrl}/api/v1/projects`, {
+      const response = await fetch(`${baseUrl}/api/v0.9/projects`, {
         method: "GET",
         headers: {
           Authorization: `Bearer ${token}`,
@@ -106,7 +106,7 @@ export const useProjectsApi = () => {
   const deleteProject = useCallback(async (projectId: string): Promise<void> => {
     const { token, baseUrl } = getApiConfig();
 
-    const response = await fetch(`${baseUrl}/api/v1/projects/${projectId}`, {
+    const response = await fetch(`${baseUrl}/api/v0.9/projects/${projectId}`, {
       method: "DELETE",
       headers: {
         Authorization: `Bearer ${token}`,

--- a/portals/management-portal/src/hooks/validation.ts
+++ b/portals/management-portal/src/hooks/validation.ts
@@ -98,13 +98,13 @@ const authedFetch = async (path: string, init?: RequestInit) => {
 /** ----- Hook ----- */
 
 export const useGithubProjectValidation = () => {
-  /** POST: /api/v1/api-projects/validate */
+  /** POST: /api/v0.9/api-projects/validate */
   const validateGithubApiProject = useCallback(
     async (
       payload: GithubProjectValidationRequest,
       opts?: { signal?: AbortSignal }
     ): Promise<GithubProjectValidationResponse> => {
-      const res = await authedFetch(`/api/v1/api-projects/validate`, {
+      const res = await authedFetch(`/api/v0.9/api-projects/validate`, {
         method: "POST",
         body: JSON.stringify(payload),
         signal: opts?.signal,
@@ -135,7 +135,7 @@ export const useOpenApiValidation = () => {
       const formData = new FormData();
       formData.append("url", url);
 
-      const res = await fetch(`${baseUrl}/api/v1/validate/open-api`, {
+      const res = await fetch(`${baseUrl}/api/v0.9/validate/open-api`, {
         method: "POST",
         headers: { Authorization: `Bearer ${token}` },
         body: formData,
@@ -163,7 +163,7 @@ export const useOpenApiValidation = () => {
       const formData = new FormData();
       formData.append("definition", file);
 
-      const res = await fetch(`${baseUrl}/api/v1/validate/open-api`, {
+      const res = await fetch(`${baseUrl}/api/v0.9/validate/open-api`, {
         method: "POST",
         headers: { Authorization: `Bearer ${token}` },
         body: formData,
@@ -186,7 +186,7 @@ export const useOpenApiValidation = () => {
 
 /** NEW: API uniqueness validation hook */
 export const useApiUniquenessValidation = () => {
-  /** GET: /api/v1/apis/validate?name=...&version=... */
+  /** GET: /api/v0.9/apis/validate?name=...&version=... */
   const validateApiNameVersion = useCallback(
     async (
       payload: ApiNameVersionValidationRequest,
@@ -197,7 +197,7 @@ export const useApiUniquenessValidation = () => {
         version: payload.version,
       }).toString();
 
-      const res = await authedFetch(`/api/v1/apis/validate?${qs}`, {
+      const res = await authedFetch(`/api/v0.9/apis/validate?${qs}`, {
         method: "GET",
         signal: opts?.signal,
       });
@@ -213,7 +213,7 @@ export const useApiUniquenessValidation = () => {
     []
   );
 
-  /** GET: /api/v1/apis/validate?identifier=... */
+  /** GET: /api/v0.9/apis/validate?identifier=... */
   const validateApiIdentifier = useCallback(
     async (
       identifier: string,
@@ -221,7 +221,7 @@ export const useApiUniquenessValidation = () => {
     ): Promise<ApiUniquenessValidationResponse> => {
       const qs = new URLSearchParams({ identifier }).toString();
 
-      const res = await authedFetch(`/api/v1/apis/validate?${qs}`, {
+      const res = await authedFetch(`/api/v0.9/apis/validate?${qs}`, {
         method: "GET",
         signal: opts?.signal,
       });


### PR DESCRIPTION
### Purpose

- Platform API and AI Workspace changes related to https://github.com/wso2/api-platform/issues/2109

#### Platform API Changes

Introduces `globalPolicies` and `operationPolicies` as first-class fields on LLM provider and proxy deployment artifacts, replacing the flat `policies` list for new gateways.

**Schema change.** Artifacts now carry two distinct policy lists:

- `globalPolicies` — applied uniformly across every operation (provider-wide quota, auth, CORS). For `advanced-ratelimit`, the platform-api automatically injects `keyExtraction: [{type: "apiname"}]` so the counter is shared across all operations rather than siloed per route.
- `operationPolicies` — scoped to specific paths and HTTP methods, preserving per-operation behaviour.

**deploymenttransform package (new)**. A version-aware artifact adaptation layer that sits between the generator and the wire format. Generators always produce the canonical latest shape; `deploymenttransform` downgrades the artifact for gateways below v1.2.0 (flattens both new lists into the legacy `policies` field and stamps the correct `apiVersion`). Adding a new version boundary in future is a one-file registration, not a service-layer change.

**Version centralisation.** constants.APIBasePath is now the single source of truth for the platform-api route prefix (`/api/v0.9`). All 24 handler files build their `r.Group(...)` call from this constant. A sync test locks the cross-language coupling between the OpenAPI `servers:` URL and the handler prefix so scope enforcement cannot silently mismatch on a future version bump.

**Bug fix.** Gateway version was not being resolved from the database when generating a deployment YAML, causing the version check to always fall back to the old path regardless of the actual target gateway version.

#### AI Workspace Changes

* Guardrails tabs for LLM proxies (`LLMProxyGuardrailsTab`) and service providers (`ServiceProviderGuardrailsTab`) updated to handle the globalPolicies list and operationPolicies list instead of previous single array.