### PR TITLE
Add E2E test in release action

### DIFF
--- a/.github/workflows/ai-workspace-pr-check.yml
+++ b/.github/workflows/ai-workspace-pr-check.yml
@@ -29,42 +29,9 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Install AI Workspace dependencies
-        run: npm ci
-        working-directory: portals/ai-workspace
-
       - name: Build AI Workspace image
         run: make build
         working-directory: portals/ai-workspace
 
-      # AI Workspace E2E depends on platform-api changes that ship in this PR but
-      # are not yet published to the registry. Build the platform-api image from
-      # source and pin the compose file to that freshly built snapshot so the
-      # stack runs the PR's code instead of the last published image.
-      - name: Build Platform API image (PR changes)
-        run: |
-          PLATFORM_API_VERSION="$(tr -d '[:space:]' < platform-api/VERSION)"
-          echo "Building platform-api:${PLATFORM_API_VERSION} from source"
-          make -C platform-api build VERSION="${PLATFORM_API_VERSION}"
-          echo "Pinning ai-workspace compose to platform-api:${PLATFORM_API_VERSION}"
-          sed -i.bak -E "s#image: .*/platform-api:.*#image: ghcr.io/wso2/api-platform/platform-api:${PLATFORM_API_VERSION}#" \
-            portals/ai-workspace/docker-compose.yaml
-          rm -f portals/ai-workspace/docker-compose.yaml.bak
-
-      - name: Start quickstart stack
-        run: docker compose up -d --wait
-        working-directory: portals/ai-workspace
-
-      - name: Run Cypress E2E suite
-        run: npm run test:e2e
-        working-directory: portals/ai-workspace
-
-      - name: Print quickstart logs on failure
-        if: failure()
-        run: docker compose logs --no-color
-        working-directory: portals/ai-workspace
-
-      - name: Stop quickstart stack
-        if: always()
-        run: docker compose down -v
-        working-directory: portals/ai-workspace
+      - name: Run AI Workspace E2E suite
+        run: make test-ai-workspace

--- a/.github/workflows/ai-workspace-release.yaml
+++ b/.github/workflows/ai-workspace-release.yaml
@@ -53,8 +53,16 @@ jobs:
         with:
           driver: docker-container
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
       - name: Build Docker image for testing
         run: make -C portals/ai-workspace build
+
+      - name: Run tests
+        run: make test-ai-workspace
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ help: ## Show this help message
 	@echo '  make test-platform-api                - Run platform-api tests'
 	@echo '  make test-cli                         - Run CLI tests'
 	@echo '  make test-devportal                   - Run developer portal integration tests'
+	@echo '  make test-ai-workspace                - Run AI Workspace E2E tests'
 	@echo ''
 	@echo 'Push Targets:'
 	@echo '  make push-gateway                     - Push gateway images to registry'
@@ -155,6 +156,11 @@ test-platform-api: ## Run platform-api tests
 test-devportal: ## Run developer portal integration tests
 	@echo "Running developer portal integration tests..."
 	$(MAKE) -C portals/developer-portal it
+
+.PHONY: test-ai-workspace
+test-ai-workspace: ## Run AI Workspace E2E tests
+	@echo "Running AI Workspace E2E tests..."
+	$(MAKE) -C portals/ai-workspace e2e-ci
 
 .PHONY: build-cli
 build-cli: ## Build CLI binaries for all platforms

--- a/portals/ai-workspace/Makefile
+++ b/portals/ai-workspace/Makefile
@@ -17,13 +17,15 @@
 
 # Makefile for AI Workspace
 
+SHELL := /bin/bash
+
 VERSION ?= $(shell cat VERSION 2>/dev/null || echo "0.0.0-SNAPSHOT")
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 
 DOCKER_REGISTRY ?= ghcr.io/wso2/api-platform
 IMAGE_NAME := $(DOCKER_REGISTRY)/ai-workspace
 
