### PR TITLE
[UI] Add global policies support for LLM providers and proxies

### DIFF
--- a/.github/workflows/operator-integration-test.yml
+++ b/.github/workflows/operator-integration-test.yml
@@ -1115,7 +1115,7 @@ jobs:
           API_READY=""
           for i in $(seq 1 60); do
             API_STATUS=$(curl -s -o /tmp/subscription-precheck-body.txt -w "%{http_code}" -u admin:admin \
-              "http://localhost:9090/api/management/v0.9/rest-apis/hello-sub-api" || true)
+              "http://localhost:9090/api/management/v1alpha2/rest-apis/hello-sub-api" || true)
             if [ "${API_STATUS}" = "200" ]; then
               API_READY="yes"
               echo "hello-sub-api is resolvable via management API"

--- a/.github/workflows/operator-integration-test.yml
+++ b/.github/workflows/operator-integration-test.yml
@@ -1115,7 +1115,7 @@ jobs:
           API_READY=""
           for i in $(seq 1 60); do
             API_STATUS=$(curl -s -o /tmp/subscription-precheck-body.txt -w "%{http_code}" -u admin:admin \
-              "http://localhost:9090/api/management/v1alpha2/rest-apis/hello-sub-api" || true)
+              "http://localhost:9090/api/management/v0.9/rest-apis/hello-sub-api" || true)
             if [ "${API_STATUS}" = "200" ]; then
               API_READY="yes"
               echo "hello-sub-api is resolvable via management API"

--- a/cli/it/resources/gateway/sample-api.yaml
+++ b/cli/it/resources/gateway/sample-api.yaml
@@ -17,7 +17,7 @@
 # --------------------------------------------------------------------
 
 # Sample API definition for CLI integration tests
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: RestApi
 metadata:
   name: petstore-api-v1.0

--- a/cli/it/resources/gateway/sample-mcp-config.yaml
+++ b/cli/it/resources/gateway/sample-mcp-config.yaml
@@ -17,7 +17,7 @@
 # --------------------------------------------------------------------
 
 # Sample MCP configuration for CLI integration tests
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: Mcp
 metadata:
   name: test-mcp-v1.0

--- a/cli/src/cmd/gateway/restapi/apikey/create.go
+++ b/cli/src/cmd/gateway/restapi/apikey/create.go
@@ -47,7 +47,7 @@ ap gateway rest-api api-key create --file api-key.yaml
 ap gateway rest-api api-key create -f api-key.json
 
 # The file is an ApiKey custom resource, e.g.:
-#   apiVersion: gateway.api-platform.wso2.com/v1alpha1
+#   apiVersion: gateway.api-platform.wso2.com/v1alpha2
 #   kind: ApiKey
 #   metadata:
 #     name: petstore-key-acme

--- a/cli/src/cmd/gateway/subscription/create.go
+++ b/cli/src/cmd/gateway/subscription/create.go
@@ -41,7 +41,7 @@ ap gateway subscription create --file subscription.yaml
 ap gateway subscription create -f subscription.json
 
 # The file is a Subscription custom resource, e.g.:
-#   apiVersion: gateway.api-platform.wso2.com/v1alpha1
+#   apiVersion: gateway.api-platform.wso2.com/v1alpha2
 #   kind: Subscription
 #   metadata:
 #     name: petstore-acme-bronze

--- a/cli/src/cmd/gateway/subscriptionplan/create.go
+++ b/cli/src/cmd/gateway/subscriptionplan/create.go
@@ -41,7 +41,7 @@ ap gateway subscription-plan create --file subscription-plan.yaml
 ap gateway subscription-plan create -f subscription-plan.json
 
 # The file is a SubscriptionPlan custom resource, e.g.:
-#   apiVersion: gateway.api-platform.wso2.com/v1alpha1
+#   apiVersion: gateway.api-platform.wso2.com/v1alpha2
 #   kind: SubscriptionPlan
 #   metadata:
 #     name: bronze-1k-per-min

