### PR TITLE
Adding API gateway 1.1.0 performance test results 

### DIFF
--- a/gateway/perf/api-gateway-1.1.0-perf-test-results/four-core-results-summary.csv
+++ b/gateway/perf/api-gateway-1.1.0-perf-test-results/four-core-results-summary.csv
@@ -1,0 +1,12 @@
+,,,,,,,,,,,,,,,,,,
+Scenario Name,Concurrent Users,Throughput (Requests/sec),Average Response Time (ms),# Samples,Error Count,Error %,Average Users in the System,Standard Deviation of Response Time (ms),Minimum Response Time (ms),Maximum Response Time (ms),75th Percentile of Response Time (ms),90th Percentile of Response Time (ms),95th Percentile of Response Time (ms),98th Percentile of Response Time (ms),99th Percentile of Response Time (ms),99.9th Percentile of Response Time (ms),Received (KB/sec),Sent (KB/sec)
+API with 8 routes,100,9795.19,10.08,8221898,0,0,98,7.56,0,56,10,22,30,34,37,43,1607.14,2267.05
+API with 8 routes,500,9273.67,53.76,7784921,0,0,498,14.9,2,134,65,74,78,83,87,96,1525.45,2146.35
+API with 8 routes,800,9055.49,88.17,7601697,0,0,798,16.29,1,192,97,105,112,124,136,155,1493.43,2095.85
+API with 8 routes,1000,9107.1,109.62,7645393,0,0,998,18.17,1,249,116,136,147,158,166,186,1502.24,2107.8
+,,,,,,,,,,,,,,,,,,
+Scenario Name,Concurrent Users,Throughput (Requests/sec),Average Response Time (ms),# Samples,Error Count,Error %,Average Users in the System,Standard Deviation of Response Time (ms),Minimum Response Time (ms),Maximum Response Time (ms),75th Percentile of Response Time (ms),90th Percentile of Response Time (ms),95th Percentile of Response Time (ms),98th Percentile of Response Time (ms),99th Percentile of Response Time (ms),99.9th Percentile of Response Time (ms),Received (KB/sec),Sent (KB/sec)
+API with 8 routes + Mediation policy,100,8411.27,11.76,7060903,0,0,98,8.16,1,58,13,26,31,37,40,47,1618.29,1915.95
+API with 8 routes + Mediation policy,500,7956.58,62.68,6679203,0,0,498,16.23,3,171,75,83,88,94,98,115,1534,1812.37
+API with 8 routes + Mediation policy,800,7809.48,102.26,6555630,0,0,798,22.03,4,272,112,131,145,161,170,193,1508.15,1778.87
+API with 8 routes + Mediation policy,1000,7847.94,127.24,6588123,0,0,998,24.94,10,292,144,164,175,186,193,215,1516,1787.63

--- a/gateway/perf/api-gateway-1.1.0-perf-test-results/two-core-results-summary.csv
+++ b/gateway/perf/api-gateway-1.1.0-perf-test-results/two-core-results-summary.csv
@@ -1,0 +1,16 @@
+,,,,,,,,,,,,,,,,,,
+Scenario Name,Concurrent Users,Throughput (Requests/sec),Average Response Time (ms),# Samples,Error Count,Error %,Average Users in the System,Standard Deviation of Response Time (ms),Minimum Response Time (ms),Maximum Response Time (ms),75th Percentile of Response Time (ms),90th Percentile of Response Time (ms),95th Percentile of Response Time (ms),98th Percentile of Response Time (ms),99th Percentile of Response Time (ms),99.9th Percentile of Response Time (ms),Received (KB/sec),Sent (KB/sec)
+API with 8 routes,10,4676.14,2.05,3925517,0,0,9,1.38,0,25,2,3,3,4,10,15,2050.38,1060.58
+API with 8 routes,50,5540.17,8.92,4650614,0,0,49,6.31,2,51,8,12,28,30,31,37,2429.31,1256.54
+API with 8 routes,100,5805.39,17.12,4873343,0,0,99,8.77,1,64,18,34,37,40,42,49,2545.67,1316.7
+API with 8 routes,500,5374.3,92.85,4511917,0,0,499,16.69,2,374,102,110,116,136,142,158,2361.07,1218.93
+API with 8 routes,800,5063.14,157.79,4250938,0,0,798,22.86,1,296,174,185,193,203,211,247,2224.44,1148.36
+API with 8 routes,1000,5217.19,191.44,4380850,0,0,998,30.47,2,385,209,229,246,259,269,295,2292.07,1183.29
+,,,,,,,,,,,,,,,,,,
+Scenario Name,Concurrent Users,Throughput (Requests/sec),Average Response Time (ms),# Samples,Error Count,Error %,Average Users in the System,Standard Deviation of Response Time (ms),Minimum Response Time (ms),Maximum Response Time (ms),75th Percentile of Response Time (ms),90th Percentile of Response Time (ms),95th Percentile of Response Time (ms),98th Percentile of Response Time (ms),99th Percentile of Response Time (ms),99.9th Percentile of Response Time (ms),Received (KB/sec),Sent (KB/sec)
+API with 8 routes + Mediation policy,10,4236.1,2.27,3555691,0,0,9,1.58,0,27,2,3,3,6,12,17,1977.41,964.92
+API with 8 routes + Mediation policy,50,4896.46,10.11,4109930,0,0,49,6.58,0,45,11,19,28,31,33,36,2285.71,1115.33
+API with 8 routes + Mediation policy,100,4989.48,19.93,4188548,0,0,99,8.31,0,64,23,34,38,42,44,50,2329.19,1136.52
+API with 8 routes + Mediation policy,500,4756.01,104.95,3992549,0,0,499,19.2,0,245,113,131,143,153,160,179,2222.78,1083.34
+API with 8 routes + Mediation policy,800,4566.6,174.97,3834296,0,0,799,30.18,1,384,194,210,225,247,259,293,2135.06,1040.2
+API with 8 routes + Mediation policy,1000,4588.9,217.79,3852982,0,0,999,42.21,3,507,246,279,293,309,321,367,2145.58,1045.27


### PR DESCRIPTION
## Purpose

This PR adds performance test results for API Gateway 1.1.0. It includes results for both 2 CPU and 4 CPU allocation scenarios.