### PR TITLE
Add api details to apikey updated webhook event

### DIFF
--- a/portals/developer-portal/docs/administer/webhook-integration.md
+++ b/portals/developer-portal/docs/administer/webhook-integration.md
@@ -249,6 +249,12 @@ Fired whenever a single key's application association changes: the key is associ
   "encrypted_fields": [],
   "data": {
     "key_id": "key-uuid",
+    "name": "my-key",
+    "api": {
+      "name": "Order API",
+      "version": "v1.0",
+      "ref_id": "cp-api-uuid"
+    },
     "application": {
       "id": "app-uuid",
       "name": "My App"
@@ -258,6 +264,7 @@ Fired whenever a single key's application association changes: the key is associ
 ```
 
 - `application` is `null` when the key's association was removed, or when the key's app was deleted
+- `api` is `null` if the key's API metadata is unavailable (should not occur in normal operation)
 - Renaming an app fires this event once per key currently associated with it, each with the app's new `name`
 - Deleting an app fires this event once per key currently associated with it, each with `application: null` — there is no separate "deleted" variant
 

--- a/portals/developer-portal/docs/administer/webhook-integration.md
+++ b/portals/developer-portal/docs/administer/webhook-integration.md
@@ -264,7 +264,6 @@ Fired whenever a single key's application association changes: the key is associ
 ```
 
 - `application` is `null` when the key's association was removed, or when the key's app was deleted
-- `api` is `null` if the key's API metadata is unavailable (should not occur in normal operation)
 - Renaming an app fires this event once per key currently associated with it, each with the app's new `name`
 - Deleting an app fires this event once per key currently associated with it, each with `application: null` — there is no separate "deleted" variant
 

--- a/portals/developer-portal/src/controllers/devportalController.js
+++ b/portals/developer-portal/src/controllers/devportalController.js
@@ -161,9 +161,7 @@ const publishApplicationDeletedEvents = async (orgId, applicationId, appToDelete
             }
             for (const key of affectedKeys) {
                 const meta = key.dp_api_metadata;
-                const api = meta
-                    ? { name: meta.name || null, version: meta.version || null, ref_id: meta.ref_id || '' }
-                    : null;
+                const api = { name: meta.name || null, version: meta.version || null, ref_id: meta.ref_id || '' };
                 await apiKeyService.publishKeyApplicationUpdated(orgId, key.uuid, key.name, api, null, t);
             }
         });

