### PR TITLE
ci: extract controller policies in jfrog scan matrix jobs

### DIFF
--- a/.github/workflows/jfrog-scan.yaml
+++ b/.github/workflows/jfrog-scan.yaml
@@ -14,14 +14,16 @@ jobs:
       matrix:
         include:
           - { name: gateway-runtime, make_dir: gateway/gateway-runtime }
-          - { name: gateway-controller, make_dir: gateway/gateway-controller }
+          # gateway-controller embeds the compiled policy YAMLs, so it needs the policy
+          # export from the gateway-runtime build first (needs_policies).
+          - { name: gateway-controller, make_dir: gateway/gateway-controller, needs_policies: true }
           - { name: gateway-builder, make_dir: gateway/gateway-builder }
           - { name: platform-api, make_dir: platform-api }
           - { name: ai-workspace, make_dir: portals/ai-workspace }
           - { name: event-gateway-runtime, make_dir: event-gateway/gateway-runtime }
           # event-gateway-controller is built from the gateway-controller Makefile target,
-          # tagged under its own image name.
-          - { name: event-gateway-controller, make_dir: gateway/gateway-controller }
+          # tagged under its own image name; it needs the same policy export.
+          - { name: event-gateway-controller, make_dir: gateway/gateway-controller, needs_policies: true }
 
     # Hard ceiling for the whole job. The scan step has its own per-attempt timeout below,
     # so this only guards against an unexpected hang in build/setup.
@@ -61,6 +63,16 @@ jobs:
         env:
           JF_URL: ${{ secrets.JF_URL }}
           JF_ACCESS_TOKEN: ${{ secrets.JF_ACCESS_TOKEN }}
+
+      # The gateway-controller / event-gateway-controller images COPY in the compiled
+      # policy definitions, which are produced by the gateway-runtime "policy-export"
+      # Dockerfile stage into gateway/target/build/gateway-controller/policies. The old
+      # single-job workflow got these for free because gateway-runtime built first; with one
+      # job per image we extract them explicitly before building the controller image.
+      - name: Extract controller policy definitions
+        if: ${{ matrix.needs_policies }}
+        run: |
+          make -C gateway/gateway-runtime extract-policies VERSION=trivy
 
       - name: Build & push ${{ matrix.name }} to temp registry
         run: |


### PR DESCRIPTION
## Purpose

PR #2241 parallelized the `Jfrog Scan` workflow into one job per image. That exposed a hidden inter-image build dependency: the `gateway-controller` and `event-gateway-controller` images COPY in the compiled policy definitions, which are produced by the gateway-runtime build's `policy-export` Dockerfile stage into `gateway/target/build/gateway-controller/policies`. In the old single job, gateway-runtime built first and left that directory on disk for the controller build to consume. With one job per image on a fresh runner, the directory is no longer present, so both controller builds now fail in ~30s with:

```
ERROR: failed to build: failed to get build context policies: stat ../target/build/gateway-controller/policies: no such file or directory
make: *** [Makefile:106: build-and-push-multiarch] Error 1
```

The other five images (gateway-runtime, platform-api, gateway-builder, ai-workspace, event-gateway-runtime) build and scan correctly under the matrix, including the previously-timing-out gateway-runtime scan.

## Goals

Make the `gateway-controller` and `event-gateway-controller` builds self-contained under the per-image matrix by producing the policy definitions they depend on.

## Approach

- Add a `needs_policies` matrix flag to the two controller images.
- Before building those images, run `make -C gateway/gateway-runtime extract-policies`, which builds the `policy-export` stage and exports the YAMLs to `gateway/target/build/gateway-controller/policies` — the exact path the controller build consumes. This is the same extraction the gateway-runtime build runs internally, so it is already proven in this CI environment.
- The step is gated with `if: ${{ matrix.needs_policies }}`, so the other five images are unaffected.

## User stories

N/A

## Documentation

N/A — CI-only change with no product or user-facing documentation impact.

## Automation tests

- Unit tests: N/A — CI workflow change.
- Integration tests: The workflow is its own test; the matrix run from #2241 confirmed the five non-controller jobs pass, and this change addresses the two controller jobs. Can be validated via `workflow_dispatch` before merge.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — no source code change; GitHub Actions YAML only.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

Follow-up to #2241.

## Test environment

GitHub Actions `ubuntu-latest` runner.