### PR TITLE
Add Gateway Version Feature in AI Workspace

### DIFF
--- a/portals/ai-workspace/configs/config.toml
+++ b/portals/ai-workspace/configs/config.toml
@@ -27,7 +27,7 @@ platform_api_base_url = "https://localhost:9243/api/v1"
 controlplane_host = "host.docker.internal:9243"
 
 default_org_region = "us"
-platform_gateway_versions = '[{"version":"2026.05.13","channel":"STS"},{"version":"1.1","latestVersion":"v1.1.0","channel":"LTS"},{"version":"1.0","latestVersion":"v1.0.0","channel":"LTS"}]'
+platform_gateway_versions = '[{"version":"1.1","latestVersion":"v1.1.0","channel":"LTS"},{"version":"1.0","latestVersion":"v1.0.0","channel":"LTS"}]'
 
 # OIDC — disabled in quickstart mode. Uncomment and set auth_mode = "oidc" to use.
 # oidc_authority    = "https://api.asgardeo.io/t/<YOUR_ORG>/oauth2/token"

--- a/portals/ai-workspace/configs/config.toml
+++ b/portals/ai-workspace/configs/config.toml
@@ -27,6 +27,7 @@ platform_api_base_url = "https://localhost:9243/api/v1"
 controlplane_host = "host.docker.internal:9243"
 
 default_org_region = "us"
+platform_gateway_versions = '[{"version":"2026.05.13","channel":"STS"},{"version":"1.1","latestVersion":"v1.1.0","channel":"LTS"},{"version":"1.0","latestVersion":"v1.0.0","channel":"LTS"}]'
 
 # OIDC — disabled in quickstart mode. Uncomment and set auth_mode = "oidc" to use.
 # oidc_authority    = "https://api.asgardeo.io/t/<YOUR_ORG>/oauth2/token"

--- a/portals/ai-workspace/entrypoint.sh
+++ b/portals/ai-workspace/entrypoint.sh
@@ -50,7 +50,7 @@ if [ -f "$CONFIG_FILE" ]; then
 
     # Split on first '='
     key=$(echo "$line" | sed 's/[[:space:]]*=.*//' | tr -d '[:space:]')
-    value=$(echo "$line" | sed 's/^[^=]*=[[:space:]]*//' | sed 's/^"//' | sed 's/"[[:space:]]*$//')
+    value=$(echo "$line" | sed 's/^[^=]*=[[:space:]]*//' | sed "s/^['\"]//;s/['\"][[:space:]]*\$//")
 
     # Map config.toml key → VITE_* env var name
     case "$key" in

--- a/portals/ai-workspace/entrypoint.sh
+++ b/portals/ai-workspace/entrypoint.sh
@@ -65,6 +65,7 @@ if [ -f "$CONFIG_FILE" ]; then
       oidc_org_name_claim)        vite_key="VITE_OIDC_ORG_NAME_CLAIM" ;;
       oidc_org_handle_claim)      vite_key="VITE_OIDC_ORG_HANDLE_CLAIM" ;;
       oidc_scope)                 vite_key="VITE_OIDC_SCOPE" ;;
+      platform_gateway_versions)  vite_key="VITE_PLATFORM_GATEWAY_VERSIONS" ;;
       *)                          continue ;;
     esac
 

--- a/portals/ai-workspace/production/README.md
+++ b/portals/ai-workspace/production/README.md
@@ -154,7 +154,7 @@ controlplane_host = "<platform-api-host>"
 default_org_region = "us"
 
 # Available gateway versions shown in the create-gateway version selector (JSON array string).
-platform_gateway_versions = '[{"version":"2026.05.13","channel":"STS"},{"version":"1.1","latestVersion":"v1.1.0","channel":"LTS"},{"version":"1.0","latestVersion":"v1.0.0","channel":"LTS"}]'
+platform_gateway_versions = '[{"version":"1.1","latestVersion":"v1.1.0","channel":"LTS"},{"version":"1.0","latestVersion":"v1.0.0","channel":"LTS"}]'
 ```
 
 > **Redirect URIs** are derived automatically from `domain`:

--- a/portals/ai-workspace/production/README.md
+++ b/portals/ai-workspace/production/README.md
@@ -152,6 +152,9 @@ controlplane_host = "<platform-api-host>"
 
 # Default region assigned to new organizations on first login.
 default_org_region = "us"
+
+# Available gateway versions shown in the create-gateway version selector (JSON array string).
+platform_gateway_versions = '[{"version":"2026.05.13","channel":"STS"},{"version":"1.1","latestVersion":"v1.1.0","channel":"LTS"},{"version":"1.0","latestVersion":"v1.0.0","channel":"LTS"}]'
 ```
 
 > **Redirect URIs** are derived automatically from `domain`:
@@ -160,19 +163,20 @@ default_org_region = "us"
 
 ### config.toml → environment variable mapping
 