--- a/portals/developer-portal/src/controllers/devportalController.js
+++ b/portals/developer-portal/src/controllers/devportalController.js
@@ -150,7 +150,7 @@ const revokeAppKeyMappings = async (orgId, appId) => {
  * previously-associated key. Must be called only after the application row (and its
  * app_uuid references) have actually been deleted — best-effort, never throws.
  */
-const publishApplicationDeletedEvents = async (orgId, applicationId, appToDelete, affectedKeyIds) => {
+const publishApplicationDeletedEvents = async (orgId, applicationId, appToDelete, affectedKeys) => {
     try {
         await sequelize.transaction(async (t) => {
             if (appToDelete) {
@@ -159,8 +159,12 @@ const publishApplicationDeletedEvents = async (orgId, applicationId, appToDelete
                     { transaction: t, orgId: orgId, aggregateType: 'application', aggregateId: applicationId }
                 );
             }
-            for (const keyId of affectedKeyIds) {
-                await apiKeyService.publishKeyApplicationUpdated(orgId, keyId, null, t);
+            for (const key of affectedKeys) {
+                const meta = key.dp_api_metadata;
+                const api = meta
+                    ? { name: meta.name || null, version: meta.version || null, ref_id: meta.ref_id || '' }
+                    : null;
+                await apiKeyService.publishKeyApplicationUpdated(orgId, key.uuid, key.name, api, null, t);
             }
         });
     } catch (pubErr) {
@@ -169,20 +173,19 @@ const publishApplicationDeletedEvents = async (orgId, applicationId, appToDelete
 };
 
 /**
- * Snapshots the app name + currently-associated key IDs and deletes the application row,
+ * Snapshots the app name + currently-associated keys and deletes the application row,
  * all inside one transaction — so the snapshot exactly matches what's actually deleted,
  * with no race window for a concurrent associate/dissociate call to go unnoticed.
  */
 const deleteApplicationAndSnapshotKeys = async (orgId, applicationId, userId) => {
     let appToDelete = null;
-    let affectedKeyIds = [];
+    let affectedKeys = [];
     await sequelize.transaction(async (t) => {
         appToDelete = await appDao.get(orgId, applicationId, userId, t);
-        const associatedKeys = await apiKeyService.list(orgId, { appId: applicationId }, t);
-        affectedKeyIds = associatedKeys.map((k) => k.uuid);
+        affectedKeys = await apiKeyService.list(orgId, { appId: applicationId }, t);
         await appDao.delete(orgId, applicationId, userId, t);
     });
-    return { appToDelete, affectedKeyIds };
+    return { appToDelete, affectedKeys };
 };
 
 const getApplication = async (req, res) => {
@@ -212,16 +215,16 @@ const deleteApplication = async (req, res) => {
         }
         try {
             await revokeAppKeyMappings(orgId, applicationId);
-            const { appToDelete, affectedKeyIds } = await deleteApplicationAndSnapshotKeys(orgId, applicationId, userId);
+            const { appToDelete, affectedKeys } = await deleteApplicationAndSnapshotKeys(orgId, applicationId, userId);
             trackAppDeletion({ orgId: orgId, appId: applicationId, idpId: userId }, req);
-            await publishApplicationDeletedEvents(orgId, applicationId, appToDelete, affectedKeyIds);
+            await publishApplicationDeletedEvents(orgId, applicationId, appToDelete, affectedKeys);
             res.status(200).send("Resource Deleted Successfully");
         } catch (error) {
             if (error.statusCode === 404) {
                 await revokeAppKeyMappings(orgId, applicationId);
-                const { appToDelete, affectedKeyIds } = await deleteApplicationAndSnapshotKeys(orgId, applicationId, userId);
+                const { appToDelete, affectedKeys } = await deleteApplicationAndSnapshotKeys(orgId, applicationId, userId);
                 trackAppDeletion({ orgId: orgId, appId: applicationId, idpId: userId }, req);
-                await publishApplicationDeletedEvents(orgId, applicationId, appToDelete, affectedKeyIds);
+                await publishApplicationDeletedEvents(orgId, applicationId, appToDelete, affectedKeys);
                 return res.status(200).send("Resource Deleted Successfully");
             }
             logger.error('Error occurred while deleting the application', { orgId: orgId, appId: applicationId, error: error.message, stack: error.stack });

--- a/portals/developer-portal/src/dao/apiKeyDao.js
+++ b/portals/developer-portal/src/dao/apiKeyDao.js
@@ -24,7 +24,7 @@ const constants = require('../utils/constants');
 
 const API_METADATA_INCLUDE = {
     model: APIMetadata,
-    attributes: ['uuid', 'name', 'version', 'handle']
+    attributes: ['uuid', 'name', 'version', 'handle', 'ref_id']
 };
 
 function appMappingInclude(required = false, appId = null) {

--- a/portals/developer-portal/src/services/apiKeyService.js
+++ b/portals/developer-portal/src/services/apiKeyService.js
@@ -141,9 +141,7 @@ async function notifyApplicationKeysChanged(orgId, appId, application, transacti
     const keys = await apiKeyDao.list(orgId, { appId }, transaction);
     for (const key of keys) {
         const meta = key.dp_api_metadata;
-        const api = meta
-            ? { name: meta.name || null, version: meta.version || null, ref_id: meta.ref_id || '' }
-            : null;
+        const api = { name: meta.name || null, version: meta.version || null, ref_id: meta.ref_id || '' };
         await publishKeyApplicationUpdated(orgId, key.uuid, key.name, api, application, transaction);
     }
 }
@@ -306,9 +304,7 @@ async function associateApplication({ orgId, apiId, keyId, appId, actor }) {
         if (!updated) throw Object.assign(new Error('API key not found'), { status: 404 });
 
         const meta = existing.dp_api_metadata;
-        const api = meta
-            ? { name: meta.name || null, version: meta.version || null, ref_id: meta.ref_id || '' }
-            : null;
+        const api = { name: meta.name || null, version: meta.version || null, ref_id: meta.ref_id || '' };
         await publishKeyApplicationUpdated(orgId, keyId, existing.name, api, application, t);
     });
 
@@ -332,9 +328,7 @@ async function removeApplicationAssociation({ orgId, apiId, keyId, actor }) {
     await sequelize.transaction(async (t) => {
         await apiKeyDao.setApplication(orgId, keyId, null, actor, t);
         const meta = existing.dp_api_metadata;
-        const api = meta
-            ? { name: meta.name || null, version: meta.version || null, ref_id: meta.ref_id || '' }
-            : null;
+        const api = { name: meta.name || null, version: meta.version || null, ref_id: meta.ref_id || '' };
         await publishKeyApplicationUpdated(orgId, keyId, existing.name, api, null, t);
     });
 

--- a/portals/developer-portal/src/services/apiKeyService.js
+++ b/portals/developer-portal/src/services/apiKeyService.js
@@ -121,12 +121,12 @@ function applicationOf(key) {
 }
 
 /**
- * Publish apikey.application_updated for a single key — { key_id, application }.
+ * Publish apikey.application_updated for a single key — { key_id, name, api, application }.
  * `application` is { id, name } when associated, or null when cleared.
  */
-async function publishKeyApplicationUpdated(orgId, keyId, application, transaction) {
+async function publishKeyApplicationUpdated(orgId, keyId, name, api, application, transaction) {
     await publish('apikey.application_updated',
-        { key_id: keyId, application },
+        { key_id: keyId, name, api, application },
         { transaction, orgId, aggregateType: 'apikey', aggregateId: keyId }
     );
 }
@@ -140,7 +140,11 @@ async function notifyApplicationKeysChanged(orgId, appId, application, transacti
     if (!appId) return;
     const keys = await apiKeyDao.list(orgId, { appId }, transaction);
     for (const key of keys) {
-        await publishKeyApplicationUpdated(orgId, key.uuid, application, transaction);
+        const meta = key.dp_api_metadata;
+        const api = meta
+            ? { name: meta.name || null, version: meta.version || null, ref_id: meta.ref_id || '' }
+            : null;
+        await publishKeyApplicationUpdated(orgId, key.uuid, key.name, api, application, transaction);
     }
 }
 
@@ -189,7 +193,9 @@ async function generate({ orgId, apiId, subscriptionId, appId, name, expiresAt, 
             );
 
             if (application) {
-                await publishKeyApplicationUpdated(orgId, keyId, application, t);
+                await publishKeyApplicationUpdated(orgId, keyId, normalizedName,
+                    { name: api.name, version: api.version, ref_id: api.refId },
+                    application, t);
             }
         });
     } catch (err) {
@@ -299,7 +305,11 @@ async function associateApplication({ orgId, apiId, keyId, appId, actor }) {
         const updated = await apiKeyDao.setApplication(orgId, keyId, application.id, actor, t, { activeOnly: true });
         if (!updated) throw Object.assign(new Error('API key not found'), { status: 404 });
 
-        await publishKeyApplicationUpdated(orgId, keyId, application, t);
+        const meta = existing.dp_api_metadata;
+        const api = meta
+            ? { name: meta.name || null, version: meta.version || null, ref_id: meta.ref_id || '' }
+            : null;
+        await publishKeyApplicationUpdated(orgId, keyId, existing.name, api, application, t);
     });
 
     logger.info('API key associated to application', { keyId, orgId, appId: application.id, actor });
@@ -321,7 +331,11 @@ async function removeApplicationAssociation({ orgId, apiId, keyId, actor }) {
 
     await sequelize.transaction(async (t) => {
         await apiKeyDao.setApplication(orgId, keyId, null, actor, t);
-        await publishKeyApplicationUpdated(orgId, keyId, null, t);
+        const meta = existing.dp_api_metadata;
+        const api = meta
+            ? { name: meta.name || null, version: meta.version || null, ref_id: meta.ref_id || '' }
+            : null;
+        await publishKeyApplicationUpdated(orgId, keyId, existing.name, api, null, t);
     });
 
     logger.info('API key application association removed', { keyId, orgId, actor });


### PR DESCRIPTION
## Purpose
$subject

## Approach
Updated the apikey.application_updated event payload:

Example:
```
{
  "event_type": "apikey.application_updated",
  "encrypted_fields": [],
  "data": {
    "key_id": "7f3a1c2d-4e5b-6f7a-8b9c-0d1e2f3a4b5c",
    "name": "my-prod-key",
    "api": {
      "name": "Order API",
      "version": "v1.0",
      "ref_id": "cp-api-uuid"
    },
    "application": {
      "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
      "name": "My App"
    }
  }
}
```

