### PR TITLE
Add subscription plan change and token regeneration features

### DIFF
--- a/docs/rest-apis/devportal/README.md
+++ b/docs/rest-apis/devportal/README.md
@@ -80,6 +80,8 @@ Base URLs:
 - [Get a subscription](subscriptions.md#get-a-subscription)
 - [Update a subscription](subscriptions.md#update-a-subscription)
 - [Delete a subscription](subscriptions.md#delete-a-subscription)
+- [Change subscription plan](subscriptions.md#change-subscription-plan)
+- [Regenerate subscription token](subscriptions.md#regenerate-subscription-token)
 
 ### [API Keys](api-keys.md)
 

--- a/docs/rest-apis/devportal/schemas.md
+++ b/docs/rest-apis/devportal/schemas.md
@@ -1056,6 +1056,26 @@ xor
 |status|ACTIVE|
 |status|INACTIVE|
 
+<h2 id="tocS_SubscriptionChangePlanRequest">SubscriptionChangePlanRequest</h2>
+
+<a id="schemasubscriptionchangeplanrequest"></a>
+<a id="schema_SubscriptionChangePlanRequest"></a>
+<a id="tocSsubscriptionchangeplanrequest"></a>
+<a id="tocssubscriptionchangeplanrequest"></a>
+
+```json
+{
+  "planId": "pol-9a3d1f7e"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|planId|string|true|none|Developer Portal subscription plan ID to switch to.|
+
 <h2 id="tocS_SubscriptionResponse">SubscriptionResponse</h2>
 
 <a id="schemasubscriptionresponse"></a>

--- a/docs/rest-apis/devportal/subscriptions.md
+++ b/docs/rest-apis/devportal/subscriptions.md
@@ -471,3 +471,177 @@ This operation requires <strong>Basic Auth</strong> authentication.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|JSON message response.|[MessageResponse](schemas.md#schemamessageresponse)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[SimpleErrorResponse](schemas.md#schemasimpleerrorresponse)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+## Change subscription plan
+
+<a id="opIdchangePlan"></a>
+
+`POST /devportal/v1/subscriptions/{subId}/change-plan`
+
+> Code samples
+
+```shell
+
+curl -X POST https://devportal.api-platform.io/devportal/v1/subscriptions/{subId}/change-plan \
+  -u {username}:{password} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}' \
+  -d @payload.json
+
+```
+
+Changes the subscription plan in-place. The subscription UUID and token remain unchanged; only the plan is updated. A `subscription.plan_changed` webhook event is published to the organization's configured webhook subscribers.
+
+> Payload
+
+```json
+{
+  "planId": "pol-9a3d1f7e"
+}
+```
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="change-subscription-plan-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[SubscriptionChangePlanRequest](schemas.md#schemasubscriptionchangeplanrequest)|true|Subscription plan change payload. `planId` is the Developer Portal subscription plan ID.|
+|subId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "subscriptionId": "sub-12345",
+  "apiId": "api-7f4c2a6b",
+  "subscriptionToken": "a3f1e8b2c4d6e8f0a1b3c5d7e9f10b2c4d6e8f0a1b3c5d7e9f10b2c4d6e8f0a1",
+  "subscriptionPlanName": "Gold",
+  "status": "ACTIVE",
+  "createdBy": "alice@example.com",
+  "createdAt": "2026-05-07T08:30:00Z"
+}
+```
+
+> 400 Response
+
+```json
+{
+  "code": "400",
+  "message": "Bad Request",
+  "description": "apiId is required"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Not Found",
+  "description": "Subscription not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "status": "error",
+  "code": "INTERNAL_SERVER_ERROR",
+  "message": "An unexpected error occurred."
+}
+```
+
+<h3 id="change-subscription-plan-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Subscription DTO.|[SubscriptionResponse](schemas.md#schemasubscriptionresponse)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request.|[SimpleErrorResponse](schemas.md#schemasimpleerrorresponse)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[SimpleErrorResponse](schemas.md#schemasimpleerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|
+
+## Regenerate subscription token
+
+<a id="opIdregenerateSubscriptionToken"></a>
+
+`POST /devportal/v1/subscriptions/{subId}/regenerate-token`
+
+> Code samples
+
+```shell
+
+curl -X POST https://devportal.api-platform.io/devportal/v1/subscriptions/{subId}/regenerate-token \
+  -u {username}:{password} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+Regenerates the subscription token, immediately invalidating the old one. A `subscription.token_regenerated` webhook event is published to the organization's configured webhook subscribers so they can update the token at the gateway. The new plaintext token is returned in the response.
+
+### Authentication
+
+<aside class="warning">
+This operation requires <strong>Basic Auth</strong> authentication.
+
+</aside>
+
+<h3 id="regenerate-subscription-token-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|subId|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "subscriptionId": "sub-12345",
+  "apiId": "api-7f4c2a6b",
+  "subscriptionToken": "a3f1e8b2c4d6e8f0a1b3c5d7e9f10b2c4d6e8f0a1b3c5d7e9f10b2c4d6e8f0a1",
+  "subscriptionPlanName": "Gold",
+  "status": "ACTIVE",
+  "createdBy": "alice@example.com",
+  "createdAt": "2026-05-07T08:30:00Z"
+}
+```
+
+> 404 Response
+
+```json
+{
+  "code": "404",
+  "message": "Not Found",
+  "description": "Subscription not found"
+}
+```
+
+> 500 Response
+
+```json
+{
+  "status": "error",
+  "code": "INTERNAL_SERVER_ERROR",
+  "message": "An unexpected error occurred."
+}
+```
+
+<h3 id="regenerate-subscription-token-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Subscription DTO.|[SubscriptionResponse](schemas.md#schemasubscriptionresponse)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found.|[SimpleErrorResponse](schemas.md#schemasimpleerrorresponse)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error.|[ErrorResponse](schemas.md#schemaerrorresponse)|

--- a/portals/developer-portal/docs/administer/webhook-integration.md
+++ b/portals/developer-portal/docs/administer/webhook-integration.md
@@ -28,7 +28,9 @@ The portal fires events in the background via a delivery worker. Each delivery i
 | `apikey.revoked` | An API key was revoked | — |
 | `apikey.application_updated` | A key's application association changed | — |
 | `subscription.created` | A developer subscribed to an API | Subscription token (`token`) |
-| `subscription.updated` | A subscription's status changed, or its token was regenerated | Subscription token (`token`, only on token regeneration) |
+| `subscription.updated` | A subscription's status changed (ACTIVE ↔ INACTIVE) | — |
+| `subscription.plan_changed` | A subscription's plan was changed in-place | — |
+| `subscription.token_regenerated` | A subscription token was regenerated | New subscription token (`token`) |
 | `subscription.deleted` | A developer unsubscribed | — |
 | `application.created` | A developer created an application | — |
 | `application.updated` | An application was renamed or its details changed | — |
@@ -74,7 +76,7 @@ The response never includes the secret. To set a public key for envelope-encrypt
 | `name` | Yes | Unique within the organization |
 | `url` | Yes | HTTPS endpoint that receives webhook POSTs (e.g. a handler in front of your gateway). Must be unique within the organization |
 | `secret` | No | Minimum 32-character string used to sign each event with HMAC-SHA256. Stored encrypted; never returned in API responses. If omitted, deliveries are sent unsigned (no `X-Devportal-Signature` header) |
-| `publicKey` | Recommended | PEM-encoded RSA-2048 public key for envelope-encrypting sensitive fields in `apikey.generated`, `apikey.regenerated`, `subscription.created`, and `subscription.updated` events |
+| `publicKey` | Recommended | PEM-encoded RSA-2048 public key for envelope-encrypting sensitive fields in `apikey.generated`, `apikey.regenerated`, `subscription.created`, and `subscription.token_regenerated` events |
 | `events` | No | Event type allowlist. Wildcards supported (`apikey.*`). Omit or leave empty to receive all events |
 | `enabled` | No | Defaults to `true`. Disable a subscriber without deleting it |
 | `timeoutMs` | No | HTTP request timeout in milliseconds (default: 5000) |
@@ -295,11 +297,67 @@ Fired when a developer subscribes to an API. The subscription token is delivered
 
 ### `subscription.updated`
 
-Fired when a subscription's status changes, or when the subscription token is regenerated. When the token is regenerated, `token` carries the new value encrypted using the subscriber's RSA public key — use the same decryption steps as `subscription.created`.
+Fired when a subscription's status changes (ACTIVE ↔ INACTIVE). No encrypted fields are included.
 
 ```json
 {
   "event_type": "subscription.updated",
+  "encrypted_fields": [],
+  "data": {
+    "subscription_id": "sub-uuid",
+    "subscriber_id": "user@example.com",
+    "subscription_plan": {
+      "ref_id": "plan-uuid",
+      "name": "Gold"
+    },
+    "api": {
+      "name": "Order API",
+      "version": "v1.0",
+      "ref_id": "cp-api-uuid"
+    },
+    "status": "INACTIVE"
+  }
+}
+```
+
+### `subscription.plan_changed`
+
+Fired when a developer switches their subscription to a different plan. The subscription UUID and token are unchanged — only the plan association is updated. Your subscriber should update the rate-limit or quota tier for this `subscription_id` without revoking access.
+
+```json
+{
+  "event_type": "subscription.plan_changed",
+  "encrypted_fields": [],
+  "data": {
+    "subscription_id": "sub-uuid",
+    "subscriber_id": "user@example.com",
+    "subscription_plan": {
+      "ref_id": "new-plan-uuid",
+      "name": "Platinum"
+    },
+    "previous_plan": {
+      "ref_id": "old-plan-uuid",
+      "name": "Gold"
+    },
+    "api": {
+      "name": "Order API",
+      "version": "v1.0",
+      "ref_id": "cp-api-uuid"
+    }
+  }
+}
+```
+
+- `subscription_plan` reflects the **new** plan; `previous_plan` is the plan that was in effect before the change
+- The subscription token is not rotated — existing integrations continue to work without any credential update
+
+### `subscription.token_regenerated`
+
+Fired when a developer regenerates a subscription token. The old token is immediately invalidated; `token` carries the new value encrypted using the subscriber's RSA public key. Your subscriber must replace the stored credential for this `subscription_id` at the gateway before the next request arrives.
+
+```json
+{
+  "event_type": "subscription.token_regenerated",
   "encrypted_fields": ["token"],
   "data": {
     "subscription_id": "sub-uuid",
@@ -323,7 +381,9 @@ Fired when a subscription's status changes, or when the subscription token is re
 }
 ```
 
-- `token` and its entry in `encrypted_fields` are absent when the update did not involve token regeneration (e.g. a status change only)
+- `token` decrypts to the new subscription token — use the same decryption steps as `subscription.created`
+- `token` and its entry in `encrypted_fields` are present only when a public key is configured for the subscriber; if no public key is configured, the new token is not delivered via webhook
+- This is the only event that carries a new token secret after creation — if decryption fails, the developer must regenerate again
 
 ### `subscription.deleted`
 

--- a/portals/developer-portal/docs/devportal-openapi-spec-v1.yaml
+++ b/portals/developer-portal/docs/devportal-openapi-spec-v1.yaml
@@ -1055,6 +1055,56 @@ paths:
         - OAuth2Security:
             - dp:subscription_delete
             - dp:subscription_manage
+  /devportal/v1/subscriptions/{subId}/change-plan:
+    parameters:
+      - $ref: "#/components/parameters/subId"
+    post:
+      tags:
+        - Subscriptions
+      operationId: changePlan
+      summary: Change subscription plan
+      description: >-
+        Changes the subscription plan in-place. The subscription UUID and token remain unchanged;
+        only the plan is updated. A `subscription.plan_changed` webhook event is published to
+        the organization's configured webhook subscribers.
+      requestBody:
+        $ref: "#/components/requestBodies/SubscriptionChangePlanBody"
+      responses:
+        "200":
+          $ref: "#/components/responses/SubscriptionResponse"
+        "400":
+          $ref: "#/components/responses/SimpleBadRequest"
+        "404":
+          $ref: "#/components/responses/SimpleNotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:subscription_update
+            - dp:subscription_manage
+  /devportal/v1/subscriptions/{subId}/regenerate-token:
+    parameters:
+      - $ref: "#/components/parameters/subId"
+    post:
+      tags:
+        - Subscriptions
+      operationId: regenerateSubscriptionToken
+      summary: Regenerate subscription token
+      description: >-
+        Regenerates the subscription token, immediately invalidating the old one. A
+        `subscription.token_regenerated` webhook event is published to the organization's
+        configured webhook subscribers so they can update the token at the gateway.
+        The new plaintext token is returned in the response.
+      responses:
+        "200":
+          $ref: "#/components/responses/SubscriptionResponse"
+        "404":
+          $ref: "#/components/responses/SimpleNotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:subscription_manage
   /devportal/v1/apis/{apiId}/api-keys/generate:
     parameters:
       - $ref: "#/components/parameters/apiId"
@@ -2444,6 +2494,15 @@ components:
             $ref: "#/components/schemas/SubscriptionUpdateRequest"
           example:
             status: ACTIVE
+    SubscriptionChangePlanBody:
+      required: true
+      description: Subscription plan change payload. `planId` is the Developer Portal subscription plan ID.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/SubscriptionChangePlanRequest"
+          example:
+            planId: pol-9a3d1f7e
     ApiKeyBody:
       required: true
       description: >-
@@ -4162,6 +4221,16 @@ components:
             - ACTIVE
             - INACTIVE
           example: ACTIVE
+      additionalProperties: false
+    SubscriptionChangePlanRequest:
+      type: object
+      required:
+        - planId
+      properties:
+        planId:
+          type: string
+          description: Developer Portal subscription plan ID to switch to.
+          example: pol-9a3d1f7e
       additionalProperties: false
     SubscriptionResponse:
       type: object

--- a/portals/developer-portal/src/dao/subscriptionDao.js
+++ b/portals/developer-portal/src/dao/subscriptionDao.js
@@ -144,6 +144,38 @@ async function updateStatus(orgId, subId, status, createdBy, transaction) {
     return count > 0;
 }
 
+async function updatePlan(orgId, subId, planId, updatedBy, transaction) {
+    const where = { UUID: subId, ORG_UUID: orgId, CREATED_BY: updatedBy };
+    const [count] = await SubscriptionMapping.update(
+        { PLAN_UUID: planId, UPDATED_BY: updatedBy, UPDATED_AT: new Date() },
+        { where, transaction }
+    );
+    return count > 0;
+}
+
+async function regenerateToken(orgId, subId, updatedBy, transaction) {
+    const where = { UUID: subId, ORG_UUID: orgId, CREATED_BY: updatedBy };
+    for (let attempt = 0; attempt < 3; attempt++) {
+        const newToken = generateSubToken();
+        try {
+            const [count] = await SubscriptionMapping.update(
+                { TOKEN: encryptToken(newToken), UPDATED_BY: updatedBy, UPDATED_AT: new Date() },
+                { where, transaction }
+            );
+            if (count === 0) return null;
+            return newToken;
+        } catch (err) {
+            const isTokenCollision =
+                err.name === 'SequelizeUniqueConstraintError' &&
+                err.fields && Object.keys(err.fields).some(
+                    f => f.includes('TOKEN') || f.includes('sub_token')
+                );
+            if (isTokenCollision && attempt < 2) continue;
+            throw err;
+        }
+    }
+}
+
 async function deleteSubscription(orgId, subId, createdBy, transaction) {
     const where = { uuid: subId, org_uuid: orgId };
     if (createdBy) where.created_by = createdBy;
@@ -214,6 +246,8 @@ module.exports = {
     get,
     getById,
     updateStatus,
+    updatePlan,
+    regenerateToken,
     delete: deleteSubscription,
     listByApi,
     listByOrg,

--- a/portals/developer-portal/src/dao/subscriptionDao.js
+++ b/portals/developer-portal/src/dao/subscriptionDao.js
@@ -145,21 +145,21 @@ async function updateStatus(orgId, subId, status, createdBy, transaction) {
 }
 
 async function updatePlan(orgId, subId, planId, updatedBy, transaction) {
-    const where = { UUID: subId, ORG_UUID: orgId, CREATED_BY: updatedBy };
+    const where = { uuid: subId, org_uuid: orgId, created_by: updatedBy };
     const [count] = await SubscriptionMapping.update(
-        { PLAN_UUID: planId, UPDATED_BY: updatedBy, UPDATED_AT: new Date() },
+        { plan_uuid: planId, updated_by: updatedBy, updated_at: new Date() },
         { where, transaction }
     );
     return count > 0;
 }
 
 async function regenerateToken(orgId, subId, updatedBy, transaction) {
-    const where = { UUID: subId, ORG_UUID: orgId, CREATED_BY: updatedBy };
+    const where = { uuid: subId, org_uuid: orgId, created_by: updatedBy };
     for (let attempt = 0; attempt < 3; attempt++) {
         const newToken = generateSubToken();
         try {
             const [count] = await SubscriptionMapping.update(
-                { TOKEN: encryptToken(newToken), UPDATED_BY: updatedBy, UPDATED_AT: new Date() },
+                { token: encryptToken(newToken), updated_by: updatedBy, updated_at: new Date() },
                 { where, transaction }
             );
             if (count === 0) return null;
@@ -168,7 +168,7 @@ async function regenerateToken(orgId, subId, updatedBy, transaction) {
             const isTokenCollision =
                 err.name === 'SequelizeUniqueConstraintError' &&
                 err.fields && Object.keys(err.fields).some(
-                    f => f.includes('TOKEN') || f.includes('sub_token')
+                    f => f.includes('token')
                 );
             if (isTokenCollision && attempt < 2) continue;
             throw err;

--- a/portals/developer-portal/src/defaultContent/pages/api-landing/partials/api-subscription-plans.hbs
+++ b/portals/developer-portal/src/defaultContent/pages/api-landing/partials/api-subscription-plans.hbs
@@ -268,16 +268,21 @@
           var args = _switchArgs;
           closeUnsub();
           try {
-            var delResp = await fetch(devportalApi.org('/subscriptions/' + encodeURIComponent(args.subscriptionId)), {
-              method: 'DELETE',
-              headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window.devportalApi.csrfToken() },
-            });
-            if (!delResp.ok) {
-              var errData = await delResp.json().catch(function () { return {}; });
-              showAlert('Failed to remove existing subscription: ' + (errData.description || 'Unknown error'), 'error');
-              return;
+            var resp = await fetch(
+              devportalApi.org('/subscriptions/' + encodeURIComponent(args.subscriptionId) + '/change-plan'),
+              {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window.devportalApi.csrfToken() },
+                body: JSON.stringify({ planId: args.policyId }),
+              }
+            );
+            if (resp.ok) {
+              window.__subscriptionChanged = true;
+              window.location.reload();
+            } else {
+              var errData = await resp.json().catch(function () { return {}; });
+              showAlert('Failed to switch plan: ' + (errData.description || 'Unknown error'), 'error');
             }
-            await subscribe(args.orgId, args.apiId, args.planName, args.policyId);
           } catch (e) {
             showAlert('Error during plan change: ' + e.message, 'error');
           }
@@ -340,7 +345,7 @@
             var label = displayName || planName;
             showUnsubDialog(
               'Switch to <strong>' + label + '</strong> plan?',
-              'Your ' + (currentPlan || 'current') + ' subscription will be cancelled and a new ' + label + ' subscription will be created.',
+              'Switching from ' + (currentPlan || 'your current plan') + ' to ' + label + '. Your subscription token will remain the same.',
               'Switch plan'
             );
           }

--- a/portals/developer-portal/src/defaultContent/pages/mcp-landing/partials/mcp-subscription-plans.hbs
+++ b/portals/developer-portal/src/defaultContent/pages/mcp-landing/partials/mcp-subscription-plans.hbs
@@ -273,16 +273,21 @@
           var args = _switchArgs;
           closeUnsub();
           try {
-            var delResp = await fetch(devportalApi.org('/subscriptions/' + encodeURIComponent(args.subscriptionId)), {
-              method: 'DELETE',
-              headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window.devportalApi.csrfToken() },
-            });
-            if (!delResp.ok) {
-              var errData = await delResp.json().catch(function () { return {}; });
-              showAlert('Failed to remove existing subscription: ' + (errData.description || 'Unknown error'), 'error');
-              return;
+            var resp = await fetch(
+              devportalApi.org('/subscriptions/' + encodeURIComponent(args.subscriptionId) + '/change-plan'),
+              {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window.devportalApi.csrfToken() },
+                body: JSON.stringify({ planId: args.policyId }),
+              }
+            );
+            if (resp.ok) {
+              window.__subscriptionChanged = true;
+              window.location.reload();
+            } else {
+              var errData = await resp.json().catch(function () { return {}; });
+              showAlert('Failed to switch plan: ' + (errData.description || 'Unknown error'), 'error');
             }
-            await subscribe(args.orgId, args.apiId, args.planName, args.policyId);
           } catch (e) {
             showAlert('Error during plan change: ' + e.message, 'error');
           }
@@ -330,7 +335,7 @@
             var label = displayName || planName;
             showUnsubDialog(
               'Switch to <strong>' + label + '</strong> plan?',
-              'Your ' + (currentPlan || 'current') + ' subscription will be cancelled and a new ' + label + ' subscription will be created.',
+              'Switching from ' + (currentPlan || 'your current plan') + ' to ' + label + '. Your subscription token will remain the same.',
               'Switch plan'
             );
           }

--- a/portals/developer-portal/src/defaultContent/pages/subscriptions/partials/subscription-list.hbs
+++ b/portals/developer-portal/src/defaultContent/pages/subscriptions/partials/subscription-list.hbs
@@ -106,6 +106,9 @@
       <p class="mc-config-note" style="margin:0.625rem 0 0;">Use this token as the <code class="mc-inline-code">Subscription-Key</code> header when calling this API.</p>
       <hr class="mc-manage-divider">
       <div class="mc-manage-actions">
+        <button id="subManageRegenerateBtn" class="dp-btn mc-manage-action-btn mc-manage-action-btn--regenerate">
+          <i class="bi bi-arrow-clockwise"></i> Regenerate Token
+        </button>
         <button id="subManageSuspendBtn" class="dp-btn mc-manage-action-btn mc-manage-action-btn--suspend">
           <i class="bi bi-pause-circle"></i>
           <span class="sub-suspend-label">Suspend</span>
@@ -129,6 +132,21 @@
     <div class="mc-unsub-actions">
       <button id="subUnsubCancelBtn" class="dp-btn dp-btn--outline">Cancel</button>
       <button id="subUnsubConfirmBtn" class="dp-btn mc-unsub-confirm-btn">Unsubscribe</button>
+    </div>
+  </div>
+</div>
+
+<!-- Regenerate token confirmation dialog -->
+<div id="subRegenerateDialog" class="mc-overlay" style="display:none;" role="dialog" aria-modal="true">
+  <div class="mc-unsub-dialog">
+    <div class="mc-unsub-header">
+      <span class="mc-unsub-icon"><i class="bi bi-exclamation-triangle-fill"></i></span>
+      <h2 class="mc-unsub-title">Regenerate token?</h2>
+    </div>
+    <p class="mc-unsub-desc">Your current token will be invalidated immediately. Any applications using it will need to be updated with the new token.</p>
+    <div class="mc-unsub-actions">
+      <button id="subRegenerateCancelBtn" class="dp-btn dp-btn--outline">Cancel</button>
+      <button id="subRegenerateConfirmBtn" class="dp-btn mc-unsub-confirm-btn">Regenerate</button>
     </div>
   </div>
 </div>

--- a/portals/developer-portal/src/routes/api/handlers/subscriptionsHandler.js
+++ b/portals/developer-portal/src/routes/api/handlers/subscriptionsHandler.js
@@ -30,4 +30,6 @@ module.exports = {
     getSubscription: subscriptionService.getSubscription,
     updateSubscription: compose(requireCsrfForMutatingApi, subscriptionService.updateSubscription),
     deleteSubscription: compose(requireCsrfForMutatingApi, subscriptionService.deleteSubscription),
+    changePlan: compose(requireCsrfForMutatingApi, subscriptionService.changePlan),
+    regenerateSubscriptionToken: compose(requireCsrfForMutatingApi, subscriptionService.regenerateSubscriptionToken),
 };

--- a/portals/developer-portal/src/scripts/subscription.js
+++ b/portals/developer-portal/src/scripts/subscription.js
@@ -163,18 +163,23 @@ async function runPendingPlanSwitch(orgId, apiId, planName, displayName, subscri
     }
 
     try {
-        const deleteResponse = await fetch(devportalApi.org(`/subscriptions/${encodeURIComponent(subscriptionId)}`), {
-            method: 'DELETE',
-            headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window.devportalApi.csrfToken() },
-        });
+        const response = await fetch(
+            devportalApi.org(`/subscriptions/${encodeURIComponent(subscriptionId)}/change-plan`),
+            {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window.devportalApi.csrfToken() },
+                body: JSON.stringify({ planId }),
+            }
+        );
 
-        if (!deleteResponse.ok) {
-            const errorData = await deleteResponse.json().catch(() => ({}));
-            await showAlert(`Failed to remove existing subscription: ${errorData.description || 'Unknown error'}`, 'error');
-            return;
+        if (response.ok) {
+            window.__subscriptionChanged = true;
+            await showAlert(`Switched to "${displayName}" successfully!`, 'success');
+            refreshModalOrReload(orgId);
+        } else {
+            const errorData = await response.json().catch(() => ({}));
+            await showAlert(`Failed to switch plan: ${errorData.description || 'Unknown error'}`, 'error');
         }
-
-        await subscribe(orgId, apiId, planName, planId);
     } catch (error) {
         await showAlert(`Error during plan change: ${error.message}`, 'error');
     }

--- a/portals/developer-portal/src/scripts/subscriptions-page.js
+++ b/portals/developer-portal/src/scripts/subscriptions-page.js
@@ -21,6 +21,7 @@ const tokenCache = {};
 let _manageSub = null;
 let _manageRevealed = false;
 let _manageCopyTimer = null;
+let _regenerateInFlight = false;
 
 /* ── Open / close manage modal ─────────────────────────────────── */
 function openSubManage(subId) {
@@ -140,20 +141,22 @@ function closeRegenerateDialog() {
 }
 
 async function confirmRegenerateToken() {
-    if (!_manageSub) return;
+    if (!_manageSub || _regenerateInFlight) return;
+    const subId = _manageSub.id;
     closeRegenerateDialog();
     const orgId = window.__subscriptionOrgId;
     if (!orgId) return;
+    _regenerateInFlight = true;
     try {
         const resp = await fetch(
-            devportalApi.org(orgId, `/subscriptions/${encodeURIComponent(_manageSub.id)}/regenerate-token`),
+            devportalApi.org(`/subscriptions/${encodeURIComponent(subId)}/regenerate-token`),
             { method: 'POST', headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window.devportalApi.csrfToken() } }
         );
         if (resp.ok) {
             const data = await resp.json();
             const newToken = data.subscriptionToken;
-            delete tokenCache[_manageSub.id];
-            if (newToken) tokenCache[_manageSub.id] = newToken;
+            delete tokenCache[subId];
+            if (newToken) tokenCache[subId] = newToken;
             _manageRevealed = true;
             document.getElementById('subManageTokenVal').textContent = newToken || '•'.repeat(28);
             const ri = document.getElementById('subManageRevealIcon');
@@ -172,6 +175,8 @@ async function confirmRegenerateToken() {
         if (typeof showAlert === 'function') {
             await showAlert('Error: ' + e.message, 'error');
         }
+    } finally {
+        _regenerateInFlight = false;
     }
 }
 

--- a/portals/developer-portal/src/scripts/subscriptions-page.js
+++ b/portals/developer-portal/src/scripts/subscriptions-page.js
@@ -127,6 +127,54 @@ async function copySubToken() {
     _manageCopyTimer = setTimeout(resetSubManageCopyBtn, 1600);
 }
 
+/* ── Regenerate token ───────────────────────────────────────────── */
+function askRegenerateToken() {
+    if (!_manageSub) return;
+    const dialog = document.getElementById('subRegenerateDialog');
+    if (dialog) dialog.style.display = 'flex';
+}
+
+function closeRegenerateDialog() {
+    const dialog = document.getElementById('subRegenerateDialog');
+    if (dialog) dialog.style.display = 'none';
+}
+
+async function confirmRegenerateToken() {
+    if (!_manageSub) return;
+    closeRegenerateDialog();
+    const orgId = window.__subscriptionOrgId;
+    if (!orgId) return;
+    try {
+        const resp = await fetch(
+            devportalApi.org(orgId, `/subscriptions/${encodeURIComponent(_manageSub.id)}/regenerate-token`),
+            { method: 'POST', headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window.devportalApi.csrfToken() } }
+        );
+        if (resp.ok) {
+            const data = await resp.json();
+            const newToken = data.subscriptionToken;
+            delete tokenCache[_manageSub.id];
+            if (newToken) tokenCache[_manageSub.id] = newToken;
+            _manageRevealed = true;
+            document.getElementById('subManageTokenVal').textContent = newToken || '•'.repeat(28);
+            const ri = document.getElementById('subManageRevealIcon');
+            if (ri) ri.className = 'bi bi-eye-slash';
+            resetSubManageCopyBtn();
+            if (typeof showAlert === 'function') {
+                await showAlert('Token regenerated. Copy your new token before closing this window.', 'success');
+            }
+        } else {
+            const data = await resp.json().catch(() => ({}));
+            if (typeof showAlert === 'function') {
+                await showAlert('Failed to regenerate token: ' + (data.description || 'Unknown error'), 'error');
+            }
+        }
+    } catch (e) {
+        if (typeof showAlert === 'function') {
+            await showAlert('Error: ' + e.message, 'error');
+        }
+    }
+}
+
 /* ── Suspend / Resume ───────────────────────────────────────────── */
 async function toggleSubSuspend() {
     if (!_manageSub) return;
@@ -223,6 +271,7 @@ async function executeDeleteSubscription(subscriptionId) {
         document.getElementById('subManageClose')?.addEventListener('click', closeSubManage);
         document.getElementById('subManageRevealBtn')?.addEventListener('click', revealSubToken);
         document.getElementById('subManageCopyBtn')?.addEventListener('click', copySubToken);
+        document.getElementById('subManageRegenerateBtn')?.addEventListener('click', askRegenerateToken);
         document.getElementById('subManageSuspendBtn')?.addEventListener('click', toggleSubSuspend);
         document.getElementById('subManageUnsubBtn')?.addEventListener('click', askSubUnsub);
         manageModal.addEventListener('click', function (e) { if (e.target === manageModal) closeSubManage(); });
@@ -233,5 +282,12 @@ async function executeDeleteSubscription(subscriptionId) {
         document.getElementById('subUnsubCancelBtn')?.addEventListener('click', closeSubUnsub);
         document.getElementById('subUnsubConfirmBtn')?.addEventListener('click', confirmSubUnsub);
         unsubDialog.addEventListener('click', function (e) { if (e.target === unsubDialog) closeSubUnsub(); });
+    }
+
+    const regenerateDialog = document.getElementById('subRegenerateDialog');
+    if (regenerateDialog) {
+        document.getElementById('subRegenerateCancelBtn')?.addEventListener('click', closeRegenerateDialog);
+        document.getElementById('subRegenerateConfirmBtn')?.addEventListener('click', confirmRegenerateToken);
+        regenerateDialog.addEventListener('click', function (e) { if (e.target === regenerateDialog) closeRegenerateDialog(); });
     }
 })();

--- a/portals/developer-portal/src/scripts/warning.js
+++ b/portals/developer-portal/src/scripts/warning.js
@@ -144,7 +144,7 @@ function openWarningModal(param1, param2, param3, param4, param5, param6, param7
             sanitizedParam7 +
             '" plan. Switching to "' +
             sanitizedParam5 +
-            '" will delete your existing subscription and generate a new token. Do you want to proceed?';
+            '" will update your subscription immediately. Your existing token will remain valid.';
         modalFunction.innerText = 'Confirm';
         modalFunction.onclick = function() {
             if (typeof runPendingPlanSwitch === 'function') {

--- a/portals/developer-portal/src/services/subscriptionService.js
+++ b/portals/developer-portal/src/services/subscriptionService.js
@@ -215,6 +215,115 @@ const updateSubscription = async (req, res) => {
     }
 };
 
+const changePlan = async (req, res) => {
+    const orgId = req.orgId;
+    const subscriptionId = req.params.subId;
+    const { planId: reqPlanId } = req.body;
+
+    try {
+        const existing = await subDao.get(orgId, subscriptionId, req.user.sub);
+        if (!existing) {
+            return res.status(404).json({
+                code: '404', message: 'Not Found', description: 'Subscription not found',
+            });
+        }
+
+        const apiId = existing.DP_API_METADATA ? existing.DP_API_METADATA.UUID : null;
+        if (!apiId) {
+            return res.status(400).json({
+                code: '400', message: 'Bad Request', description: 'API not found for this subscription',
+            });
+        }
+
+        const apiMetadataResponse = await apiDao.get(orgId, apiId);
+        if (!apiMetadataResponse || apiMetadataResponse.length === 0) {
+            return res.status(404).json({
+                code: '404', message: 'Not Found', description: 'API not found',
+            });
+        }
+        const apiMetadata = apiMetadataResponse[0];
+        const plans = apiMetadata.DP_SUBSCRIPTION_PLANs || [];
+        const newPlan = plans.find(p => p.UUID === reqPlanId);
+        if (!newPlan) {
+            return res.status(400).json({
+                code: '400', message: 'Bad Request', description: 'Subscription plan not found for this API',
+            });
+        }
+
+        const previousPlan = existing.DP_SUBSCRIPTION_PLAN;
+
+        await sequelize.transaction(async (t) => {
+            const updated = await subDao.updatePlan(orgId, subscriptionId, reqPlanId, req.user.sub, t);
+            if (!updated) {
+                const err = new Error('Subscription not found');
+                err.status = 404;
+                throw err;
+            }
+            const payload = {
+                ...buildWebhookPayload(existing, apiMetadata, newPlan),
+                previous_plan: {
+                    ref_id: previousPlan ? (previousPlan.REF_ID || null) : null,
+                    name: previousPlan ? (previousPlan.NAME || null) : null,
+                },
+            };
+            await safePublish('subscription.plan_changed', payload, {
+                transaction: t, orgId, aggregateType: 'subscription', aggregateId: subscriptionId,
+            });
+        });
+
+        logUserAction('SUBSCRIPTION_PLAN_CHANGED', req, { orgId, subscriptionId, planId: reqPlanId });
+        const updated = await subDao.get(orgId, subscriptionId, req.user.sub);
+        return res.status(200).json(formatSubscriptionResponse(updated));
+    } catch (error) {
+        if (error.status === 404) {
+            return res.status(404).json({ code: '404', message: 'Not Found', description: 'Subscription not found' });
+        }
+        logger.error('Error changing subscription plan', { error: error.message, subscriptionId });
+        util.handleError(res, error);
+    }
+};
+
+const regenerateSubscriptionToken = async (req, res) => {
+    const orgId = req.orgId;
+    const subscriptionId = req.params.subId;
+
+    try {
+        const existing = await subDao.get(orgId, subscriptionId, req.user.sub);
+        if (!existing) {
+            return res.status(404).json({
+                code: '404', message: 'Not Found', description: 'Subscription not found',
+            });
+        }
+
+        const apiMetadata = existing.DP_API_METADATA;
+        const plan = existing.DP_SUBSCRIPTION_PLAN;
+        let newToken;
+
+        await sequelize.transaction(async (t) => {
+            newToken = await subDao.regenerateToken(orgId, subscriptionId, req.user.sub, t);
+            if (!newToken) {
+                const err = new Error('Subscription not found');
+                err.status = 404;
+                throw err;
+            }
+            await safePublish('subscription.token_regenerated', buildWebhookPayload(existing, apiMetadata, plan), {
+                transaction: t, orgId, aggregateType: 'subscription', aggregateId: subscriptionId,
+                secretFields: { token: newToken },
+            });
+        });
+
+        logUserAction('SUBSCRIPTION_TOKEN_REGENERATED', req, { orgId, subscriptionId });
+        const updated = await subDao.get(orgId, subscriptionId, req.user.sub);
+        return res.status(200).json(formatSubscriptionResponse(updated));
+    } catch (error) {
+        if (error.status === 404) {
+            return res.status(404).json({ code: '404', message: 'Not Found', description: 'Subscription not found' });
+        }
+        logger.error('Error regenerating subscription token', { error: error.message, subscriptionId });
+        util.handleError(res, error);
+    }
+};
+
 const deleteSubscription = async (req, res) => {
     const orgId = req.orgId;
     const subscriptionId = req.params.subId;
@@ -262,4 +371,6 @@ module.exports = {
     getSubscription,
     updateSubscription,
     deleteSubscription,
+    changePlan,
+    regenerateSubscriptionToken,
 };

--- a/portals/developer-portal/src/services/subscriptionService.js
+++ b/portals/developer-portal/src/services/subscriptionService.js
@@ -228,7 +228,7 @@ const changePlan = async (req, res) => {
             });
         }
 
-        const apiId = existing.DP_API_METADATA ? existing.DP_API_METADATA.UUID : null;
+        const apiId = existing.dp_api_metadata ? existing.dp_api_metadata.uuid : null;
         if (!apiId) {
             return res.status(400).json({
                 code: '400', message: 'Bad Request', description: 'API not found for this subscription',
@@ -242,15 +242,15 @@ const changePlan = async (req, res) => {
             });
         }
         const apiMetadata = apiMetadataResponse[0];
-        const plans = apiMetadata.DP_SUBSCRIPTION_PLANs || [];
-        const newPlan = plans.find(p => p.UUID === reqPlanId);
+        const plans = apiMetadata.dp_subscription_plans || [];
+        const newPlan = plans.find(p => p.uuid === reqPlanId);
         if (!newPlan) {
             return res.status(400).json({
                 code: '400', message: 'Bad Request', description: 'Subscription plan not found for this API',
             });
         }
 
-        const previousPlan = existing.DP_SUBSCRIPTION_PLAN;
+        const previousPlan = existing.dp_subscription_plan;
 
         await sequelize.transaction(async (t) => {
             const updated = await subDao.updatePlan(orgId, subscriptionId, reqPlanId, req.user.sub, t);
@@ -262,8 +262,8 @@ const changePlan = async (req, res) => {
             const payload = {
                 ...buildWebhookPayload(existing, apiMetadata, newPlan),
                 previous_plan: {
-                    ref_id: previousPlan ? (previousPlan.REF_ID || null) : null,
-                    name: previousPlan ? (previousPlan.NAME || null) : null,
+                    ref_id: previousPlan ? (previousPlan.ref_id || null) : null,
+                    name: previousPlan ? (previousPlan.name || null) : null,
                 },
             };
             await safePublish('subscription.plan_changed', payload, {
@@ -295,8 +295,8 @@ const regenerateSubscriptionToken = async (req, res) => {
             });
         }
 
-        const apiMetadata = existing.DP_API_METADATA;
-        const plan = existing.DP_SUBSCRIPTION_PLAN;
+        const apiMetadata = existing.dp_api_metadata;
+        const plan = existing.dp_subscription_plan;
         let newToken;
 
         await sequelize.transaction(async (t) => {

--- a/portals/developer-portal/src/services/webhooks/eventPublisher.js
+++ b/portals/developer-portal/src/services/webhooks/eventPublisher.js
@@ -29,6 +29,8 @@ const VALID_EVENT_TYPES = new Set([
     'subscription.created',
     'subscription.updated',
     'subscription.deleted',
+    'subscription.plan_changed',
+    'subscription.token_regenerated',
     'apikey.generated',
     'apikey.regenerated',
     'apikey.revoked',


### PR DESCRIPTION
## Purpose
Introduce new set of webhook events

## Approach
Added webhook events for subscription plan_change and token regenration.

## Summary

#### subscription.updated
Fired when a subscription's status changes (ACTIVE ↔ INACTIVE). No encrypted fields are included.

```
{
  "event_type": "subscription.updated",
  "encrypted_fields": [],
  "data": {
    "subscription_id": "sub-myflights-api-v1-a1b2c3d4",
    "subscriber_id": "user@example.com",
    "subscription_plan": {
      "ref_id": "plan-uuid",
      "name": "Gold"
    },
    "api": {
      "name": "MyFlights API",
      "version": "1.0.0",
      "ref_id": "ref123"
    },
    "status": "INACTIVE"
  }
}
```

#### subscription.plan_changed

Fired when a user switches their subscription to a different plan. The subscription UUID and token are unchanged — only the plan is updated. Use this to adjust quota or rate-limit tier for the subscription without revoking access.

```
{
  "event_type": "subscription.plan_changed",
  "encrypted_fields": [],
  "data": {
    "subscription_id": "sub-myflights-api-v1-a1b2c3d4",
    "subscriber_id": "user@example.com",
    "subscription_plan": {
      "ref_id": "new-plan-uuid",
      "name": "Platinum"
    },
    "previous_plan": {
      "ref_id": "old-plan-uuid",
      "name": "Gold"
    },
    "api": {
      "name": "MyFlights API",
      "version": "1.0.0",
      "ref_id": ""
    }
  }
}
```

subscription_plan reflects the new plan; previous_plan is the plan that was in effect before the change. The subscription token is not rotated — existing integrations continue working without any credential update.

#### subscription.token_regenerated

Fired when a user regenerates their subscription token. The old token is immediately invalidated; token carries the new value encrypted using the subscriber's RSA public key. Subscribers must replace the stored credential for this subscription_id at the gateway before the next request arrives.

```
{
  "event_type": "subscription.token_regenerated",
  "encrypted_fields": ["token"],
  "data": {
    "subscription_id": "sub-myflights-api-v1-a1b2c3d4",
    "subscriber_id": "user@example.com",
    "subscription_plan": {
      "ref_id": "plan-uuid",
      "name": "Gold"
    },
    "api": {
      "name": "MyFlights API",
      "version": "1.0.0",
      "ref_id": ""
    },
    "token": {
      "wrappedKey": "<base64 RSA-OAEP wrapped AES key>",
      "iv": "<base64 12-byte GCM IV>",
      "tag": "<base64 16-byte GCM auth tag>",
      "ciphertext": "<base64 AES-256-GCM ciphertext>"
    }
  }
}
```

token carries the new subscription token encrypted using the subscriber's RSA public key — present in encrypted_fields and data only when the subscriber has a public key configured. This is the only event that delivers a new token secret after the initial subscription.created — if decryption fails, the user must regenerate again.

