### PR TITLE
change AI-Gateway test

### DIFF
--- a/portals/ai-workspace/cypress/e2e/003-gateways/003-ai-gateway.cy.js
+++ b/portals/ai-workspace/cypress/e2e/003-gateways/003-ai-gateway.cy.js
@@ -17,8 +17,8 @@
  */
 
 describe('AI Workspace - AI gateway lifecycle', () => {
-  const suffix = Date.now().toString().slice(-8);
-  const gatewayName = `E2E AI Gateway ${suffix}`;
+  const suffix = Date.now().toString().slice(-4);
+  const gatewayName = `gw-${suffix}`;
 
   beforeEach(() => {
     cy.login();
@@ -49,7 +49,7 @@ describe('AI Workspace - AI gateway lifecycle', () => {
 
     cy.location('pathname', { timeout: 30000 }).should(
       'include',
-      `/gateways/view/${toSlug(gatewayName)}`
+      `/gateways/view/${gatewayName}`
     );
     cy.contains(gatewayName, { timeout: 30000 }).should('be.visible');
 
@@ -72,15 +72,3 @@ describe('AI Workspace - AI gateway lifecycle', () => {
     cy.contains(gatewayName, { timeout: 30000 }).should('not.exist');
   });
 });
-
-function toSlug(value) {
-  return value
-    .trim()
-    .toLowerCase()
-    .replace(/\s+/g, '-')
-    .replace(/[^a-z0-9-]/g, '')
-    .replace(/^-+|-+$/g, '')
-    .replace(/-+/g, '-')
-    .substring(0, 64)
-    .replace(/-+$/g, '');
-}


### PR DESCRIPTION
This pull request simplifies the Cypress end-to-end test for the AI gateway lifecycle by standardizing the gateway name format and removing unnecessary slugification logic. The changes make the test more predictable and easier to maintain.

**Test simplification and consistency:**

* Changed the `gatewayName` format to a short, predictable string (e.g., `gw-1234`) instead of a longer, more complex name, making test runs more consistent and easier to debug.
* Updated the test to use the raw `gatewayName` in URL path assertions, removing the need to convert names to slugs.
* Removed the unused `toSlug` helper function, as it is no longer necessary with the new naming convention.