-.PHONY: help run build push build-and-push-multiarch version-set version-bump-patch version-bump-minor version-bump-major version-bump-next-dev version-get-release e2e-deps e2e-test e2e-open
+.PHONY: help run build push build-and-push-multiarch version-set version-bump-patch version-bump-minor version-bump-major version-bump-next-dev version-get-release e2e-deps e2e-test e2e-open e2e-ci
 
 help: ## Show this help message
 	@echo 'AI Workspace Build System (Version: $(VERSION))'
@@ -46,6 +48,32 @@ e2e-test: ## Run Cypress headlessly against a locally running docker compose sta
 
 e2e-open: ## Open Cypress UI against a locally running docker compose stack
 	CYPRESS_BASE_URL=https://localhost:5380 npx cypress open --e2e --config-file cypress.config.js
+
+e2e-ci: ## Run AI Workspace E2E against a local quickstart stack
+	@set -euo pipefail; \
+	backup_file="$$(mktemp)"; \
+	cp docker-compose.yaml "$$backup_file"; \
+	cleanup() { \
+		status=$$?; \
+		if [ $$status -ne 0 ]; then \
+			docker compose logs --no-color || true; \
+		fi; \
+		docker compose down -v >/dev/null 2>&1 || true; \
+		mv "$$backup_file" docker-compose.yaml; \
+		exit $$status; \
+	}; \
+	trap cleanup EXIT; \
+	trap 'exit 130' INT; \
+	trap 'exit 143' TERM; \
+	npm ci; \
+	platform_api_version="$$(tr -d '[:space:]' < ../../platform-api/VERSION)"; \
+	echo "Building platform-api:$${platform_api_version} from source"; \
+	$(MAKE) -C ../../platform-api build VERSION="$${platform_api_version}"; \
+	echo "Pinning ai-workspace compose to platform-api:$${platform_api_version}"; \
+	sed -i.bak -E "s#image: .*/platform-api:.*#image: $(DOCKER_REGISTRY)/platform-api:$${platform_api_version}#" docker-compose.yaml; \
+	rm -f docker-compose.yaml.bak; \
+	docker compose up -d --wait; \
+	$(MAKE) e2e-test
 
 build: ## Build Docker image
 	@echo "Building Docker image ($(IMAGE_NAME):$(VERSION))..."


### PR DESCRIPTION
This pull request refactors how the AI Workspace end-to-end (E2E) tests are run in CI workflows and the Makefile, consolidating multiple steps into a single, reusable Makefile target. This improves maintainability, ensures consistency between local and CI test runs, and simplifies the workflow configuration.

Issue: https://github.com/wso2/api-platform/issues/2283

**CI/CD Workflow Simplification:**

* In `.github/workflows/ai-workspace-pr-check.yml` and `.github/workflows/ai-workspace-release.yaml`, the previous multi-step E2E test setup (installing dependencies, building images, manually patching compose files, running and tearing down the stack, and printing logs on failure) is replaced with a single call to `make test-ai-workspace`, which handles all required steps internally. [[1]](diffhunk://#diff-ca13ebfefc734b98fb2474abfbe541cc1efc4c951f1232f6e6e58395ba97d07bL32-R37) [[2]](diffhunk://#diff-709dd54b74ab6b5c2635f39191d5af7b1a303d97de4a590379ebeab4dc0a5c0aR56-R66)

**Makefile Improvements:**

* Adds a new `test-ai-workspace` target to the root `Makefile`, which delegates to a new `e2e-ci` target in `portals/ai-workspace/Makefile`. This target is now documented in the help output. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R59) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R160-R164)
* Implements the `e2e-ci` target in `portals/ai-workspace/Makefile`, encapsulating all logic for building dependencies, patching the `docker-compose.yaml`, running the stack, executing tests, capturing logs on failure, and cleaning up—ensuring idempotent and robust test execution.
* Sets `SHELL := /bin/bash` in the `portals/ai-workspace/Makefile` to ensure compatibility with advanced shell features used in the new targets.

These changes centralize E2E test logic, reduce duplication, and make local and CI test execution more consistent and reliable.