### PR TITLE
Introduce Gateway Association for the AI artifact

### DIFF
--- a/platform-api/src/internal/constants/error.go
+++ b/platform-api/src/internal/constants/error.go
@@ -98,6 +98,7 @@ var (
 	ErrDeploymentAlreadyDeployed     = errors.New("cannot restore to the currently deployed deployment")
 	ErrInvalidDeploymentRestoreState = errors.New("deployment cannot be restored: only ARCHIVED or UNDEPLOYED deployments are eligible")
 	ErrGatewayIDMismatch             = errors.New("gateway ID mismatch: deployment is bound to a different gateway")
+	ErrAssociationGatewayDeployed    = errors.New("cannot remove gateway association: the provider is actively deployed on the gateway - undeploy it first")
 )
 
 var (

--- a/platform-api/src/internal/model/llm.go
+++ b/platform-api/src/internal/model/llm.go
@@ -158,6 +158,16 @@ type LLMProviderTemplateResourceMappings struct {
 	Resources []LLMProviderTemplateResourceMapping `json:"resources,omitempty" db:"-"`
 }
 
+// AssociatedGatewayMapping is a resolved gateway association persisted in the
+// artifact_gateway_mappings table alongside an artifact (e.g. an LLM provider).
+// GatewayHandle is populated on reads (joined from the gateways table) and is what
+// callers reference by name; GatewayUUID is used for the foreign-key write.
+type AssociatedGatewayMapping struct {
+	GatewayUUID   string `json:"gatewayUuid" db:"gateway_uuid"`
+	GatewayHandle string `json:"gatewayHandle" db:"handle"`
+	Metadata      string `json:"metadata,omitempty" db:"metadata"`
+}
+
 type LLMProviderTemplate struct {
 	UUID             string                       `json:"uuid" db:"uuid"`
 	OrganizationUUID string                       `json:"organizationId" db:"organization_uuid"`
@@ -202,6 +212,8 @@ type LLMProvider struct {
 	UpdatedAt        time.Time          `json:"updatedAt" db:"updated_at"`
 	Configuration    LLMProviderConfig  `json:"configuration" db:"configuration"`
 	Origin           string             `json:"origin,omitempty" db:"origin"`
+	AssociatedGateways []AssociatedGatewayMapping `json:"-" db:"-"`
+	ReplaceAssociatedGateways bool `json:"-" db:"-"`
 }
 
 type LLMProviderConfig struct {
@@ -236,6 +248,8 @@ type LLMProxy struct {
 	UpdatedAt        time.Time      `json:"updatedAt" db:"updated_at"`
 	Configuration    LLMProxyConfig `json:"configuration" db:"configuration"`
 	Origin           string         `json:"origin,omitempty" db:"origin"`
+	AssociatedGateways []AssociatedGatewayMapping `json:"-" db:"-"`
+	ReplaceAssociatedGateways bool `json:"-" db:"-"`
 }
 
 type LLMProxyConfig struct {

--- a/platform-api/src/internal/model/mcp.go
+++ b/platform-api/src/internal/model/mcp.go
@@ -35,6 +35,8 @@ type MCPProxy struct {
 	UpdatedAt        time.Time             `json:"updatedAt" db:"-"`
 	Configuration    MCPProxyConfiguration `json:"configuration" db:"-"`
 	Origin           string                `json:"origin,omitempty" db:"origin"`
+	AssociatedGateways []AssociatedGatewayMapping `json:"-" db:"-"`
+	ReplaceAssociatedGateways bool `json:"-" db:"-"`
 }
 
 type MCPProxyConfiguration struct {

--- a/platform-api/src/internal/repository/deployment.go
+++ b/platform-api/src/internal/repository/deployment.go
@@ -793,6 +793,40 @@ func (r *DeploymentRepo) GetDeployedGatewayIDs(artifactUUID, orgUUID string) ([]
 	return gatewayIDs, nil
 }
 
+// GetLiveGatewayIDs returns the gateways on which the artifact is currently live, i.e.
+// deployed or in a transitional state where it is still present on the gateway. Fully
+// undeployed/archived/failed gateways are excluded.
+func (r *DeploymentRepo) GetLiveGatewayIDs(artifactUUID, orgUUID string) ([]string, error) {
+	query := `
+		SELECT gateway_uuid FROM deployment_status
+		WHERE artifact_uuid = ? AND organization_uuid = ? AND status IN (?, ?, ?)`
+
+	rows, err := r.db.Query(r.db.Rebind(query), artifactUUID, orgUUID,
+		string(model.DeploymentStatusDeployed),
+		string(model.DeploymentStatusDeploying),
+		string(model.DeploymentStatusUndeploying),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var gatewayIDs []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		gatewayIDs = append(gatewayIDs, id)
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating live gateway IDs: %w", err)
+	}
+
+	return gatewayIDs, nil
+}
+
 // GetControlPlaneDeploymentsByGateway retrieves the control-plane-owned deployments for a
 // specific gateway. Data-plane-originated (gateway_api) artifacts are excluded because they are
 // owned by the gateway and pushed up to the CP (DP->CP); syncing them back down would make the

--- a/platform-api/src/internal/repository/interfaces.go
+++ b/platform-api/src/internal/repository/interfaces.go
@@ -136,6 +136,9 @@ type DeploymentRepository interface {
 	GetDeployedGatewayIDs(artifactUUID, orgUUID string) ([]string, error)
 	HasActiveDeployment(artifactUUID, orgUUID string) (bool, error)
 	GetLatestDeploymentTime(artifactUUID, orgUUID string) (*time.Time, error)
+	// GetLiveGatewayIDs returns the gateways on which the artifact is currently live
+	// (status DEPLOYED, DEPLOYING, or UNDEPLOYING) — i.e. still present on the gateway.
+	GetLiveGatewayIDs(artifactUUID, orgUUID string) ([]string, error)
 
 	// Gateway deployment methods
 	GetControlPlaneDeploymentsByGateway(gatewayID, orgUUID string, since *time.Time) ([]*model.DeploymentInfo, error)
@@ -237,6 +240,9 @@ type LLMProviderRepository interface {
 	Update(p *model.LLMProvider) error
 	Delete(providerID, orgUUID string) error
 	Exists(providerID, orgUUID string) (bool, error)
+	// EnsureGatewayAssociation creates a gateway association for the provider if one
+	// does not already exist and resolves the metadata to use for the deployment.
+	EnsureGatewayAssociation(providerUUID, gatewayUUID, orgUUID, deployMetadata string, metadataProvided bool) (string, error)
 }
 
 // APIKeyRepository defines the interface for API key persistence
@@ -264,6 +270,9 @@ type LLMProxyRepository interface {
 	Update(p *model.LLMProxy) error
 	Delete(proxyID, orgUUID string) error
 	Exists(proxyID, orgUUID string) (bool, error)
+	// EnsureGatewayAssociation creates a gateway association for the proxy if one does
+	// not already exist and resolves the metadata to use for the deployment.
+	EnsureGatewayAssociation(proxyUUID, gatewayUUID, orgUUID, deployMetadata string, metadataProvided bool) (string, error)
 }
 
 // MCPProxyRepository defines the interface for MCP proxy persistence
@@ -278,6 +287,7 @@ type MCPProxyRepository interface {
 	Update(p *model.MCPProxy) error
 	Delete(handle, orgUUID string) error
 	Exists(handle, orgUUID string) (bool, error)
+	EnsureGatewayAssociation(proxyUUID, gatewayUUID, orgUUID, deployMetadata string, metadataProvided bool) (string, error)
 }
 
 // WebSubAPIHmacSecretRepository defines the interface for WebSub API HMAC secret persistence

--- a/platform-api/src/internal/repository/llm.go
+++ b/platform-api/src/internal/repository/llm.go
@@ -664,6 +664,125 @@ func (r *LLMProviderTemplateRepo) CountProvidersUsingTemplate(templateID, orgUUI
 	return count, nil
 }
 
+// insertArtifactGatewayAssociations writes the given gateway associations for an artifact
+// within the supplied transaction. metadata is a BYTEA column; a nil slice is stored as NULL.
+func insertArtifactGatewayAssociations(tx *sql.Tx, db *database.DB, artifactUUID, orgUUID string, assocs []model.AssociatedGatewayMapping, now time.Time) error {
+	if len(assocs) == 0 {
+		return nil
+	}
+	query := `
+		INSERT INTO artifact_gateway_mappings (
+			artifact_uuid, organization_uuid, gateway_uuid, metadata, created_at, updated_at
+		)
+		VALUES (?, ?, ?, ?, ?, ?)`
+	for _, assoc := range assocs {
+		var metadata []byte
+		if assoc.Metadata != "" {
+			metadata = []byte(assoc.Metadata)
+		}
+		if _, err := tx.Exec(db.Rebind(query), artifactUUID, orgUUID, assoc.GatewayUUID, metadata, now, now); err != nil {
+			return fmt.Errorf("failed to create gateway association: %w", err)
+		}
+	}
+	return nil
+}
+
+// replaceArtifactGatewayAssociations replaces the full set of gateway associations for an
+// artifact within the supplied transaction (delete-all then insert). Deployments are not touched.
+func replaceArtifactGatewayAssociations(tx *sql.Tx, db *database.DB, artifactUUID, orgUUID string, assocs []model.AssociatedGatewayMapping, now time.Time) error {
+	if _, err := tx.Exec(db.Rebind(
+		`DELETE FROM artifact_gateway_mappings WHERE artifact_uuid = ? AND organization_uuid = ?`),
+		artifactUUID, orgUUID); err != nil {
+		return fmt.Errorf("failed to clear gateway associations: %w", err)
+	}
+	return insertArtifactGatewayAssociations(tx, db, artifactUUID, orgUUID, assocs, now)
+}
+
+// loadArtifactGatewayAssociations returns the gateway associations for an artifact, joining
+// the gateways table to resolve each gateway handle.
+func loadArtifactGatewayAssociations(db *database.DB, artifactUUID, orgUUID string) ([]model.AssociatedGatewayMapping, error) {
+	query := `
+		SELECT m.gateway_uuid, g.handle, m.metadata
+		FROM artifact_gateway_mappings m
+		JOIN gateways g ON g.uuid = m.gateway_uuid
+		WHERE m.artifact_uuid = ? AND m.organization_uuid = ?
+		ORDER BY m.created_at`
+	rows, err := db.Query(db.Rebind(query), artifactUUID, orgUUID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var associations []model.AssociatedGatewayMapping
+	for rows.Next() {
+		var assoc model.AssociatedGatewayMapping
+		var metadata []byte
+		if err := rows.Scan(&assoc.GatewayUUID, &assoc.GatewayHandle, &metadata); err != nil {
+			return nil, err
+		}
+		if len(metadata) > 0 {
+			assoc.Metadata = string(metadata)
+		}
+		associations = append(associations, assoc)
+	}
+	return associations, rows.Err()
+}
+
+// ensureArtifactGatewayAssociation creates a gateway association for an artifact if one does
+// not already exist and resolves the metadata to use for the deployment.
+//
+// metadataProvided distinguishes an omitted deploy metadata field from one explicitly set to
+// empty, so a caller can deploy with empty metadata even when the association already carries
+// a value. An association that already exists is never modified at deploy time:
+//   - No association yet → create it, seeding its metadata from deployMetadata.
+//   - Association exists, metadataProvided → use deployMetadata for the deployment (including
+//     an explicit empty value); the association is left untouched.
+//   - Association exists, metadata omitted → fall back to the association's stored metadata.
+//
+// It returns the metadata to persist on the deployment record. An empty string means "no metadata".
+func ensureArtifactGatewayAssociation(db *database.DB, artifactUUID, gatewayUUID, orgUUID, deployMetadata string, metadataProvided bool) (string, error) {
+
+	var existingMetadata []byte
+	selectQuery := `
+		SELECT metadata
+		FROM artifact_gateway_mappings
+		WHERE artifact_uuid = ? AND gateway_uuid = ? AND organization_uuid = ?`
+	err := db.QueryRow(db.Rebind(selectQuery), artifactUUID, gatewayUUID, orgUUID).Scan(&existingMetadata)
+	exists := true
+	if errors.Is(err, sql.ErrNoRows) {
+		exists = false
+	} else if err != nil {
+		return "", fmt.Errorf("failed to check gateway association: %w", err)
+	}
+
+	if !exists {
+		now := time.Now()
+		var metaArg []byte
+		if strings.TrimSpace(deployMetadata) != "" {
+			metaArg = []byte(deployMetadata)
+		}
+		insertQuery := `
+			INSERT INTO artifact_gateway_mappings (
+				artifact_uuid, organization_uuid, gateway_uuid, metadata, created_at, updated_at
+			)
+			VALUES (?, ?, ?, ?, ?, ?)`
+		if _, err := db.Exec(db.Rebind(insertQuery), artifactUUID, orgUUID, gatewayUUID, metaArg, now, now); err != nil {
+			return "", fmt.Errorf("failed to create gateway association: %w", err)
+		}
+		return deployMetadata, nil
+	}
+
+	// Existing association is never modified at deploy time. When the deploy request
+	// provides metadata (even an explicit empty value), it is used as-is
+	if metadataProvided {
+		return deployMetadata, nil
+	}
+	if len(existingMetadata) > 0 {
+		return string(existingMetadata), nil
+	}
+	return "", nil
+}
+
 // ---- LLM Providers ----
 
 type LLMProviderRepo struct {
@@ -735,6 +854,11 @@ func (r *LLMProviderRepo) Create(p *model.LLMProvider) error {
 		return fmt.Errorf("failed to upsert artifact secret refs: %w", err)
 	}
 
+	// Persist gateway associations (if any) within the same transaction.
+	if err := insertArtifactGatewayAssociations(tx, r.db, p.UUID, p.OrganizationUUID, p.AssociatedGateways, now); err != nil {
+		return err
+	}
+
 	if err := tx.Commit(); err != nil {
 		return err
 	}
@@ -782,7 +906,20 @@ func (r *LLMProviderRepo) GetByID(providerID, orgUUID string) (*model.LLMProvide
 		}
 	}
 
+	associations, err := loadArtifactGatewayAssociations(r.db, p.UUID, orgUUID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load gateway associations for provider %s: %w", p.ID, err)
+	}
+	p.AssociatedGateways = associations
+
 	return &p, nil
+}
+
+// EnsureGatewayAssociation creates a gateway association for the provider if one does not
+// already exist and resolves the metadata to use for the deployment. See
+// ensureArtifactGatewayAssociation for the full semantics.
+func (r *LLMProviderRepo) EnsureGatewayAssociation(providerUUID, gatewayUUID, orgUUID, deployMetadata string, metadataProvided bool) (string, error) {
+	return ensureArtifactGatewayAssociation(r.db, providerUUID, gatewayUUID, orgUUID, deployMetadata, metadataProvided)
 }
 
 func (r *LLMProviderRepo) List(orgUUID string, limit, offset int) ([]*model.LLMProvider, error) {
@@ -894,6 +1031,14 @@ func (r *LLMProviderRepo) Update(p *model.LLMProvider) error {
 
 	if err := upsertArtifactSecretRefs(tx, r.db, p.OrganizationUUID, providerUUID, []byte(configurationJSON)); err != nil {
 		return fmt.Errorf("failed to upsert artifact secret refs: %w", err)
+	}
+
+	// Replace the full set of gateway associations within the same transaction when the
+	// caller manages associations. Deployments are intentionally left untouched.
+	if p.ReplaceAssociatedGateways {
+		if err := replaceArtifactGatewayAssociations(tx, r.db, providerUUID, p.OrganizationUUID, p.AssociatedGateways, now); err != nil {
+			return err
+		}
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -1008,6 +1153,11 @@ func (r *LLMProxyRepo) Create(p *model.LLMProxy) error {
 		return fmt.Errorf("failed to upsert artifact secret refs: %w", err)
 	}
 
+	// Persist gateway associations (if any) within the same transaction.
+	if err := insertArtifactGatewayAssociations(tx, r.db, p.UUID, p.OrganizationUUID, p.AssociatedGateways, now); err != nil {
+		return err
+	}
+
 	if err := tx.Commit(); err != nil {
 		return err
 	}
@@ -1048,6 +1198,12 @@ func (r *LLMProxyRepo) GetByID(proxyID, orgUUID string) (*model.LLMProxy, error)
 			p.Configuration = *config
 		}
 	}
+
+	associations, err := loadArtifactGatewayAssociations(r.db, p.UUID, orgUUID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load gateway associations for proxy %s: %w", p.ID, err)
+	}
+	p.AssociatedGateways = associations
 
 	return &p, nil
 }
@@ -1274,10 +1430,25 @@ func (r *LLMProxyRepo) Update(p *model.LLMProxy) error {
 		return fmt.Errorf("failed to upsert artifact secret refs: %w", err)
 	}
 
+	// Replace the full set of gateway associations within the same transaction when the
+	// caller manages associations. Deployments are intentionally left untouched.
+	if p.ReplaceAssociatedGateways {
+		if err := replaceArtifactGatewayAssociations(tx, r.db, proxyUUID, p.OrganizationUUID, p.AssociatedGateways, now); err != nil {
+			return err
+		}
+	}
+
 	if err := tx.Commit(); err != nil {
 		return err
 	}
 	return nil
+}
+
+// EnsureGatewayAssociation creates a gateway association for the proxy if one does not
+// already exist and resolves the metadata to use for the deployment. See
+// ensureArtifactGatewayAssociation for the full semantics.
+func (r *LLMProxyRepo) EnsureGatewayAssociation(proxyUUID, gatewayUUID, orgUUID, deployMetadata string, metadataProvided bool) (string, error) {
+	return ensureArtifactGatewayAssociation(r.db, proxyUUID, gatewayUUID, orgUUID, deployMetadata, metadataProvided)
 }
 
 func (r *LLMProxyRepo) Delete(proxyID, orgUUID string) error {

--- a/platform-api/src/internal/repository/mcp.go
+++ b/platform-api/src/internal/repository/mcp.go
@@ -97,6 +97,11 @@ func (r *MCPProxyRepo) Create(p *model.MCPProxy) error {
 		return fmt.Errorf("failed to upsert artifact secret refs: %w", err)
 	}
 
+	// Persist gateway associations (if any) within the same transaction.
+	if err := insertArtifactGatewayAssociations(tx, r.db, p.UUID, p.OrganizationUUID, p.AssociatedGateways, now); err != nil {
+		return err
+	}
+
 	if err := tx.Commit(); err != nil {
 		return err
 	}
@@ -134,6 +139,12 @@ func (r *MCPProxyRepo) GetByHandle(handle, orgUUID string) (*model.MCPProxy, err
 			p.Configuration = *config
 		}
 	}
+
+	associations, err := loadArtifactGatewayAssociations(r.db, p.UUID, orgUUID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load gateway associations for MCP proxy %s: %w", p.Handle, err)
+	}
+	p.AssociatedGateways = associations
 
 	return &p, nil
 }
@@ -326,10 +337,25 @@ func (r *MCPProxyRepo) Update(p *model.MCPProxy) error {
 		return fmt.Errorf("failed to upsert artifact secret refs: %w", err)
 	}
 
+	// Replace the full set of gateway associations within the same transaction when the
+	// caller manages associations. Deployments are intentionally left untouched.
+	if p.ReplaceAssociatedGateways {
+		if err := replaceArtifactGatewayAssociations(tx, r.db, proxyUUID, p.OrganizationUUID, p.AssociatedGateways, now); err != nil {
+			return err
+		}
+	}
+
 	if err := tx.Commit(); err != nil {
 		return err
 	}
 	return nil
+}
+
+// EnsureGatewayAssociation creates a gateway association for the MCP proxy if one does not
+// already exist and resolves the metadata to use for the deployment. See
+// ensureArtifactGatewayAssociation for the full semantics.
+func (r *MCPProxyRepo) EnsureGatewayAssociation(proxyUUID, gatewayUUID, orgUUID, deployMetadata string, metadataProvided bool) (string, error) {
+	return ensureArtifactGatewayAssociation(r.db, proxyUUID, gatewayUUID, orgUUID, deployMetadata, metadataProvided)
 }
 
 // Delete deletes an MCP proxy by its handle and organization UUID

--- a/platform-api/src/internal/service/llm.go
+++ b/platform-api/src/internal/service/llm.go
@@ -669,6 +669,13 @@ func (s *LLMProviderService) Create(orgUUID, createdBy string, req *api.LLMProvi
 		openapiSpec = tpl.OpenAPISpec
 	}
 
+	// Resolve any associated gateways up-front so they can be persisted within the
+	// same transaction as the provider create.
+	associatedGateways, err := resolveAssociatedGateways(s.gatewayRepo, orgUUID, req.AssociatedGateways)
+	if err != nil {
+		return nil, err
+	}
+
 	contextValue := utils.DefaultStringPtr(req.Context, "/")
 	m := &model.LLMProvider{
 		OrganizationUUID: orgUUID,
@@ -692,6 +699,7 @@ func (s *LLMProviderService) Create(orgUUID, createdBy string, req *api.LLMProvi
 			Security:          mapSecurityAPIToModel(req.Security),
 		},
 		Origin: constants.OriginCP,
+		AssociatedGateways: associatedGateways,
 	}
 	migrateLegacyProviderPoliciesInPlace(&m.Configuration)
 
@@ -872,6 +880,20 @@ func (s *LLMProviderService) Update(orgUUID, handle, updatedBy string, req *api.
 	// If auth object is omitted, treat it as explicit removal and clear stored auth.
 	m.Configuration.Upstream = preserveUpstreamAuthValue(existing.Configuration.Upstream, m.Configuration.Upstream)
 
+	// Gateway associations are managed only when the field is present in the request. An
+	// omitted field leaves associations untouched; an explicit (possibly empty) list
+	// replaces the full set. A gateway the provider is actively deployed on must remain
+	// associated, so the update is rejected if it would drop such a gateway. Deployments
+	// themselves are never modified here.
+	requested, manage, err := resolveManagedAssociatedGateways(s.gatewayRepo, s.deploymentRepo, orgUUID, existing.UUID, existing.AssociatedGateways, req.AssociatedGateways)
+	if err != nil {
+		return nil, err
+	}
+	if manage {
+		m.AssociatedGateways = requested
+		m.ReplaceAssociatedGateways = true
+	}
+
 	if err := s.repo.Update(m); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, constants.ErrLLMProviderNotFound
@@ -994,6 +1016,13 @@ func (s *LLMProxyService) Create(orgUUID, createdBy string, req *api.LLMProxy) (
 		return nil, err
 	}
 
+	// Resolve any associated gateways up-front so they can be persisted within the
+	// same transaction as the proxy create.
+	associatedGateways, err := resolveAssociatedGateways(s.gatewayRepo, orgUUID, req.AssociatedGateways)
+	if err != nil {
+		return nil, err
+	}
+
 	contextValue := utils.DefaultStringPtr(req.Context, "/")
 	m := &model.LLMProxy{
 		OrganizationUUID: orgUUID,
@@ -1016,6 +1045,7 @@ func (s *LLMProxyService) Create(orgUUID, createdBy string, req *api.LLMProxy) (
 			Security:          mapSecurityAPIToModel(req.Security),
 		},
 		Origin: constants.OriginCP,
+		AssociatedGateways: associatedGateways,
 	}
 	migrateLegacyProxyPoliciesInPlace(&m.Configuration)
 
@@ -1239,6 +1269,21 @@ func (s *LLMProxyService) Update(orgUUID, handle, updatedBy string, req *api.LLM
 
 	// Preserve stored upstream auth credential when not supplied in update payload
 	m.Configuration.UpstreamAuth = preserveUpstreamAuthCredential(existing.Configuration.UpstreamAuth, m.Configuration.UpstreamAuth)
+
+	// Gateway associations are managed only when the field is present in the request. An
+	// omitted field leaves associations untouched; an explicit (possibly empty) list
+	// replaces the full set. A gateway the proxy is actively deployed on must remain
+	// associated, so the update is rejected if it would drop such a gateway. Deployments
+	// themselves are never modified here.
+	requested, manage, err := resolveManagedAssociatedGateways(s.gatewayRepo, s.deploymentRepo, orgUUID, existing.UUID, existing.AssociatedGateways, req.AssociatedGateways)
+	if err != nil {
+		return nil, err
+	}
+	if manage {
+		m.AssociatedGateways = requested
+		m.ReplaceAssociatedGateways = true
+	}
+
 	if err := s.repo.Update(m); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, constants.ErrLLMProxyNotFound
@@ -2223,7 +2268,31 @@ func mapProviderModelToAPI(m *model.LLMProvider, templateHandle string) *api.LLM
 		CreatedAt:         utils.TimePtr(m.CreatedAt),
 		UpdatedAt:         utils.TimePtr(m.UpdatedAt),
 	}
+	if associated := mapAssociatedGatewaysModelToAPI(m.AssociatedGateways); associated != nil {
+		out.AssociatedGateways = associated
+	}
 	return out
+}
+
+// mapAssociatedGatewaysModelToAPI maps persisted gateway associations back to the
+// API shape, deserializing each metadata payload into the configurations object.
+// Returns nil when there are no associations so the field is omitted from responses.
+func mapAssociatedGatewaysModelToAPI(in []model.AssociatedGatewayMapping) *[]api.AssociatedGateway {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]api.AssociatedGateway, 0, len(in))
+	for _, a := range in {
+		ag := api.AssociatedGateway{Name: a.GatewayHandle}
+		if a.Metadata != "" {
+			configurations := map[string]interface{}{}
+			if err := json.Unmarshal([]byte(a.Metadata), &configurations); err == nil {
+				ag.Configurations = &configurations
+			}
+		}
+		out = append(out, ag)
+	}
+	return &out
 }
 
 func validateModelProviders(template string, providers *[]api.LLMModelProvider) error {
@@ -2562,6 +2631,9 @@ func mapProxyModelToAPI(m *model.LLMProxy) *api.LLMProxy {
 	out.GlobalPolicies = globalPoliciesProxy
 	out.OperationPolicies = operationPoliciesProxy
 	out.Policies = nil
+	if associated := mapAssociatedGatewaysModelToAPI(m.AssociatedGateways); associated != nil {
+		out.AssociatedGateways = associated
+	}
 	return out
 }
 
@@ -2605,4 +2677,121 @@ func marshalUpstreamForValidation(upstream interface{}) (string, error) {
 		return "", err
 	}
 	return string(b), nil
+}
+
+func isAssociatedGatewaysAvailable(associatedGateways *[]api.AssociatedGateway) bool {
+	if associatedGateways == nil || len(*associatedGateways) == 0 {
+		return false
+	}
+	return true
+}
+
+// guardLiveGatewaysRetained rejects an association update that would drop a gateway the
+// artifact is actively deployed on. The set of requested gateways must be a superset of
+// the gateways currently live (DEPLOYED/DEPLOYING/UNDEPLOYING) for the artifact; any live
+// gateway missing from the request is reported as a violation. Deployments are not touched.
+// existingAssociations is only used to resolve gateway handles for friendlier errors.
+func guardLiveGatewaysRetained(deploymentRepo repository.DeploymentRepository, orgUUID, artifactUUID string, existingAssociations, requested []model.AssociatedGatewayMapping) error {
+	if deploymentRepo == nil {
+		return fmt.Errorf("could not initialize deployment repository")
+	}
+	liveGatewayIDs, err := deploymentRepo.GetLiveGatewayIDs(artifactUUID, orgUUID)
+	if err != nil {
+		return fmt.Errorf("failed to check active deployments: %w", err)
+	}
+	if len(liveGatewayIDs) == 0 {
+		return nil
+	}
+
+	requestedSet := make(map[string]struct{}, len(requested))
+	for _, ag := range requested {
+		requestedSet[ag.GatewayUUID] = struct{}{}
+	}
+	// Resolve gateway handles for friendlier error messages, falling back to the UUID.
+	handleByUUID := make(map[string]string, len(existingAssociations))
+	for _, ag := range existingAssociations {
+		handleByUUID[ag.GatewayUUID] = ag.GatewayHandle
+	}
+
+	var violations []string
+	for _, gwID := range liveGatewayIDs {
+		if _, ok := requestedSet[gwID]; ok {
+			continue
+		}
+		label := handleByUUID[gwID]
+		if label == "" {
+			label = gwID
+		}
+		violations = append(violations, label)
+	}
+	if len(violations) > 0 {
+		return fmt.Errorf("%w: %s", constants.ErrAssociationGatewayDeployed, strings.Join(violations, ", "))
+	}
+	return nil
+}
+
+// resolveManagedAssociatedGateways is the shared update-time entry point for managing an
+// artifact's gateway associations, used by LLM providers, LLM proxies and MCP proxies.
+//
+// It encodes the omitted-vs-empty semantics: when the request's associatedGateways field
+// is omitted (nil), manage is false and associations are left untouched; when it is
+// present (even empty), it resolves the requested set and rejects the update if it would
+// drop a gateway the artifact is actively deployed on. Callers assign the returned set to
+// their own model and set its ReplaceAssociatedGateways flag only when manage is true.
+func resolveManagedAssociatedGateways(
+	gatewayRepo repository.GatewayRepository,
+	deploymentRepo repository.DeploymentRepository,
+	orgUUID, artifactUUID string,
+	existingAssociations []model.AssociatedGatewayMapping,
+	requestedGateways *[]api.AssociatedGateway,
+) (resolved []model.AssociatedGatewayMapping, manage bool, err error) {
+	if requestedGateways == nil {
+		return nil, false, nil
+	}
+	resolved, err = resolveAssociatedGateways(gatewayRepo, orgUUID, requestedGateways)
+	if err != nil {
+		return nil, false, err
+	}
+	if err := guardLiveGatewaysRetained(deploymentRepo, orgUUID, artifactUUID, existingAssociations, resolved); err != nil {
+		return nil, false, err
+	}
+	return resolved, true, nil
+}
+
+// resolveAssociatedGateways validates each requested gateway association, resolving
+// the gateway handle to its UUID and serializing any per-gateway configuration
+// overrides into the metadata column. Returns nil when no associations are requested.
+func resolveAssociatedGateways(gatewayRepo repository.GatewayRepository, orgUUID string, associatedGateways *[]api.AssociatedGateway) ([]model.AssociatedGatewayMapping, error) {
+	if !isAssociatedGatewaysAvailable(associatedGateways) {
+		return nil, nil
+	}
+	if gatewayRepo == nil {
+		return nil, fmt.Errorf("could not initialize gateway repository")
+	}
+
+	resolved := make([]model.AssociatedGatewayMapping, 0, len(*associatedGateways))
+	for _, ag := range *associatedGateways {
+		gw, err := gatewayRepo.GetByHandleAndOrgID(ag.Name, orgUUID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to validate associated gateway %q: %w", ag.Name, err)
+		}
+		if gw == nil {
+			return nil, constants.ErrGatewayNotFound
+		}
+
+		metadata := ""
+		if ag.Configurations != nil && len(*ag.Configurations) > 0 {
+			metadataJSON, err := json.Marshal(*ag.Configurations)
+			if err != nil {
+				return nil, fmt.Errorf("failed to serialize configurations for gateway %q: %w", ag.Name, err)
+			}
+			metadata = string(metadataJSON)
+		}
+
+		resolved = append(resolved, model.AssociatedGatewayMapping{
+			GatewayUUID: gw.ID,
+			Metadata:    metadata,
+		})
+	}
+	return resolved, nil
 }

--- a/platform-api/src/internal/service/llm_deployment.go
+++ b/platform-api/src/internal/service/llm_deployment.go
@@ -18,6 +18,7 @@
 package service
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -162,6 +163,29 @@ func (s *LLMProviderDeploymentService) DeployLLMProvider(providerID string, req 
 	// Validate deployment name is provided
 	if req.Name == "" {
 		return nil, constants.ErrDeploymentNameRequired
+	}
+
+	// Ensure a gateway association exists for the target gateway before deploying, and
+	// resolve the deployment metadata. The first deployment to a gateway creates the
+	// association and seeds its metadata from this deployment. For an existing
+	// association the deploy request value overrides for this deployment; when the
+	// metadata field is omitted, the association's stored metadata is used. An existing
+	// association's metadata is never modified at deploy time.
+	//
+	// metadataProvided distinguishes an omitted metadata field from one explicitly set
+	// (even to empty), so a deploy can request empty metadata while the association
+	// keeps its creation-time value.
+	metadataProvided := req.Metadata != nil
+	deployMetaJSON, err := marshalDeploymentMetadata(metadata)
+	if err != nil {
+		return nil, err
+	}
+	effectiveMetaJSON, err := s.providerRepo.EnsureGatewayAssociation(provider.UUID, gatewayID, orgUUID, deployMetaJSON, metadataProvided)
+	if err != nil {
+		return nil, fmt.Errorf("failed to ensure gateway association: %w", err)
+	}
+	if metadata, err = unmarshalDeploymentMetadata(effectiveMetaJSON); err != nil {
+		return nil, err
 	}
 
 	var baseDeploymentID *string
@@ -1207,6 +1231,33 @@ func isBoolTrue(v *bool) bool {
 	return v != nil && *v
 }
 
+// marshalDeploymentMetadata serializes the deployment metadata map to the JSON form
+// stored in the metadata column shared with artifact_gateway_mappings. An empty or
+// nil map yields an empty string ("no metadata").
+func marshalDeploymentMetadata(m map[string]any) (string, error) {
+	if len(m) == 0 {
+		return "", nil
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal deployment metadata: %w", err)
+	}
+	return string(b), nil
+}
+
+// unmarshalDeploymentMetadata parses the JSON metadata form back into a map for the
+// deployment record. An empty string yields an empty (non-nil) map.
+func unmarshalDeploymentMetadata(s string) (map[string]any, error) {
+	if strings.TrimSpace(s) == "" {
+		return map[string]any{}, nil
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(s), &m); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal deployment metadata: %w", err)
+	}
+	return m, nil
+}
+
 // DeployLLMProxy creates a new immutable deployment artifact and deploys it to a gateway
 func (s *LLMProxyDeploymentService) DeployLLMProxy(proxyID string, req *api.DeployRequest, orgUUID string) (*api.DeploymentResponse, error) {
 	// Validate request
@@ -1252,6 +1303,25 @@ func (s *LLMProxyDeploymentService) DeployLLMProxy(proxyID string, req *api.Depl
 	// Validate deployment name is provided
 	if req.Name == "" {
 		return nil, constants.ErrDeploymentNameRequired
+	}
+
+	// Ensure a gateway association exists for the target gateway before deploying, and
+	// resolve the deployment metadata. The first deployment to a gateway creates the
+	// association and seeds its metadata from this deployment. For an existing
+	// association the deploy request value overrides for this deployment; when the
+	// metadata field is omitted, the association's stored metadata is used. An existing
+	// association's metadata is never modified at deploy time.
+	metadataProvided := req.Metadata != nil
+	deployMetaJSON, err := marshalDeploymentMetadata(metadata)
+	if err != nil {
+		return nil, err
+	}
+	effectiveMetaJSON, err := s.proxyRepo.EnsureGatewayAssociation(proxy.UUID, gatewayID, orgUUID, deployMetaJSON, metadataProvided)
+	if err != nil {
+		return nil, fmt.Errorf("failed to ensure gateway association: %w", err)
+	}
+	if metadata, err = unmarshalDeploymentMetadata(effectiveMetaJSON); err != nil {
+		return nil, err
 	}
 
 	var baseDeploymentID *string

--- a/platform-api/src/internal/service/mcp.go
+++ b/platform-api/src/internal/service/mcp.go
@@ -129,6 +129,13 @@ func (s *MCPProxyService) Create(orgUUID, createdBy string, req *api.MCPProxy) (
 		}
 	}
 
+	// Resolve any associated gateways up-front so they can be persisted within the
+	// same transaction as the MCP proxy create.
+	associatedGateways, err := resolveAssociatedGateways(s.gatewayRepo, orgUUID, req.AssociatedGateways)
+	if err != nil {
+		return nil, err
+	}
+
 	// Create MCP proxy model
 	m := &model.MCPProxy{
 		Handle:           req.Id,
@@ -149,6 +156,7 @@ func (s *MCPProxyService) Create(orgUUID, createdBy string, req *api.MCPProxy) (
 			Capabilities: mapMcpCapabilitiesAPIToModel(req.Capabilities),
 		},
 		Origin: constants.OriginCP,
+		AssociatedGateways: associatedGateways,
 	}
 
 	if err := s.repo.Create(m); err != nil {
@@ -300,6 +308,20 @@ func (s *MCPProxyService) Update(orgUUID, handle, updatedBy string, req *api.MCP
 	// Preserve existing upstream auth credential if not provided in update request
 	// (the auth value is redacted in GET responses, so clients send empty value on updates)
 	existing.Configuration.Upstream = *preserveMCPUpstreamAuthValue(&existingUpstreamConfig, &existing.Configuration.Upstream)
+
+	// Gateway associations are managed only when the field is present in the request. An
+	// omitted field leaves associations untouched; an explicit (possibly empty) list
+	// replaces the full set. A gateway the proxy is actively deployed on must remain
+	// associated, so the update is rejected if it would drop such a gateway. Deployments
+	// themselves are never modified here.
+	requested, manage, err := resolveManagedAssociatedGateways(s.gatewayRepo, s.deploymentRepo, orgUUID, existing.UUID, existing.AssociatedGateways, req.AssociatedGateways)
+	if err != nil {
+		return nil, err
+	}
+	if manage {
+		existing.AssociatedGateways = requested
+		existing.ReplaceAssociatedGateways = true
+	}
 
 	if err := s.repo.Update(existing); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -482,7 +504,7 @@ func mapMCPProxyModelToAPI(m *model.MCPProxy) *api.MCPProxy {
 		specVersion = &sv
 	}
 
-	return &api.MCPProxy{
+	out := &api.MCPProxy{
 		Id:             m.Handle,
 		Name:           m.Name,
 		Description:    &desc,
@@ -499,6 +521,10 @@ func mapMCPProxyModelToAPI(m *model.MCPProxy) *api.MCPProxy {
 		CreatedAt:      utils.TimePtr(m.CreatedAt),
 		UpdatedAt:      utils.TimePtr(m.UpdatedAt),
 	}
+	if associated := mapAssociatedGatewaysModelToAPI(m.AssociatedGateways); associated != nil {
+		out.AssociatedGateways = associated
+	}
+	return out
 }
 
 func mapMCPProxyModelToListItem(m *model.MCPProxy) *api.MCPProxyListItem {

--- a/platform-api/src/internal/service/mcp_deployment.go
+++ b/platform-api/src/internal/service/mcp_deployment.go
@@ -175,6 +175,25 @@ func (s *MCPDeploymentService) deployMCPProxy(proxyUUID string, req *api.DeployR
 		return nil, err
 	}
 
+	// Ensure a gateway association exists for the target gateway before deploying, and
+	// resolve the deployment metadata. The first deployment to a gateway creates the
+	// association and seeds its metadata from this deployment. For an existing
+	// association the deploy request value overrides for this deployment; when the
+	// metadata field is omitted, the association's stored metadata is used. An existing
+	// association's metadata is never modified at deploy time.
+	metadataProvided := req.Metadata != nil
+	deployMetaJSON, err := marshalDeploymentMetadata(metadata)
+	if err != nil {
+		return nil, err
+	}
+	effectiveMetaJSON, err := s.mcpRepo.EnsureGatewayAssociation(mcpProxy.UUID, gatewayID, orgId, deployMetaJSON, metadataProvided)
+	if err != nil {
+		return nil, fmt.Errorf("failed to ensure gateway association: %w", err)
+	}
+	if metadata, err = unmarshalDeploymentMetadata(effectiveMetaJSON); err != nil {
+		return nil, err
+	}
+
 	// Generate deployment ID
 	deploymentID, err := utils.GenerateUUID()
 	if err != nil {


### PR DESCRIPTION
## Purpose

Add **gateway association** support to the platform-api for the three control-plane AI artifact types — **LLM providers, LLM proxies, and MCP proxies**.

A gateway association records *which gateways an artifact is intended to run on*, together with optional per-gateway configuration overrides. This lets an artifact declare its target gateways at create/update time (independently of being deployed), and makes deployment self-service: deploying an artifact to a gateway automatically establishes the association if one does not already exist.

The persistence table (`artifact_gateway_mappings`) and the `associatedGateways` OpenAPI field/type already exist in `main`; this PR implements the model, repository, and service logic that wires them into the create / read / update / deploy flows.

Related to : https://github.com/wso2/api-platform/issues/2262

## Behaviour

### Create
`POST` of an LLM provider / LLM proxy / MCP proxy accepts an optional `associatedGateways` list. Each entry is `{ name, configurations }`, where `name` is the gateway handle and `configurations` is a free-form object of per-gateway overrides. On create, each gateway handle is validated and resolved to its UUID, `configurations` is serialized to the association's metadata, and the associations are written **in the same transaction** as the artifact.

### Read
`GET` of an artifact returns its `associatedGateways`, resolved back to gateway handles (joined from the `gateways` table) with each stored metadata payload deserialized into `configurations`. The field is omitted from the response when there are no associations.

### Update
`associatedGateways` on update is **managed only when the field is present** in the request:
- **Omitted** → associations are left untouched.
- **Present (including an explicit empty list)** → the full set of associations is **replaced**.

An update that would drop a gateway the artifact is **actively deployed on** is rejected (`ErrAssociationGatewayDeployed`) — the requested set must be a superset of the currently-live gateways. "Live" means a deployment in `DEPLOYED`, `DEPLOYING`, or `UNDEPLOYING` state. Deployments themselves are never modified by an association update.

### Deploy
Before an artifact is deployed to a gateway, the association is ensured:
- **No association yet** → it is created, seeding its metadata from the deploy request.
- **Association already exists** → its metadata is **never modified** at deploy time.

The effective deployment metadata is resolved with omitted-vs-empty semantics:
- Deploy `metadata` **omitted** → fall back to the association's stored metadata.
- Deploy `metadata` **provided** (including an explicit empty value) → use the request value for this deployment.

## Implementation details

- Refer to the Design Doc for more details - https://docs.google.com/document/d/1DWklILdlBFAijachx2M3zz1iD8D7qlY3tuxEDyo7io8/edit?tab=t.w3lefdjelsk5#heading=h.qxwb86l2rlwz

**`constants/error.go`**
- New sentinel error `ErrAssociationGatewayDeployed` for the "cannot drop an actively-deployed gateway" case.

**`model/llm.go`, `model/mcp.go`**
- New `AssociatedGatewayMapping` type (`GatewayUUID`, `GatewayHandle`, `Metadata`) — `GatewayUUID` is used for the FK write, `GatewayHandle` is populated on reads.
- `LLMProvider`, `LLMProxy`, and `MCPProxy` gain a transient `AssociatedGateways []AssociatedGatewayMapping` and a `ReplaceAssociatedGateways bool` flag (both `db:"-"`; the flag opts a model into the delete-all-then-insert replace path on update).

**`repository/interfaces.go`**
- `DeploymentRepository` gains `GetLiveGatewayIDs(artifactUUID, orgUUID)`.
- `LLMProviderRepository`, `LLMProxyRepository`, and `MCPProxyRepository` each gain `EnsureGatewayAssociation(...)`.

**`repository/deployment.go`**
- `GetLiveGatewayIDs` returns the gateways an artifact is currently live on (`DEPLOYED`/`DEPLOYING`/`UNDEPLOYING`), backing the update-time guard.

**`repository/llm.go`, `repository/mcp.go`**
- Shared, transaction-aware helpers on `artifact_gateway_mappings`:
  - `insertArtifactGatewayAssociations` — bulk insert (metadata is a `BYTEA` column; nil → `NULL`).
  - `replaceArtifactGatewayAssociations` — delete-all then insert, for the update replace path.
  - `loadArtifactGatewayAssociations` — read + join `gateways` to resolve handles.
  - `ensureArtifactGatewayAssociation` — the deploy-time create-if-absent + metadata-resolution logic.
- `Create` persists associations in the artifact's transaction; `GetByID`/`GetByHandle` load them; `Update` replaces them when `ReplaceAssociatedGateways` is set. Each repo exposes `EnsureGatewayAssociation` for the deploy path.

**`service/llm.go`, `service/mcp.go`**
- `resolveAssociatedGateways` — validates gateway handles and serializes `configurations` into metadata (shared across all three artifact types).
- `resolveManagedAssociatedGateways` — the update-time entry point encoding the omitted-vs-empty semantics and applying the live-gateway guard (`guardLiveGatewaysRetained`).
- `mapAssociatedGatewaysModelToAPI` — maps persisted associations back to the API shape for responses.
- Create/Update handlers for LLM provider, LLM proxy, and MCP proxy call into these helpers.

**`service/llm_deployment.go`, `service/mcp_deployment.go`**
- Deploy flows call `EnsureGatewayAssociation` before deploying and resolve the effective metadata.
- `marshalDeploymentMetadata` / `unmarshalDeploymentMetadata` convert deployment metadata to/from the JSON form shared with the association metadata column.

## Design notes

- **No schema or OpenAPI changes** — builds entirely on the existing `artifact_gateway_mappings` table and the `AssociatedGateway` spec type.
- **Transactional integrity** — association writes on create/update happen within the artifact's own DB transaction, so an artifact and its associations commit or roll back together.
- **Omitted vs. empty** is treated as a first-class distinction (via pointer-nil checks) on both update and deploy, so callers can explicitly clear associations / request empty metadata without it being confused with "no change".
- **Shared logic** across LLM provider / LLM proxy / MCP proxy avoids three divergent implementations.

## Files changed

11 files, implementation only (`platform-api/src/internal/…`): `constants/error.go`, `model/llm.go`, `model/mcp.go`, `repository/deployment.go`, `repository/interfaces.go`, `repository/llm.go`, `repository/mcp.go`, `service/llm.go`, `service/llm_deployment.go`, `service/mcp.go`, `service/mcp_deployment.go`.
