### PR TITLE
[Gateway] Add data_version column to gateway-controller artifacts table

### DIFF
--- a/gateway/gateway-controller/pkg/models/data_version.go
+++ b/gateway/gateway-controller/pkg/models/data_version.go
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package models
+
+import (
+	"fmt"
+	"strings"
+)
+
+// defaultDataVersion is used when the YAML apiVersion is missing or unparseable.
+const defaultDataVersion = "1.0"
+
+// dataMinorVersions holds the current data-shape minor version for each kind.
+//
+// BUMP the value here when you make a backward-compatible change to a kind's
+// stored data shape WITHOUT bumping the YAML apiVersion. The major version is
+// taken from the apiVersion (".../v1" -> "1"); the minor below is appended,
+// yielding a stored data_version of "1.<minor>". This lets stored rows record
+// exactly which data shape they were written with, enabling future data
+// migrations.
+//
+// Keep this map exhaustive over the ArtifactKind constants — a missing entry
+// silently falls back to minor 0 (see TestDataMinorVersionsExhaustive).
+var dataMinorVersions = map[ArtifactKind]int{
+	KindRestApi:      0,
+	KindWebSubApi:    0,
+	KindWebBrokerApi: 0,
+	KindMcp:          0,
+	KindLlmProxy:     0,
+	KindLlmProvider:  0,
+}
+
+// majorFromApiVersion parses "<group>/v<N>..." and returns "N" (the leading
+// numeric run after "/v"). Any alpha/beta qualifier is stripped, so
+// "gateway.api-platform.wso2.com/v1alpha2" -> "1". Returns "" if unparseable.
+func majorFromApiVersion(apiVersion string) string {
+	idx := strings.LastIndex(apiVersion, "/v")
+	if idx == -1 {
+		return ""
+	}
+	suffix := apiVersion[idx+2:] // text after "/v"
+	major := suffix
+	for i, r := range suffix {
+		if r < '0' || r > '9' {
+			major = suffix[:i]
+			break
+		}
+	}
+	if major == "" {
+		return ""
+	}
+	return major
+}
+
+// ComputeDataVersion derives the stored data_version "<major>.<minor>" from the
+// YAML apiVersion (major) and the per-kind data-shape minor constant. It falls
+// back to defaultDataVersion ("1.0") when the apiVersion is missing or
+// unparseable.
+func ComputeDataVersion(kind ArtifactKind, apiVersion string) string {
+	major := majorFromApiVersion(apiVersion)
+	if major == "" {
+		return defaultDataVersion
+	}
+	minor := dataMinorVersions[kind] // missing kind -> 0 (guarded by exhaustiveness test)
+	return fmt.Sprintf("%s.%d", major, minor)
+}