-| config.toml key        | Environment variable           |
-|------------------------|-------------------------------|
-| `domain`               | `VITE_DOMAIN`                 |
-| `auth_mode`            | `VITE_AUTH_MODE`              |
-| `oidc_authority`       | `VITE_OIDC_AUTHORITY`         |
-| `oidc_client_id`       | `VITE_OIDC_CLIENT_ID`         |
-| `oidc_org_id_claim`    | `VITE_OIDC_ORG_ID_CLAIM`      |
-| `oidc_org_name_claim`  | `VITE_OIDC_ORG_NAME_CLAIM`    |
-| `oidc_org_handle_claim`| `VITE_OIDC_ORG_HANDLE_CLAIM`  |
-| `oidc_scope`           | `VITE_OIDC_SCOPE`             |
-| `platform_api_base_url`| `VITE_PLATFORM_API_BASE_URL`  |
-| `controlplane_host`    | `VITE_CONTROLPLANE_HOST`      |
-| `default_org_region`   | `VITE_DEFAULT_ORG_REGION`     |
+| config.toml key              | Environment variable              |
+|------------------------------|-----------------------------------|
+| `domain`                     | `VITE_DOMAIN`                     |
+| `auth_mode`                  | `VITE_AUTH_MODE`                  |
+| `oidc_authority`             | `VITE_OIDC_AUTHORITY`             |
+| `oidc_client_id`             | `VITE_OIDC_CLIENT_ID`             |
+| `oidc_org_id_claim`          | `VITE_OIDC_ORG_ID_CLAIM`          |
+| `oidc_org_name_claim`        | `VITE_OIDC_ORG_NAME_CLAIM`        |
+| `oidc_org_handle_claim`      | `VITE_OIDC_ORG_HANDLE_CLAIM`      |
+| `oidc_scope`                 | `VITE_OIDC_SCOPE`                 |
+| `platform_api_base_url`      | `VITE_PLATFORM_API_BASE_URL`      |
+| `controlplane_host`          | `VITE_CONTROLPLANE_HOST`          |
+| `default_org_region`         | `VITE_DEFAULT_ORG_REGION`         |
+| `platform_gateway_versions`  | `VITE_PLATFORM_GATEWAY_VERSIONS`  |
 
 Environment variables (e.g. passed via `docker run -e` or a Kubernetes `env:` block) always
 override the corresponding `config.toml` value.

--- a/portals/ai-workspace/src/apis/gateway/gatewayApi.ts
+++ b/portals/ai-workspace/src/apis/gateway/gatewayApi.ts
@@ -50,6 +50,10 @@ function transformRequestToApiFormat(
     description: request.description,
   };
 
