### PR TITLE
Add Default project for new Organizations

### DIFF
--- a/portals/ai-workspace/src/apis/projectApis.ts
+++ b/portals/ai-workspace/src/apis/projectApis.ts
@@ -43,6 +43,18 @@ export interface ProjectListResponse {
 // ============================================================================
 // Project API Functions
 // ============================================================================
+export const DEFAULT_PROJECT_NAME = 'Default';
+
+/**
+ * Create the starter "Default Project" for a newly provisioned organization.
+ */
+export async function createDefaultProject(): Promise<void> {
+  try {
+    await createProject({ name: DEFAULT_PROJECT_NAME }, PLATFORM_API_BASE_URL);
+  } catch (error) {
+    logger.error('Failed to create default project for new organization:', error);
+  }
+}
 
 /**
  * Create a new project.

--- a/portals/ai-workspace/src/contexts/AppShellContext.tsx
+++ b/portals/ai-workspace/src/contexts/AppShellContext.tsx
@@ -26,7 +26,7 @@ import React, {
   ReactNode,
 } from 'react';
 import { logger } from '../utils/logger';
-import { getProjects } from '../apis/projectApis';
+import { getProjects, createDefaultProject } from '../apis/projectApis';
 import type { Organization, ProjectBase } from '../utils/types';
 import { useChoreoUser } from './ChoreoUserContext';
 import { useAppAuth } from './AppAuthContext';
@@ -106,7 +106,11 @@ export const AppShellProvider: React.FC<AppShellProviderProps> = ({
   const fetchProjectsForOrg = useCallback(async (): Promise<ProjectBase[]> => {
     setIsProjectsLoading(true);
     try {
-      const projectList = await getProjects();
+      let projectList = await getProjects();
+      if (projectList.length === 0) {
+        await createDefaultProject();
+        projectList = await getProjects();
+      }
       setProjectsForCurrentOrganization(projectList);
       setCurrentProjectState(null);
       return projectList;


### PR DESCRIPTION
This pull request introduces logic to automatically create a "Default Project" for a newly provisioned organization if no projects exist, ensuring that every organization starts with at least one project. The key changes are grouped below:

**Default Project Creation Logic:**

* Added a new constant `DEFAULT_PROJECT_NAME` and a `createDefaultProject` function to `projectApis.ts`, which attempts to create a starter project and logs an error if it fails.
* Updated the `fetchProjectsForOrg` function in `AppShellContext.tsx` to check if the project list is empty after fetching; if so, it calls `createDefaultProject` and refetches the project list to guarantee at least one project exists.

**API Imports:**

* Updated imports in `AppShellContext.tsx` to include the new `createDefaultProject` function from `projectApis.ts`.