### PR TITLE
Add Readonly mode in AI Workspace

### DIFF
--- a/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/EditExternalServer.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/EditExternalServer.tsx
@@ -41,6 +41,7 @@ import { mcpProxiesApis } from '../../../../apis/MCP/mcpProxiesApis';
 import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
 import type { MCPServer } from '../../../../utils/types';
 import { useMemo } from 'react';
+import { DisabledActionTooltip } from '../../../../utils/readOnlyArtifacts';
 
 const MAX_NAME_LENGTH = 255;
 const MAX_DESCRIPTION_LENGTH = 1023;
@@ -112,6 +113,7 @@ export default function EditExternalServer() {
   const [version, setVersion] = useState('');
   const [context, setContext] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const isReadOnlyServer = Boolean(server?.readOnly);
 
   useEffect(() => {
     if (!serverId || !organizationId) return;
@@ -159,7 +161,7 @@ export default function EditExternalServer() {
   };
 
   const handleSubmit = async () => {
-    if (!serverId || !server) return;
+    if (!serverId || !server || isReadOnlyServer) return;
 
     setIsSubmitting(true);
     try {
@@ -258,6 +260,12 @@ export default function EditExternalServer() {
 
         <Box sx={{ mb: 4 }}>
           <Stack spacing={3}>
+            {isReadOnlyServer ? (
+              <Alert severity="info">
+                This MCP proxy was created from a gateway. Editing is
+                unavailable in AI Workspace.
+              </Alert>
+            ) : null}
             {isContextOrVersionChanged && (
               <Alert severity="warning">
                 You have modified the context or version of this MCP Proxy.
@@ -272,6 +280,7 @@ export default function EditExternalServer() {
                   fullWidth
                   required
                   value={name}
+                  disabled={isReadOnlyServer}
                   onChange={(e) => setName(e.target.value)}
                   placeholder="Enter server name"
                   error={name.length > MAX_NAME_LENGTH}
@@ -288,6 +297,7 @@ export default function EditExternalServer() {
                 <TextField
                   fullWidth
                   value={version}
+                  disabled={isReadOnlyServer}
                   onChange={(e) => setVersion(e.target.value)}
                   placeholder="e.g., 1.0"
                   error={version.length > MAX_VERSION_LENGTH}
@@ -305,6 +315,7 @@ export default function EditExternalServer() {
               <TextField
                 fullWidth
                 value={description}
+                disabled={isReadOnlyServer}
                 onChange={(e) => setDescription(e.target.value)}
                 placeholder="Enter description"
                 multiline
@@ -323,6 +334,7 @@ export default function EditExternalServer() {
               <TextField
                 fullWidth
                 value={context}
+                disabled={isReadOnlyServer}
                 onChange={(e) => setContext(e.target.value)}
                 placeholder="Enter context path"
                 error={context.length > MAX_CONTEXT_LENGTH}
@@ -340,13 +352,17 @@ export default function EditExternalServer() {
           <Button variant="outlined" onClick={handleCancel}>
             Cancel
           </Button>
-          <Button
-            variant="contained"
-            onClick={handleSubmit}
-            disabled={isSubmitting || !isFormValid()}
-          >
-            {isSubmitting ? 'Updating...' : 'Update'}
-          </Button>
+          <DisabledActionTooltip disabled={isReadOnlyServer}>
+            <span>
+              <Button
+                variant="contained"
+                onClick={handleSubmit}
+                disabled={isReadOnlyServer || isSubmitting || !isFormValid()}
+              >
+                {isSubmitting ? 'Updating...' : 'Update'}
+              </Button>
+            </span>
+          </DisabledActionTooltip>
         </Box>
       </Box>
     </PageContent>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/ExternalServersDeploy.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/ExternalServersDeploy.tsx
@@ -19,6 +19,7 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
+  Alert,
   Button,
   PageContent,
   Stack,
@@ -99,7 +100,14 @@ function ExternalServersDeployLayout({ serverId }: ExternalServersDeployLayoutPr
             defaultMessage="Deploy MCP Proxy to your Gateways"
           />
         </Typography>
-        <GatewayDeployMainSection showConfigureOption={false} />
+        {server?.readOnly ? (
+          <Alert severity="info">
+            This MCP proxy was created from a gateway. Deployment actions are
+            unavailable in AI Workspace.
+          </Alert>
+        ) : (
+          <GatewayDeployMainSection showConfigureOption={false} />
+        )}
       </Stack>
     </PageContent>
   );

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/ExternalServersOverview.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/ExternalServersOverview.tsx
@@ -25,6 +25,7 @@ import React, {
 } from 'react';
 import { Link as RouterLink, useNavigate, useParams } from 'react-router-dom';
 import {
+  Alert,
   Avatar,
   Box,
   Button,
@@ -72,6 +73,10 @@ import ExternalServersValidationDetails from './ExternalServersValidationDetails
 import type { EndpointValidationResponse } from './externalServersValidationTypes';
 import ExternalServerStepBanner from '../quickStart/ExternalServerStepBanner';
 import type { ExternalServerStepBannerStepId } from '../quickStart/ExternalServerStepBanner';
+import {
+  DisabledActionTooltip,
+  GATEWAY_MANAGED_ARTIFACT_TOOLTIP,
+} from '../../../../utils/readOnlyArtifacts';
 
 function getInitials(name: string): string {
   const words = name.trim().split(/\s+/);
@@ -196,6 +201,7 @@ export default function ExternalServersOverview(): JSX.Element {
   const [selectedPolicies, setSelectedPolicies] = useState<SelectedPolicy[]>(
     []
   );
+  const isReadOnlyServer = Boolean(server?.readOnly);
 
   const selectedPoliciesRef = useRef<SelectedPolicy[]>([]);
   const [initialPolicies, setInitialPolicies] = useState<SelectedPolicy[]>([]);
@@ -431,11 +437,12 @@ export default function ExternalServersOverview(): JSX.Element {
   }, [selectedPolicies, initialPolicies]);
 
   const handleCancelChanges = () => {
+    if (isReadOnlyServer) return;
     updateSelectedPolicies(initialPolicies);
   };
 
   const handleSaveChanges = async () => {
-    if (!server || !organizationId) return;
+    if (!server || !organizationId || isReadOnlyServer) return;
     const orderedPolicies = selectedPoliciesRef.current;
 
     // Convert selectedPolicies -> flat policy payload (preserve current UI order)
@@ -489,6 +496,7 @@ export default function ExternalServersOverview(): JSX.Element {
   };
 
   const handleAddPolicy = (policy: Omit<SelectedPolicy, 'instanceId'>) => {
+    if (isReadOnlyServer) return;
     const nextItem: SelectedPolicy = {
       instanceId: `${policy.policyId}-${Date.now()}`,
       ...policy,
@@ -498,6 +506,7 @@ export default function ExternalServersOverview(): JSX.Element {
   };
 
   const handleUpdatePolicy = (instanceId: string, params: ParameterValues) => {
+    if (isReadOnlyServer) return;
     updateSelectedPolicies((prev) =>
       prev.map((policy) =>
         policy.instanceId === instanceId ? { ...policy, params } : policy
@@ -506,6 +515,7 @@ export default function ExternalServersOverview(): JSX.Element {
   };
 
   const handleRemovePolicy = (instanceId: string) => {
+    if (isReadOnlyServer) return;
     updateSelectedPolicies((prev) =>
       prev.filter((policy) => policy.instanceId !== instanceId)
     );
@@ -515,6 +525,7 @@ export default function ExternalServersOverview(): JSX.Element {
     draggedInstanceId: string,
     targetInstanceId: string
   ) => {
+    if (isReadOnlyServer) return;
     updateSelectedPolicies((prev) => {
       const draggedIndex = prev.findIndex(
         (policy) => policy.instanceId === draggedInstanceId
@@ -616,6 +627,12 @@ export default function ExternalServersOverview(): JSX.Element {
       />
 
       <Stack spacing={3} sx={{ mt: 2, mb: 4 }}>
+        {isReadOnlyServer ? (
+          <Alert severity="info">
+            This MCP proxy was created from a gateway. Editing and deployment
+            actions are unavailable in AI Workspace.
+          </Alert>
+        ) : null}
         {/* Top Card - Server Info */}
         <Card>
           <Box
@@ -655,11 +672,23 @@ export default function ExternalServersOverview(): JSX.Element {
                     variant="outlined"
                     color="primary"
                   />
-                  <Tooltip title="Edit MCP Proxy">
-                    <IconButton component={RouterLink} to="edit" size="small">
-                      <Edit size={16} />
-                    </IconButton>
-                  </Tooltip>
+                  <DisabledActionTooltip
+                    disabled={isReadOnlyServer}
+                    title={GATEWAY_MANAGED_ARTIFACT_TOOLTIP}
+                  >
+                    <span>
+                      <Tooltip title={isReadOnlyServer ? '' : 'Edit MCP Proxy'}>
+                        <IconButton
+                          component={isReadOnlyServer ? 'button' : RouterLink}
+                          to={isReadOnlyServer ? undefined : 'edit'}
+                          size="small"
+                          disabled={isReadOnlyServer}
+                        >
+                          <Edit size={16} />
+                        </IconButton>
+                      </Tooltip>
+                    </span>
+                  </DisabledActionTooltip>
                 </Stack>
                 <Typography variant="body2" color="text.secondary">
                   {server.description}
@@ -695,17 +724,27 @@ export default function ExternalServersOverview(): JSX.Element {
               spacing={1}
               sx={{ alignSelf: 'flex-start', ml: 'auto', gap: 1 }}
             >
-              <Button
-                variant="contained"
-                component={RouterLink}
-                to="deploy"
-                onClick={handleBlockedNavigation}
+              <DisabledActionTooltip
+                disabled={isReadOnlyServer}
+                title={GATEWAY_MANAGED_ARTIFACT_TOOLTIP}
               >
-                <FormattedMessage
-                  id="aiWorkspace.pages.appShell.appShellPages.externalServers.overview.deployToGateway"
-                  defaultMessage="Deploy to Gateway"
-                />
-              </Button>
+                <span>
+                  <Button
+                    variant="contained"
+                    component={isReadOnlyServer ? 'button' : RouterLink}
+                    to={isReadOnlyServer ? undefined : 'deploy'}
+                    onClick={
+                      isReadOnlyServer ? undefined : handleBlockedNavigation
+                    }
+                    disabled={isReadOnlyServer}
+                  >
+                    <FormattedMessage
+                      id="aiWorkspace.pages.appShell.appShellPages.externalServers.overview.deployToGateway"
+                      defaultMessage="Deploy to Gateway"
+                    />
+                  </Button>
+                </span>
+              </DisabledActionTooltip>
             </Stack>
           </Box>
         </Card>
@@ -840,6 +879,7 @@ export default function ExternalServersOverview(): JSX.Element {
                 onRemovePolicy={handleRemovePolicy}
                 onReorderPolicies={handleReorderPolicies}
                 validationResult={validationResult}
+                readOnly={isReadOnlyServer}
               />
             </TabPanel>
           </Box>
@@ -871,14 +911,18 @@ export default function ExternalServersOverview(): JSX.Element {
               <Button
                 variant="outlined"
                 color="secondary"
-                disabled={!hasUnsavedChanges || isSavingChanges}
+                disabled={
+                  isReadOnlyServer || !hasUnsavedChanges || isSavingChanges
+                }
                 onClick={handleCancelChanges}
               >
                 Cancel
               </Button>
               <Button
                 variant="contained"
-                disabled={!hasUnsavedChanges || isSavingChanges}
+                disabled={
+                  isReadOnlyServer || !hasUnsavedChanges || isSavingChanges
+                }
                 onClick={() => void handleSaveChanges()}
               >
                 {isSavingChanges ? 'Saving...' : 'Save'}

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/PolicyMapper.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/PolicyMapper.tsx
@@ -50,6 +50,10 @@ import { logger } from '../../../../utils/logger';
 import ErrorAlert from '../../../../Components/common/ErrorAlert';
 import ExternalServersValidationDetails from './ExternalServersValidationDetails';
 import type { EndpointValidationResponse } from './externalServersValidationTypes';
+import {
+  DisabledActionTooltip,
+  GATEWAY_MANAGED_ARTIFACT_TOOLTIP,
+} from '../../../../utils/readOnlyArtifacts';
 
 export type SelectedPolicy = {
   instanceId: string;
@@ -70,6 +74,7 @@ type Props = {
     targetInstanceId: string
   ) => void;
   validationResult?: EndpointValidationResponse | null;
+  readOnly?: boolean;
 };
 
 function DragHandle(): JSX.Element {
@@ -107,6 +112,7 @@ export default function PolicyMapper({
   onRemovePolicy,
   onReorderPolicies,
   validationResult,
+  readOnly = false,
 }: Props): JSX.Element {
   const intl = useIntl();
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
@@ -150,6 +156,7 @@ export default function PolicyMapper({
   }, [isDrawerOpen]);
 
   const handleOpenDrawer = async () => {
+    if (readOnly) return;
     setEditingInstanceId(null);
     setIsDrawerOpen(true);
     setIsFetchingPolicies(true);
@@ -165,6 +172,7 @@ export default function PolicyMapper({
   };
 
   const handleEditPolicyItem = async (item: SelectedPolicy) => {
+    if (readOnly) return;
     setEditingInstanceId(item.instanceId);
     setIsDrawerOpen(true);
     setIsFetchingPolicies(true);
@@ -210,6 +218,7 @@ export default function PolicyMapper({
   };
 
   const handlePolicyClick = async (policy: PolicyHubPolicy) => {
+    if (readOnly) return;
     setSelectedDrawerPolicy(policy.name);
     setIsDetailView(true);
     setPolicyDefinition(null);
@@ -244,6 +253,7 @@ export default function PolicyMapper({
   };
 
   const handlePolicySubmit = async (params: ParameterValues) => {
+    if (readOnly) return;
     const policy = fetchedPolicies.find((p) => p.name === selectedDrawerPolicy);
     if (!policy) return;
 
@@ -271,6 +281,11 @@ export default function PolicyMapper({
   const hasPolicies = selectedPolicies.length > 0;
 
   const handleDrop = (targetInstanceId: string) => {
+    if (readOnly) {
+      setDraggedInstanceId(null);
+      setDragOverInstanceId(null);
+      return;
+    }
     if (!draggedInstanceId || draggedInstanceId === targetInstanceId) {
       setDraggedInstanceId(null);
       setDragOverInstanceId(null);
@@ -312,17 +327,25 @@ export default function PolicyMapper({
                 </Typography>
               </Box>
               {hasPolicies && (
-                <Button
-                  variant="contained"
-                  onClick={() => void handleOpenDrawer()}
-                  startIcon={<Plus size={18} />}
-                  sx={{ whiteSpace: 'nowrap', flexShrink: 0, mt: 2 }}
+                <DisabledActionTooltip
+                  disabled={readOnly}
+                  title={GATEWAY_MANAGED_ARTIFACT_TOOLTIP}
                 >
-                  <FormattedMessage
-                    id="aiWorkspace.pages.appShell.appShellPages.externalServers.policyMapper.addPolicies"
-                    defaultMessage="Add Policies"
-                  />
-                </Button>
+                  <span>
+                    <Button
+                      variant="contained"
+                      onClick={() => void handleOpenDrawer()}
+                      startIcon={<Plus size={18} />}
+                      disabled={readOnly}
+                      sx={{ whiteSpace: 'nowrap', flexShrink: 0, mt: 2 }}
+                    >
+                      <FormattedMessage
+                        id="aiWorkspace.pages.appShell.appShellPages.externalServers.policyMapper.addPolicies"
+                        defaultMessage="Add Policies"
+                      />
+                    </Button>
+                  </span>
+                </DisabledActionTooltip>
               )}
             </Box>
 
@@ -351,16 +374,24 @@ export default function PolicyMapper({
                       defaultMessage="No policies added yet."
                     />
                   </Typography>
-                  <Button
-                    variant="contained"
-                    onClick={() => void handleOpenDrawer()}
-                    startIcon={<Plus size={18} />}
+                  <DisabledActionTooltip
+                    disabled={readOnly}
+                    title={GATEWAY_MANAGED_ARTIFACT_TOOLTIP}
                   >
-                    <FormattedMessage
-                      id="aiWorkspace.pages.appShell.appShellPages.externalServers.policyMapper.addPolicies"
-                      defaultMessage="Add Policies"
-                    />
-                  </Button>
+                    <span>
+                      <Button
+                        variant="contained"
+                        onClick={() => void handleOpenDrawer()}
+                        startIcon={<Plus size={18} />}
+                        disabled={readOnly}
+                      >
+                        <FormattedMessage
+                          id="aiWorkspace.pages.appShell.appShellPages.externalServers.policyMapper.addPolicies"
+                          defaultMessage="Add Policies"
+                        />
+                      </Button>
+                    </span>
+                  </DisabledActionTooltip>
                 </Stack>
               </Box>
             ) : (
@@ -371,19 +402,28 @@ export default function PolicyMapper({
                     draggedInstanceId !== item.instanceId;
 
                   return (
-                    <Box
+                    <DisabledActionTooltip
                       key={item.instanceId}
-                      draggable
-                      onDragStart={() => setDraggedInstanceId(item.instanceId)}
+                      disabled={readOnly}
+                      title={GATEWAY_MANAGED_ARTIFACT_TOOLTIP}
+                    >
+                      <Box
+                      key={item.instanceId}
+                      draggable={!readOnly}
+                      onDragStart={() =>
+                        !readOnly && setDraggedInstanceId(item.instanceId)
+                      }
                       onDragEnd={() => {
                         setDraggedInstanceId(null);
                         setDragOverInstanceId(null);
                       }}
                       onDragOver={(event: React.DragEvent) => {
+                        if (readOnly) return;
                         event.preventDefault();
                         setDragOverInstanceId(item.instanceId);
                       }}
                       onDrop={(event: React.DragEvent) => {
+                        if (readOnly) return;
                         event.preventDefault();
                         handleDrop(item.instanceId);
                       }}
@@ -404,14 +444,16 @@ export default function PolicyMapper({
                         boxShadow: isDragOver
                           ? '0 0 0 3px rgba(29, 78, 216, 0.12)'
                           : '0 1px 3px rgba(0, 0, 0, 0.04)',
-                        cursor: 'pointer',
+                        cursor: readOnly ? 'default' : 'pointer',
                         opacity:
                           draggedInstanceId === item.instanceId ? 0.5 : 1,
                         transition: 'all 0.15s ease',
-                        '&:hover': {
-                          borderColor: '#D1D5DB',
-                          boxShadow: '0 2px 6px rgba(0, 0, 0, 0.08)',
-                        },
+                        '&:hover': readOnly
+                          ? undefined
+                          : {
+                              borderColor: '#D1D5DB',
+                              boxShadow: '0 2px 6px rgba(0, 0, 0, 0.08)',
+                            },
                       }}
                     >
                       <DragHandle />
@@ -442,6 +484,7 @@ export default function PolicyMapper({
                           event.stopPropagation();
                           onRemovePolicy(item.instanceId);
                         }}
+                        disabled={readOnly}
                         sx={{
                           color: '#9CA3AF',
                           '&:hover': { color: '#EF4444' },
@@ -449,7 +492,8 @@ export default function PolicyMapper({
                       >
                         <X size={16} />
                       </IconButton>
-                    </Box>
+                      </Box>
+                    </DisabledActionTooltip>
                   );
                 })}
               </Stack>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/EditLLMProxy.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/EditLLMProxy.tsx
@@ -38,6 +38,7 @@ import {
   buildProjectPath,
 } from '../../../../utils/projectRouting';
 import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
+import { DisabledActionTooltip } from '../../../../utils/readOnlyArtifacts';
 
 const MAX_NAME_LENGTH = 255;
 const MAX_DESCRIPTION_LENGTH = 1023;
@@ -50,6 +51,7 @@ function EditLLMProxyForm() {
   const { currentOrganization, currentProject } = useAppShell();
   const { proxy, isLoading, error, updateProxy } = useProxy();
   const showSnackbar = useAIWorkspaceSnackbar();
+  const isReadOnlyProxy = Boolean(proxy?.readOnly);
 
   const isProjectLevel = Boolean(currentProject?.id);
   const proxiesPath = isProjectLevel
@@ -85,7 +87,7 @@ function EditLLMProxyForm() {
   };
 
   const handleSubmit = async () => {
-    if (!proxyId) return;
+    if (!proxyId || isReadOnlyProxy) return;
 
     setIsSubmitting(true);
     try {
@@ -177,6 +179,12 @@ function EditLLMProxyForm() {
 
         <Box sx={{ mb: 4 }}>
           <Stack spacing={3}>
+            {isReadOnlyProxy ? (
+              <Alert severity="info">
+                This proxy was created from a gateway. Editing is unavailable
+                in AI Workspace.
+              </Alert>
+            ) : null}
             {isContextOrVersionChanged && (
               <Alert severity="warning">
                 You have modified the context or version of this proxy. After
@@ -191,6 +199,7 @@ function EditLLMProxyForm() {
                   fullWidth
                   required
                   value={name}
+                  disabled={isReadOnlyProxy}
                   onChange={(e) => setName(e.target.value)}
                   placeholder="Enter proxy name"
                   error={name.length > MAX_NAME_LENGTH}
@@ -207,6 +216,7 @@ function EditLLMProxyForm() {
                 <TextField
                   fullWidth
                   value={version}
+                  disabled={isReadOnlyProxy}
                   onChange={(e) => setVersion(e.target.value)}
                   placeholder="e.g., 1.0"
                   error={version.length > MAX_VERSION_LENGTH}
@@ -224,6 +234,7 @@ function EditLLMProxyForm() {
               <TextField
                 fullWidth
                 value={description}
+                disabled={isReadOnlyProxy}
                 onChange={(e) => setDescription(e.target.value)}
                 placeholder="Enter description"
                 multiline
@@ -242,6 +253,7 @@ function EditLLMProxyForm() {
               <TextField
                 fullWidth
                 value={context}
+                disabled={isReadOnlyProxy}
                 onChange={(e) => setContext(e.target.value)}
                 placeholder="Enter context path"
                 error={context.length > MAX_CONTEXT_LENGTH}
@@ -259,13 +271,17 @@ function EditLLMProxyForm() {
           <Button variant="outlined" color="secondary" onClick={handleCancel}>
             Cancel
           </Button>
-          <Button
-            variant="contained"
-            onClick={handleSubmit}
-            disabled={isSubmitting || !isFormValid()}
-          >
-            {isSubmitting ? 'Updating...' : 'Update'}
-          </Button>
+          <DisabledActionTooltip disabled={isReadOnlyProxy}>
+            <span>
+              <Button
+                variant="contained"
+                onClick={handleSubmit}
+                disabled={isReadOnlyProxy || isSubmitting || !isFormValid()}
+              >
+                {isSubmitting ? 'Updating...' : 'Update'}
+              </Button>
+            </span>
+          </DisabledActionTooltip>
         </Box>
       </Box>
     </PageContent>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyDefinitionTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyDefinitionTab.tsx
@@ -42,6 +42,7 @@ import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
 import NoData from '../../../../assets/images/NoData.svg';
 import { logger } from '../../../../utils/logger';
 import SwaggerSpecViewer from '../../../../Components/SwaggerSpecViewer';
+import { DisabledActionTooltip } from '../../../../utils/readOnlyArtifacts';
 
 type OpenApiSpec = Record<string, unknown>;
 
@@ -156,6 +157,7 @@ export default function LLMProxyDefinitionTab() {
   const [isFetchingSpec, setIsFetchingSpec] = useState(false);
   const [updateSpecModalOpen, setUpdateSpecModalOpen] = useState(false);
   const showSnackbar = useAIWorkspaceSnackbar();
+  const isReadOnlyProxy = Boolean(proxy?.readOnly);
 
   useEffect(() => {
     setEditorText(proxy?.openapi || '');
@@ -178,15 +180,18 @@ export default function LLMProxyDefinitionTab() {
   const hasDefinition = editorText.trim().length > 0;
 
   const updateEditorText = (nextText: string) => {
+    if (isReadOnlyProxy) return;
     setEditorText(nextText);
     setLocalProxy((prev) => (prev ? { ...prev, openapi: nextText } : prev));
   };
 
   const handleUploadClick = () => {
+    if (isReadOnlyProxy) return;
     fileInputRef.current?.click();
   };
 
   const applySpecificationFromText = (text: string, sourceName?: string) => {
+    if (isReadOnlyProxy) return;
     const parsed = parseOpenApiSpec(text);
     const nextValidationError = validateOpenApiText(text, parsed);
     if (nextValidationError) {
@@ -202,6 +207,7 @@ export default function LLMProxyDefinitionTab() {
   };
 
   const handleFetchAndClose = async (url: string) => {
+    if (isReadOnlyProxy) return;
     const nextUrl = url.trim();
     if (!nextUrl) {
       showSnackbar('Enter a valid OpenAPI URL first.', 'error');
@@ -227,6 +233,7 @@ export default function LLMProxyDefinitionTab() {
   };
 
   const handleFileChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
+    if (isReadOnlyProxy) return;
     const file = e.target.files?.[0];
     if (!file) return;
 
@@ -248,17 +255,22 @@ export default function LLMProxyDefinitionTab() {
   return (
     <Stack spacing={2}>
       <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
-        <Button
-          variant="outlined"
-          size="small"
-          startIcon={<PenLine size={16} />}
-          onClick={() => setUpdateSpecModalOpen(true)}
-        >
-          <FormattedMessage
-            id="aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxyDefinitionTab.update.openapi.definition"
-            defaultMessage={'Update OpenAPI Definition'}
-          />
-        </Button>
+        <DisabledActionTooltip disabled={isReadOnlyProxy}>
+          <span>
+            <Button
+              variant="outlined"
+              size="small"
+              startIcon={<PenLine size={16} />}
+              onClick={() => setUpdateSpecModalOpen(true)}
+              disabled={isReadOnlyProxy}
+            >
+              <FormattedMessage
+                id="aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxyDefinitionTab.update.openapi.definition"
+                defaultMessage={'Update OpenAPI Definition'}
+              />
+            </Button>
+          </span>
+        </DisabledActionTooltip>
       </Box>
 
       <Dialog
@@ -285,6 +297,7 @@ export default function LLMProxyDefinitionTab() {
                   size="small"
                   fullWidth
                   value={specUrl}
+                  disabled={isReadOnlyProxy}
                   onChange={(e) => {
                     setSpecUrl(e.target.value);
                   }}
@@ -294,7 +307,7 @@ export default function LLMProxyDefinitionTab() {
                   <Button
                     variant="outlined"
                     size="small"
-                    disabled={isFetchingSpec}
+                    disabled={isReadOnlyProxy || isFetchingSpec}
                     onClick={() => {
                       void handleFetchAndClose(specUrl);
                     }}
@@ -305,7 +318,12 @@ export default function LLMProxyDefinitionTab() {
               </Stack>
             </FormControl>
             <Divider sx={{ my: 2 }}>Or</Divider>
-            <Button variant="outlined" fullWidth onClick={handleUploadClick}>
+            <Button
+              variant="outlined"
+              fullWidth
+              onClick={handleUploadClick}
+              disabled={isReadOnlyProxy}
+            >
               Upload Your Specification
             </Button>
             <input
@@ -389,6 +407,7 @@ export default function LLMProxyDefinitionTab() {
                   lineHeight: 20,
                   wordWrap: 'on',
                   automaticLayout: true,
+                  readOnly: isReadOnlyProxy,
                 }}
                 theme="vs-dark"
                 loading={<Box sx={{ p: 2 }}>Loading editor...</Box>}

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyDeploy.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyDeploy.tsx
@@ -18,15 +18,17 @@
 
 import React from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { Button, PageContent, Stack, Typography } from '@wso2/oxygen-ui';
+import { Alert, Button, PageContent, Stack, Typography } from '@wso2/oxygen-ui';
 import { ChevronLeft } from '@wso2/oxygen-ui-icons-react';
 import { GatewayDeployProvider } from '../../../../contexts/GatewayDeployContext';
 import { GatewayDeployMainSection } from '../../../../Components/GatewayDeploy';
 import { FormattedMessage } from 'react-intl';
+import { ProxyProvider, useProxy } from '../../../../contexts/proxy';
 
 function LLMProxyDeployContent() {
   const { proxyId } = useParams<{ proxyId: string }>();
   const navigate = useNavigate();
+  const { proxy } = useProxy();
 
   if (!proxyId) {
     return (
@@ -65,7 +67,14 @@ function LLMProxyDeployContent() {
               defaultMessage={'Deploy App LLM Proxy to your Gateways'}
             />
           </Typography>
-          <GatewayDeployMainSection showConfigureOption={false} />
+          {proxy?.readOnly ? (
+            <Alert severity="info">
+              This proxy was created from a gateway. Deployment actions are
+              unavailable in AI Workspace.
+            </Alert>
+          ) : (
+            <GatewayDeployMainSection showConfigureOption={false} />
+          )}
         </Stack>
       </GatewayDeployProvider>
     </PageContent>
@@ -88,5 +97,9 @@ export default function LLMProxyDeploy() {
     );
   }
 
-  return <LLMProxyDeployContent />;
+  return (
+    <ProxyProvider proxyId={proxyId}>
+      <LLMProxyDeployContent />
+    </ProxyProvider>
+  );
 }

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyDeploymentsCard.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyDeploymentsCard.tsx
@@ -51,6 +51,10 @@ import { logger } from '../../../../utils/logger';
 import type { Gateway } from '../../../../apis/gatewayTypes';
 import type { DeploymentResponse } from '../../../../utils/types';
 import { FormattedMessage } from 'react-intl';
+import {
+  DisabledActionTooltip,
+  GATEWAY_MANAGED_ARTIFACT_TOOLTIP,
+} from '../../../../utils/readOnlyArtifacts';
 
 interface GatewayWithDeployment extends Gateway {
   deployment?: DeploymentResponse;
@@ -66,6 +70,7 @@ export default function LLMProxyDeploymentsCard() {
   const [generatingKey, setGeneratingKey] = useState(false);
   const [generatedKey, setGeneratedKey] = useState<string | null>(null);
   const [keyError, setKeyError] = useState<string | null>(null);
+  const isReadOnlyProxy = Boolean(proxy?.readOnly);
   const apiKeyLocation = proxy?.security?.apiKey?.in ?? 'header';
   const apiKeyName = proxy?.security?.apiKey?.key ?? 'X-API-Key';
 
@@ -144,6 +149,7 @@ export default function LLMProxyDeploymentsCard() {
   }, [currentOrganization?.uuid, proxy?.id]);
 
   const handleGenerateAPIKey = async () => {
+    if (isReadOnlyProxy) return;
     if (!currentOrganization?.uuid || !proxy?.id) {
       return;
     }
@@ -367,41 +373,47 @@ export default function LLMProxyDeploymentsCard() {
                     />
                   </Typography>
                 </Box>
-                <Tooltip
-                  title={
-                    deployedGateways.length === 0
-                      ? 'No deployed gateways available. Deploy to a gateway first to generate an API key.'
-                      : ''
-                  }
-                  placement="top"
+                <DisabledActionTooltip
+                  disabled={isReadOnlyProxy}
+                  title={GATEWAY_MANAGED_ARTIFACT_TOOLTIP}
                 >
-                  <span>
-                    <Button
-                      variant="contained"
-                      size="medium"
-                      onClick={handleGenerateAPIKey}
-                      disabled={
-                        generatingKey ||
-                        deployedGateways.length === 0
-                      }
-                    >
-                      {generatingKey ? (
-                        <>
-                          <CircularProgress size={16} sx={{ mr: 1 }} />
+                  <Tooltip
+                    title={
+                      !isReadOnlyProxy && deployedGateways.length === 0
+                        ? 'No deployed gateways available. Deploy to a gateway first to generate an API key.'
+                        : ''
+                    }
+                    placement="top"
+                  >
+                    <span>
+                      <Button
+                        variant="contained"
+                        size="medium"
+                        onClick={handleGenerateAPIKey}
+                        disabled={
+                          isReadOnlyProxy ||
+                          generatingKey ||
+                          deployedGateways.length === 0
+                        }
+                      >
+                        {generatingKey ? (
+                          <>
+                            <CircularProgress size={16} sx={{ mr: 1 }} />
+                            <FormattedMessage
+                              id="aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxyDeploymentsCard.generating"
+                              defaultMessage={'Generating...'}
+                            />
+                          </>
+                        ) : (
                           <FormattedMessage
-                            id="aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxyDeploymentsCard.generating"
-                            defaultMessage={'Generating...'}
+                            id="aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxyDeploymentsCard.generate.api.key"
+                            defaultMessage={'Generate API Key'}
                           />
-                        </>
-                      ) : (
-                        <FormattedMessage
-                          id="aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxyDeploymentsCard.generate.api.key"
-                          defaultMessage={'Generate API Key'}
-                        />
-                      )}
-                    </Button>
-                  </span>
-                </Tooltip>
+                        )}
+                      </Button>
+                    </span>
+                  </Tooltip>
+                </DisabledActionTooltip>
               </Stack>
 
               {keyError && (

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyGuardrailsTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyGuardrailsTab.tsx
@@ -61,6 +61,7 @@ import type {
 import { parsePolicyYaml } from '../../PolicyParameterEditor/yamlParser';
 import { FormattedMessage } from 'react-intl';
 import ErrorAlert from '../../../../Components/common/ErrorAlert';
+import { DisabledActionTooltip } from '../../../../utils/readOnlyArtifacts';
 
 // ─── Shared helpers ──────────────────────────────────────────────────────────
 
@@ -143,6 +144,7 @@ const parseOpenApiText = (text: string): ResourceItem[] => {
  */
 export default function LLMProxyGuardrailsTab() {
   const { proxy, setLocalProxy } = useProxy();
+  const isReadOnlyProxy = Boolean(proxy?.readOnly);
   const {
     guardrails: availableGuardrails = [],
     isLoading: isLoadingGuardrails,
@@ -280,12 +282,14 @@ export default function LLMProxyGuardrailsTab() {
   // ── Drawer openers ──────────────────────────────────────────────────────
 
   const openAddDrawerForGlobal = () => {
+    if (isReadOnlyProxy) return;
     setEditingTarget(null);
     setDrawerContext({ scope: 'global' });
     setDrawerOpen(true);
   };
 
   const openAddDrawerForResource = (method: string, path: string) => {
+    if (isReadOnlyProxy) return;
     setEditingTarget(null);
     setDrawerContext({ scope: 'resource', method, path });
     setDrawerOpen(true);
@@ -296,6 +300,7 @@ export default function LLMProxyGuardrailsTab() {
     pathIndex: number | null,
     scope: DrawerContext
   ) => {
+    if (isReadOnlyProxy) return;
     const policy = policies[policyIndex];
     if (!policy) return;
 
@@ -340,6 +345,7 @@ export default function LLMProxyGuardrailsTab() {
     name: string;
     version?: string;
   }) => {
+    if (isReadOnlyProxy) return;
     setSelectedGuardrail(guardrail.name);
     setIsDetailView(true);
     setPolicyDefinition(null);
@@ -389,7 +395,7 @@ export default function LLMProxyGuardrailsTab() {
   };
 
   const handlePolicySubmit = async (params: ParameterValues) => {
-    if (!proxy || !selectedGuardrailPolicy) return;
+    if (isReadOnlyProxy || !proxy || !selectedGuardrailPolicy) return;
 
     const updatedPolicies = (() => {
       // Edit mode: update existing policy path params
@@ -457,6 +463,7 @@ export default function LLMProxyGuardrailsTab() {
     policyIndex: number,
     pathIndex: number | null
   ) => {
+    if (isReadOnlyProxy) return;
     setLocalProxy((prev) => {
       if (!prev) return prev;
       const existingPolicies = prev.policies ?? [];
@@ -508,15 +515,20 @@ export default function LLMProxyGuardrailsTab() {
             </Grid>
 
             <Grid size={{ xs: 12, sm: 'auto' }}>
-              <Button
-                size="small"
-                variant="outlined"
-                startIcon={<Plus size={16} />}
-                onClick={openAddDrawerForGlobal}
-                sx={{ whiteSpace: 'nowrap' }}
-              >
-                Add
-              </Button>
+              <DisabledActionTooltip disabled={isReadOnlyProxy}>
+                <span>
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    startIcon={<Plus size={16} />}
+                    onClick={openAddDrawerForGlobal}
+                    disabled={isReadOnlyProxy}
+                    sx={{ whiteSpace: 'nowrap' }}
+                  >
+                    Add
+                  </Button>
+                </span>
+              </DisabledActionTooltip>
             </Grid>
           </Grid>
 
@@ -534,13 +546,22 @@ export default function LLMProxyGuardrailsTab() {
               <GuardrailPill
                 key={g.id}
                 label={`${g.displayName} (${g.version.replace(/^v/, '')})`}
-                onClick={() =>
-                  handleEditGuardrailPill(g.policyIndex, g.pathIndex, {
-                    scope: 'global',
-                  })
+                onClick={
+                  isReadOnlyProxy
+                    ? undefined
+                    : () =>
+                        handleEditGuardrailPill(g.policyIndex, g.pathIndex, {
+                          scope: 'global',
+                        })
                 }
-                onRemove={() =>
-                  void handleRemoveAppliedGuardrail(g.policyIndex, g.pathIndex)
+                onRemove={
+                  isReadOnlyProxy
+                    ? undefined
+                    : () =>
+                        void handleRemoveAppliedGuardrail(
+                          g.policyIndex,
+                          g.pathIndex
+                        )
                 }
               />
             ))}
@@ -782,19 +803,26 @@ export default function LLMProxyGuardrailsTab() {
                                   </Typography>
                                 </Grid>
                                 <Grid size={{ xs: 12, sm: 'auto' }}>
-                                  <Button
-                                    size="small"
-                                    variant="outlined"
-                                    startIcon={<Plus size={16} />}
-                                    onClick={() =>
-                                      openAddDrawerForResource(
-                                        method,
-                                        resource.path
-                                      )
-                                    }
+                                  <DisabledActionTooltip
+                                    disabled={isReadOnlyProxy}
                                   >
-                                    Add Guardrail
-                                  </Button>
+                                    <span>
+                                      <Button
+                                        size="small"
+                                        variant="outlined"
+                                        startIcon={<Plus size={16} />}
+                                        onClick={() =>
+                                          openAddDrawerForResource(
+                                            method,
+                                            resource.path
+                                          )
+                                        }
+                                        disabled={isReadOnlyProxy}
+                                      >
+                                        Add Guardrail
+                                      </Button>
+                                    </span>
+                                  </DisabledActionTooltip>
                                 </Grid>
                                 <Grid size={{ xs: 12 }}>
                                   <Stack
@@ -810,22 +838,28 @@ export default function LLMProxyGuardrailsTab() {
                                           label={`${
                                             g.displayName
                                           } (${g.version.replace(/^v/, '')})`}
-                                          onClick={() =>
-                                            handleEditGuardrailPill(
-                                              g.policyIndex,
-                                              g.pathIndex,
-                                              {
-                                                scope: 'resource',
-                                                method,
-                                                path: resource.path,
-                                              }
-                                            )
+                                          onClick={
+                                            isReadOnlyProxy
+                                              ? undefined
+                                              : () =>
+                                                  handleEditGuardrailPill(
+                                                    g.policyIndex,
+                                                    g.pathIndex,
+                                                    {
+                                                      scope: 'resource',
+                                                      method,
+                                                      path: resource.path,
+                                                    }
+                                                  )
                                           }
-                                          onRemove={() =>
-                                            void handleRemoveAppliedGuardrail(
-                                              g.policyIndex,
-                                              g.pathIndex
-                                            )
+                                          onRemove={
+                                            isReadOnlyProxy
+                                              ? undefined
+                                              : () =>
+                                                  void handleRemoveAppliedGuardrail(
+                                                    g.policyIndex,
+                                                    g.pathIndex
+                                                  )
                                           }
                                         />
                                       ))

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyOverview.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyOverview.tsx
@@ -69,6 +69,10 @@ import type {
   Proxy as LLMProxy,
   UpdateProxyRequest,
 } from '../../../../utils/types';
+import {
+  DisabledActionTooltip,
+  GATEWAY_MANAGED_ARTIFACT_TOOLTIP,
+} from '../../../../utils/readOnlyArtifacts';
 
 type TabPanelProps = {
   value: number;
@@ -151,6 +155,7 @@ function ProxyOverviewContent() {
   const [updateError, setUpdateError] = useState<string | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const isReadOnlyProxy = Boolean(proxy?.readOnly);
 
   const getProviderId = (providerValue?: LLMProxy['provider']): string => {
     if (!providerValue) return '';
@@ -208,7 +213,9 @@ function ProxyOverviewContent() {
   };
 
   const handleSaveChanges = async () => {
-    if (!proxy || !hasUnsavedChanges || isSavingChanges) return;
+    if (!proxy || !hasUnsavedChanges || isSavingChanges || isReadOnlyProxy) {
+      return;
+    }
     try {
       setIsSavingChanges(true);
       setUpdateError(null);
@@ -300,6 +307,12 @@ function ProxyOverviewContent() {
             {updateError}
           </Alert>
         )}
+        {isReadOnlyProxy ? (
+          <Alert severity="info">
+            This proxy was created from a gateway. Editing and deployment
+            actions are unavailable in AI Workspace.
+          </Alert>
+        ) : null}
 
         {/* Header card with editable fields */}
         <Card>
@@ -349,15 +362,31 @@ function ProxyOverviewContent() {
                       variant="outlined"
                       color="primary"
                     />
-                    <Tooltip title="Edit Proxy">
-                      <IconButton
-                        component={RouterLink}
-                        to={`${proxiesPath}/${proxy.id}/edit`}
-                        size="small"
-                      >
-                        <Edit size={16} />
-                      </IconButton>
-                    </Tooltip>
+                    <DisabledActionTooltip
+                      disabled={isReadOnlyProxy}
+                      title={GATEWAY_MANAGED_ARTIFACT_TOOLTIP}
+                    >
+                      <span>
+                        <Tooltip
+                          title={
+                            isReadOnlyProxy ? '' : 'Edit Proxy'
+                          }
+                        >
+                          <IconButton
+                            component={isReadOnlyProxy ? 'button' : RouterLink}
+                            to={
+                              isReadOnlyProxy
+                                ? undefined
+                                : `${proxiesPath}/${proxy.id}/edit`
+                            }
+                            size="small"
+                            disabled={isReadOnlyProxy}
+                          >
+                            <Edit size={16} />
+                          </IconButton>
+                        </Tooltip>
+                      </span>
+                    </DisabledActionTooltip>
                   </Stack>
                   <Stack spacing={0.1} sx={{ mt: 1 }}>
                     <Stack direction="row" alignItems="center" gap={2}>
@@ -403,13 +432,25 @@ function ProxyOverviewContent() {
                 alignItems="flex-end"
                 sx={{ alignSelf: 'stretch' }}
               >
-                <Button
-                  variant="contained"
-                  component={RouterLink}
-                  to={`${proxiesPath}/${proxy.id}/deploy`}
+                <DisabledActionTooltip
+                  disabled={isReadOnlyProxy}
+                  title={GATEWAY_MANAGED_ARTIFACT_TOOLTIP}
                 >
-                  Deploy to Gateway
-                </Button>
+                  <span>
+                    <Button
+                      variant="contained"
+                      component={isReadOnlyProxy ? 'button' : RouterLink}
+                      to={
+                        isReadOnlyProxy
+                          ? undefined
+                          : `${proxiesPath}/${proxy.id}/deploy`
+                      }
+                      disabled={isReadOnlyProxy}
+                    >
+                      Deploy to Gateway
+                    </Button>
+                  </span>
+                </DisabledActionTooltip>
                 <IconButton
                   color="error"
                   onClick={() => setDeleteDialogOpen(true)}
@@ -489,14 +530,18 @@ function ProxyOverviewContent() {
                 <Button
                   variant="outlined"
                   color="secondary"
-                  disabled={!hasUnsavedChanges || isSavingChanges}
+                  disabled={
+                    isReadOnlyProxy || !hasUnsavedChanges || isSavingChanges
+                  }
                   onClick={handleCancelChanges}
                 >
                   Cancel
                 </Button>
                 <Button
                   variant="contained"
-                  disabled={!hasUnsavedChanges || isSavingChanges}
+                  disabled={
+                    isReadOnlyProxy || !hasUnsavedChanges || isSavingChanges
+                  }
                   onClick={() => void handleSaveChanges()}
                 >
                   {isSavingChanges ? <CircularProgress size={20} /> : 'Save'}

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyOverviewTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyOverviewTab.tsx
@@ -54,6 +54,10 @@ import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
 import SwaggerSpecViewer from '../../../../Components/SwaggerSpecViewer';
 import type { Gateway } from '../../../../apis/gatewayTypes';
 import type { DeploymentResponse, UserAPIKey } from '../../../../utils/types';
+import {
+  DisabledActionTooltip,
+  GATEWAY_MANAGED_ARTIFACT_TOOLTIP,
+} from '../../../../utils/readOnlyArtifacts';
 
 type OpenApiSpec = Record<string, unknown>;
 
@@ -118,6 +122,7 @@ export default function LLMProxyOverviewTab() {
   const [isDeletingKey, setIsDeletingKey] = useState(false);
   const [apiKeys, setApiKeys] = useState<UserAPIKey[]>([]);
   const [keysLoading, setKeysLoading] = useState(false);
+  const isReadOnlyProxy = Boolean(proxy?.readOnly);
 
   const apiKeyLocation = proxy?.security?.apiKey?.in ?? 'header';
   const apiKeyName = proxy?.security?.apiKey?.key ?? 'X-API-Key';
@@ -370,6 +375,7 @@ export default function LLMProxyOverviewTab() {
   };
 
   const handleGenerateAPIKey = async () => {
+    if (isReadOnlyProxy) return;
     if (!currentOrganization?.uuid || !proxy?.id) {
       return;
     }
@@ -415,6 +421,7 @@ export default function LLMProxyOverviewTab() {
   };
 
   const handleOpenApiKeyModal = () => {
+    if (isReadOnlyProxy) return;
     setKeyError(null);
     setGeneratedKey(null);
     setApiKeyDisplayName('');
@@ -453,7 +460,7 @@ export default function LLMProxyOverviewTab() {
   };
 
   const handleDeleteApiKey = async () => {
-    if (!deleteTargetKeyName || !proxy?.id) {
+    if (isReadOnlyProxy || !deleteTargetKeyName || !proxy?.id) {
       return;
     }
 
@@ -656,25 +663,32 @@ export default function LLMProxyOverviewTab() {
                           />
                         </Typography>
                       </Box>
-                      <Tooltip
-                        title={
-                          deployedGateways.length === 0
-                            ? 'No deployed gateways available. Deploy to a gateway first to generate an API key.'
-                            : ''
-                        }
-                        placement="top"
+                      <DisabledActionTooltip
+                        disabled={isReadOnlyProxy}
+                        title={GATEWAY_MANAGED_ARTIFACT_TOOLTIP}
                       >
-                        <span>
-                          <Button
-                            variant="contained"
-                            size="medium"
-                            onClick={handleOpenApiKeyModal}
-                            disabled={deployedGateways.length === 0}
-                          >
-                            Generate API Key
-                          </Button>
-                        </span>
-                      </Tooltip>
+                        <Tooltip
+                          title={
+                            !isReadOnlyProxy && deployedGateways.length === 0
+                              ? 'No deployed gateways available. Deploy to a gateway first to generate an API key.'
+                              : ''
+                          }
+                          placement="top"
+                        >
+                          <span>
+                            <Button
+                              variant="contained"
+                              size="medium"
+                              onClick={handleOpenApiKeyModal}
+                              disabled={
+                                isReadOnlyProxy || deployedGateways.length === 0
+                              }
+                            >
+                              Generate API Key
+                            </Button>
+                          </span>
+                        </Tooltip>
+                      </DisabledActionTooltip>
                     </Stack>
 
                     {keyError && (
@@ -749,28 +763,39 @@ export default function LLMProxyOverviewTab() {
                                   </Tooltip>
                                 </ListingTable.Cell>
                                 <ListingTable.Cell align="right">
-                                  <Tooltip
-                                    title={
-                                      key.name
-                                        ? 'Delete API key'
-                                        : 'Unable to delete key without a name'
-                                    }
+                                  <DisabledActionTooltip
+                                    disabled={isReadOnlyProxy}
+                                    title={GATEWAY_MANAGED_ARTIFACT_TOOLTIP}
                                   >
-                                    <span>
-                                      <IconButton
-                                        size="small"
-                                        color="error"
-                                        onClick={() =>
-                                          setDeleteTargetKeyName(
-                                            key.name?.trim() || null
-                                          )
-                                        }
-                                        disabled={!key.name || isDeletingKey}
-                                      >
-                                        <Trash2 size={16} />
-                                      </IconButton>
-                                    </span>
-                                  </Tooltip>
+                                    <Tooltip
+                                      title={
+                                        isReadOnlyProxy
+                                          ? ''
+                                          : key.name
+                                            ? 'Delete API key'
+                                            : 'Unable to delete key without a name'
+                                      }
+                                    >
+                                      <span>
+                                        <IconButton
+                                          size="small"
+                                          color="error"
+                                          onClick={() =>
+                                            setDeleteTargetKeyName(
+                                              key.name?.trim() || null
+                                            )
+                                          }
+                                          disabled={
+                                            isReadOnlyProxy ||
+                                            !key.name ||
+                                            isDeletingKey
+                                          }
+                                        >
+                                          <Trash2 size={16} />
+                                        </IconButton>
+                                      </span>
+                                    </Tooltip>
+                                  </DisabledActionTooltip>
                                 </ListingTable.Cell>
                               </ListingTable.Row>
                             ))}
@@ -895,6 +920,7 @@ export default function LLMProxyOverviewTab() {
                   size="small"
                   fullWidth
                   value={apiKeyDisplayName}
+                  disabled={isReadOnlyProxy}
                   onChange={(event) => setApiKeyDisplayName(event.target.value)}
                   placeholder="Ex: Production Key"
                 />
@@ -928,7 +954,11 @@ export default function LLMProxyOverviewTab() {
                 onClick={() => {
                   void handleGenerateAPIKey();
                 }}
-                disabled={generatingKey || !apiKeyDisplayName.trim()}
+                disabled={
+                  isReadOnlyProxy ||
+                  generatingKey ||
+                  !apiKeyDisplayName.trim()
+                }
               >
                 {generatingKey ? (
                   <>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyProviderTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyProviderTab.tsx
@@ -37,6 +37,7 @@ import { logger } from '../../../../utils/logger';
 import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
 import type { LLMProvider, ProxyApiKeySecurity } from '../../../../utils/types';
 import { FormattedMessage } from 'react-intl';
+import { DisabledActionTooltip } from '../../../../utils/readOnlyArtifacts';
 
 /**
  * Provider tab – lets the user select / change the LLM Service Provider
@@ -54,6 +55,7 @@ export default function LLMProxyProviderTab() {
     null
   );
   const [apiKey, setApiKey] = useState('');
+  const isReadOnlyProxy = Boolean(proxy?.readOnly);
 
   const providerOptions = providersResponse.list;
   const selectedProxyProviderId =
@@ -107,6 +109,7 @@ export default function LLMProxyProviderTab() {
   };
 
   const handleSaveApiKey = () => {
+    if (isReadOnlyProxy) return;
     if (!proxy || !apiKey.trim() || !providerDetail) {
       showSnackbar('Please enter an API key.', 'error');
       return;
@@ -137,6 +140,7 @@ export default function LLMProxyProviderTab() {
   };
 
   const handleProviderChange = async (event: { target: { value: string } }) => {
+    if (isReadOnlyProxy) return;
     const newProviderId = event.target.value;
     if (!proxy || newProviderId === selectedProxyProviderId) return;
 
@@ -199,7 +203,7 @@ export default function LLMProxyProviderTab() {
               value={selectedProxyProviderId}
               onChange={handleProviderChange}
               displayEmpty
-              disabled={isProvidersLoading}
+              disabled={isProvidersLoading || isReadOnlyProxy}
             >
               {isProvidersLoading ? (
                 <MenuItem value="" disabled>
@@ -267,6 +271,7 @@ export default function LLMProxyProviderTab() {
                         type="password"
                         placeholder="Enter API key"
                         value={apiKey}
+                        disabled={isReadOnlyProxy}
                         onChange={(e) => setApiKey(e.target.value)}
                         fullWidth
                       />
@@ -274,17 +279,21 @@ export default function LLMProxyProviderTab() {
                   </Grid>
                 </Grid>
 
-                <Button
-                  variant="contained"
-                  onClick={handleSaveApiKey}
-                  disabled={!apiKey.trim()}
-                  sx={{ alignSelf: 'flex-start' }}
-                >
-                  <FormattedMessage
-                    id="aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxyProviderTab.save.api.key"
-                    defaultMessage={'Save API Key'}
-                  />
-                </Button>
+                <DisabledActionTooltip disabled={isReadOnlyProxy}>
+                  <span>
+                    <Button
+                      variant="contained"
+                      onClick={handleSaveApiKey}
+                      disabled={isReadOnlyProxy || !apiKey.trim()}
+                      sx={{ alignSelf: 'flex-start' }}
+                    >
+                      <FormattedMessage
+                        id="aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxyProviderTab.save.api.key"
+                        defaultMessage={'Save API Key'}
+                      />
+                    </Button>
+                  </span>
+                </DisabledActionTooltip>
               </Stack>
             </Stack>
           )}

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxySecurityTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxySecurityTab.tsx
@@ -45,13 +45,15 @@ import { FormattedMessage } from 'react-intl';
  */
 export default function LLMProxySecurityTab() {
   const { proxy, isLoading, error, setLocalProxy } = useProxy();
+  const isReadOnlyProxy = Boolean(proxy?.readOnly);
 
   const [authenticationType, setAuthenticationType] = useState('');
   const [apiKeyEnabled, setApiKeyEnabled] = useState(true);
   const [keyName, setKeyName] = useState('');
   const [keyLocation, setKeyLocation] = useState<'header' | 'query'>('header');
 
-  const isFormDisabled = !apiKeyEnabled || isLoading || Boolean(error);
+  const isFormDisabled =
+    !apiKeyEnabled || isLoading || Boolean(error) || isReadOnlyProxy;
 
   useEffect(() => {
     if (!proxy) return;
@@ -82,24 +84,28 @@ export default function LLMProxySecurityTab() {
   };
 
   const handleAuthChange = (event: { target: { value: string } }) => {
+    if (isReadOnlyProxy) return;
     const nextType = event.target.value;
     setAuthenticationType(nextType);
     stageSecurity(nextType, keyName, keyLocation, apiKeyEnabled);
   };
 
   const handleApiKeyEnabledChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (isReadOnlyProxy) return;
     const nextEnabled = event.target.checked;
     setApiKeyEnabled(nextEnabled);
     stageSecurity(authenticationType, keyName, keyLocation, nextEnabled);
   };
 
   const handleKeyNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (isReadOnlyProxy) return;
     const nextKey = event.target.value;
     setKeyName(nextKey);
     stageSecurity(authenticationType, nextKey, keyLocation, apiKeyEnabled);
   };
 
   const handleKeyLocationChange = (event: { target: { value: string } }) => {
+    if (isReadOnlyProxy) return;
     const nextIn = event.target.value as 'header' | 'query';
     setKeyLocation(nextIn);
     stageSecurity(authenticationType, keyName, nextIn, apiKeyEnabled);
@@ -135,7 +141,7 @@ export default function LLMProxySecurityTab() {
                 <Switch
                   size="small"
                   checked={apiKeyEnabled}
-                  disabled={isLoading || Boolean(error)}
+                  disabled={isLoading || Boolean(error) || isReadOnlyProxy}
                   onChange={handleApiKeyEnabledChange}
                 />
               </Tooltip>
@@ -144,7 +150,11 @@ export default function LLMProxySecurityTab() {
 
           <FormControl fullWidth size="small">
             <FormLabel>Authentication type</FormLabel>
-            <Select value={authenticationType} onChange={handleAuthChange}>
+            <Select
+              value={authenticationType}
+              onChange={handleAuthChange}
+              disabled={isReadOnlyProxy}
+            >
               <MenuItem value="apiKey">API Key</MenuItem>
             </Select>
           </FormControl>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/EditServiceProvider.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/EditServiceProvider.tsx
@@ -38,6 +38,9 @@ import {
 import { useAppShell } from '../../../../contexts/AppShellContext';
 import { buildOrgPath } from '../../../../utils/projectRouting';
 import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
+import {
+  DisabledActionTooltip,
+} from '../../../../utils/readOnlyArtifacts';
 
 const MAX_NAME_LENGTH = 255;
 const MAX_DESCRIPTION_LENGTH = 1023;
@@ -50,6 +53,7 @@ function EditServiceProviderForm() {
   const { currentOrganization } = useAppShell();
   const { provider, isLoading, error, updateProvider } = useLLMProvider();
   const showSnackbar = useAIWorkspaceSnackbar();
+  const isReadOnlyProvider = Boolean(provider?.readOnly);
 
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
@@ -81,7 +85,7 @@ function EditServiceProviderForm() {
   };
 
   const handleSubmit = async () => {
-    if (!providerId) return;
+    if (!providerId || isReadOnlyProvider) return;
 
     setIsSubmitting(true);
     try {
@@ -187,6 +191,12 @@ function EditServiceProviderForm() {
 
         <Box sx={{ mb: 4 }}>
           <Stack spacing={3}>
+            {isReadOnlyProvider ? (
+              <Alert severity="info">
+                This provider was created from a gateway. Editing is
+                unavailable in AI Workspace.
+              </Alert>
+            ) : null}
             {isContextOrVersionChanged && (
               <Alert severity="warning">
                 You have modified the context or version of this service
@@ -201,6 +211,7 @@ function EditServiceProviderForm() {
                   fullWidth
                   required
                   value={name}
+                  disabled={isReadOnlyProvider}
                   onChange={(e) => setName(e.target.value)}
                   placeholder="Enter service provider name"
                   error={name.length > MAX_NAME_LENGTH}
@@ -217,6 +228,7 @@ function EditServiceProviderForm() {
                 <TextField
                   fullWidth
                   value={version}
+                  disabled={isReadOnlyProvider}
                   onChange={(e) => setVersion(e.target.value)}
                   placeholder="e.g., 1.0"
                   error={version.length > MAX_VERSION_LENGTH}
@@ -234,6 +246,7 @@ function EditServiceProviderForm() {
               <TextField
                 fullWidth
                 value={description}
+                disabled={isReadOnlyProvider}
                 onChange={(e) => setDescription(e.target.value)}
                 placeholder="Enter description"
                 multiline
@@ -252,6 +265,7 @@ function EditServiceProviderForm() {
               <TextField
                 fullWidth
                 value={context}
+                disabled={isReadOnlyProvider}
                 onChange={(e) => setContext(e.target.value)}
                 placeholder="Enter context path"
                 error={context.length > MAX_CONTEXT_LENGTH}
@@ -269,13 +283,15 @@ function EditServiceProviderForm() {
           <Button variant="outlined" color="secondary" onClick={handleCancel}>
             Cancel
           </Button>
-          <Button
-            variant="contained"
-            onClick={handleSubmit}
-            disabled={isSubmitting || !isFormValid()}
-          >
-            {isSubmitting ? 'Updating...' : 'Update'}
-          </Button>
+          <DisabledActionTooltip disabled={isReadOnlyProvider}>
+            <Button
+              variant="contained"
+              onClick={handleSubmit}
+              disabled={isReadOnlyProvider || isSubmitting || !isFormValid()}
+            >
+              {isSubmitting ? 'Updating...' : 'Update'}
+            </Button>
+          </DisabledActionTooltip>
         </Box>
       </Box>
     </PageContent>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderConnectionTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderConnectionTab.tsx
@@ -53,6 +53,8 @@ export default function ServiceProviderConnectionTab() {
   const [providerTemplate, setProviderTemplate] =
     useState<ProviderTemplate | null>(null);
   const showSnackbar = useAIWorkspaceSnackbar();
+  const isReadOnlyProvider = Boolean(provider?.readOnly);
+  const isFormDisabled = isLoading || Boolean(error) || isReadOnlyProvider;
 
   const valuePrefix = useMemo(() => {
     return providerTemplate?.metadata?.auth?.valuePrefix || '';
@@ -109,7 +111,7 @@ export default function ServiceProviderConnectionTab() {
   }, [provider]);
 
   const handleUpdateProviderEndpoint = async (value = providerEndpoint) => {
-    if (!provider || isLoading || error) return;
+    if (!provider || isLoading || error || isReadOnlyProvider) return;
     const nextUrl = value.trim();
     if (!nextUrl || nextUrl === (provider.upstream?.main?.url || '')) return;
     try {
@@ -145,7 +147,7 @@ export default function ServiceProviderConnectionTab() {
   };
 
   const handleUpdateAuthentication = async (value = authenticationType) => {
-    if (!provider || isLoading || error) return;
+    if (!provider || isLoading || error || isReadOnlyProvider) return;
     const nextType = value.trim();
     if (!nextType || nextType === (provider.upstream?.main?.auth?.type || ''))
       return;
@@ -184,7 +186,7 @@ export default function ServiceProviderConnectionTab() {
   const handleUpdateAuthenticationHeader = async (
     value = authenticationHeader
   ) => {
-    if (!provider || isLoading || error) return;
+    if (!provider || isLoading || error || isReadOnlyProvider) return;
     const nextHeader = value.trim();
     if (nextHeader === (provider.upstream?.main?.auth?.header || '')) return;
 
@@ -221,7 +223,7 @@ export default function ServiceProviderConnectionTab() {
   };
 
   const handleUpdateCredential = async (value = credentialValue) => {
-    if (!provider || isLoading || error) return;
+    if (!provider || isLoading || error || isReadOnlyProvider) return;
     if (isCredentialMasked) return;
     const nextValue = value.trim();
     if (nextValue === MASKED_CREDENTIAL_VALUE) return;
@@ -272,6 +274,7 @@ export default function ServiceProviderConnectionTab() {
           <TextField
             size="small"
             value={providerEndpoint}
+            disabled={isFormDisabled}
             onChange={(e) => {
               const nextValue = e.target.value;
               setProviderEndpoint(nextValue);
@@ -292,6 +295,7 @@ export default function ServiceProviderConnectionTab() {
           <Select
             size="small"
             value={authenticationType || 'api-key'}
+            disabled={isFormDisabled}
             onChange={(e) => {
               const nextValue = String(e.target.value);
               setAuthenticationType(nextValue);
@@ -314,6 +318,7 @@ export default function ServiceProviderConnectionTab() {
           <TextField
             size="small"
             value={authenticationHeader}
+            disabled={isFormDisabled}
             onChange={(e) => {
               const nextValue = e.target.value;
               setAuthenticationHeader(nextValue);
@@ -335,6 +340,7 @@ export default function ServiceProviderConnectionTab() {
             size="small"
             type={showCredential ? 'text' : 'password'}
             value={credentialValue}
+            disabled={isFormDisabled}
             onFocus={() => {
               if (isCredentialMasked) {
                 setCredentialValue('');
@@ -361,6 +367,7 @@ export default function ServiceProviderConnectionTab() {
                   <InputAdornment position="end">
                     <IconButton
                       size="small"
+                      disabled={isFormDisabled}
                       onClick={() => setShowCredential((prev) => !prev)}
                       aria-label={
                         showCredential ? 'Hide credentials' : 'Show credentials'

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderDeploy.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderDeploy.tsx
@@ -19,6 +19,7 @@
 import React, { useMemo } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
+  Alert,
   Box,
   Button,
   Grid,
@@ -123,7 +124,14 @@ function ServiceProviderDeployLayout({ providerId }: ServiceProviderDeployLayout
       </Grid>
 
       <Stack spacing={2} sx={{ mt: 2 }}>
-        <GatewayDeployMainSection />
+        {provider?.readOnly ? (
+          <Alert severity="info">
+            This provider was created from a gateway. Deployment actions are
+            unavailable in AI Workspace.
+          </Alert>
+        ) : (
+          <GatewayDeployMainSection />
+        )}
       </Stack>
     </PageContent>
   );

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderDeploymentsCard.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderDeploymentsCard.tsx
@@ -54,6 +54,10 @@ import { useLLMProvider } from '../../../../contexts/llmProvider';
 import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
 import type { UserAPIKey } from '../../../../utils/types';
 import { logger } from '../../../../utils/logger';
+import {
+  DisabledActionTooltip,
+  GATEWAY_MANAGED_ARTIFACT_TOOLTIP,
+} from '../../../../utils/readOnlyArtifacts';
 
 type ServiceProviderDeploymentsCardProps = {
   isGatewaysLoading: boolean;
@@ -122,6 +126,7 @@ export default function ServiceProviderDeploymentsCard({
 
   const apiKeyLocation = provider?.security?.apiKey?.in ?? 'header';
   const apiKeyName = provider?.security?.apiKey?.key ?? 'X-API-Key';
+  const isReadOnlyProvider = Boolean(provider?.readOnly);
 
   const deployedGateways = useMemo(() => {
     if (!deployments?.list || deployments.list.length === 0) return [];
@@ -456,25 +461,16 @@ export default function ServiceProviderDeploymentsCard({
                     />
                   </Typography>
                 </Box>
-                <Tooltip
-                  title={
-                    gateways.length === 0
-                      ? 'No deployed gateways available. Deploy to a gateway first to generate an API key.'
-                      : ''
-                  }
-                  placement="top"
-                >
-                  <span>
-                    <Button
-                      variant="contained"
-                      size="medium"
-                      onClick={handleOpenApiKeyModal}
-                      disabled={gateways.length === 0}
-                    >
-                      Generate API Key
-                    </Button>
-                  </span>
-                </Tooltip>
+                <DisabledActionTooltip disabled={false}>
+                  <Button
+                    variant="contained"
+                    size="medium"
+                    onClick={handleOpenApiKeyModal}
+                    disabled={gateways.length === 0}
+                  >
+                    Generate API Key
+                  </Button>
+                </DisabledActionTooltip>
               </Stack>
 
               {keyError && (

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderGuardrailsTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderGuardrailsTab.tsx
@@ -64,6 +64,9 @@ import type { AccessControl } from '../../../../utils/types';
 import { parsePolicyYaml } from '../../PolicyParameterEditor/yamlParser';
 import { FormattedMessage } from 'react-intl';
 import ErrorAlert from '../../../../Components/common/ErrorAlert';
+import {
+  DisabledActionTooltip,
+} from '../../../../utils/readOnlyArtifacts';
 
 type ResourceItem = {
   method: string;
@@ -157,6 +160,7 @@ const parseOpenApiText = (
 export default function ServiceProviderGuardrailsTab() {
   const { provider, isLoading, error, updateProvider, isDraftMode } =
     useLLMProvider();
+  const isReadOnlyProvider = Boolean(provider?.readOnly);
   const {
     guardrails: availableGuardrails = [],
     isLoading: isLoadingGuardrails,
@@ -497,7 +501,7 @@ export default function ServiceProviderGuardrailsTab() {
     policyIndex: number,
     pathIndex: number | null
   ) => {
-    if (!provider || isLoading || error) return;
+    if (!provider || isLoading || error || isReadOnlyProvider) return;
 
     const {
       status,
@@ -566,18 +570,21 @@ export default function ServiceProviderGuardrailsTab() {
             </Grid>
 
             <Grid size={{ xs: 12, sm: 'auto' }}>
-              <Button
-                size="small"
-                variant="outlined"
-                startIcon={<Plus size={16} />}
-                onClick={openAddDrawerForGlobal}
-                sx={{ whiteSpace: 'nowrap' }}
-              >
-                <FormattedMessage
-                  id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderGuardrailsTab.add.guardrail"
-                  defaultMessage={'Add'}
-                />
-              </Button>
+              <DisabledActionTooltip disabled={isReadOnlyProvider}>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  startIcon={<Plus size={16} />}
+                  onClick={openAddDrawerForGlobal}
+                  disabled={isReadOnlyProvider}
+                  sx={{ whiteSpace: 'nowrap' }}
+                >
+                  <FormattedMessage
+                    id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderGuardrailsTab.add.guardrail"
+                    defaultMessage={'Add'}
+                  />
+                </Button>
+              </DisabledActionTooltip>
             </Grid>
           </Grid>
 
@@ -595,13 +602,22 @@ export default function ServiceProviderGuardrailsTab() {
               <GuardrailPill
                 key={g.id}
                 label={`${g.displayName} (${g.version})`}
-                onClick={() =>
-                  handleEditGuardrailPill(g.policyIndex, g.pathIndex, {
-                    scope: 'global',
-                  })
+                onClick={
+                  isReadOnlyProvider
+                    ? undefined
+                    : () =>
+                        handleEditGuardrailPill(g.policyIndex, g.pathIndex, {
+                          scope: 'global',
+                        })
                 }
-                onRemove={() =>
-                  void handleRemoveAppliedGuardrail(g.policyIndex, g.pathIndex)
+                onRemove={
+                  isReadOnlyProvider
+                    ? undefined
+                    : () =>
+                        void handleRemoveAppliedGuardrail(
+                          g.policyIndex,
+                          g.pathIndex
+                        )
                 }
               />
             ))}
@@ -813,22 +829,27 @@ export default function ServiceProviderGuardrailsTab() {
                               </Grid>
 
                               <Grid size={{ xs: 12, sm: 'auto' }}>
-                                <Button
-                                  size="small"
-                                  variant="outlined"
-                                  startIcon={<Plus size={16} />}
-                                  onClick={() =>
-                                    openAddDrawerForResource(
-                                      method,
-                                      resource.path
-                                    )
-                                  }
+                                <DisabledActionTooltip
+                                  disabled={isReadOnlyProvider}
                                 >
-                                  <FormattedMessage
-                                    id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderGuardrailsTab.add.guardrail"
-                                    defaultMessage={'Add'}
-                                  />
-                                </Button>
+                                  <Button
+                                    size="small"
+                                    variant="outlined"
+                                    startIcon={<Plus size={16} />}
+                                    onClick={() =>
+                                      openAddDrawerForResource(
+                                        method,
+                                        resource.path
+                                      )
+                                    }
+                                    disabled={isReadOnlyProvider}
+                                  >
+                                    <FormattedMessage
+                                      id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderGuardrailsTab.add.guardrail"
+                                      defaultMessage={'Add'}
+                                    />
+                                  </Button>
+                                </DisabledActionTooltip>
                               </Grid>
 
                               <Grid size={{ xs: 12 }}>
@@ -848,22 +869,28 @@ export default function ServiceProviderGuardrailsTab() {
                                           /^v/,
                                           ''
                                         )})`}
-                                        onClick={() =>
-                                          handleEditGuardrailPill(
-                                            guardrail.policyIndex,
-                                            guardrail.pathIndex,
-                                            {
-                                              scope: 'resource',
-                                              method,
-                                              path: resource.path,
-                                            }
-                                          )
+                                        onClick={
+                                          isReadOnlyProvider
+                                            ? undefined
+                                            : () =>
+                                                handleEditGuardrailPill(
+                                                  guardrail.policyIndex,
+                                                  guardrail.pathIndex,
+                                                  {
+                                                    scope: 'resource',
+                                                    method,
+                                                    path: resource.path,
+                                                  }
+                                                )
                                         }
-                                        onRemove={() =>
-                                          void handleRemoveAppliedGuardrail(
-                                            guardrail.policyIndex,
-                                            guardrail.pathIndex
-                                          )
+                                        onRemove={
+                                          isReadOnlyProvider
+                                            ? undefined
+                                            : () =>
+                                                void handleRemoveAppliedGuardrail(
+                                                  guardrail.policyIndex,
+                                                  guardrail.pathIndex
+                                                )
                                         }
                                       />
                                     ))

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderModelsTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderModelsTab.tsx
@@ -38,6 +38,7 @@ import { useLLMProvider } from '../../../../contexts/llmProvider';
 import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
 import { FormattedMessage } from 'react-intl';
 import NoModelsImage from '../../../../assets/images/NoModels.svg';
+import { DisabledActionTooltip } from '../../../../utils/readOnlyArtifacts';
 
 type ProviderOption = {
   id: string;
@@ -153,6 +154,7 @@ function ModelPill({
 export default function ServiceProviderModelsTab() {
   const { provider, isLoading, error, updateProvider, isDraftMode } =
     useLLMProvider();
+  const isReadOnlyProvider = Boolean(provider?.readOnly);
   const modelCatalog = useMemo<Record<string, string[]>>(
     () => ({
       meta: [
@@ -215,7 +217,9 @@ export default function ServiceProviderModelsTab() {
     errorMessage: string,
     nextSelectedProviderId = selectedProviderId
   ) => {
-    if (!provider || isLoading || error || isSaving) return false;
+    if (!provider || isLoading || error || isSaving || isReadOnlyProvider) {
+      return false;
+    }
 
     const {
       status,
@@ -418,9 +422,9 @@ export default function ServiceProviderModelsTab() {
                         name={p.name}
                         selected={p.id === selectedProviderId}
                         onClick={() => setSelectedProviderId(p.id)}
-                        removeDisabled={isSaving}
+                        removeDisabled={isSaving || isReadOnlyProvider}
                         onRemove={
-                          p.id === 'azureai-foundry'
+                          p.id === 'azureai-foundry' && !isReadOnlyProvider
                             ? () => {
                                 void removeProvider(p.id);
                               }
@@ -431,36 +435,38 @@ export default function ServiceProviderModelsTab() {
                     ))}
                   </Stack>
 
-                  <Tooltip
-                    placement="top"
-                    title={
-                      disableAddProviderButton ? (
-                        <FormattedMessage
-                          id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderModelsTab.single.provider.support.tooltip"
-                          defaultMessage={
-                            'Only one model provider is supported for this service provider.'
-                          }
-                        />
-                      ) : (
-                        ''
-                      )
-                    }
-                  >
-                    <Box component="span">
-                      <Button
-                        size="small"
-                        variant="outlined"
-                        startIcon={<Plus size={16} />}
-                        disabled={disableAddProviderButton}
-                        onClick={() => setDrawerOpen(true)}
-                      >
-                        <FormattedMessage
-                          id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderModelsTab.add.model.provider.2"
-                          defaultMessage={'Add Model Provider'}
-                        />
-                      </Button>
-                    </Box>
-                  </Tooltip>
+                  <DisabledActionTooltip disabled={isReadOnlyProvider}>
+                    <Tooltip
+                      placement="top"
+                      title={
+                        disableAddProviderButton ? (
+                          <FormattedMessage
+                            id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderModelsTab.single.provider.support.tooltip"
+                            defaultMessage={
+                              'Only one model provider is supported for this service provider.'
+                            }
+                          />
+                        ) : (
+                          ''
+                        )
+                      }
+                    >
+                      <Box component="span">
+                        <Button
+                          size="small"
+                          variant="outlined"
+                          startIcon={<Plus size={16} />}
+                          disabled={disableAddProviderButton || isReadOnlyProvider}
+                          onClick={() => setDrawerOpen(true)}
+                        >
+                          <FormattedMessage
+                            id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderModelsTab.add.model.provider.2"
+                            defaultMessage={'Add Model Provider'}
+                          />
+                        </Button>
+                      </Box>
+                    </Tooltip>
+                  </DisabledActionTooltip>
                 </Stack>
               ) : (
                 <Box
@@ -488,18 +494,20 @@ export default function ServiceProviderModelsTab() {
                         defaultMessage={'No providers added yet.'}
                       />
                     </Typography>
-                    <Button
-                      size="small"
-                      variant="outlined"
-                      startIcon={<Plus size={16} />}
-                      disabled={isSaving}
-                      onClick={() => setDrawerOpen(true)}
-                    >
-                      <FormattedMessage
-                        id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderModelsTab.add.model.provider.2"
-                        defaultMessage={'Add Model Provider'}
-                      />
-                    </Button>
+                    <DisabledActionTooltip disabled={isReadOnlyProvider}>
+                      <Button
+                        size="small"
+                        variant="outlined"
+                        startIcon={<Plus size={16} />}
+                        disabled={isSaving || isReadOnlyProvider}
+                        onClick={() => setDrawerOpen(true)}
+                      >
+                        <FormattedMessage
+                          id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderModelsTab.add.model.provider.2"
+                          defaultMessage={'Add Model Provider'}
+                        />
+                      </Button>
+                    </DisabledActionTooltip>
                   </Stack>
                 </Box>
               )}
@@ -533,7 +541,7 @@ export default function ServiceProviderModelsTab() {
                     size="small"
                     fullWidth
                     value={newModelName}
-                    disabled={isSaving}
+                    disabled={isSaving || isReadOnlyProvider}
                     onChange={(event) => setNewModelName(event.target.value)}
                     onKeyDown={(event) => {
                       if (event.key === 'Enter') {
@@ -564,9 +572,11 @@ export default function ServiceProviderModelsTab() {
                       <ModelPill
                         key={m.id}
                         label={m.name}
-                        removeDisabled={isSaving}
+                        removeDisabled={isSaving || isReadOnlyProvider}
                         onRemove={() => {
-                          void removeModel(m.id);
+                          if (!isReadOnlyProvider) {
+                            void removeModel(m.id);
+                          }
                         }}
                         removeAriaLabel={`Remove model ${m.name}`}
                       />
@@ -704,7 +714,7 @@ export default function ServiceProviderModelsTab() {
             <Button
               variant="contained"
               onClick={addProvider}
-              disabled={!selectedOption || isSaving}
+              disabled={!selectedOption || isSaving || isReadOnlyProvider}
             >
               <FormattedMessage
                 id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderModelsTab.add"

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverview.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverview.tsx
@@ -31,6 +31,7 @@ import {
   useParams,
 } from 'react-router-dom';
 import {
+  Alert,
   Avatar,
   Box,
   Button,
@@ -95,6 +96,10 @@ import {
   AIEntityProvider,
   useAIEntity,
 } from '../../../../contexts/AIEntitiesContext';
+import {
+  DisabledActionTooltip,
+  GATEWAY_MANAGED_ARTIFACT_TOOLTIP,
+} from '../../../../utils/readOnlyArtifacts';
 
 import AnthropicLogo from '../../../../assets/brands/Anthropic.jpg';
 import AWSBedrockLogo from '../../../../assets/brands/AWSBedrock.webp';
@@ -406,6 +411,10 @@ function ServiceProviderOverviewContent() {
   };
 
   const handleDeployNavigation = () => {
+    if (isReadOnlyProvider) {
+      showSnackbar(GATEWAY_MANAGED_ARTIFACT_TOOLTIP, 'warning');
+      return;
+    }
     if (hasUnsavedChanges) {
       showSnackbar(UNSAVED_CHANGES_MESSAGE, 'error');
       return;
@@ -465,6 +474,8 @@ function ServiceProviderOverviewContent() {
   const isProxyQuotaReached = orgProxyCount >= MAX_LLM_PROXIES_PER_ORG;
   const proxyQuotaTooltip =
     'You cannot create more App LLM Proxies because your organization has reached the maximum limit of 5 proxies.';
+  const isReadOnlyProvider = Boolean(provider?.readOnly);
+  const createProxyTooltip = isProxyQuotaReached ? proxyQuotaTooltip : '';
 
   const handleCreateProxyClick = () => {
     if (!provider?.id || isProxyQuotaReached) {
@@ -519,6 +530,10 @@ function ServiceProviderOverviewContent() {
     if (stepId === 'add-guardrails') {
       setTabIndex(5);
     } else if (stepId === 'deploy-to-gateway') {
+      if (isReadOnlyProvider) {
+        showSnackbar(GATEWAY_MANAGED_ARTIFACT_TOOLTIP, 'warning');
+        return;
+      }
       if (!provider?.id) return;
       const deployPath = isProjectLevel
         ? buildProjectPath(
@@ -1041,20 +1056,21 @@ function ServiceProviderOverviewContent() {
               </Box>
 
               <Stack spacing={2} p={2}>
-                <Tooltip title={isProxyQuotaReached ? proxyQuotaTooltip : ''}>
-                  <Box component="span">
-                    <Button
-                      variant="outlined"
-                      onClick={handleCreateProxyClick}
-                      disabled={!provider.id || isProxyQuotaReached}
-                    >
-                      <FormattedMessage
-                        id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderOverview.create.llm.proxy"
-                        defaultMessage="Create App LLM Proxy"
-                      />
-                    </Button>
-                  </Box>
-                </Tooltip>
+                <DisabledActionTooltip
+                  disabled={isProxyQuotaReached}
+                  title={createProxyTooltip}
+                >
+                  <Button
+                    variant="outlined"
+                    onClick={handleCreateProxyClick}
+                    disabled={!provider.id || isProxyQuotaReached}
+                  >
+                    <FormattedMessage
+                      id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderOverview.create.llm.proxy"
+                      defaultMessage="Create App LLM Proxy"
+                    />
+                  </Button>
+                </DisabledActionTooltip>
               </Stack>
             </Box>
           </Box>
@@ -1189,6 +1205,12 @@ function ServiceProviderOverviewContent() {
           defaultMessage={'Back to list'}
         />
       </Button>
+      {isReadOnlyProvider ? (
+        <Alert severity="info" sx={{ mt: 2 }}>
+          This provider was created from a gateway. Configuration changes are
+          unavailable in AI Workspace,
+        </Alert>
+      ) : null}
       <Box mt={1}>
         <LLLMStepBanner
           providerName={provider.name}
@@ -1271,11 +1293,16 @@ function ServiceProviderOverviewContent() {
                     variant="outlined"
                     color="primary"
                   />
-                  <Tooltip title="Edit Service Provider">
-                    <IconButton component={RouterLink} to="edit" size="small">
+                  <DisabledActionTooltip disabled={isReadOnlyProvider}>
+                    <IconButton
+                      component={isReadOnlyProvider ? 'button' : RouterLink}
+                      to={isReadOnlyProvider ? undefined : 'edit'}
+                      size="small"
+                      disabled={isReadOnlyProvider}
+                    >
                       <Edit size={16} />
                     </IconButton>
-                  </Tooltip>
+                  </DisabledActionTooltip>
                 </Stack>
                 <Typography variant="body2" color="text.secondary">
                   {truncatedDescription}
@@ -1313,33 +1340,41 @@ function ServiceProviderOverviewContent() {
                 width: { xs: '100%', sm: 200 },
               }}
             >
-              <Button
-                variant="contained"
-                component={RouterLink}
-                to="deploy"
-                onClick={handleBlockedNavigation}
+              <DisabledActionTooltip
+                disabled={isReadOnlyProvider}
                 fullWidth
               >
-                <FormattedMessage
-                  id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderOverview.deploy.to.gateway"
-                  defaultMessage={'Deploy to Gateway'}
-                />
-              </Button>
-              <Tooltip title={isProxyQuotaReached ? proxyQuotaTooltip : ''}>
-                <Box component="span" sx={{ width: '100%' }}>
-                  <Button
-                    variant="outlined"
-                    onClick={handleCreateProxyClick}
-                    disabled={!provider.id || isProxyQuotaReached}
-                    fullWidth
-                  >
-                    <FormattedMessage
-                      id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderOverview.create.llm.proxy"
-                      defaultMessage="Create App LLM Proxy"
-                    />
-                  </Button>
-                </Box>
-              </Tooltip>
+                <Button
+                  variant="contained"
+                  component={isReadOnlyProvider ? 'button' : RouterLink}
+                  to={isReadOnlyProvider ? undefined : 'deploy'}
+                  onClick={isReadOnlyProvider ? undefined : handleBlockedNavigation}
+                  disabled={isReadOnlyProvider}
+                  fullWidth
+                >
+                  <FormattedMessage
+                    id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderOverview.deploy.to.gateway"
+                    defaultMessage={'Deploy to Gateway'}
+                  />
+                </Button>
+              </DisabledActionTooltip>
+              <DisabledActionTooltip
+                disabled={isProxyQuotaReached}
+                title={createProxyTooltip}
+                fullWidth
+              >
+                <Button
+                  variant="outlined"
+                  onClick={handleCreateProxyClick}
+                  disabled={!provider.id || isProxyQuotaReached}
+                  fullWidth
+                >
+                  <FormattedMessage
+                    id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderOverview.create.llm.proxy"
+                    defaultMessage="Create App LLM Proxy"
+                  />
+                </Button>
+              </DisabledActionTooltip>
             </Stack>
           </Box>
         </Card>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverviewTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverviewTab.tsx
@@ -68,6 +68,10 @@ import SwaggerSpecViewer from '../../../../Components/SwaggerSpecViewer';
 import { filterOpenApiSpecByAccessControl } from '../../../../utils/openApiAccessControl';
 import { buildProjectPath } from '../../../../utils/projectRouting';
 import {
+  DisabledActionTooltip,
+  GATEWAY_MANAGED_ARTIFACT_TOOLTIP,
+} from '../../../../utils/readOnlyArtifacts';
+import {
   getCurrentDeployment,
   getProxyIdentifier,
 } from './ProviderMap/ProviderMapTab';
@@ -155,6 +159,7 @@ export default function ServiceProviderOverviewTab({
   const apiKeyLocation = provider?.security?.apiKey?.in ?? 'header';
   const apiKeyName = provider?.security?.apiKey?.key ?? 'X-API-Key';
   const showSnackbar = useAIWorkspaceSnackbar();
+  const isReadOnlyProvider = Boolean(provider?.readOnly);
 
   const parsedOpenApiSpec = useMemo(
     () => parseOpenApiSpec(provider?.openapi || ''),
@@ -597,7 +602,11 @@ export default function ServiceProviderOverviewTab({
   );
 
   const handleDeleteApiKey = async () => {
-    if (!deleteTargetKeyName || !provider?.id || !currentOrganization?.uuid) {
+    if (
+      !deleteTargetKeyName ||
+      !provider?.id ||
+      !currentOrganization?.uuid
+    ) {
       return;
     }
 
@@ -813,25 +822,16 @@ export default function ServiceProviderOverviewTab({
                           />
                         </Typography>
                       </Box>
-                      <Tooltip
-                        title={
-                          deployedGateways.length === 0
-                            ? 'No deployed gateways available. Deploy to a gateway first to generate an API key.'
-                            : ''
-                        }
-                        placement="top"
-                      >
-                        <span>
-                          <Button
-                            variant="contained"
-                            size="medium"
-                            onClick={handleOpenApiKeyModal}
-                            disabled={deployedGateways.length === 0}
-                          >
-                            Generate API Key
-                          </Button>
-                        </span>
-                      </Tooltip>
+                      <DisabledActionTooltip disabled={false}>
+                        <Button
+                          variant="contained"
+                          size="medium"
+                          onClick={handleOpenApiKeyModal}
+                          disabled={deployedGateways.length === 0}
+                        >
+                          Generate API Key
+                        </Button>
+                      </DisabledActionTooltip>
                     </Stack>
 
                     {keyError && (

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderRateLimitingTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderRateLimitingTab.tsx
@@ -57,6 +57,7 @@ import { filterOpenApiSpecByAccessControl } from '../../../../utils/openApiAcces
 import { ResourceRow } from '../../../../Components/ResourceView';
 import { FormattedMessage } from 'react-intl';
 import type { AccessControl } from '../../../../utils/types';
+import { GATEWAY_MANAGED_ARTIFACT_TOOLTIP } from '../../../../utils/readOnlyArtifacts';
 
 type ResourceItem = {
   method: string;
@@ -79,6 +80,7 @@ type CriteriaMap = Record<string, RateLimitCriteria[]>;
 type CriteriaRowsProps = {
   criteria: RateLimitCriteria[];
   onChange: (next: RateLimitCriteria[]) => void;
+  disabled?: boolean;
 };
 
 const UNITS = ['hour', 'day', 'week', 'month'] as const;
@@ -142,7 +144,11 @@ function extractResourcesFromSpecJson(spec: any): ResourceItem[] {
   return extracted;
 }
 
-function CriteriaRows({ criteria, onChange }: CriteriaRowsProps) {
+function CriteriaRows({
+  criteria,
+  onChange,
+  disabled = false,
+}: CriteriaRowsProps) {
   const [rows, setRows] = useState<RateLimitCriteria[]>(criteria);
   const [openMap, setOpenMap] = useState<Record<string, boolean>>({});
 
@@ -221,13 +227,14 @@ function CriteriaRows({ criteria, onChange }: CriteriaRowsProps) {
                     <Switch
                       size="small"
                       checked={Boolean(item.enabled)}
+                      disabled={disabled}
                       onChange={() => toggleEnabled(item.label)}
                     />
                   }
                 />
                 <IconButton
                   size="small"
-                  disabled={!item.enabled}
+                  disabled={!item.enabled || disabled}
                   onClick={() => toggleOpen(item.label)}
                 >
                   {openMap[item.label] ? (
@@ -249,6 +256,7 @@ function CriteriaRows({ criteria, onChange }: CriteriaRowsProps) {
                       <TextField
                         size="small"
                         value={item.quota}
+                        disabled={disabled}
                         onChange={(e) =>
                           updateRow(item.label, { quota: e.target.value })
                         }
@@ -276,6 +284,7 @@ function CriteriaRows({ criteria, onChange }: CriteriaRowsProps) {
                           size="small"
                           type="number"
                           value={item.resetValue}
+                          disabled={disabled}
                           onChange={(e) =>
                             updateRow(item.label, { resetValue: e.target.value })
                           }
@@ -285,6 +294,7 @@ function CriteriaRows({ criteria, onChange }: CriteriaRowsProps) {
                         <Select
                           size="small"
                           value={item.resetUnit || 'hour'}
+                          disabled={disabled}
                           onChange={(e) => {
                             updateRow(item.label, {
                               resetUnit: String(e.target.value),
@@ -318,6 +328,8 @@ function ModeToggle({
   disableResource,
   disableGlobalReason,
   disableResourceReason,
+  disabled = false,
+  disabledReason,
 }: {
   value: 'global' | 'resource';
   onChange: (v: 'global' | 'resource') => void;
@@ -325,6 +337,8 @@ function ModeToggle({
   disableResource?: boolean;
   disableGlobalReason?: string;
   disableResourceReason?: string;
+  disabled?: boolean;
+  disabledReason?: string;
 }) {
   const handleChange = (
     _e: React.MouseEvent<HTMLElement>,
@@ -341,13 +355,19 @@ function ModeToggle({
       onChange={handleChange}
     >
       <Tooltip
-        title={disableGlobal ? disableGlobalReason || '' : ''}
+        title={
+          disabled
+            ? disabledReason || ''
+            : disableGlobal
+              ? disableGlobalReason || ''
+              : ''
+        }
         placement="top"
       >
         <Box component="span">
           <ToggleButton
             value="global"
-            disabled={Boolean(disableGlobal)}
+            disabled={disabled || Boolean(disableGlobal)}
             sx={{ textTransform: 'none' }}
           >
             Provider-wide
@@ -355,13 +375,19 @@ function ModeToggle({
         </Box>
       </Tooltip>
       <Tooltip
-        title={disableResource ? disableResourceReason || '' : ''}
+        title={
+          disabled
+            ? disabledReason || ''
+            : disableResource
+              ? disableResourceReason || ''
+              : ''
+        }
         placement="top"
       >
         <Box component="span">
           <ToggleButton
             value="resource"
-            disabled={Boolean(disableResource)}
+            disabled={disabled || Boolean(disableResource)}
             sx={{ textTransform: 'none' }}
           >
             Per Resource
@@ -527,6 +553,7 @@ export default function ServiceProviderRateLimitingTab({
 }: ServiceProviderRateLimitingTabProps) {
   const { provider, isLoading, error, updateProvider, isDraftMode } =
     useLLMProvider();
+  const isReadOnlyProvider = Boolean(provider?.readOnly);
   const [backendRateMode, setBackendRateMode] = useState<'global' | 'resource'>(
     'global'
   );
@@ -818,7 +845,7 @@ export default function ServiceProviderRateLimitingTab({
   };
 
   const handleSaveRateLimiting = async (): Promise<boolean> => {
-    if (!provider || isLoading || error) return false;
+    if (!provider || isLoading || error || isReadOnlyProvider) return false;
     if (backendHasGlobalConfig && backendHasResourceConfig) {
       showSnackbar(
         'Backend cannot have both Provider-wide and Per Resource values. Remove one side and try again.',
@@ -930,6 +957,8 @@ export default function ServiceProviderRateLimitingTab({
                 <ModeToggle
                   value={backendRateMode}
                   onChange={handleBackendModeChange}
+                  disabled={isReadOnlyProvider}
+                  disabledReason={GATEWAY_MANAGED_ARTIFACT_TOOLTIP}
                   disableGlobal={
                     backendRateMode !== 'global' && backendHasResourceConfig
                   }
@@ -1002,6 +1031,7 @@ export default function ServiceProviderRateLimitingTab({
                         >
                           <CriteriaRows
                             criteria={backendDefaultCriteria}
+                            disabled={isReadOnlyProvider}
                             onChange={(next) => {
                               setBackendDefaultCriteria(next);
                               setIsDirty(true);
@@ -1119,6 +1149,7 @@ export default function ServiceProviderRateLimitingTab({
                               >
                                 <CriteriaRows
                                   criteria={criteria}
+                                  disabled={isReadOnlyProvider}
                                   onChange={(next) =>
                                     updateBackendResourceCriteria(key, next)
                                   }
@@ -1136,6 +1167,7 @@ export default function ServiceProviderRateLimitingTab({
                     <Divider />
                     <CriteriaRows
                       criteria={backendGlobalCriteria}
+                      disabled={isReadOnlyProvider}
                       onChange={(next) => {
                         setBackendGlobalCriteria(next);
                         setIsDirty(true);
@@ -1165,6 +1197,8 @@ export default function ServiceProviderRateLimitingTab({
                 <ModeToggle
                   value={consumerRateMode}
                   onChange={handleConsumerModeChange}
+                  disabled={isReadOnlyProvider}
+                  disabledReason={GATEWAY_MANAGED_ARTIFACT_TOOLTIP}
                   disableGlobal={consumerRateMode !== 'global' && consumerHasResourceConfig}
                   disableResource={consumerRateMode !== 'resource' && consumerHasGlobalConfig}
                   disableGlobalReason='If you need Provider-wide, remove Per Resource values first.'
@@ -1232,6 +1266,7 @@ export default function ServiceProviderRateLimitingTab({
                         >
                           <CriteriaRows
                             criteria={consumerDefaultCriteria}
+                            disabled={isReadOnlyProvider}
                             onChange={(next) => {
                               setConsumerDefaultCriteria(next);
                               setIsDirty(true);
@@ -1351,6 +1386,7 @@ export default function ServiceProviderRateLimitingTab({
                               >
                                 <CriteriaRows
                                   criteria={criteria}
+                                  disabled={isReadOnlyProvider}
                                   onChange={(next) =>
                                     updateConsumerResourceCriteria(key, next)
                                   }
@@ -1368,6 +1404,7 @@ export default function ServiceProviderRateLimitingTab({
                     <Divider />
                     <CriteriaRows
                       criteria={consumerGlobalCriteria}
+                      disabled={isReadOnlyProvider}
                       onChange={(next) => {
                         setConsumerGlobalCriteria(next);
                         setIsDirty(true);

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderResourcesTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderResourcesTab.tsx
@@ -46,6 +46,9 @@ import { useLLMProvider } from '../../../../contexts/llmProvider';
 import { PLATFORM_API_BASE_URL } from '../../../../config.env';
 import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
 import { logger } from '../../../../utils/logger';
+import {
+  DisabledActionTooltip,
+} from '../../../../utils/readOnlyArtifacts';
 import NoData from '../../../../assets/images/NoData.svg';
 import { ExpandableResourceRow } from '../../../../Components/ResourceView';
 import { FormattedMessage } from 'react-intl';
@@ -179,6 +182,7 @@ function buildOperationSpec(
 export default function ServiceProviderResourcesTab() {
   const { provider, isLoading, error, updateProvider, isDraftMode } =
     useLLMProvider();
+  const isReadOnlyProvider = Boolean(provider?.readOnly);
   const [resourceMode, setResourceMode] = useState<'allow' | 'deny'>('allow');
   const [pendingResourceMode, setPendingResourceMode] = useState<
     'allow' | 'deny' | null
@@ -240,7 +244,7 @@ export default function ServiceProviderResourcesTab() {
     exceptions: ResourceItem[],
     nextOpenapi: string
   ) => {
-    if (!provider || isLoading || error) return;
+    if (!provider || isLoading || error || isReadOnlyProvider) return;
     const {
       status,
       createdAt,
@@ -279,6 +283,7 @@ export default function ServiceProviderResourcesTab() {
     _event: React.MouseEvent<HTMLElement>,
     newMode: 'allow' | 'deny' | null
   ) => {
+    if (isReadOnlyProvider) return;
     if (!newMode || newMode === resourceMode) return;
     setPendingResourceMode(newMode);
     setResourceModeConfirmOpen(true);
@@ -290,6 +295,10 @@ export default function ServiceProviderResourcesTab() {
   };
 
   const handleApplyResourceModeChange = () => {
+    if (isReadOnlyProvider) {
+      handleCancelResourceModeChange();
+      return;
+    }
     if (!pendingResourceMode || pendingResourceMode === resourceMode) {
       handleCancelResourceModeChange();
       return;
@@ -349,12 +358,14 @@ export default function ServiceProviderResourcesTab() {
   const updateSpecFileInputRef = useRef<HTMLInputElement | null>(null);
 
   const handleUpdateSpecUploadClick = () => {
+    if (isReadOnlyProvider) return;
     updateSpecFileInputRef.current?.click();
   };
 
   const handleUpdateSpecFileChange = async (
     e: React.ChangeEvent<HTMLInputElement>
   ) => {
+    if (isReadOnlyProvider) return;
     const file = e.target.files?.[0];
     if (!file) return;
 
@@ -380,6 +391,7 @@ export default function ServiceProviderResourcesTab() {
   };
 
   const applySpecificationFromUrl = async (url: string) => {
+    if (isReadOnlyProvider) return;
     if (!url.trim()) return;
     setIsFetchingSpec(true);
     try {
@@ -410,10 +422,12 @@ export default function ServiceProviderResourcesTab() {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const handleUploadClick = () => {
+    if (isReadOnlyProvider) return;
     fileInputRef.current?.click();
   };
 
   const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (isReadOnlyProvider) return;
     const file = e.target.files?.[0];
     if (!file) return;
 
@@ -539,6 +553,7 @@ export default function ServiceProviderResourcesTab() {
   };
 
   const moveSelectedToExceptions = () => {
+    if (isReadOnlyProvider) return;
     if (!selectedAvailableKeys.length) return;
     const selected = availableResources.filter((resource) =>
       selectedAvailableKeySet.has(getResourceKey(resource))
@@ -551,6 +566,7 @@ export default function ServiceProviderResourcesTab() {
   };
 
   const moveSelectedToAvailable = () => {
+    if (isReadOnlyProvider) return;
     if (!selectedExceptionKeys.length) return;
     const nextExceptions = exceptionResources.filter(
       (resource) => !selectedExceptionKeySet.has(getResourceKey(resource))
@@ -561,6 +577,7 @@ export default function ServiceProviderResourcesTab() {
   };
 
   const moveAllToExceptions = () => {
+    if (isReadOnlyProvider) return;
     const nextExceptions = normalized;
     setExceptionResources(nextExceptions);
     setSelectedAvailableKeys([]);
@@ -568,6 +585,7 @@ export default function ServiceProviderResourcesTab() {
   };
 
   const moveAllToAvailable = () => {
+    if (isReadOnlyProvider) return;
     setExceptionResources([]);
     setSelectedExceptionKeys([]);
     void updateAccessControl(resourceMode, [], openapiText);
@@ -668,7 +686,13 @@ export default function ServiceProviderResourcesTab() {
               exclusive
               onChange={handleResourceModeChange}
             >
-              <ToggleButton value="allow" sx={{ textTransform: 'none' }}>
+              <DisabledActionTooltip disabled={isReadOnlyProvider}>
+                <Box component="span">
+                  <ToggleButton
+                    value="allow"
+                    disabled={isReadOnlyProvider}
+                    sx={{ textTransform: 'none' }}
+                  >
                 <FormattedMessage
                   id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderResourcesTab.allow.all"
                   defaultMessage={'Allow all'}
@@ -681,13 +705,21 @@ export default function ServiceProviderResourcesTab() {
                       defaultMessage="Allow all exposes every available resource. Any exception you add will be hidden."
                     />
                   }
-                >
-                  <IconButton size="small">
-                    <HelpCircle size={16} />
-                  </IconButton>
-                </Tooltip>
-              </ToggleButton>
-              <ToggleButton value="deny" sx={{ textTransform: 'none' }}>
+                  >
+                    <IconButton size="small">
+                      <HelpCircle size={16} />
+                    </IconButton>
+                  </Tooltip>
+                  </ToggleButton>
+                </Box>
+              </DisabledActionTooltip>
+              <DisabledActionTooltip disabled={isReadOnlyProvider}>
+                <Box component="span">
+                  <ToggleButton
+                    value="deny"
+                    disabled={isReadOnlyProvider}
+                    sx={{ textTransform: 'none' }}
+                  >
                 <FormattedMessage
                   id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderResourcesTab.deny.all"
                   defaultMessage={'Deny all'}
@@ -700,12 +732,14 @@ export default function ServiceProviderResourcesTab() {
                       defaultMessage="Deny all hides every available resource. Any exception you add will be exposed."
                     />
                   }
-                >
-                  <IconButton size="small">
-                    <HelpCircle size={16} />
-                  </IconButton>
-                </Tooltip>
-              </ToggleButton>
+                  >
+                    <IconButton size="small">
+                      <HelpCircle size={16} />
+                    </IconButton>
+                  </Tooltip>
+                  </ToggleButton>
+                </Box>
+              </DisabledActionTooltip>
             </ToggleButtonGroup>
           </Box>
 
@@ -728,17 +762,20 @@ export default function ServiceProviderResourcesTab() {
               accept=".json,.yaml,.yml"
               onChange={handleFileChange}
             /> */}
-            <Button
-              variant="outlined"
-              size="small"
-              startIcon={<PenLine size={16} />}
-              onClick={() => setUpdateSpecModalOpen(true)}
-            >
-              <FormattedMessage
-                id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderResourcesTab.update.openapi.definition"
-                defaultMessage={'Update OpenAPI Definition'}
-              />
-            </Button>
+            <DisabledActionTooltip disabled={isReadOnlyProvider}>
+              <Button
+                variant="outlined"
+                size="small"
+                startIcon={<PenLine size={16} />}
+                onClick={() => setUpdateSpecModalOpen(true)}
+                disabled={isReadOnlyProvider}
+              >
+                <FormattedMessage
+                  id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderResourcesTab.update.openapi.definition"
+                  defaultMessage={'Update OpenAPI Definition'}
+                />
+              </Button>
+            </DisabledActionTooltip>
           </Box>
         </Box>
 
@@ -839,50 +876,58 @@ export default function ServiceProviderResourcesTab() {
             }}
           >
             <Stack spacing={1}>
-              <Button
-                variant="outlined"
-                size="small"
-                onClick={moveAllToExceptions}
-                disabled={!availableResources.length}
-              >
+              <DisabledActionTooltip disabled={isReadOnlyProvider}>
+                <Button
+                  variant="outlined"
+                  size="small"
+                  onClick={moveAllToExceptions}
+                  disabled={!availableResources.length || isReadOnlyProvider}
+                >
                 <FormattedMessage
                   id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderResourcesTab.message"
                   defaultMessage={'>>'}
                 />
-              </Button>
-              <Button
-                variant="outlined"
-                size="small"
-                onClick={moveSelectedToExceptions}
-                disabled={!selectedAvailableKeys.length}
-              >
+                </Button>
+              </DisabledActionTooltip>
+              <DisabledActionTooltip disabled={isReadOnlyProvider}>
+                <Button
+                  variant="outlined"
+                  size="small"
+                  onClick={moveSelectedToExceptions}
+                  disabled={!selectedAvailableKeys.length || isReadOnlyProvider}
+                >
                 <FormattedMessage
                   id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderResourcesTab.message.2"
                   defaultMessage={'>'}
                 />
-              </Button>
-              <Button
-                variant="outlined"
-                size="small"
-                onClick={moveSelectedToAvailable}
-                disabled={!selectedExceptionKeys.length}
-              >
+                </Button>
+              </DisabledActionTooltip>
+              <DisabledActionTooltip disabled={isReadOnlyProvider}>
+                <Button
+                  variant="outlined"
+                  size="small"
+                  onClick={moveSelectedToAvailable}
+                  disabled={!selectedExceptionKeys.length || isReadOnlyProvider}
+                >
                 <FormattedMessage
                   id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderResourcesTab.message.3"
                   defaultMessage={'<'}
                 />
-              </Button>
-              <Button
-                variant="outlined"
-                size="small"
-                onClick={moveAllToAvailable}
-                disabled={!exceptionResources.length}
-              >
+                </Button>
+              </DisabledActionTooltip>
+              <DisabledActionTooltip disabled={isReadOnlyProvider}>
+                <Button
+                  variant="outlined"
+                  size="small"
+                  onClick={moveAllToAvailable}
+                  disabled={!exceptionResources.length || isReadOnlyProvider}
+                >
                 <FormattedMessage
                   id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderResourcesTab.message.4"
                   defaultMessage={'<<'}
                 />
-              </Button>
+                </Button>
+              </DisabledActionTooltip>
             </Stack>
           </Box>
 
@@ -1039,7 +1084,7 @@ export default function ServiceProviderResourcesTab() {
                   <Button
                     variant="outlined"
                     size="small"
-                    disabled={isFetchingSpec}
+                    disabled={isFetchingSpec || isReadOnlyProvider}
                     onClick={() => {
                       void applySpecificationFromUrl(specUrl);
                     }}
@@ -1054,6 +1099,7 @@ export default function ServiceProviderResourcesTab() {
               variant="outlined"
               fullWidth
               onClick={handleUpdateSpecUploadClick}
+              disabled={isReadOnlyProvider}
             >
               Upload Your Specification
             </Button>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderSecurityTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderSecurityTab.tsx
@@ -42,8 +42,9 @@ export default function ServiceProviderSecurityTab() {
   const [keyValue, setKeyValue] = useState('');
   const [keyIn, setKeyIn] = useState<'header' | 'query'>('header');
   const showSnackbar = useAIWorkspaceSnackbar();
+  const isReadOnlyProvider = Boolean(provider?.readOnly);
   const isSecurityFormDisabled =
-    !apiKeyEnabled || isLoading || Boolean(error);
+    !apiKeyEnabled || isLoading || Boolean(error) || isReadOnlyProvider;
 
   useEffect(() => {
     if (!provider) return;
@@ -61,7 +62,7 @@ export default function ServiceProviderSecurityTab() {
     nextIn: 'header' | 'query',
     nextEnabled: boolean
   ) => {
-    if (!provider || isLoading || error) return;
+    if (!provider || isLoading || error || isReadOnlyProvider) return;
     const {
       status,
       createdAt,
@@ -162,7 +163,7 @@ export default function ServiceProviderSecurityTab() {
                   <Switch
                     size="small"
                     checked={apiKeyEnabled}
-                    disabled={isLoading || Boolean(error)}
+                    disabled={isLoading || Boolean(error) || isReadOnlyProvider}
                     onChange={handleApiKeyEnabledChange}
                   />
                 </Tooltip>

--- a/portals/ai-workspace/src/utils/readOnlyArtifacts.tsx
+++ b/portals/ai-workspace/src/utils/readOnlyArtifacts.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { ReactNode } from 'react';
+import { Box, Tooltip } from '@wso2/oxygen-ui';
+
+export const GATEWAY_MANAGED_ARTIFACT_TOOLTIP =
+  'This operation is unavailable because the artifact was created from a gateway.';
+
+type DisabledActionTooltipProps = {
+  children: ReactNode;
+  disabled: boolean;
+  title?: ReactNode;
+  fullWidth?: boolean;
+};
+
+export function DisabledActionTooltip({
+  children,
+  disabled,
+  title = GATEWAY_MANAGED_ARTIFACT_TOOLTIP,
+  fullWidth = false,
+}: DisabledActionTooltipProps) {
+  return (
+    <Tooltip
+      title={disabled ? title : ''}
+      disableHoverListener={!disabled}
+      disableFocusListener={!disabled}
+      disableTouchListener={!disabled}
+      placement="top"
+    >
+      <Box
+        component="span"
+        sx={fullWidth ? { width: '100%', display: 'inline-flex' } : undefined}
+      >
+        {children}
+      </Box>
+    </Tooltip>
+  );
+}

--- a/portals/ai-workspace/src/utils/types.ts
+++ b/portals/ai-workspace/src/utils/types.ts
@@ -377,6 +377,7 @@ export interface LLMProvider {
   policies?: Policy[];
   security?: SecurityConfig;
   status?: 'Active' | 'Degraded' | 'Paused' | string;
+  readOnly?: boolean;
   createdAt?: string;
   createdBy?: string;
   updatedAt?: string;
@@ -552,6 +553,7 @@ export interface Proxy {
   openapi?: string;
   policies?: Policy[];
   security?: ProxySecurityConfig;
+  readOnly?: boolean;
   createdAt?: string;
   updatedAt?: string;
 }
@@ -729,6 +731,7 @@ export interface MCPServer {
   kind?: string;
   policies?: unknown[];
   capabilities?: MCPServerCapabilities;
+  readOnly?: boolean;
   createdAt?: string;
   updatedAt?: string;
 }


### PR DESCRIPTION
This pull request introduces comprehensive support for "read-only" MCP proxy servers that are managed externally (via a gateway) and should not be editable or deployable from the AI Workspace UI. The changes ensure that when a server is marked as read-only, all relevant editing, deployment, and policy management actions are disabled, and informative tooltips or alerts are shown to the user.

Key changes include:

**Read-only Server Detection and Enforcement:**
* Added detection of the `readOnly` property on servers and propagated this as `isReadOnlyServer` throughout the UI components. All editing, deployment, and policy management actions are now conditionally disabled if the server is read-only. [[1]](diffhunk://#diff-f06e5a05ce44f8e07a93034d3ee819b4d550beaadf7d2dcd6ad3d79ccaf1276cR116) [[2]](diffhunk://#diff-b8fc070a1515d2b9fdf1cd82cfb560f3b9f40e0db05552359adc0cf588d5b143R204) [[3]](diffhunk://#diff-c3718ec9144b7d884e15851a6a566e014f182111dde5dc4a3ea3c8c6196db74aR115)

**UI Feedback and Disabled Actions:**
* Displayed informational `Alert` components in the Edit, Overview, and Deploy pages to inform users when a server is read-only and actions are unavailable. [[1]](diffhunk://#diff-f06e5a05ce44f8e07a93034d3ee819b4d550beaadf7d2dcd6ad3d79ccaf1276cR263-R268) [[2]](diffhunk://#diff-b8fc070a1515d2b9fdf1cd82cfb560f3b9f40e0db05552359adc0cf588d5b143R630-R635) [[3]](diffhunk://#diff-dd9b3434d86b6bb1ea91d40f38c6cf2192ade4188f57892c7accbe4483ec8775R103-R110)
* Wrapped action buttons (Edit, Deploy, Save, Cancel) and policy management controls in `DisabledActionTooltip` components, providing tooltips that explain why actions are disabled. [[1]](diffhunk://#diff-b8fc070a1515d2b9fdf1cd82cfb560f3b9f40e0db05552359adc0cf588d5b143L658-R691) [[2]](diffhunk://#diff-b8fc070a1515d2b9fdf1cd82cfb560f3b9f40e0db05552359adc0cf588d5b143R727-R747) [[3]](diffhunk://#diff-c3718ec9144b7d884e15851a6a566e014f182111dde5dc4a3ea3c8c6196db74aR53-R56)

**Form and Button Disabling:**
* Disabled all relevant form fields (name, version, description, context) and action buttons (Update, Save, Cancel, Deploy) when the server is read-only. [[1]](diffhunk://#diff-f06e5a05ce44f8e07a93034d3ee819b4d550beaadf7d2dcd6ad3d79ccaf1276cR283) [[2]](diffhunk://#diff-f06e5a05ce44f8e07a93034d3ee819b4d550beaadf7d2dcd6ad3d79ccaf1276cR300) [[3]](diffhunk://#diff-f06e5a05ce44f8e07a93034d3ee819b4d550beaadf7d2dcd6ad3d79ccaf1276cR318) [[4]](diffhunk://#diff-f06e5a05ce44f8e07a93034d3ee819b4d550beaadf7d2dcd6ad3d79ccaf1276cR337) [[5]](diffhunk://#diff-f06e5a05ce44f8e07a93034d3ee819b4d550beaadf7d2dcd6ad3d79ccaf1276cR355-R365) [[6]](diffhunk://#diff-b8fc070a1515d2b9fdf1cd82cfb560f3b9f40e0db05552359adc0cf588d5b143L874-R925)

**Policy Management Restrictions:**
* Disabled all policy management actions (add, update, remove, reorder) in the `PolicyMapper` component when in read-only mode, and passed the `readOnly` prop from parent components. [[1]](diffhunk://#diff-b8fc070a1515d2b9fdf1cd82cfb560f3b9f40e0db05552359adc0cf588d5b143R882) [[2]](diffhunk://#diff-c3718ec9144b7d884e15851a6a566e014f182111dde5dc4a3ea3c8c6196db74aR77) [[3]](diffhunk://#diff-c3718ec9144b7d884e15851a6a566e014f182111dde5dc4a3ea3c8c6196db74aR159) [[4]](diffhunk://#diff-c3718ec9144b7d884e15851a6a566e014f182111dde5dc4a3ea3c8c6196db74aR175) [[5]](diffhunk://#diff-c3718ec9144b7d884e15851a6a566e014f182111dde5dc4a3ea3c8c6196db74aR221) [[6]](diffhunk://#diff-b8fc070a1515d2b9fdf1cd82cfb560f3b9f40e0db05552359adc0cf588d5b143R499) [[7]](diffhunk://#diff-b8fc070a1515d2b9fdf1cd82cfb560f3b9f40e0db05552359adc0cf588d5b143R509) [[8]](diffhunk://#diff-b8fc070a1515d2b9fdf1cd82cfb560f3b9f40e0db05552359adc0cf588d5b143R518) [[9]](diffhunk://#diff-b8fc070a1515d2b9fdf1cd82cfb560f3b9f40e0db05552359adc0cf588d5b143R528) [[10]](diffhunk://#diff-b8fc070a1515d2b9fdf1cd82cfb560f3b9f40e0db05552359adc0cf588d5b143R440-R445)

**Imports and Utility Integration:**
* Imported and utilized `DisabledActionTooltip` and related constants from `readOnlyArtifacts` utility module across affected files. [[1]](diffhunk://#diff-f06e5a05ce44f8e07a93034d3ee819b4d550beaadf7d2dcd6ad3d79ccaf1276cR44) [[2]](diffhunk://#diff-b8fc070a1515d2b9fdf1cd82cfb560f3b9f40e0db05552359adc0cf588d5b143R76-R79) [[3]](diffhunk://#diff-c3718ec9144b7d884e15851a6a566e014f182111dde5dc4a3ea3c8c6196db74aR53-R56) [[4]](diffhunk://#diff-dd9b3434d86b6bb1ea91d40f38c6cf2192ade4188f57892c7accbe4483ec8775R22) [[5]](diffhunk://#diff-b8fc070a1515d2b9fdf1cd82cfb560f3b9f40e0db05552359adc0cf588d5b143R28)

These updates ensure a clear and consistent user experience when interacting with gateway-managed MCP proxies, preventing unsupported modifications and providing clear communication to users.