### PR TITLE
chore(helm): bump gateway chart version to 1.1.3

### DIFF
--- a/kubernetes/helm/gateway-helm-chart/Chart.yaml
+++ b/kubernetes/helm/gateway-helm-chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: gateway
 kubeVersion: ">=1.24.0-0"
 description: Helm chart for deploying the Gateway Operator components
-version: 1.1.2
+version: 1.1.3
 appVersion: "1.1.0"
 type: application
 home: https://github.com/wso2/api-platform


### PR DESCRIPTION
## Purpose

Patch release of the gateway Helm chart to publish version 1.1.3. The chart version was at 1.1.2 and needed a bump to cut a new chart release.

## Approach

- Bump `version` in `kubernetes/helm/gateway-helm-chart/Chart.yaml` from `1.1.2` to `1.1.3`
- No changes to `appVersion` (remains `1.1.0`) or image tags

## Related Issues

N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes