### PR TITLE
[Platform API]  Make org creation endpoint secure

### DIFF
--- a/platform-api/src/config/config.go
+++ b/platform-api/src/config/config.go
@@ -88,8 +88,7 @@ type Server struct {
 	Gateway          Gateway          `koanf:"gateway"`
 	EventHub         EventHub         `koanf:"event_hub"`
 
-	EnableScopeValidation   bool `koanf:"enable_scope_validation"`
-	OrgCreationRequiresAuth bool `koanf:"org_creation_requires_auth"`
+	EnableScopeValidation bool `koanf:"enable_scope_validation"`
 }
 
 // Auth groups all authentication-related configuration.
@@ -336,8 +335,6 @@ func envToKoanfKey(s string) string {
 		return "llm_template_definitions_path"
 	case "enable_scope_validation":
 		return "enable_scope_validation"
-	case "org_creation_requires_auth":
-		return "org_creation_requires_auth"
 
 	// Database
 	case "database_driver":

--- a/platform-api/src/config/default_config.go
+++ b/platform-api/src/config/default_config.go
@@ -29,7 +29,6 @@ func defaultConfig() *Server {
 		OpenAPISpecPath:            "./resources/openapi.yaml",
 		LLMTemplateDefinitionsPath: "./resources/default-llm-provider-templates",
 		EnableScopeValidation:      true,
-    	OrgCreationRequiresAuth:    false,
 		Database: Database{
 			Driver:           "sqlite3",
 			Path:             "./data/api_platform.db",

--- a/platform-api/src/internal/handler/organization.go
+++ b/platform-api/src/internal/handler/organization.go
@@ -33,16 +33,14 @@ import (
 )
 
 type OrganizationHandler struct {
-	orgService              *service.OrganizationService
-	orgCreationRequiresAuth bool
-	slogger                 *slog.Logger
+	orgService *service.OrganizationService
+	slogger    *slog.Logger
 }
 
-func NewOrganizationHandler(orgService *service.OrganizationService, orgCreationRequiresAuth bool, slogger *slog.Logger) *OrganizationHandler {
+func NewOrganizationHandler(orgService *service.OrganizationService, slogger *slog.Logger) *OrganizationHandler {
 	return &OrganizationHandler{
-		orgService:              orgService,
-		orgCreationRequiresAuth: orgCreationRequiresAuth,
-		slogger:                 slogger,
+		orgService: orgService,
+		slogger:    slogger,
 	}
 }
 
@@ -219,22 +217,10 @@ func (h *OrganizationHandler) GetOrganizationSubscription(c *gin.Context) {
 	c.JSON(http.StatusOK, subscription)
 }
 
-// RegisterPublicRoutes registers routes that do not require authentication.
-// Must be called before auth middleware is applied to the engine.
-// The org creation POST is only registered here when OrgCreationRequiresAuth is false.
-func (h *OrganizationHandler) RegisterPublicRoutes(r *gin.Engine) {
-	if !h.orgCreationRequiresAuth {
-		r.POST(constants.APIBasePath + "/organizations", h.RegisterOrganization)
-	}
-}
-
 func (h *OrganizationHandler) RegisterRoutes(r *gin.Engine) {
 	orgGroup := r.Group(constants.APIBasePath + "/organizations")
 	{
-		// When auth is required, POST is registered here — behind the auth middleware.
-		if h.orgCreationRequiresAuth {
-			orgGroup.POST("", h.RegisterOrganization)
-		}
+		orgGroup.POST("", h.RegisterOrganization)
 		orgGroup.GET("", h.GetOrganization)
 		orgGroup.HEAD("/:organizationId", h.HeadOrganizationByUuid)
 		orgGroup.GET("/:organizationId", h.GetOrganizationByUUID)

--- a/platform-api/src/internal/server/server.go
+++ b/platform-api/src/internal/server/server.go
@@ -304,7 +304,7 @@ func StartPlatformAPIServer(cfg *config.Server, slogger *slog.Logger) (*Server, 
 	)
 
 	// Initialize handlers
-	orgHandler := handler.NewOrganizationHandler(orgService, cfg.OrgCreationRequiresAuth, slogger)
+	orgHandler := handler.NewOrganizationHandler(orgService, slogger)
 	projectHandler := handler.NewProjectHandler(projectService, slogger)
 	apiHandler := handler.NewAPIHandler(apiService, slogger)
 	devPortalHandler := handler.NewDevPortalHandler(devPortalService, slogger)
@@ -378,12 +378,7 @@ func StartPlatformAPIServer(cfg *config.Server, slogger *slog.Logger) (*Server, 
 		slogger.Warn("scope validation is disabled — all authenticated requests will be allowed regardless of scope")
 	}
 
-	if !cfg.OrgCreationRequiresAuth && !demoMode() {
-		slogger.Warn("WARNING: organization creation endpoint is public — any unauthenticated caller can create organizations; set ORG_CREATION_REQUIRES_AUTH=true for production")
-	}
-
 	// Register public routes before auth middleware so they bypass authentication.
-	orgHandler.RegisterPublicRoutes(router)
 	handler.NewAuthLoginHandler(cfg).RegisterPublicRoutes(router)
 
 	// Build and apply the authenticator middleware.

--- a/platform-api/src/resources/openapi.yaml
+++ b/platform-api/src/resources/openapi.yaml
@@ -10,10 +10,6 @@ info:
     validated against a configured Identity Provider (IDP) using JWKS-based signature
     verification.
 
-    The organization registration endpoint (`POST /organizations`) is **public by default** and
-    requires no authentication. Set `ORG_CREATION_REQUIRES_AUTH=true` on the server to enforce
-    authentication for this endpoint in production environments.
-
     **Required claim**: `organization` — UUID of the caller's organization. All operations are
     automatically scoped to this organization.
 
@@ -48,15 +44,11 @@ paths:
       description: |
         Registers a new organization with a unique UUID and handle.
         This endpoint is used during the organization onboarding process.
-
-        Authentication is controlled by the `ORG_CREATION_REQUIRES_AUTH` server configuration flag.
-        By default the endpoint is public and no authentication is needed. Set
-        `ORG_CREATION_REQUIRES_AUTH=true` to require a valid Bearer JWT token.
+        A valid Bearer JWT token with the `ap:organization:create` or `ap:organization:manage` scope is required.
       operationId: RegisterOrganization
       tags:
         - Organizations
       security:
-        - {}
         - OAuth2Security:
             - ap:organization:create
             - ap:organization:manage

--- a/portals/ai-workspace/configs/config-platform-api-template.toml
+++ b/portals/ai-workspace/configs/config-platform-api-template.toml
@@ -36,11 +36,6 @@ enable_scope_validation = true
 # Controls authentication for POST /api/v0.9/organizations.
 # When true, the endpoint requires both a valid Bearer JWT and the
 # ap:organization:manage scope; requests without that scope are rejected.
-# Default: false (public) — preserves backwards-compatible behaviour for existing deployments.
-# Set to true in production to prevent unauthenticated callers from creating organizations.
-# A warning is logged at startup when this is false and APIP_DEMO_MODE is not set.
-org_creation_requires_auth = false
-
 # ---------------------------------------------------------------------------
 # Database
 # ---------------------------------------------------------------------------

--- a/portals/ai-workspace/configs/config-platform-api.toml
+++ b/portals/ai-workspace/configs/config-platform-api.toml
@@ -25,11 +25,6 @@ port      = "9243"
 
 # Validate OAuth2 scopes on incoming requests.
 enable_scope_validation = true
-# Controls authentication for POST /api/v0.9/organizations.
-# When true, the endpoint requires both a valid Bearer JWT and the
-# ap:organization:manage scope; requests without that scope are rejected.
-org_creation_requires_auth = true
-
 # ---------------------------------------------------------------------------
 # Database
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Remove orgCreationRequiresAuth configuration and related logic from the organization handler and default configuration. Update OpenAPI documentation to reflect changes in organization creation endpoint authentication requirements.

