### PR TITLE
[PlatformAPI] Enforce major-only policy version pattern in platform-api OpenAPI spec

### DIFF
--- a/platform-api/src/resources/openapi.yaml
+++ b/platform-api/src/resources/openapi.yaml
@@ -7061,8 +7061,11 @@ components:
             value: "MyValue"
         version:
           type: string
-          description: Semantic version of the policy
-          example: "1.0.0"
+          description: >
+            Version of the policy. Only major-only version is allowed (e.g., v0, v1).
+            Full semantic version (e.g., v1.0.0) is not accepted and will be rejected.
+          pattern: '^v\d+$'
+          example: v1
 
     AddGatewayToRESTAPIRequest:
       title: AddGatewayToAPIRequest object with basic gateway details
@@ -8657,7 +8660,11 @@ components:
           example: budgetControl
         version:
           type: string
-          example: v1.0.0
+          description: >
+            Version of the policy. Only major-only version is allowed (e.g., v0, v1).
+            Full semantic version (e.g., v1.0.0) is not accepted and will be rejected.
+          pattern: '^v\d+$'
+          example: v1
         paths:
           type: array
           items:
@@ -8695,6 +8702,10 @@ components:
           example: token-based-ratelimit
         version:
           type: string
+          description: >
+            Version of the policy. Only major-only version is allowed (e.g., v0, v1).
+            Full semantic version (e.g., v1.0.0) is not accepted and will be rejected.
+          pattern: '^v\d+$'
           example: v1
         executionCondition:
           type: string


### PR DESCRIPTION
## Purpose

The Gateway Controller already rejects policy versions that are not major-only (e.g. `v1.0.0` is rejected; only `v1` is accepted). The platform-api OpenAPI spec did not reflect this constraint, allowing clients to submit invalid values that would only fail at the gateway layer.

This PR aligns the platform-api spec with the gateway management API by adding `pattern: '^v\d+$'` to the `version` field on all three policy schemas: `Policy` (used by `globalPolicies`), `LLMPolicy` (deprecated flat policies), and `OperationPolicy`. The field description is also updated to explain the major-only requirement and how the Gateway Controller resolves it to the full installed version.

**Schemas updated** (`platform-api/src/resources/openapi.yaml`):
- `Policy.version` — pattern + updated description + example `v1`
- `LLMPolicy.version` — pattern + description + example corrected from `v1.0.0` → `v1`
- `OperationPolicy.version` — pattern + description