--- a/cli/src/internal/gateway/cr_test.go
+++ b/cli/src/internal/gateway/cr_test.go
@@ -34,7 +34,7 @@ func writeTempCR(t *testing.T, name, content string) string {
 }
 
 func TestParseResourceCR_ValidYAML(t *testing.T) {
-	path := writeTempCR(t, "plan.yaml", `apiVersion: gateway.api-platform.wso2.com/v1alpha1
+	path := writeTempCR(t, "plan.yaml", `apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: SubscriptionPlan
 metadata:
   name: bronze-1k-per-min

--- a/cli/src/internal/mcp/generator.go
+++ b/cli/src/internal/mcp/generator.go
@@ -421,7 +421,7 @@ func generateMCPConfigFile(url string, toolsResult ToolsResult,
 	}
 
 	mcp := gwmodels.MCPProxyConfiguration{
-		ApiVersion: gwmodels.MCPProxyConfigurationApiVersionGatewayApiPlatformWso2Comv1alpha1,
+		ApiVersion: gwmodels.MCPProxyConfigurationApiVersionGatewayApiPlatformWso2Comv1alpha2,
 		Kind:       gwmodels.MCPProxyConfigurationKindMcp,
 		Metadata: gwmodels.Metadata{
 			Name: "Generated-MCP-v1.0",

--- a/docs/ai-gateway/analytics/analytics-header-filter.md
+++ b/docs/ai-gateway/analytics/analytics-header-filter.md
@@ -55,11 +55,11 @@ Each filter parameter (`requestHeadersToFilter` and `responseHeadersToFilter`) i
 The following example demonstrates how to apply the Analytics Header Filter policy to a LlmProvider:
 
 ```bash
-curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
+curl -X POST http://localhost:9090/api/management/v1alpha2/llm-providers \
   -H "Content-Type: application/yaml" \
   -H "Authorization: Basic <base64-credentials>" \
   --data-binary @- <<'EOF'
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProvider
 metadata:
   name: openai-provider

--- a/docs/ai-gateway/llm/guardrails/aws-bedrock-guardrail.md
+++ b/docs/ai-gateway/llm/guardrails/aws-bedrock-guardrail.md
@@ -111,11 +111,11 @@ When `redactPII` is `true`:
 Deploy an LLM provider with AWS Bedrock Guardrail validation:
 
 ```bash
-curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
+curl -X POST http://localhost:9090/api/management/v1alpha2/llm-providers \
   -H "Content-Type: application/yaml" \
   -H "Authorization: Basic YWRtaW46YWRtaW4=" \
   --data-binary @- <<'EOF'
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProvider
 metadata:
   name: bedrock-guardrail-provider

--- a/docs/ai-gateway/llm/guardrails/azure-content-safety.md
+++ b/docs/ai-gateway/llm/guardrails/azure-content-safety.md
@@ -102,11 +102,11 @@ If `jsonPath` is empty or not specified, the entire payload is treated as a stri
 Deploy an LLM provider with Azure Content Safety validation:
 
 ```bash
-curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
+curl -X POST http://localhost:9090/api/management/v1alpha2/llm-providers \
   -H "Content-Type: application/yaml" \
   -H "Authorization: Basic YWRtaW46YWRtaW4=" \
   --data-binary @- <<'EOF'
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProvider
 metadata:
   name: azure-safety-provider

--- a/docs/ai-gateway/llm/guardrails/content-length.md
+++ b/docs/ai-gateway/llm/guardrails/content-length.md
@@ -54,11 +54,11 @@ If `jsonPath` is empty or not specified, the entire payload is treated as a stri
 Deploy an LLM provider that limits request payloads to between 100 bytes and 1MB:
 
 ```bash
-curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
+curl -X POST http://localhost:9090/api/management/v1alpha2/llm-providers \
   -H "Content-Type: application/yaml" \
   -H "Authorization: Basic YWRtaW46YWRtaW4=" \
   --data-binary @- <<'EOF'
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProvider
 metadata:
   name: content-length-provider

--- a/docs/ai-gateway/llm/guardrails/json-schema.md
+++ b/docs/ai-gateway/llm/guardrails/json-schema.md
@@ -63,11 +63,11 @@ The guardrail supports JSON Schema Draft 7, including:
 Deploy an LLM provider that validates that request contains a user object with required fields:
 
 ```bash
-curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
+curl -X POST http://localhost:9090/api/management/v1alpha2/llm-providers \
   -H "Content-Type: application/yaml" \
   -H "Authorization: Basic YWRtaW46YWRtaW4=" \
   --data-binary @- <<'EOF'
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProvider
 metadata:
   name: json-schema-provider

--- a/docs/ai-gateway/llm/guardrails/pii-masking-regex.md
+++ b/docs/ai-gateway/llm/guardrails/pii-masking-regex.md
@@ -64,11 +64,11 @@ If `jsonPath` is empty or not specified, the entire payload is processed as a st
 Deploy an LLM provider that masks email addresses and phone numbers in requests and restores them in responses:
 
 ```bash
-curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
+curl -X POST http://localhost:9090/api/management/v1alpha2/llm-providers \
   -H "Content-Type: application/yaml" \
   -H "Authorization: Basic YWRtaW46YWRtaW4=" \
   --data-binary @- <<'EOF'
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProvider
 metadata:
   name: pii-masking-provider

--- a/docs/ai-gateway/llm/guardrails/regex.md
+++ b/docs/ai-gateway/llm/guardrails/regex.md
@@ -63,11 +63,11 @@ The guardrail uses Go's standard regexp package, which supports RE2 syntax. Key 
 Deploy an LLM provider that protects against sensitive data leaks by blocking any payloads that mention the word "password" (case-insensitive) in either the user’s message or the LLM’s response. This is achieved by using the regex policy to validate both request and response payloads:
 
 ```bash
-curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
+curl -X POST http://localhost:9090/api/management/v1alpha2/llm-providers \
   -H "Content-Type: application/yaml" \
   -H "Authorization: Basic YWRtaW46YWRtaW4=" \
   --data-binary @- <<'EOF'
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProvider
 metadata:
   name: regex-provider

--- a/docs/ai-gateway/llm/guardrails/semantic-prompt-guard.md
+++ b/docs/ai-gateway/llm/guardrails/semantic-prompt-guard.md
@@ -113,11 +113,11 @@ The guardrail supports JSONPath expressions to extract specific text from reques
 Deploy an LLM provider that blocks prompts similar to prohibited phrases:
 
 ```bash
-curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
+curl -X POST http://localhost:9090/api/management/v1alpha2/llm-providers \
   -H "Content-Type: application/yaml" \
   -H "Authorization: Basic YWRtaW46YWRtaW4=" \
   --data-binary @- <<'EOF'
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProvider
 metadata:
   name: semantic-guard-provider
@@ -193,11 +193,11 @@ curl -X POST http://openai:8080/chat/completions \
 Deploy an LLM provider that only allows prompts similar to approved phrases:
 
 ```bash
-curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
+curl -X POST http://localhost:9090/api/management/v1alpha2/llm-providers \
   -H "Content-Type: application/yaml" \
   -H "Authorization: Basic YWRtaW46YWRtaW4=" \
   --data-binary @- <<'EOF'
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProvider
 metadata:
   name: whitelist-provider

--- a/docs/ai-gateway/llm/guardrails/sentence-count.md
+++ b/docs/ai-gateway/llm/guardrails/sentence-count.md
@@ -63,11 +63,11 @@ The guardrail counts sequences of characters ending with these punctuation marks
 Deploy an LLM provider that ensures requests contain between 1 and 10 sentences:
 
 ```bash
-curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
+curl -X POST http://localhost:9090/api/management/v1alpha2/llm-providers \
   -H "Content-Type: application/yaml" \
   -H "Authorization: Basic YWRtaW46YWRtaW4=" \
   --data-binary @- <<'EOF'
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProvider
 metadata:
   name: sentence-count-provider

--- a/docs/ai-gateway/llm/guardrails/url.md
+++ b/docs/ai-gateway/llm/guardrails/url.md
@@ -71,11 +71,11 @@ If `jsonPath` is empty or not specified, the entire payload is treated as a stri
 Deploy an LLM provider that validates URLs in request content using HTTP HEAD requests:
 
 ```bash
-curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
+curl -X POST http://localhost:9090/api/management/v1alpha2/llm-providers \
   -H "Content-Type: application/yaml" \
   -H "Authorization: Basic YWRtaW46YWRtaW4=" \
   --data-binary @- <<'EOF'
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProvider
 metadata:
   name: url-guardrail-provider

--- a/docs/ai-gateway/llm/guardrails/word-count.md
+++ b/docs/ai-gateway/llm/guardrails/word-count.md
@@ -54,11 +54,11 @@ If `jsonPath` is empty or not specified, the entire payload is treated as a stri
 Deploy an LLM provider that validates request messages contain between 10 and 500 words:
 
 ```bash
-curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
+curl -X POST http://localhost:9090/api/management/v1alpha2/llm-providers \
   -H "Content-Type: application/yaml" \
   -H "Authorization: Basic YWRtaW46YWRtaW4=" \
   --data-binary @- <<'EOF'
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProvider
 metadata:
   name: word-count-provider

--- a/docs/ai-gateway/llm/llm-templates.md
+++ b/docs/ai-gateway/llm/llm-templates.md
@@ -29,7 +29,7 @@ These templates are automatically loaded when the gateway starts and are immedia
 Each LLM provider template follows a standard YAML structure:
 
 ```yaml
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProviderTemplate
 metadata:
   name: <template-id>
@@ -71,7 +71,7 @@ Templates support three types of extraction locations:
 The OpenAI template extracts metadata from OpenAI API responses.
 
 ```yaml
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProviderTemplate
 metadata:
   name: openai
@@ -102,7 +102,7 @@ spec:
 The Azure OpenAI template is compatible with Microsoft's Azure OpenAI Service API.
 
 ```yaml
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProviderTemplate
 metadata:
   name: azure-openai
@@ -133,7 +133,7 @@ spec:
 The Anthropic template extracts metadata from Anthropic Claude API responses.
 
 ```yaml
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProviderTemplate
 metadata:
   name: anthropic
@@ -161,7 +161,7 @@ spec:
 The Gemini template is designed for Google's Gemini API.
 
 ```yaml
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProviderTemplate
 metadata:
   name: gemini
@@ -192,7 +192,7 @@ spec:
 The MistralAI template supports Mistral AI's API.
 
 ```yaml
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProviderTemplate
 metadata:
   name: mistralai
@@ -223,7 +223,7 @@ spec:
 The AWS Bedrock template is designed for Amazon Bedrock's unified API.
 
 ```yaml
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProviderTemplate
 metadata:
   name: awsbedrock
@@ -251,7 +251,7 @@ spec:
 The Azure AI Foundry template supports Microsoft's Azure AI Foundry platform.
 
 ```yaml
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProviderTemplate
 metadata:
   name: azureai-foundry
@@ -282,11 +282,11 @@ spec:
 To create an LLM provider using any of the out-of-the-box templates:
 
 ```bash
-curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
+curl -X POST http://localhost:9090/api/management/v1alpha2/llm-providers \
   -H "Content-Type: application/yaml" \
   -H "Authorization: Basic YWRtaW46YWRtaW4=" \
   --data-binary @- <<'EOF'
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProvider
 metadata:
   name: <unique-id>
@@ -332,7 +332,7 @@ The gateway automatically uses the template's metadata extraction patterns to:
 To list all available LLM provider templates:
 
 ```bash
-curl -X GET http://localhost:9090/api/management/v0.9/llm-provider-templates \
+curl -X GET http://localhost:9090/api/management/v1alpha2/llm-provider-templates \
   -H "Authorization: Basic YWRtaW46YWRtaW4="
 ```
 
@@ -341,7 +341,7 @@ curl -X GET http://localhost:9090/api/management/v0.9/llm-provider-templates \
 To retrieve details of a specific template:
 
 ```bash
-curl -X GET http://localhost:9090/api/management/v0.9/llm-provider-templates/openai \
+curl -X GET http://localhost:9090/api/management/v1alpha2/llm-provider-templates/openai \
   -H "Authorization: Basic YWRtaW46YWRtaW4="
 ```
 
@@ -350,11 +350,11 @@ curl -X GET http://localhost:9090/api/management/v0.9/llm-provider-templates/ope
 Platform administrators can create custom templates for LLM providers not covered by the out-of-the-box templates:
 
 ```bash
-curl -X POST http://localhost:9090/api/management/v0.9/llm-provider-templates \
+curl -X POST http://localhost:9090/api/management/v1alpha2/llm-provider-templates \
   -H "Content-Type: application/yaml" \
   -H "Authorization: Basic YWRtaW46YWRtaW4=" \
   --data-binary @- <<'EOF'
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProviderTemplate
 metadata:
   name: custom-provider
@@ -371,11 +371,11 @@ EOF
 To update an existing custom template:
 
 ```bash
-curl -X PUT http://localhost:9090/api/management/v0.9/llm-provider-templates/custom-provider \
+curl -X PUT http://localhost:9090/api/management/v1alpha2/llm-provider-templates/custom-provider \
   -H "Content-Type: application/yaml" \
   -H "Authorization: Basic YWRtaW46YWRtaW4=" \
   --data-binary @- <<'EOF'
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProviderTemplate
 metadata:
   name: custom-provider
@@ -393,7 +393,7 @@ EOF
 To delete a custom template:
 
 ```bash
-curl -X DELETE http://localhost:9090/api/management/v0.9/llm-provider-templates/custom-provider \
+curl -X DELETE http://localhost:9090/api/management/v1alpha2/llm-provider-templates/custom-provider \
   -H "Authorization: Basic YWRtaW46YWRtaW4="
 ```
 
@@ -403,7 +403,7 @@ curl -X DELETE http://localhost:9090/api/management/v0.9/llm-provider-templates/
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `apiVersion` | string | Yes | API version, must be `gateway.api-platform.wso2.com/v1alpha1` |
+| `apiVersion` | string | Yes | API version, must be `gateway.api-platform.wso2.com/v1alpha2` |
 | `kind` | string | Yes | Resource kind, must be `LlmProviderTemplate` |
 | `metadata.name` | string | Yes | Unique identifier for the template (used as template ID) |
 | `spec.displayName` | string | Yes | Human-readable name for the template |

--- a/docs/ai-gateway/llm/load-balancing/model-round-robin.md
+++ b/docs/ai-gateway/llm/load-balancing/model-round-robin.md
@@ -53,11 +53,11 @@ The policy requires `requestModel` configuration from the LLM provider template 
 Deploy an LLM provider with round-robin load balancing across multiple models:
 
 ```bash
-curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
+curl -X POST http://localhost:9090/api/management/v1alpha2/llm-providers \
   -H "Content-Type: application/yaml" \
   -H "Authorization: Basic YWRtaW46YWRtaW4=" \
   --data-binary @- <<'EOF'
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProvider
 metadata:
   name: round-robin-provider

--- a/docs/ai-gateway/llm/load-balancing/model-weighted-round-robin.md
+++ b/docs/ai-gateway/llm/load-balancing/model-weighted-round-robin.md
@@ -68,11 +68,11 @@ The weighted sequence would be: `[A, A, A, B, B, C]`, meaning:
 Deploy an LLM provider with weighted round-robin load balancing:
 
 ```bash
-curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
+curl -X POST http://localhost:9090/api/management/v1alpha2/llm-providers \
   -H "Content-Type: application/yaml" \
   -H "Authorization: Basic YWRtaW46YWRtaW4=" \
   --data-binary @- <<'EOF'
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProvider
 metadata:
   name: weighted-round-robin-provider

--- a/docs/ai-gateway/llm/prompt-management/prompt-decorator.md
+++ b/docs/ai-gateway/llm/prompt-management/prompt-decorator.md
@@ -82,11 +82,11 @@ The decorator supports JSONPath expressions to target specific fields. Common ex
 Add a summarization instruction to user prompts:
 
 ```bash
-curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
+curl -X POST http://localhost:9090/api/management/v1alpha2/llm-providers \
   -H "Content-Type: application/yaml" \
   -H "Authorization: Basic YWRtaW46YWRtaW4=" \
   --data-binary @- <<'EOF'
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProvider
 metadata:
   name: summarization-provider
@@ -155,11 +155,11 @@ curl -X POST http://openai:8080/chat/completions \
 Add a system message to define AI behavior:
 
 ```bash
-curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
+curl -X POST http://localhost:9090/api/management/v1alpha2/llm-providers \
   -H "Content-Type: application/yaml" \
   -H "Authorization: Basic YWRtaW46YWRtaW4=" \
   --data-binary @- <<'EOF'
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProvider
 metadata:
   name: hotel-booking-provider

--- a/docs/ai-gateway/llm/prompt-management/prompt-template.md
+++ b/docs/ai-gateway/llm/prompt-management/prompt-template.md
@@ -79,11 +79,11 @@ Translate the following text from english to spanish: Hello
 Deploy an LLM provider with a translation prompt template:
 
 ```bash
-curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
+curl -X POST http://localhost:9090/api/management/v1alpha2/llm-providers \
   -H "Content-Type: application/yaml" \
   -H "Authorization: Basic YWRtaW46YWRtaW4=" \
   --data-binary @- <<'EOF'
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProvider
 metadata:
   name: translation-provider
@@ -152,11 +152,11 @@ The policy will transform the request to:
 Create a template for summarizing content with configurable length:
 
 ```bash
-curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
+curl -X POST http://localhost:9090/api/management/v1alpha2/llm-providers \
   -H "Content-Type: application/yaml" \
   -H "Authorization: Basic YWRtaW46YWRtaW4=" \
   --data-binary @- <<'EOF'
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProvider
 metadata:
   name: summarization-provider

--- a/docs/ai-gateway/llm/quick-start-guide.md
+++ b/docs/ai-gateway/llm/quick-start-guide.md
@@ -41,11 +41,11 @@ curl http://localhost:9094/health
 The API Platform Gateway currently includes first-class support for the OpenAI LLM provider. As a platform administrator, replace `<openai-apikey>` with your openai API key and run the following command to deploy a sample OpenAI LLM provider.
 
 ```bash
-curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
+curl -X POST http://localhost:9090/api/management/v1alpha2/llm-providers \
   -H "Content-Type: application/yaml" \
   -H "Authorization: Basic YWRtaW46YWRtaW4=" \
   --data-binary @- <<'EOF'
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProvider
 metadata:
   name: openai-provider
@@ -93,11 +93,11 @@ curl -X POST https://localhost:8443/openai/latest/chat/completions \
 The API Platform Gateway provides first-class support for configuring and deploying LLM proxies. As an AI developer, run the following command to deploy a sample LLM proxy that consumes the OpenAI LLM provider previously deployed by the platform administrator.
 
 ```bash
-curl -X POST http://localhost:9090/api/management/v0.9/llm-proxies \
+curl -X POST http://localhost:9090/api/management/v1alpha2/llm-proxies \
   -H "Content-Type: application/yaml" \
   -H "Authorization: Basic YWRtaW46YWRtaW4=" \
   --data-binary @- <<'EOF'
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProxy
 metadata:
   name: openai-assistant

--- a/docs/ai-gateway/llm/semantic-caching.md
+++ b/docs/ai-gateway/llm/semantic-caching.md
@@ -116,11 +116,11 @@ The policy supports JSONPath expressions to extract specific text from request b
 Deploy an LLM provider with semantic caching using OpenAI embeddings and Redis vector store:
 
 ```bash
-curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
+curl -X POST http://localhost:9090/api/management/v1alpha2/llm-providers \
   -H "Content-Type: application/yaml" \
   -H "Authorization: Basic YWRtaW46YWRtaW4=" \
   --data-binary @- <<'EOF'
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProvider
 metadata:
   name: cached-chat-provider

--- a/docs/ai-gateway/mcp/policies/mcp-acl-list.md
+++ b/docs/ai-gateway/mcp/policies/mcp-acl-list.md
@@ -85,7 +85,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 Deny access to certain tools while allowing all others:
 
 ```yaml
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: Mcp
 metadata:
   name: mcp-server-api-v1.0
@@ -113,7 +113,7 @@ spec:
 Allow access to only whitelisted resources:
 
 ```yaml
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: Mcp
 metadata:
   name: mcp-server-api-v1.0
@@ -141,7 +141,7 @@ spec:
 Apply different access control rules to different capability types:
 
 ```yaml
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: Mcp
 metadata:
   name: mcp-server-api-v1.0

--- a/docs/ai-gateway/mcp/policies/mcp-authentication.md
+++ b/docs/ai-gateway/mcp/policies/mcp-authentication.md
@@ -136,7 +136,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 Apply MCP authentication to an API using a specific key manager:
 
 ```yaml
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: Mcp
 metadata:
     name: mcp-server-api-v1.0
@@ -162,7 +162,7 @@ spec:
 Disable authentication for specific tools while keeping it enabled for others:
 
 ```yaml
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: Mcp
 metadata:
     name: mcp-server-api-v1.0
@@ -199,7 +199,7 @@ spec:
 Advertise required scopes in the protected resource metadata (scopes are not enforced by this policy):
 
 ```yaml
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: Mcp
 metadata:
     name: mcp-server-api-v1.0
@@ -228,7 +228,7 @@ spec:
 Map JWT claims to downstream headers for use by backend services:
 
 ```yaml
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: Mcp
 metadata:
     name: mcp-server-api-v1.0
@@ -258,7 +258,7 @@ spec:
 Completely disable authentication for MCP resources while keeping it for tools:
 
 ```yaml
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: Mcp
 metadata:
     name: mcp-server-api-v1.0

--- a/docs/ai-gateway/mcp/policies/mcp-authorization.md
+++ b/docs/ai-gateway/mcp/policies/mcp-authorization.md
@@ -64,7 +64,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 Restrict access to specific tools based on scopes:
 
 ```yaml
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: Mcp
 metadata:
   name: mcp-server-api-v1.0
@@ -119,7 +119,7 @@ spec:
 Control resource access based on user claims:
 
 ```yaml
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: Mcp
 metadata:
   name: mcp-server-api-v1.0
@@ -171,7 +171,7 @@ spec:
 Restrict prompt access based on user roles:
 
 ```yaml
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: Mcp
 metadata:
   name: mcp-server-api-v1.0
@@ -209,7 +209,7 @@ spec:
 Apply authorization at the JSON-RPC method level:
 
 ```yaml
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: Mcp
 metadata:
   name: mcp-server-api-v1.0
@@ -250,7 +250,7 @@ spec:
 Combine different resource types with varying access requirements:
 
 ```yaml
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: Mcp
 metadata:
   name: mcp-server-api-v1.0

--- a/docs/ai-gateway/mcp/policies/mcp-rewrite.md
+++ b/docs/ai-gateway/mcp/policies/mcp-rewrite.md
@@ -84,7 +84,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 Expose tools with different names than the backend:
 
 ```yaml
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: Mcp
 metadata:
   name: mcp-server-api-v1.0
@@ -116,7 +116,7 @@ spec:
 Expose resources with user-friendly URIs mapped to backend resources:
 
 ```yaml
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: Mcp
 metadata:
   name: mcp-server-api-v1.0
@@ -148,7 +148,7 @@ spec:
 Rewrite prompts and tools with metadata:
 
 ```yaml
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: Mcp
 metadata:
   name: mcp-server-api-v1.0

--- a/docs/ai-gateway/mcp/quick-start-guide.md
+++ b/docs/ai-gateway/mcp/quick-start-guide.md
@@ -48,11 +48,11 @@ docker run -p 3001:3001 --name everything --network ai-gateway_gateway-network r
 Run the following command to deploy the MCP proxy.
 
 ```bash
-curl -X POST http://localhost:9090/api/management/v0.9/mcp-proxies \
+curl -X POST http://localhost:9090/api/management/v1alpha2/mcp-proxies \
   -H "Content-Type: application/yaml" \
   -H "Authorization: Basic YWRtaW46YWRtaW4=" \
   --data-binary @- <<'EOF'
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: Mcp
 metadata:
   name: everything-mcp-v1.0

--- a/docs/cli/apiproject/README.md
+++ b/docs/cli/apiproject/README.md
@@ -118,7 +118,7 @@ spec:
 A populated example:
 
 ```yaml
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: RestApi
 metadata:
   name: echo-api-v2.0

--- a/docs/cli/gateway/README.md
+++ b/docs/cli/gateway/README.md
@@ -158,7 +158,7 @@ ap gateway rest-api api-key create -f api-key.json --platform eu --gateway prod
 `ApiKey` CR shape (`api-key.yaml`):
 
 ```yaml
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: ApiKey
 metadata:
   name: petstore-key-acme
@@ -326,7 +326,7 @@ ap gateway subscription-plan create -f subscription-plan.json --platform eu --ga
 `SubscriptionPlan` CR shape (`subscription-plan.yaml`):
 
 ```yaml
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: SubscriptionPlan
 metadata:
   name: bronze-1k-per-min
@@ -426,7 +426,7 @@ ap gateway subscription create -f subscription.json --platform eu --gateway prod
 `Subscription` CR shape (`subscription.yaml`):
 
 ```yaml
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: Subscription
 metadata:
   name: petstore-acme-bronze

--- a/docs/gateway/analytics/analytics-header-filter.md
+++ b/docs/gateway/analytics/analytics-header-filter.md
@@ -55,10 +55,10 @@ Each filter parameter (`requestHeadersToFilter` and `responseHeadersToFilter`) i
 The following example demonstrates how to apply the Analytics Header Filter policy to a REST API:
 
 ```bash
-curl -X POST http://localhost:9090/api/management/v0.9/rest-apis \
+curl -X POST http://localhost:9090/api/management/v1alpha2/rest-apis \
   -H "Content-Type: application/yaml" \
   --data-binary @- <<'EOF'
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: RestApi
 metadata:
   name: mock-api-v1.0

--- a/docs/gateway/artifact-templating.md
+++ b/docs/gateway/artifact-templating.md
@@ -61,7 +61,7 @@ Functions compose as pipelines:
 ## Example
 
 ```yaml
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: RestApi
 metadata:
   name: orders-api-v1

--- a/docs/gateway/bottom-up-api-deployment-guide.md
+++ b/docs/gateway/bottom-up-api-deployment-guide.md
@@ -226,7 +226,7 @@ Bottom-up APIs are REST APIs deployed via the gateway controller that are **auto
 All REST APIs deployed via the gateway will be synced to on-prem APIM automatically. Here's a complete example:
 
 ```yaml
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: RestApi
 metadata:
   name: PetStoreAPI
@@ -299,7 +299,7 @@ Save the API definition as `petstore-api.json`:
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "RestApi",
   "metadata": {
     "name": "PetStoreAPI"
@@ -441,7 +441,7 @@ Update your API definition to add a rate limit policy:
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "RestApi",
   "metadata": {
     "name": "PetStoreAPI"
@@ -516,7 +516,7 @@ To undeploy an API, set `desiredState: undeployed` and update:
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "RestApi",
   "metadata": {
     "name": "PetStoreAPI"

--- a/docs/gateway/immutable-gateway.md
+++ b/docs/gateway/immutable-gateway.md
@@ -62,7 +62,7 @@ Use `| redact` for sensitive values to hide them from config dumps. A `| default
 Save the following as `artifacts/reading-list-v1.yaml`:
 
 ```yaml
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: RestApi
 metadata:
   name: reading-list-api-v1

--- a/docs/gateway/quick-start-guide.md
+++ b/docs/gateway/quick-start-guide.md
@@ -36,7 +36,7 @@ docker compose up -d
 curl http://localhost:9094/api/admin/v0.9/health
 
 # Deploy an API configuration
-curl -X POST http://localhost:9090/api/management/v0.9/rest-apis \
+curl -X POST http://localhost:9090/api/management/v1alpha2/rest-apis \
   -u admin:admin \
   -H "Content-Type: application/yaml" \
   --data-binary @- <<'EOF'

--- a/docs/gateway/quick-start-guide.md
+++ b/docs/gateway/quick-start-guide.md
@@ -40,7 +40,7 @@ curl -X POST http://localhost:9090/api/management/v0.9/rest-apis \
   -u admin:admin \
   -H "Content-Type: application/yaml" \
   --data-binary @- <<'EOF'
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: RestApi
 metadata:
   name: reading-list-api-v1.0

--- a/docs/rest-apis/gateway/README.md
+++ b/docs/rest-apis/gateway/README.md
@@ -4,8 +4,8 @@
 REST API for managing API configurations in the WSO2 API Platform Gateway.
 
 Base URLs:
-* <a href="http://localhost:9090/api/management/v0.9">http://localhost:9090/api/management/v0.9</a>
-* <a href="http://gateway-controller:9090/api/management/v0.9">http://gateway-controller:9090/api/management/v0.9</a>
+* <a href="http://localhost:9090/api/management/v1alpha2">http://localhost:9090/api/management/v1alpha2</a>
+* <a href="http://gateway-controller:9090/api/management/v1alpha2">http://gateway-controller:9090/api/management/v1alpha2</a>
 
 ## Table of Contents
 

--- a/docs/rest-apis/gateway/certificate-management.md
+++ b/docs/rest-apis/gateway/certificate-management.md
@@ -12,7 +12,7 @@ Manage custom TLS certificates for HTTPS upstream verification
 
 ```shell
 
-curl -X GET http://localhost:9090/api/management/v0.9/certificates \
+curl -X GET http://localhost:9090/api/management/v1alpha2/certificates \
   -u {username}:{password} \
   -H 'Accept: application/json'
 
@@ -71,7 +71,7 @@ Required roles: `admin`, `developer`
 
 ```shell
 
-curl -X POST http://localhost:9090/api/management/v0.9/certificates \
+curl -X POST http://localhost:9090/api/management/v1alpha2/certificates \
   -u {username}:{password} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
@@ -140,7 +140,7 @@ Required roles: `admin`, `developer`
 
 ```shell
 
-curl -X DELETE http://localhost:9090/api/management/v0.9/certificates/{id} \
+curl -X DELETE http://localhost:9090/api/management/v1alpha2/certificates/{id} \
   -u {username}:{password} \
   -H 'Accept: application/json'
 
@@ -203,7 +203,7 @@ Status Code **200**
 
 ```shell
 
-curl -X POST http://localhost:9090/api/management/v0.9/certificates/reload \
+curl -X POST http://localhost:9090/api/management/v1alpha2/certificates/reload \
   -u {username}:{password} \
   -H 'Accept: application/json'
 

--- a/docs/rest-apis/gateway/llm-provider-management.md
+++ b/docs/rest-apis/gateway/llm-provider-management.md
@@ -339,7 +339,7 @@ Status Code **200**
 |»»»»» exceptions|[[RouteException](schemas.md#schemarouteexception)]|false|none|Path exceptions to the access control mode|
 |»»»»»» path|string|true|none|Path pattern|
 |»»»»»» methods|[string]|true|none|HTTP methods|
-|»»»» globalPolicies|[[Policy](schemas.md#schemapolicy)]|false|none|Global (api-level) policies applied across ALL operations as one shared scope, evaluated before operation-level policies.|
+|»»»» globalPolicies|[[Policy](schemas.md#schemapolicy)]|false|none|Global (api-level) policies applied across ALL operations as one shared scope, evaluated before operation-level policies. **Note:** when using `advanced-ratelimit` here, set `keyExtraction: [{type: "apiname"}]` in `params` to create one shared counter across all operations. Without it the default `routename` key creates an independent bucket per route, defeating the provider-wide limit.|
 |»»»»» name|string|true|none|Name of the policy|
 |»»»»» version|string|true|none|Version of the policy. Only major-only version is allowed (e.g., v0, v1). Full semantic version (e.g., v1.0.0) is not accepted and will be rejected. The Gateway Controller resolves the major version to the single matching full version installed in the gateway image.|
 |»»»»» executionCondition|string|false|none|Expression controlling conditional execution of the policy|

--- a/docs/rest-apis/gateway/llm-provider-management.md
+++ b/docs/rest-apis/gateway/llm-provider-management.md
@@ -12,7 +12,7 @@ CRUD operations for LLM Provider configurations
 
 ```shell
 
-curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
+curl -X POST http://localhost:9090/api/management/v1alpha2/llm-providers \
   -u {username}:{password} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
@@ -26,7 +26,7 @@ Add a new LLM provider to the Gateway. A provider defines how to interact with a
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "LlmProvider",
   "metadata": {
     "name": "wso2-openai-provider"
@@ -92,7 +92,7 @@ Required roles: `admin`
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "LlmProvider",
   "metadata": {
     "name": "wso2-openai-provider"
@@ -163,7 +163,7 @@ Required roles: `admin`
 
 ```shell
 
-curl -X GET http://localhost:9090/api/management/v0.9/llm-providers \
+curl -X GET http://localhost:9090/api/management/v1alpha2/llm-providers \
   -u {username}:{password} \
   -H 'Accept: application/json'
 
@@ -207,7 +207,7 @@ Required roles: `admin`, `developer`
   "count": 2,
   "providers": [
     {
-      "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+      "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
       "kind": "LlmProvider",
       "metadata": {
         "name": "wso2-openai-provider"
@@ -339,7 +339,20 @@ Status Code **200**
 |»»»»» exceptions|[[RouteException](schemas.md#schemarouteexception)]|false|none|Path exceptions to the access control mode|
 |»»»»»» path|string|true|none|Path pattern|
 |»»»»»» methods|[string]|true|none|HTTP methods|
-|»»»» policies|[[LLMPolicy](schemas.md#schemallmpolicy)]|false|none|List of policies applied only to this operation (overrides or adds to API-level policies)|
+|»»»» globalPolicies|[[Policy](schemas.md#schemapolicy)]|false|none|Global (api-level) policies applied across ALL operations as one shared scope, evaluated before operation-level policies.|
+|»»»»» name|string|true|none|Name of the policy|
+|»»»»» version|string|true|none|Version of the policy. Only major-only version is allowed (e.g., v0, v1). Full semantic version (e.g., v1.0.0) is not accepted and will be rejected. The Gateway Controller resolves the major version to the single matching full version installed in the gateway image.|
+|»»»»» executionCondition|string|false|none|Expression controlling conditional execution of the policy|
+|»»»»» params|object|false|none|Arbitrary parameters for the policy (free-form key/value structure)|
+|»»»» operationPolicies|[[OperationPolicy](schemas.md#schemaoperationpolicy)]|false|none|Operation-level policies scoped to specific paths/methods, evaluated after global policies.|
+|»»»»» name|string|true|none|none|
+|»»»»» version|string|true|none|none|
+|»»»»» executionCondition|string|false|none|Expression controlling conditional execution of the policy|
+|»»»»» paths|[[OperationPolicyPath](schemas.md#schemaoperationpolicypath)]|true|none|none|
+|»»»»»» path|string|true|none|none|
+|»»»»»» methods|[string]|true|none|none|
+|»»»»»» params|object|true|none|JSON Schema describing the parameters accepted by this policy. This itself is a JSON Schema document.|
+|»»»» policies|[[LLMPolicy](schemas.md#schemallmpolicy)]|false|none|DEPRECATED - use operationPolicies. Still honoured (treated identically to operationPolicies).|
 |»»»»» name|string|true|none|none|
 |»»»»» version|string|true|none|none|
 |»»»»» paths|[[LLMPolicyPath](schemas.md#schemallmpolicypath)]|true|none|none|
@@ -364,7 +377,7 @@ Status Code **200**
 
 |Property|Value|
 |---|---|
-|apiVersion|gateway.api-platform.wso2.com/v1alpha1|
+|apiVersion|gateway.api-platform.wso2.com/v1alpha2|
 |kind|LlmProvider|
 |hostRewrite|auto|
 |hostRewrite|manual|
@@ -386,7 +399,7 @@ Status Code **200**
 
 ```shell
 
-curl -X GET http://localhost:9090/api/management/v0.9/llm-providers/{id} \
+curl -X GET http://localhost:9090/api/management/v1alpha2/llm-providers/{id} \
   -u {username}:{password} \
   -H 'Accept: application/json'
 
@@ -415,7 +428,7 @@ Required roles: `admin`, `developer`
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "LlmProvider",
   "metadata": {
     "name": "wso2-openai-provider"
@@ -485,7 +498,7 @@ Required roles: `admin`, `developer`
 
 ```shell
 
-curl -X PUT http://localhost:9090/api/management/v0.9/llm-providers/{id} \
+curl -X PUT http://localhost:9090/api/management/v1alpha2/llm-providers/{id} \
   -u {username}:{password} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
@@ -499,7 +512,7 @@ Update an existing LLM provider in the Gateway.
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "LlmProvider",
   "metadata": {
     "name": "wso2-openai-provider"
@@ -566,7 +579,7 @@ Required roles: `admin`
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "LlmProvider",
   "metadata": {
     "name": "wso2-openai-provider"
@@ -637,7 +650,7 @@ Required roles: `admin`
 
 ```shell
 
-curl -X DELETE http://localhost:9090/api/management/v0.9/llm-providers/{id} \
+curl -X DELETE http://localhost:9090/api/management/v1alpha2/llm-providers/{id} \
   -u {username}:{password} \
   -H 'Accept: application/json'
 
@@ -700,7 +713,7 @@ Status Code **200**
 
 ```shell
 
-curl -X POST http://localhost:9090/api/management/v0.9/llm-providers/{id}/api-keys \
+curl -X POST http://localhost:9090/api/management/v1alpha2/llm-providers/{id}/api-keys \
   -u {username}:{password} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
@@ -777,7 +790,7 @@ Required roles: `admin`, `consumer`
 
 ```shell
 
-curl -X GET http://localhost:9090/api/management/v0.9/llm-providers/{id}/api-keys \
+curl -X GET http://localhost:9090/api/management/v1alpha2/llm-providers/{id}/api-keys \
   -u {username}:{password} \
   -H 'Accept: application/json'
 
@@ -842,7 +855,7 @@ Required roles: `admin`, `consumer`
 
 ```shell
 
-curl -X POST http://localhost:9090/api/management/v0.9/llm-providers/{id}/api-keys/{apiKeyName}/regenerate \
+curl -X POST http://localhost:9090/api/management/v1alpha2/llm-providers/{id}/api-keys/{apiKeyName}/regenerate \
   -u {username}:{password} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
@@ -917,7 +930,7 @@ Required roles: `admin`, `consumer`
 
 ```shell
 
-curl -X PUT http://localhost:9090/api/management/v0.9/llm-providers/{id}/api-keys/{apiKeyName} \
+curl -X PUT http://localhost:9090/api/management/v1alpha2/llm-providers/{id}/api-keys/{apiKeyName} \
   -u {username}:{password} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
@@ -995,7 +1008,7 @@ Required roles: `admin`, `consumer`
 
 ```shell
 
-curl -X DELETE http://localhost:9090/api/management/v0.9/llm-providers/{id}/api-keys/{apiKeyName} \
+curl -X DELETE http://localhost:9090/api/management/v1alpha2/llm-providers/{id}/api-keys/{apiKeyName} \
   -u {username}:{password} \
   -H 'Accept: application/json'
 

--- a/docs/rest-apis/gateway/llm-provider-template-management.md
+++ b/docs/rest-apis/gateway/llm-provider-template-management.md
@@ -12,7 +12,7 @@ CRUD operations for LLM Provider Template configurations
 
 ```shell
 
-curl -X POST http://localhost:9090/api/management/v0.9/llm-provider-templates \
+curl -X POST http://localhost:9090/api/management/v1alpha2/llm-provider-templates \
   -u {username}:{password} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
@@ -26,7 +26,7 @@ Add a new LLM provider template to the Gateway. A template defines token trackin
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "LlmProviderTemplate",
   "metadata": {
     "name": "openai-template"
@@ -82,7 +82,7 @@ Required roles: `admin`
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "LlmProviderTemplate",
   "metadata": {
     "name": "openai-template"
@@ -141,7 +141,7 @@ Required roles: `admin`
 
 ```shell
 
-curl -X GET http://localhost:9090/api/management/v0.9/llm-provider-templates \
+curl -X GET http://localhost:9090/api/management/v1alpha2/llm-provider-templates \
   -u {username}:{password} \
   -H 'Accept: application/json'
 
@@ -174,7 +174,7 @@ Required roles: `admin`
   "count": 3,
   "templates": [
     {
-      "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+      "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
       "kind": "LlmProviderTemplate",
       "metadata": {
         "name": "openai-template"
@@ -282,7 +282,7 @@ Status Code **200**
 
 |Property|Value|
 |---|---|
-|apiVersion|gateway.api-platform.wso2.com/v1alpha1|
+|apiVersion|gateway.api-platform.wso2.com/v1alpha2|
 |kind|LlmProviderTemplate|
 |location|payload|
 |location|header|
@@ -301,7 +301,7 @@ Status Code **200**
 
 ```shell
 
-curl -X GET http://localhost:9090/api/management/v0.9/llm-provider-templates/{id} \
+curl -X GET http://localhost:9090/api/management/v1alpha2/llm-provider-templates/{id} \
   -u {username}:{password} \
   -H 'Accept: application/json'
 
@@ -330,7 +330,7 @@ Required roles: `admin`
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "LlmProviderTemplate",
   "metadata": {
     "name": "openai-template"
@@ -388,7 +388,7 @@ Required roles: `admin`
 
 ```shell
 
-curl -X PUT http://localhost:9090/api/management/v0.9/llm-provider-templates/{id} \
+curl -X PUT http://localhost:9090/api/management/v1alpha2/llm-provider-templates/{id} \
   -u {username}:{password} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
@@ -402,7 +402,7 @@ Update an existing LLM provider template in the Gateway.
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "LlmProviderTemplate",
   "metadata": {
     "name": "openai-template"
@@ -459,7 +459,7 @@ Required roles: `admin`
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "LlmProviderTemplate",
   "metadata": {
     "name": "openai-template"
@@ -518,7 +518,7 @@ Required roles: `admin`
 
 ```shell
 
-curl -X DELETE http://localhost:9090/api/management/v0.9/llm-provider-templates/{id} \
+curl -X DELETE http://localhost:9090/api/management/v1alpha2/llm-provider-templates/{id} \
   -u {username}:{password} \
   -H 'Accept: application/json'
 

--- a/docs/rest-apis/gateway/llm-proxy-management.md
+++ b/docs/rest-apis/gateway/llm-proxy-management.md
@@ -218,7 +218,7 @@ Status Code **200**
 |»»»»»» type|string|true|none|none|
 |»»»»»» header|string|false|none|none|
 |»»»»»» value|string|false|none|none|
-|»»»» globalPolicies|[[Policy](schemas.md#schemapolicy)]|false|none|Global (api-level) policies applied across ALL operations as one shared scope, evaluated before operation-level policies.|
+|»»»» globalPolicies|[[Policy](schemas.md#schemapolicy)]|false|none|Global (api-level) policies applied across ALL operations as one shared scope, evaluated before operation-level policies. **Note:** when using `advanced-ratelimit` here, set `keyExtraction: [{type: "apiname"}]` in `params` to create one shared counter across all operations. Without it the default `routename` key creates an independent bucket per route, defeating the proxy-wide limit.|
 |»»»»» name|string|true|none|Name of the policy|
 |»»»»» version|string|true|none|Version of the policy. Only major-only version is allowed (e.g., v0, v1). Full semantic version (e.g., v1.0.0) is not accepted and will be rejected. The Gateway Controller resolves the major version to the single matching full version installed in the gateway image.|
 |»»»»» executionCondition|string|false|none|Expression controlling conditional execution of the policy|

--- a/docs/rest-apis/gateway/llm-proxy-management.md
+++ b/docs/rest-apis/gateway/llm-proxy-management.md
@@ -12,7 +12,7 @@ CRUD operations for LLM Proxy configurations
 
 ```shell
 
-curl -X POST http://localhost:9090/api/management/v0.9/llm-proxies \
+curl -X POST http://localhost:9090/api/management/v1alpha2/llm-proxies \
   -u {username}:{password} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
@@ -26,7 +26,7 @@ Add a new LLM proxy to the Gateway. A proxy defines how to interact with an LLM 
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "LlmProxy",
   "metadata": {
     "name": "openai-proxy"
@@ -64,7 +64,7 @@ Required roles: `admin`, `developer`
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "LlmProxy",
   "metadata": {
     "name": "openai-proxy"
@@ -107,7 +107,7 @@ Required roles: `admin`, `developer`
 
 ```shell
 
-curl -X GET http://localhost:9090/api/management/v0.9/llm-proxies \
+curl -X GET http://localhost:9090/api/management/v1alpha2/llm-proxies \
   -u {username}:{password} \
   -H 'Accept: application/json'
 
@@ -151,7 +151,7 @@ Required roles: `admin`, `developer`
   "count": 2,
   "proxies": [
     {
-      "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+      "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
       "kind": "LlmProxy",
       "metadata": {
         "name": "openai-proxy"
@@ -218,7 +218,20 @@ Status Code **200**
 |»»»»»» type|string|true|none|none|
 |»»»»»» header|string|false|none|none|
 |»»»»»» value|string|false|none|none|
-|»»»» policies|[[LLMPolicy](schemas.md#schemallmpolicy)]|false|none|List of policies applied only to this operation (overrides or adds to API-level policies)|
+|»»»» globalPolicies|[[Policy](schemas.md#schemapolicy)]|false|none|Global (api-level) policies applied across ALL operations as one shared scope, evaluated before operation-level policies.|
+|»»»»» name|string|true|none|Name of the policy|
+|»»»»» version|string|true|none|Version of the policy. Only major-only version is allowed (e.g., v0, v1). Full semantic version (e.g., v1.0.0) is not accepted and will be rejected. The Gateway Controller resolves the major version to the single matching full version installed in the gateway image.|
+|»»»»» executionCondition|string|false|none|Expression controlling conditional execution of the policy|
+|»»»»» params|object|false|none|Arbitrary parameters for the policy (free-form key/value structure)|
+|»»»» operationPolicies|[[OperationPolicy](schemas.md#schemaoperationpolicy)]|false|none|Operation-level policies scoped to specific paths/methods, evaluated after global policies.|
+|»»»»» name|string|true|none|none|
+|»»»»» version|string|true|none|none|
+|»»»»» executionCondition|string|false|none|Expression controlling conditional execution of the policy|
+|»»»»» paths|[[OperationPolicyPath](schemas.md#schemaoperationpolicypath)]|true|none|none|
+|»»»»»» path|string|true|none|none|
+|»»»»»» methods|[string]|true|none|none|
+|»»»»»» params|object|true|none|JSON Schema describing the parameters accepted by this policy. This itself is a JSON Schema document.|
+|»»»» policies|[[LLMPolicy](schemas.md#schemallmpolicy)]|false|none|DEPRECATED - use operationPolicies. Still honoured (treated identically to operationPolicies).|
 |»»»»» name|string|true|none|none|
 |»»»»» version|string|true|none|none|
 |»»»»» paths|[[LLMPolicyPath](schemas.md#schemallmpolicypath)]|true|none|none|
@@ -243,7 +256,7 @@ Status Code **200**
 
 |Property|Value|
 |---|---|
-|apiVersion|gateway.api-platform.wso2.com/v1alpha1|
+|apiVersion|gateway.api-platform.wso2.com/v1alpha2|
 |kind|LlmProxy|
 |type|api-key|
 |deploymentState|deployed|
@@ -261,7 +274,7 @@ Status Code **200**
 
 ```shell
 
-curl -X GET http://localhost:9090/api/management/v0.9/llm-proxies/{id} \
+curl -X GET http://localhost:9090/api/management/v1alpha2/llm-proxies/{id} \
   -u {username}:{password} \
   -H 'Accept: application/json'
 
@@ -290,7 +303,7 @@ Required roles: `admin`, `developer`
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "LlmProxy",
   "metadata": {
     "name": "openai-proxy"
@@ -332,7 +345,7 @@ Required roles: `admin`, `developer`
 
 ```shell
 
-curl -X PUT http://localhost:9090/api/management/v0.9/llm-proxies/{id} \
+curl -X PUT http://localhost:9090/api/management/v1alpha2/llm-proxies/{id} \
   -u {username}:{password} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
@@ -346,7 +359,7 @@ Update an existing LLM proxy in the Gateway.
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "LlmProxy",
   "metadata": {
     "name": "openai-proxy"
@@ -385,7 +398,7 @@ Required roles: `admin`, `developer`
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "LlmProxy",
   "metadata": {
     "name": "openai-proxy"
@@ -428,7 +441,7 @@ Required roles: `admin`, `developer`
 
 ```shell
 
-curl -X DELETE http://localhost:9090/api/management/v0.9/llm-proxies/{id} \
+curl -X DELETE http://localhost:9090/api/management/v1alpha2/llm-proxies/{id} \
   -u {username}:{password} \
   -H 'Accept: application/json'
 
@@ -491,7 +504,7 @@ Status Code **200**
 
 ```shell
 
-curl -X POST http://localhost:9090/api/management/v0.9/llm-proxies/{id}/api-keys \
+curl -X POST http://localhost:9090/api/management/v1alpha2/llm-proxies/{id}/api-keys \
   -u {username}:{password} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
@@ -568,7 +581,7 @@ Required roles: `admin`, `consumer`
 
 ```shell
 
-curl -X GET http://localhost:9090/api/management/v0.9/llm-proxies/{id}/api-keys \
+curl -X GET http://localhost:9090/api/management/v1alpha2/llm-proxies/{id}/api-keys \
   -u {username}:{password} \
   -H 'Accept: application/json'
 
@@ -633,7 +646,7 @@ Required roles: `admin`, `consumer`
 
 ```shell
 
-curl -X POST http://localhost:9090/api/management/v0.9/llm-proxies/{id}/api-keys/{apiKeyName}/regenerate \
+curl -X POST http://localhost:9090/api/management/v1alpha2/llm-proxies/{id}/api-keys/{apiKeyName}/regenerate \
   -u {username}:{password} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
@@ -708,7 +721,7 @@ Required roles: `admin`, `consumer`
 
 ```shell
 
-curl -X PUT http://localhost:9090/api/management/v0.9/llm-proxies/{id}/api-keys/{apiKeyName} \
+curl -X PUT http://localhost:9090/api/management/v1alpha2/llm-proxies/{id}/api-keys/{apiKeyName} \
   -u {username}:{password} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
@@ -786,7 +799,7 @@ Required roles: `admin`, `consumer`
 
 ```shell
 
-curl -X DELETE http://localhost:9090/api/management/v0.9/llm-proxies/{id}/api-keys/{apiKeyName} \
+curl -X DELETE http://localhost:9090/api/management/v1alpha2/llm-proxies/{id}/api-keys/{apiKeyName} \
   -u {username}:{password} \
   -H 'Accept: application/json'
 

--- a/docs/rest-apis/gateway/mcp-proxy-management.md
+++ b/docs/rest-apis/gateway/mcp-proxy-management.md
@@ -12,7 +12,7 @@ CRUD operations for MCPProxies
 
 ```shell
 
-curl -X POST http://localhost:9090/api/management/v0.9/mcp-proxies \
+curl -X POST http://localhost:9090/api/management/v1alpha2/mcp-proxies \
   -u {username}:{password} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
@@ -26,7 +26,7 @@ Add a new MCPProxy to the Gateway.
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "Mcp",
   "metadata": {
     "name": "everything-mcp-v1.0"
@@ -67,7 +67,7 @@ Required roles: `admin`, `developer`
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "Mcp",
   "metadata": {
     "name": "everything-mcp-v1.0"
@@ -113,7 +113,7 @@ Required roles: `admin`, `developer`
 
 ```shell
 
-curl -X GET http://localhost:9090/api/management/v0.9/mcp-proxies \
+curl -X GET http://localhost:9090/api/management/v1alpha2/mcp-proxies \
   -u {username}:{password} \
   -H 'Accept: application/json'
 
@@ -156,7 +156,7 @@ Required roles: `admin`, `developer`
   "count": 5,
   "mcpProxies": [
     {
-      "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+      "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
       "kind": "Mcp",
       "metadata": {
         "name": "everything-mcp-v1.0"
@@ -303,7 +303,7 @@ Status Code **200**
 
 |Property|Value|
 |---|---|
-|apiVersion|gateway.api-platform.wso2.com/v1alpha1|
+|apiVersion|gateway.api-platform.wso2.com/v1alpha2|
 |kind|Mcp|
 |hostRewrite|auto|
 |hostRewrite|manual|
@@ -323,7 +323,7 @@ Status Code **200**
 
 ```shell
 
-curl -X GET http://localhost:9090/api/management/v0.9/mcp-proxies/{id} \
+curl -X GET http://localhost:9090/api/management/v1alpha2/mcp-proxies/{id} \
   -u {username}:{password} \
   -H 'Accept: application/json'
 
@@ -356,7 +356,7 @@ Required roles: `admin`, `developer`
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "Mcp",
   "metadata": {
     "name": "everything-mcp-v1.0"
@@ -401,7 +401,7 @@ Required roles: `admin`, `developer`
 
 ```shell
 
-curl -X PUT http://localhost:9090/api/management/v0.9/mcp-proxies/{id} \
+curl -X PUT http://localhost:9090/api/management/v1alpha2/mcp-proxies/{id} \
   -u {username}:{password} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
@@ -415,7 +415,7 @@ Update an existing MCPProxy in the Gateway.
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "Mcp",
   "metadata": {
     "name": "everything-mcp-v1.0"
@@ -461,7 +461,7 @@ Required roles: `admin`, `developer`
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "Mcp",
   "metadata": {
     "name": "everything-mcp-v1.0"
@@ -507,7 +507,7 @@ Required roles: `admin`, `developer`
 
 ```shell
 
-curl -X DELETE http://localhost:9090/api/management/v0.9/mcp-proxies/{id} \
+curl -X DELETE http://localhost:9090/api/management/v1alpha2/mcp-proxies/{id} \
   -u {username}:{password} \
   -H 'Accept: application/json'
 

--- a/docs/rest-apis/gateway/rest-api-management.md
+++ b/docs/rest-apis/gateway/rest-api-management.md
@@ -12,7 +12,7 @@ CRUD operations for Rest APIs
 
 ```shell
 
-curl -X POST http://localhost:9090/api/management/v0.9/rest-apis \
+curl -X POST http://localhost:9090/api/management/v1alpha2/rest-apis \
   -u {username}:{password} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
@@ -26,7 +26,7 @@ Add a new RestAPI to the Gateway.
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "RestApi",
   "metadata": {
     "name": "reading-list-api-v1.0"
@@ -111,7 +111,7 @@ Required roles: `admin`, `developer`
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "RestApi",
   "metadata": {
     "name": "reading-list-api-v1.0"
@@ -201,7 +201,7 @@ Required roles: `admin`, `developer`
 
 ```shell
 
-curl -X GET http://localhost:9090/api/management/v0.9/rest-apis \
+curl -X GET http://localhost:9090/api/management/v1alpha2/rest-apis \
   -u {username}:{password} \
   -H 'Accept: application/json'
 
@@ -244,7 +244,7 @@ Required roles: `admin`, `developer`
   "count": 5,
   "apis": [
     {
-      "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+      "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
       "kind": "RestApi",
       "metadata": {
         "name": "reading-list-api-v1.0"
@@ -413,7 +413,7 @@ Status Code **200**
 
 |Property|Value|
 |---|---|
-|apiVersion|gateway.api-platform.wso2.com/v1alpha1|
+|apiVersion|gateway.api-platform.wso2.com/v1alpha2|
 |kind|RestApi|
 |hostRewrite|auto|
 |hostRewrite|manual|
@@ -439,7 +439,7 @@ Status Code **200**
 
 ```shell
 
-curl -X GET http://localhost:9090/api/management/v0.9/rest-apis/{id} \
+curl -X GET http://localhost:9090/api/management/v1alpha2/rest-apis/{id} \
   -u {username}:{password} \
   -H 'Accept: application/json'
 
@@ -472,7 +472,7 @@ Required roles: `admin`, `developer`
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "RestApi",
   "metadata": {
     "name": "reading-list-api-v1.0"
@@ -561,7 +561,7 @@ Required roles: `admin`, `developer`
 
 ```shell
 
-curl -X PUT http://localhost:9090/api/management/v0.9/rest-apis/{id} \
+curl -X PUT http://localhost:9090/api/management/v1alpha2/rest-apis/{id} \
   -u {username}:{password} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
@@ -575,7 +575,7 @@ Update an existing RestAPI in the Gateway.
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "RestApi",
   "metadata": {
     "name": "reading-list-api-v1.0"
@@ -665,7 +665,7 @@ Required roles: `admin`, `developer`
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "RestApi",
   "metadata": {
     "name": "reading-list-api-v1.0"
@@ -755,7 +755,7 @@ Required roles: `admin`, `developer`
 
 ```shell
 
-curl -X DELETE http://localhost:9090/api/management/v0.9/rest-apis/{id} \
+curl -X DELETE http://localhost:9090/api/management/v1alpha2/rest-apis/{id} \
   -u {username}:{password} \
   -H 'Accept: application/json'
 
@@ -822,7 +822,7 @@ Status Code **200**
 
 ```shell
 
-curl -X POST http://localhost:9090/api/management/v0.9/rest-apis/{id}/api-keys \
+curl -X POST http://localhost:9090/api/management/v1alpha2/rest-apis/{id}/api-keys \
   -u {username}:{password} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
@@ -902,7 +902,7 @@ Required roles: `admin`, `consumer`
 
 ```shell
 
-curl -X GET http://localhost:9090/api/management/v0.9/rest-apis/{id}/api-keys \
+curl -X GET http://localhost:9090/api/management/v1alpha2/rest-apis/{id}/api-keys \
   -u {username}:{password} \
   -H 'Accept: application/json'
 
@@ -971,7 +971,7 @@ Required roles: `admin`, `consumer`
 
 ```shell
 
-curl -X POST http://localhost:9090/api/management/v0.9/rest-apis/{id}/api-keys/{apiKeyName}/regenerate \
+curl -X POST http://localhost:9090/api/management/v1alpha2/rest-apis/{id}/api-keys/{apiKeyName}/regenerate \
   -u {username}:{password} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
@@ -1052,7 +1052,7 @@ Required roles: `admin`, `consumer`
 
 ```shell
 
-curl -X PUT http://localhost:9090/api/management/v0.9/rest-apis/{id}/api-keys/{apiKeyName} \
+curl -X PUT http://localhost:9090/api/management/v1alpha2/rest-apis/{id}/api-keys/{apiKeyName} \
   -u {username}:{password} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
@@ -1135,7 +1135,7 @@ Required roles: `admin`, `consumer`
 
 ```shell
 
-curl -X DELETE http://localhost:9090/api/management/v0.9/rest-apis/{id}/api-keys/{apiKeyName} \
+curl -X DELETE http://localhost:9090/api/management/v1alpha2/rest-apis/{id}/api-keys/{apiKeyName} \
   -u {username}:{password} \
   -H 'Accept: application/json'
 
@@ -1195,7 +1195,7 @@ Required roles: `admin`, `consumer`
 
 ```shell
 
-curl -X POST http://localhost:9090/api/management/v0.9/subscription-plans \
+curl -X POST http://localhost:9090/api/management/v1alpha2/subscription-plans \
   -u {username}:{password} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
@@ -1273,7 +1273,7 @@ Required roles: `admin`, `developer`
 
 ```shell
 
-curl -X GET http://localhost:9090/api/management/v0.9/subscription-plans \
+curl -X GET http://localhost:9090/api/management/v1alpha2/subscription-plans \
   -u {username}:{password} \
   -H 'Accept: application/json'
 
@@ -1332,7 +1332,7 @@ Required roles: `admin`, `developer`
 
 ```shell
 
-curl -X GET http://localhost:9090/api/management/v0.9/subscription-plans/{planId} \
+curl -X GET http://localhost:9090/api/management/v1alpha2/subscription-plans/{planId} \
   -u {username}:{password} \
   -H 'Accept: application/json'
 
@@ -1393,7 +1393,7 @@ Required roles: `admin`, `developer`
 
 ```shell
 
-curl -X PUT http://localhost:9090/api/management/v0.9/subscription-plans/{planId} \
+curl -X PUT http://localhost:9090/api/management/v1alpha2/subscription-plans/{planId} \
   -u {username}:{password} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
@@ -1471,7 +1471,7 @@ Required roles: `admin`, `developer`
 
 ```shell
 
-curl -X DELETE http://localhost:9090/api/management/v0.9/subscription-plans/{planId} \
+curl -X DELETE http://localhost:9090/api/management/v1alpha2/subscription-plans/{planId} \
   -u {username}:{password} \
   -H 'Accept: application/json'
 
@@ -1529,7 +1529,7 @@ Required roles: `admin`, `developer`
 
 ```shell
 
-curl -X POST http://localhost:9090/api/management/v0.9/subscriptions \
+curl -X POST http://localhost:9090/api/management/v1alpha2/subscriptions \
   -u {username}:{password} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
@@ -1607,7 +1607,7 @@ Required roles: `admin`, `developer`
 
 ```shell
 
-curl -X GET http://localhost:9090/api/management/v0.9/subscriptions \
+curl -X GET http://localhost:9090/api/management/v1alpha2/subscriptions \
   -u {username}:{password} \
   -H 'Accept: application/json'
 
@@ -1682,7 +1682,7 @@ Required roles: `admin`, `developer`
 
 ```shell
 
-curl -X GET http://localhost:9090/api/management/v0.9/subscriptions/{subscriptionId} \
+curl -X GET http://localhost:9090/api/management/v1alpha2/subscriptions/{subscriptionId} \
   -u {username}:{password} \
   -H 'Accept: application/json'
 
@@ -1743,7 +1743,7 @@ Required roles: `admin`, `developer`
 
 ```shell
 
-curl -X PUT http://localhost:9090/api/management/v0.9/subscriptions/{subscriptionId} \
+curl -X PUT http://localhost:9090/api/management/v1alpha2/subscriptions/{subscriptionId} \
   -u {username}:{password} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
@@ -1815,7 +1815,7 @@ Required roles: `admin`, `developer`
 
 ```shell
 
-curl -X DELETE http://localhost:9090/api/management/v0.9/subscriptions/{subscriptionId} \
+curl -X DELETE http://localhost:9090/api/management/v1alpha2/subscriptions/{subscriptionId} \
   -u {username}:{password} \
   -H 'Accept: application/json'
 

--- a/docs/rest-apis/gateway/schemas.md
+++ b/docs/rest-apis/gateway/schemas.md
@@ -3926,7 +3926,7 @@ Metadata for an HMAC secret. The plaintext value is never included.
 {
   "status": "success",
   "message": "Webhook secret generated successfully",
-  "secret": "whsec_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b",
+  "secret": "whsec_<generated-once-placeholder>",
   "webhookSecret": {
     "name": "github-webhook",
     "displayName": "GitHub Webhook",

--- a/docs/rest-apis/gateway/schemas.md
+++ b/docs/rest-apis/gateway/schemas.md
@@ -46,7 +46,7 @@ Server-managed lifecycle information for a resource
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "RestApi",
   "metadata": {
     "name": "reading-list-api-v1.0"
@@ -124,7 +124,7 @@ Server-managed lifecycle information for a resource
 
 |Property|Value|
 |---|---|
-|apiVersion|gateway.api-platform.wso2.com/v1alpha1|
+|apiVersion|gateway.api-platform.wso2.com/v1alpha2|
 |kind|RestApi|
 
 <h2 id="tocS_RestAPI">RestAPI</h2>
@@ -136,7 +136,7 @@ Server-managed lifecycle information for a resource
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "RestApi",
   "metadata": {
     "name": "reading-list-api-v1.0"
@@ -232,7 +232,7 @@ and
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "WebSubApi",
   "metadata": {
     "name": "github-events-v1.0"
@@ -269,7 +269,7 @@ and
 
 |Property|Value|
 |---|---|
-|apiVersion|gateway.api-platform.wso2.com/v1alpha1|
+|apiVersion|gateway.api-platform.wso2.com/v1alpha2|
 |kind|WebSubApi|
 
 <h2 id="tocS_WebSubAPI">WebSubAPI</h2>
@@ -281,7 +281,7 @@ and
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "WebSubApi",
   "metadata": {
     "name": "github-events-v1.0"
@@ -1064,7 +1064,7 @@ Channel (topic/event stream) definition for async APIs.
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "WebBrokerApi",
   "metadata": {
     "name": "stock-trading-v1.0"
@@ -1135,7 +1135,7 @@ Channel (topic/event stream) definition for async APIs.
 
 |Property|Value|
 |---|---|
-|apiVersion|gateway.api-platform.wso2.com/v1alpha1|
+|apiVersion|gateway.api-platform.wso2.com/v1alpha2|
 |kind|WebBrokerApi|
 
 <h2 id="tocS_WebBrokerApi">WebBrokerApi</h2>
@@ -1147,7 +1147,7 @@ Channel (topic/event stream) definition for async APIs.
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "WebBrokerApi",
   "metadata": {
     "name": "stock-trading-v1.0"
@@ -2167,7 +2167,7 @@ Details of an API key
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "Mcp",
   "metadata": {
     "name": "everything-mcp-v1.0"
@@ -2201,7 +2201,7 @@ Details of an API key
 
 |Property|Value|
 |---|---|
-|apiVersion|gateway.api-platform.wso2.com/v1alpha1|
+|apiVersion|gateway.api-platform.wso2.com/v1alpha2|
 |kind|Mcp|
 
 <h2 id="tocS_MCPProxyConfiguration">MCPProxyConfiguration</h2>
@@ -2213,7 +2213,7 @@ Details of an API key
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "Mcp",
   "metadata": {
     "name": "everything-mcp-v1.0"
@@ -2522,7 +2522,7 @@ continued
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "LlmProviderTemplate",
   "metadata": {
     "name": "openai-template"
@@ -2571,7 +2571,7 @@ continued
 
 |Property|Value|
 |---|---|
-|apiVersion|gateway.api-platform.wso2.com/v1alpha1|
+|apiVersion|gateway.api-platform.wso2.com/v1alpha2|
 |kind|LlmProviderTemplate|
 
 <h2 id="tocS_LLMProviderTemplate">LLMProviderTemplate</h2>
@@ -2583,7 +2583,7 @@ continued
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "LlmProviderTemplate",
   "metadata": {
     "name": "openai-template"
@@ -2859,7 +2859,7 @@ and
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "LlmProvider",
   "metadata": {
     "name": "wso2-openai-provider"
@@ -2918,7 +2918,7 @@ and
 
 |Property|Value|
 |---|---|
-|apiVersion|gateway.api-platform.wso2.com/v1alpha1|
+|apiVersion|gateway.api-platform.wso2.com/v1alpha2|
 |kind|LlmProvider|
 
 <h2 id="tocS_LLMProviderConfiguration">LLMProviderConfiguration</h2>
@@ -2930,7 +2930,7 @@ and
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "LlmProvider",
   "metadata": {
     "name": "wso2-openai-provider"
@@ -3033,7 +3033,15 @@ and
       }
     ]
   },
-  "policies": [
+  "globalPolicies": [
+    {
+      "name": "cors",
+      "version": "v1",
+      "executionCondition": "request.metadata[authenticated] != true",
+      "params": {}
+    }
+  ],
+  "operationPolicies": [
     {
       "name": "llm-cost-based-ratelimit",
       "version": "v1",
@@ -3081,7 +3089,9 @@ continued
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |accessControl|[LLMAccessControl](#schemallmaccesscontrol)|true|none|none|
-|policies|[[LLMPolicy](#schemallmpolicy)]|false|none|List of policies applied only to this operation (overrides or adds to API-level policies)|
+|globalPolicies|[[Policy](#schemapolicy)]|false|none|Global (api-level) policies applied across ALL operations as one shared scope, evaluated before operation-level policies.|
+|operationPolicies|[[OperationPolicy](#schemaoperationpolicy)]|false|none|Operation-level policies scoped to specific paths/methods, evaluated after global policies.|
+|policies|[[LLMPolicy](#schemallmpolicy)]|false|none|DEPRECATED - use operationPolicies. Still honoured (treated identically to operationPolicies).|
 |deploymentState|string|false|none|Desired deployment state - 'deployed' (default) or 'undeployed'. When set to 'undeployed', the LLM Provider is removed from router traffic but configuration and policies are preserved for potential redeployment.|
 
 #### Enumerated Values
@@ -3298,6 +3308,66 @@ continued
 |methods|[string]|true|none|none|
 |params|object|true|none|JSON Schema describing the parameters accepted by this policy. This itself is a JSON Schema document.|
 
+<h2 id="tocS_OperationPolicy">OperationPolicy</h2>
+
+<a id="schemaoperationpolicy"></a>
+<a id="schema_OperationPolicy"></a>
+<a id="tocSoperationpolicy"></a>
+<a id="tocsoperationpolicy"></a>
+
+```json
+{
+  "name": "token-based-ratelimit",
+  "version": "v1",
+  "executionCondition": "string",
+  "paths": [
+    {
+      "path": "/chat/completions",
+      "methods": [
+        "string"
+      ],
+      "params": {}
+    }
+  ]
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|name|string|true|none|none|
+|version|string|true|none|none|
+|executionCondition|string|false|none|Expression controlling conditional execution of the policy|
+|paths|[[OperationPolicyPath](#schemaoperationpolicypath)]|true|none|none|
+
+<h2 id="tocS_OperationPolicyPath">OperationPolicyPath</h2>
+
+<a id="schemaoperationpolicypath"></a>
+<a id="schema_OperationPolicyPath"></a>
+<a id="tocSoperationpolicypath"></a>
+<a id="tocsoperationpolicypath"></a>
+
+```json
+{
+  "path": "/chat/completions",
+  "methods": [
+    "string"
+  ],
+  "params": {}
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|path|string|true|none|none|
+|methods|[string]|true|none|none|
+|params|object|true|none|JSON Schema describing the parameters accepted by this policy. This itself is a JSON Schema document.|
+
 <h2 id="tocS_LLMProxyConfigurationRequest">LLMProxyConfigurationRequest</h2>
 
 <a id="schemallmproxyconfigurationrequest"></a>
@@ -3307,7 +3377,7 @@ continued
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "LlmProxy",
   "metadata": {
     "name": "openai-proxy"
@@ -3338,7 +3408,7 @@ continued
 
 |Property|Value|
 |---|---|
-|apiVersion|gateway.api-platform.wso2.com/v1alpha1|
+|apiVersion|gateway.api-platform.wso2.com/v1alpha2|
 |kind|LlmProxy|
 
 <h2 id="tocS_LLMProxyConfiguration">LLMProxyConfiguration</h2>
@@ -3350,7 +3420,7 @@ continued
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "LlmProxy",
   "metadata": {
     "name": "openai-proxy"
@@ -3411,6 +3481,30 @@ and
       "value": "string"
     }
   },
+  "globalPolicies": [
+    {
+      "name": "cors",
+      "version": "v1",
+      "executionCondition": "request.metadata[authenticated] != true",
+      "params": {}
+    }
+  ],
+  "operationPolicies": [
+    {
+      "name": "token-based-ratelimit",
+      "version": "v1",
+      "executionCondition": "string",
+      "paths": [
+        {
+          "path": "/chat/completions",
+          "methods": [
+            "string"
+          ],
+          "params": {}
+        }
+      ]
+    }
+  ],
   "policies": [
     {
       "name": "llm-cost-based-ratelimit",
@@ -3440,7 +3534,9 @@ and
 |context|string|false|none|Base path for all API routes (must start with /, no trailing slash)|
 |vhost|string|false|none|Virtual host name used for routing. Supports standard domain names, subdomains, or wildcard domains. Must follow RFC-compliant hostname rules. Wildcards are only allowed in the left-most label (e.g., *.example.com).|
 |provider|[LLMProxyProvider](#schemallmproxyprovider)|true|none|none|
-|policies|[[LLMPolicy](#schemallmpolicy)]|false|none|List of policies applied only to this operation (overrides or adds to API-level policies)|
+|globalPolicies|[[Policy](#schemapolicy)]|false|none|Global (api-level) policies applied across ALL operations as one shared scope, evaluated before operation-level policies.|
+|operationPolicies|[[OperationPolicy](#schemaoperationpolicy)]|false|none|Operation-level policies scoped to specific paths/methods, evaluated after global policies.|
+|policies|[[LLMPolicy](#schemallmpolicy)]|false|none|DEPRECATED - use operationPolicies. Still honoured (treated identically to operationPolicies).|
 |deploymentState|string|false|none|Desired deployment state - 'deployed' (default) or 'undeployed'. When set to 'undeployed', the LLM Proxy is removed from router traffic but configuration and policies are preserved for potential redeployment.|
 
 #### Enumerated Values
@@ -3459,7 +3555,7 @@ and
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "Secret",
   "metadata": {
     "name": "database-password"
@@ -3486,7 +3582,7 @@ and
 
 |Property|Value|
 |---|---|
-|apiVersion|gateway.api-platform.wso2.com/v1alpha1|
+|apiVersion|gateway.api-platform.wso2.com/v1alpha2|
 |kind|Secret|
 
 <h2 id="tocS_SecretConfiguration">SecretConfiguration</h2>
@@ -3498,7 +3594,7 @@ and
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "Secret",
   "metadata": {
     "name": "database-password"
@@ -3592,7 +3688,7 @@ and
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "Secret",
   "metadata": {
     "name": "database-password"
@@ -3623,7 +3719,7 @@ and
 
 |Property|Value|
 |---|---|
-|apiVersion|gateway.api-platform.wso2.com/v1alpha1|
+|apiVersion|gateway.api-platform.wso2.com/v1alpha2|
 |kind|Secret|
 
 <h2 id="tocS_CertificateUploadRequest">CertificateUploadRequest</h2>
@@ -3762,6 +3858,127 @@ and
 |totalCount|integer|false|none|Total number of API keys|
 |status|string|false|none|none|
 
+<h2 id="tocS_WebhookSecretCreationRequest">WebhookSecretCreationRequest</h2>
+
+<a id="schemawebhooksecretcreationrequest"></a>
+<a id="schema_WebhookSecretCreationRequest"></a>
+<a id="tocSwebhooksecretcreationrequest"></a>
+<a id="tocswebhooksecretcreationrequest"></a>
+
+```json
+{
+  "displayName": "GitHub Webhook"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|displayName|string|true|none|Human-readable label for this secret (used to derive the immutable name slug).|
+
+<h2 id="tocS_WebhookSecretInfo">WebhookSecretInfo</h2>
+
+<a id="schemawebhooksecretinfo"></a>
+<a id="schema_WebhookSecretInfo"></a>
+<a id="tocSwebhooksecretinfo"></a>
+<a id="tocswebhooksecretinfo"></a>
+
+```json
+{
+  "name": "github-webhook",
+  "displayName": "GitHub Webhook",
+  "status": "active",
+  "createdAt": "2026-06-01T10:00:00Z",
+  "updatedAt": "2026-06-01T10:00:00Z"
+}
+
+```
+
+Metadata for an HMAC secret. The plaintext value is never included.
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|name|string|false|none|URL-safe slug (immutable, used as path parameter for regenerate/delete).|
+|displayName|string|false|none|Human-readable label.|
+|status|string|false|none|none|
+|createdAt|string(date-time)|false|none|none|
+|updatedAt|string(date-time)|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|status|active|
+|status|revoked|
+
+<h2 id="tocS_WebhookSecretCreationResponse">WebhookSecretCreationResponse</h2>
+
+<a id="schemawebhooksecretcreationresponse"></a>
+<a id="schema_WebhookSecretCreationResponse"></a>
+<a id="tocSwebhooksecretcreationresponse"></a>
+<a id="tocswebhooksecretcreationresponse"></a>
+
+```json
+{
+  "status": "success",
+  "message": "Webhook secret generated successfully",
+  "secret": "whsec_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b",
+  "webhookSecret": {
+    "name": "github-webhook",
+    "displayName": "GitHub Webhook",
+    "status": "active",
+    "createdAt": "2026-06-01T10:00:00Z",
+    "updatedAt": "2026-06-01T10:00:00Z"
+  }
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|status|string|true|none|none|
+|message|string|true|none|none|
+|secret|string|true|none|The generated plaintext secret value (whsec_ prefix + 64 hex chars).<br>Returned exactly once — store it immediately as it will not be retrievable again.|
+|webhookSecret|[WebhookSecretInfo](#schemawebhooksecretinfo)|false|none|Metadata for an HMAC secret. The plaintext value is never included.|
+
+<h2 id="tocS_WebhookSecretListResponse">WebhookSecretListResponse</h2>
+
+<a id="schemawebhooksecretlistresponse"></a>
+<a id="schema_WebhookSecretListResponse"></a>
+<a id="tocSwebhooksecretlistresponse"></a>
+<a id="tocswebhooksecretlistresponse"></a>
+
+```json
+{
+  "status": "success",
+  "totalCount": 2,
+  "secrets": [
+    {
+      "name": "github-webhook",
+      "displayName": "GitHub Webhook",
+      "status": "active",
+      "createdAt": "2026-06-01T10:00:00Z",
+      "updatedAt": "2026-06-01T10:00:00Z"
+    }
+  ]
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|status|string|false|none|none|
+|totalCount|integer|false|none|Total number of active secrets for this API|
+|secrets|[[WebhookSecretInfo](#schemawebhooksecretinfo)]|false|none|[Metadata for an HMAC secret. The plaintext value is never included.]|
+
 <h2 id="tocS_SecretListResponse">SecretListResponse</h2>
 
 <a id="schemasecretlistresponse"></a>
@@ -3775,7 +3992,7 @@ and
   "count": 5,
   "secrets": [
     {
-      "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+      "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
       "kind": "Secret",
       "metadata": {
         "name": "database-password"
@@ -3838,7 +4055,7 @@ Id and optional timestamps. Not the full ResourceStatus model (no `state` or
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "Secret",
   "metadata": {
     "name": "database-password"
@@ -3872,7 +4089,7 @@ POST/PUT /secrets response. `spec.value` is not returned; see SecretConfiguratio
 
 |Property|Value|
 |---|---|
-|apiVersion|gateway.api-platform.wso2.com/v1alpha1|
+|apiVersion|gateway.api-platform.wso2.com/v1alpha2|
 |kind|Secret|
 
 <h2 id="tocS_SecretConfigurationResponseRetrieved">SecretConfigurationResponseRetrieved</h2>
@@ -3884,7 +4101,7 @@ POST/PUT /secrets response. `spec.value` is not returned; see SecretConfiguratio
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "Secret",
   "metadata": {
     "name": "database-password"
@@ -3919,5 +4136,5 @@ GET /secrets/{id} response including decrypted `spec.value`.
 
 |Property|Value|
 |---|---|
-|apiVersion|gateway.api-platform.wso2.com/v1alpha1|
+|apiVersion|gateway.api-platform.wso2.com/v1alpha2|
 |kind|Secret|

--- a/docs/rest-apis/gateway/secrets-management.md
+++ b/docs/rest-apis/gateway/secrets-management.md
@@ -12,7 +12,7 @@ CRUD operations for Secrets
 
 ```shell
 
-curl -X GET http://localhost:9090/api/management/v0.9/secrets \
+curl -X GET http://localhost:9090/api/management/v1alpha2/secrets \
   -u {username}:{password} \
   -H 'Accept: application/json'
 
@@ -40,7 +40,7 @@ Required roles: `admin`
   "count": 5,
   "secrets": [
     {
-      "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+      "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
       "kind": "Secret",
       "metadata": {
         "name": "database-password"
@@ -76,7 +76,7 @@ Required roles: `admin`
 
 ```shell
 
-curl -X POST http://localhost:9090/api/management/v0.9/secrets \
+curl -X POST http://localhost:9090/api/management/v1alpha2/secrets \
   -u {username}:{password} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
@@ -91,7 +91,7 @@ The value is encrypted using the primary encryption provider before persistence.
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "Secret",
   "metadata": {
     "name": "database-password"
@@ -125,7 +125,7 @@ Required roles: `admin`
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "Secret",
   "metadata": {
     "name": "database-password"
@@ -177,7 +177,7 @@ Required roles: `admin`
 
 ```shell
 
-curl -X GET http://localhost:9090/api/management/v0.9/secrets/{id} \
+curl -X GET http://localhost:9090/api/management/v1alpha2/secrets/{id} \
   -u {username}:{password} \
   -H 'Accept: application/json'
 
@@ -208,7 +208,7 @@ Required roles: `admin`
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "Secret",
   "metadata": {
     "name": "database-password"
@@ -260,7 +260,7 @@ Required roles: `admin`
 
 ```shell
 
-curl -X PUT http://localhost:9090/api/management/v0.9/secrets/{id} \
+curl -X PUT http://localhost:9090/api/management/v1alpha2/secrets/{id} \
   -u {username}:{password} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
@@ -276,7 +276,7 @@ to newer keys during updates. Old secrets remain readable via the provider chain
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "Secret",
   "metadata": {
     "name": "database-password"
@@ -311,7 +311,7 @@ Required roles: `admin`
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "Secret",
   "metadata": {
     "name": "database-password"
@@ -363,7 +363,7 @@ Required roles: `admin`
 
 ```shell
 
-curl -X DELETE http://localhost:9090/api/management/v0.9/secrets/{id} \
+curl -X DELETE http://localhost:9090/api/management/v1alpha2/secrets/{id} \
   -u {username}:{password} \
   -H 'Accept: application/json'
 

--- a/docs/rest-apis/gateway/webbroker-api-management.md
+++ b/docs/rest-apis/gateway/webbroker-api-management.md
@@ -10,7 +10,7 @@
 
 ```shell
 
-curl -X POST http://localhost:9090/api/management/v0.9/webbroker-apis \
+curl -X POST http://localhost:9090/api/management/v1alpha2/webbroker-apis \
   -u {username}:{password} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
@@ -24,7 +24,7 @@ Add a new WebBrokerAPI to the Gateway. WebBrokerAPI provides bidirectional strea
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "WebBrokerApi",
   "metadata": {
     "name": "stock-trading-v1.0"
@@ -102,7 +102,7 @@ Required roles: `admin`, `developer`
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "WebBrokerApi",
   "metadata": {
     "name": "stock-trading-v1.0"
@@ -185,7 +185,7 @@ Required roles: `admin`, `developer`
 
 ```shell
 
-curl -X GET http://localhost:9090/api/management/v0.9/webbroker-apis \
+curl -X GET http://localhost:9090/api/management/v1alpha2/webbroker-apis \
   -u {username}:{password} \
   -H 'Accept: application/json'
 
@@ -227,7 +227,7 @@ Required roles: `admin`, `developer`
   "count": 3,
   "apis": [
     {
-      "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+      "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
       "kind": "WebBrokerApi",
       "metadata": {
         "name": "stock-trading-v1.0"
@@ -374,7 +374,7 @@ Status Code **200**
 
 |Property|Value|
 |---|---|
-|apiVersion|gateway.api-platform.wso2.com/v1alpha1|
+|apiVersion|gateway.api-platform.wso2.com/v1alpha2|
 |kind|WebBrokerApi|
 |deploymentState|deployed|
 |deploymentState|undeployed|
@@ -391,7 +391,7 @@ Status Code **200**
 
 ```shell
 
-curl -X GET http://localhost:9090/api/management/v0.9/webbroker-apis/{id} \
+curl -X GET http://localhost:9090/api/management/v1alpha2/webbroker-apis/{id} \
   -u {username}:{password} \
   -H 'Accept: application/json'
 
@@ -424,7 +424,7 @@ Required roles: `admin`, `developer`
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "WebBrokerApi",
   "metadata": {
     "name": "stock-trading-v1.0"
@@ -506,7 +506,7 @@ Required roles: `admin`, `developer`
 
 ```shell
 
-curl -X DELETE http://localhost:9090/api/management/v0.9/webbroker-apis/{id} \
+curl -X DELETE http://localhost:9090/api/management/v1alpha2/webbroker-apis/{id} \
   -u {username}:{password} \
   -H 'Accept: application/json'
 
@@ -573,7 +573,7 @@ Status Code **200**
 
 ```shell
 
-curl -X POST http://localhost:9090/api/management/v0.9/webbroker-apis/{id}/api-keys \
+curl -X POST http://localhost:9090/api/management/v1alpha2/webbroker-apis/{id}/api-keys \
   -u {username}:{password} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
@@ -650,7 +650,7 @@ Required roles: `admin`, `consumer`
 
 ```shell
 
-curl -X GET http://localhost:9090/api/management/v0.9/webbroker-apis/{id}/api-keys \
+curl -X GET http://localhost:9090/api/management/v1alpha2/webbroker-apis/{id}/api-keys \
   -u {username}:{password} \
   -H 'Accept: application/json'
 
@@ -715,7 +715,7 @@ Required roles: `admin`, `consumer`
 
 ```shell
 
-curl -X POST http://localhost:9090/api/management/v0.9/webbroker-apis/{id}/api-keys/{apiKeyName}/regenerate \
+curl -X POST http://localhost:9090/api/management/v1alpha2/webbroker-apis/{id}/api-keys/{apiKeyName}/regenerate \
   -u {username}:{password} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
@@ -790,7 +790,7 @@ Required roles: `admin`, `consumer`
 
 ```shell
 
-curl -X PUT http://localhost:9090/api/management/v0.9/webbroker-apis/{id}/api-keys/{apiKeyName} \
+curl -X PUT http://localhost:9090/api/management/v1alpha2/webbroker-apis/{id}/api-keys/{apiKeyName} \
   -u {username}:{password} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
@@ -870,7 +870,7 @@ Required roles: `admin`, `consumer`
 
 ```shell
 
-curl -X DELETE http://localhost:9090/api/management/v0.9/webbroker-apis/{id}/api-keys/{apiKeyName} \
+curl -X DELETE http://localhost:9090/api/management/v1alpha2/webbroker-apis/{id}/api-keys/{apiKeyName} \
   -u {username}:{password} \
   -H 'Accept: application/json'
 

--- a/docs/rest-apis/gateway/websub-api-management.md
+++ b/docs/rest-apis/gateway/websub-api-management.md
@@ -10,7 +10,7 @@
 
 ```shell
 
-curl -X POST http://localhost:9090/api/management/v0.9/websub-apis \
+curl -X POST http://localhost:9090/api/management/v1alpha2/websub-apis \
   -u {username}:{password} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
@@ -24,7 +24,7 @@ Add a new WebSubAPI to the Gateway.
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "WebSubApi",
   "metadata": {
     "name": "github-events-v1.0"
@@ -68,7 +68,7 @@ Required roles: `admin`, `developer`
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "WebSubApi",
   "metadata": {
     "name": "github-events-v1.0"
@@ -117,7 +117,7 @@ Required roles: `admin`, `developer`
 
 ```shell
 
-curl -X GET http://localhost:9090/api/management/v0.9/websub-apis \
+curl -X GET http://localhost:9090/api/management/v1alpha2/websub-apis \
   -u {username}:{password} \
   -H 'Accept: application/json'
 
@@ -160,7 +160,7 @@ Required roles: `admin`, `developer`
   "count": 5,
   "apis": [
     {
-      "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+      "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
       "kind": "WebSubApi",
       "metadata": {
         "name": "github-events-v1.0"
@@ -263,7 +263,7 @@ Status Code **200**
 
 |Property|Value|
 |---|---|
-|apiVersion|gateway.api-platform.wso2.com/v1alpha1|
+|apiVersion|gateway.api-platform.wso2.com/v1alpha2|
 |kind|WebSubApi|
 |deploymentState|deployed|
 |deploymentState|undeployed|
@@ -280,7 +280,7 @@ Status Code **200**
 
 ```shell
 
-curl -X POST http://localhost:9090/api/management/v0.9/websub-apis/{id}/api-keys \
+curl -X POST http://localhost:9090/api/management/v1alpha2/websub-apis/{id}/api-keys \
   -u {username}:{password} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
@@ -357,7 +357,7 @@ Required roles: `admin`, `consumer`
 
 ```shell
 
-curl -X GET http://localhost:9090/api/management/v0.9/websub-apis/{id}/api-keys \
+curl -X GET http://localhost:9090/api/management/v1alpha2/websub-apis/{id}/api-keys \
   -u {username}:{password} \
   -H 'Accept: application/json'
 
@@ -422,7 +422,7 @@ Required roles: `admin`, `consumer`
 
 ```shell
 
-curl -X POST http://localhost:9090/api/management/v0.9/websub-apis/{id}/api-keys/{apiKeyName}/regenerate \
+curl -X POST http://localhost:9090/api/management/v1alpha2/websub-apis/{id}/api-keys/{apiKeyName}/regenerate \
   -u {username}:{password} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
@@ -497,7 +497,7 @@ Required roles: `admin`, `consumer`
 
 ```shell
 
-curl -X PUT http://localhost:9090/api/management/v0.9/websub-apis/{id}/api-keys/{apiKeyName} \
+curl -X PUT http://localhost:9090/api/management/v1alpha2/websub-apis/{id}/api-keys/{apiKeyName} \
   -u {username}:{password} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
@@ -575,7 +575,7 @@ Required roles: `admin`, `consumer`
 
 ```shell
 
-curl -X DELETE http://localhost:9090/api/management/v0.9/websub-apis/{id}/api-keys/{apiKeyName} \
+curl -X DELETE http://localhost:9090/api/management/v1alpha2/websub-apis/{id}/api-keys/{apiKeyName} \
   -u {username}:{password} \
   -H 'Accept: application/json'
 
@@ -629,7 +629,7 @@ Required roles: `admin`, `consumer`
 
 ```shell
 
-curl -X GET http://localhost:9090/api/management/v0.9/websub-apis/{id} \
+curl -X GET http://localhost:9090/api/management/v1alpha2/websub-apis/{id} \
   -u {username}:{password} \
   -H 'Accept: application/json'
 
@@ -662,7 +662,7 @@ Required roles: `admin`, `developer`
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "WebSubApi",
   "metadata": {
     "name": "github-events-v1.0"
@@ -710,7 +710,7 @@ Required roles: `admin`, `developer`
 
 ```shell
 
-curl -X PUT http://localhost:9090/api/management/v0.9/websub-apis/{id} \
+curl -X PUT http://localhost:9090/api/management/v1alpha2/websub-apis/{id} \
   -u {username}:{password} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
@@ -724,7 +724,7 @@ Update an existing WebSubAPI in the Gateway.
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "WebSubApi",
   "metadata": {
     "name": "github-events-v1.0"
@@ -773,7 +773,7 @@ Required roles: `admin`, `developer`
 
 ```json
 {
-  "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+  "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "WebSubApi",
   "metadata": {
     "name": "github-events-v1.0"
@@ -822,7 +822,7 @@ Required roles: `admin`, `developer`
 
 ```shell
 
-curl -X DELETE http://localhost:9090/api/management/v0.9/websub-apis/{id} \
+curl -X DELETE http://localhost:9090/api/management/v1alpha2/websub-apis/{id} \
   -u {username}:{password} \
   -H 'Accept: application/json'
 

--- a/event-gateway/it/features/webbroker-api-management.feature
+++ b/event-gateway/it/features/webbroker-api-management.feature
@@ -31,7 +31,7 @@ Feature: WebBroker API Management
     When I create a WebBroker API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
         "kind": "WebBrokerApi",
         "metadata": { "name": "wb-create-test-v1.0" },
         "spec": {
@@ -76,7 +76,7 @@ Feature: WebBroker API Management
     When I create a WebBroker API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
         "kind": "WebBrokerApi",
         "metadata": { "name": "wb-auth-test-v1.0" },
         "spec": {
@@ -127,7 +127,7 @@ Feature: WebBroker API Management
     When I create a WebBroker API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
         "kind": "WebBrokerApi",
         "metadata": { "name": "wb-list-test-v1.0" },
         "spec": {
@@ -173,7 +173,7 @@ Feature: WebBroker API Management
     When I create a WebBroker API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
         "kind": "WebBrokerApi",
         "metadata": { "name": "wb-get-test-v1.0" },
         "spec": {
@@ -225,7 +225,7 @@ Feature: WebBroker API Management
     When I create a WebBroker API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
         "kind": "WebBrokerApi",
         "metadata": { "name": "wb-delete-test-v1.0" },
         "spec": {

--- a/event-gateway/it/features/webbroker-api-management.feature
+++ b/event-gateway/it/features/webbroker-api-management.feature
@@ -31,7 +31,7 @@ Feature: WebBroker API Management
     When I create a WebBroker API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
         "kind": "WebBrokerApi",
         "metadata": { "name": "wb-create-test-v1.0" },
         "spec": {
@@ -76,7 +76,7 @@ Feature: WebBroker API Management
     When I create a WebBroker API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
         "kind": "WebBrokerApi",
         "metadata": { "name": "wb-auth-test-v1.0" },
         "spec": {
@@ -127,7 +127,7 @@ Feature: WebBroker API Management
     When I create a WebBroker API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
         "kind": "WebBrokerApi",
         "metadata": { "name": "wb-list-test-v1.0" },
         "spec": {
@@ -173,7 +173,7 @@ Feature: WebBroker API Management
     When I create a WebBroker API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
         "kind": "WebBrokerApi",
         "metadata": { "name": "wb-get-test-v1.0" },
         "spec": {
@@ -225,7 +225,7 @@ Feature: WebBroker API Management
     When I create a WebBroker API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
         "kind": "WebBrokerApi",
         "metadata": { "name": "wb-delete-test-v1.0" },
         "spec": {

--- a/event-gateway/it/features/webbroker-e2e.feature
+++ b/event-gateway/it/features/webbroker-e2e.feature
@@ -38,7 +38,7 @@ Feature: WebBroker End-to-End Flow
     When I create a WebBroker API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
         "kind": "WebBrokerApi",
         "metadata": { "name": "stock-trading-conn-v1.0" },
         "spec": {
@@ -91,7 +91,7 @@ Feature: WebBroker End-to-End Flow
     When I create a WebBroker API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
         "kind": "WebBrokerApi",
         "metadata": { "name": "stock-trading-echo-v1.0" },
         "spec": {
@@ -148,7 +148,7 @@ Feature: WebBroker End-to-End Flow
     When I create a WebBroker API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
         "kind": "WebBrokerApi",
         "metadata": { "name": "stock-trading-pprod-v1.0" },
         "spec": {
@@ -203,7 +203,7 @@ Feature: WebBroker End-to-End Flow
     When I create a WebBroker API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
         "kind": "WebBrokerApi",
         "metadata": { "name": "stock-trading-pcons-v1.0" },
         "spec": {
@@ -261,7 +261,7 @@ Feature: WebBroker End-to-End Flow
     When I create a WebBroker API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
         "kind": "WebBrokerApi",
         "metadata": { "name": "stock-trading-auth-rej-v1.0" },
         "spec": {
@@ -315,7 +315,7 @@ Feature: WebBroker End-to-End Flow
     When I create a WebBroker API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
         "kind": "WebBrokerApi",
         "metadata": { "name": "stock-trading-auth-ok-v1.0" },
         "spec": {

--- a/event-gateway/it/features/webbroker-e2e.feature
+++ b/event-gateway/it/features/webbroker-e2e.feature
@@ -38,7 +38,7 @@ Feature: WebBroker End-to-End Flow
     When I create a WebBroker API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
         "kind": "WebBrokerApi",
         "metadata": { "name": "stock-trading-conn-v1.0" },
         "spec": {
@@ -91,7 +91,7 @@ Feature: WebBroker End-to-End Flow
     When I create a WebBroker API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
         "kind": "WebBrokerApi",
         "metadata": { "name": "stock-trading-echo-v1.0" },
         "spec": {
@@ -148,7 +148,7 @@ Feature: WebBroker End-to-End Flow
     When I create a WebBroker API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
         "kind": "WebBrokerApi",
         "metadata": { "name": "stock-trading-pprod-v1.0" },
         "spec": {
@@ -203,7 +203,7 @@ Feature: WebBroker End-to-End Flow
     When I create a WebBroker API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
         "kind": "WebBrokerApi",
         "metadata": { "name": "stock-trading-pcons-v1.0" },
         "spec": {
@@ -261,7 +261,7 @@ Feature: WebBroker End-to-End Flow
     When I create a WebBroker API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
         "kind": "WebBrokerApi",
         "metadata": { "name": "stock-trading-auth-rej-v1.0" },
         "spec": {
@@ -315,7 +315,7 @@ Feature: WebBroker End-to-End Flow
     When I create a WebBroker API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
         "kind": "WebBrokerApi",
         "metadata": { "name": "stock-trading-auth-ok-v1.0" },
         "spec": {

--- a/event-gateway/it/features/websub-api-management.feature
+++ b/event-gateway/it/features/websub-api-management.feature
@@ -31,7 +31,7 @@ Feature: WebSub API Management
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
         "kind": "WebSubApi",
         "metadata": {
           "name": "repo-watcher-v1-0"
@@ -62,7 +62,7 @@ Feature: WebSub API Management
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
         "kind": "WebSubApi",
         "metadata": {
           "name": "secure-events-v1-0"
@@ -107,7 +107,7 @@ Feature: WebSub API Management
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
         "kind": "WebSubApi",
         "metadata": { "name": "list-test-v1-0" },
         "spec": {
@@ -137,7 +137,7 @@ Feature: WebSub API Management
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
         "kind": "WebSubApi",
         "metadata": { "name": "get-test-v1-0" },
         "spec": {
@@ -174,7 +174,7 @@ Feature: WebSub API Management
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
         "kind": "WebSubApi",
         "metadata": { "name": "update-test-v1-0" },
         "spec": {
@@ -192,7 +192,7 @@ Feature: WebSub API Management
     When I update the WebSub API "update-test-v1-0" with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
         "kind": "WebSubApi",
         "metadata": { "name": "update-test-v1-0" },
         "spec": {
@@ -228,7 +228,7 @@ Feature: WebSub API Management
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
         "kind": "WebSubApi",
         "metadata": { "name": "delete-test-v1-0" },
         "spec": {

--- a/event-gateway/it/features/websub-api-management.feature
+++ b/event-gateway/it/features/websub-api-management.feature
@@ -31,7 +31,7 @@ Feature: WebSub API Management
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
         "kind": "WebSubApi",
         "metadata": {
           "name": "repo-watcher-v1-0"
@@ -62,7 +62,7 @@ Feature: WebSub API Management
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
         "kind": "WebSubApi",
         "metadata": {
           "name": "secure-events-v1-0"
@@ -107,7 +107,7 @@ Feature: WebSub API Management
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
         "kind": "WebSubApi",
         "metadata": { "name": "list-test-v1-0" },
         "spec": {
@@ -137,7 +137,7 @@ Feature: WebSub API Management
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
         "kind": "WebSubApi",
         "metadata": { "name": "get-test-v1-0" },
         "spec": {
@@ -174,7 +174,7 @@ Feature: WebSub API Management
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
         "kind": "WebSubApi",
         "metadata": { "name": "update-test-v1-0" },
         "spec": {
@@ -192,7 +192,7 @@ Feature: WebSub API Management
     When I update the WebSub API "update-test-v1-0" with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
         "kind": "WebSubApi",
         "metadata": { "name": "update-test-v1-0" },
         "spec": {
@@ -228,7 +228,7 @@ Feature: WebSub API Management
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
         "kind": "WebSubApi",
         "metadata": { "name": "delete-test-v1-0" },
         "spec": {

--- a/event-gateway/it/features/websub-e2e.feature
+++ b/event-gateway/it/features/websub-e2e.feature
@@ -31,7 +31,7 @@ Feature: WebSub End-to-End Flow
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
         "kind": "WebSubApi",
         "metadata": { "name": "e2e-subscribe-v1-0" },
         "spec": {
@@ -59,7 +59,7 @@ Feature: WebSub End-to-End Flow
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
         "kind": "WebSubApi",
         "metadata": { "name": "e2e-auth-v1-0" },
         "spec": {
@@ -99,7 +99,7 @@ Feature: WebSub End-to-End Flow
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
         "kind": "WebSubApi",
         "metadata": { "name": "e2e-unknown-topic-v1-0" },
         "spec": {
@@ -129,7 +129,7 @@ Feature: WebSub End-to-End Flow
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
         "kind": "WebSubApi",
         "metadata": { "name": "e2e-publish-v1-0" },
         "spec": {
@@ -157,7 +157,7 @@ Feature: WebSub End-to-End Flow
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
         "kind": "WebSubApi",
         "metadata": { "name": "e2e-bad-topic-v1-0" },
         "spec": {
@@ -188,7 +188,7 @@ Feature: WebSub End-to-End Flow
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
         "kind": "WebSubApi",
         "metadata": { "name": "e2e-full-v1-0" },
         "spec": {
@@ -235,7 +235,7 @@ Feature: WebSub End-to-End Flow
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
         "kind": "WebSubApi",
         "metadata": { "name": "e2e-unsub-v1-0" },
         "spec": {

--- a/event-gateway/it/features/websub-e2e.feature
+++ b/event-gateway/it/features/websub-e2e.feature
@@ -31,7 +31,7 @@ Feature: WebSub End-to-End Flow
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
         "kind": "WebSubApi",
         "metadata": { "name": "e2e-subscribe-v1-0" },
         "spec": {
@@ -59,7 +59,7 @@ Feature: WebSub End-to-End Flow
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
         "kind": "WebSubApi",
         "metadata": { "name": "e2e-auth-v1-0" },
         "spec": {
@@ -99,7 +99,7 @@ Feature: WebSub End-to-End Flow
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
         "kind": "WebSubApi",
         "metadata": { "name": "e2e-unknown-topic-v1-0" },
         "spec": {
@@ -129,7 +129,7 @@ Feature: WebSub End-to-End Flow
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
         "kind": "WebSubApi",
         "metadata": { "name": "e2e-publish-v1-0" },
         "spec": {
@@ -157,7 +157,7 @@ Feature: WebSub End-to-End Flow
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
         "kind": "WebSubApi",
         "metadata": { "name": "e2e-bad-topic-v1-0" },
         "spec": {
@@ -188,7 +188,7 @@ Feature: WebSub End-to-End Flow
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
         "kind": "WebSubApi",
         "metadata": { "name": "e2e-full-v1-0" },
         "spec": {
@@ -235,7 +235,7 @@ Feature: WebSub End-to-End Flow
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
         "kind": "WebSubApi",
         "metadata": { "name": "e2e-unsub-v1-0" },
         "spec": {

--- a/event-gateway/it/features/websub-webhook-secrets.feature
+++ b/event-gateway/it/features/websub-webhook-secrets.feature
@@ -31,7 +31,7 @@ Feature: WebSub API Webhook Secret Management
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
         "kind": "WebSubApi",
         "metadata": { "name": "secret-create-v1-0" },
         "spec": {
@@ -65,7 +65,7 @@ Feature: WebSub API Webhook Secret Management
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
         "kind": "WebSubApi",
         "metadata": { "name": "secret-list-v1-0" },
         "spec": {
@@ -102,7 +102,7 @@ Feature: WebSub API Webhook Secret Management
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
         "kind": "WebSubApi",
         "metadata": { "name": "secret-regen-v1-0" },
         "spec": {
@@ -139,7 +139,7 @@ Feature: WebSub API Webhook Secret Management
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
         "kind": "WebSubApi",
         "metadata": { "name": "secret-del-v1-0" },
         "spec": {
@@ -183,7 +183,7 @@ Feature: WebSub API Webhook Secret Management
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
         "kind": "WebSubApi",
         "metadata": { "name": "secret-dup-v1-0" },
         "spec": {
@@ -215,7 +215,7 @@ Feature: WebSub API Webhook Secret Management
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
         "kind": "WebSubApi",
         "metadata": { "name": "secret-regen-404-v1-0" },
         "spec": {
@@ -243,7 +243,7 @@ Feature: WebSub API Webhook Secret Management
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
         "kind": "WebSubApi",
         "metadata": { "name": "secret-del-404-v1-0" },
         "spec": {
@@ -273,7 +273,7 @@ Feature: WebSub API Webhook Secret Management
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
         "kind": "WebSubApi",
         "metadata": { "name": "hmac-valid-v1-0" },
         "spec": {
@@ -320,7 +320,7 @@ Feature: WebSub API Webhook Secret Management
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
         "kind": "WebSubApi",
         "metadata": { "name": "hmac-reject-v1-0" },
         "spec": {
@@ -367,7 +367,7 @@ Feature: WebSub API Webhook Secret Management
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
         "kind": "WebSubApi",
         "metadata": { "name": "hmac-regen-v1-0" },
         "spec": {
@@ -421,7 +421,7 @@ Feature: WebSub API Webhook Secret Management
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
         "kind": "WebSubApi",
         "metadata": { "name": "hmac-deleted-v1-0" },
         "spec": {

--- a/event-gateway/it/features/websub-webhook-secrets.feature
+++ b/event-gateway/it/features/websub-webhook-secrets.feature
@@ -31,7 +31,7 @@ Feature: WebSub API Webhook Secret Management
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
         "kind": "WebSubApi",
         "metadata": { "name": "secret-create-v1-0" },
         "spec": {
@@ -65,7 +65,7 @@ Feature: WebSub API Webhook Secret Management
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
         "kind": "WebSubApi",
         "metadata": { "name": "secret-list-v1-0" },
         "spec": {
@@ -102,7 +102,7 @@ Feature: WebSub API Webhook Secret Management
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
         "kind": "WebSubApi",
         "metadata": { "name": "secret-regen-v1-0" },
         "spec": {
@@ -139,7 +139,7 @@ Feature: WebSub API Webhook Secret Management
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
         "kind": "WebSubApi",
         "metadata": { "name": "secret-del-v1-0" },
         "spec": {
@@ -183,7 +183,7 @@ Feature: WebSub API Webhook Secret Management
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
         "kind": "WebSubApi",
         "metadata": { "name": "secret-dup-v1-0" },
         "spec": {
@@ -215,7 +215,7 @@ Feature: WebSub API Webhook Secret Management
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
         "kind": "WebSubApi",
         "metadata": { "name": "secret-regen-404-v1-0" },
         "spec": {
@@ -243,7 +243,7 @@ Feature: WebSub API Webhook Secret Management
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
         "kind": "WebSubApi",
         "metadata": { "name": "secret-del-404-v1-0" },
         "spec": {
@@ -273,7 +273,7 @@ Feature: WebSub API Webhook Secret Management
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
         "kind": "WebSubApi",
         "metadata": { "name": "hmac-valid-v1-0" },
         "spec": {
@@ -320,7 +320,7 @@ Feature: WebSub API Webhook Secret Management
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
         "kind": "WebSubApi",
         "metadata": { "name": "hmac-reject-v1-0" },
         "spec": {
@@ -367,7 +367,7 @@ Feature: WebSub API Webhook Secret Management
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
         "kind": "WebSubApi",
         "metadata": { "name": "hmac-regen-v1-0" },
         "spec": {
@@ -421,7 +421,7 @@ Feature: WebSub API Webhook Secret Management
     When I create a WebSub API with the following configuration:
       """
       {
-        "apiVersion": "gateway.api-platform.wso2.com/v1alpha1",
+        "apiVersion": "gateway.api-platform.wso2.com/v1alpha2",
         "kind": "WebSubApi",
         "metadata": { "name": "hmac-deleted-v1-0" },
         "spec": {

--- a/event-gateway/it/state.go
+++ b/event-gateway/it/state.go
@@ -45,7 +45,7 @@ const (
 	WebhookListenerPort = "8090"
 
 	// GatewayManagementAPIBasePath is the base path for the management REST API.
-	GatewayManagementAPIBasePath = "/api/management/v1alpha2"
+	GatewayManagementAPIBasePath = "/api/management/v0.9"
 )
 
 // AuthUser holds credentials for a test user.

--- a/event-gateway/it/state.go
+++ b/event-gateway/it/state.go
@@ -45,7 +45,7 @@ const (
 	WebhookListenerPort = "8090"
 
 	// GatewayManagementAPIBasePath is the base path for the management REST API.
-	GatewayManagementAPIBasePath = "/api/management/v0.9"
+	GatewayManagementAPIBasePath = "/api/management/v1alpha2"
 )
 
 // AuthUser holds credentials for a test user.

--- a/event-gateway/spec/postman/Control Plane.postman_collection.json
+++ b/event-gateway/spec/postman/Control Plane.postman_collection.json
@@ -29,7 +29,7 @@
         "header": [],
         "body": {
           "mode": "raw",
-          "raw": "{\r\n    \"apiVersion\": \"gateway.api-platform.wso2.com/v1alpha2\",\r\n    \"kind\": \"WebSubApi\",\r\n    \"metadata\": {\r\n        \"name\": \"repo-watcher-v1-0\"\r\n    },\r\n    \"spec\": {\r\n        \"displayName\": \"repo-watcher\",\r\n        \"version\": \"v1.0\",\r\n        \"context\": \"/repos\",\r\n        \"allChannelPolicies\": {\r\n            \"on_subscription\": [\r\n                {\r\n                    \"name\": \"api-key-auth\",\r\n                    \"version\": \"v1\",\r\n                    \"params\": {\r\n                        \"in\": \"header\",\r\n                        \"name\": \"X-API-Key\"\r\n                    }\r\n                }\r\n            ],\r\n            \"on_unsubscription\": [\r\n                {\r\n                    \"name\": \"api-key-auth\",\r\n                    \"version\": \"v1\",\r\n                    \"params\": {\r\n                        \"in\": \"header\",\r\n                        \"name\": \"X-API-Key\"\r\n                    }\r\n                }\r\n            ],\r\n            \"on_message_received\": [\r\n                {\r\n                    \"name\": \"hmac-signature-validation\",\r\n                    \"version\": \"v1\",\r\n                    \"params\": {\r\n                        \"header\": \"X-Hub-Signature-256\",\r\n                        \"secret\": \"your-publisher-webhook-secret\",\r\n                        \"algorithm\": \"sha256\"\r\n                    }\r\n                }\r\n            ],\r\n            \"on_message_delivery\": [\r\n                {\r\n                    \"name\": \"hmac-sign-messages\",\r\n                    \"version\": \"v1\",\r\n                    \"params\": {\r\n                        \"header\": \"X-Hub-Signature-256\",\r\n                        \"secret\": \"your-publisher-webhook-secret\",\r\n                        \"algorithm\": \"sha256\"\r\n                    }\r\n                }\r\n            ]\r\n        },\r\n        \"channelPolicies\": {\r\n            \"issues\": {\r\n                \"on_subscription\": [\r\n                    {\r\n                        \"name\": \"rbac\",\r\n                        \"version\": \"v1\",\r\n                        \"params\": {\r\n                            \"allowedRoles\": [\r\n                                \"admin\",\r\n                                \"issue-manager\"\r\n                            ]\r\n                        }\r\n                    }\r\n                ],\r\n                \"on_message_received\": [],\r\n                \"on_message_delivery\": []\r\n            },\r\n            \"pull-requests\": {\r\n                \"on_subscription\": [\r\n                    {\r\n                        \"name\": \"rbac\",\r\n                        \"version\": \"v1\",\r\n                        \"params\": {\r\n                            \"allowedRoles\": [\r\n                                \"admin\",\r\n                                \"developer\"\r\n                            ]\r\n                        }\r\n                    }\r\n                ],\r\n                \"on_message_received\": [],\r\n                \"on_message_delivery\": []\r\n            }\r\n        },\r\n        \"deploymentState\": \"deployed\"\r\n    }\r\n}\r\n",
+          "raw": "{\r\n    \"apiVersion\": \"gateway.api-platform.wso2.com/v1alpha1\",\r\n    \"kind\": \"WebSubApi\",\r\n    \"metadata\": {\r\n        \"name\": \"repo-watcher-v1-0\"\r\n    },\r\n    \"spec\": {\r\n        \"displayName\": \"repo-watcher\",\r\n        \"version\": \"v1.0\",\r\n        \"context\": \"/repos\",\r\n        \"allChannelPolicies\": {\r\n            \"on_subscription\": [\r\n                {\r\n                    \"name\": \"api-key-auth\",\r\n                    \"version\": \"v1\",\r\n                    \"params\": {\r\n                        \"in\": \"header\",\r\n                        \"name\": \"X-API-Key\"\r\n                    }\r\n                }\r\n            ],\r\n            \"on_unsubscription\": [\r\n                {\r\n                    \"name\": \"api-key-auth\",\r\n                    \"version\": \"v1\",\r\n                    \"params\": {\r\n                        \"in\": \"header\",\r\n                        \"name\": \"X-API-Key\"\r\n                    }\r\n                }\r\n            ],\r\n            \"on_message_received\": [\r\n                {\r\n                    \"name\": \"hmac-signature-validation\",\r\n                    \"version\": \"v1\",\r\n                    \"params\": {\r\n                        \"header\": \"X-Hub-Signature-256\",\r\n                        \"secret\": \"your-publisher-webhook-secret\",\r\n                        \"algorithm\": \"sha256\"\r\n                    }\r\n                }\r\n            ],\r\n            \"on_message_delivery\": [\r\n                {\r\n                    \"name\": \"hmac-sign-messages\",\r\n                    \"version\": \"v1\",\r\n                    \"params\": {\r\n                        \"header\": \"X-Hub-Signature-256\",\r\n                        \"secret\": \"your-publisher-webhook-secret\",\r\n                        \"algorithm\": \"sha256\"\r\n                    }\r\n                }\r\n            ]\r\n        },\r\n        \"channelPolicies\": {\r\n            \"issues\": {\r\n                \"on_subscription\": [\r\n                    {\r\n                        \"name\": \"rbac\",\r\n                        \"version\": \"v1\",\r\n                        \"params\": {\r\n                            \"allowedRoles\": [\r\n                                \"admin\",\r\n                                \"issue-manager\"\r\n                            ]\r\n                        }\r\n                    }\r\n                ],\r\n                \"on_message_received\": [],\r\n                \"on_message_delivery\": []\r\n            },\r\n            \"pull-requests\": {\r\n                \"on_subscription\": [\r\n                    {\r\n                        \"name\": \"rbac\",\r\n                        \"version\": \"v1\",\r\n                        \"params\": {\r\n                            \"allowedRoles\": [\r\n                                \"admin\",\r\n                                \"developer\"\r\n                            ]\r\n                        }\r\n                    }\r\n                ],\r\n                \"on_message_received\": [],\r\n                \"on_message_delivery\": []\r\n            }\r\n        },\r\n        \"deploymentState\": \"deployed\"\r\n    }\r\n}\r\n",
           "options": {
             "raw": {
               "language": "json"
@@ -37,7 +37,7 @@
           }
         },
         "url": {
-          "raw": "http://{{host}}/api/management/v1alpha2/websub-apis",
+          "raw": "http://{{host}}/api/management/v0.9/websub-apis",
           "protocol": "http",
           "host": [
             "{{host}}"
@@ -45,7 +45,7 @@
           "path": [
             "api",
             "management",
-            "v1alpha2",
+            "v0.9",
             "websub-apis"
           ]
         }
@@ -73,7 +73,7 @@
         "method": "GET",
         "header": [],
         "url": {
-          "raw": "http://{{host}}/api/management/v1alpha2/websub-apis/repo-watcher-v1-0",
+          "raw": "http://{{host}}/api/management/v0.9/websub-apis/repo-watcher-v1-0",
           "protocol": "http",
           "host": [
             "{{host}}"
@@ -81,7 +81,7 @@
           "path": [
             "api",
             "management",
-            "v1alpha2",
+            "v0.9",
             "websub-apis",
             "repo-watcher-v1-0"
           ]
@@ -111,7 +111,7 @@
         "header": [],
         "body": {
           "mode": "raw",
-          "raw": "{\r\n    \"apiVersion\": \"gateway.api-platform.wso2.com/v1alpha2\",\r\n    \"kind\": \"WebSubApi\",\r\n    \"metadata\": {\r\n        \"name\": \"repo-watcher-v1-0\"\r\n    },\r\n    \"spec\": {\r\n        \"displayName\": \"repo-watcher\",\r\n        \"version\": \"v1.0\",\r\n        \"context\": \"/repos\",\r\n        \"receiver\": {\r\n            \"policies\": [\r\n                {\r\n                    \"name\": \"hmac-signature-validation\",\r\n                    \"version\": \"v1\",\r\n                    \"params\": {\r\n                        \"header\": \"X-Hub-Signature-256\",\r\n                        \"secret\": \"your-publisher-webhook-secret\",\r\n                        \"algorithm\": \"sha256\"\r\n                    }\r\n                }\r\n            ]\r\n        },\r\n        \"hub\": {\r\n            \"policies\": [\r\n                {\r\n                    \"name\": \"api-key-auth\",\r\n                    \"version\": \"v1\",\r\n                    \"params\": {\r\n                        \"in\": \"header\",\r\n                        \"name\": \"X-API-Key\"\r\n                    }\r\n                }\r\n            ],\r\n            \"channels\": [\r\n                {\r\n                    \"name\": \"issues\",\r\n                    \"policies\": [\r\n                        {\r\n                            \"name\": \"rbac\",\r\n                            \"version\": \"v1\",\r\n                            \"params\": {\r\n                                \"allowedRoles\": [\r\n                                    \"admin\",\r\n                                    \"issue-manager\"\r\n                                ]\r\n                            }\r\n                        }\r\n                    ]\r\n                },\r\n                {\r\n                    \"name\": \"pull-requests\",\r\n                    \"policies\": [\r\n                        {\r\n                            \"name\": \"rbac\",\r\n                            \"version\": \"v1\",\r\n                            \"params\": {\r\n                                \"allowedRoles\": [\r\n                                    \"admin\",\r\n                                    \"developer\"\r\n                                ]\r\n                            }\r\n                        }\r\n                    ]\r\n                },\r\n                {\r\n                    \"name\": \"releases\",\r\n                    \"policies\": [\r\n                        {\r\n                            \"name\": \"rbac\",\r\n                            \"version\": \"v1\",\r\n                            \"params\": {\r\n                                \"allowedRoles\": [\r\n                                    \"admin\"\r\n                                ]\r\n                            }\r\n                        }\r\n                    ]\r\n                }\r\n            ]\r\n        },\r\n        \"deploymentState\": \"deployed\"\r\n    }\r\n}\r\n",
+          "raw": "{\r\n    \"apiVersion\": \"gateway.api-platform.wso2.com/v1alpha1\",\r\n    \"kind\": \"WebSubApi\",\r\n    \"metadata\": {\r\n        \"name\": \"repo-watcher-v1-0\"\r\n    },\r\n    \"spec\": {\r\n        \"displayName\": \"repo-watcher\",\r\n        \"version\": \"v1.0\",\r\n        \"context\": \"/repos\",\r\n        \"receiver\": {\r\n            \"policies\": [\r\n                {\r\n                    \"name\": \"hmac-signature-validation\",\r\n                    \"version\": \"v1\",\r\n                    \"params\": {\r\n                        \"header\": \"X-Hub-Signature-256\",\r\n                        \"secret\": \"your-publisher-webhook-secret\",\r\n                        \"algorithm\": \"sha256\"\r\n                    }\r\n                }\r\n            ]\r\n        },\r\n        \"hub\": {\r\n            \"policies\": [\r\n                {\r\n                    \"name\": \"api-key-auth\",\r\n                    \"version\": \"v1\",\r\n                    \"params\": {\r\n                        \"in\": \"header\",\r\n                        \"name\": \"X-API-Key\"\r\n                    }\r\n                }\r\n            ],\r\n            \"channels\": [\r\n                {\r\n                    \"name\": \"issues\",\r\n                    \"policies\": [\r\n                        {\r\n                            \"name\": \"rbac\",\r\n                            \"version\": \"v1\",\r\n                            \"params\": {\r\n                                \"allowedRoles\": [\r\n                                    \"admin\",\r\n                                    \"issue-manager\"\r\n                                ]\r\n                            }\r\n                        }\r\n                    ]\r\n                },\r\n                {\r\n                    \"name\": \"pull-requests\",\r\n                    \"policies\": [\r\n                        {\r\n                            \"name\": \"rbac\",\r\n                            \"version\": \"v1\",\r\n                            \"params\": {\r\n                                \"allowedRoles\": [\r\n                                    \"admin\",\r\n                                    \"developer\"\r\n                                ]\r\n                            }\r\n                        }\r\n                    ]\r\n                },\r\n                {\r\n                    \"name\": \"releases\",\r\n                    \"policies\": [\r\n                        {\r\n                            \"name\": \"rbac\",\r\n                            \"version\": \"v1\",\r\n                            \"params\": {\r\n                                \"allowedRoles\": [\r\n                                    \"admin\"\r\n                                ]\r\n                            }\r\n                        }\r\n                    ]\r\n                }\r\n            ]\r\n        },\r\n        \"deploymentState\": \"deployed\"\r\n    }\r\n}\r\n",
           "options": {
             "raw": {
               "language": "json"
@@ -119,7 +119,7 @@
           }
         },
         "url": {
-          "raw": "http://{{host}}/api/management/v1alpha2/websub-apis/repo-watcher-v1-0",
+          "raw": "http://{{host}}/api/management/v0.9/websub-apis/repo-watcher-v1-0",
           "protocol": "http",
           "host": [
             "{{host}}"
@@ -127,7 +127,7 @@
           "path": [
             "api",
             "management",
-            "v1alpha2",
+            "v0.9",
             "websub-apis",
             "repo-watcher-v1-0"
           ]
@@ -156,7 +156,7 @@
         "method": "DELETE",
         "header": [],
         "url": {
-          "raw": "http://{{host}}/api/management/v1alpha2/websub-apis/repo-watcher-v1-0",
+          "raw": "http://{{host}}/api/management/v0.9/websub-apis/repo-watcher-v1-0",
           "protocol": "http",
           "host": [
             "{{host}}"
@@ -164,7 +164,7 @@
           "path": [
             "api",
             "management",
-            "v1alpha2",
+            "v0.9",
             "websub-apis",
             "repo-watcher-v1-0"
           ]
@@ -193,7 +193,7 @@
         "method": "GET",
         "header": [],
         "url": {
-          "raw": "http://{{host}}/api/management/v1alpha2/websub-apis",
+          "raw": "http://{{host}}/api/management/v0.9/websub-apis",
           "protocol": "http",
           "host": [
             "{{host}}"
@@ -201,7 +201,7 @@
           "path": [
             "api",
             "management",
-            "v1alpha2",
+            "v0.9",
             "websub-apis"
           ]
         }

--- a/event-gateway/spec/postman/Control Plane.postman_collection.json
+++ b/event-gateway/spec/postman/Control Plane.postman_collection.json
@@ -29,7 +29,7 @@
         "header": [],
         "body": {
           "mode": "raw",
-          "raw": "{\r\n    \"apiVersion\": \"gateway.api-platform.wso2.com/v1alpha1\",\r\n    \"kind\": \"WebSubApi\",\r\n    \"metadata\": {\r\n        \"name\": \"repo-watcher-v1-0\"\r\n    },\r\n    \"spec\": {\r\n        \"displayName\": \"repo-watcher\",\r\n        \"version\": \"v1.0\",\r\n        \"context\": \"/repos\",\r\n        \"allChannelPolicies\": {\r\n            \"on_subscription\": [\r\n                {\r\n                    \"name\": \"api-key-auth\",\r\n                    \"version\": \"v1\",\r\n                    \"params\": {\r\n                        \"in\": \"header\",\r\n                        \"name\": \"X-API-Key\"\r\n                    }\r\n                }\r\n            ],\r\n            \"on_unsubscription\": [\r\n                {\r\n                    \"name\": \"api-key-auth\",\r\n                    \"version\": \"v1\",\r\n                    \"params\": {\r\n                        \"in\": \"header\",\r\n                        \"name\": \"X-API-Key\"\r\n                    }\r\n                }\r\n            ],\r\n            \"on_message_received\": [\r\n                {\r\n                    \"name\": \"hmac-signature-validation\",\r\n                    \"version\": \"v1\",\r\n                    \"params\": {\r\n                        \"header\": \"X-Hub-Signature-256\",\r\n                        \"secret\": \"your-publisher-webhook-secret\",\r\n                        \"algorithm\": \"sha256\"\r\n                    }\r\n                }\r\n            ],\r\n            \"on_message_delivery\": [\r\n                {\r\n                    \"name\": \"hmac-sign-messages\",\r\n                    \"version\": \"v1\",\r\n                    \"params\": {\r\n                        \"header\": \"X-Hub-Signature-256\",\r\n                        \"secret\": \"your-publisher-webhook-secret\",\r\n                        \"algorithm\": \"sha256\"\r\n                    }\r\n                }\r\n            ]\r\n        },\r\n        \"channelPolicies\": {\r\n            \"issues\": {\r\n                \"on_subscription\": [\r\n                    {\r\n                        \"name\": \"rbac\",\r\n                        \"version\": \"v1\",\r\n                        \"params\": {\r\n                            \"allowedRoles\": [\r\n                                \"admin\",\r\n                                \"issue-manager\"\r\n                            ]\r\n                        }\r\n                    }\r\n                ],\r\n                \"on_message_received\": [],\r\n                \"on_message_delivery\": []\r\n            },\r\n            \"pull-requests\": {\r\n                \"on_subscription\": [\r\n                    {\r\n                        \"name\": \"rbac\",\r\n                        \"version\": \"v1\",\r\n                        \"params\": {\r\n                            \"allowedRoles\": [\r\n                                \"admin\",\r\n                                \"developer\"\r\n                            ]\r\n                        }\r\n                    }\r\n                ],\r\n                \"on_message_received\": [],\r\n                \"on_message_delivery\": []\r\n            }\r\n        },\r\n        \"deploymentState\": \"deployed\"\r\n    }\r\n}\r\n",
+          "raw": "{\r\n    \"apiVersion\": \"gateway.api-platform.wso2.com/v1alpha2\",\r\n    \"kind\": \"WebSubApi\",\r\n    \"metadata\": {\r\n        \"name\": \"repo-watcher-v1-0\"\r\n    },\r\n    \"spec\": {\r\n        \"displayName\": \"repo-watcher\",\r\n        \"version\": \"v1.0\",\r\n        \"context\": \"/repos\",\r\n        \"allChannelPolicies\": {\r\n            \"on_subscription\": [\r\n                {\r\n                    \"name\": \"api-key-auth\",\r\n                    \"version\": \"v1\",\r\n                    \"params\": {\r\n                        \"in\": \"header\",\r\n                        \"name\": \"X-API-Key\"\r\n                    }\r\n                }\r\n            ],\r\n            \"on_unsubscription\": [\r\n                {\r\n                    \"name\": \"api-key-auth\",\r\n                    \"version\": \"v1\",\r\n                    \"params\": {\r\n                        \"in\": \"header\",\r\n                        \"name\": \"X-API-Key\"\r\n                    }\r\n                }\r\n            ],\r\n            \"on_message_received\": [\r\n                {\r\n                    \"name\": \"hmac-signature-validation\",\r\n                    \"version\": \"v1\",\r\n                    \"params\": {\r\n                        \"header\": \"X-Hub-Signature-256\",\r\n                        \"secret\": \"your-publisher-webhook-secret\",\r\n                        \"algorithm\": \"sha256\"\r\n                    }\r\n                }\r\n            ],\r\n            \"on_message_delivery\": [\r\n                {\r\n                    \"name\": \"hmac-sign-messages\",\r\n                    \"version\": \"v1\",\r\n                    \"params\": {\r\n                        \"header\": \"X-Hub-Signature-256\",\r\n                        \"secret\": \"your-publisher-webhook-secret\",\r\n                        \"algorithm\": \"sha256\"\r\n                    }\r\n                }\r\n            ]\r\n        },\r\n        \"channelPolicies\": {\r\n            \"issues\": {\r\n                \"on_subscription\": [\r\n                    {\r\n                        \"name\": \"rbac\",\r\n                        \"version\": \"v1\",\r\n                        \"params\": {\r\n                            \"allowedRoles\": [\r\n                                \"admin\",\r\n                                \"issue-manager\"\r\n                            ]\r\n                        }\r\n                    }\r\n                ],\r\n                \"on_message_received\": [],\r\n                \"on_message_delivery\": []\r\n            },\r\n            \"pull-requests\": {\r\n                \"on_subscription\": [\r\n                    {\r\n                        \"name\": \"rbac\",\r\n                        \"version\": \"v1\",\r\n                        \"params\": {\r\n                            \"allowedRoles\": [\r\n                                \"admin\",\r\n                                \"developer\"\r\n                            ]\r\n                        }\r\n                    }\r\n                ],\r\n                \"on_message_received\": [],\r\n                \"on_message_delivery\": []\r\n            }\r\n        },\r\n        \"deploymentState\": \"deployed\"\r\n    }\r\n}\r\n",
           "options": {
             "raw": {
               "language": "json"
@@ -37,7 +37,7 @@
           }
         },
         "url": {
-          "raw": "http://{{host}}/api/management/v0.9/websub-apis",
+          "raw": "http://{{host}}/api/management/v1alpha2/websub-apis",
           "protocol": "http",
           "host": [
             "{{host}}"
@@ -45,7 +45,7 @@
           "path": [
             "api",
             "management",
-            "v0.9",
+            "v1alpha2",
             "websub-apis"
           ]
         }
@@ -73,7 +73,7 @@
         "method": "GET",
         "header": [],
         "url": {
-          "raw": "http://{{host}}/api/management/v0.9/websub-apis/repo-watcher-v1-0",
+          "raw": "http://{{host}}/api/management/v1alpha2/websub-apis/repo-watcher-v1-0",
           "protocol": "http",
           "host": [
             "{{host}}"
@@ -81,7 +81,7 @@
           "path": [
             "api",
             "management",
-            "v0.9",
+            "v1alpha2",
             "websub-apis",
             "repo-watcher-v1-0"
           ]
@@ -111,7 +111,7 @@
         "header": [],
         "body": {
           "mode": "raw",
-          "raw": "{\r\n    \"apiVersion\": \"gateway.api-platform.wso2.com/v1alpha1\",\r\n    \"kind\": \"WebSubApi\",\r\n    \"metadata\": {\r\n        \"name\": \"repo-watcher-v1-0\"\r\n    },\r\n    \"spec\": {\r\n        \"displayName\": \"repo-watcher\",\r\n        \"version\": \"v1.0\",\r\n        \"context\": \"/repos\",\r\n        \"receiver\": {\r\n            \"policies\": [\r\n                {\r\n                    \"name\": \"hmac-signature-validation\",\r\n                    \"version\": \"v1\",\r\n                    \"params\": {\r\n                        \"header\": \"X-Hub-Signature-256\",\r\n                        \"secret\": \"your-publisher-webhook-secret\",\r\n                        \"algorithm\": \"sha256\"\r\n                    }\r\n                }\r\n            ]\r\n        },\r\n        \"hub\": {\r\n            \"policies\": [\r\n                {\r\n                    \"name\": \"api-key-auth\",\r\n                    \"version\": \"v1\",\r\n                    \"params\": {\r\n                        \"in\": \"header\",\r\n                        \"name\": \"X-API-Key\"\r\n                    }\r\n                }\r\n            ],\r\n            \"channels\": [\r\n                {\r\n                    \"name\": \"issues\",\r\n                    \"policies\": [\r\n                        {\r\n                            \"name\": \"rbac\",\r\n                            \"version\": \"v1\",\r\n                            \"params\": {\r\n                                \"allowedRoles\": [\r\n                                    \"admin\",\r\n                                    \"issue-manager\"\r\n                                ]\r\n                            }\r\n                        }\r\n                    ]\r\n                },\r\n                {\r\n                    \"name\": \"pull-requests\",\r\n                    \"policies\": [\r\n                        {\r\n                            \"name\": \"rbac\",\r\n                            \"version\": \"v1\",\r\n                            \"params\": {\r\n                                \"allowedRoles\": [\r\n                                    \"admin\",\r\n                                    \"developer\"\r\n                                ]\r\n                            }\r\n                        }\r\n                    ]\r\n                },\r\n                {\r\n                    \"name\": \"releases\",\r\n                    \"policies\": [\r\n                        {\r\n                            \"name\": \"rbac\",\r\n                            \"version\": \"v1\",\r\n                            \"params\": {\r\n                                \"allowedRoles\": [\r\n                                    \"admin\"\r\n                                ]\r\n                            }\r\n                        }\r\n                    ]\r\n                }\r\n            ]\r\n        },\r\n        \"deploymentState\": \"deployed\"\r\n    }\r\n}\r\n",
+          "raw": "{\r\n    \"apiVersion\": \"gateway.api-platform.wso2.com/v1alpha2\",\r\n    \"kind\": \"WebSubApi\",\r\n    \"metadata\": {\r\n        \"name\": \"repo-watcher-v1-0\"\r\n    },\r\n    \"spec\": {\r\n        \"displayName\": \"repo-watcher\",\r\n        \"version\": \"v1.0\",\r\n        \"context\": \"/repos\",\r\n        \"receiver\": {\r\n            \"policies\": [\r\n                {\r\n                    \"name\": \"hmac-signature-validation\",\r\n                    \"version\": \"v1\",\r\n                    \"params\": {\r\n                        \"header\": \"X-Hub-Signature-256\",\r\n                        \"secret\": \"your-publisher-webhook-secret\",\r\n                        \"algorithm\": \"sha256\"\r\n                    }\r\n                }\r\n            ]\r\n        },\r\n        \"hub\": {\r\n            \"policies\": [\r\n                {\r\n                    \"name\": \"api-key-auth\",\r\n                    \"version\": \"v1\",\r\n                    \"params\": {\r\n                        \"in\": \"header\",\r\n                        \"name\": \"X-API-Key\"\r\n                    }\r\n                }\r\n            ],\r\n            \"channels\": [\r\n                {\r\n                    \"name\": \"issues\",\r\n                    \"policies\": [\r\n                        {\r\n                            \"name\": \"rbac\",\r\n                            \"version\": \"v1\",\r\n                            \"params\": {\r\n                                \"allowedRoles\": [\r\n                                    \"admin\",\r\n                                    \"issue-manager\"\r\n                                ]\r\n                            }\r\n                        }\r\n                    ]\r\n                },\r\n                {\r\n                    \"name\": \"pull-requests\",\r\n                    \"policies\": [\r\n                        {\r\n                            \"name\": \"rbac\",\r\n                            \"version\": \"v1\",\r\n                            \"params\": {\r\n                                \"allowedRoles\": [\r\n                                    \"admin\",\r\n                                    \"developer\"\r\n                                ]\r\n                            }\r\n                        }\r\n                    ]\r\n                },\r\n                {\r\n                    \"name\": \"releases\",\r\n                    \"policies\": [\r\n                        {\r\n                            \"name\": \"rbac\",\r\n                            \"version\": \"v1\",\r\n                            \"params\": {\r\n                                \"allowedRoles\": [\r\n                                    \"admin\"\r\n                                ]\r\n                            }\r\n                        }\r\n                    ]\r\n                }\r\n            ]\r\n        },\r\n        \"deploymentState\": \"deployed\"\r\n    }\r\n}\r\n",
           "options": {
             "raw": {
               "language": "json"
@@ -119,7 +119,7 @@
           }
         },
         "url": {
-          "raw": "http://{{host}}/api/management/v0.9/websub-apis/repo-watcher-v1-0",
+          "raw": "http://{{host}}/api/management/v1alpha2/websub-apis/repo-watcher-v1-0",
           "protocol": "http",
           "host": [
             "{{host}}"
@@ -127,7 +127,7 @@
           "path": [
             "api",
             "management",
-            "v0.9",
+            "v1alpha2",
             "websub-apis",
             "repo-watcher-v1-0"
           ]
@@ -156,7 +156,7 @@
         "method": "DELETE",
         "header": [],
         "url": {
-          "raw": "http://{{host}}/api/management/v0.9/websub-apis/repo-watcher-v1-0",
+          "raw": "http://{{host}}/api/management/v1alpha2/websub-apis/repo-watcher-v1-0",
           "protocol": "http",
           "host": [
             "{{host}}"
@@ -164,7 +164,7 @@
           "path": [
             "api",
             "management",
-            "v0.9",
+            "v1alpha2",
             "websub-apis",
             "repo-watcher-v1-0"
           ]
@@ -193,7 +193,7 @@
         "method": "GET",
         "header": [],
         "url": {
-          "raw": "http://{{host}}/api/management/v0.9/websub-apis",
+          "raw": "http://{{host}}/api/management/v1alpha2/websub-apis",
           "protocol": "http",
           "host": [
             "{{host}}"
@@ -201,7 +201,7 @@
           "path": [
             "api",
             "management",
-            "v0.9",
+            "v1alpha2",
             "websub-apis"
           ]
         }

--- a/gateway/spec/impls/2-use-sqlite/data-model.md
+++ b/gateway/spec/impls/2-use-sqlite/data-model.md
@@ -154,7 +154,7 @@ INSERT INTO deployments (
     'v1.0',
     '/weather',
     'RestApi',
-    '{"version":"gateway.api-platform.wso2.com/v1alpha1","kind":"RestApi","data":{"name":"Weather API","version":"v1.0","context":"/weather","upstream":[{"url":"http://api.weather.com"}],"operations":[{"method":"GET","path":"/{country}/{city}"}]}}',
+    '{"version":"gateway.api-platform.wso2.com/v1alpha2","kind":"RestApi","data":{"name":"Weather API","version":"v1.0","context":"/weather","upstream":[{"url":"http://api.weather.com"}],"operations":[{"method":"GET","path":"/{country}/{city}"}]}}',
     'pending',
     '2025-10-19T10:00:00Z',
     '2025-10-19T10:00:00Z',
@@ -189,7 +189,7 @@ type StoredAPIConfig struct {
 **Example JSON** (stored in `configuration` column):
 ```json
 {
-  "version": "gateway.api-platform.wso2.com/v1alpha1",
+  "version": "gateway.api-platform.wso2.com/v1alpha2",
   "kind": "RestApi",
   "data": {
     "name": "Weather API",

--- a/portals/ai-workspace/configs/config-platform-api-template.toml
+++ b/portals/ai-workspace/configs/config-platform-api-template.toml
@@ -33,7 +33,7 @@ port      = "9243"   # HTTP/HTTPS listen port for Platform API
 # Set to false only to temporarily bypass during development.
 enable_scope_validation = true
 
-# Controls authentication for POST /api/v1/organizations.
+# Controls authentication for POST /api/v1alpha2/organizations.
 # When true, the endpoint requires both a valid Bearer JWT and the
 # ap:organization:manage scope; requests without that scope are rejected.
 # Default: false (public) — preserves backwards-compatible behaviour for existing deployments.

--- a/portals/ai-workspace/configs/config-platform-api.toml
+++ b/portals/ai-workspace/configs/config-platform-api.toml
@@ -25,7 +25,7 @@ port      = "9243"
 
 # Validate OAuth2 scopes on incoming requests.
 enable_scope_validation = true
-# Controls authentication for POST /api/v1/organizations.
+# Controls authentication for POST /api/v1alpha2/organizations.
 # When true, the endpoint requires both a valid Bearer JWT and the
 # ap:organization:manage scope; requests without that scope are rejected.
 org_creation_requires_auth = true

--- a/portals/ai-workspace/configs/config-template.toml
+++ b/portals/ai-workspace/configs/config-template.toml
@@ -40,9 +40,9 @@ auth_mode = "basic"
 # oidc_org_handle_claim = "org_handle"
 
 # Platform API base URL — used by the UI to make API calls (may be a relative
-# path when nginx proxying is in use, e.g. /api-proxy/api/v1).
-# Defaults to https://localhost:9243/api/v1 if unset.
-platform_api_base_url = "https://localhost:9243/api/v1"
+# path when nginx proxying is in use, e.g. /api-proxy/api/v1alpha2).
+# Defaults to https://localhost:9243/api/v1alpha2 if unset.
+platform_api_base_url = "https://localhost:9243/api/v1alpha2"
 
 # Control-plane host — the host:port that deployed gateways use to reach
 # the Platform API. Shown in gateway setup instructions (keys.env, helm values).

--- a/portals/ai-workspace/configs/config.toml
+++ b/portals/ai-workspace/configs/config.toml
@@ -20,7 +20,7 @@ domain = "localhost:5380"
 auth_mode = "basic"
 
 # Platform API base URL — used by the UI to make API calls.
-platform_api_base_url = "https://localhost:9243/api/v1"
+platform_api_base_url = "https://localhost:9243/api/v1alpha2"
 
 # Control-plane host — the externally reachable address gateways use to reach
 # the Platform API. Shown in gateway setup instructions (keys.env, helm values).

--- a/portals/ai-workspace/cypress/e2e/001-providers/001-provider-and-proxy.cy.js
+++ b/portals/ai-workspace/cypress/e2e/001-providers/001-provider-and-proxy.cy.js
@@ -48,7 +48,7 @@ describe('AI Workspace - OpenAI provider and proxy lifecycle', () => {
         expect(authToken).to.not.equal('');
 
         return cy.request({
-          url: '/api-proxy/api/v1/organizations',
+          url: '/api-proxy/api/v1alpha2/organizations',
           headers: {
             Authorization: `Bearer ${authToken}`,
           },
@@ -185,7 +185,7 @@ describe('AI Workspace - OpenAI provider and proxy lifecycle', () => {
 
 function deleteLinkedProxies(authToken, organizationId, providerId) {
   return requestWithAuth(authToken, {
-    url: `/api-proxy/api/v1/llm-providers/${encodeURIComponent(providerId)}/llm-proxies?organizationId=${encodeURIComponent(organizationId)}`,
+    url: `/api-proxy/api/v1alpha2/llm-providers/${encodeURIComponent(providerId)}/llm-proxies?organizationId=${encodeURIComponent(organizationId)}`,
     failOnStatusCode: false,
   }).then((response) => {
     expect(response.status).to.be.oneOf([200, 404]);
@@ -202,7 +202,7 @@ function deleteLinkedProxies(authToken, organizationId, providerId) {
     return cy.wrap(proxies).each((proxy) =>
       requestWithAuth(authToken, {
         method: 'DELETE',
-        url: `/api-proxy/api/v1/llm-proxies/${encodeURIComponent(proxy.id)}?organizationId=${encodeURIComponent(organizationId)}`,
+        url: `/api-proxy/api/v1alpha2/llm-proxies/${encodeURIComponent(proxy.id)}?organizationId=${encodeURIComponent(organizationId)}`,
         failOnStatusCode: false,
       }).then((deleteResponse) => {
         expect(deleteResponse.status).to.be.oneOf([200, 204, 404]);
@@ -213,7 +213,7 @@ function deleteLinkedProxies(authToken, organizationId, providerId) {
 
 function deleteProjectByName(authToken, targetProjectName, fallbackProjectName) {
   return requestWithAuth(authToken, {
-    url: '/api-proxy/api/v1/projects',
+    url: '/api-proxy/api/v1alpha2/projects',
   }).then((response) => {
     expect(response.status).to.eq(200);
 
@@ -239,7 +239,7 @@ function deleteProjectByName(authToken, targetProjectName, fallbackProjectName) 
 function ensureFallbackProject(authToken, fallbackProjectName) {
   return requestWithAuth(authToken, {
     method: 'POST',
-    url: '/api-proxy/api/v1/projects',
+    url: '/api-proxy/api/v1alpha2/projects',
     body: {
       name: fallbackProjectName,
       description: 'Reserved project to satisfy E2E cleanup invariants.',
@@ -253,7 +253,7 @@ function ensureFallbackProject(authToken, fallbackProjectName) {
 function deleteProject(authToken, projectId) {
   return requestWithAuth(authToken, {
     method: 'DELETE',
-    url: `/api-proxy/api/v1/projects/${encodeURIComponent(projectId)}`,
+    url: `/api-proxy/api/v1alpha2/projects/${encodeURIComponent(projectId)}`,
     failOnStatusCode: false,
   }).then((response) => {
     expect(response.status).to.be.oneOf([200, 204, 404]);
@@ -263,7 +263,7 @@ function deleteProject(authToken, projectId) {
 function deleteProvider(authToken, organizationId, providerId) {
   return requestWithAuth(authToken, {
     method: 'DELETE',
-    url: `/api-proxy/api/v1/llm-providers/${encodeURIComponent(providerId)}?organizationId=${encodeURIComponent(organizationId)}`,
+    url: `/api-proxy/api/v1alpha2/llm-providers/${encodeURIComponent(providerId)}?organizationId=${encodeURIComponent(organizationId)}`,
     failOnStatusCode: false,
   }).then((response) => {
     expect(response.status).to.be.oneOf([200, 204, 404]);

--- a/portals/ai-workspace/docker-compose.yaml
+++ b/portals/ai-workspace/docker-compose.yaml
@@ -82,7 +82,7 @@ services:
       # Route all Platform API calls through nginx (/api-proxy/ → platform-api:9243/).
       # Relative paths avoid direct browser-to-platform-api connections and
       # sidestep self-signed TLS certificate issues.
-      - VITE_PLATFORM_API_BASE_URL=/api-proxy/api/v1
+      - VITE_PLATFORM_API_BASE_URL=/api-proxy/api/v1alpha2
       - VITE_PORTAL_API_BASE_URL=/api-proxy/api/portal/v1
     volumes:
       - ./configs/config.toml:/etc/ai-workspace/config.toml:ro

--- a/portals/ai-workspace/src/apis/platformApis.ts
+++ b/portals/ai-workspace/src/apis/platformApis.ts
@@ -28,7 +28,7 @@ import { logger } from '../utils/logger';
  * Organization schema from the Platform API.
  *
  * curl reference:
- *   POST https://localhost:9243/api/v1/organizations
+ *   POST https://localhost:9243/api/v1alpha2/organizations
  *   -H 'Authorization: Bearer <token>'
  *   -H 'accept: application/json' -H 'content-type: application/json'
  *   --data-raw '{"id":"<uuid>","name":"<name>","handle":"<handle>","region":"us"}'

--- a/portals/ai-workspace/src/clients/choreoApiClient.ts
+++ b/portals/ai-workspace/src/clients/choreoApiClient.ts
@@ -20,7 +20,7 @@
 // Platform API Client
 // ----------------------------------------------------------------------------
 // Replaces the Asgardeo-backed httpRequest with native fetch.
-// All calls go to PLATFORM_API_BASE_URL (default: https://localhost:9243/api/v1).
+// All calls go to PLATFORM_API_BASE_URL (default: https://localhost:9243/api/v1alpha2).
 //
 // Token storage:
 //   localStorage.setItem('platform_auth_token', '<your-token>')

--- a/portals/ai-workspace/src/config.env.ts
+++ b/portals/ai-workspace/src/config.env.ts
@@ -147,7 +147,7 @@ export const POLICY_HUB_WEB_URL = getEnvOrDefault(
 // only if calling the platform API directly.
 export const PLATFORM_API_BASE_URL = getEnvOrDefault(
   'VITE_PLATFORM_API_BASE_URL',
-  '/api-proxy/api/v1'
+  '/api-proxy/api/v1alpha2'
 );
 
 // Control-plane host shown in gateway setup instructions (host:port).

--- a/portals/ai-workspace/src/contexts/ChoreoUserContext.tsx
+++ b/portals/ai-workspace/src/contexts/ChoreoUserContext.tsx
@@ -20,7 +20,7 @@
 // ChoreoUserContext — Platform API (standalone) version
 // ----------------------------------------------------------------------------
 // Asgardeo authentication has been removed. All org data comes from the
-// Platform API (https://localhost:9243/api/v1).
+// Platform API (https://localhost:9243/api/v1alpha2).
 // Token exchange and IDP-specific logic are no-ops.
 // ============================================================================
 

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyGuardrailsTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyGuardrailsTab.tsx
@@ -173,6 +173,7 @@ export default function LLMProxyGuardrailsTab() {
   const [editingTarget, setEditingTarget] = useState<{
     policyIndex: number;
     pathIndex: number | null;
+    source: 'global' | 'operation' | 'legacy';
   } | null>(null);
   const [selectedCategories, setSelectedCategories] = useState<string[]>(['AI']);
   const [drawerGuardrails, setDrawerGuardrails] = useState<typeof availableGuardrails>([]);
@@ -227,43 +228,68 @@ export default function LLMProxyGuardrailsTab() {
   const getDisplayName = (policyName: string): string =>
     displayNameMap[policyName] || policyName;
 
-  const globalGuardrails = useMemo(
-    () =>
-      policies.flatMap((policy, policyIndex) => {
-        const version = policy.version
-          ? `v${policy.version.split('.')[0]}`
-          : 'v0';
-        const displayName = getDisplayName(policy.name);
-        if (!policy.paths || policy.paths.length === 0) {
-          return [
-            {
-              id: `${policy.name}-${version}-${policyIndex}-default`,
+  const globalGuardrails = useMemo(() => {
+    const items: Array<{
+      id: string;
+      name: string;
+      displayName: string;
+      version: string;
+      source: 'global' | 'legacy';
+      policyIndex: number;
+      pathIndex: number | null;
+    }> = [];
+
+    // New globalPolicies list
+    (proxy?.globalPolicies ?? []).forEach((policy, policyIndex) => {
+      const version = policy.version
+        ? `v${policy.version.replace(/^v/, '').split('.')[0]}`
+        : 'v0';
+      items.push({
+        id: `global-${policy.name}-${version}-${policyIndex}`,
+        name: policy.name,
+        displayName: getDisplayName(policy.name),
+        version,
+        source: 'global',
+        policyIndex,
+        pathIndex: null,
+      });
+    });
+
+    // Legacy policies with path === '/*'
+    policies.forEach((policy, policyIndex) => {
+      const version = policy.version
+        ? `v${policy.version.split('.')[0]}`
+        : 'v0';
+      const displayName = getDisplayName(policy.name);
+      if (!policy.paths || policy.paths.length === 0) {
+        items.push({
+          id: `legacy-${policy.name}-${version}-${policyIndex}-default`,
+          name: policy.name,
+          displayName,
+          version,
+          source: 'legacy',
+          policyIndex,
+          pathIndex: null,
+        });
+      } else {
+        policy.paths.forEach((pathConfig, pathIndex) => {
+          if (pathConfig.path === '/*') {
+            items.push({
+              id: `legacy-${policy.name}-${version}-${policyIndex}-${pathIndex}`,
               name: policy.name,
               displayName,
               version,
+              source: 'legacy',
               policyIndex,
-              pathIndex: null as number | null,
-            },
-          ];
-        }
+              pathIndex,
+            });
+          }
+        });
+      }
+    });
 
-        return policy.paths.flatMap((pathConfig, pathIndex) =>
-          pathConfig.path === '/*'
-            ? [
-                {
-                  id: `${policy.name}-${version}-${policyIndex}-${pathIndex}`,
-                  name: policy.name,
-                  displayName,
-                  version,
-                  policyIndex,
-                  pathIndex,
-                },
-              ]
-            : []
-        );
-      }),
-    [policies, displayNameMap]
-  );
+    return items;
+  }, [proxy?.globalPolicies, policies, displayNameMap]);
 
   const resources = useMemo(
     () => parseOpenApiText(proxy?.openapi || ''),
@@ -294,17 +320,38 @@ export default function LLMProxyGuardrailsTab() {
   const handleEditGuardrailPill = (
     policyIndex: number,
     pathIndex: number | null,
-    scope: DrawerContext
+    scope: DrawerContext,
+    source: 'global' | 'operation' | 'legacy'
   ) => {
-    const policy = policies[policyIndex];
-    if (!policy) return;
+    let policyName: string;
+    let existingParams: ParameterValues = {};
 
-    const existingParams =
-      pathIndex !== null ? policy.paths?.[pathIndex]?.params ?? {} : {};
+    if (source === 'global') {
+      const policy = (proxy?.globalPolicies ?? [])[policyIndex];
+      if (!policy) return;
+      policyName = policy.name;
+      existingParams = (policy.params as ParameterValues) ?? {};
+    } else if (source === 'operation') {
+      const policy = (proxy?.operationPolicies ?? [])[policyIndex];
+      if (!policy) return;
+      policyName = policy.name;
+      existingParams =
+        pathIndex !== null
+          ? ((policy.paths[pathIndex]?.params as ParameterValues) ?? {})
+          : {};
+    } else {
+      const policy = policies[policyIndex];
+      if (!policy) return;
+      policyName = policy.name;
+      existingParams =
+        pathIndex !== null
+          ? ((policy.paths?.[pathIndex]?.params as ParameterValues) ?? {})
+          : {};
+    }
 
-    setEditingTarget({ policyIndex, pathIndex });
+    setEditingTarget({ policyIndex, pathIndex, source });
     setDrawerContext(scope);
-    setSelectedGuardrail(policy.name);
+    setSelectedGuardrail(policyName);
     setGuardrailSettings(existingParams);
     setIsDetailView(true);
     setPolicyDefinition(null);
@@ -312,7 +359,7 @@ export default function LLMProxyGuardrailsTab() {
     setDrawerOpen(true);
 
     const guardrailMeta = availableGuardrails.find(
-      (g) => g.name === policy.name
+      (g) => g.name === policyName
     );
     if (!guardrailMeta?.version) {
       setDefinitionError('No version available for this guardrail.');
@@ -391,63 +438,105 @@ export default function LLMProxyGuardrailsTab() {
   const handlePolicySubmit = async (params: ParameterValues) => {
     if (!proxy || !selectedGuardrailPolicy) return;
 
-    const updatedPolicies = (() => {
-      // Edit mode: update existing policy path params
-      if (editingTarget) {
-        const { policyIndex, pathIndex } = editingTarget;
-        const updated = [...policies];
-        const existing = updated[policyIndex];
-        if (!existing) return policies;
-
-        if (pathIndex !== null) {
-          const existingPaths = [...(existing.paths ?? [])];
-          existingPaths[pathIndex] = {
-            ...existingPaths[pathIndex],
-            params,
-          };
-          updated[policyIndex] = { ...existing, paths: existingPaths };
-        }
-        return updated;
+    if (editingTarget) {
+      const { policyIndex, pathIndex, source } = editingTarget;
+      if (source === 'global') {
+        setLocalProxy((prev) => {
+          if (!prev) return prev;
+          const globalPolicies = [...(prev.globalPolicies ?? [])];
+          globalPolicies[policyIndex] = { ...globalPolicies[policyIndex], params };
+          return { ...prev, globalPolicies };
+        });
+      } else if (source === 'operation') {
+        setLocalProxy((prev) => {
+          if (!prev) return prev;
+          const operationPolicies = [...(prev.operationPolicies ?? [])];
+          const existing = operationPolicies[policyIndex];
+          const paths = [...existing.paths];
+          if (pathIndex !== null) {
+            paths[pathIndex] = { ...paths[pathIndex], params };
+          }
+          operationPolicies[policyIndex] = { ...existing, paths };
+          return { ...prev, operationPolicies };
+        });
+      } else {
+        // legacy
+        setLocalProxy((prev) => {
+          if (!prev) return prev;
+          const updated = [...(prev.policies ?? [])];
+          const existing = updated[policyIndex];
+          if (!existing) return prev;
+          if (pathIndex !== null) {
+            const existingPaths = [...(existing.paths ?? [])];
+            existingPaths[pathIndex] = { ...existingPaths[pathIndex], params };
+            updated[policyIndex] = { ...existing, paths: existingPaths };
+          }
+          return { ...prev, policies: updated };
+        });
       }
-
-      // Add mode: add new policy path
-      const nextPath = buildPolicyPath(params);
-      const existingIndex = policies.findIndex(
-        (p) =>
-          p.name === selectedGuardrailPolicy.name &&
-          p.version === selectedGuardrailVersion
-      );
-
-      if (existingIndex === -1) {
-        return [
-          ...policies,
-          {
+    } else if (drawerContext.scope === 'global') {
+      // Add mode — global scope → globalPolicies
+      setLocalProxy((prev) => {
+        if (!prev) return prev;
+        const globalPolicies = [...(prev.globalPolicies ?? [])];
+        const existingIndex = globalPolicies.findIndex(
+          (p) =>
+            p.name === selectedGuardrailPolicy.name &&
+            p.version === selectedGuardrailVersion
+        );
+        if (existingIndex === -1) {
+          globalPolicies.push({
             name: selectedGuardrailPolicy.name,
             version: selectedGuardrailVersion,
-            paths: [nextPath],
-          },
-        ];
-      }
-
-      const existing = policies[existingIndex];
-      const existingPaths = existing.paths ?? [];
-
-      const updated = [...policies];
-      updated[existingIndex] = {
-        ...existing,
-        paths: [...existingPaths, nextPath],
-      };
-      return updated;
-    })();
-
-    setLocalProxy((prev) =>
-      prev
-        ? {
-            ...prev,
-            policies: updatedPolicies,
+            params,
+          });
+        } else {
+          globalPolicies[existingIndex] = {
+            ...globalPolicies[existingIndex],
+            params,
+          };
+        }
+        return { ...prev, globalPolicies };
+      });
+    } else {
+      // Add mode — resource scope → operationPolicies
+      const resourcePath = drawerContext.path;
+      const resourceMethod = drawerContext.method;
+      const newPathEntry = { path: resourcePath, methods: [resourceMethod], params };
+      setLocalProxy((prev) => {
+        if (!prev) return prev;
+        const operationPolicies = [...(prev.operationPolicies ?? [])];
+        const existingPolicyIndex = operationPolicies.findIndex(
+          (p) =>
+            p.name === selectedGuardrailPolicy.name &&
+            p.version === selectedGuardrailVersion
+        );
+        if (existingPolicyIndex === -1) {
+          operationPolicies.push({
+            name: selectedGuardrailPolicy.name,
+            version: selectedGuardrailVersion,
+            paths: [newPathEntry],
+          });
+        } else {
+          const existing = operationPolicies[existingPolicyIndex];
+          const alreadyHasPath = existing.paths.some(
+            (p) =>
+              p.path === resourcePath &&
+              p.methods
+                .map((m) => m.toUpperCase())
+                .includes(resourceMethod.toUpperCase())
+          );
+          if (!alreadyHasPath) {
+            operationPolicies[existingPolicyIndex] = {
+              ...existing,
+              paths: [...existing.paths, newPathEntry],
+            };
           }
-        : prev
-    );
+        }
+        return { ...prev, operationPolicies };
+      });
+    }
+
     setGuardrailSettings(params);
     setDrawerOpen(false);
     setIsDetailView(false);
@@ -455,33 +544,52 @@ export default function LLMProxyGuardrailsTab() {
 
   const handleRemoveAppliedGuardrail = (
     policyIndex: number,
-    pathIndex: number | null
+    pathIndex: number | null,
+    source: 'global' | 'operation' | 'legacy'
   ) => {
-    setLocalProxy((prev) => {
-      if (!prev) return prev;
-      const existingPolicies = prev.policies ?? [];
-
-      const updatedPolicies = existingPolicies.flatMap((policy, index) => {
-        if (index !== policyIndex) return [policy];
-
-        if (pathIndex === null) {
-          return [];
-        }
-
-        const existingPaths = policy.paths ?? [];
-        const nextPaths = existingPaths.filter((_, idx) => idx !== pathIndex);
-        if (nextPaths.length === 0) {
-          return [];
-        }
-
-        return [{ ...policy, paths: nextPaths }];
+    if (source === 'global') {
+      setLocalProxy((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          globalPolicies: (prev.globalPolicies ?? []).filter(
+            (_, idx) => idx !== policyIndex
+          ),
+        };
       });
-
-      return {
-        ...prev,
-        policies: updatedPolicies,
-      };
-    });
+    } else if (source === 'operation') {
+      setLocalProxy((prev) => {
+        if (!prev) return prev;
+        const operationPolicies = [...(prev.operationPolicies ?? [])];
+        const existing = operationPolicies[policyIndex];
+        if (pathIndex !== null) {
+          const paths = existing.paths.filter((_, idx) => idx !== pathIndex);
+          if (paths.length === 0) {
+            operationPolicies.splice(policyIndex, 1);
+          } else {
+            operationPolicies[policyIndex] = { ...existing, paths };
+          }
+        } else {
+          operationPolicies.splice(policyIndex, 1);
+        }
+        return { ...prev, operationPolicies };
+      });
+    } else {
+      // legacy
+      setLocalProxy((prev) => {
+        if (!prev) return prev;
+        const existingPolicies = prev.policies ?? [];
+        const updatedPolicies = existingPolicies.flatMap((policy, index) => {
+          if (index !== policyIndex) return [policy];
+          if (pathIndex === null) return [];
+          const existingPaths = policy.paths ?? [];
+          const nextPaths = existingPaths.filter((_, idx) => idx !== pathIndex);
+          if (nextPaths.length === 0) return [];
+          return [{ ...policy, paths: nextPaths }];
+        });
+        return { ...prev, policies: updatedPolicies };
+      });
+    }
   };
 
   // ── Render ──────────────────────────────────────────────────────────────
@@ -537,10 +645,10 @@ export default function LLMProxyGuardrailsTab() {
                 onClick={() =>
                   handleEditGuardrailPill(g.policyIndex, g.pathIndex, {
                     scope: 'global',
-                  })
+                  }, g.source)
                 }
                 onRemove={() =>
-                  void handleRemoveAppliedGuardrail(g.policyIndex, g.pathIndex)
+                  void handleRemoveAppliedGuardrail(g.policyIndex, g.pathIndex, g.source)
                 }
               />
             ))}
@@ -637,6 +745,9 @@ export default function LLMProxyGuardrailsTab() {
               <Stack spacing={1.25}>
                 {(() => {
                   const hasResourcePolicy = (resource: ResourceItem) =>
+                    (proxy?.operationPolicies ?? []).some((policy) =>
+                      policy.paths.some((pc) => matchesResource(pc, resource))
+                    ) ||
                     policies.some((policy) =>
                       (policy.paths ?? []).some(
                         (pc) =>
@@ -692,9 +803,31 @@ export default function LLMProxyGuardrailsTab() {
                         name: string;
                         displayName: string;
                         version: string;
+                        source: 'operation' | 'legacy';
                         policyIndex: number;
                         pathIndex: number;
                       }> = [];
+                      // New operationPolicies
+                      (proxy?.operationPolicies ?? []).forEach(
+                        (policy, policyIndex) => {
+                          policy.paths.forEach((pc, pathIndex) => {
+                            if (!matchesResource(pc, resource)) return;
+                            const version = policy.version
+                              ? `v${policy.version.replace(/^v/, '').split('.')[0]}`
+                              : 'v0';
+                            items.push({
+                              id: `op-${policy.name}-${version}-${policyIndex}-${pathIndex}`,
+                              name: policy.name,
+                              displayName: getDisplayName(policy.name),
+                              version,
+                              source: 'operation',
+                              policyIndex,
+                              pathIndex,
+                            });
+                          });
+                        }
+                      );
+                      // Legacy policies
                       policies.forEach((policy, policyIndex) => {
                         (policy.paths ?? []).forEach((pc, pathIndex) => {
                           if (pc.path === '/*') return;
@@ -702,12 +835,12 @@ export default function LLMProxyGuardrailsTab() {
                           const version = policy.version
                             ? `v${policy.version.split('.')[0]}`
                             : 'v0';
-                          const displayName = getDisplayName(policy.name);
                           items.push({
-                            id: `${policy.name}-${version}-${policyIndex}-${pathIndex}`,
+                            id: `legacy-${policy.name}-${version}-${policyIndex}-${pathIndex}`,
                             name: policy.name,
-                            displayName,
+                            displayName: getDisplayName(policy.name),
                             version,
+                            source: 'legacy',
                             policyIndex,
                             pathIndex,
                           });
@@ -818,13 +951,15 @@ export default function LLMProxyGuardrailsTab() {
                                                 scope: 'resource',
                                                 method,
                                                 path: resource.path,
-                                              }
+                                              },
+                                              g.source
                                             )
                                           }
                                           onRemove={() =>
                                             void handleRemoveAppliedGuardrail(
                                               g.policyIndex,
-                                              g.pathIndex
+                                              g.pathIndex,
+                                              g.source
                                             )
                                           }
                                         />

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderGuardrailsTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderGuardrailsTab.tsx
@@ -187,6 +187,7 @@ export default function ServiceProviderGuardrailsTab() {
   const [editingTarget, setEditingTarget] = useState<{
     policyIndex: number;
     pathIndex: number | null;
+    source: 'global' | 'operation' | 'legacy';
   } | null>(null);
   const [selectedCategories, setSelectedCategories] = useState<string[]>(['AI']);
   const [drawerGuardrails, setDrawerGuardrails] = useState<typeof availableGuardrails>([]);
@@ -241,43 +242,68 @@ export default function ServiceProviderGuardrailsTab() {
   const getDisplayName = (policyName: string): string =>
     displayNameMap[policyName] || policyName;
 
-  const globalGuardrails = useMemo(
-    () =>
-      policies.flatMap((policy, policyIndex) => {
-        const version = policy.version
-          ? `v${policy.version.replace(/^v/, '').split('.')[0]}`
-          : 'v0';
-        const displayName = getDisplayName(policy.name);
-        if (!policy.paths || policy.paths.length === 0) {
-          return [
-            {
-              id: `${policy.name}-${version}-${policyIndex}-default`,
+  const globalGuardrails = useMemo(() => {
+    const items: Array<{
+      id: string;
+      name: string;
+      displayName: string;
+      version: string;
+      source: 'global' | 'legacy';
+      policyIndex: number;
+      pathIndex: number | null;
+    }> = [];
+
+    // New globalPolicies list
+    (provider?.globalPolicies ?? []).forEach((policy, policyIndex) => {
+      const version = policy.version
+        ? `v${policy.version.replace(/^v/, '').split('.')[0]}`
+        : 'v0';
+      items.push({
+        id: `global-${policy.name}-${version}-${policyIndex}`,
+        name: policy.name,
+        displayName: getDisplayName(policy.name),
+        version,
+        source: 'global',
+        policyIndex,
+        pathIndex: null,
+      });
+    });
+
+    // Legacy policies with path === '/*'
+    policies.forEach((policy, policyIndex) => {
+      const version = policy.version
+        ? `v${policy.version.replace(/^v/, '').split('.')[0]}`
+        : 'v0';
+      const displayName = getDisplayName(policy.name);
+      if (!policy.paths || policy.paths.length === 0) {
+        items.push({
+          id: `legacy-${policy.name}-${version}-${policyIndex}-default`,
+          name: policy.name,
+          displayName,
+          version,
+          source: 'legacy',
+          policyIndex,
+          pathIndex: null,
+        });
+      } else {
+        policy.paths.forEach((pathConfig, pathIndex) => {
+          if (pathConfig.path === '/*') {
+            items.push({
+              id: `legacy-${policy.name}-${version}-${policyIndex}-${pathIndex}`,
               name: policy.name,
               displayName,
               version,
+              source: 'legacy',
               policyIndex,
-              pathIndex: null as number | null,
-            },
-          ];
-        }
+              pathIndex,
+            });
+          }
+        });
+      }
+    });
 
-        return policy.paths.flatMap((pathConfig, pathIndex) =>
-          pathConfig.path === '/*'
-            ? [
-                {
-                  id: `${policy.name}-${version}-${policyIndex}-${pathIndex}`,
-                  name: policy.name,
-                  displayName,
-                  version,
-                  policyIndex,
-                  pathIndex,
-                },
-              ]
-            : []
-        );
-      }),
-    [policies, displayNameMap]
-  );
+    return items;
+  }, [provider?.globalPolicies, policies, displayNameMap]);
 
   const resources = useMemo(
     () => parseOpenApiText(provider?.openapi || '', provider?.accessControl),
@@ -306,17 +332,38 @@ export default function ServiceProviderGuardrailsTab() {
   const handleEditGuardrailPill = (
     policyIndex: number,
     pathIndex: number | null,
-    scope: DrawerContext
+    scope: DrawerContext,
+    source: 'global' | 'operation' | 'legacy'
   ) => {
-    const policy = policies[policyIndex];
-    if (!policy) return;
+    let policyName: string;
+    let existingParams: ParameterValues = {};
 
-    const existingParams =
-      pathIndex !== null ? policy.paths?.[pathIndex]?.params ?? {} : {};
+    if (source === 'global') {
+      const policy = (provider?.globalPolicies ?? [])[policyIndex];
+      if (!policy) return;
+      policyName = policy.name;
+      existingParams = (policy.params as ParameterValues) ?? {};
+    } else if (source === 'operation') {
+      const policy = (provider?.operationPolicies ?? [])[policyIndex];
+      if (!policy) return;
+      policyName = policy.name;
+      existingParams =
+        pathIndex !== null
+          ? ((policy.paths[pathIndex]?.params as ParameterValues) ?? {})
+          : {};
+    } else {
+      const policy = policies[policyIndex];
+      if (!policy) return;
+      policyName = policy.name;
+      existingParams =
+        pathIndex !== null
+          ? ((policy.paths?.[pathIndex]?.params as ParameterValues) ?? {})
+          : {};
+    }
 
-    setEditingTarget({ policyIndex, pathIndex });
+    setEditingTarget({ policyIndex, pathIndex, source });
     setDrawerContext(scope);
-    setSelectedGuardrail(policy.name);
+    setSelectedGuardrail(policyName);
     setGuardrailSettings(existingParams);
     setIsDetailView(true);
     setPolicyDefinition(null);
@@ -324,7 +371,7 @@ export default function ServiceProviderGuardrailsTab() {
     setDrawerOpen(true);
 
     const guardrailMeta = availableGuardrails.find(
-      (g) => g.name === policy.name
+      (g) => g.name === policyName
     );
     if (!guardrailMeta?.version) {
       setDefinitionError('No version available for this guardrail.');
@@ -413,62 +460,93 @@ export default function ServiceProviderGuardrailsTab() {
       ...updatePayload
     } = provider;
 
-    const updatedPolicies = (() => {
-      // Edit mode: update existing policy path params
-      if (editingTarget) {
-        const { policyIndex, pathIndex } = editingTarget;
-        const updated = [...policies];
-        const existing = updated[policyIndex];
-        if (!existing) return policies;
-
-        if (pathIndex !== null) {
-          const existingPaths = [...(existing.paths ?? [])];
-          existingPaths[pathIndex] = {
-            ...existingPaths[pathIndex],
-            params,
-          };
-          updated[policyIndex] = { ...existing, paths: existingPaths };
-        }
-        return updated;
-      }
-
-      // Add mode: add new policy path
-      const nextPath = buildPolicyPath(params);
-      const existingIndex = policies.findIndex(
-        (policy) =>
-          policy.name === selectedGuardrailPolicy.name &&
-          policy.version === selectedGuardrailVersion
-      );
-
-      if (existingIndex === -1) {
-        return [
-          ...policies,
-          {
-            name: selectedGuardrailPolicy.name,
-            version: selectedGuardrailVersion,
-            paths: [nextPath],
-          },
-        ];
-      }
-
-      const existing = policies[existingIndex];
-      const existingPaths = existing.paths ?? [];
-
-      const updated = [...policies];
-      updated[existingIndex] = {
-        ...existing,
-        paths: [...existingPaths, nextPath],
-      };
-      return updated;
-    })();
-
     const isEditing = !!editingTarget;
 
     try {
-      await updateProvider({
-        ...updatePayload,
-        policies: updatedPolicies,
-      });
+      if (editingTarget) {
+        const { policyIndex, pathIndex, source } = editingTarget;
+        if (source === 'global') {
+          const globalPolicies = [...(provider.globalPolicies ?? [])];
+          globalPolicies[policyIndex] = { ...globalPolicies[policyIndex], params };
+          await updateProvider({ ...updatePayload, globalPolicies });
+        } else if (source === 'operation') {
+          const operationPolicies = [...(provider.operationPolicies ?? [])];
+          const existing = operationPolicies[policyIndex];
+          const paths = [...existing.paths];
+          if (pathIndex !== null) {
+            paths[pathIndex] = { ...paths[pathIndex], params };
+          }
+          operationPolicies[policyIndex] = { ...existing, paths };
+          await updateProvider({ ...updatePayload, operationPolicies });
+        } else {
+          // legacy
+          const updated = [...policies];
+          const existing = updated[policyIndex];
+          if (!existing) return;
+          if (pathIndex !== null) {
+            const existingPaths = [...(existing.paths ?? [])];
+            existingPaths[pathIndex] = { ...existingPaths[pathIndex], params };
+            updated[policyIndex] = { ...existing, paths: existingPaths };
+          }
+          await updateProvider({ ...updatePayload, policies: updated });
+        }
+      } else if (drawerContext.scope === 'global') {
+        // Add mode — global scope → globalPolicies
+        const globalPolicies = [...(provider.globalPolicies ?? [])];
+        const existingIndex = globalPolicies.findIndex(
+          (p) =>
+            p.name === selectedGuardrailPolicy.name &&
+            p.version === selectedGuardrailVersion
+        );
+        if (existingIndex === -1) {
+          globalPolicies.push({
+            name: selectedGuardrailPolicy.name,
+            version: selectedGuardrailVersion,
+            params,
+          });
+        } else {
+          globalPolicies[existingIndex] = {
+            ...globalPolicies[existingIndex],
+            params,
+          };
+        }
+        await updateProvider({ ...updatePayload, globalPolicies });
+      } else {
+        // Add mode — resource scope → operationPolicies
+        const operationPolicies = [...(provider.operationPolicies ?? [])];
+        const resourcePath = drawerContext.path;
+        const resourceMethod = drawerContext.method;
+        const newPathEntry = { path: resourcePath, methods: [resourceMethod], params };
+        const existingPolicyIndex = operationPolicies.findIndex(
+          (p) =>
+            p.name === selectedGuardrailPolicy.name &&
+            p.version === selectedGuardrailVersion
+        );
+        if (existingPolicyIndex === -1) {
+          operationPolicies.push({
+            name: selectedGuardrailPolicy.name,
+            version: selectedGuardrailVersion,
+            paths: [newPathEntry],
+          });
+        } else {
+          const existing = operationPolicies[existingPolicyIndex];
+          const alreadyHasPath = existing.paths.some(
+            (p) =>
+              p.path === resourcePath &&
+              p.methods
+                .map((m) => m.toUpperCase())
+                .includes(resourceMethod.toUpperCase())
+          );
+          if (!alreadyHasPath) {
+            operationPolicies[existingPolicyIndex] = {
+              ...existing,
+              paths: [...existing.paths, newPathEntry],
+            };
+          }
+        }
+        await updateProvider({ ...updatePayload, operationPolicies });
+      }
+
       setGuardrailSettings(params);
       if (!isDraftMode) {
         showSnackbar(
@@ -495,7 +573,8 @@ export default function ServiceProviderGuardrailsTab() {
 
   const handleRemoveAppliedGuardrail = async (
     policyIndex: number,
-    pathIndex: number | null
+    pathIndex: number | null,
+    source: 'global' | 'operation' | 'legacy'
   ) => {
     if (!provider || isLoading || error) return;
 
@@ -508,27 +587,39 @@ export default function ServiceProviderGuardrailsTab() {
       ...updatePayload
     } = provider;
 
-    const updatedPolicies = policies.flatMap((policy, index) => {
-      if (index !== policyIndex) return [policy];
-
-      if (pathIndex === null) {
-        return [];
-      }
-
-      const existingPaths = policy.paths ?? [];
-      const nextPaths = existingPaths.filter((_, idx) => idx !== pathIndex);
-      if (nextPaths.length === 0) {
-        return [];
-      }
-
-      return [{ ...policy, paths: nextPaths }];
-    });
-
     try {
-      await updateProvider({
-        ...updatePayload,
-        policies: updatedPolicies,
-      });
+      if (source === 'global') {
+        const globalPolicies = (provider.globalPolicies ?? []).filter(
+          (_, idx) => idx !== policyIndex
+        );
+        await updateProvider({ ...updatePayload, globalPolicies });
+      } else if (source === 'operation') {
+        const operationPolicies = [...(provider.operationPolicies ?? [])];
+        const existing = operationPolicies[policyIndex];
+        if (pathIndex !== null) {
+          const paths = existing.paths.filter((_, idx) => idx !== pathIndex);
+          if (paths.length === 0) {
+            operationPolicies.splice(policyIndex, 1);
+          } else {
+            operationPolicies[policyIndex] = { ...existing, paths };
+          }
+        } else {
+          operationPolicies.splice(policyIndex, 1);
+        }
+        await updateProvider({ ...updatePayload, operationPolicies });
+      } else {
+        // legacy
+        const updatedPolicies = policies.flatMap((policy, index) => {
+          if (index !== policyIndex) return [policy];
+          if (pathIndex === null) return [];
+          const existingPaths = policy.paths ?? [];
+          const nextPaths = existingPaths.filter((_, idx) => idx !== pathIndex);
+          if (nextPaths.length === 0) return [];
+          return [{ ...policy, paths: nextPaths }];
+        });
+        await updateProvider({ ...updatePayload, policies: updatedPolicies });
+      }
+
       if (!isDraftMode) {
         showSnackbar('Guardrail removed successfully.', 'success');
       }
@@ -598,10 +689,10 @@ export default function ServiceProviderGuardrailsTab() {
                 onClick={() =>
                   handleEditGuardrailPill(g.policyIndex, g.pathIndex, {
                     scope: 'global',
-                  })
+                  }, g.source)
                 }
                 onRemove={() =>
-                  void handleRemoveAppliedGuardrail(g.policyIndex, g.pathIndex)
+                  void handleRemoveAppliedGuardrail(g.policyIndex, g.pathIndex, g.source)
                 }
               />
             ))}
@@ -686,6 +777,9 @@ export default function ServiceProviderGuardrailsTab() {
             <Stack spacing={1.25}>
               {(() => {
                 const hasResourcePolicy = (resource: ResourceItem) =>
+                  (provider?.operationPolicies ?? []).some((policy) =>
+                    policy.paths.some((pc) => matchesResource(pc, resource))
+                  ) ||
                   policies.some((policy) =>
                     (policy.paths ?? []).some(
                       (pc) => pc.path !== '/*' && matchesResource(pc, resource)
@@ -739,9 +833,31 @@ export default function ServiceProviderGuardrailsTab() {
                       name: string;
                       displayName: string;
                       version: string;
+                      source: 'operation' | 'legacy';
                       policyIndex: number;
                       pathIndex: number;
                     }> = [];
+                    // New operationPolicies
+                    (provider?.operationPolicies ?? []).forEach(
+                      (policy, policyIndex) => {
+                        policy.paths.forEach((pathConfig, pathIndex) => {
+                          if (!matchesResource(pathConfig, resource)) return;
+                          const version = policy.version
+                            ? `v${policy.version.replace(/^v/, '').split('.')[0]}`
+                            : 'v0';
+                          items.push({
+                            id: `op-${policy.name}-${version}-${policyIndex}-${pathIndex}`,
+                            name: policy.name,
+                            displayName: getDisplayName(policy.name),
+                            version,
+                            source: 'operation',
+                            policyIndex,
+                            pathIndex,
+                          });
+                        });
+                      }
+                    );
+                    // Legacy policies
                     policies.forEach((policy, policyIndex) => {
                       (policy.paths ?? []).forEach((pathConfig, pathIndex) => {
                         if (pathConfig.path === '/*') return;
@@ -749,12 +865,12 @@ export default function ServiceProviderGuardrailsTab() {
                         const version = policy.version
                           ? `v${policy.version.replace(/^v/, '').split('.')[0]}`
                           : 'v0';
-                        const displayName = getDisplayName(policy.name);
                         items.push({
-                          id: `${policy.name}-${version}-${policyIndex}-${pathIndex}`,
+                          id: `legacy-${policy.name}-${version}-${policyIndex}-${pathIndex}`,
                           name: policy.name,
-                          displayName,
+                          displayName: getDisplayName(policy.name),
                           version,
+                          source: 'legacy',
                           policyIndex,
                           pathIndex,
                         });
@@ -856,13 +972,15 @@ export default function ServiceProviderGuardrailsTab() {
                                               scope: 'resource',
                                               method,
                                               path: resource.path,
-                                            }
+                                            },
+                                            guardrail.source
                                           )
                                         }
                                         onRemove={() =>
                                           void handleRemoveAppliedGuardrail(
                                             guardrail.policyIndex,
-                                            guardrail.pathIndex
+                                            guardrail.pathIndex,
+                                            guardrail.source
                                           )
                                         }
                                       />

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderNew.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderNew.tsx
@@ -331,27 +331,15 @@ export default function ServiceProviderNew() {
         template: selectedTemplateId,
         openapi: openapiSpec,
         upstream,
-        policies: [
+        globalPolicies: [
           ...(selectedTemplateId !== 'azure-openai' &&
           selectedTemplateId !== 'azureai-foundry'
-            ? [
-                {
-                  name: 'llm-cost',
-                  version: 'v1',
-                  paths: [{ path: '/*', methods: ['*'], params: {} }],
-                },
-              ]
+            ? [{ name: 'llm-cost', version: 'v1', params: {} }]
             : []),
           ...guardrails.map((guardrail) => ({
             name: guardrail.name,
             version: guardrail.version,
-            paths: [
-              {
-                path: '/*',
-                methods: ['*'],
-                params: guardrail.settings ?? {},
-              },
-            ],
+            params: guardrail.settings ?? {},
           })),
         ],
         accessControl: {

--- a/portals/ai-workspace/src/utils/types.ts
+++ b/portals/ai-workspace/src/utils/types.ts
@@ -315,6 +315,26 @@ export interface Policy {
 }
 
 /**
+ * Global (api-level) policy — no path binding
+ */
+export interface GlobalPolicy {
+  name: string;
+  version: string;
+  executionCondition?: string;
+  params?: Record<string, unknown>;
+}
+
+/**
+ * Operation policy — path-bound
+ */
+export interface OperationPolicy {
+  name: string;
+  version: string;
+  executionCondition?: string;
+  paths: PolicyPath[];
+}
+
+/**
  * API Key security configuration
  */
 export interface ApiKeySecurity {
@@ -374,6 +394,8 @@ export interface LLMProvider {
   upstream?: Upstream;
   accessControl?: AccessControl;
   rateLimiting?: RateLimiting;
+  globalPolicies?: GlobalPolicy[];
+  operationPolicies?: OperationPolicy[];
   policies?: Policy[];
   security?: SecurityConfig;
   status?: 'Active' | 'Degraded' | 'Paused' | string;
@@ -397,6 +419,8 @@ export interface CreateLLMProviderRequest {
   modelProviders?: ModelProvider[];
   upstream: Upstream;
   accessControl: AccessControl;
+  globalPolicies?: GlobalPolicy[];
+  operationPolicies?: OperationPolicy[];
   policies?: Policy[];
   openapi?: string;
 }
@@ -550,6 +574,8 @@ export interface Proxy {
   vhost?: string;
   provider?: string | ProxyProviderConfig;
   openapi?: string;
+  globalPolicies?: GlobalPolicy[];
+  operationPolicies?: OperationPolicy[];
   policies?: Policy[];
   security?: ProxySecurityConfig;
   createdAt?: string;
@@ -591,6 +617,8 @@ export interface CreateProxyRequest {
   vhost?: string;
   provider: ProxyProviderConfig;
   openapi: string;
+  globalPolicies?: GlobalPolicy[];
+  operationPolicies?: OperationPolicy[];
   policies: Policy[];
   security: ProxySecurityConfig;
 }

--- a/portals/management-portal/src/hooks/GithubAPICreation.ts
+++ b/portals/management-portal/src/hooks/GithubAPICreation.ts
@@ -114,7 +114,7 @@ export const useGithubAPICreation = () => {
       provider: GitProvider = "github",
       opts?: { signal?: AbortSignal }
     ): Promise<GitBranch[]> => {
-      const res = await authedFetch(`/api/v1/git/repo/fetch-branches`, {
+      const res = await authedFetch(`/api/v1alpha2/git/repo/fetch-branches`, {
         method: "POST",
         body: JSON.stringify({ repoUrl, provider }),
         signal: opts?.signal,
@@ -136,7 +136,7 @@ export const useGithubAPICreation = () => {
       branch: string,
       opts?: { signal?: AbortSignal }
     ): Promise<GitFetchContentResponse> => {
-      const res = await authedFetch(`/api/v1/git/repo/branch/fetch-content`, {
+      const res = await authedFetch(`/api/v1alpha2/git/repo/branch/fetch-content`, {
         method: "POST",
         body: JSON.stringify({ repoUrl, provider, branch }),
         signal: opts?.signal,
@@ -152,13 +152,13 @@ export const useGithubAPICreation = () => {
     []
   );
 
-  /** POST: /api/v1/api-projects/import */
+  /** POST: /api/v1alpha2/api-projects/import */
   const importApiProject = useCallback(
     async (
       payload: ImportApiProjectRequest,
       opts?: { signal?: AbortSignal }
     ): Promise<ApiSummary> => {
-      const res = await authedFetch(`/api/v1/api-projects/import`, {
+      const res = await authedFetch(`/api/v1alpha2/api-projects/import`, {
         method: "POST",
         body: JSON.stringify(payload),
         signal: opts?.signal,

--- a/portals/management-portal/src/hooks/apiPublish.ts
+++ b/portals/management-portal/src/hooks/apiPublish.ts
@@ -78,7 +78,7 @@ const normalizePublication = (item: any): ApiPublicationWithPortal => ({
 export const useApiPublishApi = () => {
   const fetchPublications = useCallback(async (apiId: string): Promise<ApiPublicationWithPortal[]> => {
     const { token, baseUrl } = getApiConfig();
-    const response = await fetch(`${baseUrl}/api/v1/apis/${apiId}/publications`, {
+    const response = await fetch(`${baseUrl}/api/v1alpha2/apis/${apiId}/publications`, {
       method: "GET",
       headers: { Authorization: `Bearer ${token}` },
     });
@@ -95,7 +95,7 @@ export const useApiPublishApi = () => {
   const publishApiToDevPortal = useCallback(async (apiId: string, payload: ApiPublishPayload): Promise<PublishResponse> => {
     const { token, baseUrl } = getApiConfig();
 
-    const response = await fetch(`${baseUrl}/api/v1/rest-apis/${apiId}/publications`, {
+    const response = await fetch(`${baseUrl}/api/v1alpha2/rest-apis/${apiId}/publications`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${token}`,
@@ -116,7 +116,7 @@ export const useApiPublishApi = () => {
   const unpublishApiFromDevPortal = useCallback(async (apiId: string, devPortalId: string): Promise<UnpublishResponse> => {
     const { token, baseUrl } = getApiConfig();
 
-    const response = await fetch(`${baseUrl}/api/v1/rest-apis/${apiId}/publications/${devPortalId}`, {
+    const response = await fetch(`${baseUrl}/api/v1alpha2/rest-apis/${apiId}/publications/${devPortalId}`, {
       method: "DELETE",
       headers: {
         Authorization: `Bearer ${token}`,

--- a/portals/management-portal/src/hooks/apis.ts
+++ b/portals/management-portal/src/hooks/apis.ts
@@ -177,7 +177,7 @@ export const useApisApi = () => {
         body.contract = contract;
       }
 
-      const response = await fetch(`${baseUrl}/api/v1/apis`, {
+      const response = await fetch(`${baseUrl}/api/v1alpha2/apis`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -200,9 +200,9 @@ export const useApisApi = () => {
   );
 
   /**
-   * Fetch from /api/v1/apis with optional projectId filter:
-   * - /api/v1/apis                 => all APIs in org
-   * - /api/v1/apis?projectId=....  => APIs for a specific project
+   * Fetch from /api/v1alpha2/apis with optional projectId filter:
+   * - /api/v1alpha2/apis                 => all APIs in org
+   * - /api/v1alpha2/apis?projectId=....  => APIs for a specific project
    */
   const fetchProjectApis = useCallback(
     async (projectId: string): Promise<ApiSummary[]> => {
@@ -210,8 +210,8 @@ export const useApisApi = () => {
 
       const url =
         projectId && projectId.length > 0
-          ? `${baseUrl}/api/v1/apis?projectId=${encodeURIComponent(projectId)}`
-          : `${baseUrl}/api/v1/apis`;
+          ? `${baseUrl}/api/v1alpha2/apis?projectId=${encodeURIComponent(projectId)}`
+          : `${baseUrl}/api/v1alpha2/apis`;
 
       const response = await fetch(url, {
         method: "GET",
@@ -251,7 +251,7 @@ export const useApisApi = () => {
   const fetchApi = useCallback(async (apiId: string): Promise<ApiSummary> => {
     const { token, baseUrl } = getApiConfig();
 
-    const response = await fetch(`${baseUrl}/api/v1/apis/${apiId}`, {
+    const response = await fetch(`${baseUrl}/api/v1alpha2/apis/${apiId}`, {
       method: "GET",
       headers: {
         Authorization: `Bearer ${token}`,
@@ -272,7 +272,7 @@ export const useApisApi = () => {
   const deleteApi = useCallback(async (apiId: string): Promise<void> => {
     const { token, baseUrl } = getApiConfig();
 
-    const response = await fetch(`${baseUrl}/api/v1/apis/${apiId}`, {
+    const response = await fetch(`${baseUrl}/api/v1alpha2/apis/${apiId}`, {
       method: "DELETE",
       headers: {
         Authorization: `Bearer ${token}`,
@@ -293,7 +293,7 @@ export const useApisApi = () => {
       const { token, baseUrl } = getApiConfig();
 
       const response = await fetch(
-        `${baseUrl}/api/v1/apis/${encodeURIComponent(apiId)}/gateways`,
+        `${baseUrl}/api/v1alpha2/apis/${encodeURIComponent(apiId)}/gateways`,
         {
           method: "GET",
           headers: { Authorization: `Bearer ${token}` },
@@ -339,7 +339,7 @@ export const useApisApi = () => {
         formData.append("definition", payload.definition);
       }
 
-      const res = await fetch(`${baseUrl}/api/v1/import/open-api`, {
+      const res = await fetch(`${baseUrl}/api/v1alpha2/import/open-api`, {
         method: "POST",
         headers: {
           Authorization: `Bearer ${token}`,
@@ -380,7 +380,7 @@ export const useApisApi = () => {
       const payload = gatewayIds.map((gatewayId) => ({ gatewayId }));
 
       const response = await fetch(
-        `${baseUrl}/api/v1/apis/${encodeURIComponent(apiId)}/gateways`,
+        `${baseUrl}/api/v1alpha2/apis/${encodeURIComponent(apiId)}/gateways`,
         {
           method: "POST",
           headers: {

--- a/portals/management-portal/src/hooks/deployments.ts
+++ b/portals/management-portal/src/hooks/deployments.ts
@@ -58,7 +58,7 @@ export const useDeploymentsApi = () => {
       targets: DeployTargetRequest[]
     ): Promise<DeployRevisionResponse> => {
       const { token, baseUrl } = getApiConfig();
-      const url = `${baseUrl}/api/v1/apis/${encodeURIComponent(
+      const url = `${baseUrl}/api/v1alpha2/apis/${encodeURIComponent(
         apiId
       )}/deploy-revision?revisionId=${encodeURIComponent(String(revisionId))}`;
 
@@ -91,7 +91,7 @@ export const useDeploymentsApi = () => {
   const fetchApiDeployments = useCallback(
     async (apiId: string): Promise<ApiDeploymentRecord[]> => {
       const { token, baseUrl } = getApiConfig();
-      const url = `${baseUrl}/api/v1/apis/${encodeURIComponent(apiId)}/deployments`;
+      const url = `${baseUrl}/api/v1alpha2/apis/${encodeURIComponent(apiId)}/deployments`;
 
       const res = await fetch(url, {
         method: "GET",

--- a/portals/management-portal/src/hooks/devportals.ts
+++ b/portals/management-portal/src/hooks/devportals.ts
@@ -54,7 +54,7 @@ export const useDevPortalsApi = () => {
   const fetchDevPortals = useCallback(async (): Promise<Portal[]> => {
     const { token, baseUrl } = getApiConfig();
 
-    const response = await fetch(`${baseUrl}/api/v1/devportals`, {
+    const response = await fetch(`${baseUrl}/api/v1alpha2/devportals`, {
       method: "GET",
       headers: {
         Authorization: `Bearer ${token}`,
@@ -77,7 +77,7 @@ export const useDevPortalsApi = () => {
     async (uuid: string): Promise<Portal> => {
       const { token, baseUrl } = getApiConfig();
 
-      const response = await fetch(`${baseUrl}/api/v1/devportals/${uuid}`, {
+      const response = await fetch(`${baseUrl}/api/v1alpha2/devportals/${uuid}`, {
         method: "GET",
         headers: {
           Authorization: `Bearer ${token}`,
@@ -101,7 +101,7 @@ export const useDevPortalsApi = () => {
     async (payload: CreatePortalPayload): Promise<Portal> => {
       const { token, baseUrl } = getApiConfig();
 
-      const response = await fetch(`${baseUrl}/api/v1/devportals`, {
+      const response = await fetch(`${baseUrl}/api/v1alpha2/devportals`, {
         method: "POST",
         headers: {
           Authorization: `Bearer ${token}`,
@@ -130,7 +130,7 @@ export const useDevPortalsApi = () => {
     ): Promise<DevPortalAPIModel> => {
       const { token, baseUrl } = getApiConfig();
 
-      const response = await fetch(`${baseUrl}/api/v1/devportals/${uuid}`, {
+      const response = await fetch(`${baseUrl}/api/v1alpha2/devportals/${uuid}`, {
         method: "PUT",
         headers: {
           Authorization: `Bearer ${token}`,
@@ -156,7 +156,7 @@ export const useDevPortalsApi = () => {
     async (uuid: string): Promise<void> => {
       const { token, baseUrl } = getApiConfig();
 
-      const response = await fetch(`${baseUrl}/api/v1/devportals/${uuid}`, {
+      const response = await fetch(`${baseUrl}/api/v1alpha2/devportals/${uuid}`, {
         method: "DELETE",
         headers: {
           Authorization: `Bearer ${token}`,
@@ -178,7 +178,7 @@ export const useDevPortalsApi = () => {
   const activateDevPortal = useCallback(async (uuid: string): Promise<void> => {
     const { token, baseUrl } = getApiConfig();
 
-    const response = await fetch(`${baseUrl}/api/v1/devportals/${uuid}/activate`, {
+    const response = await fetch(`${baseUrl}/api/v1alpha2/devportals/${uuid}/activate`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${token}`,

--- a/portals/management-portal/src/hooks/gateways.ts
+++ b/portals/management-portal/src/hooks/gateways.ts
@@ -77,7 +77,7 @@ export const useGatewaysApi = () => {
   const createGateway = useCallback(
     async (payload: CreateGatewayPayload): Promise<Gateway> => {
       const { token, baseUrl } = getApiConfig();
-      const response = await fetch(`${baseUrl}/api/v1/gateways`, {
+      const response = await fetch(`${baseUrl}/api/v1alpha2/gateways`, {
         method: "POST",
         headers: {
           Authorization: `Bearer ${token}`,
@@ -109,7 +109,7 @@ export const useGatewaysApi = () => {
   const fetchGateways = useCallback(async (): Promise<Gateway[]> => {
     const { token, baseUrl } = getApiConfig();
 
-    const response = await fetch(`${baseUrl}/api/v1/gateways`, {
+    const response = await fetch(`${baseUrl}/api/v1alpha2/gateways`, {
       method: "GET",
       headers: {
         Authorization: `Bearer ${token}`,
@@ -131,7 +131,7 @@ export const useGatewaysApi = () => {
     async (gatewayId: string): Promise<Gateway> => {
       const { token, baseUrl } = getApiConfig();
 
-      const response = await fetch(`${baseUrl}/api/v1/gateways/${gatewayId}`, {
+      const response = await fetch(`${baseUrl}/api/v1alpha2/gateways/${gatewayId}`, {
         method: "GET",
         headers: {
           Authorization: `Bearer ${token}`,
@@ -155,7 +155,7 @@ export const useGatewaysApi = () => {
     async (gatewayId: string): Promise<void> => {
       const { token, baseUrl } = getApiConfig();
 
-      const response = await fetch(`${baseUrl}/api/v1/gateways/${gatewayId}`, {
+      const response = await fetch(`${baseUrl}/api/v1alpha2/gateways/${gatewayId}`, {
         method: "DELETE",
         headers: {
           Authorization: `Bearer ${token}`,
@@ -178,7 +178,7 @@ export const useGatewaysApi = () => {
       const { token, baseUrl } = getApiConfig();
 
       const response = await fetch(
-        `${baseUrl}/api/v1/gateways/${payload.gatewayId}`,
+        `${baseUrl}/api/v1alpha2/gateways/${payload.gatewayId}`,
         {
           method: "DELETE",
           headers: {
@@ -204,7 +204,7 @@ export const useGatewaysApi = () => {
       const { token, baseUrl } = getApiConfig();
 
       const response = await fetch(
-        `${baseUrl}/api/v1/gateways/${gatewayId}/tokens`,
+        `${baseUrl}/api/v1alpha2/gateways/${gatewayId}/tokens`,
         {
           method: "POST",
           headers: {
@@ -230,7 +230,7 @@ export const useGatewaysApi = () => {
   const fetchGatewayStatuses = useCallback(
     async (gatewayId?: string): Promise<GatewayStatus[]> => {
       const { token, baseUrl } = getApiConfig();
-      const url = new URL(`${baseUrl}/api/v1/gateways`);
+      const url = new URL(`${baseUrl}/api/v1alpha2/gateways`);
       if (gatewayId) url.searchParams.set("gatewayId", gatewayId);
 
       const response = await fetch(url.toString(), {

--- a/portals/management-portal/src/hooks/orgs.tsx
+++ b/portals/management-portal/src/hooks/orgs.tsx
@@ -41,7 +41,7 @@ export const useCreateOrganization = () => {
         ...overrides,
       };
 
-      const response = await fetch(`${baseUrl}/api/v1/organizations`, {
+      const response = await fetch(`${baseUrl}/api/v1alpha2/organizations`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -113,7 +113,7 @@ export const useOrganizationsApi = () => {
   const fetchOrganizations = useCallback(async (): Promise<OrganizationResponse[]> => {
     const { token, baseUrl } = getApiConfig();
 
-    const response = await fetch(`${baseUrl}/api/v1/organizations`, {
+    const response = await fetch(`${baseUrl}/api/v1alpha2/organizations`, {
       method: "GET",
       headers: {
         Authorization: `Bearer ${token}`,

--- a/portals/management-portal/src/hooks/projects.ts
+++ b/portals/management-portal/src/hooks/projects.ts
@@ -26,7 +26,7 @@ export const useProjectsApi = () => {
     ): Promise<Project> => {
       const { token, baseUrl } = getApiConfig();
 
-      const response = await fetch(`${baseUrl}/api/v1/projects`, {
+      const response = await fetch(`${baseUrl}/api/v1alpha2/projects`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -51,7 +51,7 @@ export const useProjectsApi = () => {
   const fetchProject = useCallback(async (projectId: string): Promise<Project> => {
     const { token, baseUrl } = getApiConfig();
 
-    const response = await fetch(`${baseUrl}/api/v1/projects/${projectId}`, {
+    const response = await fetch(`${baseUrl}/api/v1alpha2/projects/${projectId}`, {
       method: "GET",
       headers: {
         Authorization: `Bearer ${token}`,
@@ -73,7 +73,7 @@ export const useProjectsApi = () => {
     async (): Promise<Project[]> => {
       const { token, baseUrl } = getApiConfig();
 
-      const response = await fetch(`${baseUrl}/api/v1/projects`, {
+      const response = await fetch(`${baseUrl}/api/v1alpha2/projects`, {
         method: "GET",
         headers: {
           Authorization: `Bearer ${token}`,
@@ -106,7 +106,7 @@ export const useProjectsApi = () => {
   const deleteProject = useCallback(async (projectId: string): Promise<void> => {
     const { token, baseUrl } = getApiConfig();
 
-    const response = await fetch(`${baseUrl}/api/v1/projects/${projectId}`, {
+    const response = await fetch(`${baseUrl}/api/v1alpha2/projects/${projectId}`, {
       method: "DELETE",
       headers: {
         Authorization: `Bearer ${token}`,

--- a/portals/management-portal/src/hooks/validation.ts
+++ b/portals/management-portal/src/hooks/validation.ts
@@ -98,13 +98,13 @@ const authedFetch = async (path: string, init?: RequestInit) => {
 /** ----- Hook ----- */
 
 export const useGithubProjectValidation = () => {
-  /** POST: /api/v1/api-projects/validate */
+  /** POST: /api/v1alpha2/api-projects/validate */
   const validateGithubApiProject = useCallback(
     async (
       payload: GithubProjectValidationRequest,
       opts?: { signal?: AbortSignal }
     ): Promise<GithubProjectValidationResponse> => {
-      const res = await authedFetch(`/api/v1/api-projects/validate`, {
+      const res = await authedFetch(`/api/v1alpha2/api-projects/validate`, {
         method: "POST",
         body: JSON.stringify(payload),
         signal: opts?.signal,
@@ -135,7 +135,7 @@ export const useOpenApiValidation = () => {
       const formData = new FormData();
       formData.append("url", url);
 
-      const res = await fetch(`${baseUrl}/api/v1/validate/open-api`, {
+      const res = await fetch(`${baseUrl}/api/v1alpha2/validate/open-api`, {
         method: "POST",
         headers: { Authorization: `Bearer ${token}` },
         body: formData,
@@ -163,7 +163,7 @@ export const useOpenApiValidation = () => {
       const formData = new FormData();
       formData.append("definition", file);
 
-      const res = await fetch(`${baseUrl}/api/v1/validate/open-api`, {
+      const res = await fetch(`${baseUrl}/api/v1alpha2/validate/open-api`, {
         method: "POST",
         headers: { Authorization: `Bearer ${token}` },
         body: formData,
@@ -186,7 +186,7 @@ export const useOpenApiValidation = () => {
 
 /** NEW: API uniqueness validation hook */
 export const useApiUniquenessValidation = () => {
-  /** GET: /api/v1/apis/validate?name=...&version=... */
+  /** GET: /api/v1alpha2/apis/validate?name=...&version=... */
   const validateApiNameVersion = useCallback(
     async (
       payload: ApiNameVersionValidationRequest,
@@ -197,7 +197,7 @@ export const useApiUniquenessValidation = () => {
         version: payload.version,
       }).toString();
 
-      const res = await authedFetch(`/api/v1/apis/validate?${qs}`, {
+      const res = await authedFetch(`/api/v1alpha2/apis/validate?${qs}`, {
         method: "GET",
         signal: opts?.signal,
       });
@@ -213,7 +213,7 @@ export const useApiUniquenessValidation = () => {
     []
   );
 
-  /** GET: /api/v1/apis/validate?identifier=... */
+  /** GET: /api/v1alpha2/apis/validate?identifier=... */
   const validateApiIdentifier = useCallback(
     async (
       identifier: string,
@@ -221,7 +221,7 @@ export const useApiUniquenessValidation = () => {
     ): Promise<ApiUniquenessValidationResponse> => {
       const qs = new URLSearchParams({ identifier }).toString();
 
-      const res = await authedFetch(`/api/v1/apis/validate?${qs}`, {
+      const res = await authedFetch(`/api/v1alpha2/apis/validate?${qs}`, {
         method: "GET",
         signal: opts?.signal,
       });

--- a/portals/management-portal/src/pages/overview/StepTwoApis.tsx
+++ b/portals/management-portal/src/pages/overview/StepTwoApis.tsx
@@ -87,7 +87,7 @@ export default function StepTwoApis({
 
   // -------- Display + Copy strings --------
   const CMD_DISPLAY_MD = `\`\`\`bash
-curl -X POST http://localhost:9090/api/management/v0.9/rest-apis \\
+curl -X POST http://localhost:9090/api/management/v1alpha2/rest-apis \\
   -H "Content-Type: application/yaml" \\
   --data-binary @- <<'EOF'
 version: api-platform.wso2.com/v1
@@ -106,7 +106,7 @@ spec:
 EOF
 \`\`\``;
 
-  const CMD_COPY = `curl -X POST http://localhost:9090/api/management/v0.9/rest-apis \\
+  const CMD_COPY = `curl -X POST http://localhost:9090/api/management/v1alpha2/rest-apis \\
   -H "Content-Type: application/yaml" \\
   --data-binary @- <<'EOF'
 version: api-platform.wso2.com/v1

--- a/samples/ai-gw-llm-proxy/inject-mock.sh
+++ b/samples/ai-gw-llm-proxy/inject-mock.sh
@@ -23,7 +23,7 @@ fi
 
 MGMT_PORT="${MGMT_PORT:-9090}"
 INBOUND_API_KEY="${INBOUND_API_KEY:-demo-api-key}"
-MGMT_BASE="http://localhost:${MGMT_PORT}/api/management/v0.9"
+MGMT_BASE="http://localhost:${MGMT_PORT}/api/management/v1alpha2"
 AUTH="Authorization: Basic YWRtaW46YWRtaW4="
 
 print_info "Registering LLM Provider (upstream: mock-llm-openai, policy: token-based-ratelimit)..."

--- a/samples/ai-gw-llm-proxy/provider.yaml
+++ b/samples/ai-gw-llm-proxy/provider.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProvider
 metadata:
   name: openai-provider

--- a/samples/ai-gw-llm-proxy/proxy.yaml
+++ b/samples/ai-gw-llm-proxy/proxy.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProxy
 metadata:
   name: openai-assistant

--- a/samples/ai-gw-mcp-claude-desktop/inject-mock.sh
+++ b/samples/ai-gw-mcp-claude-desktop/inject-mock.sh
@@ -22,7 +22,7 @@ if [ -f "${SCRIPT_DIR}/.env" ]; then
 fi
 
 MGMT_PORT="${MGMT_PORT:-9090}"
-MGMT_BASE="http://localhost:${MGMT_PORT}/api/management/v0.9"
+MGMT_BASE="http://localhost:${MGMT_PORT}/api/management/v1alpha2"
 AUTH="Authorization: Basic YWRtaW46YWRtaW4="
 
 print_info "Registering MCP Proxy (context: /reading-list, policy: mcp-auth)..."

--- a/samples/ai-gw-mcp-claude-desktop/mcp.yaml
+++ b/samples/ai-gw-mcp-claude-desktop/mcp.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: Mcp
 metadata:
   name: reading-list-mcp-v1.0

--- a/samples/llm-cost-control-and-privacy-control/llm-provider.yaml
+++ b/samples/llm-cost-control-and-privacy-control/llm-provider.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProvider
 metadata:
   name: wso2-openai-provider

--- a/samples/llm-cost-control-and-privacy-control/llm-proxy.yaml
+++ b/samples/llm-cost-control-and-privacy-control/llm-proxy.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1alpha2
 kind: LlmProxy
 metadata:
   name: openai-proxy

--- a/samples/llm-cost-control-and-privacy-control/setup.sh
+++ b/samples/llm-cost-control-and-privacy-control/setup.sh
@@ -9,7 +9,7 @@ DIST_NAME="wso2apip-ai-gateway-${DIST_VERSION}"
 DIST_ZIP="${DIST_NAME}.zip"
 DIST_URL="https://github.com/wso2/api-platform/releases/download/ai-gateway/v${DIST_VERSION}/${DIST_ZIP}"
 
-GATEWAY_MGMT_URL="http://localhost:9090/api/management/v0.9"
+GATEWAY_MGMT_URL="http://localhost:9090/api/management/v1alpha2"
 GATEWAY_HEALTH_URL="http://localhost:9094/health"
 AUTH_HEADER="Authorization: Basic YWRtaW46YWRtaW4="   # admin:admin
 

--- a/samples/llm-cost-control-and-privacy-control/teardown.sh
+++ b/samples/llm-cost-control-and-privacy-control/teardown.sh
@@ -8,7 +8,7 @@ DIST_VERSION="1.1.0"
 DIST_NAME="wso2apip-ai-gateway-${DIST_VERSION}"
 DIST_ZIP="${DIST_NAME}.zip"
 
-GATEWAY_MGMT_URL="http://localhost:9090/api/management/v0.9"
+GATEWAY_MGMT_URL="http://localhost:9090/api/management/v1alpha2"
 AUTH_HEADER="Authorization: Basic YWRtaW46YWRtaW4="   # admin:admin
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
### Purpose

Portal UI, event-gateway, CLI, samples, and documentation updates to support the `globalPolicies` / `operationPolicies` feature and the `v1alpha2` version bump.

**AI Workspace portal.**
* Guardrails tabs for LLM proxies (`LLMProxyGuardrailsTab`) and service providers (`ServiceProviderGuardrailsTab`) updated to surface global vs. per-operation policy configuration.

**CLI.**
* Sample YAML resources and generator updated to `v1alpha2`.

**Samples.**
* LLM provider/proxy sample YAMLs updated to `v1alpha2` artifact apiVersion.

**Docs.**
* Gateway REST API reference pages updated to reflect the new `globalPolicies` / `operationPolicies` fields and `v1alpha2` versions.

**CI.**
* `operator-integration-test.yml` YAML indentation fixes (two annotation blocks had a one-space misalignment that caused YAML parse failures at apply time).