### PR TITLE
[API Platform] Refactor user identification in API handlers to use GetUserIDFromRequest

### DIFF
--- a/platform-api/src/internal/handler/api.go
+++ b/platform-api/src/internal/handler/api.go
@@ -91,7 +91,7 @@ func (h *APIHandler) CreateAPI(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	createdBy, _ := middleware.GetUsernameFromRequest(r)
+	createdBy, _ := middleware.GetUserIDFromRequest(r)
 	apiResponse, err := h.apiService.CreateAPI(&req, orgId, createdBy)
 	if err != nil {
 		if errors.Is(err, constants.ErrHandleExists) {
@@ -279,7 +279,7 @@ func (h *APIHandler) UpdateAPI(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	updatedBy, _ := middleware.GetUsernameFromRequest(r)
+	updatedBy, _ := middleware.GetUserIDFromRequest(r)
 	apiResponse, err := h.apiService.UpdateAPIByHandle(apiId, &req, orgId, updatedBy)
 	if err != nil {
 		if respondArtifactGuardError(w, err) {
@@ -340,7 +340,7 @@ func (h *APIHandler) DeleteAPI(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	deletedBy, _ := middleware.GetUsernameFromRequest(r)
+	deletedBy, _ := middleware.GetUserIDFromRequest(r)
 	err := h.apiService.DeleteAPIByHandle(apiId, orgId, deletedBy)
 	if err != nil {
 		if respondArtifactGuardError(w, err) {
@@ -506,7 +506,7 @@ func (h *APIHandler) ImportAPIProject(w http.ResponseWriter, r *http.Request) {
 	// Create Git service
 	gitService := service.NewGitService()
 
-	createdBy, _ := middleware.GetUsernameFromRequest(r)
+	createdBy, _ := middleware.GetUserIDFromRequest(r)
 	// Import API project
 	apiResponse, err := h.apiService.ImportAPIProject(&req, orgId, createdBy, gitService)
 	if err != nil {
@@ -735,7 +735,7 @@ func (h *APIHandler) ImportOpenAPI(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	createdBy, _ := middleware.GetUsernameFromRequest(r)
+	createdBy, _ := middleware.GetUserIDFromRequest(r)
 	// Import API from OpenAPI definition
 	apiResponse, err := h.apiService.ImportFromOpenAPI(&apiDetails, req.Url, definitionHeader, orgId, createdBy)
 	if err != nil {

--- a/platform-api/src/internal/handler/api_deployment.go
+++ b/platform-api/src/internal/handler/api_deployment.go
@@ -85,7 +85,7 @@ func (h *DeploymentHandler) DeployAPI(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	createdBy, _ := middleware.GetUsernameFromRequest(r)
+	createdBy, _ := middleware.GetUserIDFromRequest(r)
 	deployment, err := h.deploymentService.DeployAPIByHandle(apiId, &req, orgId, createdBy)
 	if err != nil {
 		if respondArtifactGuardError(w, err) {
@@ -168,7 +168,7 @@ func (h *DeploymentHandler) UndeployDeployment(w http.ResponseWriter, r *http.Re
 			"API ID is required"))
 		return
 	}
-	actor, _ := middleware.GetUsernameFromRequest(r)
+	actor, _ := middleware.GetUserIDFromRequest(r)
 	deployment, err := h.deploymentService.UndeployDeploymentByHandle(apiId, deploymentId, gatewayId, orgId, actor)
 	if err != nil {
 		// DP-originated artifacts are read-only: undeployment cannot be initiated from the CP.
@@ -241,7 +241,7 @@ func (h *DeploymentHandler) RestoreDeployment(w http.ResponseWriter, r *http.Req
 			"API ID is required"))
 		return
 	}
-	actor, _ := middleware.GetUsernameFromRequest(r)
+	actor, _ := middleware.GetUserIDFromRequest(r)
 	deployment, err := h.deploymentService.RestoreDeploymentByHandle(apiId, deploymentId, gatewayId, orgId, actor)
 	if err != nil {
 		// DP-originated artifacts are read-only: restore cannot be initiated from the CP.
@@ -305,7 +305,7 @@ func (h *DeploymentHandler) DeleteDeployment(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	actor, _ := middleware.GetUsernameFromRequest(r)
+	actor, _ := middleware.GetUserIDFromRequest(r)
 	err := h.deploymentService.DeleteDeploymentByHandle(apiId, deploymentId, orgId, actor)
 	if err != nil {
 		if errors.Is(err, constants.ErrAPINotFound) {

--- a/platform-api/src/internal/handler/gateway.go
+++ b/platform-api/src/internal/handler/gateway.go
@@ -105,7 +105,7 @@ func (h *GatewayHandler) CreateGateway(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	createdBy, _ := middleware.GetUsernameFromRequest(r)
+	createdBy, _ := middleware.GetUserIDFromRequest(r)
 	gateway, err := h.gatewayService.RegisterGateway(orgId, req.Name, req.DisplayName, description, req.Vhost,
 		isCritical, functionalityType, version, createdBy, properties)
 	if err != nil {
@@ -261,7 +261,7 @@ func (h *GatewayHandler) UpdateGateway(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	updatedBy, _ := middleware.GetUsernameFromRequest(r)
+	updatedBy, _ := middleware.GetUserIDFromRequest(r)
 	response, err := h.gatewayService.UpdateGateway(gatewayId, orgId, updatedBy, req.Description, req.DisplayName, req.IsCritical, req.Properties)
 	if err != nil {
 		if errors.Is(err, constants.ErrGatewayNotFound) {
@@ -296,7 +296,7 @@ func (h *GatewayHandler) DeleteGateway(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	deletedBy, _ := middleware.GetUsernameFromRequest(r)
+	deletedBy, _ := middleware.GetUserIDFromRequest(r)
 	err := h.gatewayService.DeleteGateway(gatewayId, orgId, deletedBy)
 	if err != nil {
 		// Check for specific error types
@@ -383,7 +383,7 @@ func (h *GatewayHandler) RotateToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	createdBy, _ := middleware.GetUsernameFromRequest(r)
+	createdBy, _ := middleware.GetUserIDFromRequest(r)
 	response, err := h.gatewayService.RotateToken(gatewayId, orgId, createdBy)
 	if err != nil {
 		errMsg := err.Error()
@@ -435,7 +435,7 @@ func (h *GatewayHandler) RevokeToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	revokedBy, _ := middleware.GetUsernameFromRequest(r)
+	revokedBy, _ := middleware.GetUserIDFromRequest(r)
 	err := h.gatewayService.RevokeToken(gatewayId, tokenId, orgId, revokedBy)
 	if err != nil {
 		errMsg := err.Error()

--- a/platform-api/src/internal/handler/llm.go
+++ b/platform-api/src/internal/handler/llm.go
@@ -93,7 +93,7 @@ func (h *LLMHandler) CreateLLMProviderTemplate(w http.ResponseWriter, r *http.Re
 		httputil.WriteJSON(w, http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", "Invalid request body"))
 		return
 	}
-	createdBy, _ := middleware.GetUsernameFromRequest(r)
+	createdBy, _ := middleware.GetUserIDFromRequest(r)
 
 	created, err := h.templateService.Create(orgID, createdBy, &req)
 	if err != nil {
@@ -228,7 +228,7 @@ func (h *LLMHandler) CreateLLMProviderTemplateVersion(w http.ResponseWriter, r *
 		return
 	}
 	id := r.PathValue("id")
-	createdBy, _ := middleware.GetUsernameFromRequest(r)
+	createdBy, _ := middleware.GetUserIDFromRequest(r)
 
 	var req api.CreateLLMProviderTemplateVersionRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -339,7 +339,7 @@ func (h *LLMHandler) UpdateLLMProviderTemplate(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	updatedBy, _ := middleware.GetUsernameFromRequest(r)
+	updatedBy, _ := middleware.GetUserIDFromRequest(r)
 	resp, err := h.templateService.Update(orgID, id, updatedBy, &req)
 	if err != nil {
 		if respondArtifactGuardError(w, err) {
@@ -374,7 +374,7 @@ func (h *LLMHandler) DeleteLLMProviderTemplate(w http.ResponseWriter, r *http.Re
 		return
 	}
 	id := r.PathValue("id")
-	deletedBy, _ := middleware.GetUsernameFromRequest(r)
+	deletedBy, _ := middleware.GetUserIDFromRequest(r)
 
 	if err := h.templateService.Delete(orgID, id, deletedBy); err != nil {
 		if respondArtifactGuardError(w, err) {
@@ -451,7 +451,7 @@ func (h *LLMHandler) CreateLLMProvider(w http.ResponseWriter, r *http.Request) {
 		httputil.WriteJSON(w, http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", "Invalid request body"))
 		return
 	}
-	createdBy, _ := middleware.GetUsernameFromRequest(r)
+	createdBy, _ := middleware.GetUserIDFromRequest(r)
 
 	created, err := h.providerService.Create(orgID, createdBy, &req)
 	if err != nil {
@@ -558,7 +558,7 @@ func (h *LLMHandler) UpdateLLMProvider(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	updatedBy, _ := middleware.GetUsernameFromRequest(r)
+	updatedBy, _ := middleware.GetUserIDFromRequest(r)
 	resp, err := h.providerService.Update(orgID, id, updatedBy, &req)
 	if err != nil {
 		if respondArtifactGuardError(w, err) {
@@ -593,7 +593,7 @@ func (h *LLMHandler) DeleteLLMProvider(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	id := r.PathValue("id")
-	deletedBy, _ := middleware.GetUsernameFromRequest(r)
+	deletedBy, _ := middleware.GetUserIDFromRequest(r)
 
 	if err := h.providerService.Delete(orgID, id, deletedBy); err != nil {
 		if respondArtifactGuardError(w, err) {
@@ -633,7 +633,7 @@ func (h *LLMHandler) CreateLLMProxy(w http.ResponseWriter, r *http.Request) {
 		httputil.WriteJSON(w, http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", "Project ID is required"))
 		return
 	}
-	createdBy, _ := middleware.GetUsernameFromRequest(r)
+	createdBy, _ := middleware.GetUserIDFromRequest(r)
 
 	created, err := h.proxyService.Create(orgID, createdBy, &req)
 	if err != nil {
@@ -797,7 +797,7 @@ func (h *LLMHandler) UpdateLLMProxy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	updatedBy, _ := middleware.GetUsernameFromRequest(r)
+	updatedBy, _ := middleware.GetUserIDFromRequest(r)
 	resp, err := h.proxyService.Update(orgID, id, updatedBy, &req)
 	if err != nil {
 		if respondArtifactGuardError(w, err) {
@@ -829,7 +829,7 @@ func (h *LLMHandler) DeleteLLMProxy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	id := r.PathValue("id")
-	deletedBy, _ := middleware.GetUsernameFromRequest(r)
+	deletedBy, _ := middleware.GetUserIDFromRequest(r)
 
 	if err := h.proxyService.Delete(orgID, id, deletedBy); err != nil {
 		if respondArtifactGuardError(w, err) {

--- a/platform-api/src/internal/handler/mcp.go
+++ b/platform-api/src/internal/handler/mcp.go
@@ -71,7 +71,7 @@ func (h *MCPProxyHandler) CreateMCPProxy(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	createdBy, _ := middleware.GetUsernameFromRequest(r)
+	createdBy, _ := middleware.GetUserIDFromRequest(r)
 
 	if req.ProjectId == nil {
 		h.slogger.Debug("No project ID provided for MCP proxy, proceeding without project association", "mcpProxyId", req.Id)
@@ -170,7 +170,7 @@ func (h *MCPProxyHandler) UpdateMCPProxy(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	updatedBy, _ := middleware.GetUsernameFromRequest(r)
+	updatedBy, _ := middleware.GetUserIDFromRequest(r)
 	resp, err := h.service.Update(orgID, id, updatedBy, &req)
 	if err != nil {
 		h.handleServiceError(w, err)
@@ -189,7 +189,7 @@ func (h *MCPProxyHandler) DeleteMCPProxy(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	id := r.PathValue("id")
-	deletedBy, _ := middleware.GetUsernameFromRequest(r)
+	deletedBy, _ := middleware.GetUserIDFromRequest(r)
 
 	if err := h.service.Delete(orgID, id, deletedBy); err != nil {
 		h.handleServiceError(w, err)

--- a/platform-api/src/internal/handler/mcp_deployment.go
+++ b/platform-api/src/internal/handler/mcp_deployment.go
@@ -97,7 +97,7 @@ func (h *MCPProxyDeploymentHandler) DeployMCPProxy(w http.ResponseWriter, r *htt
 		return
 	}
 
-	createdBy, _ := middleware.GetUsernameFromRequest(r)
+	createdBy, _ := middleware.GetUserIDFromRequest(r)
 	deployment, err := h.deploymentService.DeployMCPProxyByHandle(proxyId, &req, orgId, createdBy)
 	if err != nil {
 		if respondArtifactGuardError(w, err) {

--- a/platform-api/src/internal/handler/organization.go
+++ b/platform-api/src/internal/handler/organization.go
@@ -79,7 +79,7 @@ func (h *OrganizationHandler) RegisterOrganization(w http.ResponseWriter, r *htt
 		id = generated
 	}
 
-	performedBy, _ := middleware.GetUsernameFromRequest(r)
+	performedBy, _ := middleware.GetUserIDFromRequest(r)
 	org, err := h.orgService.RegisterOrganization(id, req.Handle, req.Name, req.Region, performedBy)
 	if err != nil {
 		if errors.Is(err, constants.ErrHandleExists) {

--- a/platform-api/src/internal/handler/project.go
+++ b/platform-api/src/internal/handler/project.go
@@ -65,7 +65,7 @@ func (h *ProjectHandler) CreateProject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	actor, _ := middleware.GetUsernameFromRequest(r)
+	actor, _ := middleware.GetUserIDFromRequest(r)
 	project, err := h.projectService.CreateProject(&req, organizationID, actor)
 	if err != nil {
 		if errors.Is(err, constants.ErrProjectExists) {
@@ -180,7 +180,7 @@ func (h *ProjectHandler) UpdateProject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	actor, _ := middleware.GetUsernameFromRequest(r)
+	actor, _ := middleware.GetUserIDFromRequest(r)
 	project, err := h.projectService.UpdateProject(projectId, &req, orgID, actor)
 	if err != nil {
 		if errors.Is(err, constants.ErrProjectNotFound) {
@@ -218,7 +218,7 @@ func (h *ProjectHandler) DeleteProject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	actor, _ := middleware.GetUsernameFromRequest(r)
+	actor, _ := middleware.GetUserIDFromRequest(r)
 	err := h.projectService.DeleteProject(projectId, orgID, actor)
 	if err != nil {
 		if errors.Is(err, constants.ErrProjectNotFound) {

--- a/platform-api/src/internal/handler/secret.go
+++ b/platform-api/src/internal/handler/secret.go
@@ -59,7 +59,7 @@ func (h *SecretHandler) CreateSecret(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	username, _ := middleware.GetUsernameFromRequest(r)
+	userID, _ := middleware.GetUserIDFromRequest(r)
 
 	if err := r.ParseMultipartForm(32 << 20); err != nil {
 		_ = r.ParseForm()
@@ -76,7 +76,7 @@ func (h *SecretHandler) CreateSecret(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp, err := h.secretService.Create(orgID, username, &req)
+	resp, err := h.secretService.Create(orgID, userID, &req)
 	if err != nil {
 		if errors.Is(err, constants.ErrSecretAlreadyExists) {
 			httputil.WriteJSON(w, http.StatusConflict, utils.NewErrorResponse(409, "Conflict", "A secret with this name already exists in this scope"))
@@ -177,7 +177,7 @@ func (h *SecretHandler) UpdateSecret(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	username, _ := middleware.GetUsernameFromRequest(r)
+	userID, _ := middleware.GetUserIDFromRequest(r)
 
 	if err := r.ParseMultipartForm(32 << 20); err != nil {
 		_ = r.ParseForm()
@@ -192,7 +192,7 @@ func (h *SecretHandler) UpdateSecret(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp, err := h.secretService.Update(orgID, handle, username, &req)
+	resp, err := h.secretService.Update(orgID, handle, userID, &req)
 	if err != nil {
 		if errors.Is(err, constants.ErrSecretNotFound) {
 			httputil.WriteJSON(w, http.StatusNotFound, utils.NewErrorResponse(404, "Not Found", "Secret not found"))
@@ -219,9 +219,9 @@ func (h *SecretHandler) DeleteSecret(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	username, _ := middleware.GetUsernameFromRequest(r)
+	userID, _ := middleware.GetUserIDFromRequest(r)
 
-	err := h.secretService.Delete(orgID, handle, username)
+	err := h.secretService.Delete(orgID, handle, userID)
 	if err != nil {
 		if errors.Is(err, constants.ErrSecretNotFound) {
 			httputil.WriteJSON(w, http.StatusNotFound, utils.NewErrorResponse(404, "Not Found", "Secret not found"))

--- a/platform-api/src/internal/handler/subscription_plan_handler.go
+++ b/platform-api/src/internal/handler/subscription_plan_handler.go
@@ -154,9 +154,9 @@ func (h *SubscriptionPlanHandler) CreateSubscriptionPlan(w http.ResponseWriter, 
 		plan.ExpiryTime = &t
 	}
 
-	actor, ok := middleware.GetUsernameFromRequest(r)
+	actor, ok := middleware.GetUserIDFromRequest(r)
 	if !ok {
-		httputil.WriteJSON(w, http.StatusUnauthorized, utils.NewErrorResponse(401, "Unauthorized", "Username claim not found in token"))
+		httputil.WriteJSON(w, http.StatusUnauthorized, utils.NewErrorResponse(401, "Unauthorized", "User ID claim not found in token"))
 		return
 	}
 	created, err := h.planService.CreatePlan(orgId, actor, plan)
@@ -310,9 +310,9 @@ func (h *SubscriptionPlanHandler) UpdateSubscriptionPlan(w http.ResponseWriter, 
 		update.ExpiryTime = &t
 	}
 
-	actor, ok := middleware.GetUsernameFromRequest(r)
+	actor, ok := middleware.GetUserIDFromRequest(r)
 	if !ok {
-		httputil.WriteJSON(w, http.StatusUnauthorized, utils.NewErrorResponse(401, "Unauthorized", "Username claim not found in token"))
+		httputil.WriteJSON(w, http.StatusUnauthorized, utils.NewErrorResponse(401, "Unauthorized", "User ID claim not found in token"))
 		return
 	}
 	updated, err := h.planService.UpdatePlan(planId, orgId, actor, update)
@@ -346,9 +346,9 @@ func (h *SubscriptionPlanHandler) DeleteSubscriptionPlan(w http.ResponseWriter, 
 		return
 	}
 
-	actor, ok := middleware.GetUsernameFromRequest(r)
+	actor, ok := middleware.GetUserIDFromRequest(r)
 	if !ok {
-		httputil.WriteJSON(w, http.StatusUnauthorized, utils.NewErrorResponse(401, "Unauthorized", "Username claim not found in token"))
+		httputil.WriteJSON(w, http.StatusUnauthorized, utils.NewErrorResponse(401, "Unauthorized", "User ID claim not found in token"))
 		return
 	}
 	err := h.planService.DeletePlan(planId, orgId, actor)

--- a/platform-api/src/internal/handler/webbroker_api.go
+++ b/platform-api/src/internal/handler/webbroker_api.go
@@ -74,7 +74,7 @@ func (h *WebBrokerAPIHandler) CreateWebBrokerAPI(w http.ResponseWriter, r *http.
 		return
 	}
 
-	createdBy, _ := middleware.GetUsernameFromRequest(r)
+	createdBy, _ := middleware.GetUserIDFromRequest(r)
 
 	resp, err := h.webbrokerAPIService.Create(orgID, createdBy, &req)
 	if err != nil {
@@ -164,7 +164,7 @@ func (h *WebBrokerAPIHandler) UpdateWebBrokerAPI(w http.ResponseWriter, r *http.
 		return
 	}
 
-	updatedBy, _ := middleware.GetUsernameFromRequest(r)
+	updatedBy, _ := middleware.GetUserIDFromRequest(r)
 	resp, err := h.webbrokerAPIService.Update(orgID, id, updatedBy, &req)
 	if err != nil {
 		h.handleServiceError(w, err)
@@ -183,7 +183,7 @@ func (h *WebBrokerAPIHandler) DeleteWebBrokerAPI(w http.ResponseWriter, r *http.
 	}
 
 	id := r.PathValue("apiId")
-	deletedBy, _ := middleware.GetUsernameFromRequest(r)
+	deletedBy, _ := middleware.GetUserIDFromRequest(r)
 
 	if err := h.webbrokerAPIService.Delete(orgID, id, deletedBy); err != nil {
 		h.handleServiceError(w, err)

--- a/platform-api/src/internal/handler/webbroker_api_deployment.go
+++ b/platform-api/src/internal/handler/webbroker_api_deployment.go
@@ -92,7 +92,7 @@ func (h *WebBrokerAPIDeploymentHandler) DeployWebBrokerAPI(w http.ResponseWriter
 		return
 	}
 
-	createdBy, _ := middleware.GetUsernameFromRequest(r)
+	createdBy, _ := middleware.GetUserIDFromRequest(r)
 	deployment, err := h.webbrokerAPIDeploymentService.DeployWebBrokerAPIByHandle(apiId, &req, orgId, createdBy)
 	if err != nil {
 		if respondArtifactGuardError(w, err) {

--- a/platform-api/src/internal/handler/websub_api.go
+++ b/platform-api/src/internal/handler/websub_api.go
@@ -76,7 +76,7 @@ func (h *WebSubAPIHandler) CreateWebSubAPI(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	createdBy, _ := middleware.GetUsernameFromRequest(r)
+	createdBy, _ := middleware.GetUserIDFromRequest(r)
 
 	resp, err := h.websubAPIService.Create(orgID, createdBy, &req)
 	if err != nil {
@@ -157,7 +157,7 @@ func (h *WebSubAPIHandler) UpdateWebSubAPI(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	updatedBy, _ := middleware.GetUsernameFromRequest(r)
+	updatedBy, _ := middleware.GetUserIDFromRequest(r)
 	resp, err := h.websubAPIService.Update(orgID, id, updatedBy, &req)
 	if err != nil {
 		h.handleServiceError(w, err)
@@ -176,7 +176,7 @@ func (h *WebSubAPIHandler) DeleteWebSubAPI(w http.ResponseWriter, r *http.Reques
 	}
 
 	id := r.PathValue("apiId")
-	deletedBy, _ := middleware.GetUsernameFromRequest(r)
+	deletedBy, _ := middleware.GetUserIDFromRequest(r)
 
 	if err := h.websubAPIService.Delete(orgID, id, deletedBy); err != nil {
 		h.handleServiceError(w, err)

--- a/platform-api/src/internal/handler/websub_api_deployment.go
+++ b/platform-api/src/internal/handler/websub_api_deployment.go
@@ -92,7 +92,7 @@ func (h *WebSubAPIDeploymentHandler) DeployWebSubAPI(w http.ResponseWriter, r *h
 		return
 	}
 
-	createdBy, _ := middleware.GetUsernameFromRequest(r)
+	createdBy, _ := middleware.GetUserIDFromRequest(r)
 	deployment, err := h.websubAPIDeploymentService.DeployWebSubAPIByHandle(apiId, &req, orgId, createdBy)
 	if err != nil {
 		if respondArtifactGuardError(w, err) {

--- a/platform-api/src/internal/middleware/auth.go
+++ b/platform-api/src/internal/middleware/auth.go
@@ -190,7 +190,7 @@ func validateLocalJWT(r *http.Request, tokenString string, config AuthConfig) (*
 	}
 
 	ctx := r.Context()
-	ctx = context.WithValue(ctx, keyUserID, sub)
+	ctx = context.WithValue(ctx, keyUserID, resolveUserID(mapClaims, ""))
 	ctx = context.WithValue(ctx, keyUsername, claimsObj.Username)
 	ctx = context.WithValue(ctx, keyEmail, claimsObj.Email)
 	ctx = context.WithValue(ctx, keyFirstName, getStringClaim(mapClaims, "firstName"))
@@ -229,11 +229,9 @@ func PlatformClaimsMiddleware(claimNames PlatformClaimNames) func(http.Handler) 
 			orgName := getStringClaim(mapClaims, claimNames.OrgNameClaim)
 			orgHandle := getStringClaim(mapClaims, claimNames.OrgHandleClaim)
 
-			userID := authCtx.UserID
-			if claimNames.UserIDClaim != "" {
-				if v := getStringClaim(mapClaims, claimNames.UserIDClaim); v != "" {
-					userID = v
-				}
+			userID := resolveUserID(mapClaims, claimNames.UserIDClaim)
+			if userID == "" {
+				userID = authCtx.UserID
 			}
 
 			username := getStringClaim(mapClaims, claimNames.UsernameClaim)
@@ -347,6 +345,21 @@ func getStringClaim(claims jwt.MapClaims, name string) string {
 	}
 	v, _ := claims[name].(string)
 	return v
+}
+
+// resolveUserID returns the stable user identifier used for audit fields
+// (createdBy/updatedBy/etc.). It prefers an explicitly configured claim name,
+// then the conventional "userid" claim, and finally falls back to "sub".
+// Returns an empty string only when none of these are present.
+func resolveUserID(claims jwt.MapClaims, configuredClaim string) string {
+	if v := getStringClaim(claims, configuredClaim); v != "" {
+		return v
+	}
+	if v := getStringClaim(claims, "userid"); v != "" {
+		return v
+	}
+	sub, _ := claims["sub"].(string)
+	return sub
 }
 
 func audienceToString(claims jwt.MapClaims) string {
@@ -485,6 +498,7 @@ func NewTestContextMiddleware(next http.Handler) http.Handler {
 		}
 		if user := r.Header.Get("X-Test-User"); user != "" {
 			ctx = context.WithValue(ctx, keyUsername, user)
+			ctx = context.WithValue(ctx, keyUserID, user)
 		}
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})

--- a/platform-api/src/internal/middleware/auth.go
+++ b/platform-api/src/internal/middleware/auth.go
@@ -349,13 +349,13 @@ func getStringClaim(claims jwt.MapClaims, name string) string {
 
 // resolveUserID returns the stable user identifier used for audit fields
 // (createdBy/updatedBy/etc.). It prefers an explicitly configured claim name,
-// then the conventional "userid" claim, and finally falls back to "sub".
+// then the conventional "user_id" claim, and finally falls back to "sub".
 // Returns an empty string only when none of these are present.
 func resolveUserID(claims jwt.MapClaims, configuredClaim string) string {
 	if v := getStringClaim(claims, configuredClaim); v != "" {
 		return v
 	}
-	if v := getStringClaim(claims, "userid"); v != "" {
+	if v := getStringClaim(claims, "user_id"); v != "" {
 		return v
 	}
 	sub, _ := claims["sub"].(string)


### PR DESCRIPTION
**What**

Audit fields (createdBy, updatedBy, deletedBy, revokedBy, and other "who performed this" actors) now store the user's ID instead of their username. The user ID is resolved from the token's userid cn that claim is absent.

**Why**

Usernames can change over time; a user ID is a ste correct value to persist for audit trails.

**How**
- Added a single resolveUserID() helper in the aue userid → sub resolution in one place, used byboth the local-JWT and IDP/JWKS auth paths.
- Switched all audit-actor extractions in handler → GetUserIDFromRequest (46 call sites across 14handler files).                                                                                                             - Test middleware (X-Test-User) now also populate-level integration tests keep an audit identity.
- Updated related error messages ("Username claim..." → "User ID claim...") and renamed the misleading username variable in secret.go.

Note

Stored audit values — and any API responses or ev will now show an opaque user ID rather than ahuman-readable name.