+  if ('version' in request && request.version) {
+    payload.version = request.version;
+  }
+
   if ('environment' in request && request.environment) {
     payload.properties = {
       environment: request.environment,

--- a/portals/ai-workspace/src/apis/gateway/types.ts
+++ b/portals/ai-workspace/src/apis/gateway/types.ts
@@ -29,6 +29,7 @@ export interface Gateway {
   isCritical: boolean;
   functionalityType: string;
   isActive: boolean;
+  version?: string;
   createdAt?: string;
   updatedAt?: string;
   properties?: Record<string, string>;
@@ -64,6 +65,7 @@ export interface RegisterGatewayRequest {
   vhost: string;
   functionalityType: string;
   description?: string;
+  version?: string;
   sandboxVhost?: string;
   environment?: string;
 }

--- a/portals/ai-workspace/src/config.env.ts
+++ b/portals/ai-workspace/src/config.env.ts
@@ -138,7 +138,6 @@ export interface GatewayVersionEntry {
 export const PLATFORM_GATEWAY_VERSIONS = getEnvOrDefault<GatewayVersionEntry[]>(
   'VITE_PLATFORM_GATEWAY_VERSIONS',
   [
-    { version: '2026.05.13', channel: 'STS' },
     { version: '1.1', latestVersion: 'v1.1.0', channel: 'LTS' },
     { version: '1.0', latestVersion: 'v1.0.0', channel: 'LTS' },
   ]

--- a/portals/ai-workspace/src/config.env.ts
+++ b/portals/ai-workspace/src/config.env.ts
@@ -129,11 +129,21 @@ export const MOESIF_APP_API_KEY = getEnvOrDefault(
   'eyJhcHAiOiI5Mjo1NjYiLCJ2ZXIiOiIyLjEiLCJvcmciOiI2Mjg6NDE3IiwicHViIjp0cnVlLCJpYXQiOjE3Njk5MDQwMDB9.gxcZJ7eybasZ5JY_JJj2ARuTiWZNnYIeAtL8oQbhfxk'
 );
 
-// Platform Gateway Version
-export const PLATFORM_GATEWAY_VERSION = getEnvOrDefault(
-  'VITE_PLATFORM_GATEWAY_VERSION',
-  'v1.0.0'
+export interface GatewayVersionEntry {
+  version: string;
+  latestVersion?: string;
+  channel: 'STS' | 'LTS';
+}
+
+export const PLATFORM_GATEWAY_VERSIONS = getEnvOrDefault<GatewayVersionEntry[]>(
+  'VITE_PLATFORM_GATEWAY_VERSIONS',
+  [
+    { version: '2026.05.13', channel: 'STS' },
+    { version: '1.1', latestVersion: 'v1.1.0', channel: 'LTS' },
+    { version: '1.0', latestVersion: 'v1.0.0', channel: 'LTS' },
+  ]
 );
+
 
 // Policy Hub web URL
 export const POLICY_HUB_WEB_URL = getEnvOrDefault(

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/gateways/AddGateway.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/gateways/AddGateway.tsx
@@ -100,8 +100,8 @@ export default function AddGateway() {
   const [vhost, setVhost] = useState(() =>
     normalizeVhost("https://localhost:8443"),
   );
-  const [selectedVersion, setSelectedVersion] = useState<GatewayVersionEntry>(
-    () => PLATFORM_GATEWAY_VERSIONS[0] ?? { version: "1.0", channel: "LTS" },
+  const [selectedVersion, setSelectedVersion] = useState<GatewayVersionEntry | null>(
+    () => PLATFORM_GATEWAY_VERSIONS[0] ?? null,
   );
 
   // Always use AI gateway type
@@ -113,6 +113,7 @@ export default function AddGateway() {
   }, [displayName]);
 
   const isFormValid = (): boolean => {
+    if (!selectedVersion) return false;
     if (!displayName || displayName.trim().length === 0) return false;
     if (displayName.length > MAX_NAME_LENGTH) return false;
     if (description.length > MAX_DESCRIPTION_LENGTH) return false;
@@ -135,7 +136,7 @@ export default function AddGateway() {
         vhost: normalizeVhost(vhost),
         functionalityType,
         description: description || undefined,
-        version: selectedVersion.version,
+        version: selectedVersion!.version,
       });
 
       showSnackbar("AI Gateway registered successfully", "success");
@@ -188,7 +189,7 @@ export default function AddGateway() {
               <FormControl fullWidth>
                 <FormLabel required>Gateway Version</FormLabel>
                 <Select
-                  value={selectedVersion.version}
+                  value={selectedVersion?.version ?? ""}
                   onChange={(e) => {
                     const entry = PLATFORM_GATEWAY_VERSIONS.find(
                       (v) => v.version === e.target.value,

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/gateways/AddGateway.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/gateways/AddGateway.tsx
@@ -21,6 +21,7 @@ import { useNavigate, Link as RouterLink } from "react-router-dom";
 import {
   Box,
   Button,
+  Chip,
   TextField,
   Grid,
   PageContent,
@@ -28,6 +29,9 @@ import {
   Stack,
   FormControl,
   FormLabel,
+  Select,
+  MenuItem,
+  ListItemText,
 } from "@wso2/oxygen-ui";
 import { ChevronLeft } from "@wso2/oxygen-ui-icons-react";
 import { useGatewayList } from "../../../../hooks/useGateway";
@@ -35,6 +39,8 @@ import { useAppShell } from "../../../../contexts/AppShellContext";
 import { buildOrgPath } from "../../../../utils/projectRouting";
 import { setRegistrationToken } from "./registrationTokenStore";
 import { useAIWorkspaceSnackbar } from "../../../../hooks/aiWorkspaceSnackbar";
+import { PLATFORM_GATEWAY_VERSIONS } from "../../../../config.env";
+import type { GatewayVersionEntry } from "../../../../config.env";
 
 // Validation constants
 const MAX_NAME_LENGTH = 255;
@@ -94,6 +100,9 @@ export default function AddGateway() {
   const [vhost, setVhost] = useState(() =>
     normalizeVhost("https://localhost:8443"),
   );
+  const [selectedVersion, setSelectedVersion] = useState<GatewayVersionEntry>(
+    () => PLATFORM_GATEWAY_VERSIONS[0] ?? { version: "1.0", channel: "LTS" },
+  );
 
   // Always use AI gateway type
   const functionalityType = "ai";
@@ -126,6 +135,7 @@ export default function AddGateway() {
         vhost: normalizeVhost(vhost),
         functionalityType,
         description: description || undefined,
+        version: selectedVersion.version,
       });
 
       showSnackbar("AI Gateway registered successfully", "success");
@@ -174,6 +184,89 @@ export default function AddGateway() {
       <Box sx={{ mt: 2, maxWidth: 820 }}>
         <Box component="form" onSubmit={handleSubmit} noValidate>
           <Grid container spacing={2}>
+            <Grid size={{ xs: 12 }}>
+              <FormControl fullWidth>
+                <FormLabel required>Gateway Version</FormLabel>
+                <Select
+                  value={selectedVersion.version}
+                  onChange={(e) => {
+                    const entry = PLATFORM_GATEWAY_VERSIONS.find(
+                      (v) => v.version === e.target.value,
+                    );
+                    if (entry) setSelectedVersion(entry);
+                  }}
+                  renderValue={(value) => {
+                    const entry = PLATFORM_GATEWAY_VERSIONS.find(
+                      (v) => v.version === value,
+                    );
+                    if (!entry) return value;
+                    const isFirst =
+                      PLATFORM_GATEWAY_VERSIONS[0]?.version === entry.version;
+                    const isFirstLTS =
+                      entry.channel === "LTS" &&
+                      PLATFORM_GATEWAY_VERSIONS.find(
+                        (v) => v.channel === "LTS",
+                      )?.version === entry.version;
+                    const badge = isFirst
+                      ? "Latest"
+                      : isFirstLTS
+                        ? "LTS"
+                        : null;
+                    return (
+                      <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                        <span>{`AI-Gateway v${entry.version}`}</span>
+                        {badge && (
+                          <Chip
+                            label={badge}
+                            size="small"
+                            color={badge === "Latest" ? "success" : "primary"}
+                          />
+                        )}
+                      </Box>
+                    );
+                  }}
+                >
+                  {(() => {
+                    let firstLTSSeen = false;
+                    return PLATFORM_GATEWAY_VERSIONS.map((entry, index) => {
+                      const isFirst = index === 0;
+                      const isFirstLTS =
+                        !firstLTSSeen && entry.channel === "LTS";
+                      if (entry.channel === "LTS" && !firstLTSSeen)
+                        firstLTSSeen = true;
+                      const badge = isFirst
+                        ? "Latest"
+                        : isFirstLTS
+                          ? "LTS"
+                          : null;
+                      return (
+                        <MenuItem key={entry.version} value={entry.version}>
+                          <ListItemText
+                            primary={
+                              <Box
+                                sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", width: "100%" }}
+                              >
+                                <span>{`AI-Gateway v${entry.version}`}</span>
+                                {badge && (
+                                  <Chip
+                                    label={badge}
+                                    size="small"
+                                    color={
+                                      badge === "Latest" ? "success" : "primary"
+                                    }
+                                  />
+                                )}
+                              </Box>
+                            }
+                          />
+                        </MenuItem>
+                      );
+                    });
+                  })()}
+                </Select>
+              </FormControl>
+            </Grid>
+
             <Grid size={{ xs: 12 }}>
               <FormControl fullWidth>
                 <FormLabel required>Name</FormLabel>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/gateways/GatewaysList.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/gateways/GatewaysList.tsx
@@ -259,6 +259,12 @@ export default function GatewaysList() {
                         </TableCell>
                         <TableCell>
                           <FormattedMessage
+                            id="aiWorkspace.pages.appShell.appShellPages.gateways.GatewaysList.table.version"
+                            defaultMessage="Version"
+                          />
+                        </TableCell>
+                        <TableCell>
+                          <FormattedMessage
                             id="aiWorkspace.pages.appShell.appShellPages.gateways.GatewaysList.table.status"
                             defaultMessage="Status"
                           />
@@ -306,6 +312,9 @@ export default function GatewaysList() {
                           </TableCell>
                           <TableCell>
                             <Skeleton variant="text" width="80%" height={20} />
+                          </TableCell>
+                          <TableCell>
+                            <Skeleton variant="rounded" width={90} height={24} />
                           </TableCell>
                           <TableCell>
                             <Skeleton
@@ -445,6 +454,12 @@ export default function GatewaysList() {
                         </TableCell>
                         <TableCell>
                           <FormattedMessage
+                            id="aiWorkspace.pages.appShell.appShellPages.gateways.GatewaysList.table.version"
+                            defaultMessage="Version"
+                          />
+                        </TableCell>
+                        <TableCell>
+                          <FormattedMessage
                             id="aiWorkspace.pages.appShell.appShellPages.gateways.GatewaysList.table.status"
                             defaultMessage="Status"
                           />
@@ -472,7 +487,7 @@ export default function GatewaysList() {
                     <TableBody>
                       {filteredGateways.length === 0 ? (
                         <TableRow>
-                          <TableCell colSpan={isAdmin ? 5 : 4}>
+                          <TableCell colSpan={isAdmin ? 6 : 5}>
                             <Typography variant="body2" color="text.secondary">
                               <FormattedMessage
                                 id="aiWorkspace.pages.appShell.appShellPages.gateways.GatewaysList.no.ai.gateways.found"
@@ -548,6 +563,19 @@ export default function GatewaysList() {
                               >
                                 {gateway.description || '—'}
                               </Typography>
+                            </TableCell>
+                            <TableCell>
+                              {gateway.version ? (
+                                <Chip
+                                  label={`AI-Gateway v${gateway.version}`}
+                                  size="small"
+                                  variant="outlined"
+                                />
+                              ) : (
+                                <Typography variant="body2" color="text.secondary">
+                                  —
+                                </Typography>
+                              )}
                             </TableCell>
                             <TableCell>{getStatusChip(gateway)}</TableCell>
                             <TableCell>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/gateways/ViewGateway.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/gateways/ViewGateway.tsx
@@ -62,7 +62,7 @@ import { useAppShell } from "../../../../contexts/AppShellContext";
 import { buildOrgPath } from "../../../../utils/projectRouting";
 import { useAIWorkspaceSnackbar } from "../../../../hooks/aiWorkspaceSnackbar";
 import {
-  PLATFORM_GATEWAY_VERSION,
+  PLATFORM_GATEWAY_VERSIONS,
   PLATFORM_API_BASE_URL,
   CONTROLPLANE_HOST,
 } from "../../../../config.env";
@@ -90,16 +90,13 @@ import type { ColorScheme } from "../../../../utils/colorScheme";
 import AIGatewayStepBanner from "../quickStart/AIGatewayStepBanner";
 import ErrorAlert from "../../../../Components/common/ErrorAlert";
 
-// Constants for gateway setup
-const GATEWAY_VERSION = PLATFORM_GATEWAY_VERSION;
-const GATEWAY_VERSION_HELM = GATEWAY_VERSION.startsWith("v")
-  ? GATEWAY_VERSION.slice(1)
-  : GATEWAY_VERSION;
-
-const GATEWAY_BASE_VERSION = GATEWAY_VERSION_HELM.replace(/-.*$/, "");
-const GATEWAY_ZIP_NAME = `wso2apip-ai-gateway-${GATEWAY_VERSION_HELM}`;
-const GATEWAY_FOLDER_NAME = `wso2apip-ai-gateway-${GATEWAY_BASE_VERSION}`;
-const GATEWAY_ENV_FILE = `${GATEWAY_FOLDER_NAME}/configs/keys.env`;
+const resolveGatewayVersion = (gatewayVersion?: string): string => {
+  const entry = gatewayVersion
+    ? PLATFORM_GATEWAY_VERSIONS.find((v) => v.version === gatewayVersion)
+    : PLATFORM_GATEWAY_VERSIONS[0];
+  if (!entry) return gatewayVersion ? `v${gatewayVersion}` : 'v1.0.0';
+  return entry.latestVersion ?? `v${entry.version}`;
+};
 
 const getPlatformApiBaseUrl = (): string => {
   return PLATFORM_API_BASE_URL;
@@ -118,91 +115,6 @@ function getInitials(name: string): string {
   if (words.length === 1) return words[0].slice(0, 2).toUpperCase();
   return `${words[0][0]}${words[1][0]}`.toUpperCase();
 }
-// Helper functions for generating setup commands
-const getSetupGatewayDisplayCommand = () =>
-  `curl -sLO https://github.com/wso2/api-platform/releases/download/ai-gateway/${GATEWAY_VERSION}/${GATEWAY_ZIP_NAME}.zip && \\
-unzip ${GATEWAY_ZIP_NAME}.zip`;
-
-const getSetupGatewayCopyCommand = () => getSetupGatewayDisplayCommand();
-
-const getConfigureGatewayDisplayCommand = (moesifKey: string | null) => {
-  const controlPlaneHost = CONTROLPLANE_HOST;
-  const moesifLine = moesifKey ? `MOESIF_KEY=<your-moesif-key>\n` : "";
-  return `cat > ${GATEWAY_ENV_FILE} << 'ENVFILE'
-${moesifLine}GATEWAY_CONTROLPLANE_HOST=${controlPlaneHost}
-GATEWAY_REGISTRATION_TOKEN=<your-gateway-token>
-ENVFILE`;
-};
-
-const getConfigureGatewayCopyCommand = (
-  registrationToken: string | null,
-  moesifKey: string | null,
-) => {
-  const controlPlaneHost = CONTROLPLANE_HOST;
-  const tokenValue = registrationToken || "<your-gateway-token>";
-  const moesifLine = moesifKey ? `MOESIF_KEY=${moesifKey}\n` : "";
-  return `cat > ${GATEWAY_ENV_FILE} << 'ENVFILE'
-${moesifLine}GATEWAY_CONTROLPLANE_HOST=${controlPlaneHost}
-GATEWAY_REGISTRATION_TOKEN=${tokenValue}
-ENVFILE`;
-};
-
-const getStep3NavigateCommand = () => `cd ${GATEWAY_FOLDER_NAME}`;
-
-const getStartGatewayDisplayCommand = () =>
-  `docker compose --env-file configs/keys.env up`;
-
-const getStartGatewayCopyCommand = () => getStartGatewayDisplayCommand();
-
-const getK8sCustomHelmDisplayCommand = (moesifKey: string | null) => {
-  const controlPlaneHost = CONTROLPLANE_HOST;
-  const lines = [
-    `helm install gateway oci://ghcr.io/wso2/api-platform/helm-charts/gateway --version ${GATEWAY_VERSION_HELM} \\`,
-    `  --set gateway.controller.controlPlane.host="${controlPlaneHost}" \\`,
-    "  --set gateway.controller.controlPlane.port=443 \\",
-    '  --set gateway.controller.controlPlane.token.value="your-gateway-token"',
-  ];
-
-  if (moesifKey) {
-    lines[lines.length - 1] += " \\";
-    lines.push(
-      "  --set gateway.config.analytics.publishers.moesif.application_id=<your-moesif-key>",
-    );
-    lines[lines.length - 1] += " \\";
-  } else {
-    lines[lines.length - 1] += " \\";
-  }
-
-  lines.push("  --set gateway.config.analytics.enabled=true");
-  return lines.join("\n");
-};
-
-const getK8sCustomHelmCopyCommand = (
-  registrationToken: string | null,
-  moesifKey: string | null,
-) => {
-  const tokenValue = registrationToken || "your-gateway-token";
-  const controlPlaneHost = CONTROLPLANE_HOST;
-  const lines = [
-    `helm install gateway oci://ghcr.io/wso2/api-platform/helm-charts/gateway --version ${GATEWAY_VERSION_HELM} \\`,
-    `  --set gateway.controller.controlPlane.host="${controlPlaneHost}" \\`,
-    "  --set gateway.controller.controlPlane.port=443 \\",
-    `  --set gateway.controller.controlPlane.token.value="${tokenValue}"`,
-  ];
-
-  if (moesifKey) {
-    lines[lines.length - 1] += " \\";
-    lines.push(
-      `  --set gateway.config.analytics.publishers.moesif.application_id="${moesifKey}"`,
-    );
-    lines[lines.length - 1] += " \\";
-  } else {
-    lines[lines.length - 1] += " \\";
-  }
-
-  lines.push("  --set gateway.config.analytics.enabled=true");
-  return lines.join("\n");
-};
 
 type TabPanelProps = {
   value: number;
@@ -317,6 +229,97 @@ export default function ViewGateway() {
   const [registrationToken, setRegistrationTokenState] = useState<
     string | null
   >(() => getRegistrationToken());
+
+  // Version vars derived from the gateway's stored version
+  const gatewayVersion = resolveGatewayVersion(gateway?.version);
+  const gatewayVersionHelm = gatewayVersion.startsWith("v")
+    ? gatewayVersion.slice(1)
+    : gatewayVersion;
+  const gatewayBaseVersion = gatewayVersionHelm.replace(/-.*$/, "");
+  const gatewayZipName = `wso2apip-ai-gateway-${gatewayVersionHelm}`;
+  const gatewayFolderName = `wso2apip-ai-gateway-${gatewayBaseVersion}`;
+  const gatewayEnvFile = `${gatewayFolderName}/configs/keys.env`;
+
+  const getSetupGatewayDisplayCommand = () =>
+    `curl -sLO https://github.com/wso2/api-platform/releases/download/ai-gateway/${gatewayVersion}/${gatewayZipName}.zip && \\
+unzip ${gatewayZipName}.zip`;
+
+  const getSetupGatewayCopyCommand = () => getSetupGatewayDisplayCommand();
+
+  const getConfigureGatewayDisplayCommand = (moesifKey: string | null) => {
+    const controlPlaneHost = CONTROLPLANE_HOST;
+    const moesifLine = moesifKey ? `MOESIF_KEY=<your-moesif-key>\n` : "";
+    return `cat > ${gatewayEnvFile} << 'ENVFILE'
+${moesifLine}GATEWAY_CONTROLPLANE_HOST=${controlPlaneHost}
+GATEWAY_REGISTRATION_TOKEN=<your-gateway-token>
+ENVFILE`;
+  };
+
+  const getConfigureGatewayCopyCommand = (
+    token: string | null,
+    moesifKey: string | null,
+  ) => {
+    const controlPlaneHost = CONTROLPLANE_HOST;
+    const tokenValue = token || "<your-gateway-token>";
+    const moesifLine = moesifKey ? `MOESIF_KEY=${moesifKey}\n` : "";
+    return `cat > ${gatewayEnvFile} << 'ENVFILE'
+${moesifLine}GATEWAY_CONTROLPLANE_HOST=${controlPlaneHost}
+GATEWAY_REGISTRATION_TOKEN=${tokenValue}
+ENVFILE`;
+  };
+
+  const getStep3NavigateCommand = () => `cd ${gatewayFolderName}`;
+
+  const getStartGatewayDisplayCommand = () =>
+    `docker compose --env-file configs/keys.env up`;
+
+  const getStartGatewayCopyCommand = () => getStartGatewayDisplayCommand();
+
+  const getK8sCustomHelmDisplayCommand = (moesifKey: string | null) => {
+    const controlPlaneHost = CONTROLPLANE_HOST;
+    const lines = [
+      `helm install gateway oci://ghcr.io/wso2/api-platform/helm-charts/gateway --version ${gatewayVersionHelm} \\`,
+      `  --set gateway.controller.controlPlane.host="${controlPlaneHost}" \\`,
+      "  --set gateway.controller.controlPlane.port=443 \\",
+      '  --set gateway.controller.controlPlane.token.value="your-gateway-token"',
+    ];
+    if (moesifKey) {
+      lines[lines.length - 1] += " \\";
+      lines.push(
+        "  --set gateway.config.analytics.publishers.moesif.application_id=<your-moesif-key>",
+      );
+      lines[lines.length - 1] += " \\";
+    } else {
+      lines[lines.length - 1] += " \\";
+    }
+    lines.push("  --set gateway.config.analytics.enabled=true");
+    return lines.join("\n");
+  };
+
+  const getK8sCustomHelmCopyCommand = (
+    token: string | null,
+    moesifKey: string | null,
+  ) => {
+    const tokenValue = token || "your-gateway-token";
+    const controlPlaneHost = CONTROLPLANE_HOST;
+    const lines = [
+      `helm install gateway oci://ghcr.io/wso2/api-platform/helm-charts/gateway --version ${gatewayVersionHelm} \\`,
+      `  --set gateway.controller.controlPlane.host="${controlPlaneHost}" \\`,
+      "  --set gateway.controller.controlPlane.port=443 \\",
+      `  --set gateway.controller.controlPlane.token.value="${tokenValue}"`,
+    ];
+    if (moesifKey) {
+      lines[lines.length - 1] += " \\";
+      lines.push(
+        `  --set gateway.config.analytics.publishers.moesif.application_id="${moesifKey}"`,
+      );
+      lines[lines.length - 1] += " \\";
+    } else {
+      lines[lines.length - 1] += " \\";
+    }
+    lines.push("  --set gateway.config.analytics.enabled=true");
+    return lines.join("\n");
+  };
 
   // Clear the token when leaving the page
   useEffect(() => {
@@ -687,6 +690,13 @@ GATEWAY_REGISTRATION_TOKEN=${registrationToken || ""}`;
                 <Typography variant="h3">
                   {gateway?.displayName || gateway?.name}
                 </Typography>
+                {gateway?.version && (
+                  <Chip
+                    label={`AI-Gateway v${gateway.version}`}
+                    size="small"
+                    variant="outlined"
+                  />
+                )}
                 <Chip
                   label={gateway?.isActive ? "Active" : "Inactive"}
                   size="small"
@@ -940,7 +950,7 @@ GATEWAY_REGISTRATION_TOKEN=${registrationToken || ""}`;
                       color="text.secondary"
                       sx={{ mb: 2 }}
                     >
-                      Run this command to create {GATEWAY_ENV_FILE} with the
+                      Run this command to create {gatewayEnvFile} with the
                       required environment variables:
                     </Typography>
                     <TextField
@@ -1234,7 +1244,7 @@ GATEWAY_REGISTRATION_TOKEN=${registrationToken || ""}`;
                       color="text.secondary"
                       sx={{ mb: 2 }}
                     >
-                      Run this command to create {GATEWAY_ENV_FILE} with the
+                      Run this command to create {gatewayEnvFile} with the
                       required environment variables:
                     </Typography>
                     <TextField
@@ -1459,7 +1469,7 @@ GATEWAY_REGISTRATION_TOKEN=${registrationToken || ""}`;
                       color="text.secondary"
                       sx={{ mb: 2 }}
                     >
-                      Run this command to create {GATEWAY_ENV_FILE} with the
+                      Run this command to create {gatewayEnvFile} with the
                       required environment variables:
                     </Typography>
                     <TextField

--- a/portals/ai-workspace/src/utils/getEnvOrDefault.ts
+++ b/portals/ai-workspace/src/utils/getEnvOrDefault.ts
@@ -38,6 +38,15 @@ export const getEnvOrDefault = <T>(envKey: string, defaultValue: T): T => {
       return (isNaN(num) ? defaultValue : num) as T;
     }
 
+    // Handle array/object conversion
+    if (Array.isArray(defaultValue) || (typeof defaultValue === 'object' && defaultValue !== null)) {
+      try {
+        return JSON.parse(runtimeValue) as T;
+      } catch {
+        return defaultValue;
+      }
+    }
+
     return runtimeValue as T;
   }
 
@@ -54,6 +63,15 @@ export const getEnvOrDefault = <T>(envKey: string, defaultValue: T): T => {
     if (typeof defaultValue === 'number') {
       const num = Number(envValue);
       return (isNaN(num) ? defaultValue : num) as T;
+    }
+
+    // Handle array/object conversion
+    if (Array.isArray(defaultValue) || (typeof defaultValue === 'object' && defaultValue !== null)) {
+      try {
+        return JSON.parse(envValue) as T;
+      } catch {
+        return defaultValue;
+      }
     }
 
     return envValue as T;

--- a/portals/ai-workspace/src/utils/getEnvOrDefault.ts
+++ b/portals/ai-workspace/src/utils/getEnvOrDefault.ts
@@ -41,7 +41,10 @@ export const getEnvOrDefault = <T>(envKey: string, defaultValue: T): T => {
     // Handle array/object conversion
     if (Array.isArray(defaultValue) || (typeof defaultValue === 'object' && defaultValue !== null)) {
       try {
-        return JSON.parse(runtimeValue) as T;
+        const parsed = JSON.parse(runtimeValue);
+        if (Array.isArray(defaultValue) && !Array.isArray(parsed)) return defaultValue;
+        if (!Array.isArray(defaultValue) && (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed))) return defaultValue;
+        return parsed as T;
       } catch {
         return defaultValue;
       }
@@ -68,7 +71,10 @@ export const getEnvOrDefault = <T>(envKey: string, defaultValue: T): T => {
     // Handle array/object conversion
     if (Array.isArray(defaultValue) || (typeof defaultValue === 'object' && defaultValue !== null)) {
       try {
-        return JSON.parse(envValue) as T;
+        const parsed = JSON.parse(envValue);
+        if (Array.isArray(defaultValue) && !Array.isArray(parsed)) return defaultValue;
+        if (!Array.isArray(defaultValue) && (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed))) return defaultValue;
+        return parsed as T;
       } catch {
         return defaultValue;
       }


### PR DESCRIPTION
This pull request introduces support for managing and selecting multiple AI Gateway versions in the AI Workspace portal. The changes enable configuration of available gateway versions, allow users to select a version when registering a new gateway, and display version information throughout the UI. The implementation also refactors related configuration and environment variable handling for gateway versions.

<img width="1433" height="436" alt="Screenshot 2026-06-23 at 11 45 54" src="https://github.com/user-attachments/assets/9a37725c-be01-47a8-836e-76a282439e9c" />
<img width="1078" height="691" alt="Screenshot 2026-06-23 at 11 46 06" src="https://github.com/user-attachments/assets/92370b65-714e-4f6e-b263-e3c22ce97f79" />


**Gateway Version Management and Selection:**

* Added a new `platform_gateway_versions` configuration option in `config.toml` and documented its usage in `README.md`. This allows specifying multiple gateway versions with metadata for display and selection. [[1]](diffhunk://#diff-7ceadcced6e6fd09bcc791cb68dba1a49ffd2e7f6f94ffdb9ce06c59fac14520R30) [[2]](diffhunk://#diff-f7fb0c44002f4b2a464e96311e6c2434ac69a0cf76e1a95ff969915d1cd99cfdR155-R157) [[3]](diffhunk://#diff-f7fb0c44002f4b2a464e96311e6c2434ac69a0cf76e1a95ff969915d1cd99cfdL164-R167) [[4]](diffhunk://#diff-f7fb0c44002f4b2a464e96311e6c2434ac69a0cf76e1a95ff969915d1cd99cfdR179)
* Updated the entrypoint script and environment variable mapping to support `VITE_PLATFORM_GATEWAY_VERSIONS`. [[1]](diffhunk://#diff-a32a6069858b06037891787edd84e15a1aeb9e9e69d612c0cd13e71ae47de883R68) [[2]](diffhunk://#diff-f7fb0c44002f4b2a464e96311e6c2434ac69a0cf76e1a95ff969915d1cd99cfdR179)
* Refactored the configuration code to define a `GatewayVersionEntry` type and export the parsed versions array as `PLATFORM_GATEWAY_VERSIONS` instead of a single version string.

**UI/UX Enhancements for Gateway Version:**

* Modified the Add Gateway form to include a version selector based on available versions, displaying badges for "Latest" and "LTS" entries. The selected version is submitted when registering a gateway. [[1]](diffhunk://#diff-eb4c5ffe43f66cda586900b34df9e76d7e44cd654360b58ea4d694717adde37fR24-R43) [[2]](diffhunk://#diff-eb4c5ffe43f66cda586900b34df9e76d7e44cd654360b58ea4d694717adde37fR103-R105) [[3]](diffhunk://#diff-eb4c5ffe43f66cda586900b34df9e76d7e44cd654360b58ea4d694717adde37fR138) [[4]](diffhunk://#diff-eb4c5ffe43f66cda586900b34df9e76d7e44cd654360b58ea4d694717adde37fR187-R269)
* Updated the Gateways list page to show a "Version" column, including skeleton loaders and proper handling for missing version data. [[1]](diffhunk://#diff-2b07754c656249b0a12037336a998e23973f21d8cd5c129c49acbee95e5bd31fR260-R265) [[2]](diffhunk://#diff-2b07754c656249b0a12037336a998e23973f21d8cd5c129c49acbee95e5bd31fR316-R318) [[3]](diffhunk://#diff-2b07754c656249b0a12037336a998e23973f21d8cd5c129c49acbee95e5bd31fR455-R460) [[4]](diffhunk://#diff-2b07754c656249b0a12037336a998e23973f21d8cd5c129c49acbee95e5bd31fL475-R490) [[5]](diffhunk://#diff-2b07754c656249b0a12037336a998e23973f21d8cd5c129c49acbee95e5bd31fR567-R579)
* Updated the Gateway details page to use the new gateway version data and resolve the correct version for display and setup commands. [[1]](diffhunk://#diff-4250ea0c91ed6027575df19c4f91713ce761b7e7849f9d35afb6a34e82ef3744L65-R65) [[2]](diffhunk://#diff-4250ea0c91ed6027575df19c4f91713ce761b7e7849f9d35afb6a34e82ef3744L93-R99)

**API and Type Changes:**

* Extended the `Gateway` and `RegisterGatewayRequest` TypeScript interfaces to include an optional `version` field, and updated the API transformation logic to send the version if specified. [[1]](diffhunk://#diff-af79058b6755a47476b26cb97efc3407a891086a6fe653818bf83b6a88e101e9R32) [[2]](diffhunk://#diff-af79058b6755a47476b26cb97efc3407a891086a6fe653818bf83b6a88e101e9R68) [[3]](diffhunk://#diff-1871638b7606320c334085d4cd63170bc4360fabe5c6c980262567d32b27f5a8R53-R56)

These changes collectively provide a more flexible and user-friendly way to manage and deploy different versions of the AI Gateway within the platform.