--- a/gateway/gateway-controller/pkg/models/data_version_test.go
+++ b/gateway/gateway-controller/pkg/models/data_version_test.go
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package models
+
+import "testing"
+
+func TestComputeDataVersion(t *testing.T) {
+	tests := []struct {
+		name       string
+		kind       ArtifactKind
+		apiVersion string
+		want       string
+	}{
+		{"v1 rest api", KindRestApi, "gateway.api-platform.wso2.com/v1", "1.0"},
+		{"v1 llm proxy", KindLlmProxy, "gateway.api-platform.wso2.com/v1", "1.0"},
+		{"v1alpha2 strips qualifier", KindRestApi, "gateway.api-platform.wso2.com/v1alpha2", "1.0"},
+		{"v2 major", KindRestApi, "gateway.api-platform.wso2.com/v2", "2.0"},
+		{"v10 multi-digit major", KindRestApi, "gateway.api-platform.wso2.com/v10", "10.0"},
+		{"empty apiVersion falls back", KindRestApi, "", "1.0"},
+		{"unparseable falls back", KindRestApi, "not-a-version", "1.0"},
+		{"unknown kind defaults minor 0", ArtifactKind("Bogus"), "gateway.api-platform.wso2.com/v3", "3.0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ComputeDataVersion(tt.kind, tt.apiVersion); got != tt.want {
+				t.Errorf("ComputeDataVersion(%q, %q) = %q, want %q", tt.kind, tt.apiVersion, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestComputeDataVersionRespectsMinorBump(t *testing.T) {
+	// Simulate a backward-compatible data-shape bump for one kind and confirm the
+	// computed data_version reflects it, while other kinds stay at .0.
+	orig := dataMinorVersions[KindRestApi]
+	defer func() { dataMinorVersions[KindRestApi] = orig }()
+
+	dataMinorVersions[KindRestApi] = 1
+	if got := ComputeDataVersion(KindRestApi, "gateway.api-platform.wso2.com/v1"); got != "1.1" {
+		t.Errorf("after minor bump, got %q, want %q", got, "1.1")
+	}
+	if got := ComputeDataVersion(KindWebSubApi, "gateway.api-platform.wso2.com/v1"); got != "1.0" {
+		t.Errorf("unbumped kind got %q, want %q", got, "1.0")
+	}
+}
+
+// TestDataMinorVersionsExhaustive guards the §7.3 decision: every ArtifactKind
+// must have an explicit entry in dataMinorVersions, so a newly added kind can't
+// silently fall back to minor 0.
+func TestDataMinorVersionsExhaustive(t *testing.T) {
+	allKinds := []ArtifactKind{
+		KindRestApi,
+		KindWebSubApi,
+		KindWebBrokerApi,
+		KindMcp,
+		KindLlmProxy,
+		KindLlmProvider,
+	}
+	for _, k := range allKinds {
+		if _, ok := dataMinorVersions[k]; !ok {
+			t.Errorf("ArtifactKind %q has no entry in dataMinorVersions; register a minor version", k)
+		}
+	}
+}

--- a/gateway/gateway-controller/pkg/models/stored_config.go
+++ b/gateway/gateway-controller/pkg/models/stored_config.go
@@ -92,6 +92,7 @@ type StoredConfig struct {
 	Handle              string       `json:"handle"`
 	DisplayName         string       `json:"displayName"`
 	Version             string       `json:"version"`
+	DataVersion         string       `json:"dataVersion"`
 	Configuration       any          `json:"configuration"`
 	SourceConfiguration any          `json:"source_configuration,omitempty"`
 	DesiredState        DesiredState `json:"desiredState"`
@@ -109,6 +110,37 @@ type StoredConfig struct {
 // GetCompositeKey returns the composite key "kind:displayName:version" for indexing
 func (c *StoredConfig) GetCompositeKey() string {
 	return fmt.Sprintf("%s:%s:%s", c.Kind, c.DisplayName, c.Version)
+}
+
+// GetApiVersion returns the YAML apiVersion string (e.g.
+// "gateway.api-platform.wso2.com/v1") of the artifact. It prefers
+// SourceConfiguration (the user-authored artifact, e.g. an LLMProxyConfiguration)
+// and falls back to Configuration (which for LLM kinds is the derived RestAPI).
+// Returns "" if neither carries a recognised typed configuration.
+func (c *StoredConfig) GetApiVersion() string {
+	if v := apiVersionOf(c.SourceConfiguration); v != "" {
+		return v
+	}
+	return apiVersionOf(c.Configuration)
+}
+
+// apiVersionOf extracts the apiVersion from a typed configuration value.
+func apiVersionOf(cfg any) string {
+	switch sc := cfg.(type) {
+	case api.RestAPI:
+		return string(sc.ApiVersion)
+	case api.WebSubAPI:
+		return string(sc.ApiVersion)
+	case api.WebBrokerApi:
+		return string(sc.ApiVersion)
+	case api.LLMProviderConfiguration:
+		return string(sc.ApiVersion)
+	case api.LLMProxyConfiguration:
+		return string(sc.ApiVersion)
+	case api.MCPProxyConfiguration:
+		return string(sc.ApiVersion)
+	}
+	return ""
 }
 
 // GetContext returns the context path from SourceConfiguration with $version resolved.

--- a/gateway/gateway-controller/pkg/storage/gateway-controller-db.postgres.sql
+++ b/gateway/gateway-controller/pkg/storage/gateway-controller-db.postgres.sql
@@ -1,5 +1,5 @@
 -- PostgreSQL Schema for Gateway-Controller API Configurations
--- Version: 2
+-- Version: 4
 
 -- Base table for all artifact types
 CREATE TABLE IF NOT EXISTS artifacts (
@@ -7,6 +7,7 @@ CREATE TABLE IF NOT EXISTS artifacts (
     gateway_id TEXT NOT NULL,
     display_name TEXT NOT NULL,
     version TEXT NOT NULL,
+    data_version TEXT NOT NULL DEFAULT '1.0',
     kind TEXT NOT NULL,
     handle TEXT NOT NULL,
     desired_state TEXT NOT NULL CHECK(desired_state IN ('deployed', 'undeployed')),

--- a/gateway/gateway-controller/pkg/storage/gateway-controller-db.sql
+++ b/gateway/gateway-controller/pkg/storage/gateway-controller-db.sql
@@ -1,5 +1,5 @@
 -- SQLite Schema for Gateway-Controller API Configurations
--- Version: 2
+-- Version: 4
 
 -- Base table for all artifact types (REST APIs, WebSub APIs, LLM Providers, LLM Proxies, MCP Proxies)
 CREATE TABLE IF NOT EXISTS artifacts (
@@ -7,6 +7,7 @@ CREATE TABLE IF NOT EXISTS artifacts (
     gateway_id TEXT NOT NULL,
     display_name TEXT NOT NULL,
     version TEXT NOT NULL,
+    data_version TEXT NOT NULL DEFAULT '1.0',
     kind TEXT NOT NULL,
     handle TEXT NOT NULL,
     desired_state TEXT NOT NULL CHECK(desired_state IN ('deployed', 'undeployed')),
@@ -307,4 +308,4 @@ CREATE TABLE IF NOT EXISTS webhook_secrets (
 
 CREATE INDEX IF NOT EXISTS idx_webhook_secrets_artifact ON webhook_secrets(gateway_id, artifact_uuid);
 
-PRAGMA user_version = 3;
+PRAGMA user_version = 4;

--- a/gateway/gateway-controller/pkg/storage/gateway-controller-db.sqlserver.sql
+++ b/gateway/gateway-controller/pkg/storage/gateway-controller-db.sqlserver.sql
@@ -1,5 +1,5 @@
 -- SQL Server Schema for Gateway-Controller API Configurations
--- Version: 2
+-- Version: 4
 --
 -- Portable counterpart of gateway-controller-db.postgres.sql. Type mapping:
 --   TEXT (keyed)      -> NVARCHAR(64)/NVARCHAR(255)  (NVARCHAR(MAX) cannot be indexed;
@@ -19,6 +19,7 @@ CREATE TABLE dbo.artifacts (
     gateway_id NVARCHAR(64) NOT NULL,
     display_name NVARCHAR(255) NOT NULL,
     version NVARCHAR(64) NOT NULL,
+    data_version NVARCHAR(20) NOT NULL DEFAULT '1.0',
     kind NVARCHAR(64) NOT NULL,
     handle NVARCHAR(255) NOT NULL,
     desired_state NVARCHAR(20) NOT NULL CHECK(desired_state IN ('deployed', 'undeployed')),

--- a/gateway/gateway-controller/pkg/storage/sql_store.go
+++ b/gateway/gateway-controller/pkg/storage/sql_store.go
@@ -357,17 +357,27 @@ func unmarshalSourceConfig(cfg *models.StoredConfig, jsonData string) error {
 	return nil
 }
 
+// ensureDataVersion derives and sets cfg.DataVersion when it has not already
+// been populated, so every artifact write path records a data_version without
+// each caller having to compute it. See models.ComputeDataVersion.
+func ensureDataVersion(cfg *models.StoredConfig) {
+	if cfg.DataVersion == "" {
+		cfg.DataVersion = models.ComputeDataVersion(cfg.Kind, cfg.GetApiVersion())
+	}
+}
+
 func (s *sqlStore) SaveConfig(cfg *models.StoredConfig) error {
 	if cfg.Handle == "" {
 		return fmt.Errorf("handle (metadata.name) is required and cannot be empty")
 	}
+	ensureDataVersion(cfg)
 
 	query := `
 		INSERT INTO artifacts (
-			uuid, gateway_id, display_name, version, kind, handle,
+			uuid, gateway_id, display_name, version, data_version, kind, handle,
 			desired_state, deployment_id, origin, created_at, updated_at, deployed_at,
 			cp_sync_status, cp_sync_info, cp_artifact_id
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`
 
 	tx, err := s.begin()
@@ -414,6 +424,7 @@ func (s *sqlStore) SaveConfig(cfg *models.StoredConfig) error {
 		s.gatewayId,
 		cfg.DisplayName,
 		cfg.Version,
+		cfg.DataVersion,
 		cfg.Kind,
 		cfg.Handle,
 		cfg.DesiredState,
@@ -476,10 +487,11 @@ func (s *sqlStore) UpdateConfig(cfg *models.StoredConfig) error {
 		metrics.StorageErrorsTotal.WithLabelValues("update", "validation_error").Inc()
 		return fmt.Errorf("handle (metadata.name) is required and cannot be empty")
 	}
+	ensureDataVersion(cfg)
 
 	query := `
 		UPDATE artifacts
-		SET display_name = ?, version = ?, kind = ?, handle = ?,
+		SET display_name = ?, version = ?, data_version = ?, kind = ?, handle = ?,
 			desired_state = ?, deployment_id = ?, origin = ?, updated_at = ?, deployed_at = ?,
 			cp_sync_status = ?, cp_sync_info = ?, cp_artifact_id = ?
 		WHERE uuid = ? AND gateway_id = ?
@@ -530,6 +542,7 @@ func (s *sqlStore) UpdateConfig(cfg *models.StoredConfig) error {
 		s.ctx,
 		cfg.DisplayName,
 		cfg.Version,
+		cfg.DataVersion,
 		cfg.Kind,
 		cfg.Handle,
 		cfg.DesiredState,
@@ -600,6 +613,7 @@ func (s *sqlStore) UpsertConfig(cfg *models.StoredConfig) (bool, error) {
 	if cfg.Handle == "" {
 		return false, fmt.Errorf("handle (metadata.name) is required and cannot be empty")
 	}
+	ensureDataVersion(cfg)
 
 	tx, err := s.begin()
 	if err != nil {
@@ -638,24 +652,24 @@ func (s *sqlStore) UpsertConfig(cfg *models.StoredConfig) (bool, error) {
 	didWrite, err := s.upsert(tx, upsertSpec{
 		table: "artifacts",
 		columns: []string{
-			"uuid", "gateway_id", "display_name", "version", "kind", "handle",
+			"uuid", "gateway_id", "display_name", "version", "data_version", "kind", "handle",
 			"desired_state", "deployment_id", "origin", "created_at", "updated_at", "deployed_at",
 			"cp_sync_status", "cp_sync_info", "cp_artifact_id",
 		},
 		insertValues: []interface{}{
-			cfg.UUID, s.gatewayId, cfg.DisplayName, cfg.Version, cfg.Kind, cfg.Handle,
+			cfg.UUID, s.gatewayId, cfg.DisplayName, cfg.Version, cfg.DataVersion, cfg.Kind, cfg.Handle,
 			cfg.DesiredState, deploymentID, cfg.Origin, now, now, cfg.DeployedAt,
 			upsertCPSyncStatus, upsertCPSyncInfo, upsertCPArtifactID,
 		},
 		keyColumns: []string{"gateway_id", "uuid"},
 		keyValues:  []interface{}{s.gatewayId, cfg.UUID},
 		setClauses: []string{
-			"display_name = ?", "version = ?", "kind = ?", "handle = ?",
+			"display_name = ?", "version = ?", "data_version = ?", "kind = ?", "handle = ?",
 			"desired_state = ?", "deployment_id = ?", "origin = ?",
 			"updated_at = ?", "deployed_at = ?",
 		},
 		setValues: []interface{}{
-			cfg.DisplayName, cfg.Version, cfg.Kind, cfg.Handle,
+			cfg.DisplayName, cfg.Version, cfg.DataVersion, cfg.Kind, cfg.Handle,
 			cfg.DesiredState, deploymentID, cfg.Origin, now, cfg.DeployedAt,
 		},
 		guard:       "(deployed_at IS NULL OR deployed_at < ?)",
@@ -774,7 +788,7 @@ func (s *sqlStore) GetConfig(id string) (*models.StoredConfig, error) {
 
 	// Step 1: Get artifact base record
 	artifactQuery := `
-		SELECT uuid, kind, handle, display_name, version, desired_state, deployment_id, origin, created_at, updated_at, deployed_at,
+		SELECT uuid, kind, handle, display_name, version, data_version, desired_state, deployment_id, origin, created_at, updated_at, deployed_at,
 			cp_sync_status, cp_sync_info, cp_artifact_id
 		FROM artifacts
 		WHERE uuid = ? AND gateway_id = ?
@@ -793,6 +807,7 @@ func (s *sqlStore) GetConfig(id string) (*models.StoredConfig, error) {
 		&cfg.Handle,
 		&cfg.DisplayName,
 		&cfg.Version,
+		&cfg.DataVersion,
 		&cfg.DesiredState,
 		&deploymentID,
 		&cfg.Origin,
@@ -848,7 +863,7 @@ func (s *sqlStore) GetConfig(id string) (*models.StoredConfig, error) {
 // GetConfigByKindAndHandle retrieves a deployment configuration by kind and handle (metadata.name)
 func (s *sqlStore) GetConfigByKindAndHandle(kind string, handle string) (*models.StoredConfig, error) {
 	artifactQuery := `
-		SELECT uuid, kind, handle, display_name, version, desired_state, deployment_id, origin, created_at, updated_at, deployed_at,
+		SELECT uuid, kind, handle, display_name, version, data_version, desired_state, deployment_id, origin, created_at, updated_at, deployed_at,
 			cp_sync_status, cp_sync_info, cp_artifact_id
 		FROM artifacts
 		WHERE kind = ? AND handle = ? AND gateway_id = ?
@@ -867,6 +882,7 @@ func (s *sqlStore) GetConfigByKindAndHandle(kind string, handle string) (*models
 		&cfg.Handle,
 		&cfg.DisplayName,
 		&cfg.Version,
+		&cfg.DataVersion,
 		&cfg.DesiredState,
 		&deploymentID,
 		&cfg.Origin,
@@ -911,7 +927,7 @@ func (s *sqlStore) GetConfigByKindAndHandle(kind string, handle string) (*models
 // GetConfigByKindNameAndVersion retrieves a deployment configuration by kind, display name, and version.
 func (s *sqlStore) GetConfigByKindNameAndVersion(kind, displayName, version string) (*models.StoredConfig, error) {
 	artifactQuery := `
-		SELECT uuid, kind, handle, display_name, version, desired_state, deployment_id, origin, created_at, updated_at, deployed_at,
+		SELECT uuid, kind, handle, display_name, version, data_version, desired_state, deployment_id, origin, created_at, updated_at, deployed_at,
 			cp_sync_status, cp_sync_info, cp_artifact_id
 		FROM artifacts
 		WHERE kind = ? AND display_name = ? AND version = ? AND gateway_id = ?
@@ -930,6 +946,7 @@ func (s *sqlStore) GetConfigByKindNameAndVersion(kind, displayName, version stri
 		&cfg.Handle,
 		&cfg.DisplayName,
 		&cfg.Version,
+		&cfg.DataVersion,
 		&cfg.DesiredState,
 		&deploymentID,
 		&cfg.Origin,
@@ -976,7 +993,7 @@ func (s *sqlStore) GetConfigByKindNameAndVersion(kind, displayName, version stri
 func (s *sqlStore) GetAllConfigs() ([]*models.StoredConfig, error) {
 	// Use UNION ALL across all type tables joined with artifacts
 	query := `
-			SELECT a.uuid, a.kind, a.handle, a.display_name, a.version, r.configuration, a.desired_state,
+			SELECT a.uuid, a.kind, a.handle, a.display_name, a.version, a.data_version, r.configuration, a.desired_state,
 				a.deployment_id, a.origin, a.created_at, a.updated_at, a.deployed_at,
 				a.cp_sync_status, a.cp_sync_info, a.cp_artifact_id
 			FROM artifacts a
@@ -985,7 +1002,7 @@ func (s *sqlStore) GetAllConfigs() ([]*models.StoredConfig, error) {
 
 		UNION ALL
 
-			SELECT a.uuid, a.kind, a.handle, a.display_name, a.version, w.configuration, a.desired_state,
+			SELECT a.uuid, a.kind, a.handle, a.display_name, a.version, a.data_version, w.configuration, a.desired_state,
 				a.deployment_id, a.origin, a.created_at, a.updated_at, a.deployed_at,
 				a.cp_sync_status, a.cp_sync_info, a.cp_artifact_id
 			FROM artifacts a
@@ -994,7 +1011,7 @@ func (s *sqlStore) GetAllConfigs() ([]*models.StoredConfig, error) {
 
 		UNION ALL
 
-			SELECT a.uuid, a.kind, a.handle, a.display_name, a.version, lp.configuration, a.desired_state,
+			SELECT a.uuid, a.kind, a.handle, a.display_name, a.version, a.data_version, lp.configuration, a.desired_state,
 				a.deployment_id, a.origin, a.created_at, a.updated_at, a.deployed_at,
 				a.cp_sync_status, a.cp_sync_info, a.cp_artifact_id
 			FROM artifacts a
@@ -1003,7 +1020,7 @@ func (s *sqlStore) GetAllConfigs() ([]*models.StoredConfig, error) {
 
 		UNION ALL
 
-			SELECT a.uuid, a.kind, a.handle, a.display_name, a.version, lx.configuration, a.desired_state,
+			SELECT a.uuid, a.kind, a.handle, a.display_name, a.version, a.data_version, lx.configuration, a.desired_state,
 				a.deployment_id, a.origin, a.created_at, a.updated_at, a.deployed_at,
 				a.cp_sync_status, a.cp_sync_info, a.cp_artifact_id
 			FROM artifacts a
@@ -1012,7 +1029,7 @@ func (s *sqlStore) GetAllConfigs() ([]*models.StoredConfig, error) {
 
 		UNION ALL
 
-		SELECT a.uuid, a.kind, a.handle, a.display_name, a.version, m.configuration, a.desired_state,
+		SELECT a.uuid, a.kind, a.handle, a.display_name, a.version, a.data_version, m.configuration, a.desired_state,
 			a.deployment_id, a.origin, a.created_at, a.updated_at, a.deployed_at,
 			a.cp_sync_status, a.cp_sync_info, a.cp_artifact_id
 		FROM artifacts a
@@ -1038,7 +1055,7 @@ func (s *sqlStore) GetAllConfigsByKind(kind string) ([]*models.StoredConfig, err
 	}
 
 	query := fmt.Sprintf(`
-			SELECT a.uuid, a.kind, a.handle, a.display_name, a.version, r.configuration, a.desired_state,
+			SELECT a.uuid, a.kind, a.handle, a.display_name, a.version, a.data_version, r.configuration, a.desired_state,
 				a.deployment_id, a.origin, a.created_at, a.updated_at, a.deployed_at,
 				a.cp_sync_status, a.cp_sync_info, a.cp_artifact_id
 			FROM artifacts a
@@ -1056,7 +1073,7 @@ func (s *sqlStore) GetAllConfigsByKind(kind string) ([]*models.StoredConfig, err
 	return s.scanConfigRows(rows)
 }
 
-// scanConfigRows scans rows from a query that returns (uuid, kind, handle, display_name, version, configuration, desired_state, deployment_id, origin, created_at, updated_at, deployed_at, enable_cp_sync, cp_sync_status, cp_sync_info)
+// scanConfigRows scans rows from a query that returns (uuid, kind, handle, display_name, version, data_version, configuration, desired_state, deployment_id, origin, created_at, updated_at, deployed_at, enable_cp_sync, cp_sync_status, cp_sync_info)
 func (s *sqlStore) scanConfigRows(rows *sql.Rows) ([]*models.StoredConfig, error) {
 	var configs []*models.StoredConfig
 
@@ -1075,6 +1092,7 @@ func (s *sqlStore) scanConfigRows(rows *sql.Rows) ([]*models.StoredConfig, error
 			&cfg.Handle,
 			&cfg.DisplayName,
 			&cfg.Version,
+			&cfg.DataVersion,
 			&configJSON,
 			&cfg.DesiredState,
 			&deploymentID,
@@ -1128,7 +1146,7 @@ func (s *sqlStore) scanConfigRows(rows *sql.Rows) ([]*models.StoredConfig, error
 // so Configuration/SourceConfiguration will be nil.
 func (s *sqlStore) GetAllConfigsByOrigin(origin models.Origin) ([]*models.StoredConfig, error) {
 	query := `
-		SELECT uuid, kind, handle, display_name, version, desired_state,
+		SELECT uuid, kind, handle, display_name, version, data_version, desired_state,
 			deployment_id, origin, created_at, updated_at, deployed_at,
 			cp_sync_status, cp_sync_info, cp_artifact_id
 		FROM artifacts
@@ -1187,6 +1205,7 @@ func scanArtifactMetadataRows(rows *sql.Rows) ([]*models.StoredConfig, error) {
 			&cfg.Handle,
 			&cfg.DisplayName,
 			&cfg.Version,
+			&cfg.DataVersion,
 			&cfg.DesiredState,
 			&deploymentID,
 			&cfg.Origin,
@@ -1263,7 +1282,7 @@ func (s *sqlStore) UpdateCPSyncStatus(uuid, cpArtifactID string, status models.C
 // bottom-up sync. Returns ErrNotFound if no match.
 func (s *sqlStore) GetConfigByCPArtifactID(cpArtifactID string) (*models.StoredConfig, error) {
 	artifactQuery := `
-		SELECT uuid, kind, handle, display_name, version, desired_state, deployment_id, origin, created_at, updated_at, deployed_at,
+		SELECT uuid, kind, handle, display_name, version, data_version, desired_state, deployment_id, origin, created_at, updated_at, deployed_at,
 			cp_sync_status, cp_sync_info, cp_artifact_id
 		FROM artifacts
 		WHERE gateway_id = ? AND cp_artifact_id = ?
@@ -1282,6 +1301,7 @@ func (s *sqlStore) GetConfigByCPArtifactID(cpArtifactID string) (*models.StoredC
 		&cfg.Handle,
 		&cfg.DisplayName,
 		&cfg.Version,
+		&cfg.DataVersion,
 		&cfg.DesiredState,
 		&deploymentID,
 		&cfg.Origin,
@@ -1327,7 +1347,7 @@ func (s *sqlStore) GetConfigByCPArtifactID(cpArtifactID string) (*models.StoredC
 // Used by the bottom-up sync to determine which APIs need to be pushed to the control plane.
 func (s *sqlStore) GetPendingBottomUpAPIs() ([]*models.StoredConfig, error) {
 	query := `
-		SELECT a.uuid, a.kind, a.handle, a.display_name, a.version, r.configuration, a.desired_state,
+		SELECT a.uuid, a.kind, a.handle, a.display_name, a.version, a.data_version, r.configuration, a.desired_state,
 			a.deployment_id, a.origin, a.created_at, a.updated_at, a.deployed_at,
 			a.cp_sync_status, a.cp_sync_info, a.cp_artifact_id
 		FROM artifacts a

--- a/gateway/gateway-controller/pkg/storage/sql_store.go
+++ b/gateway/gateway-controller/pkg/storage/sql_store.go
@@ -1167,7 +1167,7 @@ func (s *sqlStore) GetAllConfigsByOrigin(origin models.Origin) ([]*models.Stored
 // artifacts whose control-plane sync is incomplete (cp_sync_status IN ('pending','failed')).
 func (s *sqlStore) GetPendingCPSyncArtifacts() ([]*models.StoredConfig, error) {
 	query := `
-		SELECT uuid, kind, handle, display_name, version, desired_state,
+		SELECT uuid, kind, handle, display_name, version, data_version, desired_state,
 			deployment_id, origin, created_at, updated_at, deployed_at,
 			cp_sync_status, cp_sync_info, cp_artifact_id
 		FROM artifacts

--- a/gateway/gateway-controller/pkg/storage/sqlite.go
+++ b/gateway/gateway-controller/pkg/storage/sqlite.go
@@ -73,7 +73,7 @@ func newSQLiteStorage(dbPath string, logger *slog.Logger) (*SQLiteStorage, error
 	return storage, nil
 }
 
-const currentSchemaVersion = 3
+const currentSchemaVersion = 4
 
 // initSchema creates the database schema if it doesn't exist
 func (s *SQLiteStorage) initSchema() error {

--- a/gateway/gateway-controller/pkg/storage/sqlite_test.go
+++ b/gateway/gateway-controller/pkg/storage/sqlite_test.go
@@ -78,7 +78,7 @@ func TestSQLiteStorage_SchemaInitialization(t *testing.T) {
 	var version int
 	err = storage.db.QueryRow("PRAGMA user_version").Scan(&version)
 	assert.NilError(t, err)
-	assert.Equal(t, version, 3) // Current schema version
+	assert.Equal(t, version, 4) // Current schema version
 
 	// Verify tables exist
 	tables := []string{
@@ -128,7 +128,7 @@ func TestSQLiteStorage_RejectsUnsupportedSchemaVersion(t *testing.T) {
 	// Reopen — should fail with unsupported version error
 	_, err = NewStorage(BackendConfig{Type: "sqlite", SQLitePath: dbPath}, logger)
 	assert.Assert(t, err != nil)
-	assert.ErrorContains(t, err, "failed to initialize schema: unsupported schema version 5, expected 3; delete the database to recreate")
+	assert.ErrorContains(t, err, "failed to initialize schema: unsupported schema version 5, expected 4; delete the database to recreate")
 }
 
 func TestSQLiteStorage_DeleteConfig_NotFound(t *testing.T) {
@@ -247,6 +247,58 @@ func TestSQLiteStorage_GetConfig_Success(t *testing.T) {
 	assert.Equal(t, retrievedConfig.UUID, originalConfig.UUID)
 	assert.Equal(t, retrievedConfig.Kind, originalConfig.Kind)
 	assert.Equal(t, retrievedConfig.DesiredState, originalConfig.DesiredState)
+}
+
+func TestSQLiteStorage_DataVersion_RoundTrip(t *testing.T) {
+	storage := setupTestStorage(t)
+	defer storage.db.Close()
+
+	// A v1 RestAPI with no DataVersion set should be computed to "1.0" on write.
+	cfg := createTestStoredConfig()
+	cfg.DataVersion = ""
+	err := storage.SaveConfig(cfg)
+	assert.NilError(t, err)
+	assert.Equal(t, cfg.DataVersion, "1.0") // ensureDataVersion populated it in place
+
+	retrieved, err := storage.GetConfig(cfg.UUID)
+	assert.NilError(t, err)
+	assert.Equal(t, retrieved.DataVersion, "1.0")
+}
+
+func TestSQLiteStorage_DataVersion_PreservesExplicitValue(t *testing.T) {
+	storage := setupTestStorage(t)
+	defer storage.db.Close()
+
+	// An explicitly-set DataVersion (e.g. a future minor bump) must not be overwritten.
+	cfg := createTestStoredConfig()
+	cfg.DataVersion = "1.3"
+	err := storage.SaveConfig(cfg)
+	assert.NilError(t, err)
+
+	retrieved, err := storage.GetConfig(cfg.UUID)
+	assert.NilError(t, err)
+	assert.Equal(t, retrieved.DataVersion, "1.3")
+}
+
+func TestSQLiteStorage_DataVersion_FallsBackWhenApiVersionMissing(t *testing.T) {
+	storage := setupTestStorage(t)
+	defer storage.db.Close()
+
+	// A config whose configuration carries no recognisable apiVersion falls back to "1.0".
+	cfg := createTestStoredConfig()
+	cfg.DataVersion = ""
+	cfg.Configuration = api.RestAPI{
+		Kind:     api.RestAPIKindRestApi,
+		Metadata: api.Metadata{Name: cfg.Handle},
+		Spec:     api.APIConfigData{DisplayName: cfg.DisplayName, Version: "v1.0.0", Context: "/fallback"},
+	}
+	cfg.SourceConfiguration = cfg.Configuration
+	err := storage.SaveConfig(cfg)
+	assert.NilError(t, err)
+
+	retrieved, err := storage.GetConfig(cfg.UUID)
+	assert.NilError(t, err)
+	assert.Equal(t, retrieved.DataVersion, "1.0")
 }
 
 func TestSQLiteStorage_GetConfig_JSONUnmarshalError(t *testing.T) {

--- a/gateway/gateway-controller/tests/integration/schema_test.go
+++ b/gateway/gateway-controller/tests/integration/schema_test.go
@@ -104,7 +104,7 @@ func TestSchemaInitialization(t *testing.T) {
 		var version int
 		err := rawDB.QueryRow("PRAGMA user_version").Scan(&version)
 		assert.NoError(t, err)
-		assert.Equal(t, 3, version, "Schema version should be 3")
+		assert.Equal(t, 4, version, "Schema version should be 4")
 	})
 
 	// Verify artifacts table exists
@@ -139,6 +139,7 @@ func TestSchemaInitialization(t *testing.T) {
 			"uuid":          "TEXT",
 			"display_name":  "TEXT",
 			"version":       "TEXT",
+			"data_version":  "TEXT",
 			"kind":          "TEXT",
 			"handle":        "TEXT",
 			"desired_state": "TEXT",


### PR DESCRIPTION
## Purpose

- Related to https://github.com/wso2/api-platform/issues/2109

Adds a `data_version` column to the gateway-controller `artifacts` table to record the **data-shape version** of each stored artifact (REST API, WebSub API, WebBroker API, LLM Provider, LLM Proxy, MCP Proxy).

The value is `<major>.<minor>`:
- **major** — parsed from the YAML `apiVersion` suffix (`gateway.api-platform.wso2.com/v1` → `1`).
- **minor** — a code-defined constant per kind, starting at `0` (so `v1` → `1.0`). Bump it when a kind's stored data shape changes in a backward-compatible way **without** bumping `apiVersion`. Stored rows then record exactly which data shape they were written with, enabling future data migrations.

This decouples the wire/API version (`apiVersion`, the major) from the stored-data-shape version (the minor).

## Changes

- **Schema (3 dialects):** `data_version` added to `artifacts` after `version`, matching each dialect's existing style — `TEXT NOT NULL DEFAULT '1.0'` for SQLite and Postgres, `NVARCHAR(20) NOT NULL DEFAULT '1.0'` for SQL Server. SQLite schema version bumped `3 → 4` (`PRAGMA user_version` and `currentSchemaVersion`).
- **Model:** `StoredConfig.DataVersion` field and a `GetApiVersion()` helper that prefers `SourceConfiguration` (the user-authored artifact) and falls back to `Configuration` (the LLM-derived RestAPI form).
- **Helper:** `ComputeDataVersion(kind, apiVersion)` plus an exhaustive `dataMinorVersions` map keyed by `ArtifactKind`.
- **Writes:** an `ensureDataVersion()` chokepoint in `SaveConfig`, `UpdateConfig` and `UpsertConfig`, so every artifact-addition path records a `data_version` and an explicitly-set value is never overwritten.
- **Reads:** `data_version` threaded through all artifact `SELECT`/scan paths (single-row reads and the joined `scanConfigRows` queries).