### PR TITLE
Update pull request trigger paths in workflow

### DIFF
--- a/.github/workflows/platform-api-gateway-e2e.yml
+++ b/.github/workflows/platform-api-gateway-e2e.yml
@@ -11,9 +11,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - 'tests/integration-e2e/**'
-      - '.github/workflows/platform-api-gateway-e2e.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
This pull request makes a small change to the workflow trigger configuration for the `platform-api-gateway-e2e` GitHub Actions workflow. The change removes the `paths` filter, so the workflow will now run on all pull requests to the `main` branch, regardless of which files are changed.