### PR TITLE
Remove ExecuteSchemaDDL configuration and related documentation for non-SQLite databases

### DIFF
--- a/platform-api/src/config/config.go
+++ b/platform-api/src/config/config.go
@@ -176,11 +176,6 @@ type Database struct {
 	MaxIdleConns    int    `koanf:"max_idle_conns"`
 	ConnMaxLifetime int    `koanf:"conn_max_lifetime"`
 
-	// ExecuteSchemaDDL controls whether the server runs schema DDL at startup.
-	// Defaults to true for SQLite and false for all other drivers. Set to true
-	// only if you want the server to manage schema provisioning; for production
-	// databases, prefer provisioning the schema externally before startup.
-	ExecuteSchemaDDL               bool   `koanf:"execute_schema_ddl"`
 	EncryptionKey                  string `koanf:"encryption_key"`
 	SubscriptionTokenEncryptionKey string `koanf:"subscription_token_encryption_key"`
 }
@@ -283,14 +278,6 @@ func LoadConfig(configPath string) (*Server, error) {
 		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 	}
 
-	// For server databases (non-SQLite), default execute_schema_ddl to false.
-	// Setting the key explicitly in config preserves that value here, so
-	// operators must consciously opt in to server-managed DDL for non-SQLite
-	// drivers.
-	if !k.Exists("database.execute_schema_ddl") && strings.ToLower(cfg.Database.Driver) != "sqlite3" {
-		cfg.Database.ExecuteSchemaDDL = false
-	}
-
 	if err := validateDefaultDevPortalConfig(&cfg.DefaultDevPortal); err != nil {
 		return nil, err
 	}
@@ -374,8 +361,6 @@ func envToKoanfKey(s string) string {
 		return "database.max_idle_conns"
 	case "database_conn_max_lifetime":
 		return "database.conn_max_lifetime"
-	case "database_execute_schema_ddl":
-		return "database.execute_schema_ddl"
 	case "database_encryption_key":
 		return "database.encryption_key"
 	case "database_subscription_token_encryption_key":

--- a/platform-api/src/config/config.toml
+++ b/platform-api/src/config/config.toml
@@ -39,12 +39,6 @@ port       = "9243"
 # password = "change-me"
 # ssl_mode = "disable"
 
-# Schema DDL execution — when true the server runs DDL at startup to create or
-# migrate the schema. Defaults to true for SQLite and false for all other
-# drivers. Set to true for non-SQLite only if you want the server to manage
-# schema provisioning; otherwise provision the schema externally before startup.
-# execute_schema_ddl = false
-
 # ---------------------------------------------------------------------------
 # Authentication
 # ---------------------------------------------------------------------------

--- a/platform-api/src/config/default_config.go
+++ b/platform-api/src/config/default_config.go
@@ -36,7 +36,6 @@ func defaultConfig() *Server {
 			MaxOpenConns:     25,
 			MaxIdleConns:     10,
 			ConnMaxLifetime:  300,
-			ExecuteSchemaDDL: true,
 		},
 		Auth: Auth{
 			// SkipPaths bypasses JWT/IDP auth middleware. Paths below the health/metrics

--- a/platform-api/src/internal/server/server.go
+++ b/platform-api/src/internal/server/server.go
@@ -78,16 +78,17 @@ func StartPlatformAPIServer(cfg *config.Server, slogger *slog.Logger) (*Server, 
 		return nil, err
 	}
 
-	// Schema DDL is only executed in demo mode. In non-demo (production) deployments
-	// the schema must be pre-provisioned by the operator; auto-running DDL against an
-	// external database at startup is a security risk.
-	if cfg.Database.ExecuteSchemaDDL {
+	// Schema DDL is executed only for SQLite, which is used for local/demo
+	// deployments. For all other (server) drivers the schema must be
+	// pre-provisioned by the operator; auto-running DDL against an external
+	// database at startup is a security risk.
+	if strings.ToLower(cfg.Database.Driver) == "sqlite3" {
 		if err := db.InitSchema(cfg.DBSchemaPath, slogger); err != nil {
 			slogger.Error("Failed to initialize database schema", "error", err)
 			return nil, err
 		}
 	} else {
-		slogger.Debug("Skipping schema DDL execution — set DATABASE_EXECUTE_SCHEMA_DDL=true to enable", "driver", cfg.Database.Driver)
+		slogger.Debug("Skipping schema DDL execution — schema must be pre-provisioned", "driver", cfg.Database.Driver)
 	}
 
 	// Initialize repositories

--- a/portals/ai-workspace/configs/config-platform-api-template.toml
+++ b/portals/ai-workspace/configs/config-platform-api-template.toml
@@ -63,12 +63,6 @@ path = "/app/data/api_platform.db"
 # max_idle_conns    = 10    # maximum idle connections in the pool
 # conn_max_lifetime = 300   # seconds before a connection is recycled
 
-# Schema DDL execution — when true the server runs DDL at startup to create or
-# migrate the schema. Defaults to true for SQLite and false for all other
-# drivers. Set to true for non-SQLite only if you want the server to manage
-# schema provisioning; otherwise provision the schema externally before startup.
-# execute_schema_ddl = false
-
 # Encryption key for subscription tokens stored in the database (32-byte hex string).
 # Required when subscription tokens are used; auto-generated if left empty.
 # subscription_token_encryption_key = ""

--- a/portals/ai-workspace/configs/config-platform-api.toml
+++ b/portals/ai-workspace/configs/config-platform-api.toml
@@ -45,12 +45,6 @@ path   = "/app/data/api_platform.db"   # SQLite file path (ignored for postgres)
 # password = "change-me"
 # ssl_mode = "disable"
 
-# Schema DDL execution — when true the server runs DDL at startup to create or
-# migrate the schema. Defaults to true for SQLite and false for all other
-# drivers. Set to true for non-SQLite only if you want the server to manage
-# schema provisioning; otherwise provision the schema externally before startup.
-# execute_schema_ddl = false
-
 # ---------------------------------------------------------------------------
 # Authentication
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
https://github.com/wso2/api-platform/issues/2281

Remove ExecuteSchemaDDL configuration and related documentation for non-SQLite databases, clarifying that schema DDL execution is only applicable for SQLite. Update logging messages to reflect the new schema provisioning requirements.


