### PR TITLE
Add custom LLM Provider Templates feature for ai-workspace

### DIFF
--- a/platform-api/src/api/generated.go
+++ b/platform-api/src/api/generated.go
@@ -515,6 +515,12 @@ const (
 	GetGatewayArtifactsParamsArtifactTypeRESTAPI    GetGatewayArtifactsParamsArtifactType = "REST_API"
 )
 
+// Defines values for ListLLMProviderTemplatesParamsVersions.
+const (
+	All    ListLLMProviderTemplatesParamsVersions = "all"
+	Latest ListLLMProviderTemplatesParamsVersions = "latest"
+)
+
 // Defines values for GetLLMProviderDeploymentsParamsStatus.
 const (
 	GetLLMProviderDeploymentsParamsStatusARCHIVED    GetLLMProviderDeploymentsParamsStatus = "ARCHIVED"
@@ -937,6 +943,35 @@ type CreateLLMProviderAPIKeyResponse struct {
 
 	// Status Status of the operation
 	Status string `binding:"required" json:"status" yaml:"status"`
+}
+
+// CreateLLMProviderTemplateVersionRequest defines model for CreateLLMProviderTemplateVersionRequest.
+type CreateLLMProviderTemplateVersionRequest struct {
+	CompletionTokens *ExtractionIdentifier `json:"completionTokens,omitempty" yaml:"completionTokens,omitempty"`
+
+	// Description Description of the LLM provider template
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	// ManagedBy Identifies who manages the template. Custom templates default to 'customer'.
+	ManagedBy *string                      `json:"managedBy,omitempty" yaml:"managedBy,omitempty"`
+	Metadata  *LLMProviderTemplateMetadata `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+
+	// Name Human-readable LLM Template name
+	Name string `binding:"required" json:"name" yaml:"name"`
+
+	// Openapi OpenAPI specification content (JSON or YAML) for the provider, when
+	// uploaded/pasted. Use metadata.openapiSpecUrl instead to reference the
+	// spec by URL.
+	Openapi          *string                              `json:"openapi,omitempty" yaml:"openapi,omitempty"`
+	PromptTokens     *ExtractionIdentifier                `json:"promptTokens,omitempty" yaml:"promptTokens,omitempty"`
+	RemainingTokens  *ExtractionIdentifier                `json:"remainingTokens,omitempty" yaml:"remainingTokens,omitempty"`
+	RequestModel     *ExtractionIdentifier                `json:"requestModel,omitempty" yaml:"requestModel,omitempty"`
+	ResourceMappings *LLMProviderTemplateResourceMappings `json:"resourceMappings,omitempty" yaml:"resourceMappings,omitempty"`
+	ResponseModel    *ExtractionIdentifier                `json:"responseModel,omitempty" yaml:"responseModel,omitempty"`
+	TotalTokens      *ExtractionIdentifier                `json:"totalTokens,omitempty" yaml:"totalTokens,omitempty"`
+
+	// Version New version identifier, e.g. v2.0. Must be unique for this template.
+	Version string `binding:"required" json:"version" yaml:"version"`
 }
 
 // CreateLLMProxyAPIKeyRequest defines model for CreateLLMProxyAPIKeyRequest.
@@ -1761,12 +1796,36 @@ type LLMProviderTemplate struct {
 	// Description Description of the LLM provider template
 	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 
+	// Enabled Whether this version is offered when creating providers. Disabled
+	// versions stay in the catalog but are hidden from the provider picker.
+	// Response-only: create/update default new versions to enabled; toggle
+	// via PATCH /llm-provider-templates/{id}/versions/{version}.
+	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+
+	// GroupId Stable identifier shared by every version of a template family
+	// (defaults to the first version's handle). Read-only.
+	GroupId *string `json:"groupId,omitempty" yaml:"groupId,omitempty"`
+
 	// Id Unique handle for the template
-	Id       string                       `binding:"required" json:"id" yaml:"id"`
-	Metadata *LLMProviderTemplateMetadata `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	Id string `binding:"required" json:"id" yaml:"id"`
+
+	// IsLatest Whether this is the latest version of the template.
+	IsLatest *bool `json:"isLatest,omitempty" yaml:"isLatest,omitempty"`
+
+	// ManagedBy Identifies who manages the template. Built-in templates use 'wso2';
+	// custom templates default to 'customer' and may be set to any value.
+	// Optional on create/update — the server defaults it to 'customer' when
+	// omitted, so a request/YAML without a managedBy is accepted.
+	ManagedBy *string                      `json:"managedBy,omitempty" yaml:"managedBy,omitempty"`
+	Metadata  *LLMProviderTemplateMetadata `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 
 	// Name Human-readable LLM Template name
-	Name             string                               `binding:"required" json:"name" yaml:"name"`
+	Name string `binding:"required" json:"name" yaml:"name"`
+
+	// Openapi OpenAPI specification content (JSON or YAML) for the provider, when
+	// uploaded/pasted. Use metadata.openapiSpecUrl instead to reference the
+	// spec by URL.
+	Openapi          *string                              `json:"openapi,omitempty" yaml:"openapi,omitempty"`
 	PromptTokens     *ExtractionIdentifier                `json:"promptTokens,omitempty" yaml:"promptTokens,omitempty"`
 	RemainingTokens  *ExtractionIdentifier                `json:"remainingTokens,omitempty" yaml:"remainingTokens,omitempty"`
 	RequestModel     *ExtractionIdentifier                `json:"requestModel,omitempty" yaml:"requestModel,omitempty"`
@@ -1776,6 +1835,15 @@ type LLMProviderTemplate struct {
 
 	// UpdatedAt Timestamp when the resource was last updated
 	UpdatedAt *time.Time `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
+
+	// UpdatedBy Username of the last user to update the template
+	UpdatedBy *string `json:"updatedBy,omitempty" yaml:"updatedBy,omitempty"`
+
+	// Version Content version, e.g. v1.0. Required. A new template starts at v1.0;
+	// editing updates that version in place. Supply a new unique version
+	// only when creating a new version via
+	// POST /llm-provider-templates/{id}/versions.
+	Version string `binding:"required" json:"version" yaml:"version"`
 }
 
 // LLMProviderTemplateAuth defines model for LLMProviderTemplateAuth.
@@ -1795,9 +1863,24 @@ type LLMProviderTemplateListItem struct {
 	CreatedAt   *time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
 	CreatedBy   *string    `json:"createdBy,omitempty" yaml:"createdBy,omitempty"`
 	Description *string    `json:"description,omitempty" yaml:"description,omitempty"`
-	Id          *string    `json:"id,omitempty" yaml:"id,omitempty"`
-	Name        *string    `json:"name,omitempty" yaml:"name,omitempty"`
-	UpdatedAt   *time.Time `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
+
+	// Enabled Whether this version is offered when creating providers.
+	Enabled *bool   `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	Id      *string `json:"id,omitempty" yaml:"id,omitempty"`
+
+	// IsLatest Whether this is the latest version of the template.
+	IsLatest *bool `json:"isLatest,omitempty" yaml:"isLatest,omitempty"`
+
+	// LogoUrl URL of the provider logo
+	LogoUrl *string `json:"logoUrl,omitempty" yaml:"logoUrl,omitempty"`
+
+	// ManagedBy Who manages the template ('wso2' for built-in, otherwise custom-defined).
+	ManagedBy *string    `json:"managedBy,omitempty" yaml:"managedBy,omitempty"`
+	Name      *string    `json:"name,omitempty" yaml:"name,omitempty"`
+	UpdatedAt *time.Time `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
+
+	// Version Content version, matching the v<major>.<minor> pattern (e.g. v1.0, v2.0).
+	Version *string `json:"version,omitempty" yaml:"version,omitempty"`
 }
 
 // LLMProviderTemplateListResponse defines model for LLMProviderTemplateListResponse.
@@ -3743,6 +3826,28 @@ type ListLLMProviderTemplatesParams struct {
 
 	// Offset Number of LLM provider templates to skip
 	Offset *int `form:"offset,omitempty" json:"offset,omitempty" yaml:"offset,omitempty"`
+
+	// Versions Which versions to include. The default ("latest") returns one entry
+	// per template — its latest version, for the catalog. Use "all" to
+	// return every version row across all templates.
+	Versions *ListLLMProviderTemplatesParamsVersions `form:"versions,omitempty" json:"versions,omitempty" yaml:"versions,omitempty"`
+}
+
+// ListLLMProviderTemplatesParamsVersions defines parameters for ListLLMProviderTemplates.
+type ListLLMProviderTemplatesParamsVersions string
+
+// ListLLMProviderTemplateVersionsParams defines parameters for ListLLMProviderTemplateVersions.
+type ListLLMProviderTemplateVersionsParams struct {
+	// Limit Maximum number of versions to return
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty" yaml:"limit,omitempty"`
+
+	// Offset Number of versions to skip
+	Offset *int `form:"offset,omitempty" json:"offset,omitempty" yaml:"offset,omitempty"`
+}
+
+// SetLLMProviderTemplateVersionEnabledJSONBody defines parameters for SetLLMProviderTemplateVersionEnabled.
+type SetLLMProviderTemplateVersionEnabledJSONBody struct {
+	Enabled bool `json:"enabled" yaml:"enabled"`
 }
 
 // ListLLMProvidersParams defines parameters for ListLLMProviders.
@@ -3765,18 +3870,6 @@ type GetLLMProviderDeploymentsParams struct {
 
 // GetLLMProviderDeploymentsParamsStatus defines parameters for GetLLMProviderDeployments.
 type GetLLMProviderDeploymentsParamsStatus string
-
-// RestoreLLMProviderDeploymentDeprecatedParams defines parameters for RestoreLLMProviderDeploymentDeprecated.
-type RestoreLLMProviderDeploymentDeprecatedParams struct {
-	DeploymentId string `form:"deploymentId" json:"deploymentId" yaml:"deploymentId"`
-	GatewayId    string `form:"gatewayId" json:"gatewayId" yaml:"gatewayId"`
-}
-
-// UndeployLLMProviderDeploymentDeprecatedParams defines parameters for UndeployLLMProviderDeploymentDeprecated.
-type UndeployLLMProviderDeploymentDeprecatedParams struct {
-	DeploymentId string `form:"deploymentId" json:"deploymentId" yaml:"deploymentId"`
-	GatewayId    string `form:"gatewayId" json:"gatewayId" yaml:"gatewayId"`
-}
 
 // RestoreLLMProviderDeploymentParams defines parameters for RestoreLLMProviderDeployment.
 type RestoreLLMProviderDeploymentParams struct {
@@ -3823,18 +3916,6 @@ type GetLLMProxyDeploymentsParams struct {
 // GetLLMProxyDeploymentsParamsStatus defines parameters for GetLLMProxyDeployments.
 type GetLLMProxyDeploymentsParamsStatus string
 
-// RestoreLLMProxyDeploymentDeprecatedParams defines parameters for RestoreLLMProxyDeploymentDeprecated.
-type RestoreLLMProxyDeploymentDeprecatedParams struct {
-	DeploymentId string `form:"deploymentId" json:"deploymentId" yaml:"deploymentId"`
-	GatewayId    string `form:"gatewayId" json:"gatewayId" yaml:"gatewayId"`
-}
-
-// UndeployLLMProxyDeploymentDeprecatedParams defines parameters for UndeployLLMProxyDeploymentDeprecated.
-type UndeployLLMProxyDeploymentDeprecatedParams struct {
-	DeploymentId string `form:"deploymentId" json:"deploymentId" yaml:"deploymentId"`
-	GatewayId    string `form:"gatewayId" json:"gatewayId" yaml:"gatewayId"`
-}
-
 // RestoreLLMProxyDeploymentParams defines parameters for RestoreLLMProxyDeployment.
 type RestoreLLMProxyDeploymentParams struct {
 	// GatewayId UUID of the gateway (validated against deployment's bound gateway)
@@ -3870,18 +3951,6 @@ type GetMCPProxyDeploymentsParams struct {
 
 // GetMCPProxyDeploymentsParamsStatus defines parameters for GetMCPProxyDeployments.
 type GetMCPProxyDeploymentsParamsStatus string
-
-// RestoreMCPProxyDeploymentDeprecatedParams defines parameters for RestoreMCPProxyDeploymentDeprecated.
-type RestoreMCPProxyDeploymentDeprecatedParams struct {
-	DeploymentId string `form:"deploymentId" json:"deploymentId" yaml:"deploymentId"`
-	GatewayId    string `form:"gatewayId" json:"gatewayId" yaml:"gatewayId"`
-}
-
-// UndeployMCPProxyDeploymentDeprecatedParams defines parameters for UndeployMCPProxyDeploymentDeprecated.
-type UndeployMCPProxyDeploymentDeprecatedParams struct {
-	DeploymentId string `form:"deploymentId" json:"deploymentId" yaml:"deploymentId"`
-	GatewayId    string `form:"gatewayId" json:"gatewayId" yaml:"gatewayId"`
-}
 
 // RestoreMCPProxyDeploymentParams defines parameters for RestoreMCPProxyDeployment.
 type RestoreMCPProxyDeploymentParams struct {
@@ -3930,18 +3999,6 @@ type GetDeploymentsParams struct {
 
 // GetDeploymentsParamsStatus defines parameters for GetDeployments.
 type GetDeploymentsParamsStatus string
-
-// RestoreDeploymentDeprecatedParams defines parameters for RestoreDeploymentDeprecated.
-type RestoreDeploymentDeprecatedParams struct {
-	DeploymentId string `form:"deploymentId" json:"deploymentId" yaml:"deploymentId"`
-	GatewayId    string `form:"gatewayId" json:"gatewayId" yaml:"gatewayId"`
-}
-
-// UndeployDeploymentDeprecatedParams defines parameters for UndeployDeploymentDeprecated.
-type UndeployDeploymentDeprecatedParams struct {
-	DeploymentId string `form:"deploymentId" json:"deploymentId" yaml:"deploymentId"`
-	GatewayId    string `form:"gatewayId" json:"gatewayId" yaml:"gatewayId"`
-}
 
 // RestoreDeploymentParams defines parameters for RestoreDeployment.
 type RestoreDeploymentParams struct {
@@ -4013,18 +4070,6 @@ type GetWebBrokerAPIDeploymentsParams struct {
 	Status    *string             `form:"status,omitempty" json:"status,omitempty" yaml:"status,omitempty"`
 }
 
-// RestoreWebBrokerAPIDeploymentDeprecatedParams defines parameters for RestoreWebBrokerAPIDeploymentDeprecated.
-type RestoreWebBrokerAPIDeploymentDeprecatedParams struct {
-	DeploymentId string `form:"deploymentId" json:"deploymentId" yaml:"deploymentId"`
-	GatewayId    string `form:"gatewayId" json:"gatewayId" yaml:"gatewayId"`
-}
-
-// UndeployWebBrokerAPIDeprecatedParams defines parameters for UndeployWebBrokerAPIDeprecated.
-type UndeployWebBrokerAPIDeprecatedParams struct {
-	DeploymentId string `form:"deploymentId" json:"deploymentId" yaml:"deploymentId"`
-	GatewayId    string `form:"gatewayId" json:"gatewayId" yaml:"gatewayId"`
-}
-
 // RestoreWebBrokerAPIDeploymentParams defines parameters for RestoreWebBrokerAPIDeployment.
 type RestoreWebBrokerAPIDeploymentParams struct {
 	GatewayId string `form:"gatewayId" json:"gatewayId" yaml:"gatewayId"`
@@ -4046,18 +4091,6 @@ type ListWebSubAPIsParams struct {
 type GetWebSubAPIDeploymentsParams struct {
 	GatewayId *openapi_types.UUID `form:"gatewayId,omitempty" json:"gatewayId,omitempty" yaml:"gatewayId,omitempty"`
 	Status    *string             `form:"status,omitempty" json:"status,omitempty" yaml:"status,omitempty"`
-}
-
-// RestoreWebSubAPIDeploymentDeprecatedParams defines parameters for RestoreWebSubAPIDeploymentDeprecated.
-type RestoreWebSubAPIDeploymentDeprecatedParams struct {
-	DeploymentId string `form:"deploymentId" json:"deploymentId" yaml:"deploymentId"`
-	GatewayId    string `form:"gatewayId" json:"gatewayId" yaml:"gatewayId"`
-}
-
-// UndeployWebSubAPIDeprecatedParams defines parameters for UndeployWebSubAPIDeprecated.
-type UndeployWebSubAPIDeprecatedParams struct {
-	DeploymentId string `form:"deploymentId" json:"deploymentId" yaml:"deploymentId"`
-	GatewayId    string `form:"gatewayId" json:"gatewayId" yaml:"gatewayId"`
 }
 
 // RestoreWebSubAPIDeploymentParams defines parameters for RestoreWebSubAPIDeployment.
@@ -4111,6 +4144,12 @@ type CreateLLMProviderTemplateJSONRequestBody = LLMProviderTemplate
 
 // UpdateLLMProviderTemplateJSONRequestBody defines body for UpdateLLMProviderTemplate for application/json ContentType.
 type UpdateLLMProviderTemplateJSONRequestBody = LLMProviderTemplate
+
+// CreateLLMProviderTemplateVersionJSONRequestBody defines body for CreateLLMProviderTemplateVersion for application/json ContentType.
+type CreateLLMProviderTemplateVersionJSONRequestBody = CreateLLMProviderTemplateVersionRequest
+
+// SetLLMProviderTemplateVersionEnabledJSONRequestBody defines body for SetLLMProviderTemplateVersionEnabled for application/json ContentType.
+type SetLLMProviderTemplateVersionEnabledJSONRequestBody SetLLMProviderTemplateVersionEnabledJSONBody
 
 // CreateLLMProviderJSONRequestBody defines body for CreateLLMProvider for application/json ContentType.
 type CreateLLMProviderJSONRequestBody = LLMProvider

--- a/platform-api/src/api/manual_types.go
+++ b/platform-api/src/api/manual_types.go
@@ -82,3 +82,18 @@ type ValidateRESTAPIParams struct {
 	// Version **API Version** to check for existence within the organization.
 	Version *ApiVersionQ `form:"version,omitempty" json:"version,omitempty" yaml:"version,omitempty"`
 }
+
+// UnpublishFromDevPortalRequest defines model for UnpublishFromDevPortalRequest.
+type UnpublishFromDevPortalRequest struct {
+	// DevPortalUuid UUID of the DevPortal to unpublish from
+	DevPortalUuid openapi_types.UUID `binding:"required" json:"devPortalUuid" yaml:"devPortalUuid"`
+}
+
+// UnpublishRESTAPIFromDevPortalJSONRequestBody defines body for UnpublishRESTAPIFromDevPortal.
+type UnpublishRESTAPIFromDevPortalJSONRequestBody = UnpublishFromDevPortalRequest
+
+// UnpublishWebBrokerAPIFromDevPortalJSONRequestBody defines body for UnpublishWebBrokerAPIFromDevPortal.
+type UnpublishWebBrokerAPIFromDevPortalJSONRequestBody = UnpublishFromDevPortalRequest
+
+// UnpublishWebSubAPIFromDevPortalJSONRequestBody defines body for UnpublishWebSubAPIFromDevPortal.
+type UnpublishWebSubAPIFromDevPortalJSONRequestBody = UnpublishFromDevPortalRequest

--- a/platform-api/src/internal/constants/error.go
+++ b/platform-api/src/internal/constants/error.go
@@ -119,6 +119,10 @@ var (
 var (
 	ErrLLMProviderTemplateExists   = errors.New("llm provider template already exists")
 	ErrLLMProviderTemplateNotFound = errors.New("llm provider template not found")
+	ErrLLMProviderTemplateVersionExists = errors.New("llm provider template version already exists")
+	ErrLLMProviderTemplateInUse    = errors.New("llm provider template is in use by one or more providers")
+	ErrLLMProviderTemplateReadOnly          = errors.New("built-in llm provider template is read-only")
+	ErrLLMProviderTemplateManagedByReserved = errors.New("'wso2' is reserved and cannot be used as managedBy on custom templates")
 	ErrLLMProviderExists           = errors.New("llm provider already exists")
 	ErrLLMProviderNotFound         = errors.New("llm provider not found")
 	ErrLLMProviderLimitReached     = errors.New("llm provider limit reached for organization")

--- a/platform-api/src/internal/database/connection.go
+++ b/platform-api/src/internal/database/connection.go
@@ -273,10 +273,21 @@ func splitSQLStatements(sql string) []string {
 	var statements []string
 	current := strings.Builder{}
 	inString := false
+	inLineComment := false
 	escapeNext := false
 
-	// Process character by character to properly handle strings and comments
-	for _, r := range sql {
+	runes := []rune(sql)
+	for i := 0; i < len(runes); i++ {
+		r := runes[i]
+
+		if inLineComment {
+			current.WriteRune(r)
+			if r == '\n' {
+				inLineComment = false
+			}
+			continue
+		}
+
 		if escapeNext {
 			current.WriteRune(r)
 			escapeNext = false
@@ -286,6 +297,13 @@ func splitSQLStatements(sql string) []string {
 		// Handle escape sequences
 		if r == '\\' {
 			escapeNext = true
+			current.WriteRune(r)
+			continue
+		}
+
+		// Start of a -- line comment (only when not inside a string literal)
+		if !inString && r == '-' && i+1 < len(runes) && runes[i+1] == '-' {
+			inLineComment = true
 			current.WriteRune(r)
 			continue
 		}

--- a/platform-api/src/internal/database/schema.postgres.sql
+++ b/platform-api/src/internal/database/schema.postgres.sql
@@ -493,6 +493,7 @@ CREATE INDEX IF NOT EXISTS idx_gateway_custom_policies_org ON gateway_custom_pol
 CREATE INDEX IF NOT EXISTS idx_gateway_custom_policy_usages_artifact ON gateway_custom_policy_usages(artifact_uuid);
 CREATE INDEX IF NOT EXISTS idx_llm_provider_templates_org ON llm_provider_templates(organization_uuid);
 CREATE INDEX IF NOT EXISTS idx_llm_provider_templates_group ON llm_provider_templates(organization_uuid, group_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_llm_provider_templates_latest ON llm_provider_templates(organization_uuid, group_id) WHERE is_latest = 1;
 CREATE INDEX IF NOT EXISTS idx_llm_providers_template ON llm_providers(template_uuid);
 CREATE INDEX IF NOT EXISTS idx_llm_providers_org ON llm_providers(organization_uuid);
 CREATE INDEX IF NOT EXISTS idx_llm_proxies_project ON llm_proxies(project_uuid);

--- a/platform-api/src/internal/database/schema.sql
+++ b/platform-api/src/internal/database/schema.sql
@@ -485,6 +485,7 @@ CREATE INDEX IF NOT EXISTS idx_gateway_custom_policies_org ON gateway_custom_pol
 CREATE INDEX IF NOT EXISTS idx_gateway_custom_policy_usages_artifact ON gateway_custom_policy_usages(artifact_uuid);
 CREATE INDEX IF NOT EXISTS idx_llm_provider_templates_org ON llm_provider_templates(organization_uuid);
 CREATE INDEX IF NOT EXISTS idx_llm_provider_templates_group ON llm_provider_templates(organization_uuid, group_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_llm_provider_templates_latest ON llm_provider_templates(organization_uuid, group_id) WHERE is_latest = 1;
 CREATE INDEX IF NOT EXISTS idx_llm_providers_template ON llm_providers(template_uuid);
 CREATE INDEX IF NOT EXISTS idx_llm_providers_org ON llm_providers(organization_uuid);
 CREATE INDEX IF NOT EXISTS idx_llm_proxies_project ON llm_proxies(project_uuid);

--- a/platform-api/src/internal/database/schema.sqlite.sql
+++ b/platform-api/src/internal/database/schema.sqlite.sql
@@ -492,6 +492,7 @@ CREATE INDEX IF NOT EXISTS idx_gateway_custom_policies_org ON gateway_custom_pol
 CREATE INDEX IF NOT EXISTS idx_gateway_custom_policy_usages_artifact ON gateway_custom_policy_usages(artifact_uuid);
 CREATE INDEX IF NOT EXISTS idx_llm_provider_templates_org ON llm_provider_templates(organization_uuid);
 CREATE INDEX IF NOT EXISTS idx_llm_provider_templates_group ON llm_provider_templates(organization_uuid, group_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_llm_provider_templates_latest ON llm_provider_templates(organization_uuid, group_id) WHERE is_latest = 1;
 CREATE INDEX IF NOT EXISTS idx_llm_providers_template ON llm_providers(template_uuid);
 CREATE INDEX IF NOT EXISTS idx_llm_providers_org ON llm_providers(organization_uuid);
 CREATE INDEX IF NOT EXISTS idx_llm_proxies_project ON llm_proxies(project_uuid);

--- a/platform-api/src/internal/database/schema.sqlserver.sql
+++ b/platform-api/src/internal/database/schema.sqlserver.sql
@@ -333,7 +333,6 @@ CREATE TABLE dbo.llm_provider_templates (
     created_at DATETIME2(7) DEFAULT SYSUTCDATETIME(),
     updated_by VARCHAR(200),
     updated_at DATETIME2(7) DEFAULT SYSUTCDATETIME(),
-    organization_uuid VARCHAR(40) NOT NULL,
     FOREIGN KEY (organization_uuid) REFERENCES organizations(uuid) ON DELETE CASCADE,
     UNIQUE(organization_uuid, group_id, version),
     UNIQUE(organization_uuid, handle)

--- a/platform-api/src/internal/database/schema.sqlserver.sql
+++ b/platform-api/src/internal/database/schema.sqlserver.sql
@@ -333,6 +333,7 @@ CREATE TABLE dbo.llm_provider_templates (
     created_at DATETIME2(7) DEFAULT SYSUTCDATETIME(),
     updated_by VARCHAR(200),
     updated_at DATETIME2(7) DEFAULT SYSUTCDATETIME(),
+    organization_uuid VARCHAR(40) NOT NULL,
     FOREIGN KEY (organization_uuid) REFERENCES organizations(uuid) ON DELETE CASCADE,
     UNIQUE(organization_uuid, group_id, version),
     UNIQUE(organization_uuid, handle)
@@ -574,6 +575,8 @@ IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = N'idx_llm_provider_templat
 CREATE INDEX idx_llm_provider_templates_org ON dbo.llm_provider_templates(organization_uuid);
 IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = N'idx_llm_provider_templates_group' AND object_id = OBJECT_ID(N'dbo.llm_provider_templates'))
 CREATE INDEX idx_llm_provider_templates_group ON dbo.llm_provider_templates(organization_uuid, group_id);
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = N'idx_llm_provider_templates_latest' AND object_id = OBJECT_ID(N'dbo.llm_provider_templates'))
+CREATE UNIQUE INDEX idx_llm_provider_templates_latest ON dbo.llm_provider_templates(organization_uuid, group_id) WHERE is_latest = 1;
 IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = N'idx_llm_providers_template' AND object_id = OBJECT_ID(N'dbo.llm_providers'))
 CREATE INDEX idx_llm_providers_template ON dbo.llm_providers(template_uuid);
 IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = N'idx_llm_providers_org' AND object_id = OBJECT_ID(N'dbo.llm_providers'))

--- a/platform-api/src/internal/handler/llm.go
+++ b/platform-api/src/internal/handler/llm.go
@@ -18,6 +18,7 @@
 package handler
 
 import (
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"net/http"
@@ -56,6 +57,11 @@ func (h *LLMHandler) RegisterRoutes(r *gin.Engine) {
 		v1.POST("/llm-provider-templates", h.CreateLLMProviderTemplate)
 		v1.GET("/llm-provider-templates", h.ListLLMProviderTemplates)
 		v1.GET("/llm-provider-templates/:id", h.GetLLMProviderTemplate)
+		v1.GET("/llm-provider-templates/:id/versions", h.ListLLMProviderTemplateVersions)
+		v1.GET("/llm-provider-templates/:id/versions/:version", h.GetLLMProviderTemplateVersion)
+		v1.POST("/llm-provider-templates/:id/versions", h.CreateLLMProviderTemplateVersion)
+		v1.PATCH("/llm-provider-templates/:id/versions/:version", h.SetLLMProviderTemplateVersionEnabled)
+		v1.DELETE("/llm-provider-templates/:id/versions/:version", h.DeleteLLMProviderTemplateVersion)
 		v1.PUT("/llm-provider-templates/:id", h.UpdateLLMProviderTemplate)
 		v1.DELETE("/llm-provider-templates/:id", h.DeleteLLMProviderTemplate)
 
@@ -98,6 +104,9 @@ func (h *LLMHandler) CreateLLMProviderTemplate(c *gin.Context) {
 		case errors.Is(err, constants.ErrLLMProviderTemplateExists):
 			c.JSON(http.StatusConflict, utils.NewErrorResponse(409, "Conflict", "LLM provider template already exists"))
 			return
+		case errors.Is(err, constants.ErrLLMProviderTemplateManagedByReserved):
+			c.JSON(http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", "'wso2' is reserved and cannot be used as managedBy on custom templates"))
+			return
 		case errors.Is(err, constants.ErrInvalidInput):
 			c.JSON(http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", "Invalid input"))
 			return
@@ -134,7 +143,9 @@ func (h *LLMHandler) ListLLMProviderTemplates(c *gin.Context) {
 		offset = 0
 	}
 
-	resp, err := h.templateService.List(orgID, limit, offset)
+	allVersions := strings.EqualFold(c.Query("versions"), "all")
+
+	resp, err := h.templateService.List(orgID, limit, offset, allVersions)
 	if err != nil {
 		h.slogger.Error("Failed to list LLM provider templates", "organizationId", orgID, "error", err)
 		c.JSON(http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error", "Failed to list LLM provider templates"))
@@ -169,6 +180,150 @@ func (h *LLMHandler) GetLLMProviderTemplate(c *gin.Context) {
 	c.JSON(http.StatusOK, resp)
 }
 
+func (h *LLMHandler) ListLLMProviderTemplateVersions(c *gin.Context) {
+	orgID, ok := middleware.GetOrganizationFromContext(c)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, utils.NewErrorResponse(401, "Unauthorized", "Organization claim not found in token"))
+		return
+	}
+	id := c.Param("id")
+
+	limit, err := strconv.Atoi(c.DefaultQuery("limit", "20"))
+	if err != nil || limit <= 0 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	offset, err := strconv.Atoi(c.DefaultQuery("offset", "0"))
+	if err != nil || offset < 0 {
+		offset = 0
+	}
+
+	resp, err := h.templateService.ListVersions(orgID, id, limit, offset)
+	if err != nil {
+		switch {
+		case errors.Is(err, constants.ErrLLMProviderTemplateNotFound):
+			c.JSON(http.StatusNotFound, utils.NewErrorResponse(404, "Not Found", "LLM provider template not found"))
+			return
+		case errors.Is(err, constants.ErrInvalidInput):
+			c.JSON(http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", "Invalid template id"))
+			return
+		default:
+			h.slogger.Error("Failed to list LLM provider template versions", "organizationId", orgID, "templateId", id, "error", err)
+			c.JSON(http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error", "Failed to list LLM provider template versions"))
+			return
+		}
+	}
+	c.JSON(http.StatusOK, resp)
+}
+
+func (h *LLMHandler) CreateLLMProviderTemplateVersion(c *gin.Context) {
+	orgID, ok := middleware.GetOrganizationFromContext(c)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, utils.NewErrorResponse(401, "Unauthorized", "Organization claim not found in token"))
+		return
+	}
+	id := c.Param("id")
+
+	createdBy, _ := middleware.GetUsernameFromContext(c)
+
+	var req api.CreateLLMProviderTemplateVersionRequest
+	if err := json.NewDecoder(c.Request.Body).Decode(&req); err != nil {
+		c.JSON(http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", "Invalid request body"))
+		return
+	}
+
+	created, err := h.templateService.CreateVersion(orgID, id, createdBy, &req)
+	if err != nil {
+		switch {
+		case errors.Is(err, constants.ErrLLMProviderTemplateNotFound):
+			c.JSON(http.StatusNotFound, utils.NewErrorResponse(404, "Not Found", "LLM provider template not found"))
+			return
+		case errors.Is(err, constants.ErrLLMProviderTemplateVersionExists):
+			c.JSON(http.StatusConflict, utils.NewErrorResponse(409, "Conflict", "The version already exists"))
+			return
+		case errors.Is(err, constants.ErrLLMProviderTemplateManagedByReserved):
+			c.JSON(http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", "'wso2' is reserved and cannot be used as managedBy on custom templates"))
+			return
+		case errors.Is(err, constants.ErrInvalidInput):
+			c.JSON(http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", "Invalid input. Version must match the v<major>.<minor> pattern (e.g. v1.0)"))
+			return
+		default:
+			h.slogger.Error("Failed to create LLM provider template version", "organizationId", orgID, "templateId", id, "error", err)
+			c.JSON(http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error", "Failed to create LLM provider template version"))
+			return
+		}
+	}
+	c.JSON(http.StatusCreated, created)
+}
+
+func (h *LLMHandler) GetLLMProviderTemplateVersion(c *gin.Context) {
+	orgID, ok := middleware.GetOrganizationFromContext(c)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, utils.NewErrorResponse(401, "Unauthorized", "Organization claim not found in token"))
+		return
+	}
+	id := c.Param("id")
+	version := c.Param("version")
+
+	resp, err := h.templateService.GetVersion(orgID, id, version)
+	if err != nil {
+		switch {
+		case errors.Is(err, constants.ErrLLMProviderTemplateNotFound):
+			c.JSON(http.StatusNotFound, utils.NewErrorResponse(404, "Not Found", "LLM provider template version not found"))
+			return
+		case errors.Is(err, constants.ErrInvalidInput):
+			c.JSON(http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", "Invalid template id or version"))
+			return
+		default:
+			h.slogger.Error("Failed to get LLM provider template version", "organizationId", orgID, "templateId", id, "version", version, "error", err)
+			c.JSON(http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error", "Failed to get LLM provider template version"))
+			return
+		}
+	}
+	c.JSON(http.StatusOK, resp)
+}
+
+// SetLLMProviderTemplateVersionEnabled enables or disables a specific version of a template.
+func (h *LLMHandler) SetLLMProviderTemplateVersionEnabled(c *gin.Context) {
+	orgID, ok := middleware.GetOrganizationFromContext(c)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, utils.NewErrorResponse(401, "Unauthorized", "Organization claim not found in token"))
+		return
+	}
+	id := c.Param("id")
+	version := c.Param("version")
+
+	var body struct {
+		Enabled *bool `json:"enabled"`
+	}
+	if err := json.NewDecoder(c.Request.Body).Decode(&body); err != nil || body.Enabled == nil {
+		c.JSON(http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", "Request body must include a boolean 'enabled' field"))
+		return
+	}
+
+	resp, err := h.templateService.SetVersionEnabled(orgID, id, version, *body.Enabled)
+	if err != nil {
+		switch {
+		case errors.Is(err, constants.ErrLLMProviderTemplateNotFound):
+			c.JSON(http.StatusNotFound, utils.NewErrorResponse(404, "Not Found", "LLM provider template version not found"))
+			return
+		case errors.Is(err, constants.ErrInvalidInput):
+			c.JSON(http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", "Invalid template id or version"))
+			return
+		case errors.Is(err, constants.ErrLLMProviderTemplateInUse):
+			c.JSON(http.StatusConflict, utils.NewErrorResponse(409, "Conflict", "Cannot disable template version while providers are using it"))
+			return
+		default:
+			h.slogger.Error("Failed to set LLM provider template version enabled", "organizationId", orgID, "templateId", id, "version", version, "error", err)
+			c.JSON(http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error", "Failed to update template version"))
+			return
+		}
+	}
+	c.JSON(http.StatusOK, resp)
+}
+
 func (h *LLMHandler) UpdateLLMProviderTemplate(c *gin.Context) {
 	orgID, ok := middleware.GetOrganizationFromContext(c)
 	if !ok {
@@ -189,6 +344,12 @@ func (h *LLMHandler) UpdateLLMProviderTemplate(c *gin.Context) {
 		switch {
 		case errors.Is(err, constants.ErrLLMProviderTemplateNotFound):
 			c.JSON(http.StatusNotFound, utils.NewErrorResponse(404, "Not Found", "LLM provider template not found"))
+			return
+		case errors.Is(err, constants.ErrLLMProviderTemplateReadOnly):
+			c.JSON(http.StatusForbidden, utils.NewErrorResponse(403, "Forbidden", "Built-in templates are read-only and cannot be edited"))
+			return
+		case errors.Is(err, constants.ErrLLMProviderTemplateManagedByReserved):
+			c.JSON(http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", "'wso2' is reserved and cannot be used as managedBy on custom templates"))
 			return
 		case errors.Is(err, constants.ErrInvalidInput):
 			c.JSON(http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", "Invalid input"))
@@ -216,12 +377,52 @@ func (h *LLMHandler) DeleteLLMProviderTemplate(c *gin.Context) {
 		case errors.Is(err, constants.ErrLLMProviderTemplateNotFound):
 			c.JSON(http.StatusNotFound, utils.NewErrorResponse(404, "Not Found", "LLM provider template not found"))
 			return
+		case errors.Is(err, constants.ErrLLMProviderTemplateInUse):
+			c.JSON(http.StatusConflict, utils.NewErrorResponse(409, "Conflict", "Template cannot be deleted while providers are using it"))
+			return
+		case errors.Is(err, constants.ErrLLMProviderTemplateReadOnly):
+			c.JSON(http.StatusForbidden, utils.NewErrorResponse(403, "Forbidden", "Built-in templates are read-only and cannot be deleted"))
+			return
 		case errors.Is(err, constants.ErrInvalidInput):
 			c.JSON(http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", "Invalid template id"))
 			return
 		default:
 			h.slogger.Error("Failed to delete LLM provider template", "organizationId", orgID, "templateId", id, "error", err)
 			c.JSON(http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error", "Failed to delete LLM provider template"))
+			return
+		}
+	}
+
+	c.Status(http.StatusNoContent)
+}
+
+// DeleteLLMProviderTemplateVersion removes a single version of a template.
+func (h *LLMHandler) DeleteLLMProviderTemplateVersion(c *gin.Context) {
+	orgID, ok := middleware.GetOrganizationFromContext(c)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, utils.NewErrorResponse(401, "Unauthorized", "Organization claim not found in token"))
+		return
+	}
+	id := c.Param("id")
+	version := c.Param("version")
+
+	if err := h.templateService.DeleteVersion(orgID, id, version); err != nil {
+		switch {
+		case errors.Is(err, constants.ErrLLMProviderTemplateNotFound):
+			c.JSON(http.StatusNotFound, utils.NewErrorResponse(404, "Not Found", "LLM provider template version not found"))
+			return
+		case errors.Is(err, constants.ErrLLMProviderTemplateInUse):
+			c.JSON(http.StatusConflict, utils.NewErrorResponse(409, "Conflict", "Template version cannot be deleted while providers are using it"))
+			return
+		case errors.Is(err, constants.ErrLLMProviderTemplateReadOnly):
+			c.JSON(http.StatusForbidden, utils.NewErrorResponse(403, "Forbidden", "Built-in template versions are read-only and cannot be deleted"))
+			return
+		case errors.Is(err, constants.ErrInvalidInput):
+			c.JSON(http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", "Invalid template id or version"))
+			return
+		default:
+			h.slogger.Error("Failed to delete LLM provider template version", "organizationId", orgID, "templateId", id, "version", version, "error", err)
+			c.JSON(http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error", "Failed to delete template version"))
 			return
 		}
 	}

--- a/platform-api/src/internal/model/llm.go
+++ b/platform-api/src/internal/model/llm.go
@@ -168,6 +168,9 @@ type LLMProviderTemplate struct {
 	ManagedBy        string                       `json:"managedBy,omitempty" db:"managed_by"`
 	CreatedBy        string                       `json:"createdBy,omitempty" db:"created_by"`
 	UpdatedBy        string                       `json:"updatedBy,omitempty" db:"updated_by"`
+	Version  		 string 					  `json:"version" db:"version"`
+	IsLatest 		 bool    					  `json:"isLatest" db:"is_latest"`
+	Enabled 		 bool 						  `json:"enabled" db:"enabled"`
 	Metadata         *LLMProviderTemplateMetadata `json:"metadata,omitempty" db:"-"`
 	PromptTokens     *ExtractionIdentifier        `json:"promptTokens,omitempty" db:"-"`
 	CompletionTokens *ExtractionIdentifier        `json:"completionTokens,omitempty" db:"-"`
@@ -176,6 +179,7 @@ type LLMProviderTemplate struct {
 	RequestModel     *ExtractionIdentifier        `json:"requestModel,omitempty" db:"-"`
 	ResponseModel    *ExtractionIdentifier        `json:"responseModel,omitempty" db:"-"`
 	ResourceMappings *LLMProviderTemplateResourceMappings `json:"resourceMappings,omitempty" db:"-"`
+	OpenAPISpec      string                               `json:"openapi,omitempty" db:"openapi_spec"`
 	CreatedAt        time.Time                            `json:"createdAt" db:"created_at"`
 	UpdatedAt        time.Time                            `json:"updatedAt" db:"updated_at"`
 }

--- a/platform-api/src/internal/repository/interfaces.go
+++ b/platform-api/src/internal/repository/interfaces.go
@@ -201,13 +201,25 @@ type SubscriptionRepository interface {
 // LLMProviderTemplateRepository defines the interface for LLM provider template persistence
 type LLMProviderTemplateRepository interface {
 	Create(t *model.LLMProviderTemplate) error
+	CreateNewVersion(t *model.LLMProviderTemplate) error
 	GetByID(templateID, orgUUID string) (*model.LLMProviderTemplate, error)
 	GetByUUID(uuid, orgUUID string) (*model.LLMProviderTemplate, error)
+	GetByVersion(templateID, orgUUID, version string) (*model.LLMProviderTemplate, error)
+	ListVersions(templateID, orgUUID string, limit, offset int) ([]*model.LLMProviderTemplate, error)
+	CountVersions(templateID, orgUUID string) (int, error)
 	List(orgUUID string, limit, offset int) ([]*model.LLMProviderTemplate, error)
 	Count(orgUUID string) (int, error)
+	ListAllVersions(orgUUID string, limit, offset int) ([]*model.LLMProviderTemplate, error)
+	CountAllVersions(orgUUID string) (int, error)
 	Update(t *model.LLMProviderTemplate) error
+	RenameFamily(baseHandle, orgUUID, name string) error
+	SetEnabled(templateID, orgUUID, version string, enabled bool) error
+	DeleteVersion(templateID, orgUUID, version string) error
 	Delete(templateID, orgUUID string) error
 	Exists(templateID, orgUUID string) (bool, error)
+	GetGroupID(handle, orgUUID string) (string, error)
+	ManagedByForHandle(handle, orgUUID string) (string, error)
+	CountProvidersUsingTemplate(templateID, orgUUID, version string) (int, error)
 }
 
 // LLMProviderRepository defines the interface for LLM provider persistence

--- a/platform-api/src/internal/repository/llm.go
+++ b/platform-api/src/internal/repository/llm.go
@@ -133,15 +133,15 @@ func (r *LLMProviderTemplateRepo) CreateNewVersion(t *model.LLMProviderTemplate)
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	lockSQL := `SELECT created_by FROM llm_provider_templates WHERE group_id = ? AND organization_uuid = ? AND is_latest = ?`
+	lockSQL := `SELECT uuid FROM llm_provider_templates WHERE group_id = ? AND organization_uuid = ? AND is_latest = ?`
 	switch r.db.Driver() {
 	case database.DriverPostgres, database.DriverPostgreSQL, database.DriverPGX:
 		lockSQL += " FOR UPDATE"
 	case database.DriverSQLServer, database.DriverMSSQL:
-		lockSQL = `SELECT created_by FROM llm_provider_templates WITH (UPDLOCK, HOLDLOCK) WHERE group_id = ? AND organization_uuid = ? AND is_latest = ?`
+		lockSQL = `SELECT uuid FROM llm_provider_templates WITH (UPDLOCK, HOLDLOCK) WHERE group_id = ? AND organization_uuid = ? AND is_latest = ?`
 	}
-	var createdBy sql.NullString
-	err = tx.QueryRow(r.db.Rebind(lockSQL), t.GroupID, t.OrganizationUUID, 1).Scan(&createdBy)
+	var lockedUUID string
+	err = tx.QueryRow(r.db.Rebind(lockSQL), t.GroupID, t.OrganizationUUID, 1).Scan(&lockedUUID)
 	if errors.Is(err, sql.ErrNoRows) {
 		return sql.ErrNoRows
 	}
@@ -173,7 +173,6 @@ func (r *LLMProviderTemplateRepo) CreateNewVersion(t *model.LLMProviderTemplate)
 	t.UUID = uuidStr
 	t.IsLatest = true
 	t.Enabled = true
-	t.CreatedBy = createdBy.String
 	t.UpdatedBy = t.CreatedBy
 	t.CreatedAt = time.Now()
 	t.UpdatedAt = time.Now()
@@ -434,10 +433,10 @@ func (r *LLMProviderTemplateRepo) Update(t *model.LLMProviderTemplate) error {
 
 	result, err := r.db.Exec(r.db.Rebind(`
 		UPDATE llm_provider_templates
-		SET name = ?, description = ?, configuration = ?, openapi_spec = ?, updated_by = ?, updated_at = ?
+		SET name = ?, managed_by = ?, description = ?, configuration = ?, openapi_spec = ?, updated_by = ?, updated_at = ?
 		WHERE handle = ? AND organization_uuid = ?
 	`),
-		t.Name, t.Description, configJSON, []byte(t.OpenAPISpec), t.UpdatedBy, t.UpdatedAt,
+		t.Name, t.ManagedBy, t.Description, configJSON, []byte(t.OpenAPISpec), t.UpdatedBy, t.UpdatedAt,
 		t.ID, t.OrganizationUUID,
 	)
 	if err != nil {

--- a/platform-api/src/internal/repository/llm.go
+++ b/platform-api/src/internal/repository/llm.go
@@ -360,7 +360,7 @@ func (r *LLMProviderTemplateRepo) List(orgUUID string, limit, offset int) ([]*mo
 		SELECT uuid, organization_uuid, handle, group_id, name, managed_by, description, created_by, updated_by, configuration, openapi_spec, version, is_latest, enabled, created_at, updated_at
 		FROM llm_provider_templates
 		WHERE organization_uuid = ?
-		  AND (managed_by = 'wso2' OR (managed_by != 'wso2' AND is_latest = ?))
+		  AND is_latest = ?
 		ORDER BY created_at DESC
 		` + pageClause
 	rows, err := r.db.Query(r.db.Rebind(query), append([]any{orgUUID, 1}, pageArgs...)...)
@@ -604,7 +604,7 @@ func (r *LLMProviderTemplateRepo) Count(orgUUID string) (int, error) {
 	if err := r.db.QueryRow(r.db.Rebind(`
 		SELECT COUNT(*) FROM llm_provider_templates
 		WHERE organization_uuid = ?
-		  AND (managed_by = 'wso2' OR (managed_by != 'wso2' AND is_latest = ?))
+		  AND is_latest = ?
 	`), orgUUID, 1).Scan(&count); err != nil {
 		return 0, err
 	}

--- a/platform-api/src/internal/repository/llm.go
+++ b/platform-api/src/internal/repository/llm.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"platform-api/src/internal/constants"
@@ -36,18 +37,26 @@ type LLMProviderTemplateRepo struct {
 }
 
 type llmProviderTemplateConfig struct {
-	Metadata         *model.LLMProviderTemplateMetadata `json:"metadata,omitempty"`
-	PromptTokens     *model.ExtractionIdentifier        `json:"promptTokens,omitempty"`
-	CompletionTokens *model.ExtractionIdentifier        `json:"completionTokens,omitempty"`
-	TotalTokens      *model.ExtractionIdentifier        `json:"totalTokens,omitempty"`
-	RemainingTokens  *model.ExtractionIdentifier        `json:"remainingTokens,omitempty"`
-	RequestModel     *model.ExtractionIdentifier        `json:"requestModel,omitempty"`
-	ResponseModel    *model.ExtractionIdentifier        `json:"responseModel,omitempty"`
+	ManagedBy        string                                     `json:"managedBy,omitempty"`
+	Metadata         *model.LLMProviderTemplateMetadata         `json:"metadata,omitempty"`
+	PromptTokens     *model.ExtractionIdentifier                `json:"promptTokens,omitempty"`
+	CompletionTokens *model.ExtractionIdentifier                `json:"completionTokens,omitempty"`
+	TotalTokens      *model.ExtractionIdentifier                `json:"totalTokens,omitempty"`
+	RemainingTokens  *model.ExtractionIdentifier                `json:"remainingTokens,omitempty"`
+	RequestModel     *model.ExtractionIdentifier                `json:"requestModel,omitempty"`
+	ResponseModel    *model.ExtractionIdentifier                `json:"responseModel,omitempty"`
 	ResourceMappings *model.LLMProviderTemplateResourceMappings `json:"resourceMappings,omitempty"`
 }
 
 func NewLLMProviderTemplateRepo(db *database.DB) LLMProviderTemplateRepository {
 	return &LLMProviderTemplateRepo{db: db}
+}
+
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
 }
 
 func (r *LLMProviderTemplateRepo) Create(t *model.LLMProviderTemplate) error {
@@ -58,11 +67,9 @@ func (r *LLMProviderTemplateRepo) Create(t *model.LLMProviderTemplate) error {
 	t.UUID = uuidStr
 	t.CreatedAt = time.Now()
 	t.UpdatedAt = time.Now()
-	if t.GroupID == "" {
-		t.GroupID = t.ID
-	}
 
 	configJSON, err := json.Marshal(&llmProviderTemplateConfig{
+		ManagedBy:        t.ManagedBy,
 		Metadata:         t.Metadata,
 		PromptTokens:     t.PromptTokens,
 		CompletionTokens: t.CompletionTokens,
@@ -76,81 +83,250 @@ func (r *LLMProviderTemplateRepo) Create(t *model.LLMProviderTemplate) error {
 		return err
 	}
 
+	if t.Version == "" {
+		t.Version = "v1.0"
+	}
+	if t.ManagedBy == "" {
+		t.ManagedBy = "customer"
+	}
+	if t.GroupID == "" {
+		t.GroupID = t.ID
+	}
+	t.IsLatest = true
+	t.Enabled = true
+	t.UpdatedBy = t.CreatedBy
+
 	query := `
 		INSERT INTO llm_provider_templates (
-			uuid, organization_uuid, handle, group_id, name, description, managed_by, created_by,
-			configuration, created_at, updated_at
+			uuid, organization_uuid, handle, group_id, name, managed_by, description, created_by, updated_by,
+			configuration, openapi_spec, version, is_latest, enabled, created_at, updated_at
 		)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`
 	_, err = r.db.Exec(r.db.Rebind(query),
-		t.UUID, t.OrganizationUUID, t.ID, t.GroupID, t.Name, t.Description, t.ManagedBy, t.CreatedBy,
-		string(configJSON),
+		t.UUID, t.OrganizationUUID, t.ID, t.GroupID, t.Name, t.ManagedBy, t.Description, t.CreatedBy, t.UpdatedBy,
+		configJSON, []byte(t.OpenAPISpec), t.Version, boolToInt(t.IsLatest), boolToInt(t.Enabled),
 		t.CreatedAt, t.UpdatedAt,
 	)
 	return err
 }
 
+func (r *LLMProviderTemplateRepo) CreateNewVersion(t *model.LLMProviderTemplate) error {
+	configJSON, err := json.Marshal(&llmProviderTemplateConfig{
+		ManagedBy:        t.ManagedBy,
+		Metadata:         t.Metadata,
+		PromptTokens:     t.PromptTokens,
+		CompletionTokens: t.CompletionTokens,
+		TotalTokens:      t.TotalTokens,
+		RemainingTokens:  t.RemainingTokens,
+		RequestModel:     t.RequestModel,
+		ResponseModel:    t.ResponseModel,
+		ResourceMappings: t.ResourceMappings,
+	})
+	if err != nil {
+		return err
+	}
+
+	tx, err := r.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	lockSQL := `SELECT created_by FROM llm_provider_templates WHERE group_id = ? AND organization_uuid = ? AND is_latest = ?`
+	switch r.db.Driver() {
+	case database.DriverPostgres, database.DriverPostgreSQL, database.DriverPGX:
+		lockSQL += " FOR UPDATE"
+	case database.DriverSQLServer, database.DriverMSSQL:
+		lockSQL = `SELECT created_by FROM llm_provider_templates WITH (UPDLOCK, HOLDLOCK) WHERE group_id = ? AND organization_uuid = ? AND is_latest = ?`
+	}
+	var createdBy sql.NullString
+	err = tx.QueryRow(r.db.Rebind(lockSQL), t.GroupID, t.OrganizationUUID, 1).Scan(&createdBy)
+	if errors.Is(err, sql.ErrNoRows) {
+		return sql.ErrNoRows
+	}
+	if err != nil {
+		return err
+	}
+
+	var sameVersion int
+	if err = tx.QueryRow(r.db.Rebind(`
+		SELECT COUNT(*) FROM llm_provider_templates WHERE group_id = ? AND organization_uuid = ? AND version = ?
+	`), t.GroupID, t.OrganizationUUID, t.Version).Scan(&sameVersion); err != nil {
+		return err
+	}
+	if sameVersion > 0 {
+		return constants.ErrLLMProviderTemplateVersionExists
+	}
+
+	// Demote the current latest within this family (same group_id).
+	if _, err = tx.Exec(r.db.Rebind(`
+		UPDATE llm_provider_templates SET is_latest = ? WHERE group_id = ? AND organization_uuid = ? AND is_latest = ?
+	`), 0, t.GroupID, t.OrganizationUUID, 1); err != nil {
+		return err
+	}
+
+	uuidStr, err := utils.GenerateUUID()
+	if err != nil {
+		return fmt.Errorf("failed to generate LLM provider template ID: %w", err)
+	}
+	t.UUID = uuidStr
+	t.IsLatest = true
+	t.Enabled = true
+	t.CreatedBy = createdBy.String
+	t.UpdatedBy = t.CreatedBy
+	t.CreatedAt = time.Now()
+	t.UpdatedAt = time.Now()
+
+	if _, err = tx.Exec(r.db.Rebind(`
+		INSERT INTO llm_provider_templates (
+			uuid, organization_uuid, handle, group_id, name, managed_by, description, created_by, updated_by,
+			configuration, openapi_spec, version, is_latest, enabled, created_at, updated_at
+		)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`),
+		t.UUID, t.OrganizationUUID, t.ID, t.GroupID, t.Name, t.ManagedBy, t.Description, t.CreatedBy, t.UpdatedBy,
+		configJSON, []byte(t.OpenAPISpec), t.Version, boolToInt(t.IsLatest), boolToInt(t.Enabled),
+		t.CreatedAt, t.UpdatedAt,
+	); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+func (r *LLMProviderTemplateRepo) familyGroupID(handle, orgUUID string) (string, error) {
+	var base string
+	err := r.db.QueryRow(r.db.Rebind(`
+		SELECT group_id FROM llm_provider_templates WHERE handle = ? AND organization_uuid = ?
+		ORDER BY (SELECT NULL) `+r.db.FetchFirstClause(1)), handle, orgUUID).Scan(&base)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return base, nil
+}
+
+func (r *LLMProviderTemplateRepo) GetGroupID(handle, orgUUID string) (string, error) {
+	return r.familyGroupID(handle, orgUUID)
+}
+
+func (r *LLMProviderTemplateRepo) ManagedByForHandle(handle, orgUUID string) (string, error) {
+	var managedBy string
+	err := r.db.QueryRow(r.db.Rebind(`
+		SELECT managed_by FROM llm_provider_templates WHERE handle = ? AND organization_uuid = ?
+		ORDER BY (SELECT NULL) `+r.db.FetchFirstClause(1)), handle, orgUUID).Scan(&managedBy)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return managedBy, nil
+}
+
 func (r *LLMProviderTemplateRepo) GetByID(templateID, orgUUID string) (*model.LLMProviderTemplate, error) {
 	row := r.db.QueryRow(r.db.Rebind(`
-		SELECT uuid, organization_uuid, handle, group_id, name, description, managed_by, created_by, configuration, created_at, updated_at
+		SELECT uuid, organization_uuid, handle, group_id, name, managed_by, description, created_by, updated_by, configuration, openapi_spec, version, is_latest, enabled, created_at, updated_at
 		FROM llm_provider_templates
 		WHERE handle = ? AND organization_uuid = ?
 	`), templateID, orgUUID)
-
-	var t model.LLMProviderTemplate
-	var createdBy sql.NullString
-	var configJSON []byte
-	if err := row.Scan(
-		&t.UUID, &t.OrganizationUUID, &t.ID, &t.GroupID, &t.Name, &t.Description, &t.ManagedBy, &createdBy, &configJSON,
-		&t.CreatedAt, &t.UpdatedAt,
-	); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, nil
-		}
-		return nil, err
-	}
-	t.CreatedBy = createdBy.String
-
-	if len(configJSON) > 0 {
-		var cfg llmProviderTemplateConfig
-		if err := json.Unmarshal(configJSON, &cfg); err != nil {
-			return nil, err
-		}
-		t.Metadata = cfg.Metadata
-		t.PromptTokens = cfg.PromptTokens
-		t.CompletionTokens = cfg.CompletionTokens
-		t.TotalTokens = cfg.TotalTokens
-		t.RemainingTokens = cfg.RemainingTokens
-		t.RequestModel = cfg.RequestModel
-		t.ResponseModel = cfg.ResponseModel
-		t.ResourceMappings = cfg.ResourceMappings
-	}
-
-	return &t, nil
+	return scanTemplateRow(row)
 }
 
 func (r *LLMProviderTemplateRepo) GetByUUID(uuid, orgUUID string) (*model.LLMProviderTemplate, error) {
 	row := r.db.QueryRow(r.db.Rebind(`
-		SELECT uuid, organization_uuid, handle, group_id, name, description, managed_by, created_by, configuration, created_at, updated_at
+		SELECT uuid, organization_uuid, handle, group_id, name, managed_by, description, created_by, updated_by, configuration, openapi_spec, version, is_latest, enabled, created_at, updated_at
 		FROM llm_provider_templates
 		WHERE uuid = ? AND organization_uuid = ?
 	`), uuid, orgUUID)
+	return scanTemplateRow(row)
+}
 
-	var t model.LLMProviderTemplate
-	var createdBy sql.NullString
-	var configJSON []byte
-	if err := row.Scan(
-		&t.UUID, &t.OrganizationUUID, &t.ID, &t.GroupID, &t.Name, &t.Description, &t.ManagedBy, &createdBy, &configJSON,
-		&t.CreatedAt, &t.UpdatedAt,
-	); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, nil
-		}
+func (r *LLMProviderTemplateRepo) GetByVersion(templateID, orgUUID, version string) (*model.LLMProviderTemplate, error) {
+	base, err := r.familyGroupID(templateID, orgUUID)
+	if err != nil {
 		return nil, err
 	}
-	t.CreatedBy = createdBy.String
+	if base == "" {
+		return nil, nil
+	}
+	row := r.db.QueryRow(r.db.Rebind(`
+		SELECT uuid, organization_uuid, handle, group_id, name, managed_by, description, created_by, updated_by, configuration, openapi_spec, version, is_latest, enabled, created_at, updated_at
+		FROM llm_provider_templates
+		WHERE group_id = ? AND organization_uuid = ? AND version = ?
+	`), base, orgUUID, version)
+	return scanTemplateRow(row)
+}
 
+func (r *LLMProviderTemplateRepo) ListVersions(templateID, orgUUID string, limit, offset int) ([]*model.LLMProviderTemplate, error) {
+	base, err := r.familyGroupID(templateID, orgUUID)
+	if err != nil {
+		return nil, err
+	}
+	if base == "" {
+		return nil, nil
+	}
+	pageClause, pageArgs := r.db.PaginationClause(limit, offset)
+	query := `
+		SELECT uuid, organization_uuid, handle, group_id, name, managed_by, description, created_by, updated_by, configuration, openapi_spec, version, is_latest, enabled, created_at, updated_at
+		FROM llm_provider_templates
+		WHERE group_id = ? AND organization_uuid = ?
+		ORDER BY created_at DESC
+		` + pageClause
+	rows, err := r.db.Query(r.db.Rebind(query), append([]any{base, orgUUID}, pageArgs...)...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var res []*model.LLMProviderTemplate
+	for rows.Next() {
+		t, err := scanTemplate(rows)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, t)
+	}
+	return res, rows.Err()
+}
+
+func (r *LLMProviderTemplateRepo) CountVersions(templateID, orgUUID string) (int, error) {
+	base, err := r.familyGroupID(templateID, orgUUID)
+	if err != nil {
+		return 0, err
+	}
+	if base == "" {
+		return 0, nil
+	}
+	var count int
+	if err := r.db.QueryRow(r.db.Rebind(`SELECT COUNT(*) FROM llm_provider_templates WHERE group_id = ? AND organization_uuid = ?`), base, orgUUID).Scan(&count); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+func scanTemplate(s rowScanner) (*model.LLMProviderTemplate, error) {
+	var t model.LLMProviderTemplate
+	// configuration and openapi_spec are binary columns (BLOB/BYTEA/VARBINARY);
+	// is_latest and enabled are integer columns. Scanning an integer column
+	// straight into a Go bool fails on Postgres/SQL Server, so scan into int
+	// and convert.
+	var configJSON []byte
+	var openapiSpec []byte
+	var isLatest, enabled int
+	if err := s.Scan(
+		&t.UUID, &t.OrganizationUUID, &t.ID, &t.GroupID, &t.Name, &t.ManagedBy, &t.Description, &t.CreatedBy, &t.UpdatedBy,
+		&configJSON, &openapiSpec, &t.Version, &isLatest, &enabled,
+		&t.CreatedAt, &t.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+	t.IsLatest = isLatest != 0
+	t.Enabled = enabled != 0
+	t.OpenAPISpec = string(openapiSpec)
 	if len(configJSON) > 0 {
 		var cfg llmProviderTemplateConfig
 		if err := json.Unmarshal(configJSON, &cfg); err != nil {
@@ -165,17 +341,53 @@ func (r *LLMProviderTemplateRepo) GetByUUID(uuid, orgUUID string) (*model.LLMPro
 		t.ResponseModel = cfg.ResponseModel
 		t.ResourceMappings = cfg.ResourceMappings
 	}
-
 	return &t, nil
+}
+
+func scanTemplateRow(row *sql.Row) (*model.LLMProviderTemplate, error) {
+	t, err := scanTemplate(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return t, nil
 }
 
 func (r *LLMProviderTemplateRepo) List(orgUUID string, limit, offset int) ([]*model.LLMProviderTemplate, error) {
 	pageClause, pageArgs := r.db.PaginationClause(limit, offset)
 	query := `
-		SELECT uuid, organization_uuid, handle, group_id, name, description, managed_by, created_by, configuration, created_at, updated_at
+		SELECT uuid, organization_uuid, handle, group_id, name, managed_by, description, created_by, updated_by, configuration, openapi_spec, version, is_latest, enabled, created_at, updated_at
 		FROM llm_provider_templates
 		WHERE organization_uuid = ?
+		  AND (managed_by = 'wso2' OR (managed_by != 'wso2' AND is_latest = ?))
 		ORDER BY created_at DESC
+		` + pageClause
+	rows, err := r.db.Query(r.db.Rebind(query), append([]any{orgUUID, 1}, pageArgs...)...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var res []*model.LLMProviderTemplate
+	for rows.Next() {
+		t, err := scanTemplate(rows)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, t)
+	}
+	return res, rows.Err()
+}
+
+func (r *LLMProviderTemplateRepo) ListAllVersions(orgUUID string, limit, offset int) ([]*model.LLMProviderTemplate, error) {
+	pageClause, pageArgs := r.db.PaginationClause(limit, offset)
+	query := `
+		SELECT uuid, organization_uuid, handle, group_id, name, managed_by, description, created_by, updated_by, configuration, openapi_spec, version, is_latest, enabled, created_at, updated_at
+		FROM llm_provider_templates
+		WHERE organization_uuid = ?
+		ORDER BY name ASC, created_at DESC
 		` + pageClause
 	rows, err := r.db.Query(r.db.Rebind(query), append([]any{orgUUID}, pageArgs...)...)
 	if err != nil {
@@ -185,40 +397,28 @@ func (r *LLMProviderTemplateRepo) List(orgUUID string, limit, offset int) ([]*mo
 
 	var res []*model.LLMProviderTemplate
 	for rows.Next() {
-		var t model.LLMProviderTemplate
-		var createdBy sql.NullString
-	var configJSON []byte
-		err := rows.Scan(
-			&t.UUID, &t.OrganizationUUID, &t.ID, &t.GroupID, &t.Name, &t.Description, &t.ManagedBy, &createdBy, &configJSON,
-			&t.CreatedAt, &t.UpdatedAt,
-		)
+		t, err := scanTemplate(rows)
 		if err != nil {
 			return nil, err
 		}
-		t.CreatedBy = createdBy.String
-		if len(configJSON) > 0 {
-			var cfg llmProviderTemplateConfig
-			if err := json.Unmarshal(configJSON, &cfg); err != nil {
-				return nil, err
-			}
-			t.Metadata = cfg.Metadata
-			t.PromptTokens = cfg.PromptTokens
-			t.CompletionTokens = cfg.CompletionTokens
-			t.TotalTokens = cfg.TotalTokens
-			t.RemainingTokens = cfg.RemainingTokens
-			t.RequestModel = cfg.RequestModel
-			t.ResponseModel = cfg.ResponseModel
-			t.ResourceMappings = cfg.ResourceMappings
-		}
-		res = append(res, &t)
+		res = append(res, t)
 	}
 	return res, rows.Err()
+}
+
+func (r *LLMProviderTemplateRepo) CountAllVersions(orgUUID string) (int, error) {
+	var count int
+	if err := r.db.QueryRow(r.db.Rebind(`SELECT COUNT(*) FROM llm_provider_templates WHERE organization_uuid = ?`), orgUUID).Scan(&count); err != nil {
+		return 0, err
+	}
+	return count, nil
 }
 
 func (r *LLMProviderTemplateRepo) Update(t *model.LLMProviderTemplate) error {
 	t.UpdatedAt = time.Now()
 
 	configJSON, err := json.Marshal(&llmProviderTemplateConfig{
+		ManagedBy:        t.ManagedBy,
 		Metadata:         t.Metadata,
 		PromptTokens:     t.PromptTokens,
 		CompletionTokens: t.CompletionTokens,
@@ -232,15 +432,12 @@ func (r *LLMProviderTemplateRepo) Update(t *model.LLMProviderTemplate) error {
 		return err
 	}
 
-	query := `
+	result, err := r.db.Exec(r.db.Rebind(`
 		UPDATE llm_provider_templates
-		SET name = ?, description = ?, configuration = ?, updated_by = ?, updated_at = ?
+		SET name = ?, description = ?, configuration = ?, openapi_spec = ?, updated_by = ?, updated_at = ?
 		WHERE handle = ? AND organization_uuid = ?
-	`
-	result, err := r.db.Exec(r.db.Rebind(query),
-		t.Name, t.Description,
-		string(configJSON),
-		t.UpdatedBy, t.UpdatedAt,
+	`),
+		t.Name, t.Description, configJSON, []byte(t.OpenAPISpec), t.UpdatedBy, t.UpdatedAt,
 		t.ID, t.OrganizationUUID,
 	)
 	if err != nil {
@@ -257,8 +454,78 @@ func (r *LLMProviderTemplateRepo) Update(t *model.LLMProviderTemplate) error {
 	return nil
 }
 
+func (r *LLMProviderTemplateRepo) RenameFamily(baseHandle, orgUUID, name string) error {
+	_, err := r.db.Exec(r.db.Rebind(`
+		UPDATE llm_provider_templates SET name = ?, updated_at = ?
+		WHERE group_id = ? AND organization_uuid = ? AND managed_by != ?
+	`), name, time.Now(), baseHandle, orgUUID, "wso2")
+	return err
+}
+
 func (r *LLMProviderTemplateRepo) Delete(templateID, orgUUID string) error {
-	result, err := r.db.Exec(r.db.Rebind(`DELETE FROM llm_provider_templates WHERE handle = ? AND organization_uuid = ?`), templateID, orgUUID)
+	base, err := r.familyGroupID(templateID, orgUUID)
+	if err != nil {
+		return err
+	}
+	if base == "" {
+		return sql.ErrNoRows
+	}
+
+	tx, err := r.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	result, err := tx.Exec(r.db.Rebind(`
+		DELETE FROM llm_provider_templates
+		WHERE group_id = ? AND organization_uuid = ? AND managed_by != ?
+	`), base, orgUUID, "wso2")
+	if err != nil {
+		return err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+
+	var remaining, latestCount int
+	if err := tx.QueryRow(r.db.Rebind(`
+		SELECT COUNT(*), COALESCE(SUM(CASE WHEN is_latest = 1 THEN 1 ELSE 0 END), 0)
+		FROM llm_provider_templates WHERE group_id = ? AND organization_uuid = ?
+	`), base, orgUUID).Scan(&remaining, &latestCount); err != nil {
+		return err
+	}
+	if remaining > 0 && latestCount == 0 {
+		if _, err := tx.Exec(r.db.Rebind(`
+			UPDATE llm_provider_templates SET is_latest = ?
+			WHERE uuid = (
+				SELECT uuid FROM llm_provider_templates
+				WHERE group_id = ? AND organization_uuid = ?
+				ORDER BY created_at DESC `+r.db.FetchFirstClause(1)+`
+			)
+		`), 1, base, orgUUID); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+func (r *LLMProviderTemplateRepo) SetEnabled(templateID, orgUUID, version string, enabled bool) error {
+	base, err := r.familyGroupID(templateID, orgUUID)
+	if err != nil {
+		return err
+	}
+	if base == "" {
+		return sql.ErrNoRows
+	}
+	result, err := r.db.Exec(r.db.Rebind(`
+		UPDATE llm_provider_templates SET enabled = ?, updated_at = ?
+		WHERE group_id = ? AND organization_uuid = ? AND version = ?
+	`), boolToInt(enabled), time.Now(), base, orgUUID, version)
 	if err != nil {
 		return err
 	}
@@ -272,6 +539,58 @@ func (r *LLMProviderTemplateRepo) Delete(templateID, orgUUID string) error {
 	return nil
 }
 
+func (r *LLMProviderTemplateRepo) DeleteVersion(templateID, orgUUID, version string) error {
+	base, err := r.familyGroupID(templateID, orgUUID)
+	if err != nil {
+		return err
+	}
+	if base == "" {
+		return sql.ErrNoRows
+	}
+
+	tx, err := r.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	result, err := tx.Exec(r.db.Rebind(`
+		DELETE FROM llm_provider_templates
+		WHERE group_id = ? AND organization_uuid = ? AND version = ?
+	`), base, orgUUID, version)
+	if err != nil {
+		return err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+
+	var remaining, latestCount int
+	if err := tx.QueryRow(r.db.Rebind(`
+		SELECT COUNT(*), COALESCE(SUM(CASE WHEN is_latest = 1 THEN 1 ELSE 0 END), 0)
+		FROM llm_provider_templates WHERE group_id = ? AND organization_uuid = ?
+	`), base, orgUUID).Scan(&remaining, &latestCount); err != nil {
+		return err
+	}
+	if remaining > 0 && latestCount == 0 {
+		if _, err := tx.Exec(r.db.Rebind(`
+			UPDATE llm_provider_templates SET is_latest = ?
+			WHERE uuid = (
+				SELECT uuid FROM llm_provider_templates
+				WHERE group_id = ? AND organization_uuid = ?
+				ORDER BY created_at DESC `+r.db.FetchFirstClause(1)+`
+			)
+		`), 1, base, orgUUID); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
 func (r *LLMProviderTemplateRepo) Exists(templateID, orgUUID string) (bool, error) {
 	var count int
 	err := r.db.QueryRow(r.db.Rebind(`SELECT COUNT(*) FROM llm_provider_templates WHERE handle = ? AND organization_uuid = ?`), templateID, orgUUID).Scan(&count)
@@ -283,7 +602,35 @@ func (r *LLMProviderTemplateRepo) Exists(templateID, orgUUID string) (bool, erro
 
 func (r *LLMProviderTemplateRepo) Count(orgUUID string) (int, error) {
 	var count int
-	if err := r.db.QueryRow(r.db.Rebind(`SELECT COUNT(*) FROM llm_provider_templates WHERE organization_uuid = ?`), orgUUID).Scan(&count); err != nil {
+	if err := r.db.QueryRow(r.db.Rebind(`
+		SELECT COUNT(*) FROM llm_provider_templates
+		WHERE organization_uuid = ?
+		  AND (managed_by = 'wso2' OR (managed_by != 'wso2' AND is_latest = ?))
+	`), orgUUID, 1).Scan(&count); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+func (r *LLMProviderTemplateRepo) CountProvidersUsingTemplate(templateID, orgUUID, version string) (int, error) {
+	base, err := r.familyGroupID(templateID, orgUUID)
+	if err != nil {
+		return 0, err
+	}
+	if base == "" {
+		return 0, nil
+	}
+	query := `
+		SELECT COUNT(*)
+		FROM llm_providers p
+		JOIN llm_provider_templates t ON p.template_uuid = t.uuid
+		WHERE t.group_id = ? AND t.organization_uuid = ?`
+	args := []interface{}{base, orgUUID}
+	if strings.TrimSpace(version) != "" {
+		query += ` AND t.version = ?`
+		args = append(args, version)
+	}
+	var count int
+	if err := r.db.QueryRow(r.db.Rebind(query), args...).Scan(&count); err != nil {
 		return 0, err
 	}
 	return count, nil

--- a/platform-api/src/internal/repository/llm_test.go
+++ b/platform-api/src/internal/repository/llm_test.go
@@ -1,0 +1,106 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package repository
+
+import (
+	"testing"
+	"time"
+
+	"platform-api/src/internal/model"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// TestLLMProviderTemplateRepo_GetByID_ExactVersion verifies that GetByID honours
+// the exact handle it is given (rather than always returning the family's latest
+// version), and returns nil for an unknown handle. This is the resolution that
+// keeps a provider bound to the specific template version selected at creation
+// time.
+func TestLLMProviderTemplateRepo_GetByID_ExactVersion(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	t.Cleanup(cleanup)
+
+	repo := NewLLMProviderTemplateRepo(db)
+
+	orgUUID := "org-tpl-001"
+	projectUUID := "project-tpl-001"
+	createTestOrganizationAndProject(t, db, orgUUID, projectUUID)
+
+	now := time.Now()
+	// Built-in v1.0 — seeded with handle == group_id (no version suffix), as
+	// the template loader does (managedBy "wso2").
+	v1 := &model.LLMProviderTemplate{
+		OrganizationUUID: orgUUID,
+		ID:               "mistralai",
+		GroupID:   "mistralai",
+		Name:             "Mistral",
+		ManagedBy:        "wso2",
+		Version:          "v1.0",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+	if err := repo.Create(v1); err != nil {
+		t.Fatalf("failed to create v1.0: %v", err)
+	}
+	v1UUID := v1.UUID
+
+	// Custom v2.0 spun off the built-in — version-suffixed handle, managedBy
+	// "customer"; this demotes v1.0 and becomes the family's latest.
+	v2 := &model.LLMProviderTemplate{
+		OrganizationUUID: orgUUID,
+		ID:               "mistralai-v2-0",
+		GroupID:   "mistralai",
+		Name:             "Mistral",
+		ManagedBy:        "customer",
+		Version:          "v2.0",
+	}
+	if err := repo.CreateNewVersion(v2); err != nil {
+		t.Fatalf("failed to create v2.0: %v", err)
+	}
+
+	// Built-in handle must resolve to its own v1.0 — NOT the latest (v2.0). This
+	// is the bug fix: previously GetByID always returned the is_latest row.
+	got, err := repo.GetByID("mistralai", orgUUID)
+	if err != nil {
+		t.Fatalf("GetByID(builtin) error: %v", err)
+	}
+	if got == nil || got.Version != "v1.0" || got.UUID != v1UUID {
+		t.Fatalf("GetByID(builtin) = %+v, want version v1.0 (uuid %s)", got, v1UUID)
+	}
+	if got.ManagedBy != "wso2" {
+		t.Errorf("GetByID(builtin).ManagedBy = %q, want wso2", got.ManagedBy)
+	}
+
+	// The version-specific custom handle must return v2.0.
+	got, err = repo.GetByID("mistralai-v2-0", orgUUID)
+	if err != nil {
+		t.Fatalf("GetByID(v2) error: %v", err)
+	}
+	if got == nil || got.Version != "v2.0" || got.ManagedBy != "customer" {
+		t.Fatalf("GetByID(v2) = %+v, want version v2.0 (managedBy customer)", got)
+	}
+
+	// An unknown handle resolves to nothing (no spurious latest match).
+	got, err = repo.GetByID("does-not-exist", orgUUID)
+	if err != nil {
+		t.Fatalf("GetByID(unknown) error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("GetByID(unknown) = %+v, want nil", got)
+	}
+}

--- a/platform-api/src/internal/service/llm.go
+++ b/platform-api/src/internal/service/llm.go
@@ -131,10 +131,9 @@ func (s *LLMProviderTemplateService) Create(orgUUID, createdBy string, req *api.
 	version := "v1.0"
 	if v := req.Version; v != "" {
 		normalized, ok := normalizeTemplateVersion(v)
-		if !ok {
+		if !ok || normalized != version {
 			return nil, constants.ErrInvalidInput
 		}
-		version = normalized
 	}
 	handle := makeTemplateHandle(baseHandle, version)
 
@@ -293,7 +292,11 @@ func (s *LLMProviderTemplateService) Update(orgUUID, handle, updatedBy string, r
 		return nil, fmt.Errorf("failed to update template: %w", err)
 	}
 
-	if base, baseErr := s.repo.GetGroupID(handle, orgUUID); baseErr == nil && base != "" {
+	base, baseErr := s.repo.GetGroupID(handle, orgUUID)
+	if baseErr != nil {
+		return nil, fmt.Errorf("failed to resolve template family: %w", baseErr)
+	}
+	if base != "" {
 		if err := s.repo.RenameFamily(base, orgUUID, req.Name); err != nil {
 			return nil, fmt.Errorf("failed to propagate template name: %w", err)
 		}
@@ -418,9 +421,11 @@ func (s *LLMProviderTemplateService) GetVersion(orgUUID, handle, version string)
 	if handle == "" || v == "" {
 		return nil, constants.ErrInvalidInput
 	}
-	if normalized, ok := normalizeTemplateVersion(v); ok {
-		v = normalized
+	normalized, ok := normalizeTemplateVersion(v)
+	if !ok {
+		return nil, constants.ErrInvalidInput
 	}
+	v = normalized
 	m, err := s.repo.GetByVersion(handle, orgUUID, v)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get template version: %w", err)
@@ -438,9 +443,11 @@ func (s *LLMProviderTemplateService) SetVersionEnabled(orgUUID, handle, version 
 	if handle == "" || v == "" {
 		return nil, constants.ErrInvalidInput
 	}
-	if normalized, ok := normalizeTemplateVersion(v); ok {
-		v = normalized
+	normalized, ok := normalizeTemplateVersion(v)
+	if !ok {
+		return nil, constants.ErrInvalidInput
 	}
+	v = normalized
 	if !enabled {
 		inUse, err := s.repo.CountProvidersUsingTemplate(handle, orgUUID, v)
 		if err != nil {
@@ -504,9 +511,11 @@ func (s *LLMProviderTemplateService) DeleteVersion(orgUUID, handle, version stri
 	if handle == "" || v == "" {
 		return constants.ErrInvalidInput
 	}
-	if normalized, ok := normalizeTemplateVersion(v); ok {
-		v = normalized
+	normalized, ok := normalizeTemplateVersion(v)
+	if !ok {
+		return constants.ErrInvalidInput
 	}
+	v = normalized
 	target, err := s.repo.GetByVersion(handle, orgUUID, v)
 	if err != nil {
 		return fmt.Errorf("failed to resolve template version: %w", err)

--- a/platform-api/src/internal/service/llm.go
+++ b/platform-api/src/internal/service/llm.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"strings"
 
 	"platform-api/src/api"
@@ -119,11 +120,29 @@ func (s *LLMProviderTemplateService) Create(orgUUID, createdBy string, req *api.
 	if req == nil {
 		return nil, constants.ErrInvalidInput
 	}
-	if req.Id == "" || req.Name == "" {
+	if req.Name == "" {
 		return nil, constants.ErrInvalidInput
 	}
 
-	exists, err := s.repo.Exists(req.Id, orgUUID)
+	baseHandle, err := utils.GenerateHandle(req.Name, nil)
+	if err != nil || baseHandle == "" {
+		return nil, constants.ErrInvalidInput
+	}
+	version := "v1.0"
+	if v := req.Version; v != "" {
+		normalized, ok := normalizeTemplateVersion(v)
+		if !ok {
+			return nil, constants.ErrInvalidInput
+		}
+		version = normalized
+	}
+	handle := makeTemplateHandle(baseHandle, version)
+
+	if req.ManagedBy != nil && strings.TrimSpace(*req.ManagedBy) == constants.PolicyManagedByWSO2 {
+		return nil, constants.ErrLLMProviderTemplateManagedByReserved
+	}
+
+	exists, err := s.repo.Exists(handle, orgUUID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check template exists: %w", err)
 	}
@@ -133,11 +152,14 @@ func (s *LLMProviderTemplateService) Create(orgUUID, createdBy string, req *api.
 
 	m := &model.LLMProviderTemplate{
 		OrganizationUUID: orgUUID,
-		ID:               req.Id,
+		ID:               handle,
+		GroupID:          baseHandle,
+		Version:          version,
 		Name:             req.Name,
 		Description:      utils.ValueOrEmpty(req.Description),
-		ManagedBy:        constants.PolicyManagedByCustomer,
+		ManagedBy:        defaultTemplateManagedBy(req.ManagedBy),
 		CreatedBy:        createdBy,
+		OpenAPISpec:      utils.ValueOrEmpty(req.Openapi),
 		Metadata:         mapTemplateMetadataAPI(req.Metadata),
 		PromptTokens:     mapExtractionIdentifierAPI(req.PromptTokens),
 		CompletionTokens: mapExtractionIdentifierAPI(req.CompletionTokens),
@@ -164,12 +186,18 @@ func (s *LLMProviderTemplateService) Create(orgUUID, createdBy string, req *api.
 	return mapTemplateModelToAPI(m), nil
 }
 
-func (s *LLMProviderTemplateService) List(orgUUID string, limit, offset int) (*api.LLMProviderTemplateListResponse, error) {
-	items, err := s.repo.List(orgUUID, limit, offset)
+func (s *LLMProviderTemplateService) List(orgUUID string, limit, offset int, allVersions bool) (*api.LLMProviderTemplateListResponse, error) {
+	listFn := s.repo.List
+	countFn := s.repo.Count
+	if allVersions {
+		listFn = s.repo.ListAllVersions
+		countFn = s.repo.CountAllVersions
+	}
+	items, err := listFn(orgUUID, limit, offset)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list templates: %w", err)
 	}
-	totalCount, err := s.repo.Count(orgUUID)
+	totalCount, err := countFn(orgUUID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to count templates: %w", err)
 	}
@@ -183,18 +211,7 @@ func (s *LLMProviderTemplateService) List(orgUUID string, limit, offset int) (*a
 	}
 	resp.List = make([]api.LLMProviderTemplateListItem, 0, len(items))
 	for _, t := range items {
-		id := t.ID
-		name := t.Name
-		desc := utils.StringPtrIfNotEmpty(t.Description)
-		createdBy := utils.StringPtrIfNotEmpty(t.CreatedBy)
-		resp.List = append(resp.List, api.LLMProviderTemplateListItem{
-			Id:          &id,
-			Name:        &name,
-			Description: desc,
-			CreatedBy:   createdBy,
-			CreatedAt:   utils.TimePtr(t.CreatedAt),
-			UpdatedAt:   utils.TimePtr(t.UpdatedAt),
-		})
+		resp.List = append(resp.List, templateListItem(t))
 	}
 	return resp, nil
 }
@@ -223,6 +240,29 @@ func (s *LLMProviderTemplateService) Update(orgUUID, handle, updatedBy string, r
 	if req.Name == "" {
 		return nil, constants.ErrInvalidInput
 	}
+	if req.ManagedBy != nil && strings.TrimSpace(*req.ManagedBy) == constants.PolicyManagedByWSO2 {
+		return nil, constants.ErrLLMProviderTemplateManagedByReserved
+	}
+
+	existing, err := s.repo.GetByID(handle, orgUUID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve template: %w", err)
+	}
+	if existing == nil {
+		return nil, constants.ErrLLMProviderTemplateNotFound
+	}
+	if existing.ManagedBy == "wso2" {
+		return nil, constants.ErrLLMProviderTemplateReadOnly
+	}
+
+	managedBy := existing.ManagedBy
+	if req.ManagedBy != nil {
+		managedBy = defaultTemplateManagedBy(req.ManagedBy)
+	}
+	openapiSpec := existing.OpenAPISpec
+	if req.Openapi != nil {
+		openapiSpec = utils.ValueOrEmpty(req.Openapi)
+	}
 
 	m := &model.LLMProviderTemplate{
 		OrganizationUUID: orgUUID,
@@ -230,6 +270,8 @@ func (s *LLMProviderTemplateService) Update(orgUUID, handle, updatedBy string, r
 		Name:             req.Name,
 		Description:      utils.ValueOrEmpty(req.Description),
 		UpdatedBy:        updatedBy,
+		ManagedBy:        managedBy,
+		OpenAPISpec:      openapiSpec,
 		Metadata:         mapTemplateMetadataAPI(req.Metadata),
 		PromptTokens:     mapExtractionIdentifierAPI(req.PromptTokens),
 		CompletionTokens: mapExtractionIdentifierAPI(req.CompletionTokens),
@@ -251,6 +293,12 @@ func (s *LLMProviderTemplateService) Update(orgUUID, handle, updatedBy string, r
 		return nil, fmt.Errorf("failed to update template: %w", err)
 	}
 
+	if base, baseErr := s.repo.GetGroupID(handle, orgUUID); baseErr == nil && base != "" {
+		if err := s.repo.RenameFamily(base, orgUUID, req.Name); err != nil {
+			return nil, fmt.Errorf("failed to propagate template name: %w", err)
+		}
+	}
+
 	updated, err := s.repo.GetByID(handle, orgUUID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch updated template: %w", err)
@@ -264,16 +312,181 @@ func (s *LLMProviderTemplateService) Update(orgUUID, handle, updatedBy string, r
 	return mapTemplateModelToAPI(updated), nil
 }
 
+var templateVersionPattern = regexp.MustCompile(`^[vV]\d+\.\d+$`)
+
+func normalizeTemplateVersion(v string) (string, bool) {
+	v = strings.TrimSpace(v)
+	if !templateVersionPattern.MatchString(v) {
+		return "", false
+	}
+	return "v" + strings.TrimPrefix(strings.TrimPrefix(v, "v"), "V"), true
+}
+func makeTemplateHandle(baseHandle, version string) string {
+	return baseHandle + "-" + strings.ReplaceAll(strings.ToLower(strings.TrimSpace(version)), ".", "-")
+}
+
+func (s *LLMProviderTemplateService) CreateVersion(orgUUID, handle, createdBy string, req *api.CreateLLMProviderTemplateVersionRequest) (*api.LLMProviderTemplate, error) {
+	if handle == "" || req == nil {
+		return nil, constants.ErrInvalidInput
+	}
+	if req.Name == "" {
+		return nil, constants.ErrInvalidInput
+	}
+	version, ok := normalizeTemplateVersion(req.Version)
+	if !ok {
+		return nil, constants.ErrInvalidInput
+	}
+
+	baseHandle, err := s.repo.GetGroupID(handle, orgUUID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve template family: %w", err)
+	}
+	if baseHandle == "" {
+		return nil, constants.ErrLLMProviderTemplateNotFound
+	}
+
+	m := &model.LLMProviderTemplate{
+		OrganizationUUID: orgUUID,
+		ID:               makeTemplateHandle(baseHandle, version),
+		GroupID:          baseHandle,
+		Name:             req.Name,
+		Description:      utils.ValueOrEmpty(req.Description),
+		ManagedBy:        constants.PolicyManagedByCustomer,
+		CreatedBy:        createdBy,
+		Version:          version,
+		OpenAPISpec:      utils.ValueOrEmpty(req.Openapi),
+		Metadata:         mapTemplateMetadataAPI(req.Metadata),
+		PromptTokens:     mapExtractionIdentifierAPI(req.PromptTokens),
+		CompletionTokens: mapExtractionIdentifierAPI(req.CompletionTokens),
+		TotalTokens:      mapExtractionIdentifierAPI(req.TotalTokens),
+		RemainingTokens:  mapExtractionIdentifierAPI(req.RemainingTokens),
+		RequestModel:     mapExtractionIdentifierAPI(req.RequestModel),
+		ResponseModel:    mapExtractionIdentifierAPI(req.ResponseModel),
+	}
+	resourceMappings, err := mapTemplateResourceMappingsAPI(req.ResourceMappings)
+	if err != nil {
+		return nil, err
+	}
+	m.ResourceMappings = resourceMappings
+
+	if err := s.repo.CreateNewVersion(m); err != nil {
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			return nil, constants.ErrLLMProviderTemplateNotFound
+		case errors.Is(err, constants.ErrLLMProviderTemplateVersionExists):
+			return nil, constants.ErrLLMProviderTemplateVersionExists
+		default:
+			return nil, fmt.Errorf("failed to create new template version: %w", err)
+		}
+	}
+
+	return mapTemplateModelToAPI(m), nil
+}
+
+func (s *LLMProviderTemplateService) ListVersions(orgUUID, handle string, limit, offset int) (*api.LLMProviderTemplateListResponse, error) {
+	if handle == "" {
+		return nil, constants.ErrInvalidInput
+	}
+	total, err := s.repo.CountVersions(handle, orgUUID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to count template versions: %w", err)
+	}
+	if total == 0 {
+		return nil, constants.ErrLLMProviderTemplateNotFound
+	}
+	items, err := s.repo.ListVersions(handle, orgUUID, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list template versions: %w", err)
+	}
+	resp := &api.LLMProviderTemplateListResponse{
+		Count: len(items),
+		Pagination: api.Pagination{
+			Limit:  limit,
+			Offset: offset,
+			Total:  total,
+		},
+	}
+	resp.List = make([]api.LLMProviderTemplateListItem, 0, len(items))
+	for _, t := range items {
+		resp.List = append(resp.List, templateListItem(t))
+	}
+	return resp, nil
+}
+
+func (s *LLMProviderTemplateService) GetVersion(orgUUID, handle, version string) (*api.LLMProviderTemplate, error) {
+	v := strings.TrimSpace(version)
+	if handle == "" || v == "" {
+		return nil, constants.ErrInvalidInput
+	}
+	if normalized, ok := normalizeTemplateVersion(v); ok {
+		v = normalized
+	}
+	m, err := s.repo.GetByVersion(handle, orgUUID, v)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get template version: %w", err)
+	}
+	if m == nil {
+		return nil, constants.ErrLLMProviderTemplateNotFound
+	}
+	return mapTemplateModelToAPI(m), nil
+}
+
+// SetVersionEnabled enables or disables a specific version of a template.
+// Disabling is blocked when any provider was created from this specific version.
+func (s *LLMProviderTemplateService) SetVersionEnabled(orgUUID, handle, version string, enabled bool) (*api.LLMProviderTemplate, error) {
+	v := strings.TrimSpace(version)
+	if handle == "" || v == "" {
+		return nil, constants.ErrInvalidInput
+	}
+	if normalized, ok := normalizeTemplateVersion(v); ok {
+		v = normalized
+	}
+	if !enabled {
+		inUse, err := s.repo.CountProvidersUsingTemplate(handle, orgUUID, v)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check template version usage: %w", err)
+		}
+		if inUse > 0 {
+			return nil, constants.ErrLLMProviderTemplateInUse
+		}
+	}
+	if err := s.repo.SetEnabled(handle, orgUUID, v, enabled); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, constants.ErrLLMProviderTemplateNotFound
+		}
+		return nil, fmt.Errorf("failed to set template version enabled: %w", err)
+	}
+	m, err := s.repo.GetByVersion(handle, orgUUID, v)
+	if err != nil {
+		return nil, fmt.Errorf("failed to reload template version: %w", err)
+	}
+	if m == nil {
+		return nil, constants.ErrLLMProviderTemplateNotFound
+	}
+	return mapTemplateModelToAPI(m), nil
+}
+
 func (s *LLMProviderTemplateService) Delete(orgUUID, handle, deletedBy string) error {
 	if handle == "" {
 		return constants.ErrInvalidInput
 	}
-	tpl, err := s.repo.GetByID(handle, orgUUID)
+	managedBy, err := s.repo.ManagedByForHandle(handle, orgUUID)
 	if err != nil {
-		return fmt.Errorf("failed to get template: %w", err)
+		return fmt.Errorf("failed to resolve template: %w", err)
 	}
-	if tpl == nil {
+	if managedBy == "" {
 		return constants.ErrLLMProviderTemplateNotFound
+	}
+	if managedBy == "wso2" {
+		return constants.ErrLLMProviderTemplateReadOnly
+	}
+	// Block deletion while any provider (built from any version) still depends on it.
+	inUse, err := s.repo.CountProvidersUsingTemplate(handle, orgUUID, "")
+	if err != nil {
+		return fmt.Errorf("failed to check template usage: %w", err)
+	}
+	if inUse > 0 {
+		return constants.ErrLLMProviderTemplateInUse
 	}
 	if err := s.repo.Delete(handle, orgUUID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -281,7 +494,43 @@ func (s *LLMProviderTemplateService) Delete(orgUUID, handle, deletedBy string) e
 		}
 		return fmt.Errorf("failed to delete template: %w", err)
 	}
-	_ = s.auditRepo.Record("DELETE", tpl.UUID, "llm_provider_template", orgUUID, deletedBy)
+	// Family-level delete: log the stable handle rather than a single version's UUID.
+	_ = s.auditRepo.Record("DELETE", handle, "llm_provider_template", orgUUID, deletedBy)
+	return nil
+}
+
+func (s *LLMProviderTemplateService) DeleteVersion(orgUUID, handle, version string) error {
+	v := strings.TrimSpace(version)
+	if handle == "" || v == "" {
+		return constants.ErrInvalidInput
+	}
+	if normalized, ok := normalizeTemplateVersion(v); ok {
+		v = normalized
+	}
+	target, err := s.repo.GetByVersion(handle, orgUUID, v)
+	if err != nil {
+		return fmt.Errorf("failed to resolve template version: %w", err)
+	}
+	if target == nil {
+		return constants.ErrLLMProviderTemplateNotFound
+	}
+	if target.ManagedBy == "wso2" {
+		return constants.ErrLLMProviderTemplateReadOnly
+	}
+	// Block deletion while any provider built from this specific version still depends on it.
+	inUse, err := s.repo.CountProvidersUsingTemplate(handle, orgUUID, v)
+	if err != nil {
+		return fmt.Errorf("failed to check template version usage: %w", err)
+	}
+	if inUse > 0 {
+		return constants.ErrLLMProviderTemplateInUse
+	}
+	if err := s.repo.DeleteVersion(handle, orgUUID, v); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return constants.ErrLLMProviderTemplateNotFound
+		}
+		return fmt.Errorf("failed to delete template version: %w", err)
+	}
 	return nil
 }
 
@@ -346,6 +595,14 @@ func (s *LLMProviderService) Create(orgUUID, createdBy string, req *api.LLMProvi
 	if err := validateLLMResourceLimit(providerCount, constants.MaxLLMProvidersPerOrganization, constants.ErrLLMProviderLimitReached); err != nil {
 		return nil, err
 	}
+	if !tpl.Enabled {
+		return nil, constants.ErrInvalidInput
+	}
+
+	openapiSpec := utils.ValueOrEmpty(req.Openapi)
+	if openapiSpec == "" {
+		openapiSpec = tpl.OpenAPISpec
+	}
 
 	contextValue := utils.DefaultStringPtr(req.Context, "/")
 	m := &model.LLMProvider{
@@ -356,7 +613,7 @@ func (s *LLMProviderService) Create(orgUUID, createdBy string, req *api.LLMProvi
 		CreatedBy:        createdBy,
 		Version:          req.Version,
 		TemplateUUID:     tpl.UUID,
-		OpenAPISpec:      utils.ValueOrEmpty(req.Openapi),
+		OpenAPISpec:      openapiSpec,
 		ModelProviders:   mapModelProvidersAPI(req.ModelProviders),
 		Configuration: model.LLMProviderConfig{
 			Context:           &contextValue,
@@ -1533,15 +1790,49 @@ func mapResourceWiseRateLimitingAPIToModel(in *api.ResourceWiseRateLimitingConfi
 	}
 }
 
+func templateListItem(t *model.LLMProviderTemplate) api.LLMProviderTemplateListItem {
+	id := t.ID
+	name := t.Name
+	version := t.Version
+	isLatest := t.IsLatest
+	enabled := t.Enabled
+	var logoURL string
+	if t.Metadata != nil {
+		logoURL = t.Metadata.LogoURL
+	}
+	return api.LLMProviderTemplateListItem{
+		Id:          &id,
+		Name:        &name,
+		Description: utils.StringPtrIfNotEmpty(t.Description),
+		ManagedBy:   utils.StringPtrIfNotEmpty(t.ManagedBy),
+		CreatedBy:   utils.StringPtrIfNotEmpty(t.CreatedBy),
+		Version:     &version,
+		IsLatest:    &isLatest,
+		Enabled:     &enabled,
+		LogoUrl:     utils.StringPtrIfNotEmpty(logoURL),
+		CreatedAt:   utils.TimePtr(t.CreatedAt),
+		UpdatedAt:   utils.TimePtr(t.UpdatedAt),
+	}
+}
+
 func mapTemplateModelToAPI(m *model.LLMProviderTemplate) *api.LLMProviderTemplate {
 	if m == nil {
 		return nil
 	}
+	isLatest := m.IsLatest
+	enabled := m.Enabled
 	return &api.LLMProviderTemplate{
 		Id:               m.ID,
+		GroupId:          utils.StringPtrIfNotEmpty(m.GroupID),
 		Name:             m.Name,
 		Description:      utils.StringPtrIfNotEmpty(m.Description),
+		ManagedBy:        utils.StringPtrIfNotEmpty(m.ManagedBy),
 		CreatedBy:        utils.StringPtrIfNotEmpty(m.CreatedBy),
+		UpdatedBy:        utils.StringPtrIfNotEmpty(m.UpdatedBy),
+		Version:          m.Version,
+		IsLatest:         &isLatest,
+		Enabled:          &enabled,
+		Openapi:          utils.StringPtrIfNotEmpty(m.OpenAPISpec),
 		Metadata:         mapTemplateMetadataModelToAPI(m.Metadata),
 		PromptTokens:     mapExtractionIdentifierModelToAPI(m.PromptTokens),
 		CompletionTokens: mapExtractionIdentifierModelToAPI(m.CompletionTokens),
@@ -1634,6 +1925,17 @@ func mapTemplateResourceMappingModelToAPI(in *model.LLMProviderTemplateResourceM
 		RequestModel:     mapExtractionIdentifierModelToAPI(in.RequestModel),
 		ResponseModel:    mapExtractionIdentifierModelToAPI(in.ResponseModel),
 	}
+}
+
+// defaultTemplateManagedBy normalizes the managedBy label supplied on a custom
+// template. An empty value defaults to "customer"; built-in templates are seeded
+// with "wso2" by the template seeder/loader.
+func defaultTemplateManagedBy(in *string) string {
+	v := strings.TrimSpace(utils.ValueOrEmpty(in))
+	if v == "" {
+		return "customer"
+	}
+	return v
 }
 
 func mapTemplateMetadataAPI(in *api.LLMProviderTemplateMetadata) *model.LLMProviderTemplateMetadata {
@@ -1742,16 +2044,16 @@ func mapProviderModelToAPI(m *model.LLMProvider, templateHandle string) *api.LLM
 	}
 
 	out := &api.LLMProvider{
-		Id:             m.ID,
-		Name:           m.Name,
-		Description:    utils.StringPtrIfNotEmpty(m.Description),
-		CreatedBy:      utils.StringPtrIfNotEmpty(m.CreatedBy),
-		Version:        m.Version,
-		Context:        ctx,
-		Vhost:          m.Configuration.VHost,
-		Template:       templateHandle,
-		Openapi:        utils.StringPtrIfNotEmpty(m.OpenAPISpec),
-		ModelProviders: modelProviders,
+		Id:                m.ID,
+		Name:              m.Name,
+		Description:       utils.StringPtrIfNotEmpty(m.Description),
+		CreatedBy:         utils.StringPtrIfNotEmpty(m.CreatedBy),
+		Version:           m.Version,
+		Context:           ctx,
+		Vhost:             m.Configuration.VHost,
+		Template:          templateHandle,
+		Openapi:           utils.StringPtrIfNotEmpty(m.OpenAPISpec),
+		ModelProviders:    modelProviders,
 		RateLimiting:      mapRateLimitingModelToAPI(m.Configuration.RateLimiting),
 		Upstream:          upstream,
 		AccessControl:     ac,
@@ -1759,8 +2061,8 @@ func mapProviderModelToAPI(m *model.LLMProvider, templateHandle string) *api.LLM
 		OperationPolicies: operationPolicies,
 		Policies:          nil,
 		Security:          mapSecurityModelToAPI(m.Configuration.Security),
-		CreatedAt:      utils.TimePtr(m.CreatedAt),
-		UpdatedAt:      utils.TimePtr(m.UpdatedAt),
+		CreatedAt:         utils.TimePtr(m.CreatedAt),
+		UpdatedAt:         utils.TimePtr(m.UpdatedAt),
 	}
 	return out
 }

--- a/platform-api/src/internal/service/llm.go
+++ b/platform-api/src/internal/service/llm.go
@@ -340,6 +340,11 @@ func (s *LLMProviderTemplateService) CreateVersion(orgUUID, handle, createdBy st
 		return nil, constants.ErrInvalidInput
 	}
 
+	managedBy := defaultTemplateManagedBy(req.ManagedBy)
+	if managedBy == constants.PolicyManagedByWSO2 {
+		managedBy = constants.PolicyManagedByCustomer
+	}
+
 	baseHandle, err := s.repo.GetGroupID(handle, orgUUID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve template family: %w", err)
@@ -354,7 +359,7 @@ func (s *LLMProviderTemplateService) CreateVersion(orgUUID, handle, createdBy st
 		GroupID:          baseHandle,
 		Name:             req.Name,
 		Description:      utils.ValueOrEmpty(req.Description),
-		ManagedBy:        constants.PolicyManagedByCustomer,
+		ManagedBy:        managedBy,
 		CreatedBy:        createdBy,
 		Version:          version,
 		OpenAPISpec:      utils.ValueOrEmpty(req.Openapi),

--- a/platform-api/src/internal/service/llm_provider_template_test.go
+++ b/platform-api/src/internal/service/llm_provider_template_test.go
@@ -1,0 +1,717 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package service
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+
+	"platform-api/src/api"
+	"platform-api/src/internal/constants"
+	"platform-api/src/internal/model"
+	"platform-api/src/internal/repository"
+)
+
+// mockLLMProviderTemplateCRUDRepo is a configurable fake covering the
+// LLMProviderTemplateRepository methods exercised by LLMProviderTemplateService.
+// Each field models the return value(s) of the corresponding repository call so
+// tests can drive every branch in the service without standing up a database.
+type mockLLMProviderTemplateCRUDRepo struct {
+	repository.LLMProviderTemplateRepository
+
+	existsResult bool
+	existsErr    error
+	createErr    error
+	created      *model.LLMProviderTemplate
+
+	managedByForHandleResult string
+	managedByForHandleErr    error
+
+	updateErr error
+	updated   *model.LLMProviderTemplate
+
+	getGroupIDResult string
+	getGroupIDErr    error
+
+	renameFamilyCalled bool
+	renameFamilyBase   string
+	renameFamilyOrg    string
+	renameFamilyName   string
+	renameFamilyErr    error
+
+	getByIDFunc func(templateID, orgUUID string) (*model.LLMProviderTemplate, error)
+
+	createNewVersionErr error
+	createdVersion      *model.LLMProviderTemplate
+
+	countVersionsResult int
+	countVersionsErr    error
+	listVersionsResult  []*model.LLMProviderTemplate
+	listVersionsErr     error
+
+	getByVersionFunc func(templateID, orgUUID, version string) (*model.LLMProviderTemplate, error)
+
+	setEnabledErr     error
+	setEnabledCalled  bool
+	setEnabledVersion string
+	setEnabledEnabled bool
+
+	countProvidersUsingTemplateResult  int
+	countProvidersUsingTemplateErr     error
+	countProvidersUsingTemplateCalled  bool
+	countProvidersUsingTemplateVersion string
+
+	deleteErr    error
+	deleteCalled bool
+
+	deleteVersionErr    error
+	deleteVersionCalled bool
+}
+
+func (m *mockLLMProviderTemplateCRUDRepo) Exists(templateID, orgUUID string) (bool, error) {
+	return m.existsResult, m.existsErr
+}
+
+func (m *mockLLMProviderTemplateCRUDRepo) Create(t *model.LLMProviderTemplate) error {
+	if m.createErr != nil {
+		return m.createErr
+	}
+	m.created = t
+	return nil
+}
+
+func (m *mockLLMProviderTemplateCRUDRepo) ManagedByForHandle(handle, orgUUID string) (string, error) {
+	return m.managedByForHandleResult, m.managedByForHandleErr
+}
+
+func (m *mockLLMProviderTemplateCRUDRepo) Update(t *model.LLMProviderTemplate) error {
+	if m.updateErr != nil {
+		return m.updateErr
+	}
+	m.updated = t
+	return nil
+}
+
+func (m *mockLLMProviderTemplateCRUDRepo) GetGroupID(handle, orgUUID string) (string, error) {
+	return m.getGroupIDResult, m.getGroupIDErr
+}
+
+func (m *mockLLMProviderTemplateCRUDRepo) RenameFamily(baseHandle, orgUUID, name string) error {
+	m.renameFamilyCalled = true
+	m.renameFamilyBase = baseHandle
+	m.renameFamilyOrg = orgUUID
+	m.renameFamilyName = name
+	return m.renameFamilyErr
+}
+
+func (m *mockLLMProviderTemplateCRUDRepo) GetByID(templateID, orgUUID string) (*model.LLMProviderTemplate, error) {
+	if m.getByIDFunc != nil {
+		return m.getByIDFunc(templateID, orgUUID)
+	}
+	return nil, nil
+}
+
+func (m *mockLLMProviderTemplateCRUDRepo) CreateNewVersion(t *model.LLMProviderTemplate) error {
+	if m.createNewVersionErr != nil {
+		return m.createNewVersionErr
+	}
+	m.createdVersion = t
+	return nil
+}
+
+func (m *mockLLMProviderTemplateCRUDRepo) CountVersions(templateID, orgUUID string) (int, error) {
+	return m.countVersionsResult, m.countVersionsErr
+}
+
+func (m *mockLLMProviderTemplateCRUDRepo) ListVersions(templateID, orgUUID string, limit, offset int) ([]*model.LLMProviderTemplate, error) {
+	return m.listVersionsResult, m.listVersionsErr
+}
+
+func (m *mockLLMProviderTemplateCRUDRepo) GetByVersion(templateID, orgUUID, version string) (*model.LLMProviderTemplate, error) {
+	if m.getByVersionFunc != nil {
+		return m.getByVersionFunc(templateID, orgUUID, version)
+	}
+	return nil, nil
+}
+
+func (m *mockLLMProviderTemplateCRUDRepo) SetEnabled(templateID, orgUUID, version string, enabled bool) error {
+	m.setEnabledCalled = true
+	m.setEnabledVersion = version
+	m.setEnabledEnabled = enabled
+	return m.setEnabledErr
+}
+
+func (m *mockLLMProviderTemplateCRUDRepo) CountProvidersUsingTemplate(templateID, orgUUID, version string) (int, error) {
+	m.countProvidersUsingTemplateCalled = true
+	m.countProvidersUsingTemplateVersion = version
+	return m.countProvidersUsingTemplateResult, m.countProvidersUsingTemplateErr
+}
+
+func (m *mockLLMProviderTemplateCRUDRepo) Delete(templateID, orgUUID string) error {
+	m.deleteCalled = true
+	return m.deleteErr
+}
+
+func (m *mockLLMProviderTemplateCRUDRepo) DeleteVersion(templateID, orgUUID, version string) error {
+	m.deleteVersionCalled = true
+	return m.deleteVersionErr
+}
+
+func validTemplateRequest(name string) *api.LLMProviderTemplate {
+	return &api.LLMProviderTemplate{
+		Name:    name,
+		Version: "v1.0",
+	}
+}
+
+// ---- Create ----
+
+func TestLLMProviderTemplateServiceCreate_Success(t *testing.T) {
+	repo := &mockLLMProviderTemplateCRUDRepo{}
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+
+	resp, err := svc.Create("org-1", "alice", validTemplateRequest("My Custom Provider"))
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if resp == nil || !strings.HasPrefix(resp.Id, "my-custom-provider") {
+		t.Fatalf("expected handle to be derived from name, got: %#v", resp)
+	}
+	if repo.created == nil || repo.created.CreatedBy != "alice" {
+		t.Fatalf("expected repo.Create to be called with createdBy, got: %#v", repo.created)
+	}
+	if repo.created.ManagedBy != "customer" {
+		t.Fatalf("expected default managedBy 'customer', got: %q", repo.created.ManagedBy)
+	}
+}
+
+func TestLLMProviderTemplateServiceCreate_RejectsEmptyName(t *testing.T) {
+	repo := &mockLLMProviderTemplateCRUDRepo{}
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+
+	req := validTemplateRequest("")
+	_, err := svc.Create("org-1", "alice", req)
+	if err != constants.ErrInvalidInput {
+		t.Fatalf("expected ErrInvalidInput, got: %v", err)
+	}
+	if repo.created != nil {
+		t.Fatalf("did not expect repository create to be called")
+	}
+}
+
+func TestLLMProviderTemplateServiceCreate_RejectsInvalidVersion(t *testing.T) {
+	repo := &mockLLMProviderTemplateCRUDRepo{}
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+
+	req := validTemplateRequest("My Provider")
+	req.Version = "not-a-version"
+	_, err := svc.Create("org-1", "alice", req)
+	if err != constants.ErrInvalidInput {
+		t.Fatalf("expected ErrInvalidInput, got: %v", err)
+	}
+	if repo.created != nil {
+		t.Fatalf("did not expect repository create to be called")
+	}
+}
+
+func TestLLMProviderTemplateServiceCreate_RejectsReservedManagedBy(t *testing.T) {
+	repo := &mockLLMProviderTemplateCRUDRepo{}
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+
+	wso2 := "wso2"
+	req := validTemplateRequest("My Provider")
+	req.ManagedBy = &wso2
+	_, err := svc.Create("org-1", "alice", req)
+	if err != constants.ErrLLMProviderTemplateManagedByReserved {
+		t.Fatalf("expected ErrLLMProviderTemplateManagedByReserved, got: %v", err)
+	}
+	if repo.created != nil {
+		t.Fatalf("did not expect repository create to be called")
+	}
+}
+
+func TestLLMProviderTemplateServiceCreate_ReturnsConflictForDuplicateHandle(t *testing.T) {
+	repo := &mockLLMProviderTemplateCRUDRepo{existsResult: true}
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+
+	_, err := svc.Create("org-1", "alice", validTemplateRequest("My Provider"))
+	if err != constants.ErrLLMProviderTemplateExists {
+		t.Fatalf("expected ErrLLMProviderTemplateExists, got: %v", err)
+	}
+	if repo.created != nil {
+		t.Fatalf("did not expect repository create to be called")
+	}
+}
+
+// ---- Update ----
+
+func TestLLMProviderTemplateServiceUpdate_RejectsReservedManagedBy(t *testing.T) {
+	repo := &mockLLMProviderTemplateCRUDRepo{}
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+
+	wso2 := "wso2"
+	req := validTemplateRequest("My Provider")
+	req.ManagedBy = &wso2
+	_, err := svc.Update("org-1", "my-provider", "alice", req)
+	if err != constants.ErrLLMProviderTemplateManagedByReserved {
+		t.Fatalf("expected ErrLLMProviderTemplateManagedByReserved, got: %v", err)
+	}
+	if repo.updated != nil {
+		t.Fatalf("did not expect repository update to be called")
+	}
+}
+
+func TestLLMProviderTemplateServiceUpdate_RejectsReadOnlyBuiltin(t *testing.T) {
+	repo := &mockLLMProviderTemplateCRUDRepo{}
+	repo.getByIDFunc = func(templateID, orgUUID string) (*model.LLMProviderTemplate, error) {
+		return &model.LLMProviderTemplate{ID: templateID, OrganizationUUID: orgUUID, ManagedBy: "wso2"}, nil
+	}
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+
+	_, err := svc.Update("org-1", "openai", "alice", validTemplateRequest("OpenAI"))
+	if err != constants.ErrLLMProviderTemplateReadOnly {
+		t.Fatalf("expected ErrLLMProviderTemplateReadOnly, got: %v", err)
+	}
+	if repo.updated != nil {
+		t.Fatalf("did not expect repository update to be called")
+	}
+}
+
+func TestLLMProviderTemplateServiceUpdate_ReturnsNotFoundWhenTemplateMissing(t *testing.T) {
+	repo := &mockLLMProviderTemplateCRUDRepo{}
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+
+	_, err := svc.Update("org-1", "does-not-exist", "alice", validTemplateRequest("Name"))
+	if err != constants.ErrLLMProviderTemplateNotFound {
+		t.Fatalf("expected ErrLLMProviderTemplateNotFound, got: %v", err)
+	}
+}
+
+func TestLLMProviderTemplateServiceUpdate_PreservesOpenAPISpecWhenOmitted(t *testing.T) {
+	repo := &mockLLMProviderTemplateCRUDRepo{}
+	repo.getByIDFunc = func(templateID, orgUUID string) (*model.LLMProviderTemplate, error) {
+		return &model.LLMProviderTemplate{
+			ID:               templateID,
+			OrganizationUUID: orgUUID,
+			ManagedBy:        "customer",
+			OpenAPISpec:      "openapi: 3.0.0",
+			Version:          "v1.0",
+		}, nil
+	}
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+
+	req := validTemplateRequest("Renamed")
+	req.Openapi = nil
+	req.ManagedBy = nil
+	if _, err := svc.Update("org-1", "mistralai", "alice", req); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if repo.updated == nil || repo.updated.OpenAPISpec != "openapi: 3.0.0" {
+		t.Fatalf("expected existing OpenAPI spec to be preserved, got: %#v", repo.updated)
+	}
+	if repo.updated.ManagedBy != "customer" {
+		t.Fatalf("expected existing managedBy to be preserved, got: %q", repo.updated.ManagedBy)
+	}
+}
+
+func TestLLMProviderTemplateServiceUpdate_PropagatesNameToFamily(t *testing.T) {
+	repo := &mockLLMProviderTemplateCRUDRepo{
+		managedByForHandleResult: "customer",
+		getGroupIDResult:     "mistralai",
+	}
+	repo.getByIDFunc = func(templateID, orgUUID string) (*model.LLMProviderTemplate, error) {
+		return &model.LLMProviderTemplate{ID: templateID, OrganizationUUID: orgUUID, Name: "Mistral Updated", Version: "v1.0"}, nil
+	}
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+
+	req := validTemplateRequest("Mistral Updated")
+	resp, err := svc.Update("org-1", "mistralai", "alice", req)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if !repo.renameFamilyCalled || repo.renameFamilyBase != "mistralai" || repo.renameFamilyName != "Mistral Updated" {
+		t.Fatalf("expected RenameFamily to be called with the family base handle and new name, got called=%v base=%q name=%q",
+			repo.renameFamilyCalled, repo.renameFamilyBase, repo.renameFamilyName)
+	}
+	if resp == nil || resp.Name != "Mistral Updated" {
+		t.Fatalf("expected updated template to be returned, got: %#v", resp)
+	}
+}
+
+func TestLLMProviderTemplateServiceUpdate_RejectsMismatchedID(t *testing.T) {
+	repo := &mockLLMProviderTemplateCRUDRepo{managedByForHandleResult: "customer"}
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+
+	req := validTemplateRequest("Name")
+	req.Id = "some-other-handle"
+	_, err := svc.Update("org-1", "mistralai", "alice", req)
+	if err != constants.ErrInvalidInput {
+		t.Fatalf("expected ErrInvalidInput, got: %v", err)
+	}
+}
+
+// ---- CreateVersion ----
+
+func TestLLMProviderTemplateServiceCreateVersion_Success(t *testing.T) {
+	repo := &mockLLMProviderTemplateCRUDRepo{getGroupIDResult: "mistralai"}
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+
+	req := &api.CreateLLMProviderTemplateVersionRequest{Name: "Mistral", Version: "v2.0"}
+	resp, err := svc.CreateVersion("org-1", "mistralai", "test-user", req)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if resp == nil || resp.Version != "v2.0" {
+		t.Fatalf("expected new version v2.0, got: %#v", resp)
+	}
+	if repo.createdVersion == nil || repo.createdVersion.GroupID != "mistralai" {
+		t.Fatalf("expected created version to carry the family base handle, got: %#v", repo.createdVersion)
+	}
+	if repo.createdVersion.ManagedBy != "customer" {
+		t.Fatalf("expected new custom versions to default to managedBy 'customer', got: %q", repo.createdVersion.ManagedBy)
+	}
+}
+
+func TestLLMProviderTemplateServiceCreateVersion_ForkFromBuiltinSetsCustomerManagedBy(t *testing.T) {
+	repo := &mockLLMProviderTemplateCRUDRepo{getGroupIDResult: "mistralai"}
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+
+	wso2 := "wso2"
+	req := &api.CreateLLMProviderTemplateVersionRequest{Name: "Mistral", Version: "v2.0", ManagedBy: &wso2}
+	resp, err := svc.CreateVersion("org-1", "mistralai", "test-user", req)
+	if err != nil {
+		t.Fatalf("expected no error when forking a built-in, got: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected a response, got nil")
+	}
+	if repo.createdVersion == nil {
+		t.Fatal("expected CreateNewVersion to be called")
+	}
+	if repo.createdVersion.ManagedBy != constants.PolicyManagedByCustomer {
+		t.Fatalf("expected forked version to have managedBy='customer', got: %q", repo.createdVersion.ManagedBy)
+	}
+}
+
+func TestLLMProviderTemplateServiceCreateVersion_NotFoundWhenFamilyMissing(t *testing.T) {
+	repo := &mockLLMProviderTemplateCRUDRepo{getGroupIDResult: ""}
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+
+	req := &api.CreateLLMProviderTemplateVersionRequest{Name: "Mistral", Version: "v2.0"}
+	_, err := svc.CreateVersion("org-1", "does-not-exist", "test-user", req)
+	if err != constants.ErrLLMProviderTemplateNotFound {
+		t.Fatalf("expected ErrLLMProviderTemplateNotFound, got: %v", err)
+	}
+}
+
+func TestLLMProviderTemplateServiceCreateVersion_ConflictWhenVersionExists(t *testing.T) {
+	repo := &mockLLMProviderTemplateCRUDRepo{
+		getGroupIDResult: "mistralai",
+		createNewVersionErr: constants.ErrLLMProviderTemplateVersionExists,
+	}
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+
+	req := &api.CreateLLMProviderTemplateVersionRequest{Name: "Mistral", Version: "v1.0"}
+	_, err := svc.CreateVersion("org-1", "mistralai", "test-user", req)
+	if err != constants.ErrLLMProviderTemplateVersionExists {
+		t.Fatalf("expected ErrLLMProviderTemplateVersionExists, got: %v", err)
+	}
+}
+
+func TestLLMProviderTemplateServiceCreateVersion_RejectsInvalidVersionFormat(t *testing.T) {
+	repo := &mockLLMProviderTemplateCRUDRepo{getGroupIDResult: "mistralai"}
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+
+	req := &api.CreateLLMProviderTemplateVersionRequest{Name: "Mistral", Version: "2.0"}
+	_, err := svc.CreateVersion("org-1", "mistralai", "test-user", req)
+	if err != constants.ErrInvalidInput {
+		t.Fatalf("expected ErrInvalidInput, got: %v", err)
+	}
+	if repo.createdVersion != nil {
+		t.Fatalf("did not expect CreateNewVersion to be called")
+	}
+}
+
+// ---- ListVersions / GetVersion ----
+
+func TestLLMProviderTemplateServiceListVersions_NotFoundWhenNoVersions(t *testing.T) {
+	repo := &mockLLMProviderTemplateCRUDRepo{countVersionsResult: 0}
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+
+	_, err := svc.ListVersions("org-1", "does-not-exist", 10, 0)
+	if err != constants.ErrLLMProviderTemplateNotFound {
+		t.Fatalf("expected ErrLLMProviderTemplateNotFound, got: %v", err)
+	}
+}
+
+func TestLLMProviderTemplateServiceListVersions_Success(t *testing.T) {
+	repo := &mockLLMProviderTemplateCRUDRepo{
+		countVersionsResult: 2,
+		listVersionsResult: []*model.LLMProviderTemplate{
+			{ID: "mistralai", Version: "v1.0"},
+			{ID: "mistralai-v2-0", Version: "v2.0"},
+		},
+	}
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+
+	resp, err := svc.ListVersions("org-1", "mistralai", 10, 0)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if resp == nil || resp.Count != 2 || resp.Pagination.Total != 2 {
+		t.Fatalf("expected two versions in response, got: %#v", resp)
+	}
+}
+
+func TestLLMProviderTemplateServiceGetVersion_NotFound(t *testing.T) {
+	repo := &mockLLMProviderTemplateCRUDRepo{
+		getByVersionFunc: func(templateID, orgUUID, version string) (*model.LLMProviderTemplate, error) {
+			return nil, nil
+		},
+	}
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+
+	_, err := svc.GetVersion("org-1", "mistralai", "v9.0")
+	if err != constants.ErrLLMProviderTemplateNotFound {
+		t.Fatalf("expected ErrLLMProviderTemplateNotFound, got: %v", err)
+	}
+}
+
+func TestLLMProviderTemplateServiceGetVersion_NormalizesVersionCasing(t *testing.T) {
+	var receivedVersion string
+	repo := &mockLLMProviderTemplateCRUDRepo{
+		getByVersionFunc: func(templateID, orgUUID, version string) (*model.LLMProviderTemplate, error) {
+			receivedVersion = version
+			return &model.LLMProviderTemplate{ID: templateID, Version: version}, nil
+		},
+	}
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+
+	resp, err := svc.GetVersion("org-1", "mistralai", "V2.0")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if receivedVersion != "v2.0" {
+		t.Fatalf("expected version to be normalized to v2.0, got: %q", receivedVersion)
+	}
+	if resp == nil || resp.Version != "v2.0" {
+		t.Fatalf("expected response to carry normalized version, got: %#v", resp)
+	}
+}
+
+// ---- SetVersionEnabled ----
+
+func TestLLMProviderTemplateServiceSetVersionEnabled_Success(t *testing.T) {
+	repo := &mockLLMProviderTemplateCRUDRepo{
+		getByVersionFunc: func(templateID, orgUUID, version string) (*model.LLMProviderTemplate, error) {
+			return &model.LLMProviderTemplate{ID: templateID, Version: version, Enabled: false}, nil
+		},
+	}
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+
+	resp, err := svc.SetVersionEnabled("org-1", "mistralai", "v1.0", false)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if !repo.setEnabledCalled || repo.setEnabledEnabled {
+		t.Fatalf("expected SetEnabled to be called with enabled=false, got called=%v enabled=%v", repo.setEnabledCalled, repo.setEnabledEnabled)
+	}
+	if resp == nil || resp.Enabled == nil || *resp.Enabled {
+		t.Fatalf("expected response to reflect disabled state, got: %#v", resp)
+	}
+}
+
+func TestLLMProviderTemplateServiceSetVersionEnabled_NotFound(t *testing.T) {
+	repo := &mockLLMProviderTemplateCRUDRepo{setEnabledErr: sql.ErrNoRows}
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+
+	_, err := svc.SetVersionEnabled("org-1", "does-not-exist", "v1.0", true)
+	if err != constants.ErrLLMProviderTemplateNotFound {
+		t.Fatalf("expected ErrLLMProviderTemplateNotFound, got: %v", err)
+	}
+}
+
+func TestLLMProviderTemplateServiceSetVersionEnabled_DisableBlocksWhenInUse(t *testing.T) {
+	repo := &mockLLMProviderTemplateCRUDRepo{
+		countProvidersUsingTemplateResult: 1,
+	}
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+
+	_, err := svc.SetVersionEnabled("org-1", "mistralai", "v1.0", false)
+	if err != constants.ErrLLMProviderTemplateInUse {
+		t.Fatalf("expected ErrLLMProviderTemplateInUse, got: %v", err)
+	}
+	if repo.countProvidersUsingTemplateVersion != "v1.0" {
+		t.Fatalf("expected usage check scoped to the specific version, got: %q", repo.countProvidersUsingTemplateVersion)
+	}
+	if repo.setEnabledCalled {
+		t.Fatalf("did not expect SetEnabled to be called while version is in use")
+	}
+}
+
+func TestLLMProviderTemplateServiceSetVersionEnabled_EnableIgnoresUsage(t *testing.T) {
+	repo := &mockLLMProviderTemplateCRUDRepo{
+		countProvidersUsingTemplateResult: 5,
+		getByVersionFunc: func(templateID, orgUUID, version string) (*model.LLMProviderTemplate, error) {
+			return &model.LLMProviderTemplate{ID: templateID, Version: version, Enabled: true}, nil
+		},
+	}
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+
+	resp, err := svc.SetVersionEnabled("org-1", "mistralai", "v1.0", true)
+	if err != nil {
+		t.Fatalf("expected no error on enable regardless of usage, got: %v", err)
+	}
+	if repo.countProvidersUsingTemplateCalled {
+		t.Fatalf("did not expect usage check to be called when enabling")
+	}
+	if resp == nil || resp.Enabled == nil || !*resp.Enabled {
+		t.Fatalf("expected response to reflect enabled state, got: %#v", resp)
+	}
+}
+
+// ---- Delete (whole template family) ----
+
+func TestLLMProviderTemplateServiceDelete_BlocksReadOnlyBuiltin(t *testing.T) {
+	repo := &mockLLMProviderTemplateCRUDRepo{managedByForHandleResult: "wso2"}
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+
+	err := svc.Delete("org-1", "openai", "alice")
+	if err != constants.ErrLLMProviderTemplateReadOnly {
+		t.Fatalf("expected ErrLLMProviderTemplateReadOnly, got: %v", err)
+	}
+	if repo.deleteCalled || repo.countProvidersUsingTemplateCalled {
+		t.Fatalf("did not expect usage check or delete to be called for a read-only template")
+	}
+}
+
+func TestLLMProviderTemplateServiceDelete_NotFound(t *testing.T) {
+	repo := &mockLLMProviderTemplateCRUDRepo{managedByForHandleResult: ""}
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+
+	err := svc.Delete("org-1", "does-not-exist", "alice")
+	if err != constants.ErrLLMProviderTemplateNotFound {
+		t.Fatalf("expected ErrLLMProviderTemplateNotFound, got: %v", err)
+	}
+}
+
+func TestLLMProviderTemplateServiceDelete_BlocksWhenInUse(t *testing.T) {
+	repo := &mockLLMProviderTemplateCRUDRepo{
+		managedByForHandleResult:           "customer",
+		countProvidersUsingTemplateResult: 2,
+	}
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+
+	err := svc.Delete("org-1", "mistralai", "alice")
+	if err != constants.ErrLLMProviderTemplateInUse {
+		t.Fatalf("expected ErrLLMProviderTemplateInUse, got: %v", err)
+	}
+	if repo.countProvidersUsingTemplateVersion != "" {
+		t.Fatalf("expected usage check to span the whole family (empty version), got: %q", repo.countProvidersUsingTemplateVersion)
+	}
+	if repo.deleteCalled {
+		t.Fatalf("did not expect repository delete to be called while template is in use")
+	}
+}
+
+func TestLLMProviderTemplateServiceDelete_Success(t *testing.T) {
+	repo := &mockLLMProviderTemplateCRUDRepo{
+		managedByForHandleResult:           "customer",
+		countProvidersUsingTemplateResult: 0,
+	}
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+
+	if err := svc.Delete("org-1", "mistralai", "alice"); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if !repo.deleteCalled {
+		t.Fatalf("expected repository delete to be called")
+	}
+}
+
+// ---- DeleteVersion ----
+
+func TestLLMProviderTemplateServiceDeleteVersion_NotFoundWhenVersionMissing(t *testing.T) {
+	repo := &mockLLMProviderTemplateCRUDRepo{
+		getByVersionFunc: func(templateID, orgUUID, version string) (*model.LLMProviderTemplate, error) {
+			return nil, nil
+		},
+	}
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+
+	err := svc.DeleteVersion("org-1", "mistralai", "v9.0")
+	if err != constants.ErrLLMProviderTemplateNotFound {
+		t.Fatalf("expected ErrLLMProviderTemplateNotFound, got: %v", err)
+	}
+}
+
+func TestLLMProviderTemplateServiceDeleteVersion_BlocksReadOnlyBuiltin(t *testing.T) {
+	repo := &mockLLMProviderTemplateCRUDRepo{
+		getByVersionFunc: func(templateID, orgUUID, version string) (*model.LLMProviderTemplate, error) {
+			return &model.LLMProviderTemplate{ID: templateID, Version: version, ManagedBy: "wso2"}, nil
+		},
+	}
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+
+	err := svc.DeleteVersion("org-1", "openai", "v1.0")
+	if err != constants.ErrLLMProviderTemplateReadOnly {
+		t.Fatalf("expected ErrLLMProviderTemplateReadOnly, got: %v", err)
+	}
+	if repo.deleteVersionCalled {
+		t.Fatalf("did not expect repository delete to be called for a read-only template version")
+	}
+}
+
+func TestLLMProviderTemplateServiceDeleteVersion_BlocksWhenInUse(t *testing.T) {
+	repo := &mockLLMProviderTemplateCRUDRepo{
+		getByVersionFunc: func(templateID, orgUUID, version string) (*model.LLMProviderTemplate, error) {
+			return &model.LLMProviderTemplate{ID: templateID, Version: version, ManagedBy: "customer"}, nil
+		},
+		countProvidersUsingTemplateResult: 1,
+	}
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+
+	err := svc.DeleteVersion("org-1", "mistralai-v2-0", "v2.0")
+	if err != constants.ErrLLMProviderTemplateInUse {
+		t.Fatalf("expected ErrLLMProviderTemplateInUse, got: %v", err)
+	}
+	if repo.countProvidersUsingTemplateVersion != "v2.0" {
+		t.Fatalf("expected usage check to be scoped to the specific version, got: %q", repo.countProvidersUsingTemplateVersion)
+	}
+	if repo.deleteVersionCalled {
+		t.Fatalf("did not expect repository delete to be called while version is in use")
+	}
+}
+
+func TestLLMProviderTemplateServiceDeleteVersion_Success(t *testing.T) {
+	repo := &mockLLMProviderTemplateCRUDRepo{
+		getByVersionFunc: func(templateID, orgUUID, version string) (*model.LLMProviderTemplate, error) {
+			return &model.LLMProviderTemplate{ID: templateID, Version: version, ManagedBy: "customer"}, nil
+		},
+		countProvidersUsingTemplateResult: 0,
+	}
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+
+	if err := svc.DeleteVersion("org-1", "mistralai-v2-0", "v2.0"); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if !repo.deleteVersionCalled {
+		t.Fatalf("expected repository DeleteVersion to be called")
+	}
+}

--- a/platform-api/src/internal/service/llm_template_seeder.go
+++ b/platform-api/src/internal/service/llm_template_seeder.go
@@ -20,7 +20,6 @@ package service
 import (
 	"fmt"
 
-	"platform-api/src/internal/constants"
 	"platform-api/src/internal/model"
 	"platform-api/src/internal/repository"
 )
@@ -78,6 +77,7 @@ func (s *LLMTemplateSeeder) SeedForOrg(orgUUID string) error {
 			if current != nil {
 				current.Name = tpl.Name
 				current.Description = tpl.Description
+				current.ManagedBy = tpl.ManagedBy
 				current.Metadata = tpl.Metadata
 				current.PromptTokens = tpl.PromptTokens
 				current.CompletionTokens = tpl.CompletionTokens
@@ -97,9 +97,11 @@ func (s *LLMTemplateSeeder) SeedForOrg(orgUUID string) error {
 		toCreate := &model.LLMProviderTemplate{
 			OrganizationUUID: orgUUID,
 			ID:               tpl.ID,
+			GroupID:   tpl.GroupID,
+			Version:          tpl.Version,
 			Name:             tpl.Name,
 			Description:      tpl.Description,
-			ManagedBy:        constants.PolicyManagedByWSO2,
+			ManagedBy:        tpl.ManagedBy,
 			CreatedBy:        tpl.CreatedBy,
 			Metadata:         tpl.Metadata,
 			PromptTokens:     tpl.PromptTokens,

--- a/platform-api/src/internal/service/llm_test.go
+++ b/platform-api/src/internal/service/llm_test.go
@@ -1132,7 +1132,7 @@ func TestLLMProviderServiceCreateAllowsAggregatorTemplate(t *testing.T) {
 	}
 	templateRepo := &mockLLMTemplateRepo{
 		getByIDFunc: func(templateID, orgUUID string) (*model.LLMProviderTemplate, error) {
-			return &model.LLMProviderTemplate{UUID: "tpl-agg", ID: "awsbedrock", CreatedAt: now, UpdatedAt: now}, nil
+			return &model.LLMProviderTemplate{UUID: "tpl-agg", ID: "awsbedrock", Enabled: true, CreatedAt: now, UpdatedAt: now}, nil
 		},
 	}
 	orgRepo := &mockOrganizationRepo{org: &model.Organization{ID: "org-1"}}
@@ -1175,7 +1175,7 @@ func TestLLMProviderServiceCreateMigratesLegacyPolicies(t *testing.T) {
 	}
 	templateRepo := &mockLLMTemplateRepo{
 		getByIDFunc: func(templateID, orgUUID string) (*model.LLMProviderTemplate, error) {
-			return &model.LLMProviderTemplate{UUID: "tpl-openai", ID: "openai", CreatedAt: now, UpdatedAt: now}, nil
+			return &model.LLMProviderTemplate{UUID: "tpl-openai", ID: "openai", Enabled: true, CreatedAt: now, UpdatedAt: now}, nil
 		},
 	}
 	orgRepo := &mockOrganizationRepo{org: &model.Organization{ID: "org-1"}}

--- a/platform-api/src/internal/utils/llm_provider_template_loader.go
+++ b/platform-api/src/internal/utils/llm_provider_template_loader.go
@@ -130,7 +130,10 @@ func LoadLLMProviderTemplatesFromDirectory(dirPath string) ([]*model.LLMProvider
 			seedVersion = "v1.0"
 		}
 		baseHandle := strings.TrimSpace(doc.Metadata.Name)
-		handle := baseHandle + "-" + strings.ReplaceAll(strings.ToLower(seedVersion), ".", "-")
+		handle := baseHandle
+		if managedBy != "wso2" || strings.ToLower(seedVersion) != "v1.0" {
+			handle = baseHandle + "-" + strings.ReplaceAll(strings.ToLower(seedVersion), ".", "-")
+		}
 
 		res = append(res, &model.LLMProviderTemplate{
 			ID:             handle,

--- a/platform-api/src/internal/utils/llm_provider_template_loader.go
+++ b/platform-api/src/internal/utils/llm_provider_template_loader.go
@@ -54,6 +54,8 @@ type llmProviderTemplateYAML struct {
 	} `yaml:"metadata"`
 	Spec struct {
 		DisplayName      string                                   `yaml:"displayName"`
+		ManagedBy        string                                   `yaml:"managedBy"`
+		Version          string                                   `yaml:"version"`
 		Metadata         *llmProviderTemplateMetadataYAML         `yaml:"metadata"`
 		PromptTokens     *extractionIdentifierYAML                `yaml:"promptTokens"`
 		CompletionTokens *extractionIdentifierYAML                `yaml:"completionTokens"`
@@ -118,9 +120,24 @@ func LoadLLMProviderTemplatesFromDirectory(dirPath string) ([]*model.LLMProvider
 			return nil, fmt.Errorf("template file %s is missing spec.displayName", filePath)
 		}
 
+		managedBy := strings.TrimSpace(doc.Spec.ManagedBy)
+		if managedBy == "" {
+			managedBy = "wso2"
+		}
+
+		seedVersion := strings.TrimSpace(doc.Spec.Version)
+		if seedVersion == "" {
+			seedVersion = "v1.0"
+		}
+		baseHandle := strings.TrimSpace(doc.Metadata.Name)
+		handle := baseHandle + "-" + strings.ReplaceAll(strings.ToLower(seedVersion), ".", "-")
+
 		res = append(res, &model.LLMProviderTemplate{
-			ID:               doc.Metadata.Name,
-			Name:             doc.Spec.DisplayName,
+			ID:             handle,
+			GroupID: baseHandle,
+			Version:        seedVersion,
+			Name:           doc.Spec.DisplayName,
+			ManagedBy:      managedBy,
 			Metadata:         mapTemplateMetadata(doc.Spec.Metadata),
 			PromptTokens:     mapExtractionIdentifier(doc.Spec.PromptTokens),
 			CompletionTokens: mapExtractionIdentifier(doc.Spec.CompletionTokens),

--- a/platform-api/src/resources/default-llm-provider-templates/anthropic-template.yaml
+++ b/platform-api/src/resources/default-llm-provider-templates/anthropic-template.yaml
@@ -22,6 +22,8 @@ metadata:
   name: anthropic
 spec:
   displayName: Anthropic
+  managedBy: wso2
+  version: v1.0
   metadata:
     endpointUrl: https://api.anthropic.com
     auth:

--- a/platform-api/src/resources/default-llm-provider-templates/awsbedrock-template.yaml
+++ b/platform-api/src/resources/default-llm-provider-templates/awsbedrock-template.yaml
@@ -22,6 +22,8 @@ metadata:
   name: awsbedrock
 spec:
   displayName: AWS Bedrock
+  managedBy: wso2
+  version: v1.0
   metadata:
     logoUrl: https://raw.githubusercontent.com/nomadxd/openapi-connectors/main/openapi/aws.bedrock/icon.png
     openapiSpecUrl: https://raw.githubusercontent.com/nomadxd/openapi-connectors/main/openapi/aws.bedrock/openapi.yaml

--- a/platform-api/src/resources/default-llm-provider-templates/azureaifoundry-template.yaml
+++ b/platform-api/src/resources/default-llm-provider-templates/azureaifoundry-template.yaml
@@ -22,6 +22,8 @@ metadata:
   name: azureai-foundry
 spec:
   displayName: Azure AI Foundry
+  managedBy: wso2
+  version: v1.0
   metadata:
     auth:
       type: apiKey

--- a/platform-api/src/resources/default-llm-provider-templates/azureopenai-template.yaml
+++ b/platform-api/src/resources/default-llm-provider-templates/azureopenai-template.yaml
@@ -22,6 +22,8 @@ metadata:
   name: azure-openai
 spec:
   displayName: Azure OpenAI
+  managedBy: wso2
+  version: v1.0
   metadata:
     auth:
       type: apiKey

--- a/platform-api/src/resources/default-llm-provider-templates/gemini-template.yaml
+++ b/platform-api/src/resources/default-llm-provider-templates/gemini-template.yaml
@@ -22,6 +22,8 @@ metadata:
   name: gemini
 spec:
   displayName: Gemini
+  managedBy: wso2
+  version: v1.0
   metadata:
     endpointUrl: https://generativelanguage.googleapis.com
     auth:

--- a/platform-api/src/resources/default-llm-provider-templates/mistral-template.yaml
+++ b/platform-api/src/resources/default-llm-provider-templates/mistral-template.yaml
@@ -22,6 +22,8 @@ metadata:
   name: mistralai
 spec:
   displayName: Mistral
+  managedBy: wso2
+  version: v1.0
   metadata:
     endpointUrl: https://api.mistral.ai
     auth:

--- a/platform-api/src/resources/default-llm-provider-templates/openai-template.yaml
+++ b/platform-api/src/resources/default-llm-provider-templates/openai-template.yaml
@@ -22,6 +22,8 @@ metadata:
   name: openai
 spec:
   displayName: OpenAI
+  managedBy: wso2
+  version: v1.0
   metadata:
     endpointUrl: https://api.openai.com/v1
     auth:

--- a/platform-api/src/resources/openapi.yaml
+++ b/platform-api/src/resources/openapi.yaml
@@ -2291,6 +2291,16 @@ paths:
             type: integer
             minimum: 0
             default: 0
+        - name: versions
+          in: query
+          description: |
+            Which versions to include. The default ("latest") returns one entry
+            per template — its latest version, for the catalog. Use "all" to
+            return every version row across all templates.
+          schema:
+            type: string
+            enum: [latest, all]
+            default: latest
       responses:
         '200':
           description: List of LLM provider templates
@@ -2338,7 +2348,10 @@ paths:
 
     put:
       summary: Update an existing LLM provider template
-      description: Update an existing LLM provider template configuration.
+      description: |
+        Update the latest version of a template in place (name, description, and
+        other configuration). This does NOT create a new version — use
+        POST /llm-provider-templates/{id}/versions to create a new version.
       operationId: updateLLMProviderTemplate
       security:
         - OAuth2Security:
@@ -2407,6 +2420,237 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /llm-provider-templates/{id}/versions:
+    get:
+      summary: List versions of an LLM provider template
+      description: List all immutable versions of a template, newest first.
+      operationId: listLLMProviderTemplateVersions
+      security:
+        - OAuth2Security:
+            - ap:llm_template:read
+            - ap:llm_template:manage
+      tags:
+        - LLM Provider Templates
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Unique identifier for the LLM provider template
+          schema:
+            type: string
+          example: openai
+        - name: limit
+          in: query
+          description: Maximum number of versions to return
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+        - name: offset
+          in: query
+          description: Number of versions to skip
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+      responses:
+        '200':
+          description: List of template versions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LLMProviderTemplateListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+    post:
+      summary: Create a new version of an LLM provider template
+      description: |
+        Create a new version of an existing template. The version (e.g. v2.0)
+        must be supplied in the body, match the v<major>.<minor> pattern, and be
+        unique for the template. The new version becomes the latest.
+
+        The template family is identified by the path parameter; the new version's
+        handle is computed server-side from the family handle and the supplied version.
+      operationId: createLLMProviderTemplateVersion
+      security:
+        - OAuth2Security:
+            - ap:llm_template:create
+            - ap:llm_template:manage
+      tags:
+        - LLM Provider Templates
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Unique identifier for the LLM provider template
+          schema:
+            type: string
+          example: openai
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateLLMProviderTemplateVersionRequest'
+      responses:
+        '201':
+          description: New version created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LLMProviderTemplate'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /llm-provider-templates/{id}/versions/{version}:
+    get:
+      summary: Get a specific version of an LLM provider template
+      description: Retrieve the complete configuration for a specific immutable version.
+      operationId: getLLMProviderTemplateVersion
+      security:
+        - OAuth2Security:
+            - ap:llm_template:read
+            - ap:llm_template:manage
+      tags:
+        - LLM Provider Templates
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Unique identifier for the LLM provider template
+          schema:
+            type: string
+          example: openai
+        - name: version
+          in: path
+          required: true
+          description: Version to retrieve (e.g. v2.0). Matched case-insensitively.
+          schema:
+            type: string
+          example: v2.0
+      responses:
+        '200':
+          description: LLM provider template version details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LLMProviderTemplate'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+    patch:
+      summary: Enable or disable a specific version of an LLM provider template
+      description: |
+        Toggle whether a version is offered when creating providers. Disabled
+        versions stay in the catalog but are hidden from the provider picker.
+      operationId: setLLMProviderTemplateVersionEnabled
+      security:
+        - OAuth2Security:
+            - ap:llm_template:manage
+      tags:
+        - LLM Provider Templates
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Unique identifier for the LLM provider template
+          schema:
+            type: string
+          example: openai
+        - name: version
+          in: path
+          required: true
+          description: Version to toggle (e.g. v1.0). Matched case-insensitively.
+          schema:
+            type: string
+          example: v1.0
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - enabled
+              properties:
+                enabled:
+                  type: boolean
+                  example: false
+      responses:
+        '200':
+          description: Updated template version
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LLMProviderTemplate'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+    delete:
+      summary: Delete a specific version of an LLM provider template
+      description: |
+        Delete a single version. If it was the only version the template is
+        removed; otherwise the newest remaining version becomes the latest.
+      operationId: deleteLLMProviderTemplateVersion
+      security:
+        - OAuth2Security:
+            - ap:llm_template:delete
+            - ap:llm_template:manage
+      tags:
+        - LLM Provider Templates
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Unique identifier for the LLM provider template
+          schema:
+            type: string
+          example: openai
+        - name: version
+          in: path
+          required: true
+          description: Version to delete (e.g. v2.0). Matched case-insensitively.
+          schema:
+            type: string
+          example: v2.0
+      responses:
+        '204':
+          description: Version deleted
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/InternalServerError'
 
@@ -8644,17 +8888,37 @@ components:
       required:
         - id
         - name
+        - version
       properties:
         id:
           type: string
           description: Unique handle for the template
+          maxLength: 40
+          example: openai
+        groupId:
+          type: string
+          description: |
+            Stable identifier shared by every version of a template family
+            (defaults to the first version's handle). Read-only.
+          readOnly: true
+          maxLength: 40
           example: openai
         name:
           type: string
           description: Human-readable LLM Template name
           minLength: 1
-          maxLength: 253
+          maxLength: 255
           example: OpenAI
+        managedBy:
+          type: string
+          description: |
+            Identifies who manages the template. Built-in templates use 'wso2';
+            custom templates default to 'customer' and may be set to any value.
+            Optional on create/update — the server defaults it to 'customer' when
+            omitted, so a request/YAML without a managedBy is accepted.
+          default: customer
+          maxLength: 255
+          example: wso2
         description:
           type: string
           description: Description of the LLM provider template
@@ -8664,7 +8928,50 @@ components:
           type: string
           description: Username of the creator
           readOnly: true
+          maxLength: 200
           example: jane.doe
+        updatedBy:
+          type: string
+          description: Username of the last user to update the template
+          readOnly: true
+          maxLength: 200
+          example: jane.doe
+        version:
+          type: string
+          description: |
+            Content version, e.g. v1.0. Required. A new template starts at v1.0;
+            editing updates that version in place. Supply a new unique version
+            only when creating a new version via
+            POST /llm-provider-templates/{id}/versions.
+          pattern: '^[vV]\d+\.\d+$'
+          maxLength: 30
+          example: v1.0
+        isLatest:
+          type: boolean
+          description: Whether this is the latest version of the template.
+          readOnly: true
+          example: true
+        enabled:
+          type: boolean
+          description: |
+            Whether this version is offered when creating providers. Disabled
+            versions stay in the catalog but are hidden from the provider picker.
+            Response-only: create/update default new versions to enabled; toggle
+            via PATCH /llm-provider-templates/{id}/versions/{version}.
+          readOnly: true
+          example: true
+        openapi:
+          type: string
+          description: |
+            OpenAPI specification content (JSON or YAML) for the provider, when
+            uploaded/pasted. Use metadata.openapiSpecUrl instead to reference the
+            spec by URL.
+          example: |
+            openapi: 3.0.3
+            info:
+              title: Provider API
+              version: v1.0
+            paths: {}
         metadata:
           $ref: '#/components/schemas/LLMProviderTemplateMetadata'
         promptTokens:
@@ -8694,21 +9001,103 @@ components:
           readOnly: true
           example: "2023-10-12T10:30:00Z"
 
+    CreateLLMProviderTemplateVersionRequest:
+      type: object
+      required:
+        - name
+        - version
+      properties:
+        name:
+          type: string
+          description: Human-readable LLM Template name
+          minLength: 1
+          maxLength: 255
+          example: OpenAI
+        version:
+          type: string
+          description: New version identifier, e.g. v2.0. Must be unique for this template.
+          pattern: '^[vV]\d+\.\d+$'
+          maxLength: 30
+          example: v2.0
+        managedBy:
+          type: string
+          description: |
+            Identifies who manages the template. Custom templates default to 'customer'.
+          default: customer
+          maxLength: 255
+          example: customer
+        description:
+          type: string
+          description: Description of the LLM provider template
+          maxLength: 1023
+          example: Default OpenAI template
+        openapi:
+          type: string
+          description: |
+            OpenAPI specification content (JSON or YAML) for the provider, when
+            uploaded/pasted. Use metadata.openapiSpecUrl instead to reference the
+            spec by URL.
+        metadata:
+          $ref: '#/components/schemas/LLMProviderTemplateMetadata'
+        promptTokens:
+          $ref: '#/components/schemas/ExtractionIdentifier'
+        completionTokens:
+          $ref: '#/components/schemas/ExtractionIdentifier'
+        totalTokens:
+          $ref: '#/components/schemas/ExtractionIdentifier'
+        remainingTokens:
+          $ref: '#/components/schemas/ExtractionIdentifier'
+        requestModel:
+          $ref: '#/components/schemas/ExtractionIdentifier'
+        responseModel:
+          $ref: '#/components/schemas/ExtractionIdentifier'
+        resourceMappings:
+          $ref: '#/components/schemas/LLMProviderTemplateResourceMappings'
+
     LLMProviderTemplateListItem:
       type: object
       properties:
         id:
           type: string
           example: openai
+        groupId:
+          type: string
+          description: |
+            Stable identifier shared by every version of a template family
+            (defaults to the first version's handle). Read-only.
+          readOnly: true
+          maxLength: 40
+          example: openai
         name:
           type: string
           example: OpenAI
+        managedBy:
+          type: string
+          description: Who manages the template ('wso2' for built-in, otherwise custom-defined).
+          example: wso2
         description:
           type: string
           example: Default OpenAI template
         createdBy:
           type: string
           example: jane.doe
+        version:
+          type: string
+          description: Content version, matching the v<major>.<minor> pattern (e.g. v1.0, v2.0).
+          example: v1.0
+        isLatest:
+          type: boolean
+          description: Whether this is the latest version of the template.
+          example: true
+        enabled:
+          type: boolean
+          description: Whether this version is offered when creating providers.
+          example: true
+        logoUrl:
+          type: string
+          format: uri
+          description: URL of the provider logo
+          example: https://cdn.example.com/logos/openai.svg
         createdAt:
           type: string
           format: date-time

--- a/platform-api/src/resources/openapi.yaml
+++ b/platform-api/src/resources/openapi.yaml
@@ -2612,6 +2612,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/InternalServerError'
 

--- a/portals/ai-workspace/cypress/e2e/001-providers/001-provider-and-proxy.cy.js
+++ b/portals/ai-workspace/cypress/e2e/001-providers/001-provider-and-proxy.cy.js
@@ -145,17 +145,18 @@ describe('AI Workspace - OpenAI provider and proxy lifecycle', () => {
     cy.get('[data-cyid="add-provider-button"]')
       .should('not.be.disabled')
       .click();
-    cy.wait('@createProvider').its('response.statusCode').should('be.oneOf', [200, 201]);
-
-    cy.location('pathname', { timeout: 30000 })
-      .should(
-        'match',
-        new RegExp(`^/organizations/${orgHandle}/service-provider/[^/]+$`)
-      )
-      .then((pathname) => {
-        createdProviderId = pathname.split('/').pop() || '';
-        expect(createdProviderId).to.not.equal('');
-      });
+    // Take the id from the create response, not the URL: the create flow issues
+    // POST /secrets before POST /llm-providers, so the redirect lands a beat
+    // after the click and a URL scrape can race onto the transient "new" route.
+    cy.wait('@createProvider').then(({ response }) => {
+      expect(response?.statusCode).to.be.oneOf([200, 201]);
+      createdProviderId = response?.body?.id || providerId;
+      expect(createdProviderId).to.not.equal('');
+    });
+    cy.location('pathname', { timeout: 30000 }).should(
+      'match',
+      new RegExp(`^/organizations/${orgHandle}/service-provider/(?!new$)[^/]+$`)
+    );
     cy.contains(providerName, { timeout: 30000 }).should('be.visible');
 
     cy.contains('button', 'Create App LLM Proxy', { timeout: 30000 })

--- a/portals/ai-workspace/cypress/e2e/001-providers/001-provider-and-proxy.cy.js
+++ b/portals/ai-workspace/cypress/e2e/001-providers/001-provider-and-proxy.cy.js
@@ -31,6 +31,10 @@ describe('AI Workspace - OpenAI provider and proxy lifecycle', () => {
   let authToken = '';
   let organizationId = '';
 
+  before(() => {
+    cy.sweepE2EProviders();
+  });
+
   beforeEach(() => {
     cy.login();
     cy.request({
@@ -62,13 +66,13 @@ describe('AI Workspace - OpenAI provider and proxy lifecycle', () => {
   });
 
   afterEach(() => {
-    if (!authToken || !organizationId) {
-      return;
-    }
+    const targeted = (authToken && organizationId)
+      ? deleteLinkedProxies(authToken, organizationId, createdProviderId)
+          .then(() => deleteProjectByName(authToken, projectName, cleanupProjectName))
+          .then(() => deleteProvider(authToken, organizationId, createdProviderId))
+      : cy.wrap(null);
 
-    return deleteLinkedProxies(authToken, organizationId, createdProviderId)
-      .then(() => deleteProjectByName(authToken, projectName, cleanupProjectName))
-      .then(() => deleteProvider(authToken, organizationId, createdProviderId));
+    return targeted.then(() => cy.sweepE2EProviders(authToken, organizationId));
   });
 
   it('creates and deletes an OpenAI provider and app llm proxy using only the UI', () => {
@@ -102,9 +106,21 @@ describe('AI Workspace - OpenAI provider and proxy lifecycle', () => {
       .should('be.visible')
       .click();
 
-    cy.get('[data-cyid="provider-template-openai-card"]', {
+    cy.get('[data-cyid^="provider-template-openai"]', {
       timeout: 30000,
     }).should('be.visible').click();
+
+    cy.get('body', { timeout: 30000 }).should(($body) => {
+      expect(
+        $body.find('[data-cyid="provider-name-input"] input:visible').length > 0 ||
+          $body.find('[data-cyid="template-version-continue-button"]').length > 0
+      ).to.eq(true);
+    });
+    cy.get('body').then(($body) => {
+      if ($body.find('[data-cyid="template-version-continue-button"]').length) {
+        selectTemplateVersionAndContinue();
+      }
+    });
 
     cy.get('[data-cyid="provider-name-input"] input:visible')
       .should('be.visible')
@@ -184,6 +200,9 @@ describe('AI Workspace - OpenAI provider and proxy lifecycle', () => {
 });
 
 function deleteLinkedProxies(authToken, organizationId, providerId) {
+  if (!providerId) {
+    return cy.wrap(null);
+  }
   return requestWithAuth(authToken, {
     url: `/api-proxy/api/v0.9/llm-providers/${encodeURIComponent(providerId)}/llm-proxies?organizationId=${encodeURIComponent(organizationId)}`,
     failOnStatusCode: false,
@@ -261,6 +280,9 @@ function deleteProject(authToken, projectId) {
 }
 
 function deleteProvider(authToken, organizationId, providerId) {
+  if (!providerId) {
+    return cy.wrap(null);
+  }
   return requestWithAuth(authToken, {
     method: 'DELETE',
     url: `/api-proxy/api/v0.9/llm-providers/${encodeURIComponent(providerId)}?organizationId=${encodeURIComponent(organizationId)}`,
@@ -288,4 +310,15 @@ function toSlug(value) {
     .trim()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '');
+}
+
+function selectTemplateVersionAndContinue() {
+  // Wait for the dialog's own version fetch to resolve and explicitly pick a
+  // version rather than relying on its auto-selected default.
+  cy.get('[data-cyid^="template-version-option-"]', { timeout: 30000 })
+    .first()
+    .click();
+  cy.get('[data-cyid="template-version-continue-button"]', { timeout: 30000 })
+    .should('not.be.disabled')
+    .click();
 }

--- a/portals/ai-workspace/cypress/e2e/005-provider-templates/005-custom-provider-template.cy.js
+++ b/portals/ai-workspace/cypress/e2e/005-provider-templates/005-custom-provider-template.cy.js
@@ -1,0 +1,281 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+describe('AI Workspace - Custom LLM provider template lifecycle', () => {
+  const suffix = Date.now().toString().slice(-8);
+  const orgHandle = Cypress.env('ORG_HANDLE');
+  const templateName = `E2E Custom Template ${suffix}`;
+  const templateV1Id = toTemplateId(`${templateName} v1.0`);
+  const templateV2Id = toTemplateId(`${templateName} v2.0`);
+  const providerName = `E2E Custom Template Provider ${suffix}`;
+  const providerId = toSlug(providerName);
+  let createdProviderId = '';
+  let authToken = '';
+  let organizationId = '';
+
+  before(() => {
+    cy.sweepE2EProviders();
+  });
+
+  beforeEach(() => {
+    cy.login();
+    cy.request({
+      method: 'POST',
+      url: '/api-proxy/api/portal/v1/auth/login',
+      form: true,
+      body: {
+        username: Cypress.env('ADMIN_USER'),
+        password: Cypress.env('ADMIN_PASSWORD'),
+      },
+    })
+      .then((response) => {
+        expect(response.status).to.eq(200);
+        authToken = response.body?.token ?? '';
+        expect(authToken).to.not.equal('');
+
+        return cy.request({
+          url: '/api-proxy/api/v0.9/organizations',
+          headers: {
+            Authorization: `Bearer ${authToken}`,
+          },
+        });
+      })
+      .then((response) => {
+        expect(response.status).to.eq(200);
+        organizationId = response.body?.id ?? '';
+        expect(organizationId).to.not.equal('');
+      });
+  });
+
+  afterEach(() => {
+    const targetProviderId = createdProviderId || providerId;
+    const targeted = (authToken && organizationId)
+      ? deleteProvider(authToken, organizationId, targetProviderId)
+          .then(() => waitForProviderGone(authToken, organizationId, targetProviderId))
+          .then(() => deleteProviderTemplate(authToken, organizationId, templateV2Id))
+          .then(() => deleteProviderTemplate(authToken, organizationId, templateV1Id))
+      : cy.wrap(null);
+
+    return targeted.then(() => cy.sweepE2EProviders(authToken, organizationId));
+  });
+
+  it('creates a custom template, versions it, uses it for a provider, and blocks deletion while in use', () => {
+    // --- Create the custom template (v1.0) ---------------------------------
+    cy.contains('Settings', { timeout: 30000 }).should('be.visible').click();
+    cy.contains('LLM Provider Templates', { timeout: 30000 }).should('be.visible');
+
+    cy.get('[data-cyid="add-provider-template-button"]', { timeout: 30000 })
+      .scrollIntoView()
+      .should('be.visible')
+      .click();
+
+    cy.get('input[placeholder="Enter template name"]', { timeout: 30000 })
+      .should('be.visible')
+      .type(templateName);
+    cy.get('input[placeholder="https://api.openai.com"]').type(
+      'https://api.e2e-custom-template.example.com'
+    );
+    cy.get('[data-cyid="create-provider-template-submit"]')
+      .should('not.be.disabled')
+      .click();
+
+    cy.contains('LLM Provider Templates', { timeout: 30000 }).should('be.visible');
+    cy.get(`[data-cyid="provider-template-card-${templateV1Id}"]`, {
+      timeout: 30000,
+    })
+      .should('be.visible')
+      .click();
+    cy.contains(templateName, { timeout: 30000 }).should('be.visible');
+    cy.contains('button', 'v1.0', { timeout: 30000 }).should('be.visible');
+
+    // --- Create a second version (v2.0) of the same template family --------
+    cy.contains('button', 'v1.0').click();
+    cy.contains('Create new version', { timeout: 30000 }).click();
+
+    cy.get('input[placeholder="v2.0"]', { timeout: 30000 })
+      .should('be.visible')
+      .clear()
+      .type('v2.0');
+    cy.get('input[placeholder="https://api.openai.com"]').type(
+      'https://api.e2e-custom-template.example.com'
+    );
+    cy.get('[data-cyid="create-provider-template-version-submit"]')
+      .should('not.be.disabled')
+      .click();
+
+    cy.contains(templateName, { timeout: 30000 }).should('be.visible');
+    cy.contains('button', 'v2.0', { timeout: 30000 }).should('be.visible');
+
+    // --- Use the template (now with 2 enabled versions) to create a provider ---
+    cy.get('[data-cyid="nav-service-provider"]', { timeout: 30000 })
+      .should('be.visible')
+      .click();
+    cy.get('[data-cyid="add-new-provider-button"]', { timeout: 30000 })
+      .should('be.visible')
+      .click();
+
+    cy.get(`[data-cyid="provider-template-${templateV2Id}-card"]`, {
+      timeout: 30000,
+    })
+      .should('be.visible')
+      .click();
+
+    cy.get('[data-cyid="template-version-continue-button"]', {
+      timeout: 45000,
+    }).should('be.visible');
+    cy.get('[data-cyid="template-version-option-v2.0"]', { timeout: 30000 }).click();
+    cy.get('[data-cyid="template-version-continue-button"]', { timeout: 30000 })
+      .should('not.be.disabled')
+      .click();
+
+    cy.get('[data-cyid="provider-name-input"] input:visible', {
+      timeout: 30000,
+    })
+      .should('be.visible')
+      .clear()
+      .type(providerName);
+    cy.get('[data-cyid="provider-context-input"] input:visible').should(
+      'have.value',
+      `/${providerId}`
+    );
+    cy.get('[data-cyid="provider-api-key-input"] input:visible').type(
+      'sk-e2e-custom-template-provider-key'
+    );
+    cy.get('[data-cyid="add-provider-button"]')
+      .should('not.be.disabled')
+      .click();
+
+    cy.location('pathname', { timeout: 30000 })
+      .should(
+        'match',
+        new RegExp(`^/organizations/${orgHandle}/service-provider/[^/]+$`)
+      )
+      .then((pathname) => {
+        createdProviderId = pathname.split('/').pop() || '';
+        expect(createdProviderId).to.not.equal('');
+      });
+    cy.contains(providerName, { timeout: 30000 }).should('be.visible');
+
+    // --- Deleting the version while a provider uses it must be blocked -----
+    cy.contains('Settings', { timeout: 30000 }).should('be.visible').click();
+    cy.get(`[data-cyid="provider-template-card-${templateV2Id}"]`, {
+      timeout: 30000,
+    })
+      .should('be.visible')
+      .click();
+    cy.contains('button', 'v2.0', { timeout: 30000 }).should('be.visible');
+
+    cy.get('[data-cyid="provider-template-delete-button"]', { timeout: 30000 })
+      .should('be.visible')
+      .click();
+    cy.get('[role="dialog"]').within(() => {
+      cy.contains('button', 'Delete').click();
+    });
+    cy.contains(
+      'Cannot delete: one or more providers were created from this template.',
+      { timeout: 30000 }
+    ).should('be.visible');
+
+    // --- Remove the provider, then deletion is allowed ----------------------
+    cy.then(() => deleteProvider(authToken, organizationId, createdProviderId));
+    cy.then(() => waitForProviderGone(authToken, organizationId, createdProviderId));
+
+    cy.get('[data-cyid="provider-template-delete-button"]', { timeout: 30000 })
+      .should('be.visible')
+      .click();
+    cy.get('[role="dialog"]').within(() => {
+      cy.contains('button', 'Delete').click();
+    });
+    cy.contains('button', 'v1.0', { timeout: 30000 }).should('exist');
+    cy.get('[data-cyid="provider-template-delete-button"]', { timeout: 30000 })
+      .scrollIntoView()
+      .should('be.visible')
+      .click();
+    cy.get('[role="dialog"]').within(() => {
+      cy.contains('button', 'Delete').click();
+    });
+
+    // That was the only remaining version, so the whole template is gone.
+    cy.contains('LLM Provider Templates', { timeout: 30000 }).should('be.visible');
+    cy.contains(templateName).should('not.exist');
+  });
+});
+
+function waitForProviderGone(authToken, organizationId, providerId) {
+  return requestWithAuth(authToken, {
+    url: `/api-proxy/api/v0.9/llm-providers?organizationId=${encodeURIComponent(organizationId)}`,
+  }).then((res) => {
+    const stillThere = (res.body?.list ?? []).some((p) => p.id === providerId);
+    if (stillThere) {
+      cy.wait(500);
+      return waitForProviderGone(authToken, organizationId, providerId);
+    }
+  });
+}
+
+
+function deleteProvider(authToken, organizationId, targetProviderId) {
+  if (!targetProviderId) {
+    return cy.wrap(null);
+  }
+  return requestWithAuth(authToken, {
+    method: 'DELETE',
+    url: `/api-proxy/api/v0.9/llm-providers/${encodeURIComponent(targetProviderId)}?organizationId=${encodeURIComponent(organizationId)}`,
+    failOnStatusCode: false,
+  }).then((response) => {
+    expect(response.status).to.be.oneOf([200, 204, 404]);
+  });
+}
+
+function deleteProviderTemplate(authToken, organizationId, templateId) {
+  return requestWithAuth(authToken, {
+    method: 'DELETE',
+    url: `/api-proxy/api/v0.9/llm-provider-templates/${encodeURIComponent(templateId)}?organizationId=${encodeURIComponent(organizationId)}`,
+    failOnStatusCode: false,
+  }).then((response) => {
+    expect(response.status).to.be.oneOf([200, 204, 404, 409]);
+  });
+}
+
+function requestWithAuth(authToken, options) {
+  const headers = {
+    Authorization: `Bearer ${authToken}`,
+    ...(options.headers ?? {}),
+  };
+
+  return cy.request({
+    ...options,
+    headers,
+  });
+}
+
+function toSlug(value) {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function toTemplateId(value) {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}

--- a/portals/ai-workspace/cypress/e2e/005-provider-templates/005-custom-provider-template.cy.js
+++ b/portals/ai-workspace/cypress/e2e/005-provider-templates/005-custom-provider-template.cy.js
@@ -34,6 +34,7 @@ describe('AI Workspace - Custom LLM provider template lifecycle', () => {
 
   beforeEach(() => {
     cy.login();
+    cy.intercept('POST', /\/llm-providers(\?|$)/).as('createProvider');
     cy.request({
       method: 'POST',
       url: '/api-proxy/api/portal/v1/auth/login',
@@ -160,15 +161,21 @@ describe('AI Workspace - Custom LLM provider template lifecycle', () => {
       .should('not.be.disabled')
       .click();
 
-    cy.location('pathname', { timeout: 30000 })
-      .should(
-        'match',
-        new RegExp(`^/organizations/${orgHandle}/service-provider/[^/]+$`)
-      )
-      .then((pathname) => {
-        createdProviderId = pathname.split('/').pop() || '';
-        expect(createdProviderId).to.not.equal('');
-      });
+    // Capture the provider id from the create response, not the URL. The create
+    // flow issues POST /secrets before POST /llm-providers, so the redirect to
+    // /service-provider/<id> lands a beat after the click — scraping the URL
+    // races against it and can capture the transient "new" form route.
+    cy.wait('@createProvider').then(({ response }) => {
+      expect(response?.statusCode).to.be.oneOf([200, 201]);
+      createdProviderId = response?.body?.id || providerId;
+      expect(createdProviderId).to.not.equal('');
+      expect(createdProviderId).to.not.equal('new');
+    });
+    // The view must settle on the created provider, never the "new" form route.
+    cy.location('pathname', { timeout: 30000 }).should(
+      'match',
+      new RegExp(`^/organizations/${orgHandle}/service-provider/(?!new$)[^/]+$`)
+    );
     cy.contains(providerName, { timeout: 30000 }).should('be.visible');
 
     // --- Deleting the version while a provider uses it must be blocked -----

--- a/portals/ai-workspace/cypress/support/commands.js
+++ b/portals/ai-workspace/cypress/support/commands.js
@@ -43,3 +43,115 @@ Cypress.Commands.add('login', (username, password) => {
   cy.contains('Quick Start', { timeout: 30000 }).should('be.visible');
   cy.contains('Projects').should('be.visible');
 });
+
+Cypress.Commands.add('sweepE2EProviders', (authToken, organizationId) => {
+  const PAGE_SIZE = 100;
+  const headersFor = (token) => ({ Authorization: `Bearer ${token}` });
+
+  // Collect every stale `E2E ` provider, paging until the API returns a short
+  // page. Collection finishes before any deletes so the offset window stays
+  // consistent.
+  const collectE2EProviders = (token, orgId, offset = 0, acc = []) =>
+    cy
+      .request({
+        method: 'GET',
+        url: `/api-proxy/api/v0.9/llm-providers?organizationId=${encodeURIComponent(orgId)}&limit=${PAGE_SIZE}&offset=${offset}`,
+        headers: headersFor(token),
+        failOnStatusCode: false,
+      })
+      .then((response) => {
+        // Cleanup runs in afterEach; a transient non-200 from the list endpoint
+        // must not hard-fail the spec it is cleaning up after. Skip this page.
+        if (response.status !== 200) return acc;
+        const page = response.body?.list ?? [];
+        const next = acc.concat(
+          page.filter(
+            (p) => typeof p.name === 'string' && p.name.startsWith('E2E ')
+          )
+        );
+        if (page.length < PAGE_SIZE) return next;
+        return collectE2EProviders(token, orgId, offset + PAGE_SIZE, next);
+      });
+
+  // A provider with linked proxies cannot be deleted directly, so clear those
+  // first to keep the sweep from silently leaving stale state behind.
+  const deleteLinkedProxies = (token, orgId, providerId) =>
+    cy
+      .request({
+        method: 'GET',
+        url: `/api-proxy/api/v0.9/llm-providers/${encodeURIComponent(providerId)}/llm-proxies?organizationId=${encodeURIComponent(orgId)}`,
+        headers: headersFor(token),
+        failOnStatusCode: false,
+      })
+      .then((response) => {
+        if (response.status === 404) return;
+        const proxies = response.body?.list ?? [];
+        if (!proxies.length) return;
+        return cy.wrap(proxies).each((proxy) =>
+          cy
+            .request({
+              method: 'DELETE',
+              url: `/api-proxy/api/v0.9/llm-proxies/${encodeURIComponent(proxy.id)}?organizationId=${encodeURIComponent(orgId)}`,
+              headers: headersFor(token),
+              failOnStatusCode: false,
+            })
+            .then((deleteResponse) => {
+              expect(deleteResponse.status).to.be.oneOf([200, 204, 404]);
+            })
+        );
+      });
+
+  const doSweep = (token, orgId) =>
+    collectE2EProviders(token, orgId).then((e2eProviders) => {
+      if (!e2eProviders.length) return;
+      return cy.wrap(e2eProviders).each((provider) =>
+        deleteLinkedProxies(token, orgId, provider.id).then(() =>
+          cy
+            .request({
+              method: 'DELETE',
+              url: `/api-proxy/api/v0.9/llm-providers/${encodeURIComponent(provider.id)}?organizationId=${encodeURIComponent(orgId)}`,
+              headers: headersFor(token),
+              failOnStatusCode: false,
+            })
+            .then((deleteResponse) => {
+              // Surface a failed delete so the sweep does not pass while leaving
+              // the next suite to start from dirty state.
+              expect(deleteResponse.status).to.be.oneOf([200, 204, 404]);
+            })
+        )
+      );
+    });
+
+  if (authToken && organizationId) {
+    return doSweep(authToken, organizationId);
+  }
+
+  return cy
+    .request({
+      method: 'POST',
+      url: '/api-proxy/api/portal/v1/auth/login',
+      form: true,
+      body: {
+        username: Cypress.env('ADMIN_USER'),
+        password: Cypress.env('ADMIN_PASSWORD'),
+      },
+      failOnStatusCode: false,
+    })
+    .then((loginResp) => {
+      if (loginResp.status !== 200) return;
+      const token = loginResp.body?.token;
+      if (!token) return;
+      return cy
+        .request({
+          url: '/api-proxy/api/v0.9/organizations',
+          headers: { Authorization: `Bearer ${token}` },
+          failOnStatusCode: false,
+        })
+        .then((orgResp) => {
+          if (orgResp.status !== 200) return;
+          const orgId = orgResp.body?.id;
+          if (!orgId) return;
+          return doSweep(token, orgId);
+        });
+    });
+});

--- a/portals/ai-workspace/src/App.tsx
+++ b/portals/ai-workspace/src/App.tsx
@@ -58,6 +58,10 @@ import EditLLMProxy from './pages/appShell/appShellPages/proxies/EditLLMProxy';
 import ServiceProviderLayout from './pages/appShell/appShellPages/serviceProvider/ServiceProviderLayout';
 import ServiceProviders from './pages/appShell/appShellPages/serviceProvider/ProvidersList';
 import ServiceProviderNew from './pages/appShell/appShellPages/serviceProvider/ServiceProviderNew';
+import CreateProviderTemplate from './pages/appShell/appShellPages/providerTemplate/CreateProviderTemplate';
+import ProviderTemplateOverview from './pages/appShell/appShellPages/providerTemplate/ProviderTemplateOverview';
+import EditProviderTemplate from './pages/appShell/appShellPages/providerTemplate/EditProviderTemplate';
+import CreateProviderTemplateVersion from './pages/appShell/appShellPages/providerTemplate/CreateProviderTemplateVersion';
 import ServiceProviderOverview from './pages/appShell/appShellPages/serviceProvider/ServiceProviderOverview';
 import ServiceProviderDeploy from './pages/appShell/appShellPages/serviceProvider/ServiceProviderDeploy';
 import EditServiceProvider from './pages/appShell/appShellPages/serviceProvider/EditServiceProvider';
@@ -67,6 +71,7 @@ import OrgRegisterPage from './pages/register/OrgRegisterPage';
 import Insights from './pages/appShell/appShellPages/insights/Main';
 import QuickStart from './pages/appShell/appShellPages/quickStart/Main';
 import Settings from './pages/appShell/appShellPages/settings/Main';
+import ProviderTemplatesList from './pages/appShell/appShellPages/providerTemplate/ProviderTemplatesList';
 import ExternalServersList from './pages/appShell/appShellPages/externalServers/ExternalServersList';
 import ExternalServersNew from './pages/appShell/appShellPages/externalServers/ExternalServersNew';
 import ExternalServersOverview from './pages/appShell/appShellPages/externalServers/ExternalServersOverview';
@@ -525,14 +530,54 @@ export default function App() {
                 </WithPageBoundary>
               }
             />
-            <Route
-              path="settings"
-              element={
-                <WithPageBoundary>
-                  <Settings />
-                </WithPageBoundary>
-              }
-            />
+            <Route path="settings" element={<ServiceProviderLayout />}>
+              <Route element={<Settings />}>
+                <Route
+                  index
+                  element={<Navigate to="llm-provider-templates" replace />}
+                />
+                <Route
+                  path="llm-provider-templates"
+                  element={
+                    <WithPageBoundary>
+                      <ProviderTemplatesList />
+                    </WithPageBoundary>
+                  }
+                />
+                <Route
+                  path="llm-provider-templates/new"
+                  element={
+                    <WithPageBoundary>
+                      <CreateProviderTemplate />
+                    </WithPageBoundary>
+                  }
+                />
+                <Route
+                  path="llm-provider-templates/:templateId"
+                  element={
+                    <WithPageBoundary>
+                      <ProviderTemplateOverview />
+                    </WithPageBoundary>
+                  }
+                />
+                <Route
+                  path="llm-provider-templates/:templateId/edit"
+                  element={
+                    <WithPageBoundary>
+                      <EditProviderTemplate />
+                    </WithPageBoundary>
+                  }
+                />
+                <Route
+                  path="llm-provider-templates/:templateId/new-version"
+                  element={
+                    <WithPageBoundary>
+                      <CreateProviderTemplateVersion />
+                    </WithPageBoundary>
+                  }
+                />
+              </Route>
+            </Route>
             <Route path="projects/:projectSlug" element={<ProjectShell />}>
               <Route index element={<Navigate to="home" replace />} />
               <Route
@@ -732,14 +777,18 @@ export default function App() {
                   </WithPageBoundary>
                 }
               />
-              <Route
-                path="settings"
-                element={
-                  <WithPageBoundary>
-                    <Settings />
-                  </WithPageBoundary>
-                }
-              />
+              <Route path="settings" element={<ServiceProviderLayout />}>
+                <Route element={<Settings />}>
+                  <Route
+                    index
+                    element={
+                      <WithPageBoundary>
+                        <ProviderTemplatesList />
+                      </WithPageBoundary>
+                    }
+                  />
+                </Route>
+              </Route>
             </Route>
           </Route>
         </Route>

--- a/portals/ai-workspace/src/Components/ResourceView/ResourceRow.tsx
+++ b/portals/ai-workspace/src/Components/ResourceView/ResourceRow.tsx
@@ -266,6 +266,9 @@ export default function ResourceRow({
           display: 'inline-flex',
           alignItems: 'center',
           color: '#3b4151',
+          [DARK_MODE_SELECTOR]: {
+            color: '#fff !important',
+          },
           '& .MuiIconButton-root': {
             borderRadius: 0.5,
             p: 0.35,

--- a/portals/ai-workspace/src/apis/providerTemplateApis.ts
+++ b/portals/ai-workspace/src/apis/providerTemplateApis.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { get, post, put, del } from '../clients/choreoApiClient';
+import { get, post, put, del, patch } from '../clients/choreoApiClient';
 import { logger } from '../utils/logger';
 
 // ============================================================================
@@ -126,8 +126,93 @@ export async function getProviderTemplate(
 }
 
 /**
+ * List all versions of a Provider Template (newest first).
+ *
+ * Templates are immutable per version — each edit creates a new version. This
+ * powers the version switcher on the overview page.
+ *
+ * @param templateId - The provider template ID (handle)
+ * @param organizationId - The organization ID
+ * @returns Promise with the list of versions (most recent first)
+ */
+export async function getProviderTemplateVersions(
+  templateId: string,
+  organizationId: string,
+  baseUrl: string
+): Promise<ProviderTemplate[]> {
+  try {
+    const response = await get<ProviderTemplate[] | ProviderTemplatesResponse>(
+      `/llm-provider-templates/${encodeURIComponent(templateId)}/versions?organizationId=${encodeURIComponent(organizationId)}`,
+      undefined,
+      baseUrl
+    );
+    return Array.isArray(response) ? response : response.list ?? [];
+  } catch (error) {
+    logger.error(`Failed to fetch versions for provider template ${templateId}:`, error);
+    throw error;
+  }
+}
+
+/**
+ * Fetch a specific immutable version of a Provider Template.
+ *
+ * @param templateId - The provider template ID (handle)
+ * @param version - The version to fetch (e.g. "v2")
+ * @param organizationId - The organization ID
+ * @returns Promise with that version's full template
+ */
+export async function getProviderTemplateVersion(
+  templateId: string,
+  version: string,
+  organizationId: string,
+  baseUrl: string
+): Promise<ProviderTemplate> {
+  try {
+    const response = await get<ProviderTemplate>(
+      `/llm-provider-templates/${encodeURIComponent(templateId)}/versions/${encodeURIComponent(version)}?organizationId=${encodeURIComponent(organizationId)}`,
+      undefined,
+      baseUrl
+    );
+    return response;
+  } catch (error) {
+    logger.error(`Failed to fetch version ${version} of provider template ${templateId}:`, error);
+    throw error;
+  }
+}
+
+/**
+ * Create a new version of an existing Provider Template.
+ *
+ * The supplied template must include a `version` (e.g. "v2.0") that is unique
+ * for the template; the new version becomes the latest.
+ *
+ * @param templateId - The provider template ID (handle)
+ * @param template - The new version's configuration (must include `version`)
+ * @param organizationId - The organization ID
+ * @returns Promise with the newly created version
+ */
+export async function createProviderTemplateVersion(
+  templateId: string,
+  template: ProviderTemplate,
+  organizationId: string,
+  baseUrl: string
+): Promise<ProviderTemplate> {
+  try {
+    const response = await post<ProviderTemplate>(
+      `/llm-provider-templates/${encodeURIComponent(templateId)}/versions?organizationId=${encodeURIComponent(organizationId)}`,
+      template,
+      baseUrl
+    );
+    return response;
+  } catch (error) {
+    logger.error(`Failed to create new version for provider template ${templateId}:`, error);
+    throw error;
+  }
+}
+
+/**
  * Update an existing Provider Template
- * 
+ *
  * @param templateId - The provider template ID
  * @param updates - The fields to update
  * @param organizationId - The organization ID
@@ -142,6 +227,61 @@ export async function getProviderTemplate(
  * console.log(template); // { id: '...', name: 'OpenAI Template Updated', ... }
  * ```
  */
+/**
+ * Enable or disable a specific version of a Provider Template. Disabled
+ * versions stay in the catalog but are hidden from the provider picker.
+ *
+ * @param templateId - The provider template ID (handle)
+ * @param version - The version to toggle (e.g. "v1.0")
+ * @param enabled - Whether the version should be enabled
+ * @returns Promise with the updated version
+ */
+export async function setProviderTemplateVersionEnabled(
+  templateId: string,
+  version: string,
+  enabled: boolean,
+  organizationId: string,
+  baseUrl: string
+): Promise<ProviderTemplate> {
+  try {
+    const response = await patch<ProviderTemplate>(
+      `/llm-provider-templates/${encodeURIComponent(templateId)}/versions/${encodeURIComponent(version)}?organizationId=${encodeURIComponent(organizationId)}`,
+      { enabled },
+      baseUrl
+    );
+    return response;
+  } catch (error) {
+    logger.error(`Failed to set enabled=${enabled} for ${templateId} ${version}:`, error);
+    throw error;
+  }
+}
+
+/**
+ * Delete a single version of a Provider Template. If it was the only version
+ * the template is removed; otherwise the newest remaining version becomes the
+ * latest.
+ *
+ * @param templateId - The provider template ID (handle)
+ * @param version - The version to delete (e.g. "v2.0")
+ */
+export async function deleteProviderTemplateVersion(
+  templateId: string,
+  version: string,
+  organizationId: string,
+  baseUrl: string
+): Promise<void> {
+  try {
+    await del<void>(
+      `/llm-provider-templates/${encodeURIComponent(templateId)}/versions/${encodeURIComponent(version)}?organizationId=${encodeURIComponent(organizationId)}`,
+      undefined,
+      baseUrl
+    );
+  } catch (error) {
+    logger.error(`Failed to delete version ${version} of ${templateId}:`, error);
+    throw error;
+  }
+}
+
 export async function updateProviderTemplate(
   templateId: string,
   updates: UpdateProviderTemplateRequest,

--- a/portals/ai-workspace/src/contexts/llmProvider/providerTemplate/ProviderTemplateContext.tsx
+++ b/portals/ai-workspace/src/contexts/llmProvider/providerTemplate/ProviderTemplateContext.tsx
@@ -54,9 +54,10 @@ const ProviderTemplateContext = createContext<ProviderTemplateContextValue>({
 interface ProviderTemplateProviderProps {
   children: React.ReactNode;
   templateId: string;
+  version?: string;
 }
 
-export function ProviderTemplateProvider({ children, templateId }: ProviderTemplateProviderProps) {
+export function ProviderTemplateProvider({ children, templateId, version }: ProviderTemplateProviderProps) {
   const { currentOrganization } = useAppShell();
   const [template, setTemplate] = useState<ProviderTemplate | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -64,7 +65,7 @@ export function ProviderTemplateProvider({ children, templateId }: ProviderTempl
 
   const organizationId = currentOrganization?.uuid ?? '';
 
-  // Fetch single template
+  // Fetch single template (a specific version if requested, else latest)
   const fetchTemplate = useCallback(async () => {
     if (!templateId || !organizationId) {
       setTemplate(null);
@@ -75,7 +76,9 @@ export function ProviderTemplateProvider({ children, templateId }: ProviderTempl
     try {
       setIsLoading(true);
       setError(null);
-      const fetchedTemplate = await providerTemplateApis.getProviderTemplate(templateId, organizationId, PLATFORM_API_BASE_URL);
+      const fetchedTemplate = version
+        ? await providerTemplateApis.getProviderTemplateVersion(templateId, version, organizationId, PLATFORM_API_BASE_URL)
+        : await providerTemplateApis.getProviderTemplate(templateId, organizationId, PLATFORM_API_BASE_URL);
       setTemplate(fetchedTemplate);
     } catch (err) {
       logger.error(`Failed to fetch provider template ${templateId}:`, err);
@@ -84,7 +87,7 @@ export function ProviderTemplateProvider({ children, templateId }: ProviderTempl
     } finally {
       setIsLoading(false);
     }
-  }, [templateId, organizationId, PLATFORM_API_BASE_URL]);
+  }, [templateId, version, organizationId, PLATFORM_API_BASE_URL]);
 
   useEffect(() => {
     fetchTemplate();

--- a/portals/ai-workspace/src/contexts/llmProvider/providerTemplate/ProviderTemplatesContext.tsx
+++ b/portals/ai-workspace/src/contexts/llmProvider/providerTemplate/ProviderTemplatesContext.tsx
@@ -94,8 +94,18 @@ export function ProviderTemplatesProvider({ children }: ProviderTemplatesProvide
       setIsLoading(true);
       setError(null);
       const response = await providerTemplateApis.getProviderTemplates(organizationId, PLATFORM_API_BASE_URL);
-      // Store the full API response as-is
-      setTemplatesResponse(response as ProviderTemplatesResponse);
+      // Load latest-first by creation time. (Not updatedAt: the backend seeder
+      // re-touches built-in templates on every restart, which would otherwise
+      // float them to the top. createdAt also bumps when a new version is added.)
+      const ts = (t: ProviderTemplate) =>
+        new Date(t.createdAt ?? t.updatedAt ?? 0).getTime();
+      const sorted: ProviderTemplatesResponse = {
+        ...(response as ProviderTemplatesResponse),
+        list: [...((response as ProviderTemplatesResponse).list ?? [])].sort(
+          (a, b) => ts(b) - ts(a)
+        ),
+      };
+      setTemplatesResponse(sorted);
     } catch (err) {
       logger.error('Failed to fetch provider templates:', err);
       setError(err instanceof Error ? err : new Error('Failed to fetch templates'));
@@ -118,7 +128,7 @@ export function ProviderTemplatesProvider({ children }: ProviderTemplatesProvide
       setTemplatesResponse((prev) => ({
         ...prev,
         count: prev.count + 1,
-        list: [newTemplate, ...prev.list],
+        list: [newTemplate, ...prev.list], //appear last created as first one
         pagination: { ...prev.pagination, total: prev.pagination.total + 1 },
       }));
       return newTemplate;

--- a/portals/ai-workspace/src/pages/appShell/AppSidebar.tsx
+++ b/portals/ai-workspace/src/pages/appShell/AppSidebar.tsx
@@ -27,6 +27,7 @@ import {
   Layers,
   Network,
   Rocket,
+  Settings,
   Workflow,
 } from '@wso2/oxygen-ui-icons-react';
 import McpMenuIcon from '../../assets/icons/McpMenuIcon';
@@ -302,25 +303,27 @@ export default function AppSidebar({
         </Box>
       </Sidebar.Nav>
 
-      {/* <Sidebar.Footer>
+      <Sidebar.Footer>
         <Sidebar.Category>
-          <NavLink to={settingsPath} style={navLinkStyle}>
-            <Sidebar.Item id="settings">
-              <Sidebar.ItemIcon>
-                <Settings size={20} />
-              </Sidebar.ItemIcon>
-              <Sidebar.ItemLabel>Settings</Sidebar.ItemLabel>
-            </Sidebar.Item>
-          </NavLink>
+          {hasPermission(SCOPES.LLM_TEMPLATE_MANAGE) && (
+            <NavLink to={settingsPath} style={navLinkStyle}>
+              <Sidebar.Item id="settings">
+                <Sidebar.ItemIcon>
+                  <Settings size={20} />
+                </Sidebar.ItemIcon>
+                <Sidebar.ItemLabel>Settings</Sidebar.ItemLabel>
+              </Sidebar.Item>
+            </NavLink>
+          )}
 
-          <Sidebar.Item id="help">
+          {/* <Sidebar.Item id="help">
             <Sidebar.ItemIcon>
               <HelpCircle size={20} />
             </Sidebar.ItemIcon>
             <Sidebar.ItemLabel>Help & Support</Sidebar.ItemLabel>
-          </Sidebar.Item>
+          </Sidebar.Item> */}
         </Sidebar.Category>
-      </Sidebar.Footer> */}
+      </Sidebar.Footer>
     </Sidebar>
   );
 }

--- a/portals/ai-workspace/src/pages/appShell/appShellMain.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellMain.tsx
@@ -173,6 +173,10 @@ export default function AppLayout(): JSX.Element {
         shellActions.setActiveMenuItem('service-provider');
         return;
       }
+      if (tertiarySegment === 'provider-template') {
+        shellActions.setActiveMenuItem('provider-template');
+        return;
+      }
       if (tertiarySegment === 'external-servers') {
         shellActions.setActiveMenuItem('external-servers');
         return;
@@ -208,6 +212,10 @@ export default function AppLayout(): JSX.Element {
     }
     if (primarySegment === 'service-provider') {
       shellActions.setActiveMenuItem('service-provider');
+      return;
+    }
+    if (primarySegment === 'provider-template') {
+      shellActions.setActiveMenuItem('provider-template');
       return;
     }
     if (primarySegment === 'external-servers') {

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/CreateProviderTemplate.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/CreateProviderTemplate.tsx
@@ -1,0 +1,537 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useRef, useState } from 'react';
+import { useNavigate, Link as RouterLink } from 'react-router-dom';
+import YAML from 'yaml';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Button,
+  Divider,
+  FormControl,
+  FormLabel,
+  Grid,
+  MenuItem,
+  PageContent,
+  PageTitle,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from '@wso2/oxygen-ui';
+import { ChevronDown, ChevronLeft } from '@wso2/oxygen-ui-icons-react';
+import { FormattedMessage } from 'react-intl';
+import { useProviderTemplates } from '../../../../contexts/llmProvider/providerTemplate';
+import { useAppShell } from '../../../../contexts/AppShellContext';
+import { buildOrgPath } from '../../../../utils/projectRouting';
+import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
+import type {
+  CreateProviderTemplateRequest,
+  TemplateMetadata,
+} from '../../../../utils/types';
+import {
+  DEFAULT_AUTH_CONFIG,
+  DEFAULT_TOKEN_CONFIG,
+  fromTokenConfig,
+  isValidHttpUrl,
+  TOKEN_FIELDS,
+  TOKEN_LOCATIONS,
+  type TokenConfig,
+  type TokenFieldKey,
+} from '../../../../utils/providerTemplateFields';
+
+const MAX_NAME_LENGTH = 80;
+const MAX_DESCRIPTION_LENGTH = 200;
+const INITIAL_VERSION = 'v1.0';
+
+function parseSpecServerUrl(text: string): string | null {
+  if (!text.trim()) return null;
+  let spec: { servers?: Array<{ url?: string }> } | null = null;
+  try {
+    spec = JSON.parse(text);
+  } catch {
+    try {
+      spec = YAML.parse(text) as { servers?: Array<{ url?: string }> };
+    } catch {
+      return null;
+    }
+  }
+  const url = spec?.servers?.[0]?.url;
+  return typeof url === 'string' && url.trim() ? url.trim() : null;
+}
+
+function isParseableSpec(text: string): boolean {
+  if (!text.trim()) return false;
+  let spec: unknown = null;
+  try {
+    spec = JSON.parse(text);
+  } catch {
+    try {
+      spec = YAML.parse(text);
+    } catch {
+      return false;
+    }
+  }
+  return (
+    !!spec &&
+    typeof spec === 'object' &&
+    ('openapi' in spec || 'swagger' in spec || 'paths' in spec)
+  );
+}
+
+export default function CreateProviderTemplate() {
+  const navigate = useNavigate();
+  const { currentOrganization } = useAppShell();
+  const { createTemplate } = useProviderTemplates();
+  const showSnackbar = useAIWorkspaceSnackbar();
+
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [endpointUrl, setEndpointUrl] = useState('');
+  const [openapiSpecUrl, setOpenapiSpecUrl] = useState('');
+  const [isFetchingSpec, setIsFetchingSpec] = useState(false);
+  const [specFileName, setSpecFileName] = useState('');
+  const [specContent, setSpecContent] = useState('');
+  const [specFetched, setSpecFetched] = useState(false);
+
+  const [tokenConfig, setTokenConfig] = useState<TokenConfig>(() => ({
+    ...DEFAULT_TOKEN_CONFIG,
+  }));
+  const [nameTouched, setNameTouched] = useState(false);
+  const [specUrlTouched, setSpecUrlTouched] = useState(false);
+  const [endpointUrlTouched, setEndpointUrlTouched] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const updateToken = (
+    field: TokenFieldKey,
+    key: 'identifier' | 'location',
+    value: string
+  ) => {
+    setTokenConfig((prev) => ({
+      ...prev,
+      [field]: { ...prev[field], [key]: value },
+    }));
+  };
+
+  const listPath = buildOrgPath(currentOrganization, '/settings');
+
+  const fetchSpecFromUrl = async () => {
+    const url = openapiSpecUrl.trim();
+    if (!url) return;
+    if (!isValidHttpUrl(url)) {
+      showSnackbar('Enter a valid http or https URL.', 'error');
+      return;
+    }
+    setIsFetchingSpec(true);
+    try {
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(`Failed to fetch: ${res.statusText}`);
+      const text = await res.text();
+      if (!isParseableSpec(text)) {
+        showSnackbar('That URL did not return a valid OpenAPI specification.', 'error');
+        return;
+      }
+      const serverUrl = parseSpecServerUrl(text);
+      setSpecFileName('');
+      setSpecContent('');
+      setSpecFetched(true);
+      if (serverUrl) {
+        setEndpointUrl(serverUrl);
+        showSnackbar('Specification fetched and endpoint URL added.', 'success');
+      } else {
+        showSnackbar('Specification fetched. Add the endpoint URL manually.', 'info');
+      }
+    } catch {
+      showSnackbar('Could not fetch a specification from that URL.', 'error');
+    } finally {
+      setIsFetchingSpec(false);
+    }
+  };
+
+  const handleSpecFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    try {
+      const text = await file.text();
+      if (!isParseableSpec(text)) {
+        showSnackbar('That file is not a valid OpenAPI specification (JSON or YAML).', 'error');
+        return;
+      }
+      const serverUrl = parseSpecServerUrl(text);
+      setSpecFileName(file.name);
+      setSpecContent(text);
+      setOpenapiSpecUrl('');
+      setSpecFetched(true);
+      if (serverUrl) {
+        setEndpointUrl(serverUrl);
+        showSnackbar('Specification uploaded and endpoint URL added.', 'success');
+      } else {
+        showSnackbar('Specification uploaded. Add the endpoint URL manually.', 'info');
+      }
+    } catch {
+      showSnackbar('Failed to read the specification file.', 'error');
+    } finally {
+      e.target.value = '';
+    }
+  };
+
+  const toTemplateId = (value: string): string =>
+    value
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+
+  const normalizedTemplateId = toTemplateId(`${name} ${INITIAL_VERSION}`);
+  const isNameValid = name.trim().length > 0 && name.length <= MAX_NAME_LENGTH;
+  const isDescriptionValid = description.length <= MAX_DESCRIPTION_LENGTH;
+  const isEndpointValid =
+    endpointUrl.trim().length > 0 && isValidHttpUrl(endpointUrl);
+  const specUrlEntered = openapiSpecUrl.trim().length > 0;
+  const isSpecUrlValid = isValidHttpUrl(openapiSpecUrl);
+  const isSpecReady = !specUrlEntered || (isSpecUrlValid && specFetched);
+  const isFormValid =
+    isNameValid &&
+    Boolean(normalizedTemplateId) &&
+    isDescriptionValid &&
+    isEndpointValid &&
+    isSpecReady;
+
+  const handleSubmit = async (event?: React.FormEvent) => {
+    if (event) event.preventDefault();
+    if (!isFormValid || isSubmitting) return;
+
+    const tokenFields = fromTokenConfig(tokenConfig);
+    const metadata: TemplateMetadata = {};
+
+    if (endpointUrl.trim()) metadata.endpointUrl = endpointUrl.trim();
+    if (openapiSpecUrl.trim()) metadata.openapiSpecUrl = openapiSpecUrl.trim();
+
+    metadata.auth = { ...DEFAULT_AUTH_CONFIG };
+
+    const payload: CreateProviderTemplateRequest = {
+      id: normalizedTemplateId,
+      name: name.trim(),
+      version: INITIAL_VERSION,
+      description: description.trim() || undefined,
+      ...tokenFields,
+      metadata: Object.keys(metadata).length ? metadata : undefined,
+
+      openapi: specContent.trim() ? specContent : undefined,
+    };
+
+    setIsSubmitting(true);
+    try {
+      await createTemplate(payload);
+      showSnackbar('Template created successfully.', 'success');
+      navigate(listPath); // Go back to the list, where the new template appears.
+    } catch (err: any) {
+      showSnackbar(err?.message || 'Failed to create template.', 'error');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <PageContent fullWidth>
+      <Button
+        component={RouterLink}
+        to={listPath}
+        size="small"
+        startIcon={<ChevronLeft size={24} />}
+      >
+        <FormattedMessage
+          id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.CreateProviderTemplate.back"
+          defaultMessage={'Back to list'}
+        />
+      </Button>
+
+      <Stack spacing={2} mt={2}>
+        <PageTitle>
+          <PageTitle.Header>
+            <FormattedMessage
+              id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.CreateProviderTemplate.title"
+              defaultMessage={'Add LLM Provider Template'}
+            />
+          </PageTitle.Header>
+        </PageTitle>
+      </Stack>
+
+      {/* component="form" makes Enter submit and groups inputs semantically. */}
+      <Box sx={{ mt: 2, maxWidth: 820 }}>
+        <Box component="form" onSubmit={handleSubmit} noValidate>
+          <Grid container spacing={2}>
+            <Grid size={{ xs: 12, sm: 8 }}>
+              <FormControl fullWidth>
+                <FormLabel required>
+                  <FormattedMessage
+                    id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.CreateProviderTemplate.name"
+                    defaultMessage={'Name'}
+                  />
+                </FormLabel>
+                <TextField
+                  fullWidth
+                  required
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  onBlur={() => setNameTouched(true)}
+                  placeholder="Enter template name"
+                  error={
+                    (nameTouched && name.trim().length === 0) ||
+                    name.length > MAX_NAME_LENGTH
+                  }
+                  helperText={
+                    nameTouched && name.trim().length === 0
+                      ? 'Name is required.'
+                      : name.length > MAX_NAME_LENGTH
+                        ? `Name must not exceed ${MAX_NAME_LENGTH} characters (${name.length}/${MAX_NAME_LENGTH})`
+                        : ''
+                  }
+                />
+              </FormControl>
+            </Grid>
+
+            {/* A new template always starts at v1 and read-only*/}
+            <Grid size={{ xs: 12, sm: 4 }}>
+              <FormControl fullWidth>
+                <FormLabel required>
+                  <FormattedMessage
+                    id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.CreateProviderTemplate.version"
+                    defaultMessage={'Version'}
+                  />
+                </FormLabel>
+                <TextField
+                  fullWidth
+                  value={INITIAL_VERSION}
+                  disabled
+                />
+              </FormControl>
+            </Grid>
+
+            <Grid size={{ xs: 12 }}>
+              <FormControl fullWidth>
+                <FormLabel>
+                  <FormattedMessage
+                    id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.CreateProviderTemplate.description"
+                    defaultMessage={'Description'}
+                  />
+                </FormLabel>
+                <TextField
+                  fullWidth
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  placeholder="Enter description"
+                  multiline
+                  minRows={3}
+                  error={description.length > MAX_DESCRIPTION_LENGTH}
+                  helperText={
+                    description.length > MAX_DESCRIPTION_LENGTH
+                      ? `Description must not exceed ${MAX_DESCRIPTION_LENGTH} characters (${description.length}/${MAX_DESCRIPTION_LENGTH})`
+                      : ''
+                  }
+                />
+              </FormControl>
+            </Grid>
+
+            <Grid size={{ xs: 12 }}>
+              <FormControl fullWidth>
+                <FormLabel>
+                  <FormattedMessage
+                    id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.CreateProviderTemplate.importSpec"
+                    defaultMessage={'OpenAPI Specification'}
+                  />
+                </FormLabel>
+                <Stack spacing={1.5} sx={{ mt: 1 }}>
+                  <Stack direction="row" spacing={1.5} alignItems="center">
+                    <TextField
+                      size="small"
+                      fullWidth
+                      value={openapiSpecUrl}
+                      onChange={(e) => {
+                        setOpenapiSpecUrl(e.target.value);
+                        setSpecFetched(false);
+                        setSpecUrlTouched(false);
+                      }}
+                      onBlur={() => setSpecUrlTouched(true)}
+                      placeholder="https://api.openai.com/openapi.json"
+                      error={specUrlTouched && specUrlEntered && (!isSpecUrlValid || !specFetched)}
+                      helperText={
+                        specUrlTouched && specUrlEntered && !isSpecUrlValid
+                          ? 'Enter a valid URL.'
+                          : specUrlTouched && specUrlEntered && !specFetched
+                            ? 'Fetch the specification to validate the URL.'
+                            : ''
+                      }
+                    />
+                    <Button
+                      variant="outlined"
+                      size="small"
+                      disabled={
+                        isFetchingSpec || !openapiSpecUrl.trim() || !isSpecUrlValid
+                      }
+                      onClick={() => void fetchSpecFromUrl()}
+                      sx={{ whiteSpace: 'nowrap', flexShrink: 0 }}
+                    >
+                      {isFetchingSpec ? 'Fetching…' : 'Fetch specification'}
+                    </Button>
+                  </Stack>
+                  <Divider>Or</Divider>
+                  <Button
+                    variant="outlined"
+                    fullWidth
+                    onClick={() => fileInputRef.current?.click()}
+                  >
+                    {specFileName
+                      ? `Uploaded: ${specFileName}`
+                      : 'Upload Your Specification'}
+                  </Button>
+                </Stack>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  hidden
+                  accept=".json,.yaml,.yml"
+                  onChange={handleSpecFileChange}
+                />
+              </FormControl>
+            </Grid>
+
+            <Grid size={{ xs: 12 }}>
+              <FormControl fullWidth>
+                <FormLabel required>
+                  <FormattedMessage
+                    id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.CreateProviderTemplate.endpointUrl"
+                    defaultMessage={'Endpoint URL'}
+                  />
+                </FormLabel>
+                <TextField
+                  fullWidth
+                  required
+                  value={endpointUrl}
+                  onChange={(e) => {
+                    setEndpointUrl(e.target.value);
+                    setEndpointUrlTouched(false);
+                  }}
+                  onBlur={() => setEndpointUrlTouched(true)}
+                  placeholder="https://api.openai.com"
+                  error={endpointUrlTouched && endpointUrl.trim().length > 0 && !isValidHttpUrl(endpointUrl)}
+                  helperText={
+                    endpointUrlTouched && endpointUrl.trim().length > 0 && !isValidHttpUrl(endpointUrl)
+                      ? 'Enter a valid URL.'
+                      : ''
+                  }
+                />
+              </FormControl>
+            </Grid>
+
+          </Grid>
+
+          {/* Advanced: token & model extraction mapping (collapsed by default,
+              pre-filled with the OpenAI defaults). */}
+          <Accordion
+            disableGutters
+            sx={{ mt: 2, border: '1px solid', borderColor: 'divider', borderRadius: 1, '&:before': { display: 'none' } }}
+          >
+            <AccordionSummary expandIcon={<ChevronDown size={18} />}>
+              <Box>
+                <Typography variant="subtitle2">Advanced</Typography>
+                <Typography variant="caption" color="text.secondary">
+                  Token and model mapping. Defaults to OpenAI.
+                </Typography>
+              </Box>
+            </AccordionSummary>
+            <AccordionDetails>
+              <Grid container spacing={2}>
+                {TOKEN_FIELDS.map(({ key, label }) => (
+                  <React.Fragment key={key}>
+                    <Grid size={{ xs: 12, sm: 8 }}>
+                      <FormControl fullWidth>
+                        <FormLabel>{`${label} Identifier`}</FormLabel>
+                        <TextField
+                          fullWidth
+                          value={tokenConfig[key].identifier}
+                          onChange={(e) =>
+                            updateToken(key, 'identifier', e.target.value)
+                          }
+                        />
+                      </FormControl>
+                    </Grid>
+                    <Grid size={{ xs: 12, sm: 4 }}>
+                      <FormControl fullWidth>
+                        <FormLabel>{`${label} Location`}</FormLabel>
+                        <Select
+                          value={tokenConfig[key].location}
+                          onChange={(e) =>
+                            updateToken(key, 'location', e.target.value as string)
+                          }
+                        >
+                          {TOKEN_LOCATIONS.map((option) => (
+                            <MenuItem key={option.value} value={option.value}>
+                              {option.label}
+                            </MenuItem>
+                          ))}
+                        </Select>
+                      </FormControl>
+                    </Grid>
+                  </React.Fragment>
+                ))}
+              </Grid>
+            </AccordionDetails>
+          </Accordion>
+
+          <Box sx={{ mt: 3, display: 'flex', justifyContent: 'flex-start', gap: 1 }}>
+            <Button
+              variant="outlined"
+              component={RouterLink}
+              to={listPath}
+              color="secondary"
+              type="button"
+            >
+              <FormattedMessage
+                id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.CreateProviderTemplate.cancel"
+                defaultMessage={'Cancel'}
+              />
+            </Button>
+            <Button
+              variant="contained"
+              type="submit"
+              disabled={isSubmitting || !isFormValid}
+              data-cyid="create-provider-template-submit"
+            >
+              {isSubmitting ? (
+                <FormattedMessage
+                  id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.CreateProviderTemplate.creating"
+                  defaultMessage={'Creating...'}
+                />
+              ) : (
+                <FormattedMessage
+                  id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.CreateProviderTemplate.create"
+                  defaultMessage={'Create Template'}
+                />
+              )}
+            </Button>
+          </Box>
+        </Box>
+      </Box>
+    </PageContent>
+  );
+}

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/CreateProviderTemplateVersion.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/CreateProviderTemplateVersion.tsx
@@ -1,0 +1,658 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useRef, useState } from 'react';
+import { useNavigate, useParams, Link as RouterLink } from 'react-router-dom';
+import YAML from 'yaml';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Button,
+  CircularProgress,
+  Divider,
+  FormControl,
+  FormLabel,
+  Grid,
+  MenuItem,
+  PageContent,
+  PageTitle,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from '@wso2/oxygen-ui';
+import { ChevronDown, ChevronLeft } from '@wso2/oxygen-ui-icons-react';
+import { FormattedMessage } from 'react-intl';
+import { useProviderTemplates } from '../../../../contexts/llmProvider/providerTemplate';
+import { useAppShell } from '../../../../contexts/AppShellContext';
+import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
+import * as providerTemplateApis from '../../../../apis/providerTemplateApis';
+import { PLATFORM_API_BASE_URL } from '../../../../config.env';
+import { buildOrgPath } from '../../../../utils/projectRouting';
+import type {
+  ProviderTemplate,
+  TemplateMetadata,
+} from '../../../../utils/types';
+import {
+  fromTokenConfig,
+  isValidHttpUrl,
+  toTokenConfig,
+  TOKEN_FIELDS,
+  TOKEN_LOCATIONS,
+  type TokenConfig,
+  type TokenFieldKey,
+} from '../../../../utils/providerTemplateFields';
+
+const MAX_DESCRIPTION_LENGTH = 200;
+
+const VERSION_PATTERN = /^[vV]\d+\.\d+$/;
+
+function suggestNextVersion(current?: string): string {
+  const match = /^[vV](\d+)\.\d+$/.exec((current ?? '').trim());
+  if (!match) return 'v2.0';
+  const major = parseInt(match[1], 10);
+  return `v${major + 1}.0`;
+}
+
+function toTemplateId(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+// Parse an OpenAPI spec (JSON or YAML) and return its first server URL.
+function parseSpecServerUrl(text: string): string | null {
+  if (!text.trim()) return null;
+  let spec: { servers?: Array<{ url?: string }> } | null = null;
+  try {
+    spec = JSON.parse(text);
+  } catch {
+    try {
+      spec = YAML.parse(text) as { servers?: Array<{ url?: string }> };
+    } catch {
+      return null;
+    }
+  }
+  const url = spec?.servers?.[0]?.url;
+  return typeof url === 'string' && url.trim() ? url.trim() : null;
+}
+
+// True if the text parses (JSON or YAML) into a plausible OpenAPI document.
+// Used to reject obviously-invalid specs on upload/fetch.
+function isParseableSpec(text: string): boolean {
+  if (!text.trim()) return false;
+  let spec: unknown = null;
+  try {
+    spec = JSON.parse(text);
+  } catch {
+    try {
+      spec = YAML.parse(text);
+    } catch {
+      return false;
+    }
+  }
+  return (
+    !!spec &&
+    typeof spec === 'object' &&
+    ('openapi' in spec || 'swagger' in spec || 'paths' in spec)
+  );
+}
+
+function CreateProviderTemplateVersionForm({
+  template,
+}: {
+  template: ProviderTemplate;
+}) {
+  const templateId = template.id;
+  const navigate = useNavigate();
+  const { currentOrganization } = useAppShell();
+  const { refreshTemplates } = useProviderTemplates();
+  const showSnackbar = useAIWorkspaceSnackbar();
+
+  const overviewPath = `${buildOrgPath(
+    currentOrganization,
+    '/settings/llm-provider-templates'
+  )}/${templateId}`;
+
+  const currentVersion = template.version;
+  const [version, setVersion] = useState(() => suggestNextVersion(template.version));
+
+// Description is user-entered (prefilled from the source version) and optional,
+  const [description, setDescription] = useState(template.description ?? '');
+  const [openapiSpecUrl, setOpenapiSpecUrl] = useState(
+    template.metadata?.openapiSpecUrl ?? ''
+  );
+  const [endpointUrl, setEndpointUrl] = useState(
+    template.metadata?.endpointUrl ?? ''
+  );
+  const [isFetchingSpec, setIsFetchingSpec] = useState(false);
+  const [specFileName, setSpecFileName] = useState('');
+  const [specContent, setSpecContent] = useState(template.openapi ?? '');
+  const [endpointUrlTouched, setEndpointUrlTouched] = useState(false);
+  const [specUrlTouched, setSpecUrlTouched] = useState(false);
+  const hasInheritedSpec = !specFileName && Boolean(template.openapi?.trim());
+  const [tokenConfig, setTokenConfig] = useState<TokenConfig>(() =>
+    toTokenConfig(template)
+  );
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const updateToken = (
+    field: TokenFieldKey,
+    key: 'identifier' | 'location',
+    value: string
+  ) => {
+    setTokenConfig((prev) => ({
+      ...prev,
+      [field]: { ...prev[field], [key]: value },
+    }));
+  };
+
+  const fetchSpecFromUrl = async () => {
+    const url = openapiSpecUrl.trim();
+    if (!url) return;
+    if (!isValidHttpUrl(url)) {
+      showSnackbar('Enter a valid http or https URL.', 'error');
+      return;
+    }
+    setIsFetchingSpec(true);
+    try {
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(`Failed to fetch: ${res.statusText}`);
+      const text = await res.text();
+      if (!isParseableSpec(text)) {
+        showSnackbar('That URL did not return a valid OpenAPI specification.', 'error');
+        return;
+      }
+      const serverUrl = parseSpecServerUrl(text);
+      setSpecFileName('');
+      setSpecContent('');
+      if (serverUrl) {
+        setEndpointUrl(serverUrl);
+        showSnackbar('Specification fetched and endpoint URL added.', 'success');
+      } else {
+        showSnackbar('Specification fetched. Add the endpoint URL manually.', 'info');
+      }
+    } catch {
+      showSnackbar('Could not fetch a specification from that URL.', 'error');
+    } finally {
+      setIsFetchingSpec(false);
+    }
+  };
+
+  const handleSpecFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    try {
+      const text = await file.text();
+      if (!isParseableSpec(text)) {
+        showSnackbar('That file is not a valid OpenAPI specification (JSON or YAML).', 'error');
+        return;
+      }
+      const serverUrl = parseSpecServerUrl(text);
+      setSpecFileName(file.name);
+      setSpecContent(text);
+      setOpenapiSpecUrl('');
+      if (serverUrl) {
+        setEndpointUrl(serverUrl);
+        showSnackbar('Specification uploaded and endpoint URL added.', 'success');
+      } else {
+        showSnackbar('Specification uploaded. Add the endpoint URL manually.', 'info');
+      }
+    } catch {
+      showSnackbar('Could not read that specification file.', 'error');
+    } finally {
+      e.target.value = '';
+    }
+  };
+
+  const isDescriptionValid = description.length <= MAX_DESCRIPTION_LENGTH;
+  const isEndpointValid =
+    endpointUrl.trim().length > 0 && isValidHttpUrl(endpointUrl);
+  const specUrlEntered = openapiSpecUrl.trim().length > 0;
+  const isSpecUrlValid = isValidHttpUrl(openapiSpecUrl);
+  const isVersionValid = VERSION_PATTERN.test(version.trim());
+  const isFormValid =
+    isDescriptionValid &&
+    isEndpointValid &&
+    isVersionValid &&
+    (!specUrlEntered || isSpecUrlValid);
+
+  const handleSubmit = async (event?: React.FormEvent) => {
+    if (event) event.preventDefault();
+    const organizationId = currentOrganization?.uuid;
+    if (!templateId || !organizationId || !isFormValid || isSubmitting) return;
+
+    const tokenFields = fromTokenConfig(tokenConfig);
+
+    const metadata: TemplateMetadata = { ...(template.metadata ?? {}) };
+    if (endpointUrl.trim()) metadata.endpointUrl = endpointUrl.trim();
+    else delete metadata.endpointUrl;
+    if (openapiSpecUrl.trim()) metadata.openapiSpecUrl = openapiSpecUrl.trim();
+    else delete metadata.openapiSpecUrl;
+
+    const payload: ProviderTemplate = {
+      id: toTemplateId(`${template.name ?? ''} ${version.trim()}`),
+      name: template.name,
+      version: version.trim(),
+      description: description.trim() || undefined,
+      resourceMappings: template.resourceMappings,
+      ...tokenFields,
+      metadata: Object.keys(metadata).length ? metadata : undefined,
+      openapi: specContent.trim() ? specContent : undefined,
+    };
+
+    setIsSubmitting(true);
+    try {
+      const created = await providerTemplateApis.createProviderTemplateVersion(
+        templateId,
+        payload,
+        organizationId,
+        PLATFORM_API_BASE_URL
+      );
+      await refreshTemplates();
+      showSnackbar(`New version ${version.trim()} created successfully.`, 'success');
+      const newVersionPath = created.id
+        ? `${buildOrgPath(currentOrganization, '/settings/llm-provider-templates')}/${created.id}`
+        : overviewPath;
+      navigate(newVersionPath);
+    } catch (err) {
+      showSnackbar(
+        err instanceof Error ? err.message : 'Failed to create new version.',
+        'error'
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <PageContent fullWidth>
+      <Button
+        component={RouterLink}
+        to={overviewPath}
+        size="small"
+        startIcon={<ChevronLeft size={24} />}
+      >
+        <FormattedMessage
+          id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.CreateProviderTemplateVersion.back"
+          defaultMessage={'Back to list'}
+        />
+      </Button>
+
+      <Stack spacing={2} mt={2}>
+        <PageTitle>
+          <PageTitle.Header>
+            <FormattedMessage
+              id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.CreateProviderTemplateVersion.title"
+              defaultMessage={'Create New Version'}
+            />
+          </PageTitle.Header>
+          <PageTitle.SubHeader>
+            <FormattedMessage
+              id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.CreateProviderTemplateVersion.subtitle"
+              defaultMessage={
+                'Create a new version using an updated OpenAPI specification'
+              }
+            />
+          </PageTitle.SubHeader>
+        </PageTitle>
+      </Stack>
+
+      <Box sx={{ mt: 2, maxWidth: 820 }}>
+        <Box component="form" onSubmit={handleSubmit} noValidate>
+          <Grid container spacing={2}>
+            {/* Name is fixed — a version belongs to the same template. */}
+            <Grid size={{ xs: 12, sm: 8 }}>
+              <FormControl fullWidth>
+                <FormLabel required>
+                  <FormattedMessage
+                    id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.CreateProviderTemplateVersion.name"
+                    defaultMessage={'Name'}
+                  />
+                </FormLabel>
+                <TextField fullWidth value={template.name} disabled />
+              </FormControl>
+            </Grid>
+
+            {/* Version is user-entered (prefilled with a suggested bump) and
+                must be unique, matching the v<major>.<minor> pattern. */}
+            <Grid size={{ xs: 12, sm: 4 }}>
+              <FormControl fullWidth>
+                <FormLabel required>
+                  <FormattedMessage
+                    id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.CreateProviderTemplateVersion.version"
+                    defaultMessage={'Version'}
+                  />
+                </FormLabel>
+                <TextField
+                  fullWidth
+                  value={version}
+                  onChange={(e) => setVersion(e.target.value)}
+                  placeholder="v2.0"
+                  error={version.trim().length > 0 && !isVersionValid}
+                  helperText={
+                    version.trim().length > 0 && !isVersionValid
+                      ? 'Expected: v<major>.<minor>'
+                      : ''
+                  }
+                />
+              </FormControl>
+            </Grid>
+
+            <Grid size={{ xs: 12 }}>
+              <FormControl fullWidth>
+                <FormLabel>
+                  <FormattedMessage
+                    id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.CreateProviderTemplateVersion.description"
+                    defaultMessage={'Description'}
+                  />
+                </FormLabel>
+                <TextField
+                  fullWidth
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  placeholder="Enter description"
+                  multiline
+                  minRows={3}
+                  error={description.length > MAX_DESCRIPTION_LENGTH}
+                  helperText={
+                    description.length > MAX_DESCRIPTION_LENGTH
+                      ? `Description must not exceed ${MAX_DESCRIPTION_LENGTH} characters (${description.length}/${MAX_DESCRIPTION_LENGTH})`
+                      : ''
+                  }
+                />
+              </FormControl>
+            </Grid>
+
+            <Grid size={{ xs: 12 }}>
+              <FormControl fullWidth>
+                <FormLabel>
+                  <FormattedMessage
+                    id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.CreateProviderTemplateVersion.importSpec"
+                    defaultMessage={'OpenAPI Specification'}
+                  />
+                </FormLabel>
+                <Stack spacing={1.5} sx={{ mt: 1 }}>
+                  <Stack direction="row" spacing={1.5} alignItems="center">
+                    <TextField
+                      size="small"
+                      fullWidth
+                      value={openapiSpecUrl}
+                      onChange={(e) => {
+                        setOpenapiSpecUrl(e.target.value);
+                        setSpecUrlTouched(false);
+                      }}
+                      onBlur={() => setSpecUrlTouched(true)}
+                      placeholder="https://api.openai.com/openapi.json"
+                      error={specUrlTouched && specUrlEntered && !isSpecUrlValid}
+                      helperText={
+                        specUrlTouched && specUrlEntered && !isSpecUrlValid
+                          ? 'Enter a valid URL.'
+                          : ''
+                      }
+                    />
+                    <Button
+                      variant="outlined"
+                      size="small"
+                      disabled={isFetchingSpec || !openapiSpecUrl.trim() || !isSpecUrlValid}
+                      onClick={() => void fetchSpecFromUrl()}
+                      sx={{ whiteSpace: 'nowrap', flexShrink: 0 }}
+                    >
+                      {isFetchingSpec ? 'Fetching…' : 'Fetch specification'}
+                    </Button>
+                  </Stack>
+                  <Divider>Or</Divider>
+                  <Button
+                    variant="outlined"
+                    fullWidth
+                    onClick={() => fileInputRef.current?.click()}
+                  >
+                    {specFileName
+                      ? `Uploaded: ${specFileName}`
+                      : specContent.trim()
+                        ? 'Uploaded Specification'
+                        : 'Upload Your Specification'}
+                  </Button>
+                </Stack>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  hidden
+                  accept=".json,.yaml,.yml"
+                  onChange={handleSpecFileChange}
+                />
+              </FormControl>
+            </Grid>
+
+            <Grid size={{ xs: 12 }}>
+              <FormControl fullWidth>
+                <FormLabel required>
+                  <FormattedMessage
+                    id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.CreateProviderTemplateVersion.endpointUrl"
+                    defaultMessage={'Endpoint URL'}
+                  />
+                </FormLabel>
+                <TextField
+                  fullWidth
+                  required
+                  value={endpointUrl}
+                  onChange={(e) => {
+                    setEndpointUrl(e.target.value);
+                    setEndpointUrlTouched(false);
+                  }}
+                  onBlur={() => setEndpointUrlTouched(true)}
+                  placeholder="https://api.openai.com"
+                  error={
+                    endpointUrlTouched &&
+                    endpointUrl.trim().length > 0 &&
+                    !isValidHttpUrl(endpointUrl)
+                  }
+                  helperText={
+                    endpointUrlTouched &&
+                    endpointUrl.trim().length > 0 &&
+                    !isValidHttpUrl(endpointUrl)
+                      ? 'Enter a valid URL.'
+                      : ''
+                  }
+                />
+              </FormControl>
+            </Grid>
+          </Grid>
+
+          {/* Advanced: token & model extraction mapping copied from the source
+              version (collapsed by default). */}
+          <Accordion
+            disableGutters
+            sx={{ mt: 2, border: '1px solid', borderColor: 'divider', borderRadius: 1, '&:before': { display: 'none' } }}
+          >
+            <AccordionSummary expandIcon={<ChevronDown size={18} />}>
+              <Box>
+                <Typography variant="subtitle2">Advanced</Typography>
+                <Typography variant="caption" color="text.secondary">
+                  Token and model mapping, copied from {currentVersion}.
+                </Typography>
+              </Box>
+            </AccordionSummary>
+            <AccordionDetails>
+              <Grid container spacing={2}>
+                {TOKEN_FIELDS.map(({ key, label }) => (
+                  <React.Fragment key={key}>
+                    <Grid size={{ xs: 12, sm: 8 }}>
+                      <FormControl fullWidth>
+                        <FormLabel>{`${label} Identifier`}</FormLabel>
+                        <TextField
+                          fullWidth
+                          value={tokenConfig[key].identifier}
+                          onChange={(e) =>
+                            updateToken(key, 'identifier', e.target.value)
+                          }
+                        />
+                      </FormControl>
+                    </Grid>
+                    <Grid size={{ xs: 12, sm: 4 }}>
+                      <FormControl fullWidth>
+                        <FormLabel>{`${label} Location`}</FormLabel>
+                        <Select
+                          value={tokenConfig[key].location}
+                          onChange={(e) =>
+                            updateToken(key, 'location', e.target.value as string)
+                          }
+                        >
+                          {TOKEN_LOCATIONS.map((option) => (
+                            <MenuItem key={option.value} value={option.value}>
+                              {option.label}
+                            </MenuItem>
+                          ))}
+                        </Select>
+                      </FormControl>
+                    </Grid>
+                  </React.Fragment>
+                ))}
+              </Grid>
+            </AccordionDetails>
+          </Accordion>
+
+          <Box sx={{ mt: 3, display: 'flex', justifyContent: 'flex-start', gap: 1 }}>
+            <Button
+              variant="outlined"
+              component={RouterLink}
+              to={overviewPath}
+              color="secondary"
+              type="button"
+            >
+              <FormattedMessage
+                id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.CreateProviderTemplateVersion.cancel"
+                defaultMessage={'Cancel'}
+              />
+            </Button>
+            <Button
+              variant="contained"
+              type="submit"
+              disabled={isSubmitting || !isFormValid}
+              data-cyid="create-provider-template-version-submit"
+            >
+              {isSubmitting ? (
+                <FormattedMessage
+                  id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.CreateProviderTemplateVersion.creating"
+                  defaultMessage={'Creating...'}
+                />
+              ) : (
+                <FormattedMessage
+                  id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.CreateProviderTemplateVersion.create"
+                  defaultMessage={'Create Version'}
+                />
+              )}
+            </Button>
+          </Box>
+        </Box>
+      </Box>
+    </PageContent>
+  );
+}
+
+// Container: fetch the full (latest) template so token/resource mappings and
+// metadata are available to copy into the new version.
+export default function CreateProviderTemplateVersion() {
+  const { templateId } = useParams<{ templateId: string }>();
+  const { currentOrganization } = useAppShell();
+  const [template, setTemplate] = useState<ProviderTemplate | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const listPath = buildOrgPath(currentOrganization, '/settings');
+
+  React.useEffect(() => {
+    const organizationId = currentOrganization?.uuid;
+    if (!templateId || !organizationId) return;
+
+    let isMounted = true;
+    setIsLoading(true);
+    setError(null);
+    providerTemplateApis
+      .getProviderTemplate(templateId, organizationId, PLATFORM_API_BASE_URL)
+      .then((full) => {
+        if (isMounted) setTemplate(full);
+      })
+      .catch((err: unknown) => {
+        if (isMounted) {
+          setError(err instanceof Error ? err.message : 'Failed to load template');
+        }
+      })
+      .finally(() => {
+        if (isMounted) setIsLoading(false);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [templateId, currentOrganization?.uuid]);
+
+  if (isLoading) {
+    return (
+      <PageContent fullWidth>
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            minHeight: 300,
+          }}
+        >
+          <CircularProgress />
+        </Box>
+      </PageContent>
+    );
+  }
+
+  if (error || !template) {
+    return (
+      <PageContent fullWidth>
+        <Button
+          component={RouterLink}
+          to={listPath}
+          size="small"
+          startIcon={<ChevronLeft size={24} />}
+        >
+          <FormattedMessage
+            id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.CreateProviderTemplateVersion.back"
+            defaultMessage={'Back to list'}
+          />
+        </Button>
+        <Typography variant="h6" sx={{ mt: 2 }}>
+          {error ? (
+            error
+          ) : (
+            <FormattedMessage
+              id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.CreateProviderTemplateVersion.notFound"
+              defaultMessage={'Template not found'}
+            />
+          )}
+        </Typography>
+      </PageContent>
+    );
+  }
+
+  return (
+    <CreateProviderTemplateVersionForm key={template.id} template={template} />
+  );
+}

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/EditProviderTemplate.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/EditProviderTemplate.tsx
@@ -1,0 +1,289 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { useNavigate, useParams, Link as RouterLink } from 'react-router-dom';
+import {
+  Box,
+  Button,
+  Card,
+  CircularProgress,
+  FormControl,
+  FormLabel,
+  Grid,
+  PageContent,
+  PageTitle,
+  Stack,
+  TextField,
+  Typography,
+} from '@wso2/oxygen-ui';
+import { ChevronLeft } from '@wso2/oxygen-ui-icons-react';
+import { FormattedMessage } from 'react-intl';
+import { useProviderTemplates } from '../../../../contexts/llmProvider/providerTemplate';
+import { useAppShell } from '../../../../contexts/AppShellContext';
+import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
+import * as providerTemplateApis from '../../../../apis/providerTemplateApis';
+import { PLATFORM_API_BASE_URL } from '../../../../config.env';
+import { buildOrgPath } from '../../../../utils/projectRouting';
+import type {
+  ProviderTemplate,
+  UpdateProviderTemplateRequest,
+} from '../../../../utils/types';
+
+const MAX_NAME_LENGTH = 80;
+const MAX_DESCRIPTION_LENGTH = 200;
+
+function EditProviderTemplateForm({ template }: { template: ProviderTemplate }) {
+  const templateId = template.id;
+  const navigate = useNavigate();
+  const { currentOrganization } = useAppShell();
+  const { updateTemplate } = useProviderTemplates();
+  const showSnackbar = useAIWorkspaceSnackbar();
+
+  const overviewPath = `${buildOrgPath(
+    currentOrganization,
+    '/settings/llm-provider-templates'
+  )}/${templateId}`;
+
+  const [name, setName] = useState(template.name ?? '');
+  const [description, setDescription] = useState(template.description ?? '');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const isNameValid = name.trim().length > 0 && name.length <= MAX_NAME_LENGTH;
+  const isDescriptionValid = description.length <= MAX_DESCRIPTION_LENGTH;
+  const isFormValid = isNameValid && isDescriptionValid;
+
+  const handleSubmit = async (event?: React.FormEvent) => {
+    if (event) event.preventDefault();
+    if (!templateId || !isFormValid || isSubmitting) return;
+
+    const { createdAt, createdBy, updatedAt, ...rest } = template;
+    const payload: UpdateProviderTemplateRequest = {
+      ...rest,
+      id: templateId,
+      name: name.trim(),
+      description: description.trim() || undefined,
+    };
+
+    setIsSubmitting(true);
+    try {
+      await updateTemplate(templateId, payload);
+      showSnackbar('Template updated successfully.', 'success');
+      navigate(overviewPath);
+    } catch (err) {
+      showSnackbar(
+        err instanceof Error ? err.message : 'Failed to update template.',
+        'error'
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <PageContent fullWidth>
+      <Button
+        component={RouterLink}
+        to={overviewPath}
+        size="small"
+        startIcon={<ChevronLeft size={24} />}
+      >
+        <FormattedMessage
+          id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.EditProviderTemplate.back"
+          defaultMessage={'Back'}
+        />
+      </Button>
+
+      <Stack spacing={2} mt={2}>
+        <PageTitle>
+          <PageTitle.Header>
+            <FormattedMessage
+              id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.EditProviderTemplate.title"
+              defaultMessage={'Edit LLM Provider Template'}
+            />
+          </PageTitle.Header>
+        </PageTitle>
+      </Stack>
+
+      <Box sx={{ mt: 2, maxWidth: 820 }}>
+        <Box component="form" onSubmit={handleSubmit} noValidate>
+          <Card sx={{ p: 2 }}>
+            <Typography variant="h6" sx={{ mb: 2, fontWeight: 600 }}>
+              Details
+            </Typography>
+            <Grid container spacing={2}>
+              <Grid size={{ xs: 12 }}>
+                <FormControl fullWidth>
+                  <FormLabel required>Name</FormLabel>
+                  <TextField
+                    fullWidth
+                    required
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    placeholder="Enter template name"
+                    error={name.length > MAX_NAME_LENGTH}
+                    helperText={
+                      name.length > MAX_NAME_LENGTH
+                        ? `Name must not exceed ${MAX_NAME_LENGTH} characters (${name.length}/${MAX_NAME_LENGTH})`
+                        : 'Renaming updates every version of this template.'
+                    }
+                  />
+                </FormControl>
+              </Grid>
+              <Grid size={{ xs: 12 }}>
+                <FormControl fullWidth>
+                  <FormLabel>Description</FormLabel>
+                  <TextField
+                    fullWidth
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                    placeholder="Enter description"
+                    multiline
+                    minRows={3}
+                    error={description.length > MAX_DESCRIPTION_LENGTH}
+                    helperText={
+                      description.length > MAX_DESCRIPTION_LENGTH
+                        ? `Description must not exceed ${MAX_DESCRIPTION_LENGTH} characters (${description.length}/${MAX_DESCRIPTION_LENGTH})`
+                        : ''
+                    }
+                  />
+                </FormControl>
+              </Grid>
+            </Grid>
+          </Card>
+
+          <Box sx={{ mt: 3, display: 'flex', justifyContent: 'flex-start', gap: 1 }}>
+            <Button
+              variant="outlined"
+              component={RouterLink}
+              to={overviewPath}
+              color="secondary"
+              type="button"
+            >
+              <FormattedMessage
+                id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.EditProviderTemplate.cancel"
+                defaultMessage={'Cancel'}
+              />
+            </Button>
+            <Button
+              variant="contained"
+              type="submit"
+              disabled={isSubmitting || !isFormValid}
+              data-cyid="edit-provider-template-submit"
+            >
+              {isSubmitting ? (
+                <FormattedMessage
+                  id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.EditProviderTemplate.saving"
+                  defaultMessage={'Updating...'}
+                />
+              ) : (
+                <FormattedMessage
+                  id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.EditProviderTemplate.save"
+                  defaultMessage={'Update'}
+                />
+              )}
+            </Button>
+          </Box>
+        </Box>
+      </Box>
+    </PageContent>
+  );
+}
+
+export default function EditProviderTemplate() {
+  const { templateId } = useParams<{ templateId: string }>();
+  const { currentOrganization } = useAppShell();
+  const [template, setTemplate] = useState<ProviderTemplate | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const listPath = buildOrgPath(currentOrganization, '/settings');
+
+  useEffect(() => {
+    const organizationId = currentOrganization?.uuid;
+    if (!templateId || !organizationId) return;
+
+    let isMounted = true;
+    setIsLoading(true);
+    setError(null);
+    providerTemplateApis
+      .getProviderTemplate(templateId, organizationId, PLATFORM_API_BASE_URL)
+      .then((full) => {
+        if (isMounted) setTemplate(full);
+      })
+      .catch((err: unknown) => {
+        if (isMounted) {
+          setError(err instanceof Error ? err.message : 'Failed to load template');
+        }
+      })
+      .finally(() => {
+        if (isMounted) setIsLoading(false);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [templateId, currentOrganization?.uuid]);
+
+  if (isLoading) {
+    return (
+      <PageContent fullWidth>
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            minHeight: 300,
+          }}
+        >
+          <CircularProgress />
+        </Box>
+      </PageContent>
+    );
+  }
+
+  if (error || !template) {
+    return (
+      <PageContent fullWidth>
+        <Button
+          component={RouterLink}
+          to={listPath}
+          size="small"
+          startIcon={<ChevronLeft size={24} />}
+        >
+          <FormattedMessage
+            id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.EditProviderTemplate.back"
+            defaultMessage={'Back to list'}
+          />
+        </Button>
+        <Typography variant="h6" sx={{ mt: 2 }}>
+          {error ? (
+            error
+          ) : (
+            <FormattedMessage
+              id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.EditProviderTemplate.notFound"
+              defaultMessage={'Template not found'}
+            />
+          )}
+        </Typography>
+      </PageContent>
+    );
+  }
+
+  return <EditProviderTemplateForm key={template.id} template={template} />;
+}

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/ProviderTemplateOverview.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/ProviderTemplateOverview.tsx
@@ -1,0 +1,1193 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { Link as RouterLink, useNavigate, useParams } from 'react-router-dom';
+import YAML from 'yaml';
+import {
+  Avatar,
+  Box,
+  Button,
+  Card,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  FormControl,
+  FormLabel,
+  Grid,
+  IconButton,
+  Menu,
+  MenuItem,
+  PageContent,
+  Stack,
+  Switch,
+  Tab,
+  Tabs,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@wso2/oxygen-ui';
+import { Check, ChevronDown, ChevronLeft, Clock, Download, Edit, GitBranch, Lock, Trash2 } from '@wso2/oxygen-ui-icons-react';
+import { FormattedMessage } from 'react-intl';
+import { formatRelativeTime } from '../../../../contexts/llmProvider';
+import { useProviderTemplates } from '../../../../contexts/llmProvider/providerTemplate';
+import { useAppShell } from '../../../../contexts/AppShellContext';
+import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
+import * as providerTemplateApis from '../../../../apis/providerTemplateApis';
+import { getLLMProviders } from '../../../../apis/llmProviderApis';
+import { PLATFORM_API_BASE_URL } from '../../../../config.env';
+import { buildOrgPath } from '../../../../utils/projectRouting';
+import {
+  isBuiltInProviderTemplate,
+  truncateProviderDisplayName,
+} from '../../../../utils/providerTemplateDisplay';
+import {
+  DEFAULT_AUTH_CONFIG,
+  fromTokenConfig,
+  isValidHttpUrl,
+  toTokenConfigWithDefaults,
+  type TokenConfig,
+  type TokenFieldKey,
+} from '../../../../utils/providerTemplateFields';
+import type {
+  ProviderTemplate,
+  ResourceMapping,
+  TemplateMetadata,
+  TemplateMetadataAuth,
+  UpdateProviderTemplateRequest,
+} from '../../../../utils/types';
+import { downloadTemplateYaml } from '../../../../utils/providerTemplateManifest';
+import SwaggerSpecViewer from '../../../../Components/SwaggerSpecViewer';
+import TemplateTokenMapping from './TemplateTokenMapping';
+
+function getInitials(name: string): string {
+  const words = name.trim().split(/\s+/);
+  if (words.length === 0 || words[0] === '') return '??';
+  if (words.length === 1) return words[0].slice(0, 2).toUpperCase();
+  return `${words[0][0]}${words[1][0]}`.toUpperCase();
+}
+
+type TabPanelProps = {
+  value: number;
+  index: number;
+  children: React.ReactNode;
+};
+
+function TabPanel({ value, index, children }: TabPanelProps) {
+  return (
+    <Box role="tabpanel" hidden={value !== index} sx={{ pt: 2 }}>
+      {value === index ? children : null}
+    </Box>
+  );
+}
+
+const tabs = ['Overview', 'Connection', 'Token Mapping'];
+
+function parseOpenApiSpec(text: string): Record<string, unknown> | null {
+  if (!text.trim()) return null;
+  try {
+    const json = JSON.parse(text);
+    return json && typeof json === 'object' ? (json as Record<string, unknown>) : null;
+  } catch {
+    try {
+      const yaml = YAML.parse(text);
+      return yaml && typeof yaml === 'object' ? (yaml as Record<string, unknown>) : null;
+    } catch {
+      return null;
+    }
+  }
+}
+
+function specServerUrl(text: string): string | null {
+  const spec = parseOpenApiSpec(text) as {
+    servers?: Array<{ url?: string }>;
+  } | null;
+  const url = spec?.servers?.[0]?.url;
+  return typeof url === 'string' && url.trim() ? url.trim() : null;
+}
+
+function isParseableSpec(text: string): boolean {
+  const spec = parseOpenApiSpec(text);
+  return !!spec && ('openapi' in spec || 'swagger' in spec || 'paths' in spec);
+}
+
+export default function ProviderTemplateOverview() {
+  const { templateId } = useParams<{ templateId: string }>();
+  const navigate = useNavigate();
+  const { currentOrganization } = useAppShell();
+  const { updateTemplate, refreshTemplates } = useProviderTemplates();
+  const showSnackbar = useAIWorkspaceSnackbar();
+  const [tabIndex, setTabIndex] = useState(0);
+
+  const [template, setTemplate] = useState<ProviderTemplate | undefined>();
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const [versions, setVersions] = useState<ProviderTemplate[]>([]);
+  const [selectedVersion, setSelectedVersion] = useState<string>('');
+  const [versionMenuAnchor, setVersionMenuAnchor] = useState<null | HTMLElement>(
+    null
+  );
+
+  const [endpointUrl, setEndpointUrl] = useState('');
+  const [provider, setProvider] = useState('');
+  const [openapiSpecUrl, setOpenapiSpecUrl] = useState('');
+  const [logoUrlField, setLogoUrlField] = useState('');
+  const [authType, setAuthType] = useState('');
+  const [authHeader, setAuthHeader] = useState('');
+  const [valuePrefix, setValuePrefix] = useState('');
+  const [defaultTokens, setDefaultTokens] = useState<TokenConfig>(() =>
+    toTokenConfigWithDefaults(undefined)
+  );
+
+  const [resourceMappings, setResourceMappings] = useState<ResourceMapping[]>([]);
+  const [isDirty, setIsDirty] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [urlSpecText, setUrlSpecText] = useState('');
+  const [isSpecLoading, setIsSpecLoading] = useState(false);
+  // Inline OpenAPI spec content (uploaded/pasted) — seeded from the template and
+  // editable on the Connection tab via URL fetch or file upload (same as create).
+  const [specContent, setSpecContent] = useState('');
+  const [specFileName, setSpecFileName] = useState('');
+  const [isFetchingSpec, setIsFetchingSpec] = useState(false);
+  const fileInputRef = React.useRef<HTMLInputElement | null>(null);
+  const [endpointUrlTouched, setEndpointUrlTouched] = useState(false);
+  const [openapiSpecUrlTouched, setOpenapiSpecUrlTouched] = useState(false);
+  const [logoUrlTouched, setLogoUrlTouched] = useState(false);
+  const [isTogglingEnabled, setIsTogglingEnabled] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const listPath = buildOrgPath(currentOrganization, '/settings/llm-provider-templates');
+
+  useEffect(() => {
+    const organizationId = currentOrganization?.uuid;
+    if (!templateId || !organizationId) return;
+
+    let isMounted = true;
+    setIsLoading(true);
+    setError(null);
+    providerTemplateApis
+      .getProviderTemplate(templateId, organizationId, PLATFORM_API_BASE_URL)
+      .then((full) => {
+        if (isMounted) setTemplate(full);
+      })
+      .catch((err: unknown) => {
+        if (isMounted) {
+          setError(err instanceof Error ? err : new Error('Failed to load template'));
+        }
+      })
+      .finally(() => {
+        if (isMounted) setIsLoading(false);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [templateId, currentOrganization?.uuid]);
+
+  useEffect(() => {
+    const organizationId = currentOrganization?.uuid;
+    if (!templateId || !organizationId) return;
+    setVersions([]);
+
+    let isMounted = true;
+    providerTemplateApis
+      .getProviderTemplateVersions(templateId, organizationId, PLATFORM_API_BASE_URL)
+      .then((list) => {
+        if (isMounted) {
+          setVersions(list);
+        }
+      })
+      .catch(() => {
+        if (isMounted) setVersions([]);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [templateId, currentOrganization?.uuid]);
+
+  useEffect(() => {
+    if (template?.version) setSelectedVersion(template.version);
+  }, [template?.version]);
+
+  const handleSwitchVersion = async (version: string) => {
+    const organizationId = currentOrganization?.uuid;
+    if (!templateId || !organizationId || version === selectedVersion) return;
+    setIsLoading(true);
+    try {
+      const full = await providerTemplateApis.getProviderTemplateVersion(
+        templateId,
+        version,
+        organizationId,
+        PLATFORM_API_BASE_URL
+      );
+      setSelectedVersion(version);
+      setTemplate(full);
+      if (full.id && full.id !== templateId) {
+        navigate(`${listPath}/${full.id}`, { replace: true });
+      }
+    } catch (err) {
+      showSnackbar(
+        err instanceof Error ? err.message : 'Failed to load version.',
+        'error'
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const seedDrafts = React.useCallback((t: ProviderTemplate) => {
+    setEndpointUrl(t.metadata?.endpointUrl ?? '');
+    setProvider(
+      (t.managedBy ?? t.provider)?.trim() ||
+        (isBuiltInProviderTemplate(t.id) ? 'wso2' : 'customer')
+    );
+    setOpenapiSpecUrl(t.metadata?.openapiSpecUrl ?? '');
+    setLogoUrlField(t.metadata?.logoUrl ?? '');
+    setAuthType(t.metadata?.auth?.type ?? DEFAULT_AUTH_CONFIG.type);
+    setAuthHeader(t.metadata?.auth?.header ?? DEFAULT_AUTH_CONFIG.header);
+    setValuePrefix(t.metadata?.auth?.valuePrefix ?? DEFAULT_AUTH_CONFIG.valuePrefix);
+    setDefaultTokens(toTokenConfigWithDefaults(t));
+    setResourceMappings(t.resourceMappings?.resources ?? []);
+    setSpecContent(t.openapi ?? '');
+    setSpecFileName('');
+    setIsDirty(false);
+    setEndpointUrlTouched(false);
+    setOpenapiSpecUrlTouched(false);
+    setLogoUrlTouched(false);
+  }, []);
+
+  const fetchSpecFromUrl = async () => {
+    const url = openapiSpecUrl.trim();
+    if (!url) return;
+    setIsFetchingSpec(true);
+    try {
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(`Failed to fetch: ${res.statusText}`);
+      const text = await res.text();
+      if (!isParseableSpec(text)) {
+        showSnackbar('That URL did not return a valid OpenAPI specification.', 'error');
+        return;
+      }
+      setSpecFileName('');
+      setSpecContent('');
+      setUrlSpecText(text);
+      setIsDirty(true);
+      const server = specServerUrl(text);
+      if (server) {
+        setEndpointUrl(server);
+        showSnackbar('Specification fetched and endpoint URL added.', 'success');
+      } else {
+        showSnackbar('Specification fetched. Add the endpoint URL manually.', 'info');
+      }
+    } catch {
+      showSnackbar('Could not fetch a specification from that URL.', 'error');
+    } finally {
+      setIsFetchingSpec(false);
+    }
+  };
+
+  // Upload a spec file: store its content inline (clears the URL reference).
+  const handleSpecFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    try {
+      const text = await file.text();
+      if (!isParseableSpec(text)) {
+        showSnackbar('That file is not a valid OpenAPI specification (JSON or YAML).', 'error');
+        return;
+      }
+      setSpecFileName(file.name);
+      setSpecContent(text);
+      setOpenapiSpecUrl('');
+      setIsDirty(true);
+      const server = specServerUrl(text);
+      if (server) {
+        setEndpointUrl(server);
+        showSnackbar('Specification uploaded and endpoint URL added.', 'success');
+      } else {
+        showSnackbar('Specification uploaded. Add the endpoint URL manually.', 'info');
+      }
+    } catch {
+      showSnackbar('Failed to read the specification file.', 'error');
+    } finally {
+      e.target.value = '';
+    }
+  };
+
+  useEffect(() => {
+    if (template) seedDrafts(template);
+  }, [template, seedDrafts]);
+
+  useEffect(() => {
+    const inline = template?.openapi?.trim();
+    const specUrl = template?.metadata?.openapiSpecUrl?.trim();
+    if (inline || !specUrl) {
+      setUrlSpecText('');
+      setIsSpecLoading(false);
+      return;
+    }
+    let isMounted = true;
+    setIsSpecLoading(true);
+    fetch(specUrl)
+      .then((res) => (res.ok ? res.text() : Promise.reject(new Error(`${res.status}`))))
+      .then((text) => {
+        if (isMounted) setUrlSpecText(text);
+      })
+      .catch(() => {
+        if (isMounted) setUrlSpecText('');
+      })
+      .finally(() => {
+        if (isMounted) setIsSpecLoading(false);
+      });
+    return () => {
+      isMounted = false;
+    };
+  }, [template?.openapi, template?.metadata?.openapiSpecUrl]);
+
+  const updateToken = (
+    field: TokenFieldKey,
+    key: 'identifier' | 'location',
+    value: string
+  ) => {
+    setDefaultTokens((prev) => ({
+      ...prev,
+      [field]: { ...prev[field], [key]: value },
+    }));
+    setIsDirty(true);
+  };
+
+  const handleSaveChanges = async () => {
+    if (!template?.id || isSaving) return;
+    if (!endpointUrl.trim()) {
+      showSnackbar('Endpoint URL is required.', 'error');
+      return;
+    }
+    if (
+      !isValidHttpUrl(endpointUrl) ||
+      !isValidHttpUrl(openapiSpecUrl) ||
+      !isValidHttpUrl(logoUrlField)
+    ) {
+      showSnackbar('Enter valid http(s) URLs for the endpoint, spec and logo.', 'error');
+      return;
+    }
+
+    const metadata: TemplateMetadata = {};
+    if (endpointUrl.trim()) metadata.endpointUrl = endpointUrl.trim();
+    if (logoUrlField.trim()) metadata.logoUrl = logoUrlField.trim();
+    if (openapiSpecUrl.trim()) metadata.openapiSpecUrl = openapiSpecUrl.trim();
+    const authObj: TemplateMetadataAuth = {} as TemplateMetadataAuth;
+    if (authType.trim()) authObj.type = authType.trim();
+    if (authHeader.trim()) authObj.header = authHeader.trim();
+    if (valuePrefix.trim()) authObj.valuePrefix = valuePrefix.trim();
+    if (Object.keys(authObj).length) metadata.auth = authObj;
+
+    const payload: UpdateProviderTemplateRequest = {
+      id: template.id,
+      name: template.name,
+      version: currentVersion,
+      managedBy: provider.trim() || 'customer',
+      description: template.description,
+      ...fromTokenConfig(defaultTokens),
+      metadata: Object.keys(metadata).length ? metadata : undefined,
+      resourceMappings: resourceMappings.length
+        ? { resources: resourceMappings }
+        : undefined,
+      // Inline spec content (uploaded/pasted); empty when referenced by URL.
+      openapi: specContent.trim() ? specContent : undefined,
+    };
+
+    setIsSaving(true);
+    try {
+      const updated = await updateTemplate(template.id, payload);
+      setTemplate(updated);
+      setIsDirty(false);
+      showSnackbar('Template updated successfully.', 'success');
+    } catch (err) {
+      showSnackbar(
+        err instanceof Error ? err.message : 'Failed to update template.',
+        'error'
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleCancelChanges = () => {
+    if (template) seedDrafts(template);
+  };
+
+  const parsedSpec = useMemo(
+    () =>
+      parseOpenApiSpec(
+        specContent.trim()
+          ? specContent
+          : template?.openapi?.trim()
+            ? template.openapi
+            : urlSpecText
+      ),
+    [specContent, template?.openapi, urlSpecText]
+  );
+
+  const backButton = (
+    <Button
+      component={RouterLink}
+      to={listPath}
+      size="small"
+      startIcon={<ChevronLeft size={24} />}
+    >
+      <FormattedMessage
+        id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.ProviderTemplateOverview.back"
+        defaultMessage={'Back to list'}
+      />
+    </Button>
+  );
+
+  if (isLoading) {
+    return (
+      <PageContent fullWidth>
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            minHeight: 300,
+          }}
+        >
+          <CircularProgress />
+        </Box>
+      </PageContent>
+    );
+  }
+
+  if (error) {
+    return (
+      <PageContent fullWidth>
+        {backButton}
+        <Stack spacing={1} sx={{ mt: 2 }}>
+          <Typography variant="h6" color="error">
+            <FormattedMessage
+              id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.ProviderTemplateOverview.error"
+              defaultMessage={'Error loading template'}
+            />
+          </Typography>
+          <Typography variant="body2">{error.message}</Typography>
+        </Stack>
+      </PageContent>
+    );
+  }
+
+  if (!template) {
+    return (
+      <PageContent fullWidth>
+        {backButton}
+        <Typography variant="h6" sx={{ mt: 2 }}>
+          <FormattedMessage
+            id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.ProviderTemplateOverview.notFound"
+            defaultMessage={'Template not found'}
+          />
+        </Typography>
+      </PageContent>
+    );
+  }
+
+  const metadata = template.metadata;
+  const logoUrl = metadata?.logoUrl?.trim();
+  const hasLogo = Boolean(logoUrl);
+  const description = template.description?.trim() || 'No description';
+  const lastUpdated = template.updatedAt ?? template.createdAt;
+
+  const currentVersion = selectedVersion || template.version || 'v1.0';
+  const activeProvider =
+    (() => {
+      const v = versions.find((vv) => vv.version === currentVersion);
+      return (v?.managedBy ?? v?.provider) ?? (template.managedBy ?? template.provider);
+    })();
+  const isBuiltIn = activeProvider === 'wso2';
+  const isReadOnly = isBuiltIn;
+  const canEdit = !isReadOnly;
+  const canDelete = !isReadOnly;
+  const isEnabled = template.enabled !== false;
+
+  const handleToggleEnabled = async (next: boolean) => {
+    const organizationId = currentOrganization?.uuid;
+    if (!template.id || !organizationId || isTogglingEnabled) return;
+    setIsTogglingEnabled(true);
+    try {
+      // Guard: a template that has providers created from it can't be disabled.
+      if (!next) {
+        const providers = await getLLMProviders(
+          organizationId,
+          PLATFORM_API_BASE_URL
+        );
+        const inUse = (providers.list ?? []).some(
+          (p) => p.template === template.id
+        );
+        if (inUse) {
+          showSnackbar(
+            'Cannot disable: one or more providers were created from this template.',
+            'error'
+          );
+          return;
+        }
+      }
+      const updated =
+        await providerTemplateApis.setProviderTemplateVersionEnabled(
+          template.id,
+          currentVersion,
+          next,
+          organizationId,
+          PLATFORM_API_BASE_URL
+        );
+      setTemplate(updated);
+      setVersions((prev) =>
+        prev.map((v) => (v.version === updated.version ? updated : v))
+      );
+      await refreshTemplates();
+      showSnackbar(next ? 'Version enabled.' : 'Version disabled.', 'success');
+    } catch (err: unknown) {
+      const status =
+        err instanceof Error && 'status' in err
+          ? (err as { status?: number }).status
+          : (err as { response?: { status?: number } })?.response?.status;
+      if (status === 409) {
+        showSnackbar(
+          'Cannot disable: one or more providers were created from this template version.',
+          'error'
+        );
+      } else {
+        showSnackbar('Failed to update the version.', 'error');
+      }
+    } finally {
+      setIsTogglingEnabled(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    const organizationId = currentOrganization?.uuid;
+    if (!template.id || !organizationId || isDeleting) return;
+    setIsDeleting(true);
+    try {
+      // Guard: a template that has providers created from it can't be deleted,
+      const providers = await getLLMProviders(
+        organizationId,
+        PLATFORM_API_BASE_URL
+      );
+      const inUse = (providers.list ?? []).some(
+        (p) => p.template === template.id
+      );
+      if (inUse) {
+        showSnackbar(
+          'Cannot delete: one or more providers were created from this template.',
+          'error'
+        );
+        setDeleteOpen(false);
+        return;
+      }
+
+      let allVersions = versions;
+      if (allVersions.length === 0) {
+        try {
+          allVersions = await providerTemplateApis.getProviderTemplateVersions(
+            template.id,
+            organizationId,
+            PLATFORM_API_BASE_URL
+          );
+        } catch {
+          // keep empty; navigate to list as fallback
+        }
+      }
+
+      await providerTemplateApis.deleteProviderTemplateVersion(
+        template.id,
+        currentVersion,
+        organizationId,
+        PLATFORM_API_BASE_URL
+      );
+      await refreshTemplates();
+      showSnackbar(`Version ${currentVersion} deleted.`, 'success');
+
+      // If that was the only version the template is gone; navigate to list.
+      // Otherwise navigate to a remaining version — using the deleted handle
+      // for data fetches would return 404.
+      const remaining = allVersions.filter((v) => v.version !== currentVersion);
+      setDeleteOpen(false);
+      if (remaining.length === 0) {
+        navigate(listPath);
+        return;
+      }
+      const nextVersion = remaining.find((v) => v.isLatest) ?? remaining[0];
+      navigate(nextVersion?.id ? `${listPath}/${nextVersion.id}` : listPath, { replace: true });
+    } catch {
+      showSnackbar('Failed to delete the version.', 'error');
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <PageContent fullWidth>
+      {backButton}
+
+      <Stack spacing={3} sx={{ mt: 2 }}>
+        {/* Header card */}
+        <Card>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              flexWrap: 'wrap',
+              gap: 2,
+              padding: 2,
+            }}
+          >
+            <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2 }}>
+              <Avatar
+                src={hasLogo ? logoUrl : undefined}
+                sx={{
+                  width: 72,
+                  height: 72,
+                  fontWeight: 600,
+                  fontSize: 28,
+                  bgcolor: hasLogo ? 'common.white' : 'primary.light',
+                  color: hasLogo ? 'text.primary' : 'primary.contrastText',
+                  border: hasLogo ? '1px solid' : 'none',
+                  borderColor: 'divider',
+                  p: hasLogo ? 0.5 : 0,
+                  '& img': { objectFit: 'contain' },
+                }}
+              >
+                {!hasLogo ? getInitials(template.name) : null}
+              </Avatar>
+              <Stack spacing={0.75} sx={{ minWidth: 0 }}>
+                <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+                  <Typography variant="h3" title={template.name}>
+                    {truncateProviderDisplayName(template.name)}
+                  </Typography>
+                  {canEdit && (
+                    <Tooltip title="Edit template">
+                      <IconButton component={RouterLink} to="edit" size="small">
+                        <Edit size={16} />
+                      </IconButton>
+                    </Tooltip>
+                  )}
+                  {/* Version switcher — a pill that opens the versions menu. */}
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    onClick={(e) => setVersionMenuAnchor(e.currentTarget)}
+                    endIcon={<ChevronDown size={16} />}
+                    sx={{ borderRadius: 5, px: 1.5 }}
+                  >
+                    {selectedVersion || template.version || 'v1'}
+                  </Button>
+                  <Menu
+                    anchorEl={versionMenuAnchor}
+                    open={Boolean(versionMenuAnchor)}
+                    onClose={() => setVersionMenuAnchor(null)}
+                    slotProps={{ paper: { sx: { minWidth: 260 } } }}
+                  >
+                    {(() => {
+                      const allVersions = versions.length ? versions : [template];
+                      const parseVerNum = (s: string) => {
+                        const [maj = 0, min = 0] = (s || 'v0').replace(/^v/i, '').split('.').map(Number);
+                        return maj * 1000 + min;
+                      };
+                      const visibleVersions = (isBuiltIn
+                        ? allVersions.filter((v) => (v.managedBy ?? v.provider) === 'wso2')
+                        : allVersions.filter((v) => (v.managedBy ?? v.provider) !== 'wso2')
+                      ).sort((a, b) => parseVerNum(b.version || 'v0') - parseVerNum(a.version || 'v0'));
+                      const sectionLabel = isBuiltIn ? 'Built-in Versions' : 'Custom Versions';
+
+                      return (
+                        <>
+                          <Typography
+                            variant="overline"
+                            sx={{ px: 2, py: 0.5, display: 'block', color: 'text.secondary' }}
+                          >
+                            {sectionLabel}
+                          </Typography>
+                          {visibleVersions.map((v) => {
+                            const ver = v.version || 'v1';
+                            const isSelected =
+                              ver === (selectedVersion || template.version || 'v1');
+                            return (
+                              <MenuItem
+                                key={ver}
+                                selected={isSelected}
+                                onClick={() => {
+                                  setVersionMenuAnchor(null);
+                                  void handleSwitchVersion(ver);
+                                }}
+                              >
+                                <Stack sx={{ flexGrow: 1 }}>
+                                  <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                                    {ver}
+                                  </Typography>
+                                  <Typography variant="caption" color="text.secondary">
+                                    {formatRelativeTime(v.createdAt ?? v.updatedAt)}
+                                  </Typography>
+                                </Stack>
+                                {isSelected ? <Check size={16} /> : null}
+                              </MenuItem>
+                            );
+                          })}
+                          <Divider />
+                          <MenuItem
+                            component={RouterLink}
+                            to="new-version"
+                            onClick={() => setVersionMenuAnchor(null)}
+                            sx={{ color: 'primary.main', gap: 1 }}
+                          >
+                            <GitBranch size={16} />
+                            Create new version
+                          </MenuItem>
+                        </>
+                      );
+                    })()}
+                  </Menu>
+                </Stack>
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  title={description}
+                >
+                  {description === 'No description'
+                    ? description
+                    : truncateProviderDisplayName(description, 70)}
+                </Typography>
+                <Stack direction="row" spacing={0.75} alignItems="center">
+                  <Typography variant="caption" color="text.secondary">
+                    <FormattedMessage
+                      id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.ProviderTemplateOverview.lastUpdated"
+                      defaultMessage={'Last updated :'}
+                    />
+                  </Typography>
+                  <Clock size={14} />
+                  <Typography variant="caption" color="text.secondary">
+                    {lastUpdated ? formatRelativeTime(lastUpdated) : '—'}
+                  </Typography>
+                </Stack>
+              </Stack>
+            </Box>
+
+            <Stack direction="column" spacing={1.5} alignItems="flex-end">
+              {!isBuiltIn && (
+                <Button
+                  variant="contained"
+                  onClick={() => {
+                    const name = downloadTemplateYaml(template);
+                    showSnackbar(`${name} downloaded`, 'success');
+                  }}
+                  startIcon={<Download size={16} />}
+                >
+                  <FormattedMessage
+                    id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.ProviderTemplateOverview.downloadYaml"
+                    defaultMessage={'Download YAML'}
+                  />
+                </Button>
+              )}
+              {isReadOnly && (
+                <Stack direction="row" spacing={1} alignItems="center">
+                  <Typography variant="body2" color="text.primary">
+                    {isEnabled ? 'Enabled' : 'Disabled'}
+                  </Typography>
+                  <Switch
+                    checked={isEnabled}
+                    disabled={isTogglingEnabled}
+                    onChange={(e) => void handleToggleEnabled(e.target.checked)}
+                    inputProps={{ 'aria-label': 'Enable or disable this version' }}
+                  />
+                </Stack>
+              )}
+              {/* Custom templates can be deleted entirely (all versions). */}
+              {canDelete && (
+                <Button
+                  variant="outlined"
+                  color="error"
+                  onClick={() => setDeleteOpen(true)}
+                  sx={{ minWidth: 'auto', p: '6px' }}
+                  aria-label="Delete template version"
+                  data-cyid="provider-template-delete-button"
+                >
+                  <Trash2 size={16} />
+                </Button>
+              )}
+            </Stack>
+          </Box>
+        </Card>
+
+        {/* Built-in base version: read-only notice. */}
+        {isReadOnly && (
+          <Card sx={{ bgcolor: 'action.hover' }}>
+            <Stack direction="row" spacing={1.5} alignItems="center" sx={{ p: 2 }}>
+              <Lock size={18} />
+              <Typography variant="body2">
+                <strong>Built-in version. You can only enable or disable it.</strong>
+              </Typography>
+            </Stack>
+          </Card>
+        )}
+
+        {/* Tabbed card */}
+        <Card>
+          <Tabs
+            value={tabIndex}
+            onChange={(_, value) => setTabIndex(value)}
+            variant="scrollable"
+            allowScrollButtonsMobile
+          >
+            {tabs.map((label) => (
+              <Tab key={label} label={label} />
+            ))}
+          </Tabs>
+          <Divider />
+          <Box padding={2}>
+            {/* Overview */}
+            <TabPanel value={tabIndex} index={0}>
+              <Box>
+                {!isReadOnly && (
+                  <>
+                    {/* Logo URL */}
+                    <Box sx={{ mb: 3 }}>
+                      <FormControl fullWidth>
+                        <FormLabel>Logo URL</FormLabel>
+                        <TextField
+                          fullWidth
+                          value={logoUrlField}
+                          onChange={(e) => {
+                            setLogoUrlField(e.target.value);
+                            setIsDirty(true);
+                            setLogoUrlTouched(false);
+                          }}
+                          onBlur={() => setLogoUrlTouched(true)}
+                          placeholder="https://cdn.example.com/logos/openai.svg"
+                          error={logoUrlTouched && !isValidHttpUrl(logoUrlField)}
+                          helperText={
+                            logoUrlTouched && !isValidHttpUrl(logoUrlField)
+                              ? 'Enter a valid URL.'
+                              : ''
+                          }
+                        />
+                      </FormControl>
+                    </Box>
+
+                    {/* OpenAPI Specification source */}
+                    <Box sx={{ mb: 3 }}>
+                      <Typography variant="h6" sx={{ mb: 1, fontWeight: 600 }}>
+                        OpenAPI Specification
+                      </Typography>
+                      <FormControl fullWidth>
+                        <Stack spacing={1.5}>
+                          <Stack direction="row" spacing={1.5} alignItems="center">
+                            <TextField
+                              size="small"
+                              fullWidth
+                              value={openapiSpecUrl}
+                              onChange={(e) => {
+                                // Typing a URL must NOT discard an uploaded spec;
+                                // only a successful fetch replaces it.
+                                setOpenapiSpecUrl(e.target.value);
+                                setIsDirty(true);
+                                setOpenapiSpecUrlTouched(false);
+                              }}
+                              onBlur={() => setOpenapiSpecUrlTouched(true)}
+                              placeholder="https://api.openai.com/openapi.json"
+                              error={openapiSpecUrlTouched && !isValidHttpUrl(openapiSpecUrl)}
+                              helperText={
+                                openapiSpecUrlTouched && !isValidHttpUrl(openapiSpecUrl)
+                                  ? 'Enter a valid URL.'
+                                  : ''
+                              }
+                            />
+                            <Button
+                              variant="outlined"
+                              size="small"
+                              disabled={
+                                isFetchingSpec ||
+                                !openapiSpecUrl.trim() ||
+                                !isValidHttpUrl(openapiSpecUrl)
+                              }
+                              onClick={() => void fetchSpecFromUrl()}
+                              sx={{ whiteSpace: 'nowrap', flexShrink: 0 }}
+                            >
+                              {isFetchingSpec ? 'Fetching…' : 'Fetch specification'}
+                            </Button>
+                          </Stack>
+                          <Divider>Or</Divider>
+                          <Button
+                            variant="outlined"
+                            fullWidth
+                            onClick={() => fileInputRef.current?.click()}
+                          >
+                            {specFileName
+                              ? `Uploaded: ${specFileName}`
+                              : specContent.trim()
+                                ? 'Uploaded Specification'
+                                : 'Upload Your Specification'}
+                          </Button>
+                        </Stack>
+                        <input
+                          ref={fileInputRef}
+                          type="file"
+                          hidden
+                          accept=".json,.yaml,.yml"
+                          onChange={handleSpecFileChange}
+                        />
+                      </FormControl>
+                    </Box>
+                  </>
+                )}
+
+                {/* OpenAPI Resources viewer */}
+                <Typography variant="h6" sx={{ mb: 1, fontWeight: 600 }}>
+                  OpenAPI Resources
+                </Typography>
+                {!specContent.trim() &&
+                !urlSpecText &&
+                !template.openapi?.trim() &&
+                !template.metadata?.openapiSpecUrl?.trim() ? (
+                  <Typography variant="body2" color="text.secondary" sx={{ py: 2 }}>
+                    No available resources. Add an OpenAPI specification above to see resources.
+                  </Typography>
+                ) : isSpecLoading && !specContent.trim() ? (
+                  <Box sx={{ display: 'flex', justifyContent: 'center', py: 3 }}>
+                    <CircularProgress size={24} />
+                  </Box>
+                ) : !parsedSpec ? (
+                  <Typography variant="body2" color="error" sx={{ py: 2 }}>
+                    Failed to load the OpenAPI specification
+                    {template.metadata?.openapiSpecUrl?.trim()
+                      ? ' from the configured URL.'
+                      : '.'}
+                  </Typography>
+                ) : (
+                  <Box
+                    sx={{
+                      maxHeight: 350,
+                      overflowY: 'auto',
+                      border: '1px solid',
+                      borderColor: 'divider',
+                      borderRadius: 1,
+                      bgcolor: 'background.paper',
+                      px: 2,
+                      pt: 2,
+                    }}
+                  >
+                    <SwaggerSpecViewer
+                      spec={parsedSpec}
+                      disableTryOutBtn
+                      disableNetworkExecution
+                      hideInfoSection
+                      hideServers
+                      hideAuthorizeButton
+                      hideTagHeaders
+                      docExpansion="list"
+                      defaultModelsExpandDepth={-1}
+                    />
+                  </Box>
+                )}
+              </Box>
+            </TabPanel>
+
+            <TabPanel value={tabIndex} index={1}>
+              <Box
+                sx={
+                  isReadOnly
+                    ? { pointerEvents: 'none', opacity: 0.7 }
+                    : undefined
+                }
+              >
+                <Grid container spacing={2}>
+                <Grid size={{ xs: 12 }}>
+                  <FormControl fullWidth>
+                    <FormLabel required>Endpoint URL</FormLabel>
+                    <TextField
+                      fullWidth
+                      required
+                      value={endpointUrl}
+                      onChange={(e) => {
+                        setEndpointUrl(e.target.value);
+                        setIsDirty(true);
+                        setEndpointUrlTouched(false);
+                      }}
+                      onBlur={() => setEndpointUrlTouched(true)}
+                      placeholder="https://api.openai.com"
+                      error={endpointUrlTouched && (!endpointUrl.trim() || !isValidHttpUrl(endpointUrl))}
+                      helperText={
+                        endpointUrlTouched && !endpointUrl.trim()
+                          ? 'Endpoint URL is required.'
+                          : endpointUrlTouched && !isValidHttpUrl(endpointUrl)
+                            ? 'Enter a valid URL.'
+                            : ''
+                      }
+                    />
+                  </FormControl>
+                </Grid>
+                <Grid size={{ xs: 12, sm: 4 }}>
+                  <FormControl fullWidth>
+                    <FormLabel>Auth Type</FormLabel>
+                    <TextField
+                      fullWidth
+                      value={authType}
+                      onChange={(e) => {
+                        setAuthType(e.target.value);
+                        setIsDirty(true);
+                      }}
+                      placeholder="bearer"
+                    />
+                  </FormControl>
+                </Grid>
+                <Grid size={{ xs: 12, sm: 4 }}>
+                  <FormControl fullWidth>
+                    <FormLabel>Auth Header</FormLabel>
+                    <TextField
+                      fullWidth
+                      value={authHeader}
+                      onChange={(e) => {
+                        setAuthHeader(e.target.value);
+                        setIsDirty(true);
+                      }}
+                      placeholder="Authorization"
+                    />
+                  </FormControl>
+                </Grid>
+                <Grid size={{ xs: 12, sm: 4 }}>
+                  <FormControl fullWidth>
+                    <FormLabel>Value Prefix</FormLabel>
+                    <TextField
+                      fullWidth
+                      value={valuePrefix}
+                      onChange={(e) => {
+                        setValuePrefix(e.target.value);
+                        setIsDirty(true);
+                      }}
+                      placeholder="Bearer "
+                    />
+                  </FormControl>
+                </Grid>
+                </Grid>
+              </Box>
+            </TabPanel>
+
+            <TabPanel value={tabIndex} index={2}>
+              <Box
+                sx={
+                  isReadOnly
+                    ? { pointerEvents: 'none', opacity: 0.7 }
+                    : undefined
+                }
+              >
+                <TemplateTokenMapping
+                  defaultTokens={defaultTokens}
+                  onChangeDefaultToken={updateToken}
+                  resourceMappings={resourceMappings}
+                  onChangeResourceMappings={(next) => {
+                    setResourceMappings(next);
+                    setIsDirty(true);
+                  }}
+                  spec={parsedSpec}
+                  hidePerResource={isReadOnly}
+                />
+              </Box>
+            </TabPanel>
+          </Box>
+        </Card>
+
+        {/* Save/cancel bar — hidden for read-only built-in versions. */}
+        {!isReadOnly && (
+        <Box sx={{ position: 'sticky', bottom: 0, zIndex: 10 }}>
+          <Card>
+            <Stack
+              direction={{ xs: 'column', sm: 'row' }}
+              spacing={1}
+              alignItems={{ xs: 'flex-start', sm: 'center' }}
+              justifyContent="space-between"
+              sx={{ p: 2 }}
+            >
+              <Typography
+                variant="body2"
+                color={isDirty ? 'warning.main' : 'text.secondary'}
+              >
+                {isDirty ? 'You have unsaved changes.' : ''}
+              </Typography>
+              <Stack direction="row" spacing={1}>
+                <Button
+                  variant="outlined"
+                  color="secondary"
+                  disabled={!isDirty || isSaving}
+                  onClick={handleCancelChanges}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  variant="contained"
+                  disabled={
+                    !isDirty ||
+                    isSaving ||
+                    !endpointUrl.trim() ||
+                    !isValidHttpUrl(endpointUrl) ||
+                    !isValidHttpUrl(openapiSpecUrl) ||
+                    !isValidHttpUrl(logoUrlField)
+                  }
+                  onClick={() => void handleSaveChanges()}
+                >
+                  {isSaving ? 'Updating...' : 'Update'}
+                </Button>
+              </Stack>
+            </Stack>
+          </Card>
+        </Box>
+        )}
+      </Stack>
+
+      <Dialog open={deleteOpen} onClose={() => setDeleteOpen(false)}>
+        <DialogTitle>
+          Delete version <strong>{currentVersion}</strong> of{' '}
+          <strong>&apos;{template.name}&apos;</strong>?
+        </DialogTitle>
+        <DialogContent>
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+            {versions.length <= 1
+              ? 'This is the only version, so the template will be removed. This action is irreversible.'
+              : 'Only this version is removed; other versions remain. This action is irreversible.'}
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            variant="outlined"
+            color="secondary"
+            onClick={() => setDeleteOpen(false)}
+            disabled={isDeleting}
+          >
+            Cancel
+          </Button>
+          <Button color="error" onClick={() => void handleDelete()} disabled={isDeleting}>
+            {isDeleting ? 'Deleting...' : 'Delete'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </PageContent>
+  );
+}

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/ProviderTemplateOverview.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/ProviderTemplateOverview.tsx
@@ -636,7 +636,13 @@ export default function ProviderTemplateOverview() {
         navigate(listPath);
         return;
       }
-      const nextVersion = remaining.find((v) => v.isLatest) ?? remaining[0];
+      const parseVerNum = (s: string) => {
+        const [maj = 0, min = 0] = (s || 'v0').replace(/^v/i, '').split('.').map(Number);
+        return maj * 1000 + min;
+      };
+      const nextVersion =
+        remaining.find((v) => v.isLatest) ??
+        [...remaining].sort((a, b) => parseVerNum(b.version || 'v0') - parseVerNum(a.version || 'v0'))[0];
       navigate(nextVersion?.id ? `${listPath}/${nextVersion.id}` : listPath, { replace: true });
     } catch {
       showSnackbar('Failed to delete the version.', 'error');

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/ProviderTemplatesList.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/ProviderTemplatesList.tsx
@@ -1,0 +1,552 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Avatar,
+  Box,
+  Button,
+  Card,
+  Chip,
+  Divider,
+  IconButton,
+  InputAdornment,
+  PageContent,
+  PageTitle,
+  Skeleton,
+  Stack,
+  TextField,
+  Typography,
+} from '@wso2/oxygen-ui';
+import { ChevronLeft, ChevronRight, Clock, Cpu, Plus, Search } from '@wso2/oxygen-ui-icons-react';
+import { FormattedMessage } from 'react-intl';
+import { formatRelativeTime } from '../../../../contexts/llmProvider';
+import { useProviderTemplates } from '../../../../contexts/llmProvider/providerTemplate';
+import { useAppShell } from '../../../../contexts/AppShellContext';
+import { buildOrgPath } from '../../../../utils/projectRouting';
+import ErrorAlert from '../../../../Components/common/ErrorAlert';
+import { truncateProviderDisplayName } from '../../../../utils/providerTemplateDisplay';
+import type { ProviderTemplate } from '../../../../utils/types';
+import AnthropicLogo from '../../../../assets/brands/Anthropic.jpg';
+import AWSBedrockLogo from '../../../../assets/brands/AWSBedrock.webp';
+import AzureLogo from '../../../../assets/brands/Azure.png';
+import GoogleVertexLogo from '../../../../assets/brands/GoogleVertex.png';
+import GoogleGeminiLogo from '../../../../assets/brands/googlegemini.png';
+import MistralAILogo from '../../../../assets/brands/mistralai.png';
+import OpenAILogo from '../../../../assets/brands/openAI.png';
+
+const PROVIDER_LOGO_MAP: Record<string, string> = {
+  openai: OpenAILogo,
+  anthropic: AnthropicLogo,
+  'azure-openai': AzureLogo,
+  'azureai-foundry': AzureLogo,
+  'aws-bedrock': AWSBedrockLogo,
+  awsbedrock: AWSBedrockLogo,
+  'google-vertex': GoogleVertexLogo,
+  gemini: GoogleGeminiLogo,
+  mistralai: MistralAILogo,
+  mistral: MistralAILogo,
+};
+
+function resolveTemplateLogo(template: ProviderTemplate): string | undefined {
+  const fromMeta = template.metadata?.logoUrl?.trim() || template.logoUrl?.trim();
+  if (fromMeta) return fromMeta;
+  const id = template.id.toLowerCase();
+  if (PROVIDER_LOGO_MAP[id]) return PROVIDER_LOGO_MAP[id];
+  const matchedKey = Object.keys(PROVIDER_LOGO_MAP)
+    .sort((a, b) => b.length - a.length)
+    .find((key) => id.startsWith(key));
+  return matchedKey ? PROVIDER_LOGO_MAP[matchedKey] : undefined;
+}
+
+function getInitials(name: string): string {
+  const words = name.trim().split(/\s+/);
+  if (words.length === 0 || words[0] === '') return '??';
+  if (words.length === 1) return words[0].slice(0, 2).toUpperCase();
+  return `${words[0][0]}${words[1][0]}`.toUpperCase();
+}
+
+export default function ProviderTemplatesList({
+  embedded = false,
+}: {
+  embedded?: boolean;
+} = {}) {
+  const navigate = useNavigate();
+  const { currentOrganization } = useAppShell();
+
+  const { templatesResponse, isLoading, error, refreshTemplates } =
+    useProviderTemplates();
+
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const templates = useMemo(
+    () =>
+      templatesResponse.list.filter(
+        (template) => (template.managedBy ?? template.provider) !== 'wso2'
+      ),
+    [templatesResponse.list]
+  );
+
+  const templatesBase = buildOrgPath(
+    currentOrganization,
+    '/settings/llm-provider-templates'
+  );
+  const newTemplatePath = `${templatesBase}/new`;
+  const filteredTemplates = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
+    if (!query) return templates;
+    return templates.filter(
+      (template) =>
+        template.name.toLowerCase().includes(query) ||
+        (template.description ?? '').toLowerCase().includes(query)
+    );
+  }, [templates, searchQuery]);
+
+  // Paginate the custom templates ~2 rows at a time. Clamp the page so it stays
+  // valid when the filtered list shrinks (e.g. while searching).
+  const CUSTOM_PAGE_SIZE = 6;
+  const [customPage, setCustomPage] = useState(1);
+  const customTotalPages = Math.max(
+    1,
+    Math.ceil(filteredTemplates.length / CUSTOM_PAGE_SIZE)
+  );
+  const currentCustomPage = Math.min(customPage, customTotalPages);
+  const pagedCustomTemplates = filteredTemplates.slice(
+    (currentCustomPage - 1) * CUSTOM_PAGE_SIZE,
+    currentCustomPage * CUSTOM_PAGE_SIZE
+  );
+
+  const builtInTemplates = useMemo(
+    () =>
+      templatesResponse.list.filter(
+        (template) => (template.managedBy ?? template.provider) === 'wso2'
+      ),
+    [templatesResponse.list]
+  );
+  const filteredBuiltIn = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
+    if (!query) return builtInTemplates;
+    return builtInTemplates.filter(
+      (template) =>
+        template.name.toLowerCase().includes(query) ||
+        (template.description ?? '').toLowerCase().includes(query)
+    );
+  }, [builtInTemplates, searchQuery]);
+
+  const renderCard = (template: ProviderTemplate) => {
+    const templateId = template.id;
+    const overviewPath = `${templatesBase}/${templateId}`;
+    const logoSrc = resolveTemplateLogo(template);
+    const hasLogo = Boolean(logoSrc);
+    return (
+      <Card
+        key={templateId}
+        data-cyid={`provider-template-card-${templateId}`}
+        tabIndex={0}
+        role="button"
+        onClick={() => navigate(overviewPath)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            navigate(overviewPath);
+          }
+        }}
+        sx={{
+          height: '100%',
+          width: '100%',
+          cursor: 'pointer',
+          // Disabled templates are dimmed but still clickable (to re-enable).
+          opacity: template.enabled === false ? 0.55 : 1,
+          transition: 'box-shadow 0.2s ease, opacity 0.2s ease',
+          '&.MuiCard-root:hover': { boxShadow: 3 },
+          '&:focus-visible': {
+            outline: '2px solid',
+            outlineColor: 'primary.main',
+            outlineOffset: '2px',
+          },
+        }}
+      >
+        <Box
+          sx={{
+            height: '100%',
+            width: '100%',
+            display: 'flex',
+            flexDirection: 'column',
+            p: 2,
+          }}
+        >
+          <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1.5 }}>
+            <Avatar
+              src={hasLogo ? logoSrc : undefined}
+              sx={{
+                width: 44,
+                height: 44,
+                fontWeight: 600,
+                bgcolor: hasLogo ? 'common.white' : 'primary.light',
+                color: hasLogo ? 'text.primary' : 'primary.contrastText',
+                border: hasLogo ? '1px solid' : 'none',
+                borderColor: 'divider',
+                p: hasLogo ? 0.5 : 0,
+                '& img': { objectFit: 'contain' },
+              }}
+            >
+              {!hasLogo ? getInitials(template.name) : null}
+            </Avatar>
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <Typography
+                variant="h5"
+                noWrap
+                sx={{ fontWeight: 600 }}
+                title={template.name}
+              >
+                {truncateProviderDisplayName(template.name)}
+              </Typography>
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                fontSize="0.75rem"
+                noWrap
+                sx={{ mt: 0.5 }}
+                title={template.description?.trim() || undefined}
+              >
+                {template.description?.trim()
+                  ? truncateProviderDisplayName(template.description, 70)
+                  : 'No description'}
+              </Typography>
+            </Box>
+          </Box>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 2,
+              mt: 'auto',
+              pt: 2,
+            }}
+          >
+            <Stack direction="row" spacing={0.5} alignItems="center">
+              <Clock size={14} />
+              <Typography variant="body2" color="text.secondary">
+                {formatRelativeTime(template.createdAt ?? template.updatedAt)}
+              </Typography>
+            </Stack>
+            {template.enabled === false ? (
+              <Chip label="Disabled" size="small" variant="outlined" />
+            ) : null}
+          </Box>
+        </Box>
+      </Card>
+    );
+  };
+
+  const cardGridSx = {
+    display: 'grid',
+    gap: 2,
+    gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))',
+  } as const;
+
+  const Wrapper: React.ElementType = embedded ? React.Fragment : PageContent;
+  return (
+    <Wrapper {...(embedded ? {} : { fullWidth: true })}>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: { xs: 'flex-start', sm: 'center' },
+          justifyContent: 'space-between',
+          flexWrap: { xs: 'wrap', sm: 'nowrap' },
+          gap: 2,
+        }}
+      >
+        <PageTitle>
+          <PageTitle.Header>
+            <FormattedMessage
+              id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.ProviderTemplatesList.title"
+              defaultMessage={'LLM Provider Templates'}
+            />
+          </PageTitle.Header>
+          <PageTitle.SubHeader>
+            <FormattedMessage
+              id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.ProviderTemplatesList.subtitle"
+              defaultMessage={
+                'Define reusable templates for connecting LLM providers.'
+              }
+            />
+          </PageTitle.SubHeader>
+        </PageTitle>
+
+        {templates.length > 0 && (
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={() => navigate(newTemplatePath)}
+            startIcon={<Plus size={20} />}
+            data-cyid="add-provider-template-button"
+          >
+            <FormattedMessage
+              id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.ProviderTemplatesList.create"
+              defaultMessage={'Create'}
+            />
+          </Button>
+        )}
+      </Box>
+
+      {isLoading && (
+        <Box
+          sx={{
+            display: 'grid',
+            gap: 2,
+            gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))',
+            mt: 1,
+          }}
+        >
+          {[0, 1, 2].map((key) => (
+            <Skeleton key={key} variant="rounded" height={120} />
+          ))}
+        </Box>
+      )}
+
+      {error && !isLoading && (
+        <Box sx={{ py: 2 }}>
+          <ErrorAlert error={error} onRetry={refreshTemplates} />
+        </Box>
+      )}
+
+      {!isLoading &&
+        !error &&
+        templates.length === 0 &&
+        builtInTemplates.length === 0 && (
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              py: 6,
+            }}
+          >
+            <Stack spacing={1.5} alignItems="center" sx={{ textAlign: 'center' }}>
+              <Typography variant="h6" sx={{ fontWeight: 700 }}>
+                <FormattedMessage
+                  id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.ProviderTemplatesList.empty.title"
+                  defaultMessage={'Create your first LLM Provider Template'}
+                />
+              </Typography>
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                sx={{ maxWidth: 420 }}
+              >
+                <FormattedMessage
+                  id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.ProviderTemplatesList.empty.subtitle"
+                  defaultMessage={
+                    'A template holds the endpoint and auth details for connecting a custom LLM provider.'
+                  }
+                />
+              </Typography>
+              <Button
+                variant="contained"
+                onClick={() => navigate(newTemplatePath)}
+                startIcon={<Plus size={18} />}
+                data-cyid="add-provider-template-button"
+              >
+                <FormattedMessage
+                  id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.ProviderTemplatesList.create"
+                  defaultMessage={'Create'}
+                />
+              </Button>
+            </Stack>
+          </Box>
+        )}
+
+      {!isLoading &&
+        !error &&
+        (templates.length > 0 || builtInTemplates.length > 0) && (
+          <>
+            {templates.length > 0 && (
+              <Box sx={{ my: 3 }}>
+                <TextField
+                  fullWidth
+                  placeholder="Search templates..."
+                  value={searchQuery}
+                  onChange={(event) => {
+                    setSearchQuery(event.target.value);
+                    setCustomPage(1);
+                  }}
+                  data-cyid="provider-template-search-input"
+                  slotProps={{
+                    input: {
+                      startAdornment: (
+                        <InputAdornment position="start">
+                          <Search size={20} />
+                        </InputAdornment>
+                      ),
+                    },
+                  }}
+                />
+              </Box>
+            )}
+
+            <Typography
+              variant="h6"
+              sx={{ fontWeight: 700, mb: 0.5, mt: 0 }}
+            >
+              Custom LLM Providers
+            </Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              Templates you create to connect your own LLM providers.
+            </Typography>
+
+            {filteredTemplates.length > 0 ? (
+              <>
+                <Box sx={cardGridSx}>
+                  {pagedCustomTemplates.map((template) =>
+                    renderCard(template)
+                  )}
+                </Box>
+                {customTotalPages > 1 && (
+                  <Stack
+                    direction="row"
+                    spacing={1}
+                    alignItems="center"
+                    justifyContent="center"
+                    sx={{ mt: 3 }}
+                  >
+                    <IconButton
+                      size="small"
+                      disabled={currentCustomPage <= 1}
+                      onClick={() => setCustomPage(currentCustomPage - 1)}
+                      aria-label="Previous page"
+                    >
+                      <ChevronLeft size={18} />
+                    </IconButton>
+                    <Typography variant="body2" color="text.secondary">
+                      Page {currentCustomPage} of {customTotalPages}
+                    </Typography>
+                    <IconButton
+                      size="small"
+                      disabled={currentCustomPage >= customTotalPages}
+                      onClick={() => setCustomPage(currentCustomPage + 1)}
+                      aria-label="Next page"
+                    >
+                      <ChevronRight size={18} />
+                    </IconButton>
+                  </Stack>
+                )}
+              </>
+            ) : templates.length === 0 ? (
+              <Box
+                sx={{
+                  border: '1px dashed',
+                  borderColor: 'divider',
+                  borderRadius: 2,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  px: 3,
+                  py: 8,
+                }}
+              >
+                <Stack
+                  spacing={2}
+                  alignItems="center"
+                  justifyContent="center"
+                  sx={{ textAlign: 'center', width: '100%' }}
+                >
+                  <Box
+                    sx={{
+                      width: 72,
+                      height: 72,
+                      borderRadius: 2,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      color: 'primary.main',
+                      bgcolor: (theme) =>
+                        `color-mix(in srgb, ${theme.palette.primary.main} 12%, transparent)`,
+                      border: '1px solid',
+                      borderColor: (theme) =>
+                        `color-mix(in srgb, ${theme.palette.primary.main} 30%, transparent)`,
+                    }}
+                  >
+                    <Cpu size={32} />
+                  </Box>
+                  <Typography variant="h6" sx={{ fontWeight: 700 }}>
+                    <FormattedMessage
+                      id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.ProviderTemplatesList.empty.title"
+                      defaultMessage={
+                        'Create your first LLM Provider Template'
+                      }
+                    />
+                  </Typography>
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    sx={{ maxWidth: 460 }}
+                  >
+                    <FormattedMessage
+                      id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.ProviderTemplatesList.empty.subtitle"
+                      defaultMessage={
+                        'A template holds the endpoint and auth details for connecting a custom LLM provider.'
+                      }
+                    />
+                  </Typography>
+                  <Button
+                    variant="contained"
+                    onClick={() => navigate(newTemplatePath)}
+                    startIcon={<Plus size={18} />}
+                    data-cyid="add-provider-template-button"
+                  >
+                    <FormattedMessage
+                      id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.ProviderTemplatesList.create"
+                      defaultMessage={'Create'}
+                    />
+                  </Button>
+                </Stack>
+              </Box>
+            ) : (
+              <Typography variant="body2" color="text.secondary" sx={{ py: 1 }}>
+                No custom templates match your search.
+              </Typography>
+            )}
+
+            {builtInTemplates.length > 0 && (
+              <>
+                <Divider sx={{ my: 4 }} />
+                <Typography variant="h6" sx={{ fontWeight: 700, mb: 0.5 }}>
+                  Built-in Templates
+                </Typography>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                  Built-in LLM providers, included by default.
+                </Typography>
+                {filteredBuiltIn.length > 0 ? (
+                  <Box sx={cardGridSx}>
+                    {filteredBuiltIn.map((template) => renderCard(template))}
+                  </Box>
+                ) : (
+                  <Typography variant="body2" color="text.secondary" sx={{ py: 1 }}>
+                    No built-in templates match your search.
+                  </Typography>
+                )}
+              </>
+            )}
+          </>
+        )}
+    </Wrapper>
+  );
+}

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/TemplateTokenMapping.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/TemplateTokenMapping.tsx
@@ -1,0 +1,327 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useMemo, useState } from 'react';
+import {
+  Box,
+  Collapse,
+  FormControl,
+  FormControlLabel,
+  FormLabel,
+  IconButton,
+  MenuItem,
+  Select,
+  Stack,
+  Switch,
+  TextField,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+} from '@wso2/oxygen-ui';
+import { ChevronDown, ChevronUp, Info } from '@wso2/oxygen-ui-icons-react';
+import { ResourceRow } from '../../../../Components/ResourceView';
+import type { ResourceMapping } from '../../../../utils/types';
+import {
+  fromTokenConfig,
+  toTokenConfig,
+  TOKEN_FIELDS,
+  TOKEN_LOCATIONS,
+  type TokenConfig,
+  type TokenFieldKey,
+} from '../../../../utils/providerTemplateFields';
+
+interface DiscoveredResource {
+  method: string;
+  path: string;
+  summary?: string;
+}
+
+function extractResources(spec: Record<string, unknown> | null): DiscoveredResource[] {
+  const paths = (spec?.paths ?? null) as Record<
+    string,
+    Record<string, { summary?: string; description?: string }>
+  > | null;
+  if (!paths || typeof paths !== 'object') return [];
+  const METHODS = new Set(['get', 'post', 'put', 'patch', 'delete', 'head', 'options']);
+  const all: DiscoveredResource[] = [];
+  Object.keys(paths).forEach((path) => {
+    const ops = paths[path];
+    if (!ops || typeof ops !== 'object') return;
+    Object.keys(ops).forEach((m) => {
+      if (!METHODS.has(m.toLowerCase())) return;
+      all.push({
+        method: m.toUpperCase(),
+        path,
+        summary: ops[m]?.summary || ops[m]?.description || undefined,
+      });
+    });
+  });
+  all.sort((a, b) => a.path.localeCompare(b.path) || a.method.localeCompare(b.method));
+  // Resource overrides are path-scoped on the backend; deduplicate to one row per path.
+  const seen = new Set<string>();
+  return all.filter((r) => {
+    if (seen.has(r.path)) return false;
+    seen.add(r.path);
+    return true;
+  });
+}
+
+function TokenFieldsEditor({
+  tokens,
+  onChange,
+}: {
+  tokens: TokenConfig;
+  onChange: (field: TokenFieldKey, key: 'identifier' | 'location', value: string) => void;
+}) {
+  return (
+    <Box
+      sx={{
+        display: 'grid',
+        gap: 2,
+        gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' },
+      }}
+    >
+      {TOKEN_FIELDS.map(({ key, label }) => (
+        <FormControl key={key} fullWidth>
+          <FormLabel>{label}</FormLabel>
+          <Stack direction="row" spacing={1} alignItems="flex-start">
+            <TextField
+              fullWidth
+              size="small"
+              value={tokens[key].identifier}
+              onChange={(e) => onChange(key, 'identifier', e.target.value)}
+            />
+            <Select
+              size="small"
+              value={tokens[key].location}
+              onChange={(e) => onChange(key, 'location', e.target.value as string)}
+              sx={{ minWidth: 130, flexShrink: 0 }}
+            >
+              {TOKEN_LOCATIONS.map((o) => (
+                <MenuItem key={o.value} value={o.value}>
+                  {o.label}
+                </MenuItem>
+              ))}
+            </Select>
+          </Stack>
+        </FormControl>
+      ))}
+    </Box>
+  );
+}
+
+interface TemplateTokenMappingProps {
+  defaultTokens: TokenConfig;
+  onChangeDefaultToken: (
+    field: TokenFieldKey,
+    key: 'identifier' | 'location',
+    value: string
+  ) => void;
+  resourceMappings: ResourceMapping[];
+  onChangeResourceMappings: (next: ResourceMapping[]) => void;
+  spec: Record<string, unknown> | null;
+  hidePerResource?: boolean;
+}
+
+export default function TemplateTokenMapping({
+  defaultTokens,
+  onChangeDefaultToken,
+  resourceMappings,
+  onChangeResourceMappings,
+  spec,
+  hidePerResource = false,
+}: TemplateTokenMappingProps) {
+  const [scope, setScope] = useState<'default' | 'resource'>('default');
+  const [search, setSearch] = useState('');
+  const [openKey, setOpenKey] = useState<string | null>(null);
+
+  const resources = useMemo(() => extractResources(spec), [spec]);
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return resources;
+    return resources.filter((r) =>
+      `${r.method} ${r.path} ${r.summary ?? ''}`.toLowerCase().includes(q)
+    );
+  }, [resources, search]);
+
+  const mappingFor = (path: string) =>
+    resourceMappings.find((m) => m.resource === path);
+
+  const isOverridden = (path: string) => Boolean(mappingFor(path));
+
+  const toggleOverride = (path: string, rowKey: string, enabled: boolean) => {
+    if (enabled) {
+      if (!isOverridden(path)) {
+        const seeded: ResourceMapping = {
+          resource: path,
+          ...fromTokenConfig(defaultTokens),
+        };
+        onChangeResourceMappings([...resourceMappings, seeded]);
+      }
+      setOpenKey(rowKey);
+    } else {
+      onChangeResourceMappings(resourceMappings.filter((m) => m.resource !== path));
+      setOpenKey((prev) => (prev === rowKey ? null : prev));
+    }
+  };
+
+  // Update a single token field of a resource override.
+  const updateResourceToken = (
+    path: string,
+    field: TokenFieldKey,
+    key: 'identifier' | 'location',
+    value: string
+  ) => {
+    const existing = mappingFor(path);
+    const cfg = toTokenConfig(existing);
+    cfg[field] = { ...cfg[field], [key]: value };
+    const updated: ResourceMapping = { resource: path, ...fromTokenConfig(cfg) };
+    onChangeResourceMappings(
+      resourceMappings.some((m) => m.resource === path)
+        ? resourceMappings.map((m) => (m.resource === path ? updated : m))
+        : [...resourceMappings, updated]
+    );
+  };
+
+  const effectiveScope = hidePerResource ? 'default' : scope;
+
+  return (
+    <Box>
+      {!hidePerResource && (
+        <ToggleButtonGroup
+          exclusive
+          size="small"
+          value={effectiveScope}
+          onChange={(_, v) => v && setScope(v)}
+          sx={{ mb: 2 }}
+        >
+          <ToggleButton value="default">Global</ToggleButton>
+          <ToggleButton value="resource">Per Resource</ToggleButton>
+        </ToggleButtonGroup>
+      )}
+
+      {effectiveScope === 'default' ? (
+        <>
+          <Stack direction="row" spacing={1} alignItems="flex-start" sx={{ mb: 2.5 }}>
+            <Info size={16} style={{ marginTop: 2, flexShrink: 0, opacity: 0.7 }} />
+            <Typography variant="body2" color="text.secondary">
+              Applies to all resources unless overridden per resource.
+            </Typography>
+          </Stack>
+          <TokenFieldsEditor tokens={defaultTokens} onChange={onChangeDefaultToken} />
+        </>
+      ) : (
+        <Stack spacing={1.5}>
+          <Stack direction="row" spacing={1} alignItems="flex-start">
+            <Info size={16} style={{ marginTop: 2, flexShrink: 0, opacity: 0.7 }} />
+            <Typography variant="body2" color="text.secondary">
+              Turn on a resource to give it its own mapping.
+            </Typography>
+          </Stack>
+
+          <TextField
+            size="small"
+            fullWidth
+            placeholder="Search resources..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+
+          {filtered.length === 0 ? (
+            <Typography variant="body2" color="text.secondary" sx={{ py: 2 }}>
+              {resources.length === 0
+                ? 'No resources found. Add an OpenAPI specification on the Connection tab.'
+                : 'No resources match your search.'}
+            </Typography>
+          ) : (
+            <Box sx={{ maxHeight: 460, overflowY: 'auto', pr: 0.5 }}>
+              {filtered.map((r) => {
+                const key = `${r.method}-${r.path}`;
+                const overridden = isOverridden(r.path);
+                const isOpen = openKey === key;
+                return (
+                  <Box key={key} sx={{ mb: 0.8 }}>
+                    <ResourceRow
+                      resource={r}
+                      selected={overridden}
+                      onClick={() => setOpenKey(isOpen ? null : key)}
+                      trailing={
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                          <FormControlLabel
+                            label="Override"
+                            labelPlacement="start"
+                            onClick={(e) => e.stopPropagation()}
+                            control={
+                              <Switch
+                                size="small"
+                                checked={overridden}
+                                onChange={(e) =>
+                                  toggleOverride(r.path, key, e.target.checked)
+                                }
+                              />
+                            }
+                          />
+                          <IconButton
+                            size="small"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setOpenKey(isOpen ? null : key);
+                            }}
+                          >
+                            {isOpen ? <ChevronUp size={18} /> : <ChevronDown size={18} />}
+                          </IconButton>
+                        </Box>
+                      }
+                    />
+                    <Collapse in={isOpen} timeout="auto" unmountOnExit>
+                      <Box
+                        sx={{
+                          mt: 1,
+                          px: 1.5,
+                          py: 1.5,
+                          borderRadius: 1,
+                          border: '1px solid',
+                          borderColor: 'divider',
+                          backgroundColor: 'background.paper',
+                        }}
+                      >
+                        {overridden ? (
+                          <TokenFieldsEditor
+                            tokens={toTokenConfig(mappingFor(r.path))}
+                            onChange={(field, k, value) =>
+                              updateResourceToken(r.path, field, k, value)
+                            }
+                          />
+                        ) : (
+                          <Typography variant="body2" color="text.secondary">
+                            Uses the default mapping. Turn on{' '}
+                            <strong>Override</strong> to change it.
+                          </Typography>
+                        )}
+                      </Box>
+                    </Collapse>
+                  </Box>
+                );
+              })}
+            </Box>
+          )}
+        </Stack>
+      )}
+    </Box>
+  );
+}

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyDefinitionTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyDefinitionTab.tsx
@@ -277,7 +277,7 @@ export default function LLMProxyDefinitionTab() {
               <FormLabel>Import Specification</FormLabel>
               <Stack
                 direction="row"
-                spacing={1}
+                spacing={1.5}
                 alignItems="center"
                 sx={{ mt: 1 }}
               >
@@ -290,24 +290,28 @@ export default function LLMProxyDefinitionTab() {
                   }}
                   placeholder="Paste OpenAPI URL or upload a file"
                 />
-                <Box minWidth={152}>
-                  <Button
-                    variant="outlined"
-                    size="small"
-                    disabled={isFetchingSpec}
-                    onClick={() => {
-                      void handleFetchAndClose(specUrl);
-                    }}
-                  >
-                    {isFetchingSpec ? 'Fetching....' : 'Fetch specification'}
-                  </Button>
-                </Box>
+                <Button
+                  variant="outlined"
+                  size="small"
+                  disabled={isFetchingSpec}
+                  onClick={() => {
+                    void handleFetchAndClose(specUrl);
+                  }}
+                  sx={{ whiteSpace: 'nowrap', flexShrink: 0 }}
+                >
+                  {isFetchingSpec ? 'Fetching…' : 'Fetch specification'}
+                </Button>
+                <Divider orientation="vertical" flexItem>Or</Divider>
+                <Button
+                  variant="outlined"
+                  size="small"
+                  onClick={handleUploadClick}
+                  sx={{ whiteSpace: 'nowrap', flexShrink: 0 }}
+                >
+                  Upload Specification
+                </Button>
               </Stack>
             </FormControl>
-            <Divider sx={{ my: 2 }}>Or</Divider>
-            <Button variant="outlined" fullWidth onClick={handleUploadClick}>
-              Upload Your Specification
-            </Button>
             <input
               ref={fileInputRef}
               type="file"

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyNew.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyNew.tsx
@@ -593,7 +593,7 @@ function LLMProxyNewContent({
                   <FormLabel sx={{ mb: 0.5 }}>
                     <FormattedMessage
                       id="aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxyNew.llm.service.provider"
-                      defaultMessage="LLM Service Provider"
+                      defaultMessage="LLM Provider"
                     />
                   </FormLabel>
                   <Select

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyProviderTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyProviderTab.tsx
@@ -189,7 +189,7 @@ export default function LLMProxyProviderTab() {
           <Typography variant="h6" sx={{ mb: 1.5, fontWeight: 600 }}>
             <FormattedMessage
               id="aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxyProviderTab.llm.service.provider"
-              defaultMessage={'LLM Service Provider'}
+              defaultMessage={'LLM Provider'}
             />
           </Typography>
 

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/AddNewProvider/GuardrailsSection.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/AddNewProvider/GuardrailsSection.tsx
@@ -46,6 +46,7 @@ import { parsePolicyYaml } from '../../../PolicyParameterEditor/yamlParser';
 import type { GuardrailSelection } from './serviceProviderTypes';
 import { FormattedMessage } from 'react-intl';
 import ErrorAlert from '../../../../../Components/common/ErrorAlert';
+import { familyHandle } from '../../../../../utils/providerTemplateDisplay';
 
 type GuardrailsSectionProps = {
   guardrails: GuardrailSelection[];
@@ -73,8 +74,8 @@ export default function GuardrailsSection({
   onRemoveGuardrail,
 }: GuardrailsSectionProps) {
   const showCostPolicy =
-    selectedTemplateId !== 'azure-openai' &&
-    selectedTemplateId !== 'azureai-foundry';
+    familyHandle(selectedTemplateId) !== 'azure-openai' &&
+    familyHandle(selectedTemplateId) !== 'azureai-foundry';
   const {
     guardrails: availableGuardrails = [],
     isLoading: isLoadingGuardrails,

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/AddNewProvider/ProviderTemplateSelector.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/AddNewProvider/ProviderTemplateSelector.tsx
@@ -27,8 +27,10 @@ import {
   FormLabel,
   Grid,
   Stack,
+  Tooltip,
   Typography,
 } from '@wso2/oxygen-ui';
+import { ChevronDown, ChevronUp } from '@wso2/oxygen-ui-icons-react';
 import type {
   ProviderTemplate,
   ProviderTemplatesResponse,
@@ -42,6 +44,10 @@ import googleGeminiLogo from '../../../../../assets/brands/googlegemini.png';
 import mistralAiLogo from '../../../../../assets/brands/mistralai.png';
 import { FormattedMessage } from 'react-intl';
 import ErrorAlert from '../../../../../Components/common/ErrorAlert';
+import {
+  familyHandle,
+  truncateProviderDisplayName,
+} from '../../../../../utils/providerTemplateDisplay';
 
 // Logo mapping for provider templates by name (case-insensitive partial match)
 const getLogoForTemplate = (templateName: string): string | null => {
@@ -75,6 +81,7 @@ type ProviderTemplateSelectorProps = {
   templatesError: Error | null;
   templatesResponse: ProviderTemplatesResponse;
   selectedTemplateId: string | null;
+  selectedTemplateVersion?: string;
   onSelectTemplate: (template: ProviderTemplate) => void;
   onRetryTemplates: () => void | Promise<void>;
 };
@@ -84,9 +91,31 @@ export default function ProviderTemplateSelector({
   templatesError,
   templatesResponse,
   selectedTemplateId,
+  selectedTemplateVersion,
   onSelectTemplate,
   onRetryTemplates,
 }: ProviderTemplateSelectorProps) {
+  const COLLAPSED_COUNT = 8;
+  const [showAll, setShowAll] = React.useState(false);
+  const enabledTemplates = (templatesResponse?.list ?? []).filter(
+    (template) => template.enabled !== false
+  );
+
+  const familyMap = new Map<string, (typeof enabledTemplates)[0]>();
+  for (const t of enabledTemplates) {
+    const key = t.name.toLowerCase();
+    const existing = familyMap.get(key);
+    if (!existing || t.isLatest) familyMap.set(key, t);
+  }
+  const deduplicatedTemplates = Array.from(familyMap.values());
+
+  const hasMore = deduplicatedTemplates.length > COLLAPSED_COUNT;
+  const hiddenCount = deduplicatedTemplates.length - COLLAPSED_COUNT;
+  const visibleTemplates =
+    hasMore && !showAll
+      ? deduplicatedTemplates.slice(0, COLLAPSED_COUNT)
+      : deduplicatedTemplates;
+
   return (
     <Grid size={{ xs: 12 }}>
       <FormControl fullWidth>
@@ -125,9 +154,11 @@ export default function ProviderTemplateSelector({
               },
             }}
           >
-            {templatesResponse?.list?.map((template) => {
+            {visibleTemplates.map((template) => {
               const templateId = (template.id ?? '').toLowerCase();
-              const isComingSoon = COMING_SOON_TEMPLATE_IDS.has(templateId);
+              const isComingSoon = COMING_SOON_TEMPLATE_IDS.has(
+                familyHandle(templateId)
+              );
               const isSelected = !isComingSoon && selectedTemplateId === template.id;
               const logo = getLogoForTemplate(template.name);
               const shortName = getShortNameForTemplate(template.name);
@@ -193,17 +224,26 @@ export default function ProviderTemplateSelector({
                     )}
                   </Box>
                   <Box sx={{ minWidth: 0, flex: 1 }}>
-                    <Typography variant="subtitle2">{template.name}</Typography>
-                    {template.description && (
-                      <Typography
-                        variant="caption"
-                        color="text.secondary"
-                        noWrap
-                      >
-                        {template.description}
-                      </Typography>
-                    )}
+                    <Typography
+                      variant="subtitle2"
+                      noWrap
+                      title={template.name}
+                    >
+                      {truncateProviderDisplayName(template.name)}
+                    </Typography>
                   </Box>
+                  {/* Version chip only on the selected card, in the right corner. */}
+                  {isSelected && selectedTemplateVersion ? (
+                    <Tooltip title="Selected version">
+                      <Chip
+                        label={selectedTemplateVersion}
+                        size="small"
+                        color="primary"
+                        variant="outlined"
+                        sx={{ flexShrink: 0, mr: 1, height: 20 }}
+                      />
+                    </Tooltip>
+                  ) : null}
                   {isComingSoon ? (
                     <Chip
                       label="Coming soon"
@@ -223,6 +263,37 @@ export default function ProviderTemplateSelector({
                 </Form.CardButton>
               );
             })}
+
+            {hasMore && (
+              <Form.CardButton
+                onClick={() => setShowAll((prev) => !prev)}
+                data-cyid="provider-template-see-more"
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  gap: 1,
+                  py: 1,
+                  border: '1px dashed',
+                  borderColor: 'divider',
+                  cursor: 'pointer',
+                }}
+              >
+                {!showAll && (
+                  <Chip
+                    label={`+${hiddenCount}`}
+                    size="small"
+                    color="primary"
+                    sx={{ height: 24, fontWeight: 600 }}
+                  />
+                )}
+                <Typography variant="body2" color="text.secondary">
+                  {showAll ? 'Show less' : 'See more'}
+                </Typography>
+                {showAll ? <ChevronUp size={18} /> : <ChevronDown size={18} />}
+              </Form.CardButton>
+            )}
           </Box>
         )}
       </FormControl>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/AddNewProvider/TemplateVersionDialog.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/AddNewProvider/TemplateVersionDialog.tsx
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import { useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  List,
+  ListItemButton,
+  Stack,
+  Typography,
+} from '@wso2/oxygen-ui';
+import { Check } from '@wso2/oxygen-ui-icons-react';
+import * as providerTemplateApis from '../../../../../apis/providerTemplateApis';
+import { PLATFORM_API_BASE_URL } from '../../../../../config.env';
+import { useAppShell } from '../../../../../contexts/AppShellContext';
+import { formatRelativeTime } from '../../../../../contexts/llmProvider';
+import type { ProviderTemplate } from '../../../../../utils/types';
+
+interface TemplateVersionDialogProps {
+  open: boolean;
+  templateId: string;
+  templateName: string;
+  onClose: () => void;
+  onConfirm: (versionTemplate: ProviderTemplate) => void;
+}
+
+export default function TemplateVersionDialog({
+  open,
+  templateId,
+  templateName,
+  onClose,
+  onConfirm,
+}: TemplateVersionDialogProps) {
+  const { currentOrganization } = useAppShell();
+  const [versions, setVersions] = useState<ProviderTemplate[]>([]);
+  const [selected, setSelected] = useState<string>('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const organizationId = currentOrganization?.uuid;
+    if (!open || !templateId || !organizationId) return;
+
+    let isMounted = true;
+    setIsLoading(true);
+    setError(null);
+    setVersions([]);
+    setSelected('');
+    providerTemplateApis
+      .getProviderTemplateVersions(templateId, organizationId, PLATFORM_API_BASE_URL)
+      .then((list) => {
+        if (!isMounted) return;
+        const parseVerNum = (s: string) => {
+          const [maj = 0, min = 0] = (s || 'v0').replace(/^v/i, '').split('.').map(Number);
+          return maj * 1000 + min;
+        };
+        const enabled = list
+          .filter((v) => v.enabled !== false)
+          .sort((a, b) => parseVerNum(b.version || 'v0') - parseVerNum(a.version || 'v0'));
+        setVersions(enabled);
+        // Default to the latest version, else the first returned.
+        const latest = enabled.find((v) => v.isLatest) ?? enabled[0];
+        setSelected(latest?.version ?? '');
+      })
+      .catch((err: unknown) => {
+        if (isMounted) {
+          setError(err instanceof Error ? err.message : 'Failed to load versions');
+          setSelected('');
+        }
+      })
+      .finally(() => {
+        if (isMounted) setIsLoading(false);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [open, templateId, currentOrganization?.uuid]);
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="xs"
+      fullWidth
+      data-cyid="template-version-dialog"
+    >
+      <DialogTitle>Select a version of {templateName}</DialogTitle>
+      <DialogContent dividers>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+          The provider will be based on the version you choose.
+        </Typography>
+
+        {isLoading ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 3 }}>
+            <CircularProgress size={24} />
+          </Box>
+        ) : error ? (
+          <Typography variant="body2" color="error" sx={{ py: 2 }}>
+            {error}
+          </Typography>
+        ) : versions.length === 0 ? (
+          <Typography variant="body2" color="text.secondary" sx={{ py: 2 }}>
+            No versions found for this template.
+          </Typography>
+        ) : (
+          <List disablePadding>
+            {versions.map((v) => {
+              const ver = v.version ?? '';
+              return (
+                <ListItemButton
+                  key={ver}
+                  selected={ver === selected}
+                  onClick={() => setSelected(ver)}
+                  data-cyid={`template-version-option-${ver}`}
+                  sx={{
+                    borderRadius: 1,
+                    mb: 0.5,
+                    border: 1,
+                    borderColor: ver === selected ? 'primary.main' : 'divider',
+                  }}
+                >
+                  <Stack sx={{ flexGrow: 1 }} spacing={0.25}>
+                    <Stack direction="row" spacing={1} alignItems="center">
+                      <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                        {ver}
+                      </Typography>
+                      {v.isLatest ? (
+                        <Chip label="latest" size="small" color="primary" variant="outlined" />
+                      ) : null}
+                    </Stack>
+                    <Typography variant="caption" color="text.secondary">
+                      {formatRelativeTime(v.createdAt ?? v.updatedAt)}
+                    </Typography>
+                  </Stack>
+                  {ver === selected ? <Check size={16} /> : null}
+                </ListItemButton>
+              );
+            })}
+          </List>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button
+          onClick={onClose}
+          color="secondary"
+          variant="outlined"
+          data-cyid="template-version-cancel-button"
+        >
+          Cancel
+        </Button>
+        <Button
+          onClick={() => {
+            const vt = versions.find((v) => v.version === selected) ?? versions[0];
+            if (vt) onConfirm(vt);
+          }}
+          variant="contained"
+          disabled={!selected || isLoading || Boolean(error) || versions.length === 0}
+          data-cyid="template-version-continue-button"
+        >
+          Continue
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ProvidersList.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ProvidersList.tsx
@@ -327,14 +327,14 @@ export default function ServiceProviders() {
           <PageTitle.Header>
             <FormattedMessage
               id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ProvidersList.llm.service.providers"
-              defaultMessage={'LLM Service Providers'}
+              defaultMessage={'LLM Providers'}
             />
           </PageTitle.Header>
           <PageTitle.SubHeader>
             <FormattedMessage
               id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ProvidersList.manage.and.monitor.your.connected.llm.service.providers"
               defaultMessage={
-                'Manage and monitor your connected LLM service providers.'
+                'Manage and monitor your connected LLM Providers.'
               }
             />
           </PageTitle.SubHeader>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderConnectionTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderConnectionTab.tsx
@@ -225,10 +225,14 @@ export default function ServiceProviderConnectionTab() {
     if (isCredentialMasked) return;
     const nextValue = value.trim();
     if (nextValue === MASKED_CREDENTIAL_VALUE) return;
-    const fullValue = valuePrefix
-      ? nextValue.startsWith(valuePrefix)
+    // Join the prefix and value with a single space (e.g. "Bearer <key>").
+    // trimEnd() so a template prefix that already carries a trailing space
+    // (e.g. "Bearer ") doesn't produce a double space.
+    const prefix = valuePrefix.trimEnd();
+    const fullValue = prefix
+      ? nextValue.startsWith(prefix)
         ? nextValue
-        : `${valuePrefix}${nextValue}`
+        : `${prefix} ${nextValue}`
       : nextValue;
     if (fullValue === (provider.upstream?.main?.auth?.value || '')) return;
     try {

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderNew.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderNew.tsx
@@ -38,6 +38,8 @@ import { ChevronLeft } from '@wso2/oxygen-ui-icons-react';
 import { useAppAuth } from '../../../../contexts/AppAuthContext';
 import { SCOPES } from '../../../../auth/permissions';
 import { useAppShell } from '../../../../contexts/AppShellContext';
+import * as providerTemplateApis from '../../../../apis/providerTemplateApis';
+import { PLATFORM_API_BASE_URL } from '../../../../config.env';
 import {
   buildOrgPath,
   buildProjectPath,
@@ -51,6 +53,9 @@ import type {
   FormState,
   GuardrailSelection,
 } from './AddNewProvider/serviceProviderTypes';
+import type { ProviderTemplate } from '../../../../utils/types';
+import { familyHandle } from '../../../../utils/providerTemplateDisplay';
+import TemplateVersionDialog from './AddNewProvider/TemplateVersionDialog';
 import { FormattedMessage } from 'react-intl';
 
 const VERSION_PATTERN = /^v\d+\.\d+$/;
@@ -94,10 +99,15 @@ function TemplateBasedFormFieldsContainer({
       valuePrefix: template?.metadata?.auth?.valuePrefix || '',
     }));
 
-    // Fetch OpenAPI spec
+    // Resolve OpenAPI spec. Prefer the inline spec stored on the template
+    // (e.g. templates created by uploading an OpenAPI spec); otherwise fall
+    // back to fetching it from the template's openapiSpecUrl.
     if (templateChanged) {
+      const inlineSpec = template?.openapi;
       const specUrl = template?.metadata?.openapiSpecUrl;
-      if (specUrl) {
+      if (inlineSpec) {
+        setOpenapiSpec(inlineSpec);
+      } else if (specUrl) {
         fetch(specUrl)
           .then((res) => res.text())
           .then((text) => {
@@ -147,6 +157,19 @@ export default function ServiceProviderNew() {
   const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(
     null
   );
+
+  const [selectedTemplateVersion, setSelectedTemplateVersion] = useState<
+    string | null
+  >(null);
+
+  const [selectedVersionTemplateId, setSelectedVersionTemplateId] = useState<
+    string | null
+  >(null);
+  // Template just clicked, pending version selection in the dialog.
+  const [pendingTemplate, setPendingTemplate] = useState<ProviderTemplate | null>(
+    null
+  );
+  const [versionDialogOpen, setVersionDialogOpen] = useState(false);
   const [openapiSpec, setOpenapiSpec] = useState<string>('');
 
   const [formState, setFormState] = useState<FormState>({
@@ -299,24 +322,18 @@ export default function ServiceProviderNew() {
     if (!isFormValid || !selectedTemplateId) return;
 
     try {
-      const selectedTemplate = templatesResponse?.list?.find(
-        (t) => t.id === selectedTemplateId
-      );
       const providerId = toProviderId(formState.name);
 
       const upstream = {
         main: {
-          url: selectedTemplate?.metadata?.endpointUrl || formState.upstreamUrl,
+          url: formState.upstreamUrl,
           ref: '',
           auth: {
-            type:
-              selectedTemplate?.metadata?.auth?.type ||
-              formState.upstreamAuthType,
-            header:
-              selectedTemplate?.metadata?.auth?.header ||
-              formState.upstreamAuthHeader,
+            type: formState.upstreamAuthType,
+            header: formState.upstreamAuthHeader,
+
             value: formState.valuePrefix
-              ? `${formState.valuePrefix}${formState.upstreamAuthValue}`
+              ? `${formState.valuePrefix.trimEnd()} ${formState.upstreamAuthValue}`
               : formState.upstreamAuthValue,
           },
         },
@@ -328,12 +345,12 @@ export default function ServiceProviderNew() {
         description: formState.description.trim(),
         version: formState.version.trim(),
         context: formState.context.trim() || '/',
-        template: selectedTemplateId,
+        template: selectedVersionTemplateId ?? selectedTemplateId,
         openapi: openapiSpec,
         upstream,
         globalPolicies: [
-          ...(selectedTemplateId !== 'azure-openai' &&
-          selectedTemplateId !== 'azureai-foundry'
+          ...(familyHandle(selectedTemplateId) !== 'azure-openai' &&
+          familyHandle(selectedTemplateId) !== 'azureai-foundry'
             ? [{ name: 'llm-cost', version: 'v1', params: {} }]
             : []),
           ...guardrails.map((guardrail) => ({
@@ -377,6 +394,54 @@ export default function ServiceProviderNew() {
     }
   };
 
+  const applyTemplateSelection = (
+    baseTemplate: ProviderTemplate,
+    version: string,
+    versionTemplateId: string | null
+  ) => {
+    setSelectedTemplateId(baseTemplate.id ?? null);
+    setSelectedVersionTemplateId(versionTemplateId);
+    setSelectedTemplateVersion(version);
+    setFormState((prev) => ({ ...prev, providerType: baseTemplate.name }));
+    setOpenapiSpec('');
+    setVersionDialogOpen(false);
+    setPendingTemplate(null);
+  };
+
+  const handleSelectTemplate = async (template: ProviderTemplate) => {
+    const organizationId = currentOrganization?.uuid;
+    if (!template.id || !organizationId) return;
+    try {
+      const enabledVersions = (
+        await providerTemplateApis.getProviderTemplateVersions(
+          template.id,
+          organizationId,
+          PLATFORM_API_BASE_URL
+        )
+      ).filter((v) => v.enabled !== false);
+      if (enabledVersions.length === 0) {
+        showSnackbar(
+          'No enabled versions are available for this template.',
+          'error'
+        );
+        return;
+      }
+      if (enabledVersions.length === 1) {
+        const only = enabledVersions[0];
+        applyTemplateSelection(
+          template,
+          only?.version ?? template.version ?? 'v1.0',
+          only?.id ?? null
+        );
+        return;
+      }
+    } catch {
+      // Couldn't load versions — fall back to the picker.
+    }
+    setPendingTemplate(template);
+    setVersionDialogOpen(true);
+  };
+
   return (
     <PageContent fullWidth>
       <Button
@@ -396,7 +461,7 @@ export default function ServiceProviderNew() {
           <PageTitle.Header>
             <FormattedMessage
               id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderNew.add.llm.service.provider"
-              defaultMessage={'Add LLM Service Provider'}
+              defaultMessage={'Add LLM Provider'}
             />
           </PageTitle.Header>
         </PageTitle>
@@ -411,18 +476,30 @@ export default function ServiceProviderNew() {
             templatesResponse={templatesResponse}
             selectedTemplateId={selectedTemplateId}
             onRetryTemplates={refreshTemplates}
-            onSelectTemplate={(template) => {
-              setSelectedTemplateId(template.id ?? null);
-              setFormState((prev) => ({
-                ...prev,
-                providerType: template.name,
-              }));
-              setOpenapiSpec('');
-            }}
+            selectedTemplateVersion={selectedTemplateVersion ?? undefined}
+            onSelectTemplate={(template) => void handleSelectTemplate(template)}
           />
 
+          {pendingTemplate && (
+            <TemplateVersionDialog
+              open={versionDialogOpen}
+              templateId={pendingTemplate.id ?? ''}
+              templateName={pendingTemplate.name}
+              onClose={() => {
+                setVersionDialogOpen(false);
+                setPendingTemplate(null);
+              }}
+              onConfirm={(vt) =>
+                applyTemplateSelection(pendingTemplate, vt.version ?? '', vt.id ?? null)
+              }
+            />
+          )}
+
           {selectedTemplateId && (
-            <ProviderTemplateProvider templateId={selectedTemplateId}>
+            <ProviderTemplateProvider
+              templateId={selectedTemplateId}
+              version={selectedTemplateVersion ?? undefined}
+            >
               <TemplateBasedFormFieldsContainer
                 formState={formState}
                 setFormState={setFormState}

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProvidersSummaryCard.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProvidersSummaryCard.tsx
@@ -92,7 +92,7 @@ export default function ServiceProvidersSummaryCard({
   onCreateProvider,
   onProviderClick,
   maxItems = 5,
-  title = 'LLM Service Providers',
+  title = 'LLM Providers',
   isLoading = false,
   error,
   onRetry,

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/settings/Main.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/settings/Main.tsx
@@ -16,12 +16,110 @@
  * under the License.
  */
 
-import React from 'react';
+// ---------------------------------------------------------------------------
+// Settings layout. A persistent left sub-nav (always visible) + a vertical
+// separator; everything else — the templates list, create, overview, edit and
+// create-version pages — renders in the right pane via <Outlet />. The first
+// nav item is LLM Provider Templates. Add new items to NAV_ITEMS to extend.
+// ---------------------------------------------------------------------------
 
-export default function Settings(): JSX.Element {
+import { type ReactNode } from 'react';
+import { Navigate, Outlet, useNavigate } from 'react-router-dom';
+import {
+  Box,
+  Divider,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  PageTitle,
+  Stack,
+} from '@wso2/oxygen-ui';
+import { LayoutTemplate } from '@wso2/oxygen-ui-icons-react';
+import { FormattedMessage } from 'react-intl';
+import { useAppShell } from '../../../../contexts/AppShellContext';
+import { useAppAuth } from '../../../../contexts/AppAuthContext';
+import { SCOPES } from '../../../../auth/permissions';
+import { buildOrgPath } from '../../../../utils/projectRouting';
+
+interface NavItem {
+  key: string;
+  label: string;
+  icon: ReactNode;
+  // Settings-relative path the item navigates to.
+  path: string;
+}
+
+// Settings navigation. LLM Provider Templates is first/default.
+const NAV_ITEMS: NavItem[] = [
+  {
+    key: 'templates',
+    label: 'LLM Provider Templates',
+    icon: <LayoutTemplate size={18} />,
+    path: '/settings/llm-provider-templates',
+  },
+];
+
+export default function Settings() {
+  const navigate = useNavigate();
+  const { currentOrganization } = useAppShell();
+  const { hasPermission } = useAppAuth();
+  // Only one area today; it stays selected across all its sub-pages.
+  const selectedKey = 'templates';
+
+  // Settings requires template-manage permission; send others to org home.
+  if (!hasPermission(SCOPES.LLM_TEMPLATE_MANAGE)) {
+    return (
+      <Navigate
+        to={buildOrgPath(currentOrganization, '/home')}
+        replace
+      />
+    );
+  }
+
   return (
-    <div style={{ padding: 24 }}>
-      <h1>Hi Settings</h1>
-    </div>
+    <Box sx={{ display: 'flex', alignItems: 'stretch', minHeight: '100%', width: '100%' }}>
+      {/* Persistent left sub-nav */}
+      <Box sx={{ width: { xs: 200, md: 280 }, flexShrink: 0, p: 3 }}>
+        <Stack spacing={2}>
+          <PageTitle>
+            <PageTitle.Header>
+              <FormattedMessage
+                id="aiWorkspace.pages.appShell.appShellPages.settings.Main.title"
+                defaultMessage={'Settings'}
+              />
+            </PageTitle.Header>
+          </PageTitle>
+          <List dense disablePadding>
+            {NAV_ITEMS.map((item) => (
+              <ListItemButton
+                key={item.key}
+                selected={item.key === selectedKey}
+                onClick={() => navigate(buildOrgPath(currentOrganization, item.path))}
+                sx={{
+                  borderRadius: 1,
+                  mb: 0.5,
+                  border: 1,
+                  borderColor: 'divider',
+                }}
+              >
+                <ListItemIcon sx={{ minWidth: 32 }}>{item.icon}</ListItemIcon>
+                <ListItemText
+                  primary={item.label}
+                  slotProps={{ primary: { noWrap: true } }}
+                />
+              </ListItemButton>
+            ))}
+          </List>
+        </Stack>
+      </Box>
+
+      <Divider orientation="vertical" flexItem />
+
+      {/* Right pane — the active settings page renders here. */}
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Outlet />
+      </Box>
+    </Box>
   );
 }

--- a/portals/ai-workspace/src/utils/providerTemplateDisplay.ts
+++ b/portals/ai-workspace/src/utils/providerTemplateDisplay.ts
@@ -28,6 +28,36 @@ const PROVIDER_TEMPLATE_NAME_MAP: Record<string, string> = {
   'google-vertex': 'Google Vertex AI',
 };
 
+/**
+ * IDs of the built-in (predefined) provider templates that the backend seeds.
+ * These appear in the "Add Provider" catalog but are NOT user-created custom
+ * templates, so screens that manage custom templates should exclude them.
+ */
+const BUILTIN_PROVIDER_TEMPLATE_IDS = new Set(
+  Object.keys(PROVIDER_TEMPLATE_NAME_MAP)
+);
+
+/**
+ * Strip a trailing version suffix (`-v<major>-<minor>`) from a template handle to
+ * get the family handle, e.g. `mistralai-v2-0` -> `mistralai`. Handles without a
+ * suffix are returned unchanged (covers any legacy built-in handles). Use this
+ * for family-level checks (built-in detection, provider-specific behavior) that
+ * must not depend on the specific version.
+ */
+export function familyHandle(id?: string | null): string {
+  return (id ?? '').trim().replace(/-v\d+-\d+$/i, '');
+}
+
+/**
+ * Returns true if the given template id (any version) belongs to one of the
+ * predefined built-in families.
+ */
+export function isBuiltInProviderTemplate(id?: string | null): boolean {
+  const normalized = familyHandle(id).toLowerCase();
+  if (!normalized) return false;
+  return BUILTIN_PROVIDER_TEMPLATE_IDS.has(normalized);
+}
+
 export function getProviderTemplateDisplayName(template?: string | null): string {
   const normalizedTemplate = template?.trim().toLowerCase();
   if (!normalizedTemplate) {

--- a/portals/ai-workspace/src/utils/providerTemplateFields.ts
+++ b/portals/ai-workspace/src/utils/providerTemplateFields.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Shared definitions for the LLM provider template forms (create / edit) and
+// the read-only overview. Kept in one place so the field set and the location
+// options stay consistent across all three.
+
+import type { TokenLocation } from './types';
+
+export const TOKEN_FIELDS = [
+  { key: 'promptTokens', label: 'Prompt Tokens' },
+  { key: 'completionTokens', label: 'Completion Tokens' },
+  { key: 'totalTokens', label: 'Total Tokens' },
+  { key: 'remainingTokens', label: 'Remaining Tokens' },
+  { key: 'requestModel', label: 'Request Model' },
+  { key: 'responseModel', label: 'Response Model' },
+] as const;
+
+export type TokenFieldKey = (typeof TOKEN_FIELDS)[number]['key'];
+
+export const TOKEN_LOCATIONS = [
+  { value: 'payload', label: 'Payload' },
+  { value: 'header', label: 'Header' },
+  { value: 'queryParam', label: 'Query Param' },
+  { value: 'pathParam', label: 'Path Param' },
+] as const;
+
+export type TokenConfig = Record<
+  TokenFieldKey,
+  { identifier: string; location: string }
+>;
+
+export const EMPTY_TOKEN_CONFIG: TokenConfig = {
+  promptTokens: { identifier: '', location: 'payload' },
+  completionTokens: { identifier: '', location: 'payload' },
+  totalTokens: { identifier: '', location: 'payload' },
+  remainingTokens: { identifier: '', location: 'payload' },
+  requestModel: { identifier: '', location: 'payload' },
+  responseModel: { identifier: '', location: 'payload' },
+};
+
+// Sensible starting values (the OpenAI-style mappings used by the built-in
+// templates). Pre-filled in the create form so the user starts from a working
+// configuration and only tweaks what differs for their provider.
+export const DEFAULT_TOKEN_CONFIG: TokenConfig = {
+  promptTokens: { identifier: '$.usage.prompt_tokens', location: 'payload' },
+  completionTokens: { identifier: '$.usage.completion_tokens', location: 'payload' },
+  totalTokens: { identifier: '$.usage.total_tokens', location: 'payload' },
+  remainingTokens: { identifier: 'x-ratelimit-remaining-tokens', location: 'header' },
+  requestModel: { identifier: '$.model', location: 'payload' },
+  responseModel: { identifier: '$.model', location: 'payload' },
+};
+
+/** Default auth config (Bearer token in the standard Authorization header) used
+ * by most OpenAI-compatible providers. Pre-filled on the create form and shown
+ * as the fallback on the Connection tab when a template specifies no auth. */
+export const DEFAULT_AUTH_CONFIG = {
+  type: 'api-key',
+  header: 'Authorization',
+  valuePrefix: 'Bearer ',
+} as const;
+
+/** True if the value is a syntactically valid http(s) URL. Empty strings are
+ * treated as valid (the fields are optional) — callers check required-ness. */
+export function isValidHttpUrl(value: string): boolean {
+  const v = value.trim();
+  if (!v) return true;
+  try {
+    const url = new URL(v);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+/** Build a TokenConfig draft from an entity that carries the six TokenLocation fields. */
+export function toTokenConfig(source?: Partial<
+  Record<TokenFieldKey, TokenLocation | undefined>
+>): TokenConfig {
+  const draft: TokenConfig = {
+    promptTokens: { ...EMPTY_TOKEN_CONFIG.promptTokens },
+    completionTokens: { ...EMPTY_TOKEN_CONFIG.completionTokens },
+    totalTokens: { ...EMPTY_TOKEN_CONFIG.totalTokens },
+    remainingTokens: { ...EMPTY_TOKEN_CONFIG.remainingTokens },
+    requestModel: { ...EMPTY_TOKEN_CONFIG.requestModel },
+    responseModel: { ...EMPTY_TOKEN_CONFIG.responseModel },
+  };
+  if (!source) return draft;
+  TOKEN_FIELDS.forEach(({ key }) => {
+    const value = source[key];
+    if (value) {
+      draft[key] = {
+        identifier: value.identifier ?? '',
+        location: value.location ?? 'payload',
+      };
+    }
+  });
+  return draft;
+}
+
+/**
+ * Like toTokenConfig, but any field the source leaves blank falls back to the
+ * OpenAI default value. Used by the edit form so the defaults are always shown
+ * ("by default OpenAI values are here") rather than empty inputs.
+ */
+export function toTokenConfigWithDefaults(
+  source?: Partial<Record<TokenFieldKey, TokenLocation | undefined>>
+): TokenConfig {
+  const cfg = toTokenConfig(source);
+  TOKEN_FIELDS.forEach(({ key }) => {
+    if (!cfg[key].identifier.trim()) {
+      cfg[key] = { ...DEFAULT_TOKEN_CONFIG[key] };
+    }
+  });
+  return cfg;
+}
+
+/** Collect only the filled-in token mappings into the API shape (skips blanks). */
+export function fromTokenConfig(
+  config: TokenConfig
+): Partial<Record<TokenFieldKey, TokenLocation>> {
+  const result: Partial<Record<TokenFieldKey, TokenLocation>> = {};
+  TOKEN_FIELDS.forEach(({ key }) => {
+    const cfg = config[key];
+    if (cfg.identifier.trim()) {
+      result[key] = {
+        identifier: cfg.identifier.trim(),
+        location: cfg.location,
+      };
+    }
+  });
+  return result;
+}

--- a/portals/ai-workspace/src/utils/providerTemplateManifest.ts
+++ b/portals/ai-workspace/src/utils/providerTemplateManifest.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import YAML from 'yaml';
+import type { ProviderTemplate } from './types';
+import { familyHandle } from './providerTemplateDisplay';
+
+export function buildTemplateManifestYaml(t: ProviderTemplate): string {
+  const spec: Record<string, unknown> = { displayName: t.name };
+
+  const groupId = t.groupId?.trim() || familyHandle(t.id);
+  if (groupId) spec.groupId = groupId;
+
+  const managedBy = (t.managedBy ?? t.provider)?.trim();
+  if (managedBy) spec.managedBy = managedBy;
+
+  if (t.version) spec.version = t.version;
+
+  const tokenKeys = [
+    'promptTokens',
+    'completionTokens',
+    'totalTokens',
+    'remainingTokens',
+    'requestModel',
+    'responseModel',
+  ] as const;
+  for (const key of tokenKeys) {
+    const v = t[key];
+    if (v && v.identifier?.trim()) {
+      spec[key] = { location: v.location, identifier: v.identifier };
+    }
+  }
+
+  const manifest = {
+    apiVersion: 'gateway.api-platform.wso2.com/v1',
+    kind: 'LlmProviderTemplate',
+    metadata: { name: t.id },
+    spec,
+  };
+  return YAML.stringify(manifest);
+}
+
+// Generate a filename for the template's manifest YAML.
+export function templateManifestFileName(t: ProviderTemplate): string {
+  return `${t.id ?? 'template'}-template.yaml`;
+}
+
+// Trigger a browser download of the template's manifest YAML.
+export function downloadTemplateYaml(t: ProviderTemplate): string {
+  const fileName = templateManifestFileName(t);
+  const blob = new Blob([buildTemplateManifestYaml(t)], {
+    type: 'text/yaml;charset=utf-8',
+  });
+  const objectUrl = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = objectUrl;
+  link.download = fileName;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(objectUrl);
+  return fileName;
+}

--- a/portals/ai-workspace/src/utils/types.ts
+++ b/portals/ai-workspace/src/utils/types.ts
@@ -522,13 +522,10 @@ export interface ResourceMappings {
 }
 
 /**
- * Create Provider Template request.
- * The backend expects an explicit `id` for the template (e.g. "kimi-full"),
- * so it is required here (unlike the read model where it is optional).
+ * Create Provider Template request. Mirrors `ProviderTemplate`; `id` is
+ * required (the backend expects an explicit handle, e.g. "kimi-full").
  */
-export type CreateProviderTemplateRequest = Omit<ProviderTemplate, 'id'> & {
-  id: string;
-};
+export type CreateProviderTemplateRequest = ProviderTemplate;
 
 /**
  * Update Provider Template request - all fields optional

--- a/portals/ai-workspace/src/utils/types.ts
+++ b/portals/ai-workspace/src/utils/types.ts
@@ -448,7 +448,7 @@ export type UpdateLLMProviderRequest = Partial<
  * Token location configuration
  */
 export interface TokenLocation {
-  location: 'payload' | 'header' | 'query' | string;
+  location: 'payload' | 'header' | 'queryParam' | 'pathParam' | string;
   identifier: string;
 }
 
@@ -477,9 +477,15 @@ export interface TemplateMetadata {
  * Read-only fields (createdAt, updatedAt) excluded
  */
 export interface ProviderTemplate {
-  id?: string;
+  id: string;
   name: string;
+  provider?: string;
+  managedBy?: string;
+  groupId?: string;
   description?: string;
+  version: string;
+  isLatest?: boolean;
+  enabled?: boolean;
   promptTokens?: TokenLocation;
   completionTokens?: TokenLocation;
   totalTokens?: TokenLocation;
@@ -487,12 +493,42 @@ export interface ProviderTemplate {
   requestModel?: TokenLocation;
   responseModel?: TokenLocation;
   metadata?: TemplateMetadata;
+  resourceMappings?: ResourceMappings;
+  openapi?: string;
+  createdBy?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  /** Flat logo URL, present on list responses (LLMProviderTemplateListItem). */
+  logoUrl?: string;
 }
 
 /**
- * Create Provider Template request - only required fields
+ * Per-resource token & model extraction overrides. Each mapping targets a
+ * resource path pattern (e.g. "/responses" or "/chat/*") and may override any
+ * of the six extraction identifiers for requests matching that path.
  */
-export type CreateProviderTemplateRequest = Omit<ProviderTemplate, 'id'>;
+export interface ResourceMapping {
+  resource: string;
+  promptTokens?: TokenLocation;
+  completionTokens?: TokenLocation;
+  totalTokens?: TokenLocation;
+  remainingTokens?: TokenLocation;
+  requestModel?: TokenLocation;
+  responseModel?: TokenLocation;
+}
+
+export interface ResourceMappings {
+  resources?: ResourceMapping[];
+}
+
+/**
+ * Create Provider Template request.
+ * The backend expects an explicit `id` for the template (e.g. "kimi-full"),
+ * so it is required here (unlike the read model where it is optional).
+ */
+export type CreateProviderTemplateRequest = Omit<ProviderTemplate, 'id'> & {
+  id: string;
+};
 
 /**
  * Update Provider Template request - all fields optional


### PR DESCRIPTION
### Purpose

Today, admins can only create LLM providers from a fixed, built-in set of provider templates (OpenAI, Anthropic, Azure OpenAI, AWS Bedrock, Gemini, Mistral, Azure AI Foundry). Any LLM provider that isn't on that list can't be onboarded without changes to the gateway itself.

This PR adds **LLM Provider Templates** as a first-class, user-managed resource: org admins can define their own custom templates (name, endpoint, OpenAPI spec, token/model extraction mapping) and immediately use them to create LLM providers, the same way they use the built-in ones.

### Key points

-  Let org admins create, edit, version, and delete **custom** LLM provider templates, without code changes to the gateway. Built-in templates are shown as read-only andly and can be enable/disable.
- Keep **built-in** (`managedBy: wso2`) templates read-only and protected from edit/delete, while still letting admins fork a new custom version off a built-in template.
-  Prevent deleting a template/version that providers still depend on.
- Surface all of this through the AI Workspace UI (a new "Settings → LLM Provider Templates" section) and propagate custom templates down to the gateway-controller so deployed providers built from them work the same as built-in ones.
- Templates can have multiple immutable versions (v1.0, v2.0, …); the latest is shown by default.

### User stories

- As an org admin, I can create a custom LLM provider template so my org can onboard an LLM provider that isn't one of the built-in ones.
- As an org admin, I can publish a new version of an existing custom template (e.g. an updated endpoint or OpenAPI spec) without affecting providers already built on the previous version.
- As an org admin, I'm blocked with a clear error from deleting a template/version that one or more providers still depend on.
- As an org admin, I can see the built-in templates alongside my custom ones, but can't accidentally edit or delete a built-in one. I can only disable built-in templates.

### UI Implementations
<img width="1724" height="941" alt="image" src="https://github.com/user-attachments/assets/638acc4e-4689-42dd-98ab-1805c1198bba" />
<img width="1461" height="854" alt="image" src="https://github.com/user-attachments/assets/5d340658-e948-4396-a596-df87f6f1def8" />

<img width="1174" height="828" alt="image" src="https://github.com/user-attachments/assets/699a566b-708d-4c45-82bd-01c55db3beb9" />

