### PR TITLE
Add Readonly mode in AI Workspace for DP origin artifacts

### DIFF
--- a/portals/ai-workspace/src/Components/GatewayDeploy/GatewayDeployCardActions.tsx
+++ b/portals/ai-workspace/src/Components/GatewayDeploy/GatewayDeployCardActions.tsx
@@ -36,6 +36,7 @@ export default function GatewayDeployCardActions({
     deployingGatewayId,
     isDeployingToGateway,
     isLoadingDeployments,
+    readOnly,
   } = useGatewayDeploy();
 
   const [deployMenuAnchor, setDeployMenuAnchor] = useState<null | HTMLElement>(null);
@@ -53,7 +54,8 @@ export default function GatewayDeployCardActions({
     }
   };
 
-  const isButtonDisabled = disabled || isDeployingToGateway || isLoadingDeployments;
+  const isButtonDisabled =
+    disabled || readOnly || isDeployingToGateway || isLoadingDeployments;
 
   // If no onConfigureAndDeploy callback, show simple button
   if (!onConfigureAndDeploy) {

--- a/portals/ai-workspace/src/Components/GatewayDeploy/GatewayDeployEnvCard.tsx
+++ b/portals/ai-workspace/src/Components/GatewayDeploy/GatewayDeployEnvCard.tsx
@@ -44,6 +44,7 @@ export default function GatewayDeployEnvCard({
     deployingGatewayId,
     isDeployingToGateway,
     isPollingGateway,
+    readOnly,
   } = useGatewayDeploy();
 
   const isThisGatewayDeploying = deployingGatewayId === gateway.id;
@@ -176,7 +177,7 @@ export default function GatewayDeployEnvCard({
             color="error"
             size="small"
             onClick={handleUndeploy}
-            disabled={!isGatewayActive || isDeployingToGateway || isPolling}
+            disabled={readOnly || !isGatewayActive || isDeployingToGateway || isPolling}
           >
             {isThisGatewayDeploying ? 'Stopping...' : 'Stop'}
           </Button>
@@ -207,7 +208,7 @@ export default function GatewayDeployEnvCard({
             color="primary"
             size="small"
             onClick={handleRedeploy}
-            disabled={!isGatewayActive || isDeployingToGateway || isPolling}
+            disabled={readOnly || !isGatewayActive || isDeployingToGateway || isPolling}
           >
             Re-deploy
           </Button>
@@ -218,7 +219,7 @@ export default function GatewayDeployEnvCard({
             color="primary"
             size="small"
             onClick={handleRedeploy}
-            disabled={!isGatewayActive || isDeployingToGateway || isPolling}
+            disabled={readOnly || !isGatewayActive || isDeployingToGateway || isPolling}
           >
             {isThisGatewayDeploying ? 'Redeploying...' : 'Redeploy'}
           </Button>

--- a/portals/ai-workspace/src/Components/GatewayDeploy/GatewayDeploymentSelector.tsx
+++ b/portals/ai-workspace/src/Components/GatewayDeploy/GatewayDeploymentSelector.tsx
@@ -42,7 +42,7 @@ export default function GatewayDeploymentSelector({
   open,
   onClose,
 }: GatewayDeploymentSelectorProps) {
-  const { deployments, redeployDeployment, isDeployingToGateway } =
+  const { deployments, redeployDeployment, isDeployingToGateway, readOnly } =
     useGatewayDeploy();
 
   const [selectedDeploymentId, setSelectedDeploymentId] = useState<
@@ -271,7 +271,7 @@ export default function GatewayDeploymentSelector({
             variant="contained"
             color="primary"
             onClick={handleRestore}
-            disabled={!canRestore}
+            disabled={readOnly || !canRestore}
             startIcon={
               isRestoring ? (
                 <CircularProgress size={16} color="inherit" />

--- a/portals/ai-workspace/src/contexts/GatewayDeployContext.tsx
+++ b/portals/ai-workspace/src/contexts/GatewayDeployContext.tsx
@@ -142,6 +142,13 @@ interface GatewayDeployContextValue {
   deployingGatewayId: string | null;
   isDeployingToGateway: boolean;
   isPollingGateway: (gatewayId: string) => boolean;
+
+  /**
+   * When true, the artifact is read-only (e.g. gateway-originated): its deployment
+   * lifecycle is owned by the gateway. The deployments remain viewable, but deploy/
+   * redeploy/restore/undeploy actions are disabled.
+   */
+  readOnly: boolean;
 }
 
 const GatewayDeployContext = createContext<GatewayDeployContextValue | null>(
@@ -151,12 +158,15 @@ const GatewayDeployContext = createContext<GatewayDeployContextValue | null>(
 interface GatewayDeployProviderProps {
   apiId: string;
   resourceType?: GatewayDeployResourceType;
+  /** Disable deploy/redeploy/restore/undeploy actions while keeping deployments visible. */
+  readOnly?: boolean;
   children: ReactNode;
 }
 
 export function GatewayDeployProvider({
   apiId,
   resourceType = 'provider',
+  readOnly = false,
   children,
 }: GatewayDeployProviderProps) {
   const { currentOrganization } = useAppShell();
@@ -661,6 +671,7 @@ export function GatewayDeployProvider({
       deployingGatewayId,
       isDeployingToGateway,
       isPollingGateway,
+      readOnly,
     }),
     [
       gateways,
@@ -678,6 +689,7 @@ export function GatewayDeployProvider({
       deployingGatewayId,
       isDeployingToGateway,
       isPollingGateway,
+      readOnly,
     ]
   );
 

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/EditExternalServer.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/EditExternalServer.tsx
@@ -112,6 +112,7 @@ export default function EditExternalServer() {
   const [version, setVersion] = useState('');
   const [context, setContext] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const isReadOnlyServer = Boolean(server?.readOnly);
 
   useEffect(() => {
     if (!serverId || !organizationId) return;
@@ -158,6 +159,9 @@ export default function EditExternalServer() {
   };
 
   const handleSubmit = async () => {
+    // Allowed even for gateway-created MCP proxies: name/version/context stay locked
+    // (part of the runtime artifact), so only the description can change, which the
+    // control plane accepts without altering the gateway runtime artifact.
     if (!serverId || !server) return;
 
     setIsSubmitting(true);
@@ -256,6 +260,13 @@ export default function EditExternalServer() {
 
         <Box sx={{ mb: 4 }}>
           <Stack spacing={3}>
+            {isReadOnlyServer ? (
+              <Alert severity="info">
+                This MCP proxy was created from a gateway. The name, version and
+                context are part of the gateway runtime configuration and are
+                read-only here; only the description can be edited.
+              </Alert>
+            ) : null}
             {isContextOrVersionChanged && (
               <Alert severity="warning">
                 You have modified the context or version of this MCP Proxy.
@@ -270,6 +281,7 @@ export default function EditExternalServer() {
                   fullWidth
                   required
                   value={name}
+                  disabled={isReadOnlyServer}
                   onChange={(e) => setName(e.target.value)}
                   placeholder="Enter server name"
                   error={name.length > MAX_NAME_LENGTH}
@@ -286,6 +298,7 @@ export default function EditExternalServer() {
                 <TextField
                   fullWidth
                   value={version}
+                  disabled={isReadOnlyServer}
                   onChange={(e) => setVersion(e.target.value)}
                   placeholder="e.g., 1.0"
                   error={version.length > MAX_VERSION_LENGTH}
@@ -321,6 +334,7 @@ export default function EditExternalServer() {
               <TextField
                 fullWidth
                 value={context}
+                disabled={isReadOnlyServer}
                 onChange={(e) => setContext(e.target.value)}
                 placeholder="Enter context path"
                 error={context.length > MAX_CONTEXT_LENGTH}

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/ExternalServersDeploy.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/ExternalServersDeploy.tsx
@@ -19,6 +19,7 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
+  Alert,
   Button,
   PageContent,
   Stack,
@@ -39,30 +40,16 @@ import ExternalServerStepBanner from '../quickStart/ExternalServerStepBanner';
 import type { ExternalServerStepBannerStepId } from '../quickStart/ExternalServerStepBanner';
 
 type ExternalServersDeployLayoutProps = {
-  serverId: string;
+  server: MCPServer | null;
 };
 
-function ExternalServersDeployLayout({ serverId }: ExternalServersDeployLayoutProps) {
+function ExternalServersDeployLayout({ server }: ExternalServersDeployLayoutProps) {
   const navigate = useNavigate();
   const { deployments } = useGatewayDeploy();
-  const { currentOrganization } = useAppShell();
-  const organizationId = currentOrganization?.uuid ?? '';
-  const apimBaseUrl = PLATFORM_API_BASE_URL;
-
-  const [server, setServer] = useState<MCPServer | null>(null);
-
-  useEffect(() => {
-    if (!serverId || !organizationId) return;
-    let cancelled = false;
-    mcpProxiesApis
-      .getMCPServer(serverId, apimBaseUrl)
-      .then((res) => { if (!cancelled) setServer(res); })
-      .catch(() => {});
-    return () => { cancelled = true; };
-  }, [serverId, organizationId, apimBaseUrl]);
 
   const hasDeployments = (deployments?.list ?? []).some((d) => d.status === 'DEPLOYED');
   const hasPolicies = (server?.policies?.length ?? 0) > 0;
+  const isReadOnly = Boolean(server?.readOnly);
 
   const handleStepClick = (stepId: ExternalServerStepBannerStepId) => {
     if (stepId === 'add-policies') {
@@ -99,6 +86,13 @@ function ExternalServersDeployLayout({ serverId }: ExternalServersDeployLayoutPr
             defaultMessage="Deploy MCP Proxy to your Gateways"
           />
         </Typography>
+        {isReadOnly && (
+          <Alert severity="info">
+            This MCP proxy was created from a gateway. You can view its
+            deployments, but deploy, redeploy, restore and undeploy actions are
+            managed by the gateway and are unavailable in AI Workspace.
+          </Alert>
+        )}
         <GatewayDeployMainSection showConfigureOption={false} />
       </Stack>
     </PageContent>
@@ -107,6 +101,21 @@ function ExternalServersDeployLayout({ serverId }: ExternalServersDeployLayoutPr
 
 export default function ExternalServersDeploy() {
   const { serverId } = useParams<{ serverId: string }>();
+  const { currentOrganization } = useAppShell();
+  const organizationId = currentOrganization?.uuid ?? '';
+  const apimBaseUrl = PLATFORM_API_BASE_URL;
+
+  const [server, setServer] = useState<MCPServer | null>(null);
+
+  useEffect(() => {
+    if (!serverId || !organizationId) return;
+    let cancelled = false;
+    mcpProxiesApis
+      .getMCPServer(serverId, PLATFORM_API_BASE_URL)
+      .then((res) => { if (!cancelled) setServer(res); })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, [serverId, organizationId, apimBaseUrl]);
 
   if (!serverId) {
     return (
@@ -122,8 +131,12 @@ export default function ExternalServersDeploy() {
   }
 
   return (
-    <GatewayDeployProvider apiId={serverId} resourceType="mcp-server">
-      <ExternalServersDeployLayout serverId={serverId} />
+    <GatewayDeployProvider
+      apiId={serverId}
+      resourceType="mcp-server"
+      readOnly={Boolean(server?.readOnly)}
+    >
+      <ExternalServersDeployLayout server={server} />
     </GatewayDeployProvider>
   );
 }

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/ExternalServersDeploy.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/ExternalServersDeploy.tsx
@@ -21,6 +21,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import {
   Alert,
   Button,
+  CircularProgress,
   PageContent,
   Stack,
   Typography,
@@ -106,14 +107,19 @@ export default function ExternalServersDeploy() {
   const apimBaseUrl = PLATFORM_API_BASE_URL;
 
   const [server, setServer] = useState<MCPServer | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
 
   useEffect(() => {
     if (!serverId || !organizationId) return;
     let cancelled = false;
+    setLoading(true);
+    setError(false);
     mcpProxiesApis
       .getMCPServer(serverId, PLATFORM_API_BASE_URL)
       .then((res) => { if (!cancelled) setServer(res); })
-      .catch(() => {});
+      .catch(() => { if (!cancelled) setError(true); })
+      .finally(() => { if (!cancelled) setLoading(false); });
     return () => { cancelled = true; };
   }, [serverId, organizationId, apimBaseUrl]);
 
@@ -130,11 +136,38 @@ export default function ExternalServersDeploy() {
     );
   }
 
+  if (loading) {
+    return (
+      <PageContent fullWidth>
+        <Stack alignItems="center" sx={{ py: 6 }}>
+          <CircularProgress />
+        </Stack>
+      </PageContent>
+    );
+  }
+
+  // A failed or empty fetch must NOT fall back to a writable deploy UI: the
+  // read-only guard is derived from the server, so rendering the deploy actions
+  // without a resolved server would expose deploy/undeploy on a gateway-managed
+  // (read-only) proxy. Show an error instead and gate the writable UI entirely.
+  if (error || !server) {
+    return (
+      <PageContent fullWidth>
+        <Alert severity="error">
+          <FormattedMessage
+            id="aiWorkspace.pages.appShell.appShellPages.externalServers.deploy.failed.to.load.server"
+            defaultMessage="Failed to load the MCP proxy. Please try again."
+          />
+        </Alert>
+      </PageContent>
+    );
+  }
+
   return (
     <GatewayDeployProvider
       apiId={serverId}
       resourceType="mcp-server"
-      readOnly={Boolean(server?.readOnly)}
+      readOnly={Boolean(server.readOnly)}
     >
       <ExternalServersDeployLayout server={server} />
     </GatewayDeployProvider>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/ExternalServersOverview.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/ExternalServersOverview.tsx
@@ -72,6 +72,9 @@ import ExternalServersValidationDetails from './ExternalServersValidationDetails
 import type { EndpointValidationResponse } from './externalServersValidationTypes';
 import ExternalServerStepBanner from '../quickStart/ExternalServerStepBanner';
 import type { ExternalServerStepBannerStepId } from '../quickStart/ExternalServerStepBanner';
+import {
+  GatewayArtifactReadOnlyBanner,
+} from '../../../../utils/readOnlyArtifacts';
 
 function getInitials(name: string): string {
   const words = name.trim().split(/\s+/);
@@ -196,6 +199,7 @@ export default function ExternalServersOverview(): JSX.Element {
   const [selectedPolicies, setSelectedPolicies] = useState<SelectedPolicy[]>(
     []
   );
+  const isReadOnlyServer = Boolean(server?.readOnly);
 
   const selectedPoliciesRef = useRef<SelectedPolicy[]>([]);
   const [initialPolicies, setInitialPolicies] = useState<SelectedPolicy[]>([]);
@@ -429,11 +433,12 @@ export default function ExternalServersOverview(): JSX.Element {
   }, [selectedPolicies, initialPolicies]);
 
   const handleCancelChanges = () => {
+    if (isReadOnlyServer) return;
     updateSelectedPolicies(initialPolicies);
   };
 
   const handleSaveChanges = async () => {
-    if (!server || !organizationId) return;
+    if (!server || !organizationId || isReadOnlyServer) return;
     const orderedPolicies = selectedPoliciesRef.current;
 
     // Convert selectedPolicies -> flat policy payload (preserve current UI order)
@@ -486,6 +491,7 @@ export default function ExternalServersOverview(): JSX.Element {
   };
 
   const handleAddPolicy = (policy: Omit<SelectedPolicy, 'instanceId'>) => {
+    if (isReadOnlyServer) return;
     const nextItem: SelectedPolicy = {
       instanceId: `${policy.policyId}-${Date.now()}`,
       ...policy,
@@ -495,6 +501,7 @@ export default function ExternalServersOverview(): JSX.Element {
   };
 
   const handleUpdatePolicy = (instanceId: string, params: ParameterValues) => {
+    if (isReadOnlyServer) return;
     updateSelectedPolicies((prev) =>
       prev.map((policy) =>
         policy.instanceId === instanceId ? { ...policy, params } : policy
@@ -503,6 +510,7 @@ export default function ExternalServersOverview(): JSX.Element {
   };
 
   const handleRemovePolicy = (instanceId: string) => {
+    if (isReadOnlyServer) return;
     updateSelectedPolicies((prev) =>
       prev.filter((policy) => policy.instanceId !== instanceId)
     );
@@ -512,6 +520,7 @@ export default function ExternalServersOverview(): JSX.Element {
     draggedInstanceId: string,
     targetInstanceId: string
   ) => {
+    if (isReadOnlyServer) return;
     updateSelectedPolicies((prev) => {
       const draggedIndex = prev.findIndex(
         (policy) => policy.instanceId === draggedInstanceId
@@ -652,8 +661,15 @@ export default function ExternalServersOverview(): JSX.Element {
                     variant="outlined"
                     color="primary"
                   />
+                  {/* Edit page (name/version/context/description). Enabled even for
+                      gateway-created MCP proxies — the page keeps the runtime fields
+                      read-only and allows only the description. */}
                   <Tooltip title="Edit MCP Proxy">
-                    <IconButton component={RouterLink} to="edit" size="small">
+                    <IconButton
+                      component={RouterLink}
+                      to="edit"
+                      size="small"
+                    >
                       <Edit size={16} />
                     </IconButton>
                   </Tooltip>
@@ -692,16 +708,26 @@ export default function ExternalServersOverview(): JSX.Element {
               spacing={1}
               sx={{ alignSelf: 'flex-start', ml: 'auto', gap: 1 }}
             >
+              {/* For gateway-created (read-only) proxies the deployments remain viewable
+                  (deploy/redeploy/restore/undeploy are disabled on the page itself), so
+                  the button navigates but is relabelled "View Deployments". */}
               <Button
                 variant="contained"
                 component={RouterLink}
                 to="deploy"
-                onClick={handleBlockedNavigation}
+                onClick={isReadOnlyServer ? undefined : handleBlockedNavigation}
               >
-                <FormattedMessage
-                  id="aiWorkspace.pages.appShell.appShellPages.externalServers.overview.deployToGateway"
-                  defaultMessage="Deploy to Gateway"
-                />
+                {isReadOnlyServer ? (
+                  <FormattedMessage
+                    id="aiWorkspace.pages.appShell.appShellPages.externalServers.overview.viewDeployments"
+                    defaultMessage="View Deployments"
+                  />
+                ) : (
+                  <FormattedMessage
+                    id="aiWorkspace.pages.appShell.appShellPages.externalServers.overview.deployToGateway"
+                    defaultMessage="Deploy to Gateway"
+                  />
+                )}
               </Button>
             </Stack>
           </Box>
@@ -830,6 +856,9 @@ export default function ExternalServersOverview(): JSX.Element {
             </TabPanel>
 
             <TabPanel value={tabIndex} index={1}>
+              {isReadOnlyServer && (
+                <GatewayArtifactReadOnlyBanner message="Policies are managed by the gateway that created this MCP proxy and are read-only here." />
+              )}
               <PolicyMapper
                 selectedPolicies={selectedPolicies}
                 onAddPolicy={handleAddPolicy}
@@ -837,6 +866,7 @@ export default function ExternalServersOverview(): JSX.Element {
                 onRemovePolicy={handleRemovePolicy}
                 onReorderPolicies={handleReorderPolicies}
                 validationResult={validationResult}
+                readOnly={isReadOnlyServer}
               />
             </TabPanel>
           </Box>
@@ -868,14 +898,18 @@ export default function ExternalServersOverview(): JSX.Element {
               <Button
                 variant="outlined"
                 color="secondary"
-                disabled={!hasUnsavedChanges || isSavingChanges}
+                disabled={
+                  isReadOnlyServer || !hasUnsavedChanges || isSavingChanges
+                }
                 onClick={handleCancelChanges}
               >
                 Cancel
               </Button>
               <Button
                 variant="contained"
-                disabled={!hasUnsavedChanges || isSavingChanges}
+                disabled={
+                  isReadOnlyServer || !hasUnsavedChanges || isSavingChanges
+                }
                 onClick={() => void handleSaveChanges()}
               >
                 {isSavingChanges ? 'Saving...' : 'Save'}

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/PolicyMapper.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/PolicyMapper.tsx
@@ -50,6 +50,10 @@ import { logger } from '../../../../utils/logger';
 import ErrorAlert from '../../../../Components/common/ErrorAlert';
 import ExternalServersValidationDetails from './ExternalServersValidationDetails';
 import type { EndpointValidationResponse } from './externalServersValidationTypes';
+import {
+  DisabledActionTooltip,
+  GATEWAY_MANAGED_ARTIFACT_TOOLTIP,
+} from '../../../../utils/readOnlyArtifacts';
 
 export type SelectedPolicy = {
   instanceId: string;
@@ -70,6 +74,7 @@ type Props = {
     targetInstanceId: string
   ) => void;
   validationResult?: EndpointValidationResponse | null;
+  readOnly?: boolean;
 };
 
 function DragHandle(): JSX.Element {
@@ -107,6 +112,7 @@ export default function PolicyMapper({
   onRemovePolicy,
   onReorderPolicies,
   validationResult,
+  readOnly = false,
 }: Props): JSX.Element {
   const intl = useIntl();
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
@@ -150,6 +156,7 @@ export default function PolicyMapper({
   }, [isDrawerOpen]);
 
   const handleOpenDrawer = async () => {
+    if (readOnly) return;
     setEditingInstanceId(null);
     setIsDrawerOpen(true);
     setIsFetchingPolicies(true);
@@ -165,6 +172,7 @@ export default function PolicyMapper({
   };
 
   const handleEditPolicyItem = async (item: SelectedPolicy) => {
+    if (readOnly) return;
     setEditingInstanceId(item.instanceId);
     setIsDrawerOpen(true);
     setIsFetchingPolicies(true);
@@ -210,6 +218,7 @@ export default function PolicyMapper({
   };
 
   const handlePolicyClick = async (policy: PolicyHubPolicy) => {
+    if (readOnly) return;
     setSelectedDrawerPolicy(policy.name);
     setIsDetailView(true);
     setPolicyDefinition(null);
@@ -244,6 +253,7 @@ export default function PolicyMapper({
   };
 
   const handlePolicySubmit = async (params: ParameterValues) => {
+    if (readOnly) return;
     const policy = fetchedPolicies.find((p) => p.name === selectedDrawerPolicy);
     if (!policy) return;
 
@@ -271,6 +281,11 @@ export default function PolicyMapper({
   const hasPolicies = selectedPolicies.length > 0;
 
   const handleDrop = (targetInstanceId: string) => {
+    if (readOnly) {
+      setDraggedInstanceId(null);
+      setDragOverInstanceId(null);
+      return;
+    }
     if (!draggedInstanceId || draggedInstanceId === targetInstanceId) {
       setDraggedInstanceId(null);
       setDragOverInstanceId(null);
@@ -312,17 +327,25 @@ export default function PolicyMapper({
                 </Typography>
               </Box>
               {hasPolicies && (
-                <Button
-                  variant="contained"
-                  onClick={() => void handleOpenDrawer()}
-                  startIcon={<Plus size={18} />}
-                  sx={{ whiteSpace: 'nowrap', flexShrink: 0, mt: 2 }}
+                <DisabledActionTooltip
+                  disabled={readOnly}
+                  title={GATEWAY_MANAGED_ARTIFACT_TOOLTIP}
                 >
-                  <FormattedMessage
-                    id="aiWorkspace.pages.appShell.appShellPages.externalServers.policyMapper.addPolicies"
-                    defaultMessage="Add Policies"
-                  />
-                </Button>
+                  <span>
+                    <Button
+                      variant="contained"
+                      onClick={() => void handleOpenDrawer()}
+                      startIcon={<Plus size={18} />}
+                      disabled={readOnly}
+                      sx={{ whiteSpace: 'nowrap', flexShrink: 0, mt: 2 }}
+                    >
+                      <FormattedMessage
+                        id="aiWorkspace.pages.appShell.appShellPages.externalServers.policyMapper.addPolicies"
+                        defaultMessage="Add Policies"
+                      />
+                    </Button>
+                  </span>
+                </DisabledActionTooltip>
               )}
             </Box>
 
@@ -351,16 +374,24 @@ export default function PolicyMapper({
                       defaultMessage="No policies added yet."
                     />
                   </Typography>
-                  <Button
-                    variant="contained"
-                    onClick={() => void handleOpenDrawer()}
-                    startIcon={<Plus size={18} />}
+                  <DisabledActionTooltip
+                    disabled={readOnly}
+                    title={GATEWAY_MANAGED_ARTIFACT_TOOLTIP}
                   >
-                    <FormattedMessage
-                      id="aiWorkspace.pages.appShell.appShellPages.externalServers.policyMapper.addPolicies"
-                      defaultMessage="Add Policies"
-                    />
-                  </Button>
+                    <span>
+                      <Button
+                        variant="contained"
+                        onClick={() => void handleOpenDrawer()}
+                        startIcon={<Plus size={18} />}
+                        disabled={readOnly}
+                      >
+                        <FormattedMessage
+                          id="aiWorkspace.pages.appShell.appShellPages.externalServers.policyMapper.addPolicies"
+                          defaultMessage="Add Policies"
+                        />
+                      </Button>
+                    </span>
+                  </DisabledActionTooltip>
                 </Stack>
               </Box>
             ) : (
@@ -371,19 +402,28 @@ export default function PolicyMapper({
                     draggedInstanceId !== item.instanceId;
 
                   return (
-                    <Box
+                    <DisabledActionTooltip
                       key={item.instanceId}
-                      draggable
-                      onDragStart={() => setDraggedInstanceId(item.instanceId)}
+                      disabled={readOnly}
+                      title={GATEWAY_MANAGED_ARTIFACT_TOOLTIP}
+                    >
+                      <Box
+                      key={item.instanceId}
+                      draggable={!readOnly}
+                      onDragStart={() =>
+                        !readOnly && setDraggedInstanceId(item.instanceId)
+                      }
                       onDragEnd={() => {
                         setDraggedInstanceId(null);
                         setDragOverInstanceId(null);
                       }}
                       onDragOver={(event: React.DragEvent) => {
+                        if (readOnly) return;
                         event.preventDefault();
                         setDragOverInstanceId(item.instanceId);
                       }}
                       onDrop={(event: React.DragEvent) => {
+                        if (readOnly) return;
                         event.preventDefault();
                         handleDrop(item.instanceId);
                       }}
@@ -404,14 +444,16 @@ export default function PolicyMapper({
                         boxShadow: isDragOver
                           ? '0 0 0 3px rgba(29, 78, 216, 0.12)'
                           : '0 1px 3px rgba(0, 0, 0, 0.04)',
-                        cursor: 'pointer',
+                        cursor: readOnly ? 'default' : 'pointer',
                         opacity:
                           draggedInstanceId === item.instanceId ? 0.5 : 1,
                         transition: 'all 0.15s ease',
-                        '&:hover': {
-                          borderColor: '#D1D5DB',
-                          boxShadow: '0 2px 6px rgba(0, 0, 0, 0.08)',
-                        },
+                        '&:hover': readOnly
+                          ? undefined
+                          : {
+                              borderColor: '#D1D5DB',
+                              boxShadow: '0 2px 6px rgba(0, 0, 0, 0.08)',
+                            },
                       }}
                     >
                       <DragHandle />
@@ -442,6 +484,7 @@ export default function PolicyMapper({
                           event.stopPropagation();
                           onRemovePolicy(item.instanceId);
                         }}
+                        disabled={readOnly}
                         sx={{
                           color: '#9CA3AF',
                           '&:hover': { color: '#EF4444' },
@@ -449,7 +492,8 @@ export default function PolicyMapper({
                       >
                         <X size={16} />
                       </IconButton>
-                    </Box>
+                      </Box>
+                    </DisabledActionTooltip>
                   );
                 })}
               </Stack>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/ProviderTemplateOverview.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/ProviderTemplateOverview.tsx
@@ -75,6 +75,7 @@ import type {
   UpdateProviderTemplateRequest,
 } from '../../../../utils/types';
 import { downloadTemplateYaml } from '../../../../utils/providerTemplateManifest';
+import { GatewayArtifactReadOnlyBanner } from '../../../../utils/readOnlyArtifacts';
 import SwaggerSpecViewer from '../../../../Components/SwaggerSpecViewer';
 import TemplateTokenMapping from './TemplateTokenMapping';
 
@@ -1024,17 +1025,7 @@ export default function ProviderTemplateOverview() {
 
             <TabPanel value={tabIndex} index={1}>
               {isDpOrigin && !isReadOnly && (
-                <Card sx={{ bgcolor: 'action.hover', mb: 2 }}>
-                  <Stack direction="row" spacing={1.5} alignItems="center" sx={{ p: 2 }}>
-                    <Lock size={18} />
-                    <Typography variant="body2">
-                      <strong>
-                        Connection settings are managed by the gateway that created this
-                        template and are read-only here.
-                      </strong>
-                    </Typography>
-                  </Stack>
-                </Card>
+                <GatewayArtifactReadOnlyBanner message="Connection settings are managed by the gateway that created this template and are read-only here." />
               )}
               <Box
                 sx={
@@ -1117,17 +1108,7 @@ export default function ProviderTemplateOverview() {
 
             <TabPanel value={tabIndex} index={2}>
               {isDpOrigin && !isReadOnly && (
-                <Card sx={{ bgcolor: 'action.hover', mb: 2 }}>
-                  <Stack direction="row" spacing={1.5} alignItems="center" sx={{ p: 2 }}>
-                    <Lock size={18} />
-                    <Typography variant="body2">
-                      <strong>
-                        Token mapping is managed by the gateway that created this template
-                        and is read-only here.
-                      </strong>
-                    </Typography>
-                  </Stack>
-                </Card>
+                <GatewayArtifactReadOnlyBanner message="Token mapping is managed by the gateway that created this template and is read-only here." />
               )}
               <Box
                 sx={

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/ProviderTemplateOverview.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/ProviderTemplateOverview.tsx
@@ -530,6 +530,13 @@ export default function ProviderTemplateOverview() {
   const isReadOnly = isBuiltIn;
   const canEdit = !isReadOnly;
   const canDelete = !isReadOnly;
+  // Data-plane-originated (gateway-pushed) template: the gateway owns the runtime
+  // configuration, so the Connection (endpoint/auth) and Token Mapping (extraction +
+  // resource mappings) sections are read-only in the control plane. Name/description/
+  // OpenAPI/logo stay editable, so the Update button remains active — the locked
+  // sections simply can't contribute a change.
+  const isDpOrigin = Boolean(template.readOnly);
+  const isSectionReadOnly = isReadOnly || isDpOrigin;
   const isEnabled = template.enabled !== false;
 
   const handleToggleEnabled = async (next: boolean) => {
@@ -1016,9 +1023,22 @@ export default function ProviderTemplateOverview() {
             </TabPanel>
 
             <TabPanel value={tabIndex} index={1}>
+              {isDpOrigin && !isReadOnly && (
+                <Card sx={{ bgcolor: 'action.hover', mb: 2 }}>
+                  <Stack direction="row" spacing={1.5} alignItems="center" sx={{ p: 2 }}>
+                    <Lock size={18} />
+                    <Typography variant="body2">
+                      <strong>
+                        Connection settings are managed by the gateway that created this
+                        template and are read-only here.
+                      </strong>
+                    </Typography>
+                  </Stack>
+                </Card>
+              )}
               <Box
                 sx={
-                  isReadOnly
+                  isSectionReadOnly
                     ? { pointerEvents: 'none', opacity: 0.7 }
                     : undefined
                 }
@@ -1096,9 +1116,22 @@ export default function ProviderTemplateOverview() {
             </TabPanel>
 
             <TabPanel value={tabIndex} index={2}>
+              {isDpOrigin && !isReadOnly && (
+                <Card sx={{ bgcolor: 'action.hover', mb: 2 }}>
+                  <Stack direction="row" spacing={1.5} alignItems="center" sx={{ p: 2 }}>
+                    <Lock size={18} />
+                    <Typography variant="body2">
+                      <strong>
+                        Token mapping is managed by the gateway that created this template
+                        and is read-only here.
+                      </strong>
+                    </Typography>
+                  </Stack>
+                </Card>
+              )}
               <Box
                 sx={
-                  isReadOnly
+                  isSectionReadOnly
                     ? { pointerEvents: 'none', opacity: 0.7 }
                     : undefined
                 }
@@ -1112,7 +1145,7 @@ export default function ProviderTemplateOverview() {
                     setIsDirty(true);
                   }}
                   spec={parsedSpec}
-                  hidePerResource={isReadOnly}
+                  hidePerResource={isSectionReadOnly}
                 />
               </Box>
             </TabPanel>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/EditLLMProxy.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/EditLLMProxy.tsx
@@ -50,6 +50,7 @@ function EditLLMProxyForm() {
   const { currentOrganization, currentProject } = useAppShell();
   const { proxy, isLoading, error, updateProxy } = useProxy();
   const showSnackbar = useAIWorkspaceSnackbar();
+  const isReadOnlyProxy = Boolean(proxy?.readOnly);
 
   const isProjectLevel = Boolean(currentProject?.id);
   const proxiesPath = isProjectLevel
@@ -85,6 +86,9 @@ function EditLLMProxyForm() {
   };
 
   const handleSubmit = async () => {
+    // Allowed even for gateway-created proxies: name/version/context stay locked
+    // (part of the runtime artifact), so only the description can change, which the
+    // control plane accepts without altering the gateway runtime artifact.
     if (!proxyId) return;
 
     setIsSubmitting(true);
@@ -177,6 +181,13 @@ function EditLLMProxyForm() {
 
         <Box sx={{ mb: 4 }}>
           <Stack spacing={3}>
+            {isReadOnlyProxy ? (
+              <Alert severity="info">
+                This proxy was created from a gateway. The name, version and
+                context are part of the gateway runtime configuration and are
+                read-only here; only the description can be edited.
+              </Alert>
+            ) : null}
             {isContextOrVersionChanged && (
               <Alert severity="warning">
                 You have modified the context or version of this proxy. After
@@ -191,6 +202,7 @@ function EditLLMProxyForm() {
                   fullWidth
                   required
                   value={name}
+                  disabled={isReadOnlyProxy}
                   onChange={(e) => setName(e.target.value)}
                   placeholder="Enter proxy name"
                   error={name.length > MAX_NAME_LENGTH}
@@ -207,6 +219,7 @@ function EditLLMProxyForm() {
                 <TextField
                   fullWidth
                   value={version}
+                  disabled={isReadOnlyProxy}
                   onChange={(e) => setVersion(e.target.value)}
                   placeholder="e.g., 1.0"
                   error={version.length > MAX_VERSION_LENGTH}
@@ -242,6 +255,7 @@ function EditLLMProxyForm() {
               <TextField
                 fullWidth
                 value={context}
+                disabled={isReadOnlyProxy}
                 onChange={(e) => setContext(e.target.value)}
                 placeholder="Enter context path"
                 error={context.length > MAX_CONTEXT_LENGTH}

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxiesList.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxiesList.tsx
@@ -63,8 +63,6 @@ import { FormattedMessage } from 'react-intl';
 import NoProxies from '../../../../assets/images/NoProxies.svg';
 import ErrorAlert from '../../../../Components/common/ErrorAlert';
 
-const MAX_LLM_PROXIES_PER_ORG = 5;
-
 function getHttpStatusCode(error?: Error | null): number | null {
   if (!error) return null;
 
@@ -182,9 +180,7 @@ export default function LLMProxiesList() {
     );
   };
 
-  const isProxyQuotaReached =
-    (proxiesResponse.count ?? proxiesResponse.list.length) >=
-    MAX_LLM_PROXIES_PER_ORG;
+  const isProxyQuotaReached = false;
   const proxyQuotaTooltip =
     'You cannot create more App LLM Proxies because your organization has reached the maximum limit of 5 proxies.';
   const createProxyButtonSx = {

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyDefinitionTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyDefinitionTab.tsx
@@ -156,6 +156,10 @@ export default function LLMProxyDefinitionTab() {
   const [isFetchingSpec, setIsFetchingSpec] = useState(false);
   const [updateSpecModalOpen, setUpdateSpecModalOpen] = useState(false);
   const showSnackbar = useAIWorkspaceSnackbar();
+  // The OpenAPI definition is control-plane-only metadata: it is NOT part of the
+  // gateway runtime artifact (the proxy deployment spec carries no OpenAPI), so it
+  // stays editable even for gateway-created (read-only) proxies.
+  const isReadOnlyProxy = false;
 
   useEffect(() => {
     setEditorText(proxy?.openapi || '');
@@ -178,15 +182,18 @@ export default function LLMProxyDefinitionTab() {
   const hasDefinition = editorText.trim().length > 0;
 
   const updateEditorText = (nextText: string) => {
+    if (isReadOnlyProxy) return;
     setEditorText(nextText);
     setLocalProxy((prev) => (prev ? { ...prev, openapi: nextText } : prev));
   };
 
   const handleUploadClick = () => {
+    if (isReadOnlyProxy) return;
     fileInputRef.current?.click();
   };
 
   const applySpecificationFromText = (text: string, sourceName?: string) => {
+    if (isReadOnlyProxy) return;
     const parsed = parseOpenApiSpec(text);
     const nextValidationError = validateOpenApiText(text, parsed);
     if (nextValidationError) {
@@ -202,6 +209,7 @@ export default function LLMProxyDefinitionTab() {
   };
 
   const handleFetchAndClose = async (url: string) => {
+    if (isReadOnlyProxy) return;
     const nextUrl = url.trim();
     if (!nextUrl) {
       showSnackbar('Enter a valid OpenAPI URL first.', 'error');
@@ -227,6 +235,7 @@ export default function LLMProxyDefinitionTab() {
   };
 
   const handleFileChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
+    if (isReadOnlyProxy) return;
     const file = e.target.files?.[0];
     if (!file) return;
 

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyDeploy.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyDeploy.tsx
@@ -18,15 +18,17 @@
 
 import React from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { Button, PageContent, Stack, Typography } from '@wso2/oxygen-ui';
+import { Alert, Button, PageContent, Stack, Typography } from '@wso2/oxygen-ui';
 import { ChevronLeft } from '@wso2/oxygen-ui-icons-react';
 import { GatewayDeployProvider } from '../../../../contexts/GatewayDeployContext';
 import { GatewayDeployMainSection } from '../../../../Components/GatewayDeploy';
 import { FormattedMessage } from 'react-intl';
+import { ProxyProvider, useProxy } from '../../../../contexts/proxy';
 
 function LLMProxyDeployContent() {
   const { proxyId } = useParams<{ proxyId: string }>();
   const navigate = useNavigate();
+  const { proxy } = useProxy();
 
   if (!proxyId) {
     return (
@@ -51,7 +53,11 @@ function LLMProxyDeployContent() {
         Back to App LLM Proxy
       </Button>
 
-      <GatewayDeployProvider apiId={proxyId} resourceType="proxy">
+      <GatewayDeployProvider
+        apiId={proxyId}
+        resourceType="proxy"
+        readOnly={Boolean(proxy?.readOnly)}
+      >
         <Stack spacing={2} sx={{ mt: 2 }}>
           <Typography variant="h3">
             <FormattedMessage
@@ -65,6 +71,13 @@ function LLMProxyDeployContent() {
               defaultMessage={'Deploy App LLM Proxy to your Gateways'}
             />
           </Typography>
+          {proxy?.readOnly && (
+            <Alert severity="info">
+              This proxy was created from a gateway. You can view its deployments,
+              but deploy, redeploy, restore and undeploy actions are managed by the
+              gateway and are unavailable in AI Workspace.
+            </Alert>
+          )}
           <GatewayDeployMainSection showConfigureOption={false} />
         </Stack>
       </GatewayDeployProvider>
@@ -88,5 +101,9 @@ export default function LLMProxyDeploy() {
     );
   }
 
-  return <LLMProxyDeployContent />;
+  return (
+    <ProxyProvider proxyId={proxyId}>
+      <LLMProxyDeployContent />
+    </ProxyProvider>
+  );
 }

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyDeploymentsCard.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyDeploymentsCard.tsx
@@ -51,6 +51,10 @@ import { logger } from '../../../../utils/logger';
 import type { Gateway } from '../../../../apis/gatewayTypes';
 import type { DeploymentResponse } from '../../../../utils/types';
 import { FormattedMessage } from 'react-intl';
+import {
+  DisabledActionTooltip,
+  GATEWAY_MANAGED_ARTIFACT_TOOLTIP,
+} from '../../../../utils/readOnlyArtifacts';
 
 interface GatewayWithDeployment extends Gateway {
   deployment?: DeploymentResponse;
@@ -66,6 +70,7 @@ export default function LLMProxyDeploymentsCard() {
   const [generatingKey, setGeneratingKey] = useState(false);
   const [generatedKey, setGeneratedKey] = useState<string | null>(null);
   const [keyError, setKeyError] = useState<string | null>(null);
+  const isReadOnlyProxy = Boolean(proxy?.readOnly);
   const apiKeyLocation = proxy?.security?.apiKey?.in ?? 'header';
   const apiKeyName = proxy?.security?.apiKey?.key ?? 'X-API-Key';
 
@@ -144,6 +149,7 @@ export default function LLMProxyDeploymentsCard() {
   }, [currentOrganization?.uuid, proxy?.id]);
 
   const handleGenerateAPIKey = async () => {
+    if (isReadOnlyProxy) return;
     if (!currentOrganization?.uuid || !proxy?.id) {
       return;
     }
@@ -367,41 +373,47 @@ export default function LLMProxyDeploymentsCard() {
                     />
                   </Typography>
                 </Box>
-                <Tooltip
-                  title={
-                    deployedGateways.length === 0
-                      ? 'No deployed gateways available. Deploy to a gateway first to generate an API key.'
-                      : ''
-                  }
-                  placement="top"
+                <DisabledActionTooltip
+                  disabled={isReadOnlyProxy}
+                  title={GATEWAY_MANAGED_ARTIFACT_TOOLTIP}
                 >
-                  <span>
-                    <Button
-                      variant="contained"
-                      size="medium"
-                      onClick={handleGenerateAPIKey}
-                      disabled={
-                        generatingKey ||
-                        deployedGateways.length === 0
-                      }
-                    >
-                      {generatingKey ? (
-                        <>
-                          <CircularProgress size={16} sx={{ mr: 1 }} />
+                  <Tooltip
+                    title={
+                      !isReadOnlyProxy && deployedGateways.length === 0
+                        ? 'No deployed gateways available. Deploy to a gateway first to generate an API key.'
+                        : ''
+                    }
+                    placement="top"
+                  >
+                    <span>
+                      <Button
+                        variant="contained"
+                        size="medium"
+                        onClick={handleGenerateAPIKey}
+                        disabled={
+                          isReadOnlyProxy ||
+                          generatingKey ||
+                          deployedGateways.length === 0
+                        }
+                      >
+                        {generatingKey ? (
+                          <>
+                            <CircularProgress size={16} sx={{ mr: 1 }} />
+                            <FormattedMessage
+                              id="aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxyDeploymentsCard.generating"
+                              defaultMessage={'Generating...'}
+                            />
+                          </>
+                        ) : (
                           <FormattedMessage
-                            id="aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxyDeploymentsCard.generating"
-                            defaultMessage={'Generating...'}
+                            id="aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxyDeploymentsCard.generate.api.key"
+                            defaultMessage={'Generate API Key'}
                           />
-                        </>
-                      ) : (
-                        <FormattedMessage
-                          id="aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxyDeploymentsCard.generate.api.key"
-                          defaultMessage={'Generate API Key'}
-                        />
-                      )}
-                    </Button>
-                  </span>
-                </Tooltip>
+                        )}
+                      </Button>
+                    </span>
+                  </Tooltip>
+                </DisabledActionTooltip>
               </Stack>
 
               {keyError && (

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyGuardrailsTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyGuardrailsTab.tsx
@@ -61,6 +61,7 @@ import type {
 import { parsePolicyYaml } from '../../PolicyParameterEditor/yamlParser';
 import { FormattedMessage } from 'react-intl';
 import ErrorAlert from '../../../../Components/common/ErrorAlert';
+import { DisabledActionTooltip } from '../../../../utils/readOnlyArtifacts';
 
 // ─── Shared helpers ──────────────────────────────────────────────────────────
 
@@ -143,6 +144,7 @@ const parseOpenApiText = (text: string): ResourceItem[] => {
  */
 export default function LLMProxyGuardrailsTab() {
   const { proxy, setLocalProxy } = useProxy();
+  const isReadOnlyProxy = Boolean(proxy?.readOnly);
   const {
     guardrails: availableGuardrails = [],
     isLoading: isLoadingGuardrails,
@@ -306,12 +308,14 @@ export default function LLMProxyGuardrailsTab() {
   // ── Drawer openers ──────────────────────────────────────────────────────
 
   const openAddDrawerForGlobal = () => {
+    if (isReadOnlyProxy) return;
     setEditingTarget(null);
     setDrawerContext({ scope: 'global' });
     setDrawerOpen(true);
   };
 
   const openAddDrawerForResource = (method: string, path: string) => {
+    if (isReadOnlyProxy) return;
     setEditingTarget(null);
     setDrawerContext({ scope: 'resource', method, path });
     setDrawerOpen(true);
@@ -323,6 +327,8 @@ export default function LLMProxyGuardrailsTab() {
     scope: DrawerContext,
     source: 'global' | 'operation' | 'legacy'
   ) => {
+    if (isReadOnlyProxy) return;
+
     let policyName: string;
     let existingParams: ParameterValues = {};
 
@@ -387,6 +393,7 @@ export default function LLMProxyGuardrailsTab() {
     name: string;
     version?: string;
   }) => {
+    if (isReadOnlyProxy) return;
     setSelectedGuardrail(guardrail.name);
     setIsDetailView(true);
     setPolicyDefinition(null);
@@ -436,7 +443,7 @@ export default function LLMProxyGuardrailsTab() {
   };
 
   const handlePolicySubmit = async (params: ParameterValues) => {
-    if (!proxy || !selectedGuardrailPolicy) return;
+    if (isReadOnlyProxy || !proxy || !selectedGuardrailPolicy) return;
 
     if (editingTarget) {
       const { policyIndex, pathIndex, source } = editingTarget;
@@ -547,6 +554,7 @@ export default function LLMProxyGuardrailsTab() {
     pathIndex: number | null,
     source: 'global' | 'operation' | 'legacy'
   ) => {
+    if (isReadOnlyProxy) return;
     if (source === 'global') {
       setLocalProxy((prev) => {
         if (!prev) return prev;
@@ -616,15 +624,20 @@ export default function LLMProxyGuardrailsTab() {
             </Grid>
 
             <Grid size={{ xs: 12, sm: 'auto' }}>
-              <Button
-                size="small"
-                variant="outlined"
-                startIcon={<Plus size={16} />}
-                onClick={openAddDrawerForGlobal}
-                sx={{ whiteSpace: 'nowrap' }}
-              >
-                Add
-              </Button>
+              <DisabledActionTooltip disabled={isReadOnlyProxy}>
+                <span>
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    startIcon={<Plus size={16} />}
+                    onClick={openAddDrawerForGlobal}
+                    disabled={isReadOnlyProxy}
+                    sx={{ whiteSpace: 'nowrap' }}
+                  >
+                    Add
+                  </Button>
+                </span>
+              </DisabledActionTooltip>
             </Grid>
           </Grid>
 
@@ -642,13 +655,22 @@ export default function LLMProxyGuardrailsTab() {
               <GuardrailPill
                 key={g.id}
                 label={`${g.displayName} (${g.version.replace(/^v/, '')})`}
-                onClick={() =>
-                  handleEditGuardrailPill(g.policyIndex, g.pathIndex, {
-                    scope: 'global',
-                  }, g.source)
+                onClick={
+                  isReadOnlyProxy
+                    ? undefined
+                    : () =>
+                        handleEditGuardrailPill(g.policyIndex, g.pathIndex, {
+                            scope: 'global',
+                        }, g.source)
                 }
-                onRemove={() =>
-                  void handleRemoveAppliedGuardrail(g.policyIndex, g.pathIndex, g.source)
+                onRemove={
+                  isReadOnlyProxy
+                    ? undefined
+                    : () =>
+                        void handleRemoveAppliedGuardrail(
+                          g.policyIndex,
+                          g.pathIndex, g.source
+                        )
                 }
               />
             ))}
@@ -915,19 +937,26 @@ export default function LLMProxyGuardrailsTab() {
                                   </Typography>
                                 </Grid>
                                 <Grid size={{ xs: 12, sm: 'auto' }}>
-                                  <Button
-                                    size="small"
-                                    variant="outlined"
-                                    startIcon={<Plus size={16} />}
-                                    onClick={() =>
-                                      openAddDrawerForResource(
-                                        method,
-                                        resource.path
-                                      )
-                                    }
+                                  <DisabledActionTooltip
+                                    disabled={isReadOnlyProxy}
                                   >
-                                    Add Guardrail
-                                  </Button>
+                                    <span>
+                                      <Button
+                                        size="small"
+                                        variant="outlined"
+                                        startIcon={<Plus size={16} />}
+                                        onClick={() =>
+                                          openAddDrawerForResource(
+                                            method,
+                                            resource.path
+                                          )
+                                        }
+                                        disabled={isReadOnlyProxy}
+                                      >
+                                        Add Guardrail
+                                      </Button>
+                                    </span>
+                                  </DisabledActionTooltip>
                                 </Grid>
                                 <Grid size={{ xs: 12 }}>
                                   <Stack
@@ -943,24 +972,30 @@ export default function LLMProxyGuardrailsTab() {
                                           label={`${
                                             g.displayName
                                           } (${g.version.replace(/^v/, '')})`}
-                                          onClick={() =>
-                                            handleEditGuardrailPill(
-                                              g.policyIndex,
-                                              g.pathIndex,
-                                              {
-                                                scope: 'resource',
-                                                method,
-                                                path: resource.path,
-                                              },
-                                              g.source
-                                            )
+                                          onClick={
+                                            isReadOnlyProxy
+                                              ? undefined
+                                              : () =>
+                                                handleEditGuardrailPill(
+                                                  g.policyIndex,
+                                                  g.pathIndex,
+                                                  {
+                                                    scope: 'resource',
+                                                    method,
+                                                    path: resource.path,
+                                                  },
+                                                  g.source
+                                                )
                                           }
-                                          onRemove={() =>
-                                            void handleRemoveAppliedGuardrail(
-                                              g.policyIndex,
-                                              g.pathIndex,
-                                              g.source
-                                            )
+                                          onRemove={
+                                            isReadOnlyProxy
+                                              ? undefined
+                                              : () =>
+                                                void handleRemoveAppliedGuardrail(
+                                                  g.policyIndex,
+                                                  g.pathIndex,
+                                                  g.source
+                                                )
                                           }
                                         />
                                       ))

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyOverview.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyOverview.tsx
@@ -69,6 +69,9 @@ import type {
   Proxy as LLMProxy,
   UpdateProxyRequest,
 } from '../../../../utils/types';
+import {
+  GatewayArtifactReadOnlyBanner,
+} from '../../../../utils/readOnlyArtifacts';
 
 type TabPanelProps = {
   value: number;
@@ -151,6 +154,7 @@ function ProxyOverviewContent() {
   const [updateError, setUpdateError] = useState<string | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const isReadOnlyProxy = Boolean(proxy?.readOnly);
 
   const getProviderId = (providerValue?: LLMProxy['provider']): string => {
     if (!providerValue) return '';
@@ -208,7 +212,12 @@ function ProxyOverviewContent() {
   };
 
   const handleSaveChanges = async () => {
-    if (!proxy || !hasUnsavedChanges || isSavingChanges) return;
+    // Runtime tabs (provider/security/guardrails & policies) are locked, so a save
+    // from a gateway-created proxy only carries non-runtime edits (definition), which
+    // the control plane accepts without altering the gateway runtime artifact.
+    if (!proxy || !hasUnsavedChanges || isSavingChanges) {
+      return;
+    }
     try {
       setIsSavingChanges(true);
       setUpdateError(null);
@@ -349,6 +358,9 @@ function ProxyOverviewContent() {
                       variant="outlined"
                       color="primary"
                     />
+                    {/* Edit page (name/version/context/description). Enabled even
+                        for gateway-created proxies — the page keeps the runtime
+                        fields read-only and allows only the description. */}
                     <Tooltip title="Edit Proxy">
                       <IconButton
                         component={RouterLink}
@@ -403,12 +415,15 @@ function ProxyOverviewContent() {
                 alignItems="flex-end"
                 sx={{ alignSelf: 'stretch' }}
               >
+                {/* Deployments remain viewable for gateway-created proxies (deploy/
+                    redeploy/restore/undeploy are disabled on the page itself), so the
+                    button navigates but is relabelled "View Deployments". */}
                 <Button
                   variant="contained"
                   component={RouterLink}
                   to={`${proxiesPath}/${proxy.id}/deploy`}
                 >
-                  Deploy to Gateway
+                  {isReadOnlyProxy ? 'View Deployments' : 'Deploy to Gateway'}
                 </Button>
                 <IconButton
                   color="error"
@@ -445,6 +460,9 @@ function ProxyOverviewContent() {
                 </TabPanel>
 
                 <TabPanel value={tabIndex} index={1}>
+                  {isReadOnlyProxy && (
+                    <GatewayArtifactReadOnlyBanner message="The provider connection is managed by the gateway that created this proxy and is read-only here." />
+                  )}
                   <LLMProxyProviderTab />
                 </TabPanel>
 
@@ -453,10 +471,16 @@ function ProxyOverviewContent() {
                 </TabPanel>
 
                 <TabPanel value={tabIndex} index={3}>
+                  {isReadOnlyProxy && (
+                    <GatewayArtifactReadOnlyBanner message="Security settings are managed by the gateway that created this proxy and are read-only here." />
+                  )}
                   <LLMProxySecurityTab />
                 </TabPanel>
 
                 <TabPanel value={tabIndex} index={4}>
+                  {isReadOnlyProxy && (
+                    <GatewayArtifactReadOnlyBanner message="Guardrails & policies are managed by the gateway that created this proxy and are read-only here." />
+                  )}
                   <LLMProxyGuardrailsTab />
                 </TabPanel>
               </Box>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyOverviewTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyOverviewTab.tsx
@@ -54,6 +54,10 @@ import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
 import SwaggerSpecViewer from '../../../../Components/SwaggerSpecViewer';
 import type { Gateway } from '../../../../apis/gatewayTypes';
 import type { DeploymentResponse, UserAPIKey } from '../../../../utils/types';
+import {
+  DisabledActionTooltip,
+  GATEWAY_MANAGED_ARTIFACT_TOOLTIP,
+} from '../../../../utils/readOnlyArtifacts';
 
 type OpenApiSpec = Record<string, unknown>;
 
@@ -118,6 +122,10 @@ export default function LLMProxyOverviewTab() {
   const [isDeletingKey, setIsDeletingKey] = useState(false);
   const [apiKeys, setApiKeys] = useState<UserAPIKey[]>([]);
   const [keysLoading, setKeysLoading] = useState(false);
+  // This tab only manages consumer API keys, which are credentials for calling the
+  // proxy — NOT part of the gateway runtime artifact. So key generation/deletion stays
+  // available even for gateway-created (read-only) proxies.
+  const isReadOnlyProxy = false;
 
   const apiKeyLocation = proxy?.security?.apiKey?.in ?? 'header';
   const apiKeyName = proxy?.security?.apiKey?.key ?? 'X-API-Key';
@@ -370,6 +378,7 @@ export default function LLMProxyOverviewTab() {
   };
 
   const handleGenerateAPIKey = async () => {
+    if (isReadOnlyProxy) return;
     if (!currentOrganization?.uuid || !proxy?.id) {
       return;
     }
@@ -415,6 +424,7 @@ export default function LLMProxyOverviewTab() {
   };
 
   const handleOpenApiKeyModal = () => {
+    if (isReadOnlyProxy) return;
     setKeyError(null);
     setGeneratedKey(null);
     setApiKeyDisplayName('');
@@ -453,7 +463,7 @@ export default function LLMProxyOverviewTab() {
   };
 
   const handleDeleteApiKey = async () => {
-    if (!deleteTargetKeyName || !proxy?.id) {
+    if (isReadOnlyProxy || !deleteTargetKeyName || !proxy?.id) {
       return;
     }
 
@@ -656,25 +666,32 @@ export default function LLMProxyOverviewTab() {
                           />
                         </Typography>
                       </Box>
-                      <Tooltip
-                        title={
-                          deployedGateways.length === 0
-                            ? 'No deployed gateways available. Deploy to a gateway first to generate an API key.'
-                            : ''
-                        }
-                        placement="top"
+                      <DisabledActionTooltip
+                        disabled={isReadOnlyProxy}
+                        title={GATEWAY_MANAGED_ARTIFACT_TOOLTIP}
                       >
-                        <span>
-                          <Button
-                            variant="contained"
-                            size="medium"
-                            onClick={handleOpenApiKeyModal}
-                            disabled={deployedGateways.length === 0}
-                          >
-                            Generate API Key
-                          </Button>
-                        </span>
-                      </Tooltip>
+                        <Tooltip
+                          title={
+                            !isReadOnlyProxy && deployedGateways.length === 0
+                              ? 'No deployed gateways available. Deploy to a gateway first to generate an API key.'
+                              : ''
+                          }
+                          placement="top"
+                        >
+                          <span>
+                            <Button
+                              variant="contained"
+                              size="medium"
+                              onClick={handleOpenApiKeyModal}
+                              disabled={
+                                isReadOnlyProxy || deployedGateways.length === 0
+                              }
+                            >
+                              Generate API Key
+                            </Button>
+                          </span>
+                        </Tooltip>
+                      </DisabledActionTooltip>
                     </Stack>
 
                     {keyError && (
@@ -749,28 +766,39 @@ export default function LLMProxyOverviewTab() {
                                   </Tooltip>
                                 </ListingTable.Cell>
                                 <ListingTable.Cell align="right">
-                                  <Tooltip
-                                    title={
-                                      key.id
-                                        ? 'Delete API key'
-                                        : 'Unable to delete key without a name'
-                                    }
+                                  <DisabledActionTooltip
+                                    disabled={isReadOnlyProxy}
+                                    title={GATEWAY_MANAGED_ARTIFACT_TOOLTIP}
                                   >
-                                    <span>
-                                      <IconButton
-                                        size="small"
-                                        color="error"
-                                        onClick={() =>
-                                          setDeleteTargetKeyName(
-                                            key.id?.trim() || null
-                                          )
-                                        }
-                                        disabled={!key.id || isDeletingKey}
-                                      >
-                                        <Trash2 size={16} />
-                                      </IconButton>
-                                    </span>
-                                  </Tooltip>
+                                    <Tooltip
+                                      title={
+                                        isReadOnlyProxy
+                                          ? ''
+                                          : key.id
+                                            ? 'Delete API key'
+                                            : 'Unable to delete key without a name'
+                                      }
+                                    >
+                                      <span>
+                                        <IconButton
+                                          size="small"
+                                          color="error"
+                                          onClick={() =>
+                                            setDeleteTargetKeyName(
+                                              key.id?.trim() || null
+                                            )
+                                          }
+                                          disabled={
+                                            isReadOnlyProxy ||
+                                            !key.id ||
+                                            isDeletingKey
+                                          }
+                                        >
+                                          <Trash2 size={16} />
+                                        </IconButton>
+                                      </span>
+                                    </Tooltip>
+                                  </DisabledActionTooltip>
                                 </ListingTable.Cell>
                               </ListingTable.Row>
                             ))}
@@ -895,6 +923,7 @@ export default function LLMProxyOverviewTab() {
                   size="small"
                   fullWidth
                   value={apiKeyDisplayName}
+                  disabled={isReadOnlyProxy}
                   onChange={(event) => setApiKeyDisplayName(event.target.value)}
                   placeholder="Ex: Production Key"
                 />
@@ -928,7 +957,11 @@ export default function LLMProxyOverviewTab() {
                 onClick={() => {
                   void handleGenerateAPIKey();
                 }}
-                disabled={generatingKey || !apiKeyDisplayName.trim()}
+                disabled={
+                  isReadOnlyProxy ||
+                  generatingKey ||
+                  !apiKeyDisplayName.trim()
+                }
               >
                 {generatingKey ? (
                   <>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyProviderTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyProviderTab.tsx
@@ -37,6 +37,7 @@ import { logger } from '../../../../utils/logger';
 import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
 import type { LLMProvider, ProxyApiKeySecurity } from '../../../../utils/types';
 import { FormattedMessage } from 'react-intl';
+import { DisabledActionTooltip } from '../../../../utils/readOnlyArtifacts';
 
 /**
  * Provider tab – lets the user select / change the LLM Service Provider
@@ -54,6 +55,7 @@ export default function LLMProxyProviderTab() {
     null
   );
   const [apiKey, setApiKey] = useState('');
+  const isReadOnlyProxy = Boolean(proxy?.readOnly);
 
   const providerOptions = providersResponse.list;
   const selectedProxyProviderId =
@@ -107,6 +109,7 @@ export default function LLMProxyProviderTab() {
   };
 
   const handleSaveApiKey = () => {
+    if (isReadOnlyProxy) return;
     if (!proxy || !apiKey.trim() || !providerDetail) {
       showSnackbar('Please enter an API key.', 'error');
       return;
@@ -137,6 +140,7 @@ export default function LLMProxyProviderTab() {
   };
 
   const handleProviderChange = async (event: { target: { value: string } }) => {
+    if (isReadOnlyProxy) return;
     const newProviderId = event.target.value;
     if (!proxy || newProviderId === selectedProxyProviderId) return;
 
@@ -199,7 +203,7 @@ export default function LLMProxyProviderTab() {
               value={selectedProxyProviderId}
               onChange={handleProviderChange}
               displayEmpty
-              disabled={isProvidersLoading}
+              disabled={isProvidersLoading || isReadOnlyProxy}
             >
               {isProvidersLoading ? (
                 <MenuItem value="" disabled>
@@ -267,6 +271,7 @@ export default function LLMProxyProviderTab() {
                         type="password"
                         placeholder="Enter API key"
                         value={apiKey}
+                        disabled={isReadOnlyProxy}
                         onChange={(e) => setApiKey(e.target.value)}
                         fullWidth
                       />
@@ -274,17 +279,21 @@ export default function LLMProxyProviderTab() {
                   </Grid>
                 </Grid>
 
-                <Button
-                  variant="contained"
-                  onClick={handleSaveApiKey}
-                  disabled={!apiKey.trim()}
-                  sx={{ alignSelf: 'flex-start' }}
-                >
-                  <FormattedMessage
-                    id="aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxyProviderTab.save.api.key"
-                    defaultMessage={'Save API Key'}
-                  />
-                </Button>
+                <DisabledActionTooltip disabled={isReadOnlyProxy}>
+                  <span>
+                    <Button
+                      variant="contained"
+                      onClick={handleSaveApiKey}
+                      disabled={isReadOnlyProxy || !apiKey.trim()}
+                      sx={{ alignSelf: 'flex-start' }}
+                    >
+                      <FormattedMessage
+                        id="aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxyProviderTab.save.api.key"
+                        defaultMessage={'Save API Key'}
+                      />
+                    </Button>
+                  </span>
+                </DisabledActionTooltip>
               </Stack>
             </Stack>
           )}

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxySecurityTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxySecurityTab.tsx
@@ -45,13 +45,15 @@ import { FormattedMessage } from 'react-intl';
  */
 export default function LLMProxySecurityTab() {
   const { proxy, isLoading, error, setLocalProxy } = useProxy();
+  const isReadOnlyProxy = Boolean(proxy?.readOnly);
 
   const [authenticationType, setAuthenticationType] = useState('');
   const [apiKeyEnabled, setApiKeyEnabled] = useState(true);
   const [keyName, setKeyName] = useState('');
   const [keyLocation, setKeyLocation] = useState<'header' | 'query'>('header');
 
-  const isFormDisabled = !apiKeyEnabled || isLoading || Boolean(error);
+  const isFormDisabled =
+    !apiKeyEnabled || isLoading || Boolean(error) || isReadOnlyProxy;
 
   useEffect(() => {
     if (!proxy) return;
@@ -82,24 +84,28 @@ export default function LLMProxySecurityTab() {
   };
 
   const handleAuthChange = (event: { target: { value: string } }) => {
+    if (isReadOnlyProxy) return;
     const nextType = event.target.value;
     setAuthenticationType(nextType);
     stageSecurity(nextType, keyName, keyLocation, apiKeyEnabled);
   };
 
   const handleApiKeyEnabledChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (isReadOnlyProxy) return;
     const nextEnabled = event.target.checked;
     setApiKeyEnabled(nextEnabled);
     stageSecurity(authenticationType, keyName, keyLocation, nextEnabled);
   };
 
   const handleKeyNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (isReadOnlyProxy) return;
     const nextKey = event.target.value;
     setKeyName(nextKey);
     stageSecurity(authenticationType, nextKey, keyLocation, apiKeyEnabled);
   };
 
   const handleKeyLocationChange = (event: { target: { value: string } }) => {
+    if (isReadOnlyProxy) return;
     const nextIn = event.target.value as 'header' | 'query';
     setKeyLocation(nextIn);
     stageSecurity(authenticationType, keyName, nextIn, apiKeyEnabled);
@@ -135,7 +141,7 @@ export default function LLMProxySecurityTab() {
                 <Switch
                   size="small"
                   checked={apiKeyEnabled}
-                  disabled={isLoading || Boolean(error)}
+                  disabled={isLoading || Boolean(error) || isReadOnlyProxy}
                   onChange={handleApiKeyEnabledChange}
                 />
               </Tooltip>
@@ -144,7 +150,11 @@ export default function LLMProxySecurityTab() {
 
           <FormControl fullWidth size="small">
             <FormLabel>Authentication type</FormLabel>
-            <Select value={authenticationType} onChange={handleAuthChange}>
+            <Select
+              value={authenticationType}
+              onChange={handleAuthChange}
+              disabled={isReadOnlyProxy}
+            >
               <MenuItem value="apiKey">API Key</MenuItem>
             </Select>
           </FormControl>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/quickStart/AIGatewayStepBanner/AIGatewayStepBanner.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/quickStart/AIGatewayStepBanner/AIGatewayStepBanner.tsx
@@ -42,7 +42,6 @@ export type AIGatewayStepBannerProps = {
 };
 
 const TOTAL_STEPS = 2;
-const MAX_LLM_PROVIDERS_PER_ORG = 5;
 
 export default function AIGatewayStepBanner({
   gatewayDisplayName,
@@ -60,7 +59,7 @@ export default function AIGatewayStepBanner({
   const resolvedDisplayName = gatewayDisplayName?.trim() || 'AI Gateway';
   const completedSteps = isActive ? 2 : 1;
   const progressValue = (completedSteps / TOTAL_STEPS) * 100;
-  const isProviderQuotaReached = providerCount >= MAX_LLM_PROVIDERS_PER_ORG;
+  const isProviderQuotaReached = false;
   const newProviderPath = buildOrgPath(currentOrganization, '/service-provider/new');
 
   useEffect(() => {
@@ -213,9 +212,7 @@ export default function AIGatewayStepBanner({
         {isActive && (
           <Tooltip
             title={
-              isProviderQuotaReached
-                ? `You cannot continue because your organization already has ${MAX_LLM_PROVIDERS_PER_ORG} LLM providers. The maximum limit is ${MAX_LLM_PROVIDERS_PER_ORG}.`
-                : ''
+              ''
             }
             disableHoverListener={!isProviderQuotaReached}
           >

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/quickStart/Main.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/quickStart/Main.tsx
@@ -55,7 +55,6 @@ import { getMCPProxyOption } from './mcpProxyOption';
 import { getProviderProxyOption } from './providerProxyOption';
 import type { QuickStartOption, QuickStartOptionId } from './types';
 
-const MAX_LLM_PROVIDERS_PER_ORG = 5;
 const MAX_GATEWAYS_PER_ORG = 3;
 
 type GatewayCounts = {
@@ -239,7 +238,7 @@ export default function QuickStart(): JSX.Element {
     providersResponse.count ??
     providersResponse.pagination?.total ??
     providers.length;
-  const isProviderQuotaReached = providerCount >= MAX_LLM_PROVIDERS_PER_ORG;
+  const isProviderQuotaReached = false;
   const isGatewayQuotaReached =
     gatewayCounts.ai + gatewayCounts.api >= MAX_GATEWAYS_PER_ORG;
   const nextButtonTooltip =

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/EditServiceProvider.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/EditServiceProvider.tsx
@@ -50,6 +50,7 @@ function EditServiceProviderForm() {
   const { currentOrganization } = useAppShell();
   const { provider, isLoading, error, updateProvider } = useLLMProvider();
   const showSnackbar = useAIWorkspaceSnackbar();
+  const isReadOnlyProvider = Boolean(provider?.readOnly);
 
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
@@ -81,6 +82,9 @@ function EditServiceProviderForm() {
   };
 
   const handleSubmit = async () => {
+    // Allowed even for gateway-created providers: name/version/context stay locked
+    // (they are part of the runtime artifact), so only the description can change,
+    // which the control plane accepts without altering the gateway runtime artifact.
     if (!providerId) return;
 
     setIsSubmitting(true);
@@ -187,6 +191,13 @@ function EditServiceProviderForm() {
 
         <Box sx={{ mb: 4 }}>
           <Stack spacing={3}>
+            {isReadOnlyProvider ? (
+              <Alert severity="info">
+                This provider was created from a gateway. The name, version and
+                context are part of the gateway runtime configuration and are
+                read-only here; only the description can be edited.
+              </Alert>
+            ) : null}
             {isContextOrVersionChanged && (
               <Alert severity="warning">
                 You have modified the context or version of this service
@@ -201,6 +212,7 @@ function EditServiceProviderForm() {
                   fullWidth
                   required
                   value={name}
+                  disabled={isReadOnlyProvider}
                   onChange={(e) => setName(e.target.value)}
                   placeholder="Enter service provider name"
                   error={name.length > MAX_NAME_LENGTH}
@@ -217,6 +229,7 @@ function EditServiceProviderForm() {
                 <TextField
                   fullWidth
                   value={version}
+                  disabled={isReadOnlyProvider}
                   onChange={(e) => setVersion(e.target.value)}
                   placeholder="e.g., 1.0"
                   error={version.length > MAX_VERSION_LENGTH}
@@ -252,6 +265,7 @@ function EditServiceProviderForm() {
               <TextField
                 fullWidth
                 value={context}
+                disabled={isReadOnlyProvider}
                 onChange={(e) => setContext(e.target.value)}
                 placeholder="Enter context path"
                 error={context.length > MAX_CONTEXT_LENGTH}

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ProvidersList.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ProvidersList.tsx
@@ -93,7 +93,6 @@ const PROVIDER_LOGO_MAP: Record<string, string> = {
   mistralai: MistralAILogo,
   mistral: MistralAILogo,
 };
-const MAX_LLM_PROVIDERS_PER_ORG = 5;
 
 function getInitials(name: string): string {
   const words = name.trim().split(/\s+/);
@@ -153,8 +152,7 @@ export default function ServiceProviders() {
   // Access the list from the API response
   const providers = providersResponse.list;
   const emptyMessage = 'No Available LLM Providers';
-  const isProviderQuotaReached =
-    (providersResponse.count ?? providers.length) >= MAX_LLM_PROVIDERS_PER_ORG;
+  const isProviderQuotaReached = false;
   const providerQuotaTooltip =
     'You cannot create more providers because your organization has reached the maximum limit of 5 LLM providers.';
 

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderConnectionTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderConnectionTab.tsx
@@ -53,6 +53,8 @@ export default function ServiceProviderConnectionTab() {
   const [providerTemplate, setProviderTemplate] =
     useState<ProviderTemplate | null>(null);
   const showSnackbar = useAIWorkspaceSnackbar();
+  const isReadOnlyProvider = Boolean(provider?.readOnly);
+  const isFormDisabled = isLoading || Boolean(error) || isReadOnlyProvider;
 
   const valuePrefix = useMemo(() => {
     return providerTemplate?.metadata?.auth?.valuePrefix || '';
@@ -108,7 +110,7 @@ export default function ServiceProviderConnectionTab() {
   }, [provider]);
 
   const handleUpdateProviderEndpoint = async (value = providerEndpoint) => {
-    if (!provider || isLoading || error) return;
+    if (!provider || isLoading || error || isReadOnlyProvider) return;
     const nextUrl = value.trim();
     if (!nextUrl || nextUrl === (provider.upstream?.main?.url || '')) return;
     try {
@@ -144,7 +146,7 @@ export default function ServiceProviderConnectionTab() {
   };
 
   const handleUpdateAuthentication = async (value = authenticationType) => {
-    if (!provider || isLoading || error) return;
+    if (!provider || isLoading || error || isReadOnlyProvider) return;
     const nextType = value.trim();
     if (!nextType || nextType === (provider.upstream?.main?.auth?.type || ''))
       return;
@@ -183,7 +185,7 @@ export default function ServiceProviderConnectionTab() {
   const handleUpdateAuthenticationHeader = async (
     value = authenticationHeader
   ) => {
-    if (!provider || isLoading || error) return;
+    if (!provider || isLoading || error || isReadOnlyProvider) return;
     const nextHeader = value.trim();
     if (nextHeader === (provider.upstream?.main?.auth?.header || '')) return;
 
@@ -220,7 +222,7 @@ export default function ServiceProviderConnectionTab() {
   };
 
   const handleUpdateCredential = async (value = credentialValue) => {
-    if (!provider || isLoading || error) return;
+    if (!provider || isLoading || error || isReadOnlyProvider) return;
     if (isCredentialMasked) return;
     const nextValue = value.trim();
     if (nextValue === MASKED_CREDENTIAL_VALUE) return;
@@ -275,6 +277,7 @@ export default function ServiceProviderConnectionTab() {
           <TextField
             size="small"
             value={providerEndpoint}
+            disabled={isFormDisabled}
             onChange={(e) => {
               const nextValue = e.target.value;
               setProviderEndpoint(nextValue);
@@ -295,6 +298,7 @@ export default function ServiceProviderConnectionTab() {
           <Select
             size="small"
             value={authenticationType || 'api-key'}
+            disabled={isFormDisabled}
             onChange={(e) => {
               const nextValue = String(e.target.value);
               setAuthenticationType(nextValue);
@@ -317,6 +321,7 @@ export default function ServiceProviderConnectionTab() {
           <TextField
             size="small"
             value={authenticationHeader}
+            disabled={isFormDisabled}
             onChange={(e) => {
               const nextValue = e.target.value;
               setAuthenticationHeader(nextValue);
@@ -338,6 +343,7 @@ export default function ServiceProviderConnectionTab() {
             size="small"
             type={showCredential ? 'text' : 'password'}
             value={credentialValue}
+            disabled={isFormDisabled}
             onFocus={() => {
               if (isCredentialMasked) {
                 setCredentialValue('');
@@ -364,6 +370,7 @@ export default function ServiceProviderConnectionTab() {
                   <InputAdornment position="end">
                     <IconButton
                       size="small"
+                      disabled={isFormDisabled}
                       onClick={() => setShowCredential((prev) => !prev)}
                       aria-label={
                         showCredential ? 'Hide credentials' : 'Show credentials'

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderDeploy.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderDeploy.tsx
@@ -19,6 +19,7 @@
 import React, { useMemo } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
+  Alert,
   Box,
   Button,
   Grid,
@@ -123,6 +124,13 @@ function ServiceProviderDeployLayout({ providerId }: ServiceProviderDeployLayout
       </Grid>
 
       <Stack spacing={2} sx={{ mt: 2 }}>
+        {provider?.readOnly && (
+          <Alert severity="info">
+            This provider was created from a gateway. You can view its deployments,
+            but deploy, redeploy, restore and undeploy actions are managed by the
+            gateway and are unavailable in AI Workspace.
+          </Alert>
+        )}
         <GatewayDeployMainSection />
       </Stack>
     </PageContent>
@@ -131,6 +139,7 @@ function ServiceProviderDeployLayout({ providerId }: ServiceProviderDeployLayout
 
 function ServiceProviderDeployContent() {
   const { providerId } = useParams<{ providerId: string }>();
+  const { provider } = useLLMProvider();
 
   if (!providerId) {
     return (
@@ -147,7 +156,7 @@ function ServiceProviderDeployContent() {
 
   return (
     <AIEntityProvider type="llm-provider" id={providerId}>
-      <GatewayDeployProvider apiId={providerId}>
+      <GatewayDeployProvider apiId={providerId} readOnly={Boolean(provider?.readOnly)}>
         <ServiceProviderDeployLayout providerId={providerId} />
       </GatewayDeployProvider>
     </AIEntityProvider>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderDeploymentsCard.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderDeploymentsCard.tsx
@@ -54,6 +54,10 @@ import { useLLMProvider } from '../../../../contexts/llmProvider';
 import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
 import type { UserAPIKey } from '../../../../utils/types';
 import { logger } from '../../../../utils/logger';
+import {
+  DisabledActionTooltip,
+  GATEWAY_MANAGED_ARTIFACT_TOOLTIP,
+} from '../../../../utils/readOnlyArtifacts';
 
 type ServiceProviderDeploymentsCardProps = {
   isGatewaysLoading: boolean;
@@ -122,6 +126,7 @@ export default function ServiceProviderDeploymentsCard({
 
   const apiKeyLocation = provider?.security?.apiKey?.in ?? 'header';
   const apiKeyName = provider?.security?.apiKey?.key ?? 'X-API-Key';
+  const isReadOnlyProvider = Boolean(provider?.readOnly);
 
   const deployedGateways = useMemo(() => {
     if (!deployments?.list || deployments.list.length === 0) return [];
@@ -456,25 +461,16 @@ export default function ServiceProviderDeploymentsCard({
                     />
                   </Typography>
                 </Box>
-                <Tooltip
-                  title={
-                    gateways.length === 0
-                      ? 'No deployed gateways available. Deploy to a gateway first to generate an API key.'
-                      : ''
-                  }
-                  placement="top"
-                >
-                  <span>
-                    <Button
-                      variant="contained"
-                      size="medium"
-                      onClick={handleOpenApiKeyModal}
-                      disabled={gateways.length === 0}
-                    >
-                      Generate API Key
-                    </Button>
-                  </span>
-                </Tooltip>
+                <DisabledActionTooltip disabled={false}>
+                  <Button
+                    variant="contained"
+                    size="medium"
+                    onClick={handleOpenApiKeyModal}
+                    disabled={gateways.length === 0}
+                  >
+                    Generate API Key
+                  </Button>
+                </DisabledActionTooltip>
               </Stack>
 
               {keyError && (

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderGuardrailsTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderGuardrailsTab.tsx
@@ -64,6 +64,9 @@ import type { AccessControl } from '../../../../utils/types';
 import { parsePolicyYaml } from '../../PolicyParameterEditor/yamlParser';
 import { FormattedMessage } from 'react-intl';
 import ErrorAlert from '../../../../Components/common/ErrorAlert';
+import {
+  DisabledActionTooltip,
+} from '../../../../utils/readOnlyArtifacts';
 
 type ResourceItem = {
   method: string;
@@ -157,6 +160,7 @@ const parseOpenApiText = (
 export default function ServiceProviderGuardrailsTab() {
   const { provider, isLoading, error, updateProvider, isDraftMode } =
     useLLMProvider();
+  const isReadOnlyProvider = Boolean(provider?.readOnly);
   const {
     guardrails: availableGuardrails = [],
     isLoading: isLoadingGuardrails,
@@ -573,10 +577,9 @@ export default function ServiceProviderGuardrailsTab() {
 
   const handleRemoveAppliedGuardrail = async (
     policyIndex: number,
-    pathIndex: number | null,
-    source: 'global' | 'operation' | 'legacy'
+    pathIndex: number | null
   ) => {
-    if (!provider || isLoading || error) return;
+    if (!provider || isLoading || error || isReadOnlyProvider) return;
 
     const {
       status,
@@ -657,18 +660,21 @@ export default function ServiceProviderGuardrailsTab() {
             </Grid>
 
             <Grid size={{ xs: 12, sm: 'auto' }}>
-              <Button
-                size="small"
-                variant="outlined"
-                startIcon={<Plus size={16} />}
-                onClick={openAddDrawerForGlobal}
-                sx={{ whiteSpace: 'nowrap' }}
-              >
-                <FormattedMessage
-                  id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderGuardrailsTab.add.guardrail"
-                  defaultMessage={'Add'}
-                />
-              </Button>
+              <DisabledActionTooltip disabled={isReadOnlyProvider}>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  startIcon={<Plus size={16} />}
+                  onClick={openAddDrawerForGlobal}
+                  disabled={isReadOnlyProvider}
+                  sx={{ whiteSpace: 'nowrap' }}
+                >
+                  <FormattedMessage
+                    id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderGuardrailsTab.add.guardrail"
+                    defaultMessage={'Add'}
+                  />
+                </Button>
+              </DisabledActionTooltip>
             </Grid>
           </Grid>
 
@@ -686,13 +692,22 @@ export default function ServiceProviderGuardrailsTab() {
               <GuardrailPill
                 key={g.id}
                 label={`${g.displayName} (${g.version})`}
-                onClick={() =>
-                  handleEditGuardrailPill(g.policyIndex, g.pathIndex, {
-                    scope: 'global',
-                  }, g.source)
+                onClick={
+                  isReadOnlyProvider
+                    ? undefined
+                    : () =>
+                      handleEditGuardrailPill(g.policyIndex, g.pathIndex, {
+                        scope: 'global',
+                      }, g.source)
                 }
-                onRemove={() =>
-                  void handleRemoveAppliedGuardrail(g.policyIndex, g.pathIndex, g.source)
+                onRemove={
+                  isReadOnlyProvider
+                    ? undefined
+                    : () =>
+                      void handleRemoveAppliedGuardrail(
+                          g.policyIndex,
+                          g.pathIndex, g.source
+                      )
                 }
               />
             ))}
@@ -929,22 +944,27 @@ export default function ServiceProviderGuardrailsTab() {
                               </Grid>
 
                               <Grid size={{ xs: 12, sm: 'auto' }}>
-                                <Button
-                                  size="small"
-                                  variant="outlined"
-                                  startIcon={<Plus size={16} />}
-                                  onClick={() =>
-                                    openAddDrawerForResource(
-                                      method,
-                                      resource.path
-                                    )
-                                  }
+                                <DisabledActionTooltip
+                                  disabled={isReadOnlyProvider}
                                 >
-                                  <FormattedMessage
-                                    id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderGuardrailsTab.add.guardrail"
-                                    defaultMessage={'Add'}
-                                  />
-                                </Button>
+                                  <Button
+                                    size="small"
+                                    variant="outlined"
+                                    startIcon={<Plus size={16} />}
+                                    onClick={() =>
+                                      openAddDrawerForResource(
+                                        method,
+                                        resource.path
+                                      )
+                                    }
+                                    disabled={isReadOnlyProvider}
+                                  >
+                                    <FormattedMessage
+                                      id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderGuardrailsTab.add.guardrail"
+                                      defaultMessage={'Add'}
+                                    />
+                                  </Button>
+                                </DisabledActionTooltip>
                               </Grid>
 
                               <Grid size={{ xs: 12 }}>
@@ -964,24 +984,30 @@ export default function ServiceProviderGuardrailsTab() {
                                           /^v/,
                                           ''
                                         )})`}
-                                        onClick={() =>
-                                          handleEditGuardrailPill(
-                                            guardrail.policyIndex,
-                                            guardrail.pathIndex,
-                                            {
-                                              scope: 'resource',
-                                              method,
-                                              path: resource.path,
-                                            },
-                                            guardrail.source
-                                          )
+                                        onClick={
+                                          isReadOnlyProvider
+                                            ? undefined
+                                            : () =>
+                                              handleEditGuardrailPill(
+                                                guardrail.policyIndex,
+                                                guardrail.pathIndex,
+                                                {
+                                                  scope: 'resource',
+                                                  method,
+                                                  path: resource.path,
+                                                },
+                                                guardrail.source
+                                              )
                                         }
-                                        onRemove={() =>
-                                          void handleRemoveAppliedGuardrail(
-                                            guardrail.policyIndex,
-                                            guardrail.pathIndex,
-                                            guardrail.source
-                                          )
+                                        onRemove={
+                                          isReadOnlyProvider
+                                            ? undefined
+                                            : () =>
+                                              void handleRemoveAppliedGuardrail(
+                                                guardrail.policyIndex,
+                                                guardrail.pathIndex,
+                                                guardrail.source
+                                              )
                                         }
                                       />
                                     ))

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderModelsTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderModelsTab.tsx
@@ -38,6 +38,7 @@ import { useLLMProvider } from '../../../../contexts/llmProvider';
 import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
 import { FormattedMessage } from 'react-intl';
 import NoModelsImage from '../../../../assets/images/NoModels.svg';
+import { DisabledActionTooltip } from '../../../../utils/readOnlyArtifacts';
 
 type ProviderOption = {
   id: string;
@@ -153,6 +154,10 @@ function ModelPill({
 export default function ServiceProviderModelsTab() {
   const { provider, isLoading, error, updateProvider, isDraftMode } =
     useLLMProvider();
+  // The model catalog is control-plane-only metadata: it is NOT part of the gateway
+  // runtime artifact (the deployment spec carries no model list), so it stays editable
+  // even for gateway-created (read-only) providers.
+  const isReadOnlyProvider = false;
   const modelCatalog = useMemo<Record<string, string[]>>(
     () => ({
       meta: [
@@ -215,7 +220,9 @@ export default function ServiceProviderModelsTab() {
     errorMessage: string,
     nextSelectedProviderId = selectedProviderId
   ) => {
-    if (!provider || isLoading || error || isSaving) return false;
+    if (!provider || isLoading || error || isSaving || isReadOnlyProvider) {
+      return false;
+    }
 
     const {
       status,
@@ -418,9 +425,9 @@ export default function ServiceProviderModelsTab() {
                         name={p.name}
                         selected={p.id === selectedProviderId}
                         onClick={() => setSelectedProviderId(p.id)}
-                        removeDisabled={isSaving}
+                        removeDisabled={isSaving || isReadOnlyProvider}
                         onRemove={
-                          p.id === 'azureai-foundry'
+                          p.id === 'azureai-foundry' && !isReadOnlyProvider
                             ? () => {
                                 void removeProvider(p.id);
                               }
@@ -431,36 +438,38 @@ export default function ServiceProviderModelsTab() {
                     ))}
                   </Stack>
 
-                  <Tooltip
-                    placement="top"
-                    title={
-                      disableAddProviderButton ? (
-                        <FormattedMessage
-                          id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderModelsTab.single.provider.support.tooltip"
-                          defaultMessage={
-                            'Only one model provider is supported for this service provider.'
-                          }
-                        />
-                      ) : (
-                        ''
-                      )
-                    }
-                  >
-                    <Box component="span">
-                      <Button
-                        size="small"
-                        variant="outlined"
-                        startIcon={<Plus size={16} />}
-                        disabled={disableAddProviderButton}
-                        onClick={() => setDrawerOpen(true)}
-                      >
-                        <FormattedMessage
-                          id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderModelsTab.add.model.provider.2"
-                          defaultMessage={'Add Model Provider'}
-                        />
-                      </Button>
-                    </Box>
-                  </Tooltip>
+                  <DisabledActionTooltip disabled={isReadOnlyProvider}>
+                    <Tooltip
+                      placement="top"
+                      title={
+                        disableAddProviderButton ? (
+                          <FormattedMessage
+                            id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderModelsTab.single.provider.support.tooltip"
+                            defaultMessage={
+                              'Only one model provider is supported for this service provider.'
+                            }
+                          />
+                        ) : (
+                          ''
+                        )
+                      }
+                    >
+                      <Box component="span">
+                        <Button
+                          size="small"
+                          variant="outlined"
+                          startIcon={<Plus size={16} />}
+                          disabled={disableAddProviderButton || isReadOnlyProvider}
+                          onClick={() => setDrawerOpen(true)}
+                        >
+                          <FormattedMessage
+                            id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderModelsTab.add.model.provider.2"
+                            defaultMessage={'Add Model Provider'}
+                          />
+                        </Button>
+                      </Box>
+                    </Tooltip>
+                  </DisabledActionTooltip>
                 </Stack>
               ) : (
                 <Box
@@ -488,18 +497,20 @@ export default function ServiceProviderModelsTab() {
                         defaultMessage={'No providers added yet.'}
                       />
                     </Typography>
-                    <Button
-                      size="small"
-                      variant="outlined"
-                      startIcon={<Plus size={16} />}
-                      disabled={isSaving}
-                      onClick={() => setDrawerOpen(true)}
-                    >
-                      <FormattedMessage
-                        id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderModelsTab.add.model.provider.2"
-                        defaultMessage={'Add Model Provider'}
-                      />
-                    </Button>
+                    <DisabledActionTooltip disabled={isReadOnlyProvider}>
+                      <Button
+                        size="small"
+                        variant="outlined"
+                        startIcon={<Plus size={16} />}
+                        disabled={isSaving || isReadOnlyProvider}
+                        onClick={() => setDrawerOpen(true)}
+                      >
+                        <FormattedMessage
+                          id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderModelsTab.add.model.provider.2"
+                          defaultMessage={'Add Model Provider'}
+                        />
+                      </Button>
+                    </DisabledActionTooltip>
                   </Stack>
                 </Box>
               )}
@@ -533,7 +544,7 @@ export default function ServiceProviderModelsTab() {
                     size="small"
                     fullWidth
                     value={newModelName}
-                    disabled={isSaving}
+                    disabled={isSaving || isReadOnlyProvider}
                     onChange={(event) => setNewModelName(event.target.value)}
                     onKeyDown={(event) => {
                       if (event.key === 'Enter') {
@@ -564,9 +575,11 @@ export default function ServiceProviderModelsTab() {
                       <ModelPill
                         key={m.id}
                         label={m.name}
-                        removeDisabled={isSaving}
+                        removeDisabled={isSaving || isReadOnlyProvider}
                         onRemove={() => {
-                          void removeModel(m.id);
+                          if (!isReadOnlyProvider) {
+                            void removeModel(m.id);
+                          }
                         }}
                         removeAriaLabel={`Remove model ${m.name}`}
                       />
@@ -704,7 +717,7 @@ export default function ServiceProviderModelsTab() {
             <Button
               variant="contained"
               onClick={addProvider}
-              disabled={!selectedOption || isSaving}
+              disabled={!selectedOption || isSaving || isReadOnlyProvider}
             >
               <FormattedMessage
                 id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderModelsTab.add"

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverview.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverview.tsx
@@ -95,6 +95,10 @@ import {
   AIEntityProvider,
   useAIEntity,
 } from '../../../../contexts/AIEntitiesContext';
+import {
+  DisabledActionTooltip,
+  GatewayArtifactReadOnlyBanner,
+} from '../../../../utils/readOnlyArtifacts';
 
 import AnthropicLogo from '../../../../assets/brands/Anthropic.jpg';
 import AWSBedrockLogo from '../../../../assets/brands/AWSBedrock.webp';
@@ -203,7 +207,6 @@ const tabs = [
   'Guardrails & Policies',
   'Models',
 ];
-const MAX_LLM_PROXIES_PER_ORG = 5;
 
 type RateLimitingDraftActions = {
   saveDraftChanges: () => Promise<boolean>;
@@ -406,6 +409,8 @@ function ServiceProviderOverviewContent() {
   };
 
   const handleDeployNavigation = () => {
+    // DP-originated artifacts: the deployments page is viewable (actions are disabled
+    // there), so navigate rather than blocking with a warning.
     if (hasUnsavedChanges) {
       showSnackbar(UNSAVED_CHANGES_MESSAGE, 'error');
       return;
@@ -462,9 +467,11 @@ function ServiceProviderOverviewContent() {
     void refreshOrgProxyCount();
   }, [refreshOrgProxyCount]);
 
-  const isProxyQuotaReached = orgProxyCount >= MAX_LLM_PROXIES_PER_ORG;
+  const isProxyQuotaReached = false;
   const proxyQuotaTooltip =
     'You cannot create more App LLM Proxies because your organization has reached the maximum limit of 5 proxies.';
+  const isReadOnlyProvider = Boolean(provider?.readOnly);
+  const createProxyTooltip = isProxyQuotaReached ? proxyQuotaTooltip : '';
 
   const handleCreateProxyClick = () => {
     if (!provider?.id || isProxyQuotaReached) {
@@ -519,6 +526,7 @@ function ServiceProviderOverviewContent() {
     if (stepId === 'add-guardrails') {
       setTabIndex(5);
     } else if (stepId === 'deploy-to-gateway') {
+      // DP artifacts can still open the (read-only) deployments page.
       if (!provider?.id) return;
       const deployPath = isProjectLevel
         ? buildProjectPath(
@@ -1274,11 +1282,17 @@ function ServiceProviderOverviewContent() {
                     variant="outlined"
                     color="primary"
                   />
-                  <Tooltip title="Edit Service Provider">
-                    <IconButton component={RouterLink} to="edit" size="small">
-                      <Edit size={16} />
-                    </IconButton>
-                  </Tooltip>
+                  {/* Edit page (name/version/context/description). Enabled even for
+                      gateway-created providers — the page itself keeps the runtime
+                      fields (name/version/context) read-only and allows only the
+                      description, which is not part of the gateway runtime artifact. */}
+                  <IconButton
+                    component={RouterLink}
+                    to="edit"
+                    size="small"
+                  >
+                    <Edit size={16} />
+                  </IconButton>
                 </Stack>
                 <Typography variant="body2" color="text.secondary">
                   {truncatedDescription}
@@ -1316,33 +1330,45 @@ function ServiceProviderOverviewContent() {
                 width: { xs: '100%', sm: 200 },
               }}
             >
+              {/* For gateway-created (read-only) providers the deployments remain
+                  viewable (deploy/redeploy/restore/undeploy are disabled on the page
+                  itself), so the button navigates but is relabelled "View Deployments". */}
               <Button
                 variant="contained"
                 component={RouterLink}
                 to="deploy"
-                onClick={handleBlockedNavigation}
+                onClick={isReadOnlyProvider ? undefined : handleBlockedNavigation}
                 fullWidth
               >
-                <FormattedMessage
-                  id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderOverview.deploy.to.gateway"
-                  defaultMessage={'Deploy to Gateway'}
-                />
+                {isReadOnlyProvider ? (
+                  <FormattedMessage
+                    id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderOverview.view.deployments"
+                    defaultMessage={'View Deployments'}
+                  />
+                ) : (
+                  <FormattedMessage
+                    id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderOverview.deploy.to.gateway"
+                    defaultMessage={'Deploy to Gateway'}
+                  />
+                )}
               </Button>
-              <Tooltip title={isProxyQuotaReached ? proxyQuotaTooltip : ''}>
-                <Box component="span" sx={{ width: '100%' }}>
-                  <Button
-                    variant="outlined"
-                    onClick={handleCreateProxyClick}
-                    disabled={!provider.id || isProxyQuotaReached}
-                    fullWidth
-                  >
-                    <FormattedMessage
-                      id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderOverview.create.llm.proxy"
-                      defaultMessage="Create App LLM Proxy"
-                    />
-                  </Button>
-                </Box>
-              </Tooltip>
+              <DisabledActionTooltip
+                disabled={isProxyQuotaReached}
+                title={createProxyTooltip}
+                fullWidth
+              >
+                <Button
+                  variant="outlined"
+                  onClick={handleCreateProxyClick}
+                  disabled={!provider.id || isProxyQuotaReached}
+                  fullWidth
+                >
+                  <FormattedMessage
+                    id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderOverview.create.llm.proxy"
+                    defaultMessage="Create App LLM Proxy"
+                  />
+                </Button>
+              </DisabledActionTooltip>
             </Stack>
           </Box>
         </Card>
@@ -1373,18 +1399,30 @@ function ServiceProviderOverviewContent() {
               </TabPanel>
 
               <TabPanel value={tabIndex} index={1}>
+                {isReadOnlyProvider && (
+                  <GatewayArtifactReadOnlyBanner message="Connection settings are managed by the gateway that created this provider and are read-only here." />
+                )}
                 <ServiceProviderConnectionTab />
               </TabPanel>
 
               <TabPanel value={tabIndex} index={2}>
+                {isReadOnlyProvider && (
+                  <GatewayArtifactReadOnlyBanner message="Access control is managed by the gateway that created this provider and is read-only here." />
+                )}
                 <ServiceProviderResourcesTab />
               </TabPanel>
 
               <TabPanel value={tabIndex} index={3}>
+                {isReadOnlyProvider && (
+                  <GatewayArtifactReadOnlyBanner message="Security settings are managed by the gateway that created this provider and are read-only here." />
+                )}
                 <ServiceProviderSecurityTab />
               </TabPanel>
 
               <TabPanel value={tabIndex} index={4}>
+                {isReadOnlyProvider && (
+                  <GatewayArtifactReadOnlyBanner message="Rate limiting is managed by the gateway that created this provider and is read-only here." />
+                )}
                 <ServiceProviderRateLimitingTab
                   onDirtyChange={setIsRateLimitingDirty}
                   onActionsChange={setRateLimitingActions}
@@ -1392,6 +1430,9 @@ function ServiceProviderOverviewContent() {
               </TabPanel>
 
               <TabPanel value={tabIndex} index={5}>
+                {isReadOnlyProvider && (
+                  <GatewayArtifactReadOnlyBanner message="Guardrails & policies are managed by the gateway that created this provider and are read-only here." />
+                )}
                 <ServiceProviderGuardrailsTab />
               </TabPanel>
 

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverviewTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverviewTab.tsx
@@ -68,6 +68,10 @@ import SwaggerSpecViewer from '../../../../Components/SwaggerSpecViewer';
 import { filterOpenApiSpecByAccessControl } from '../../../../utils/openApiAccessControl';
 import { buildProjectPath } from '../../../../utils/projectRouting';
 import {
+  DisabledActionTooltip,
+  GATEWAY_MANAGED_ARTIFACT_TOOLTIP,
+} from '../../../../utils/readOnlyArtifacts';
+import {
   getCurrentDeployment,
   getProxyIdentifier,
 } from './ProviderMap/ProviderMapTab';
@@ -155,6 +159,7 @@ export default function ServiceProviderOverviewTab({
   const apiKeyLocation = provider?.security?.apiKey?.in ?? 'header';
   const apiKeyName = provider?.security?.apiKey?.key ?? 'X-API-Key';
   const showSnackbar = useAIWorkspaceSnackbar();
+  const isReadOnlyProvider = Boolean(provider?.readOnly);
 
   const parsedOpenApiSpec = useMemo(
     () => parseOpenApiSpec(provider?.openapi || ''),
@@ -598,7 +603,11 @@ export default function ServiceProviderOverviewTab({
   );
 
   const handleDeleteApiKey = async () => {
-    if (!deleteTargetKeyName || !provider?.id || !currentOrganization?.uuid) {
+    if (
+      !deleteTargetKeyName ||
+      !provider?.id ||
+      !currentOrganization?.uuid
+    ) {
       return;
     }
 
@@ -814,25 +823,16 @@ export default function ServiceProviderOverviewTab({
                           />
                         </Typography>
                       </Box>
-                      <Tooltip
-                        title={
-                          deployedGateways.length === 0
-                            ? 'No deployed gateways available. Deploy to a gateway first to generate an API key.'
-                            : ''
-                        }
-                        placement="top"
-                      >
-                        <span>
-                          <Button
-                            variant="contained"
-                            size="medium"
-                            onClick={handleOpenApiKeyModal}
-                            disabled={deployedGateways.length === 0}
-                          >
-                            Generate API Key
-                          </Button>
-                        </span>
-                      </Tooltip>
+                      <DisabledActionTooltip disabled={false}>
+                        <Button
+                          variant="contained"
+                          size="medium"
+                          onClick={handleOpenApiKeyModal}
+                          disabled={deployedGateways.length === 0}
+                        >
+                          Generate API Key
+                        </Button>
+                      </DisabledActionTooltip>
                     </Stack>
 
                     {keyError && (

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderRateLimitingTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderRateLimitingTab.tsx
@@ -57,6 +57,7 @@ import { filterOpenApiSpecByAccessControl } from '../../../../utils/openApiAcces
 import { ResourceRow } from '../../../../Components/ResourceView';
 import { FormattedMessage } from 'react-intl';
 import type { AccessControl } from '../../../../utils/types';
+import { GATEWAY_MANAGED_ARTIFACT_TOOLTIP } from '../../../../utils/readOnlyArtifacts';
 
 type ResourceItem = {
   method: string;
@@ -79,6 +80,7 @@ type CriteriaMap = Record<string, RateLimitCriteria[]>;
 type CriteriaRowsProps = {
   criteria: RateLimitCriteria[];
   onChange: (next: RateLimitCriteria[]) => void;
+  disabled?: boolean;
 };
 
 const UNITS = ['hour', 'day', 'week', 'month'] as const;
@@ -142,7 +144,11 @@ function extractResourcesFromSpecJson(spec: any): ResourceItem[] {
   return extracted;
 }
 
-function CriteriaRows({ criteria, onChange }: CriteriaRowsProps) {
+function CriteriaRows({
+  criteria,
+  onChange,
+  disabled = false,
+}: CriteriaRowsProps) {
   const [rows, setRows] = useState<RateLimitCriteria[]>(criteria);
   const [openMap, setOpenMap] = useState<Record<string, boolean>>({});
 
@@ -221,13 +227,14 @@ function CriteriaRows({ criteria, onChange }: CriteriaRowsProps) {
                     <Switch
                       size="small"
                       checked={Boolean(item.enabled)}
+                      disabled={disabled}
                       onChange={() => toggleEnabled(item.label)}
                     />
                   }
                 />
                 <IconButton
                   size="small"
-                  disabled={!item.enabled}
+                  disabled={!item.enabled || disabled}
                   onClick={() => toggleOpen(item.label)}
                 >
                   {openMap[item.label] ? (
@@ -249,6 +256,7 @@ function CriteriaRows({ criteria, onChange }: CriteriaRowsProps) {
                       <TextField
                         size="small"
                         value={item.quota}
+                        disabled={disabled}
                         onChange={(e) =>
                           updateRow(item.label, { quota: e.target.value })
                         }
@@ -276,6 +284,7 @@ function CriteriaRows({ criteria, onChange }: CriteriaRowsProps) {
                           size="small"
                           type="number"
                           value={item.resetValue}
+                          disabled={disabled}
                           onChange={(e) =>
                             updateRow(item.label, { resetValue: e.target.value })
                           }
@@ -285,6 +294,7 @@ function CriteriaRows({ criteria, onChange }: CriteriaRowsProps) {
                         <Select
                           size="small"
                           value={item.resetUnit || 'hour'}
+                          disabled={disabled}
                           onChange={(e) => {
                             updateRow(item.label, {
                               resetUnit: String(e.target.value),
@@ -318,6 +328,8 @@ function ModeToggle({
   disableResource,
   disableGlobalReason,
   disableResourceReason,
+  disabled = false,
+  disabledReason,
 }: {
   value: 'global' | 'resource';
   onChange: (v: 'global' | 'resource') => void;
@@ -325,6 +337,8 @@ function ModeToggle({
   disableResource?: boolean;
   disableGlobalReason?: string;
   disableResourceReason?: string;
+  disabled?: boolean;
+  disabledReason?: string;
 }) {
   const handleChange = (
     _e: React.MouseEvent<HTMLElement>,
@@ -341,13 +355,19 @@ function ModeToggle({
       onChange={handleChange}
     >
       <Tooltip
-        title={disableGlobal ? disableGlobalReason || '' : ''}
+        title={
+          disabled
+            ? disabledReason || ''
+            : disableGlobal
+              ? disableGlobalReason || ''
+              : ''
+        }
         placement="top"
       >
         <Box component="span">
           <ToggleButton
             value="global"
-            disabled={Boolean(disableGlobal)}
+            disabled={disabled || Boolean(disableGlobal)}
             sx={{ textTransform: 'none' }}
           >
             Provider-wide
@@ -355,13 +375,19 @@ function ModeToggle({
         </Box>
       </Tooltip>
       <Tooltip
-        title={disableResource ? disableResourceReason || '' : ''}
+        title={
+          disabled
+            ? disabledReason || ''
+            : disableResource
+              ? disableResourceReason || ''
+              : ''
+        }
         placement="top"
       >
         <Box component="span">
           <ToggleButton
             value="resource"
-            disabled={Boolean(disableResource)}
+            disabled={disabled || Boolean(disableResource)}
             sx={{ textTransform: 'none' }}
           >
             Per Resource
@@ -527,6 +553,7 @@ export default function ServiceProviderRateLimitingTab({
 }: ServiceProviderRateLimitingTabProps) {
   const { provider, isLoading, error, updateProvider, isDraftMode } =
     useLLMProvider();
+  const isReadOnlyProvider = Boolean(provider?.readOnly);
   const [backendRateMode, setBackendRateMode] = useState<'global' | 'resource'>(
     'global'
   );
@@ -818,7 +845,7 @@ export default function ServiceProviderRateLimitingTab({
   };
 
   const handleSaveRateLimiting = async (): Promise<boolean> => {
-    if (!provider || isLoading || error) return false;
+    if (!provider || isLoading || error || isReadOnlyProvider) return false;
     if (backendHasGlobalConfig && backendHasResourceConfig) {
       showSnackbar(
         'Backend cannot have both Provider-wide and Per Resource values. Remove one side and try again.',
@@ -930,6 +957,8 @@ export default function ServiceProviderRateLimitingTab({
                 <ModeToggle
                   value={backendRateMode}
                   onChange={handleBackendModeChange}
+                  disabled={isReadOnlyProvider}
+                  disabledReason={GATEWAY_MANAGED_ARTIFACT_TOOLTIP}
                   disableGlobal={
                     backendRateMode !== 'global' && backendHasResourceConfig
                   }
@@ -1002,6 +1031,7 @@ export default function ServiceProviderRateLimitingTab({
                         >
                           <CriteriaRows
                             criteria={backendDefaultCriteria}
+                            disabled={isReadOnlyProvider}
                             onChange={(next) => {
                               setBackendDefaultCriteria(next);
                               setIsDirty(true);
@@ -1119,6 +1149,7 @@ export default function ServiceProviderRateLimitingTab({
                               >
                                 <CriteriaRows
                                   criteria={criteria}
+                                  disabled={isReadOnlyProvider}
                                   onChange={(next) =>
                                     updateBackendResourceCriteria(key, next)
                                   }
@@ -1136,6 +1167,7 @@ export default function ServiceProviderRateLimitingTab({
                     <Divider />
                     <CriteriaRows
                       criteria={backendGlobalCriteria}
+                      disabled={isReadOnlyProvider}
                       onChange={(next) => {
                         setBackendGlobalCriteria(next);
                         setIsDirty(true);
@@ -1165,6 +1197,8 @@ export default function ServiceProviderRateLimitingTab({
                 <ModeToggle
                   value={consumerRateMode}
                   onChange={handleConsumerModeChange}
+                  disabled={isReadOnlyProvider}
+                  disabledReason={GATEWAY_MANAGED_ARTIFACT_TOOLTIP}
                   disableGlobal={consumerRateMode !== 'global' && consumerHasResourceConfig}
                   disableResource={consumerRateMode !== 'resource' && consumerHasGlobalConfig}
                   disableGlobalReason='If you need Provider-wide, remove Per Resource values first.'
@@ -1232,6 +1266,7 @@ export default function ServiceProviderRateLimitingTab({
                         >
                           <CriteriaRows
                             criteria={consumerDefaultCriteria}
+                            disabled={isReadOnlyProvider}
                             onChange={(next) => {
                               setConsumerDefaultCriteria(next);
                               setIsDirty(true);
@@ -1351,6 +1386,7 @@ export default function ServiceProviderRateLimitingTab({
                               >
                                 <CriteriaRows
                                   criteria={criteria}
+                                  disabled={isReadOnlyProvider}
                                   onChange={(next) =>
                                     updateConsumerResourceCriteria(key, next)
                                   }
@@ -1368,6 +1404,7 @@ export default function ServiceProviderRateLimitingTab({
                     <Divider />
                     <CriteriaRows
                       criteria={consumerGlobalCriteria}
+                      disabled={isReadOnlyProvider}
                       onChange={(next) => {
                         setConsumerGlobalCriteria(next);
                         setIsDirty(true);

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderResourcesTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderResourcesTab.tsx
@@ -46,6 +46,9 @@ import { useLLMProvider } from '../../../../contexts/llmProvider';
 import { PLATFORM_API_BASE_URL } from '../../../../config.env';
 import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
 import { logger } from '../../../../utils/logger';
+import {
+  DisabledActionTooltip,
+} from '../../../../utils/readOnlyArtifacts';
 import NoData from '../../../../assets/images/NoData.svg';
 import { ExpandableResourceRow } from '../../../../Components/ResourceView';
 import { FormattedMessage } from 'react-intl';
@@ -179,6 +182,7 @@ function buildOperationSpec(
 export default function ServiceProviderResourcesTab() {
   const { provider, isLoading, error, updateProvider, isDraftMode } =
     useLLMProvider();
+  const isReadOnlyProvider = Boolean(provider?.readOnly);
   const [resourceMode, setResourceMode] = useState<'allow' | 'deny'>('allow');
   const [pendingResourceMode, setPendingResourceMode] = useState<
     'allow' | 'deny' | null
@@ -240,7 +244,7 @@ export default function ServiceProviderResourcesTab() {
     exceptions: ResourceItem[],
     nextOpenapi: string
   ) => {
-    if (!provider || isLoading || error) return;
+    if (!provider || isLoading || error || isReadOnlyProvider) return;
     const {
       status,
       createdAt,
@@ -279,6 +283,7 @@ export default function ServiceProviderResourcesTab() {
     _event: React.MouseEvent<HTMLElement>,
     newMode: 'allow' | 'deny' | null
   ) => {
+    if (isReadOnlyProvider) return;
     if (!newMode || newMode === resourceMode) return;
     setPendingResourceMode(newMode);
     setResourceModeConfirmOpen(true);
@@ -290,6 +295,10 @@ export default function ServiceProviderResourcesTab() {
   };
 
   const handleApplyResourceModeChange = () => {
+    if (isReadOnlyProvider) {
+      handleCancelResourceModeChange();
+      return;
+    }
     if (!pendingResourceMode || pendingResourceMode === resourceMode) {
       handleCancelResourceModeChange();
       return;
@@ -348,12 +357,14 @@ export default function ServiceProviderResourcesTab() {
   const updateSpecFileInputRef = useRef<HTMLInputElement | null>(null);
 
   const handleUpdateSpecUploadClick = () => {
+    if (isReadOnlyProvider) return;
     updateSpecFileInputRef.current?.click();
   };
 
   const handleUpdateSpecFileChange = async (
     e: React.ChangeEvent<HTMLInputElement>
   ) => {
+    if (isReadOnlyProvider) return;
     const file = e.target.files?.[0];
     if (!file) return;
 
@@ -379,6 +390,7 @@ export default function ServiceProviderResourcesTab() {
   };
 
   const applySpecificationFromUrl = async (url: string) => {
+    if (isReadOnlyProvider) return;
     if (!url.trim()) return;
     setIsFetchingSpec(true);
     try {
@@ -409,10 +421,12 @@ export default function ServiceProviderResourcesTab() {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const handleUploadClick = () => {
+    if (isReadOnlyProvider) return;
     fileInputRef.current?.click();
   };
 
   const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (isReadOnlyProvider) return;
     const file = e.target.files?.[0];
     if (!file) return;
 
@@ -538,6 +552,7 @@ export default function ServiceProviderResourcesTab() {
   };
 
   const moveSelectedToExceptions = () => {
+    if (isReadOnlyProvider) return;
     if (!selectedAvailableKeys.length) return;
     const selected = availableResources.filter((resource) =>
       selectedAvailableKeySet.has(getResourceKey(resource))
@@ -550,6 +565,7 @@ export default function ServiceProviderResourcesTab() {
   };
 
   const moveSelectedToAvailable = () => {
+    if (isReadOnlyProvider) return;
     if (!selectedExceptionKeys.length) return;
     const nextExceptions = exceptionResources.filter(
       (resource) => !selectedExceptionKeySet.has(getResourceKey(resource))
@@ -560,6 +576,7 @@ export default function ServiceProviderResourcesTab() {
   };
 
   const moveAllToExceptions = () => {
+    if (isReadOnlyProvider) return;
     const nextExceptions = normalized;
     setExceptionResources(nextExceptions);
     setSelectedAvailableKeys([]);
@@ -567,6 +584,7 @@ export default function ServiceProviderResourcesTab() {
   };
 
   const moveAllToAvailable = () => {
+    if (isReadOnlyProvider) return;
     setExceptionResources([]);
     setSelectedExceptionKeys([]);
     void updateAccessControl(resourceMode, [], openapiText);
@@ -667,7 +685,13 @@ export default function ServiceProviderResourcesTab() {
               exclusive
               onChange={handleResourceModeChange}
             >
-              <ToggleButton value="allow" sx={{ textTransform: 'none' }}>
+              <DisabledActionTooltip disabled={isReadOnlyProvider}>
+                <Box component="span">
+                  <ToggleButton
+                    value="allow"
+                    disabled={isReadOnlyProvider}
+                    sx={{ textTransform: 'none' }}
+                  >
                 <FormattedMessage
                   id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderResourcesTab.allow.all"
                   defaultMessage={'Allow all'}
@@ -680,13 +704,21 @@ export default function ServiceProviderResourcesTab() {
                       defaultMessage="Allow all exposes every available resource. Any exception you add will be hidden."
                     />
                   }
-                >
-                  <IconButton size="small">
-                    <HelpCircle size={16} />
-                  </IconButton>
-                </Tooltip>
-              </ToggleButton>
-              <ToggleButton value="deny" sx={{ textTransform: 'none' }}>
+                  >
+                    <IconButton size="small">
+                      <HelpCircle size={16} />
+                    </IconButton>
+                  </Tooltip>
+                  </ToggleButton>
+                </Box>
+              </DisabledActionTooltip>
+              <DisabledActionTooltip disabled={isReadOnlyProvider}>
+                <Box component="span">
+                  <ToggleButton
+                    value="deny"
+                    disabled={isReadOnlyProvider}
+                    sx={{ textTransform: 'none' }}
+                  >
                 <FormattedMessage
                   id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderResourcesTab.deny.all"
                   defaultMessage={'Deny all'}
@@ -699,12 +731,14 @@ export default function ServiceProviderResourcesTab() {
                       defaultMessage="Deny all hides every available resource. Any exception you add will be exposed."
                     />
                   }
-                >
-                  <IconButton size="small">
-                    <HelpCircle size={16} />
-                  </IconButton>
-                </Tooltip>
-              </ToggleButton>
+                  >
+                    <IconButton size="small">
+                      <HelpCircle size={16} />
+                    </IconButton>
+                  </Tooltip>
+                  </ToggleButton>
+                </Box>
+              </DisabledActionTooltip>
             </ToggleButtonGroup>
           </Box>
 
@@ -727,17 +761,20 @@ export default function ServiceProviderResourcesTab() {
               accept=".json,.yaml,.yml"
               onChange={handleFileChange}
             /> */}
-            <Button
-              variant="outlined"
-              size="small"
-              startIcon={<PenLine size={16} />}
-              onClick={() => setUpdateSpecModalOpen(true)}
-            >
-              <FormattedMessage
-                id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderResourcesTab.update.openapi.definition"
-                defaultMessage={'Update OpenAPI Definition'}
-              />
-            </Button>
+            <DisabledActionTooltip disabled={isReadOnlyProvider}>
+              <Button
+                variant="outlined"
+                size="small"
+                startIcon={<PenLine size={16} />}
+                onClick={() => setUpdateSpecModalOpen(true)}
+                disabled={isReadOnlyProvider}
+              >
+                <FormattedMessage
+                  id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderResourcesTab.update.openapi.definition"
+                  defaultMessage={'Update OpenAPI Definition'}
+                />
+              </Button>
+            </DisabledActionTooltip>
           </Box>
         </Box>
 
@@ -838,50 +875,58 @@ export default function ServiceProviderResourcesTab() {
             }}
           >
             <Stack spacing={1}>
-              <Button
-                variant="outlined"
-                size="small"
-                onClick={moveAllToExceptions}
-                disabled={!availableResources.length}
-              >
+              <DisabledActionTooltip disabled={isReadOnlyProvider}>
+                <Button
+                  variant="outlined"
+                  size="small"
+                  onClick={moveAllToExceptions}
+                  disabled={!availableResources.length || isReadOnlyProvider}
+                >
                 <FormattedMessage
                   id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderResourcesTab.message"
                   defaultMessage={'>>'}
                 />
-              </Button>
-              <Button
-                variant="outlined"
-                size="small"
-                onClick={moveSelectedToExceptions}
-                disabled={!selectedAvailableKeys.length}
-              >
+                </Button>
+              </DisabledActionTooltip>
+              <DisabledActionTooltip disabled={isReadOnlyProvider}>
+                <Button
+                  variant="outlined"
+                  size="small"
+                  onClick={moveSelectedToExceptions}
+                  disabled={!selectedAvailableKeys.length || isReadOnlyProvider}
+                >
                 <FormattedMessage
                   id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderResourcesTab.message.2"
                   defaultMessage={'>'}
                 />
-              </Button>
-              <Button
-                variant="outlined"
-                size="small"
-                onClick={moveSelectedToAvailable}
-                disabled={!selectedExceptionKeys.length}
-              >
+                </Button>
+              </DisabledActionTooltip>
+              <DisabledActionTooltip disabled={isReadOnlyProvider}>
+                <Button
+                  variant="outlined"
+                  size="small"
+                  onClick={moveSelectedToAvailable}
+                  disabled={!selectedExceptionKeys.length || isReadOnlyProvider}
+                >
                 <FormattedMessage
                   id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderResourcesTab.message.3"
                   defaultMessage={'<'}
                 />
-              </Button>
-              <Button
-                variant="outlined"
-                size="small"
-                onClick={moveAllToAvailable}
-                disabled={!exceptionResources.length}
-              >
+                </Button>
+              </DisabledActionTooltip>
+              <DisabledActionTooltip disabled={isReadOnlyProvider}>
+                <Button
+                  variant="outlined"
+                  size="small"
+                  onClick={moveAllToAvailable}
+                  disabled={!exceptionResources.length || isReadOnlyProvider}
+                >
                 <FormattedMessage
                   id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderResourcesTab.message.4"
                   defaultMessage={'<<'}
                 />
-              </Button>
+                </Button>
+              </DisabledActionTooltip>
             </Stack>
           </Box>
 
@@ -1038,7 +1083,7 @@ export default function ServiceProviderResourcesTab() {
                   <Button
                     variant="outlined"
                     size="small"
-                    disabled={isFetchingSpec}
+                    disabled={isFetchingSpec || isReadOnlyProvider}
                     onClick={() => {
                       void applySpecificationFromUrl(specUrl);
                     }}
@@ -1053,6 +1098,7 @@ export default function ServiceProviderResourcesTab() {
               variant="outlined"
               fullWidth
               onClick={handleUpdateSpecUploadClick}
+              disabled={isReadOnlyProvider}
             >
               Upload Your Specification
             </Button>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderSecurityTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderSecurityTab.tsx
@@ -42,8 +42,9 @@ export default function ServiceProviderSecurityTab() {
   const [keyValue, setKeyValue] = useState('');
   const [keyIn, setKeyIn] = useState<'header' | 'query'>('header');
   const showSnackbar = useAIWorkspaceSnackbar();
+  const isReadOnlyProvider = Boolean(provider?.readOnly);
   const isSecurityFormDisabled =
-    !apiKeyEnabled || isLoading || Boolean(error);
+    !apiKeyEnabled || isLoading || Boolean(error) || isReadOnlyProvider;
 
   useEffect(() => {
     if (!provider) return;
@@ -61,7 +62,7 @@ export default function ServiceProviderSecurityTab() {
     nextIn: 'header' | 'query',
     nextEnabled: boolean
   ) => {
-    if (!provider || isLoading || error) return;
+    if (!provider || isLoading || error || isReadOnlyProvider) return;
     const {
       status,
       createdAt,
@@ -162,7 +163,7 @@ export default function ServiceProviderSecurityTab() {
                   <Switch
                     size="small"
                     checked={apiKeyEnabled}
-                    disabled={isLoading || Boolean(error)}
+                    disabled={isLoading || Boolean(error) || isReadOnlyProvider}
                     onChange={handleApiKeyEnabledChange}
                   />
                 </Tooltip>

--- a/portals/ai-workspace/src/utils/readOnlyArtifacts.tsx
+++ b/portals/ai-workspace/src/utils/readOnlyArtifacts.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { ReactNode } from 'react';
+import { Box, Card, Stack, Tooltip, Typography } from '@wso2/oxygen-ui';
+import { Lock } from '@wso2/oxygen-ui-icons-react';
+
+export const GATEWAY_MANAGED_ARTIFACT_TOOLTIP =
+  'This operation is unavailable because the artifact was created from a gateway.';
+
+export const GATEWAY_MANAGED_SECTION_MESSAGE =
+  'This artifact was created from a gateway. This configuration is owned by the gateway and is read-only in AI Workspace.';
+
+/**
+ * Read-only banner shown at the top of a configuration section that is part of a
+ * gateway-created (data-plane-originated) artifact's runtime configuration. Such
+ * sections cannot be edited from the control plane; only non-runtime metadata
+ * (description, models, docs) remains editable. Pass a section-specific `message`
+ * to clarify which section is locked.
+ */
+export function GatewayArtifactReadOnlyBanner({
+  message = GATEWAY_MANAGED_SECTION_MESSAGE,
+}: {
+  message?: string;
+}) {
+  return (
+    <Card sx={{ bgcolor: 'action.hover', mb: 2 }}>
+      <Stack direction="row" spacing={1.5} alignItems="center" sx={{ p: 2 }}>
+        <Lock size={18} />
+        <Typography variant="body2">
+          <strong>{message}</strong>
+        </Typography>
+      </Stack>
+    </Card>
+  );
+}
+
+type DisabledActionTooltipProps = {
+  children: ReactNode;
+  disabled: boolean;
+  title?: ReactNode;
+  fullWidth?: boolean;
+};
+
+export function DisabledActionTooltip({
+  children,
+  disabled,
+  title = GATEWAY_MANAGED_ARTIFACT_TOOLTIP,
+  fullWidth = false,
+}: DisabledActionTooltipProps) {
+  return (
+    <Tooltip
+      title={disabled ? title : ''}
+      disableHoverListener={!disabled}
+      disableFocusListener={!disabled}
+      disableTouchListener={!disabled}
+      placement="top"
+    >
+      <Box
+        component="span"
+        sx={fullWidth ? { width: '100%', display: 'inline-flex' } : undefined}
+      >
+        {children}
+      </Box>
+    </Tooltip>
+  );
+}

--- a/portals/ai-workspace/src/utils/types.ts
+++ b/portals/ai-workspace/src/utils/types.ts
@@ -383,6 +383,7 @@ export interface LLMProvider {
   policies?: Policy[];
   security?: SecurityConfig;
   status?: 'Active' | 'Degraded' | 'Paused' | string;
+  readOnly?: boolean;
   createdAt?: string;
   createdBy?: string;
   updatedAt?: string;
@@ -470,6 +471,14 @@ export interface ProviderTemplate {
   version: string;
   isLatest?: boolean;
   enabled?: boolean;
+  /**
+   * True when the template was pushed up from a data-plane gateway (origin
+   * "gateway_api"). Its gateway-consumed configuration — the Connection
+   * (endpoint/auth) and Token Mapping (extraction identifiers + resource
+   * mappings) sections — is owned by the gateway and read-only in the control
+   * plane; name/description/OpenAPI/logo remain editable.
+   */
+  readOnly?: boolean;
   promptTokens?: TokenLocation;
   completionTokens?: TokenLocation;
   totalTokens?: TokenLocation;
@@ -595,6 +604,7 @@ export interface Proxy {
   operationPolicies?: OperationPolicy[];
   policies?: Policy[];
   security?: ProxySecurityConfig;
+  readOnly?: boolean;
   createdAt?: string;
   updatedAt?: string;
 }
@@ -776,6 +786,7 @@ export interface MCPServer {
   kind?: string;
   policies?: unknown[];
   capabilities?: MCPServerCapabilities;
+  readOnly?: boolean;
   createdAt?: string;
   updatedAt?: string;
 }


### PR DESCRIPTION
This pull request introduces a "read-only" mode for gateway-originated LLM provider templates, LLM providers, LLM proxies and MCP proxies, ensuring that deployment and configuration actions are disabled in the UI when the artifact is owned by the gateway. It also improves user feedback by displaying informational alerts and disables editing of certain fields for these read-only resources.

Related to - https://github.com/wso2/api-platform/issues/2083

### UI 
#### LLM Provider
<img width="1249" height="644" alt="Screenshot 2026-07-01 at 15 28 28" src="https://github.com/user-attachments/assets/4c4a0fbe-0798-482d-903c-5247e758a5b7" />

<img width="1261" height="580" alt="Screenshot 2026-07-01 at 15 28 40" src="https://github.com/user-attachments/assets/db2ca4fb-9b89-4c00-a699-10ef82a009ab" />


#### LLM proxy
<img width="1239" height="563" alt="Screenshot 2026-07-01 at 15 29 56" src="https://github.com/user-attachments/assets/e2f9466a-3b54-4dee-9b3a-19f8c534a99d" />

<img width="1245" height="548" alt="Screenshot 2026-07-01 at 15 30 04" src="https://github.com/user-attachments/assets/cb78e362-1f4b-4f8b-961c-7f734768a796" />


#### MCP Proxy
<img width="1248" height="626" alt="Screenshot 2026-07-01 at 15 29 33" src="https://github.com/user-attachments/assets/261441a6-e8d1-402c-8722-e35c10d2d9d5" />

<img width="1259" height="602" alt="Screenshot 2026-07-01 at 15 29 14" src="https://github.com/user-attachments/assets/af0940ec-91f3-4100-8a17-d1567a2c2952" />


The most important changes are:

**Read-only mode support for gateway-originated artifacts:**

* Added a `readOnly` property to the `GatewayDeployContext` and its provider, propagating this state throughout deployment-related components (`GatewayDeployContext.tsx`). [[1]](diffhunk://#diff-c0ae94bad24619e651f1b66d78e0f3dd3c3fb9b3b79bb96b2f76716e56f3e7c9R145-R151) [[2]](diffhunk://#diff-c0ae94bad24619e651f1b66d78e0f3dd3c3fb9b3b79bb96b2f76716e56f3e7c9R161-R169) [[3]](diffhunk://#diff-c0ae94bad24619e651f1b66d78e0f3dd3c3fb9b3b79bb96b2f76716e56f3e7c9R679) [[4]](diffhunk://#diff-c0ae94bad24619e651f1b66d78e0f3dd3c3fb9b3b79bb96b2f76716e56f3e7c9R697)
* Updated deployment action components (`GatewayDeployCardActions`, `GatewayDeployEnvCard`, `GatewayDeploymentSelector`) to disable deploy, redeploy, restore, and undeploy actions when `readOnly` is true. [[1]](diffhunk://#diff-857645e7a49826bd7ffdfe2596ab489f3104099f8641851bff831827ff024392R39) [[2]](diffhunk://#diff-857645e7a49826bd7ffdfe2596ab489f3104099f8641851bff831827ff024392L56-R58) [[3]](diffhunk://#diff-02d25f59a0a0ed1bbe34413f475352eedc6f25f150adede4825dd3e224837410R47) [[4]](diffhunk://#diff-02d25f59a0a0ed1bbe34413f475352eedc6f25f150adede4825dd3e224837410L179-R180) [[5]](diffhunk://#diff-02d25f59a0a0ed1bbe34413f475352eedc6f25f150adede4825dd3e224837410L210-R211) [[6]](diffhunk://#diff-02d25f59a0a0ed1bbe34413f475352eedc6f25f150adede4825dd3e224837410L221-R222) [[7]](diffhunk://#diff-cb74e36b5571f5a98a4527c1e8d24f9b08bb471c21d741c25a38712c580c4dc7L45-R45) [[8]](diffhunk://#diff-cb74e36b5571f5a98a4527c1e8d24f9b08bb471c21d741c25a38712c580c4dc7L274-R274)

**UI/UX improvements for read-only artifacts:**

* In the external server deployment and edit pages, display an info alert when the server is read-only, and disable editing of the name, version, and context fields (but allow description changes). [[1]](diffhunk://#diff-f06e5a05ce44f8e07a93034d3ee819b4d550beaadf7d2dcd6ad3d79ccaf1276cR115) [[2]](diffhunk://#diff-f06e5a05ce44f8e07a93034d3ee819b4d550beaadf7d2dcd6ad3d79ccaf1276cR163-R165) [[3]](diffhunk://#diff-f06e5a05ce44f8e07a93034d3ee819b4d550beaadf7d2dcd6ad3d79ccaf1276cR265-R271) [[4]](diffhunk://#diff-f06e5a05ce44f8e07a93034d3ee819b4d550beaadf7d2dcd6ad3d79ccaf1276cR286) [[5]](diffhunk://#diff-f06e5a05ce44f8e07a93034d3ee819b4d550beaadf7d2dcd6ad3d79ccaf1276cR303) [[6]](diffhunk://#diff-f06e5a05ce44f8e07a93034d3ee819b4d550beaadf7d2dcd6ad3d79ccaf1276cR339) [[7]](diffhunk://#diff-dd9b3434d86b6bb1ea91d40f38c6cf2192ade4188f57892c7accbe4483ec8775R22) [[8]](diffhunk://#diff-dd9b3434d86b6bb1ea91d40f38c6cf2192ade4188f57892c7accbe4483ec8775L42-R52) [[9]](diffhunk://#diff-dd9b3434d86b6bb1ea91d40f38c6cf2192ade4188f57892c7accbe4483ec8775R89-R95)
* Pass the `readOnly` state from the loaded server to the `GatewayDeployProvider` and deployment layout, ensuring the UI reflects the correct permissions. [[1]](diffhunk://#diff-dd9b3434d86b6bb1ea91d40f38c6cf2192ade4188f57892c7accbe4483ec8775R104-R117) [[2]](diffhunk://#diff-dd9b3434d86b6bb1ea91d40f38c6cf2192ade4188f57892c7accbe4483ec8775L125-R138)
* 

**Policy editing restrictions:**

* Disabled all policy modification actions (add, update, remove, reorder, save/cancel changes) in the external server overview when the server is read-only. [[1]](diffhunk://#diff-b8fc070a1515d2b9fdf1cd82cfb560f3b9f40e0db05552359adc0cf588d5b143R202) [[2]](diffhunk://#diff-b8fc070a1515d2b9fdf1cd82cfb560f3b9f40e0db05552359adc0cf588d5b143R438-R443) [[3]](diffhunk://#diff-b8fc070a1515d2b9fdf1cd82cfb560f3b9f40e0db05552359adc0cf588d5b143R497) [[4]](diffhunk://#diff-b8fc070a1515d2b9fdf1cd82cfb560f3b9f40e0db05552359adc0cf588d5b143R507) [[5]](diffhunk://#diff-b8fc070a1515d2b9fdf1cd82cfb560f3b9f40e0db05552359adc0cf588d5b143R516) [[6]](diffhunk://#diff-b8fc070a1515d2b9fdf1cd82cfb560f3b9f40e0db05552359adc0cf588d5b143R526)

**General codebase improvements:**

* Refactored data loading in deployment and overview pages to ensure the `readOnly` state is consistently derived from the loaded server object. [[1]](diffhunk://#diff-dd9b3434d86b6bb1ea91d40f38c6cf2192ade4188f57892c7accbe4483ec8775L42-R52) [[2]](diffhunk://#diff-dd9b3434d86b6bb1ea91d40f38c6cf2192ade4188f57892c7accbe4483ec8775R104-R117) [[3]](diffhunk://#diff-dd9b3434d86b6bb1ea91d40f38c6cf2192ade4188f57892c7accbe4483ec8775L125-R138) [[4]](diffhunk://#diff-b8fc070a1515d2b9fdf1cd82cfb560f3b9f40e0db05552359adc0cf588d5b143R75-R77)