### PR TITLE
Refactor artifact updates and creation

### DIFF
--- a/platform-api/README.md
+++ b/platform-api/README.md
@@ -348,6 +348,11 @@ In **IDP mode with `AUTH_IDP_VALIDATION_MODE=role`**, IDP roles are resolved fro
 | `TLS_CERT_DIR` | `./data/certs` | Directory for TLS certificates |
 | `DEPLOYMENTS_MAX_PER_API_GATEWAY` | `20` | Maximum deployments per API per gateway |
 | `DEPLOYMENTS_TRANSITIONAL_STATUS_ENABLED` | `false` | Show `DEPLOYING`/`UNDEPLOYING` status before gateway ack |
+| `ARTIFACT_LIMITS_MAX_LLM_PROVIDERS_PER_ORG` | _unlimited_ | Max LLM providers per organization (`0` or unset = unlimited) |
+| `ARTIFACT_LIMITS_MAX_LLM_PROXIES_PER_ORG` | _unlimited_ | Max LLM proxies per organization (`0` or unset = unlimited) |
+| `ARTIFACT_LIMITS_MAX_MCP_PROXIES_PER_ORG` | _unlimited_ | Max MCP proxies per organization (`0` or unset = unlimited) |
+| `ARTIFACT_LIMITS_MAX_WEBSUB_APIS_PER_ORG` | _unlimited_ | Max WebSub APIs per organization (`0` or unset = unlimited) |
+| `ARTIFACT_LIMITS_MAX_WEBBROKER_APIS_PER_ORG` | _unlimited_ | Max WebBroker APIs per organization (`0` or unset = unlimited) |
 | `GATEWAY_ENABLE_VERSION_VERIFICATION` | `false` | Reject gateway connections with mismatched versions |
 | `API_KEY_HASHING_ALGORITHMS` | `sha256` | Comma-separated hash algorithms for API key storage |
 

--- a/platform-api/src/config/config.go
+++ b/platform-api/src/config/config.go
@@ -84,6 +84,7 @@ type Server struct {
 	WebSocket        WebSocket        `koanf:"websocket"`
 	DefaultDevPortal DefaultDevPortal `koanf:"default_devportal"`
 	Deployments      Deployments      `koanf:"deployments"`
+	ArtifactLimits   ArtifactLimits   `koanf:"artifact_limits"`
 	TLS              TLS              `koanf:"tls"`
 	APIKey           APIKey           `koanf:"api_key"`
 	Gateway          Gateway          `koanf:"gateway"`
@@ -178,7 +179,7 @@ type Database struct {
 
 	EncryptionKey                  string `koanf:"encryption_key"`
 	SubscriptionTokenEncryptionKey string `koanf:"subscription_token_encryption_key"`
-	SecretEncryptionKey string `koanf:"secret_encryption_key"`
+	SecretEncryptionKey            string `koanf:"secret_encryption_key"`
 }
 
 // DefaultDevPortal holds default DevPortal configuration for new organizations.
@@ -207,6 +208,24 @@ type Deployments struct {
 	TimeoutEnabled            bool `koanf:"timeout_enabled"`
 	TimeoutInterval           int  `koanf:"timeout_interval"`
 	TimeoutDuration           int  `koanf:"timeout_duration"`
+}
+
+// ArtifactLimits holds the maximum number of each artifact kind an organization
+// may create. Each limit is optional: a value <= 0 (the default) means unlimited,
+// so organizations may create as many artifacts of that kind as they want.
+type ArtifactLimits struct {
+	MaxLLMProvidersPerOrg  int `koanf:"max_llm_providers_per_org"`
+	MaxLLMProxiesPerOrg    int `koanf:"max_llm_proxies_per_org"`
+	MaxMCPProxiesPerOrg    int `koanf:"max_mcp_proxies_per_org"`
+	MaxWebSubAPIsPerOrg    int `koanf:"max_websub_apis_per_org"`
+	MaxWebBrokerAPIsPerOrg int `koanf:"max_webbroker_apis_per_org"`
+}
+
+// LimitReached reports whether an organization currently holding currentCount
+// artifacts of some kind has reached its configured limit. A limit <= 0 means
+// unlimited, in which case this always returns false.
+func LimitReached(currentCount, limit int) bool {
+	return limit > 0 && currentCount >= limit
 }
 
 // APIKey holds API key-specific configuration.
@@ -508,6 +527,18 @@ func envToKoanfKey(s string) string {
 		return "deployments.timeout_interval"
 	case "deployments_timeout_duration":
 		return "deployments.timeout_duration"
+
+	// Artifact limits (per organization; <= 0 means unlimited)
+	case "artifact_limits_max_llm_providers_per_org":
+		return "artifact_limits.max_llm_providers_per_org"
+	case "artifact_limits_max_llm_proxies_per_org":
+		return "artifact_limits.max_llm_proxies_per_org"
+	case "artifact_limits_max_mcp_proxies_per_org":
+		return "artifact_limits.max_mcp_proxies_per_org"
+	case "artifact_limits_max_websub_apis_per_org":
+		return "artifact_limits.max_websub_apis_per_org"
+	case "artifact_limits_max_webbroker_apis_per_org":
+		return "artifact_limits.max_webbroker_apis_per_org"
 
 	// TLS
 	case "tls_cert_dir":

--- a/platform-api/src/config/default_config.go
+++ b/platform-api/src/config/default_config.go
@@ -30,11 +30,11 @@ func defaultConfig() *Server {
 		LLMTemplateDefinitionsPath: "./resources/default-llm-provider-templates",
 		EnableScopeValidation:      true,
 		Database: Database{
-			Driver:           "sqlite3",
-			Path:             "./data/api_platform.db",
-			MaxOpenConns:     25,
-			MaxIdleConns:     10,
-			ConnMaxLifetime:  300,
+			Driver:          "sqlite3",
+			Path:            "./data/api_platform.db",
+			MaxOpenConns:    25,
+			MaxIdleConns:    10,
+			ConnMaxLifetime: 300,
 		},
 		Auth: Auth{
 			// SkipPaths bypasses JWT/IDP auth middleware. Paths below the health/metrics
@@ -121,6 +121,11 @@ func defaultConfig() *Server {
 			TimeoutInterval:  20,
 			TimeoutDuration:  60,
 		},
+		// ArtifactLimits are unlimited by default: every limit is left at its
+		// zero value, which LimitReached treats as "no limit". Operators can cap
+		// a specific artifact kind per organization by setting a positive value
+		// (config file key artifact_limits.max_* or env ARTIFACT_LIMITS_MAX_*).
+		ArtifactLimits: ArtifactLimits{},
 		TLS: TLS{
 			CertDir: "./data/certs",
 		},

--- a/platform-api/src/internal/constants/constants.go
+++ b/platform-api/src/internal/constants/constants.go
@@ -142,19 +142,13 @@ const AdminRole = "admin"
 // Deployment limit constants
 const (
 	// DeploymentLimitBuffer is the buffer added to MaxPerAPIGateway for hard limit enforcement
-	DeploymentLimitBuffer = 5
-
-	// MaxLLMProvidersPerOrganization is the maximum number of LLM providers allowed per organization.
-	MaxLLMProvidersPerOrganization = 5
-	// MaxLLMProxiesPerOrganization is the maximum number of LLM proxies allowed per organization.
-	MaxLLMProxiesPerOrganization = 5
-	// MaxMCPProxiesPerOrganization is the maximum number of MCP proxies allowed per organization.
-	MaxMCPProxiesPerOrganization = 5
-	// MaxWebSubAPIsPerOrganization is the maximum number of WebSub APIs allowed per organization.
-	MaxWebSubAPIsPerOrganization = 5
-	// MaxWebBrokerAPIsPerOrganization is the maximum number of WebBroker APIs allowed per organization.
-	MaxWebBrokerAPIsPerOrganization = 5
+	DeploymentLimitBuffer = 100
 )
+
+// Per-organization artifact creation limits are no longer hardcoded here. They are
+// configured via config.ArtifactLimits (config file keys artifact_limits.max_* or
+// env vars ARTIFACT_LIMITS_MAX_*) and default to unlimited. Enforcement uses
+// config.LimitReached, which treats a limit <= 0 as "no limit".
 
 // Gateway artifact apiVersion (the `apiVersion:` field on deployment artifacts).
 // GatewayApiVersionV1Alpha1 is the legacy value for gateways < 1.2.0 — use it only
@@ -170,8 +164,8 @@ const (
 // axis from GatewayApiVersion* (the gateway artifact apiVersion) — the two are
 // governed independently and currently hold different values ("v0.9" vs "v1").
 const (
-    APIVersion  = "v0.9"
-    APIBasePath = "/api/" + APIVersion
+	APIVersion  = "v0.9"
+	APIBasePath = "/api/" + APIVersion
 )
 
 // Custom Policy ManagedBy constants

--- a/platform-api/src/internal/constants/error.go
+++ b/platform-api/src/internal/constants/error.go
@@ -113,6 +113,14 @@ var (
 	// control plane while still deployed on one or more gateways. It can only be deleted
 	// once it is undeployed on all gateways it was deployed to.
 	ErrArtifactDeployed = errors.New("artifact is still deployed on a gateway and cannot be deleted")
+	// ErrArtifactRuntimeImmutable is returned when an update to a data-plane-originated
+	// (origin=DP) artifact would change its gateway runtime artifact. The gateway owns
+	// the runtime artifact, so a change to it cannot be applied from the control plane;
+	// edits that leave the runtime artifact unchanged (description, lifecycle status,
+	// display metadata, docs) are allowed. It is a distinct error from ErrArtifactReadOnly
+	// (which blocks all edits) and is mapped to 403 separately by the guard-response handler.
+	ErrArtifactRuntimeImmutable = errors.New(
+		"the update changes the gateway runtime configuration, which is owned by the data-plane gateway and cannot be modified from the control plane")
 )
 
 var (
@@ -126,18 +134,18 @@ var (
 )
 
 var (
-	ErrLLMProviderTemplateExists   = errors.New("llm provider template already exists")
-	ErrLLMProviderTemplateNotFound = errors.New("llm provider template not found")
-	ErrLLMProviderTemplateVersionExists = errors.New("llm provider template version already exists")
-	ErrLLMProviderTemplateInUse    = errors.New("llm provider template is in use by one or more providers")
+	ErrLLMProviderTemplateExists            = errors.New("llm provider template already exists")
+	ErrLLMProviderTemplateNotFound          = errors.New("llm provider template not found")
+	ErrLLMProviderTemplateVersionExists     = errors.New("llm provider template version already exists")
+	ErrLLMProviderTemplateInUse             = errors.New("llm provider template is in use by one or more providers")
 	ErrLLMProviderTemplateReadOnly          = errors.New("built-in llm provider template is read-only")
 	ErrLLMProviderTemplateManagedByReserved = errors.New("'wso2' is reserved and cannot be used as managedBy on custom templates")
-	ErrLLMProviderExists           = errors.New("llm provider already exists")
-	ErrLLMProviderNotFound         = errors.New("llm provider not found")
-	ErrLLMProviderLimitReached     = errors.New("llm provider limit reached for organization")
-	ErrLLMProxyExists              = errors.New("llm proxy already exists")
-	ErrLLMProxyNotFound            = errors.New("llm proxy not found")
-	ErrLLMProxyLimitReached        = errors.New("llm proxy limit reached for organization")
+	ErrLLMProviderExists                    = errors.New("llm provider already exists")
+	ErrLLMProviderNotFound                  = errors.New("llm provider not found")
+	ErrLLMProviderLimitReached              = errors.New("llm provider limit reached for organization")
+	ErrLLMProxyExists                       = errors.New("llm proxy already exists")
+	ErrLLMProxyNotFound                     = errors.New("llm proxy not found")
+	ErrLLMProxyLimitReached                 = errors.New("llm proxy limit reached for organization")
 )
 
 var (

--- a/platform-api/src/internal/handler/artifact_guard_response.go
+++ b/platform-api/src/internal/handler/artifact_guard_response.go
@@ -32,11 +32,15 @@ import (
 // data-plane-originated (origin=DP) artifact. It returns true when it handled the
 // error (and wrote a response), so callers can simply `return`.
 //
-//   - ErrArtifactReadOnly  -> 403 Forbidden (update/deploy of a DP artifact)
-//   - ErrArtifactDeployed  -> 409 Conflict  (delete of a still-deployed DP artifact)
+//   - ErrArtifactReadOnly        -> 403 Forbidden (update/deploy of a DP artifact)
+//   - ErrArtifactRuntimeImmutable -> 403 Forbidden (edit that would change a DP artifact's runtime config)
+//   - ErrArtifactDeployed        -> 409 Conflict  (delete of a still-deployed DP artifact)
 func respondArtifactGuardError(w http.ResponseWriter, err error) bool {
 	switch {
 	case errors.Is(err, constants.ErrArtifactReadOnly):
+		httputil.WriteJSON(w, http.StatusForbidden, utils.NewErrorResponse(403, "Forbidden", err.Error()))
+		return true
+	case errors.Is(err, constants.ErrArtifactRuntimeImmutable):
 		httputil.WriteJSON(w, http.StatusForbidden, utils.NewErrorResponse(403, "Forbidden", err.Error()))
 		return true
 	case errors.Is(err, constants.ErrArtifactDeployed):

--- a/platform-api/src/internal/server/server.go
+++ b/platform-api/src/internal/server/server.go
@@ -228,9 +228,9 @@ func StartPlatformAPIServer(cfg *config.Server, slogger *slog.Logger) (*Server, 
 	apiKeyService := service.NewAPIKeyService(apiRepo, artifactRepo, apiKeyRepo, gatewayEventsService, auditRepo, cfg.APIKey.HashingAlgorithms, slogger)
 	deploymentService := service.NewDeploymentService(apiRepo, artifactRepo, deploymentRepo, gatewayRepo, orgRepo, gatewayEventsService, auditRepo, apiUtil, cfg, slogger)
 	llmTemplateService := service.NewLLMProviderTemplateService(llmTemplateRepo, auditRepo)
-	llmProviderService := service.NewLLMProviderService(llmProviderRepo, llmTemplateRepo, orgRepo, llmTemplateSeeder, deploymentRepo, gatewayRepo, gatewayEventsService, slogger, auditRepo)
-	llmProxyService := service.NewLLMProxyService(llmProxyRepo, llmProviderRepo, projectRepo, deploymentRepo, gatewayRepo, gatewayEventsService, slogger, auditRepo)
-	mcpProxyService := service.NewMCPProxyService(mcpProxyRepo, projectRepo, deploymentRepo, gatewayRepo, gatewayEventsService, slogger, auditRepo)
+	llmProviderService := service.NewLLMProviderService(llmProviderRepo, llmTemplateRepo, orgRepo, llmTemplateSeeder, deploymentRepo, gatewayRepo, gatewayEventsService, slogger, auditRepo, cfg)
+	llmProxyService := service.NewLLMProxyService(llmProxyRepo, llmProviderRepo, projectRepo, deploymentRepo, gatewayRepo, gatewayEventsService, slogger, auditRepo, cfg)
+	mcpProxyService := service.NewMCPProxyService(mcpProxyRepo, projectRepo, deploymentRepo, gatewayRepo, gatewayEventsService, slogger, auditRepo, cfg)
 
 	// Initialize the shared database encryption key used for all encrypted DB columns.
 	// DATABASE_SUBSCRIPTION_TOKEN_ENCRYPTION_KEY is accepted as a legacy alias.

--- a/platform-api/src/internal/service/api.go
+++ b/platform-api/src/internal/service/api.go
@@ -273,11 +273,6 @@ func (s *APIService) UpdateAPI(apiUUID string, req *api.RESTAPI, orgUUID, update
 		return nil, constants.ErrAPINotFound
 	}
 
-	// DP-originated artifacts are read-only in the control plane.
-	if err := ensureOriginMutable(existingAPIModel.Origin); err != nil {
-		return nil, err
-	}
-
 	// Apply updates using shared helper
 	updatedAPI, err := s.applyAPIUpdates(existingAPIModel, req, orgUUID)
 	if err != nil {
@@ -288,6 +283,22 @@ func (s *APIService) UpdateAPI(apiUUID string, req *api.RESTAPI, orgUUID, update
 	updatedAPIModel := s.apiUtil.RESTAPIToModel(updatedAPI, orgUUID)
 	updatedAPIModel.ID = apiUUID // Ensure UUID remains unchanged
 	updatedAPIModel.UpdatedBy = updatedBy
+	// Carry over identity fields that are not user-editable so the runtime-artifact
+	// diff below compares like-for-like (RESTAPIToModel derives these from the request
+	// and defaults the origin to control_plane).
+	updatedAPIModel.Handle = existingAPIModel.Handle
+	updatedAPIModel.ProjectID = existingAPIModel.ProjectID
+	updatedAPIModel.Kind = existingAPIModel.Kind
+	updatedAPIModel.Origin = existingAPIModel.Origin
+
+	// A DP-originated (gateway_api) artifact is read-only in the control plane only for
+	// changes that alter the gateway runtime artifact. Allow edits that leave the
+	// deployment YAML unchanged (e.g. description, lifecycle status) by diffing the
+	// artifact the stored vs updated model produces.
+	if err := s.ensureRESTRuntimeArtifactUnchanged(existingAPIModel, updatedAPIModel); err != nil {
+		return nil, err
+	}
+
 	if err := s.apiRepo.UpdateAPI(updatedAPIModel); err != nil {
 		return nil, err
 	}
@@ -297,6 +308,28 @@ func (s *APIService) UpdateAPI(apiUUID string, req *api.RESTAPI, orgUUID, update
 	_ = s.auditRepo.Record("UPDATE", apiUUID, "rest_api", orgUUID, updatedBy)
 
 	return s.modelToRESTAPI(updatedAPIModel)
+}
+
+// ensureRESTRuntimeArtifactUnchanged rejects an edit to a DP-originated REST API when it
+// would change the gateway runtime artifact. It builds the deployment YAML both the
+// stored and updated models produce (via BuildAPIDeploymentYAML, the same builder used
+// at deploy time) and compares them. It is a no-op for control-plane artifacts. When the
+// stored artifact cannot be rebuilt the edit cannot be proven harmless, so it is kept
+// read-only; a build failure on the proposed model is a genuine validation error and is
+// surfaced as-is.
+func (s *APIService) ensureRESTRuntimeArtifactUnchanged(existing, updated *model.API) error {
+	if existing.Origin != constants.OriginDP {
+		return nil
+	}
+	existingArtifact, err := s.apiUtil.BuildAPIDeploymentYAML(existing)
+	if err != nil {
+		return constants.ErrArtifactRuntimeImmutable
+	}
+	updatedArtifact, err := s.apiUtil.BuildAPIDeploymentYAML(updated)
+	if err != nil {
+		return err
+	}
+	return compareRuntimeArtifacts(existing.Origin, existingArtifact, updatedArtifact)
 }
 
 // DeleteAPI deletes an API

--- a/platform-api/src/internal/service/artifact_cross_origin_test.go
+++ b/platform-api/src/internal/service/artifact_cross_origin_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"platform-api/src/api"
+	"platform-api/src/config"
 	"platform-api/src/internal/constants"
 	"platform-api/src/internal/dto"
 	"platform-api/src/internal/repository"
@@ -269,6 +270,7 @@ func TestCPProviderFromDPTemplate(t *testing.T) {
 		nil, // gatewayEventsService unused on create
 		newTestLogger(),
 		&noopAuditRepo{},
+		&config.Server{},
 	)
 
 	created, err := providerSvc.Create(importTestOrgID, "tester", &api.LLMProvider{
@@ -310,6 +312,7 @@ func TestCPProxyFromDPProvider(t *testing.T) {
 		nil, // gatewayEventsService unused on create
 		newTestLogger(),
 		&noopAuditRepo{},
+		&config.Server{},
 	)
 
 	created, err := proxySvc.Create(importTestOrgID, "tester", &api.LLMProxy{

--- a/platform-api/src/internal/service/artifact_guard.go
+++ b/platform-api/src/internal/service/artifact_guard.go
@@ -62,7 +62,12 @@ func ensureOriginMutable(origin string) error {
 // compareRuntimeArtifacts fingerprints two already-generated runtime artifacts and
 // defers to ensureRuntimeArtifactUnchanged. It is the common tail shared by the
 // per-kind guards once each has produced the stored and proposed artifact structs.
+// Control-plane artifacts are always mutable, so it returns immediately for any
+// non-DP origin and only fingerprints when the origin is DP.
 func compareRuntimeArtifacts(origin string, existing, proposed any) error {
+	if origin != constants.OriginDP {
+		return nil
+	}
 	existingFP, err := runtimeArtifactFingerprint(existing)
 	if err != nil {
 		return err

--- a/platform-api/src/internal/service/artifact_guard.go
+++ b/platform-api/src/internal/service/artifact_guard.go
@@ -18,10 +18,13 @@
 package service
 
 import (
+	"bytes"
 	"fmt"
 
 	"platform-api/src/internal/constants"
 	"platform-api/src/internal/repository"
+
+	"gopkg.in/yaml.v3"
 )
 
 // ensureArtifactMutableByUUID looks the artifact up by UUID and returns
@@ -54,6 +57,53 @@ func ensureOriginMutable(origin string) error {
 		return constants.ErrArtifactReadOnly
 	}
 	return nil
+}
+
+// compareRuntimeArtifacts fingerprints two already-generated runtime artifacts and
+// defers to ensureRuntimeArtifactUnchanged. It is the common tail shared by the
+// per-kind guards once each has produced the stored and proposed artifact structs.
+func compareRuntimeArtifacts(origin string, existing, proposed any) error {
+	existingFP, err := runtimeArtifactFingerprint(existing)
+	if err != nil {
+		return err
+	}
+	proposedFP, err := runtimeArtifactFingerprint(proposed)
+	if err != nil {
+		return err
+	}
+	return ensureRuntimeArtifactUnchanged(origin, existingFP, proposedFP)
+}
+
+// runtimeArtifactFingerprint serializes a generated gateway runtime artifact (any of
+// the per-kind deployment-YAML structs) into a canonical, comparable byte form. Two
+// artifacts with equal fingerprints deploy to the gateway identically. Callers build
+// the fingerprint for the currently-stored model and the would-be-updated model with
+// the SAME generator (the one used at deploy time) so defaulting/normalization is
+// symmetric and only a genuine runtime change surfaces as a difference.
+func runtimeArtifactFingerprint(artifact any) ([]byte, error) {
+	b, err := yaml.Marshal(artifact)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize runtime artifact for read-only check: %w", err)
+	}
+	return b, nil
+}
+
+// ensureRuntimeArtifactUnchanged permits an update to a DP-originated (origin
+// "gateway_api") artifact only when it does not change the gateway runtime artifact.
+// Control-plane artifacts are always mutable, so it is a no-op for them. For DP
+// artifacts, the two fingerprints are the runtime artifact the stored model produces
+// (existing) and the one the updated model would produce (proposed); when they differ
+// the update is rejected with ErrArtifactRuntimeImmutable. This lets metadata-only
+// edits (description, lifecycle status, display data, docs) through while keeping the
+// gateway-owned runtime configuration read-only in the control plane.
+func ensureRuntimeArtifactUnchanged(origin string, existing, proposed []byte) error {
+	if origin != constants.OriginDP {
+		return nil
+	}
+	if bytes.Equal(existing, proposed) {
+		return nil
+	}
+	return constants.ErrArtifactRuntimeImmutable
 }
 
 // ensureOriginDeletable enforces the deletion rule for DP-originated artifacts: they

--- a/platform-api/src/internal/service/artifact_import_lifecycle_test.go
+++ b/platform-api/src/internal/service/artifact_import_lifecycle_test.go
@@ -874,20 +874,38 @@ func TestImport_MCPProxy_ReadOnlyInGetAndList(t *testing.T) {
 	}
 }
 
-// TestCPSideGuard_UpdateBlockedForDPOrigin verifies that the control-plane CRUD services
-// reject updates to DP-originated (gateway-pushed) artifacts with ErrArtifactReadOnly,
-// for every kind. The DP artifacts are seeded through the import flow. (REST is covered by
-// TestArtifactImport_Enforcement_ReadOnlyAndDeletion; deploy/undeploy/restore guards are
-// covered by the deployment-guard tests.)
-func TestCPSideGuard_UpdateBlockedForDPOrigin(t *testing.T) {
+// TestCPSideGuard_DPOriginUpdate verifies control-plane updates to DP-originated
+// (gateway-pushed) artifacts protect the gateway-owned runtime configuration while still
+// allowing control-plane metadata edits. Templates reject a runtime (token-extraction)
+// change outright (ErrArtifactRuntimeImmutable) but allow metadata; providers/proxies/MCP
+// proxies preserve their runtime config verbatim (a runtime edit in the payload is silently
+// ignored) and apply only metadata (description/models/OpenAPI). DP artifacts are seeded
+// through the import flow. (deploy/undeploy/restore guards are covered by the
+// deployment-guard tests.)
+func TestCPSideGuard_DPOriginUpdate(t *testing.T) {
 	logger := newTestLogger()
 
 	t.Run("LLMProviderTemplate", func(t *testing.T) {
 		d := setupImportTest(t)
 		svc := NewLLMProviderTemplateService(d.templateRepo, &noopAuditRepo{})
 		mustImport(t, d, dpTemplateReq("dp-t", "blk-tmpl", "T"))
-		if _, err := svc.Update(importTestOrgID, "blk-tmpl", "tester", &api.LLMProviderTemplate{DisplayName: "Hacked"}); !errors.Is(err, constants.ErrArtifactReadOnly) {
-			t.Errorf("Template Update(DP) = %v, want ErrArtifactReadOnly", err)
+
+		// Changing a gateway-consumed field (a token-extraction identifier) is rejected.
+		if _, err := svc.Update(importTestOrgID, "blk-tmpl", "tester", &api.LLMProviderTemplate{
+			DisplayName:         "T",
+			PromptTokens: &api.ExtractionIdentifier{Location: api.ExtractionIdentifierLocation("payload"), Identifier: "$.usage.prompt_tokens"},
+		}); !errors.Is(err, constants.ErrArtifactRuntimeImmutable) {
+			t.Errorf("Template Update(DP, extraction change) = %v, want ErrArtifactRuntimeImmutable", err)
+		}
+
+		// Editing the OpenAPI spec URL / display name (neither read by the gateway at request
+		// time) leaves the runtime artifact untouched and is allowed.
+		specURL := "https://example.com/openapi.yaml"
+		if _, err := svc.Update(importTestOrgID, "blk-tmpl", "tester", &api.LLMProviderTemplate{
+			DisplayName:     "Renamed",
+			Metadata: &api.LLMProviderTemplateMetadata{OpenapiSpecUrl: &specURL},
+		}); err != nil {
+			t.Errorf("Template Update(DP, openapi/metadata edit) = %v, want success", err)
 		}
 	})
 
@@ -896,9 +914,26 @@ func TestCPSideGuard_UpdateBlockedForDPOrigin(t *testing.T) {
 		svc := NewLLMProviderService(repository.NewLLMProviderRepo(d.db), d.templateRepo,
 			repository.NewOrganizationRepo(d.db), nil, d.deployment, repository.NewGatewayRepo(d.db), nil, logger, &noopAuditRepo{})
 		mustImport(t, d, dpTemplateReq("dp-t", "p-tmpl", "T"))
-		mustImport(t, d, dpProviderReq("dp-p", "blk-prov", "P", "p-tmpl"))
-		if _, err := svc.Update(importTestOrgID, "blk-prov", "tester", &api.LLMProvider{DisplayName: "Hacked"}); !errors.Is(err, constants.ErrArtifactReadOnly) {
-			t.Errorf("Provider Update(DP) = %v, want ErrArtifactReadOnly", err)
+		provReq := dpProviderReq("dp-p", "blk-prov", "P", "p-tmpl")
+		provReq.Configuration.Spec["upstream"] = map[string]interface{}{"url": "https://api.example.com"}
+		mustImport(t, d, provReq)
+
+		// A runtime edit (name + upstream) is silently preserved and metadata (description)
+		// is applied: the update must succeed, and the gateway-owned name/upstream must stay
+		// unchanged. (The request still carries a valid upstream so field validation passes.)
+		updated, err := svc.Update(importTestOrgID, "blk-prov", "tester", &api.LLMProvider{
+			DisplayName: "Hacked", Version: "v1.0", Template: "p-tmpl",
+			Description: strPointer("a new description"),
+			Upstream:    api.Upstream{Main: api.UpstreamDefinition{Url: strPointer("https://changed.example.com")}},
+		})
+		if err != nil {
+			t.Fatalf("Provider Update(DP) = %v, want success", err)
+		}
+		if updated.DisplayName != "P" {
+			t.Errorf("provider name (runtime) must be preserved, got %q", updated.Name)
+		}
+		if updated.Description == nil || *updated.Description != "a new description" {
+			t.Errorf("provider description should be applied, got %v", updated.Description)
 		}
 	})
 
@@ -909,10 +944,19 @@ func TestCPSideGuard_UpdateBlockedForDPOrigin(t *testing.T) {
 		mustImport(t, d, dpTemplateReq("dp-t", "px-tmpl", "T"))
 		mustImport(t, d, dpProviderReq("dp-p", "px-prov", "P", "px-tmpl"))
 		mustImport(t, d, dpProxyReq("dp-x", "blk-proxy", "X", "px-prov"))
-		if _, err := svc.Update(importTestOrgID, "blk-proxy", "tester", &api.LLMProxy{
+
+		updated, err := svc.Update(importTestOrgID, "blk-proxy", "tester", &api.LLMProxy{
 			DisplayName: "Hacked", Version: "v2", Provider: api.LLMProxyProvider{Id: "px-prov"},
-		}); !errors.Is(err, constants.ErrArtifactReadOnly) {
-			t.Errorf("Proxy Update(DP) = %v, want ErrArtifactReadOnly", err)
+			Description: strPointer("a new description"),
+		})
+		if err != nil {
+			t.Fatalf("Proxy Update(DP) = %v, want success", err)
+		}
+		if updated.DisplayName != "X" {
+			t.Errorf("proxy name (runtime) must be preserved, got %q", updated.DisplayName)
+		}
+		if updated.Description == nil || *updated.Description != "a new description" {
+			t.Errorf("proxy description should be applied, got %v", updated.Description)
 		}
 	})
 
@@ -921,11 +965,20 @@ func TestCPSideGuard_UpdateBlockedForDPOrigin(t *testing.T) {
 		svc := NewMCPProxyService(repository.NewMCPProxyRepo(d.db), repository.NewProjectRepo(d.db),
 			d.deployment, repository.NewGatewayRepo(d.db), nil, logger, &noopAuditRepo{})
 		mustImport(t, d, dpMCPReq("dp-m", "blk-mcp", "M"))
-		if _, err := svc.Update(importTestOrgID, "blk-mcp", "tester", &api.MCPProxy{
+
+		updated, err := svc.Update(importTestOrgID, "blk-mcp", "tester", &api.MCPProxy{
 			Id: strPointer("blk-mcp"), DisplayName: "Hacked", Version: "v2",
-			Upstream: api.Upstream{Main: api.UpstreamDefinition{Url: strPointer("https://api.example.com")}},
-		}); !errors.Is(err, constants.ErrArtifactReadOnly) {
-			t.Errorf("MCP Update(DP) = %v, want ErrArtifactReadOnly", err)
+			Description: strPointer("a new description"),
+			Upstream:    api.Upstream{Main: api.UpstreamDefinition{Url: strPointer("https://api.example.com")}},
+		})
+		if err != nil {
+			t.Fatalf("MCP Update(DP) = %v, want success", err)
+		}
+		if updated.DisplayName != "M" {
+			t.Errorf("MCP name (runtime) must be preserved, got %q", updated.DisplayName)
+		}
+		if updated.Description == nil || *updated.Description != "a new description" {
+			t.Errorf("MCP description should be applied, got %v", updated.Description)
 		}
 	})
 }

--- a/platform-api/src/internal/service/artifact_import_lifecycle_test.go
+++ b/platform-api/src/internal/service/artifact_import_lifecycle_test.go
@@ -823,11 +823,11 @@ func TestImport_MCPProxy_ReadOnlyInGetAndList(t *testing.T) {
 	// CP-origin MCP proxy via the service.
 	proj := importTestProjectID
 	if _, err := svc.Create(importTestOrgID, "tester", &api.MCPProxy{
-		Id:        strPointer("cp-mcp"),
-		DisplayName:      "CP MCP",
-		Version:   "v1.0",
-		ProjectId: &proj,
-		Upstream:  api.Upstream{Main: api.UpstreamDefinition{Url: strPointer("https://api.example.com")}},
+		Id:          strPointer("cp-mcp"),
+		DisplayName: "CP MCP",
+		Version:     "v1.0",
+		ProjectId:   &proj,
+		Upstream:    api.Upstream{Main: api.UpstreamDefinition{Url: strPointer("https://api.example.com")}},
 	}); err != nil {
 		t.Fatalf("create CP MCP proxy: %v", err)
 	}
@@ -894,7 +894,7 @@ func TestCPSideGuard_DPOriginUpdate(t *testing.T) {
 
 		// Changing a gateway-consumed field (a token-extraction identifier) is rejected.
 		if _, err := svc.Update(importTestOrgID, "blk-tmpl", "tester", &api.LLMProviderTemplate{
-			DisplayName:         "T",
+			DisplayName:  "T",
 			PromptTokens: &api.ExtractionIdentifier{Location: api.ExtractionIdentifierLocation("payload"), Identifier: "$.usage.prompt_tokens"},
 		}); !errors.Is(err, constants.ErrArtifactRuntimeImmutable) {
 			t.Errorf("Template Update(DP, extraction change) = %v, want ErrArtifactRuntimeImmutable", err)
@@ -904,8 +904,8 @@ func TestCPSideGuard_DPOriginUpdate(t *testing.T) {
 		// time) leaves the runtime artifact untouched and is allowed.
 		specURL := "https://example.com/openapi.yaml"
 		if _, err := svc.Update(importTestOrgID, "blk-tmpl", "tester", &api.LLMProviderTemplate{
-			DisplayName:     "Renamed",
-			Metadata: &api.LLMProviderTemplateMetadata{OpenapiSpecUrl: &specURL},
+			DisplayName: "Renamed",
+			Metadata:    &api.LLMProviderTemplateMetadata{OpenapiSpecUrl: &specURL},
 		}); err != nil {
 			t.Errorf("Template Update(DP, openapi/metadata edit) = %v, want success", err)
 		}
@@ -932,7 +932,7 @@ func TestCPSideGuard_DPOriginUpdate(t *testing.T) {
 			t.Fatalf("Provider Update(DP) = %v, want success", err)
 		}
 		if updated.DisplayName != "P" {
-			t.Errorf("provider name (runtime) must be preserved, got %q", updated.Name)
+			t.Errorf("provider name (runtime) must be preserved, got %q", updated.DisplayName)
 		}
 		if updated.Description == nil || *updated.Description != "a new description" {
 			t.Errorf("provider description should be applied, got %v", updated.Description)

--- a/platform-api/src/internal/service/artifact_import_lifecycle_test.go
+++ b/platform-api/src/internal/service/artifact_import_lifecycle_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"platform-api/src/api"
+	"platform-api/src/config"
 	"platform-api/src/internal/constants"
 	"platform-api/src/internal/dto"
 	"platform-api/src/internal/model"
@@ -813,6 +814,7 @@ func TestImport_MCPProxy_ReadOnlyInGetAndList(t *testing.T) {
 		nil, // gatewayEventsService unused on create/get/list
 		newTestLogger(),
 		&noopAuditRepo{},
+		&config.Server{},
 	)
 
 	// DP-origin MCP proxy via the gateway import flow.
@@ -912,7 +914,7 @@ func TestCPSideGuard_DPOriginUpdate(t *testing.T) {
 	t.Run("LLMProvider", func(t *testing.T) {
 		d := setupImportTest(t)
 		svc := NewLLMProviderService(repository.NewLLMProviderRepo(d.db), d.templateRepo,
-			repository.NewOrganizationRepo(d.db), nil, d.deployment, repository.NewGatewayRepo(d.db), nil, logger, &noopAuditRepo{})
+			repository.NewOrganizationRepo(d.db), nil, d.deployment, repository.NewGatewayRepo(d.db), nil, logger, &noopAuditRepo{}, &config.Server{})
 		mustImport(t, d, dpTemplateReq("dp-t", "p-tmpl", "T"))
 		provReq := dpProviderReq("dp-p", "blk-prov", "P", "p-tmpl")
 		provReq.Configuration.Spec["upstream"] = map[string]interface{}{"url": "https://api.example.com"}
@@ -940,7 +942,7 @@ func TestCPSideGuard_DPOriginUpdate(t *testing.T) {
 	t.Run("LLMProxy", func(t *testing.T) {
 		d := setupImportTest(t)
 		svc := NewLLMProxyService(repository.NewLLMProxyRepo(d.db), repository.NewLLMProviderRepo(d.db),
-			repository.NewProjectRepo(d.db), d.deployment, repository.NewGatewayRepo(d.db), nil, logger, &noopAuditRepo{})
+			repository.NewProjectRepo(d.db), d.deployment, repository.NewGatewayRepo(d.db), nil, logger, &noopAuditRepo{}, &config.Server{})
 		mustImport(t, d, dpTemplateReq("dp-t", "px-tmpl", "T"))
 		mustImport(t, d, dpProviderReq("dp-p", "px-prov", "P", "px-tmpl"))
 		mustImport(t, d, dpProxyReq("dp-x", "blk-proxy", "X", "px-prov"))
@@ -963,7 +965,7 @@ func TestCPSideGuard_DPOriginUpdate(t *testing.T) {
 	t.Run("MCPProxy", func(t *testing.T) {
 		d := setupImportTest(t)
 		svc := NewMCPProxyService(repository.NewMCPProxyRepo(d.db), repository.NewProjectRepo(d.db),
-			d.deployment, repository.NewGatewayRepo(d.db), nil, logger, &noopAuditRepo{})
+			d.deployment, repository.NewGatewayRepo(d.db), nil, logger, &noopAuditRepo{}, &config.Server{})
 		mustImport(t, d, dpMCPReq("dp-m", "blk-mcp", "M"))
 
 		updated, err := svc.Update(importTestOrgID, "blk-mcp", "tester", &api.MCPProxy{

--- a/platform-api/src/internal/service/artifact_runtime_immutable_test.go
+++ b/platform-api/src/internal/service/artifact_runtime_immutable_test.go
@@ -1,0 +1,254 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"platform-api/src/internal/constants"
+	"platform-api/src/internal/model"
+	"platform-api/src/internal/utils"
+)
+
+func rtStrPtr(s string) *string { return &s }
+
+// TestEnsureRuntimeArtifactUnchanged covers the shared guard: CP artifacts are always
+// mutable, DP artifacts are mutable only when the runtime artifact is byte-identical,
+// and a rejection is the distinct ErrArtifactRuntimeImmutable (mapped to 403 separately).
+func TestEnsureRuntimeArtifactUnchanged(t *testing.T) {
+	a := []byte("artifact-a")
+	b := []byte("artifact-b")
+
+	if err := ensureRuntimeArtifactUnchanged(constants.OriginCP, a, b); err != nil {
+		t.Errorf("CP origin with differing artifacts: got %v, want nil", err)
+	}
+	if err := ensureRuntimeArtifactUnchanged(constants.OriginDP, a, a); err != nil {
+		t.Errorf("DP origin with identical artifacts: got %v, want nil", err)
+	}
+	err := ensureRuntimeArtifactUnchanged(constants.OriginDP, a, b)
+	if !errors.Is(err, constants.ErrArtifactRuntimeImmutable) {
+		t.Errorf("DP origin with differing artifacts: got %v, want ErrArtifactRuntimeImmutable", err)
+	}
+	// It is a distinct sentinel, NOT wrapping the blanket read-only error.
+	if errors.Is(err, constants.ErrArtifactReadOnly) {
+		t.Errorf("ErrArtifactRuntimeImmutable must be distinct from ErrArtifactReadOnly")
+	}
+}
+
+func baseRESTAPI(origin string) *model.API {
+	return &model.API{
+		ID:             "uuid-1",
+		Handle:         "my-api",
+		Name:           "My API",
+		Kind:           constants.RestApi,
+		Version:        "v1.0",
+		ProjectID:      "proj-1",
+		OrganizationID: "org-1",
+		Origin:         origin,
+		Configuration: model.RestAPIConfig{
+			Name:      "My API",
+			Version:   "v1.0",
+			Context:   rtStrPtr("/my-api"),
+			Transport: []string{"http", "https"},
+			Upstream: model.UpstreamConfig{
+				Main: &model.UpstreamEndpoint{URL: "https://backend.example.com"},
+			},
+			Operations: []model.Operation{
+				{Name: "get", Request: &model.OperationRequest{Method: "GET", Path: "/items"}},
+			},
+		},
+	}
+}
+
+func TestRESTRuntimeArtifactGuard(t *testing.T) {
+	svc := &APIService{apiUtil: &utils.APIUtil{}}
+
+	t.Run("metadata-only edit allowed", func(t *testing.T) {
+		existing := baseRESTAPI(constants.OriginDP)
+		updated := baseRESTAPI(constants.OriginDP)
+		updated.Description = "a shiny new description"     // not in the deployment YAML
+		updated.LifeCycleStatus = "PUBLISHED"               // not in the deployment YAML
+		updated.Configuration.Transport = []string{"https"} // not in the deployment YAML
+		if err := svc.ensureRESTRuntimeArtifactUnchanged(existing, updated); err != nil {
+			t.Errorf("metadata-only edit rejected: %v", err)
+		}
+	})
+
+	t.Run("upstream edit rejected", func(t *testing.T) {
+		existing := baseRESTAPI(constants.OriginDP)
+		updated := baseRESTAPI(constants.OriginDP)
+		updated.Configuration.Upstream.Main.URL = "https://new-backend.example.com"
+		if err := svc.ensureRESTRuntimeArtifactUnchanged(existing, updated); !errors.Is(err, constants.ErrArtifactRuntimeImmutable) {
+			t.Errorf("upstream edit: got %v, want read-only", err)
+		}
+	})
+
+	t.Run("operation edit rejected", func(t *testing.T) {
+		existing := baseRESTAPI(constants.OriginDP)
+		updated := baseRESTAPI(constants.OriginDP)
+		updated.Configuration.Operations = append(updated.Configuration.Operations,
+			model.Operation{Name: "post", Request: &model.OperationRequest{Method: "POST", Path: "/items"}})
+		if err := svc.ensureRESTRuntimeArtifactUnchanged(existing, updated); !errors.Is(err, constants.ErrArtifactRuntimeImmutable) {
+			t.Errorf("operation edit: got %v, want read-only", err)
+		}
+	})
+
+	t.Run("CP artifact always mutable", func(t *testing.T) {
+		existing := baseRESTAPI(constants.OriginCP)
+		updated := baseRESTAPI(constants.OriginCP)
+		updated.Configuration.Upstream.Main.URL = "https://new-backend.example.com"
+		if err := svc.ensureRESTRuntimeArtifactUnchanged(existing, updated); err != nil {
+			t.Errorf("CP artifact runtime edit rejected: %v", err)
+		}
+	})
+}
+
+func baseMCPProxy(origin string) *model.MCPProxy {
+	projectID := "proj-1"
+	return &model.MCPProxy{
+		UUID:             "uuid-1",
+		Handle:           "my-mcp",
+		OrganizationUUID: "org-1",
+		ProjectUUID:      &projectID,
+		Name:             "My MCP",
+		Version:          "v1.0",
+		Origin:           origin,
+		Configuration: model.MCPProxyConfiguration{
+			Name:        "My MCP",
+			Version:     "v1.0",
+			Context:     rtStrPtr("/my-mcp"),
+			SpecVersion: "2025-06-18",
+			Upstream: model.UpstreamConfig{
+				Main: &model.UpstreamEndpoint{URL: "https://mcp.example.com"},
+			},
+		},
+	}
+}
+
+// mcpFingerprint mirrors the inline diff in MCPProxyService.Update.
+func mcpFingerprint(t *testing.T, proxy *model.MCPProxy) []byte {
+	t.Helper()
+	artifact, err := (&utils.MCPUtils{}).BuildMCPDeploymentYAML(proxy)
+	if err != nil {
+		t.Fatalf("BuildMCPDeploymentYAML: %v", err)
+	}
+	fp, err := runtimeArtifactFingerprint(artifact)
+	if err != nil {
+		t.Fatalf("runtimeArtifactFingerprint: %v", err)
+	}
+	return fp
+}
+
+func TestMCPProxyRuntimeArtifactGuard(t *testing.T) {
+	t.Run("metadata-only edit allowed", func(t *testing.T) {
+		existing := baseMCPProxy(constants.OriginDP)
+		existingFP := mcpFingerprint(t, existing)
+		existing.Description = "new description"                            // not in the deployment spec
+		existing.Configuration.Capabilities = &model.MCPProxyCapabilities{} // fetched out-of-band, not in spec
+		updatedFP := mcpFingerprint(t, existing)
+		if err := ensureRuntimeArtifactUnchanged(constants.OriginDP, existingFP, updatedFP); err != nil {
+			t.Errorf("metadata-only edit rejected: %v", err)
+		}
+	})
+
+	t.Run("context edit rejected", func(t *testing.T) {
+		existing := baseMCPProxy(constants.OriginDP)
+		existingFP := mcpFingerprint(t, existing)
+		existing.Configuration.Context = rtStrPtr("/my-mcp-v2")
+		updatedFP := mcpFingerprint(t, existing)
+		if err := ensureRuntimeArtifactUnchanged(constants.OriginDP, existingFP, updatedFP); !errors.Is(err, constants.ErrArtifactRuntimeImmutable) {
+			t.Errorf("context edit: got %v, want read-only", err)
+		}
+	})
+}
+
+func baseTemplate(origin string) *model.LLMProviderTemplate {
+	return &model.LLMProviderTemplate{
+		UUID:         "uuid-1",
+		ID:           "openai-template",
+		Name:         "OpenAI Template",
+		Version:      "v1.0",
+		Origin:       origin,
+		Metadata:     &model.LLMProviderTemplateMetadata{EndpointURL: "https://api.openai.com/v1/chat/completions"},
+		PromptTokens: &model.ExtractionIdentifier{Location: "body", Identifier: "usage.prompt_tokens"},
+	}
+}
+
+func TestTemplateRuntimeArtifactGuard(t *testing.T) {
+	t.Run("name and description edit allowed", func(t *testing.T) {
+		existing := baseTemplate(constants.OriginDP)
+		updated := baseTemplate(constants.OriginDP)
+		updated.Name = "Renamed Template"
+		updated.Description = "new description"
+		updated.ManagedBy = "someone"
+		updated.OpenAPISpec = "{...}"
+		if err := ensureTemplateRuntimeArtifactUnchanged(existing, updated); err != nil {
+			t.Errorf("name/description edit rejected: %v", err)
+		}
+	})
+
+	t.Run("extraction identifier edit rejected", func(t *testing.T) {
+		existing := baseTemplate(constants.OriginDP)
+		updated := baseTemplate(constants.OriginDP)
+		updated.PromptTokens = &model.ExtractionIdentifier{Location: "header", Identifier: "x-prompt-tokens"}
+		if err := ensureTemplateRuntimeArtifactUnchanged(existing, updated); !errors.Is(err, constants.ErrArtifactRuntimeImmutable) {
+			t.Errorf("extraction identifier edit: got %v, want read-only", err)
+		}
+	})
+
+	t.Run("resource mapping edit rejected", func(t *testing.T) {
+		existing := baseTemplate(constants.OriginDP)
+		updated := baseTemplate(constants.OriginDP)
+		updated.ResourceMappings = &model.LLMProviderTemplateResourceMappings{
+			Resources: []model.LLMProviderTemplateResourceMapping{{
+				Resource: "/responses",
+				LLMProviderTemplateExtractionFields: model.LLMProviderTemplateExtractionFields{
+					PromptTokens: &model.ExtractionIdentifier{Location: "payload", Identifier: "$.usage.input_tokens"},
+				},
+			}},
+		}
+		if err := ensureTemplateRuntimeArtifactUnchanged(existing, updated); !errors.Is(err, constants.ErrArtifactRuntimeImmutable) {
+			t.Errorf("resource mapping edit: got %v, want read-only", err)
+		}
+	})
+
+	t.Run("metadata edit allowed (not consumed by gateway runtime)", func(t *testing.T) {
+		existing := baseTemplate(constants.OriginDP)
+		updated := baseTemplate(constants.OriginDP)
+		// endpointUrl / openapiSpecUrl / logoUrl / auth are authoring/reference/display
+		// data the gateway never reads at request time, so editing them is allowed.
+		updated.Metadata = &model.LLMProviderTemplateMetadata{
+			EndpointURL:    "https://api.openai.com/v2/chat",
+			OpenapiSpecURL: "https://example.com/openapi.yaml",
+			LogoURL:        "https://example.com/logo.png",
+		}
+		if err := ensureTemplateRuntimeArtifactUnchanged(existing, updated); err != nil {
+			t.Errorf("metadata edit rejected: %v", err)
+		}
+	})
+
+	t.Run("CP artifact always mutable", func(t *testing.T) {
+		existing := baseTemplate(constants.OriginCP)
+		updated := baseTemplate(constants.OriginCP)
+		updated.PromptTokens = &model.ExtractionIdentifier{Location: "header", Identifier: "x-prompt-tokens"}
+		if err := ensureTemplateRuntimeArtifactUnchanged(existing, updated); err != nil {
+			t.Errorf("CP artifact runtime edit rejected: %v", err)
+		}
+	})
+}

--- a/platform-api/src/internal/service/llm.go
+++ b/platform-api/src/internal/service/llm.go
@@ -262,9 +262,6 @@ func (s *LLMProviderTemplateService) Update(orgUUID, handle, updatedBy string, r
 	if existing.ManagedBy == "wso2" {
 		return nil, constants.ErrLLMProviderTemplateReadOnly
 	}
-	if err := ensureOriginMutable(existing.Origin); err != nil {
-		return nil, err
-	}
 	// In-place update never changes the version; a new version is created via
 	// POST /llm-provider-templates/{id}/versions. Reject a request that tries to change it
 	// rather than silently ignoring the supplied value.
@@ -303,6 +300,18 @@ func (s *LLMProviderTemplateService) Update(orgUUID, handle, updatedBy string, r
 	}
 	m.ResourceMappings = resourceMappings
 
+	// A DP-originated (gateway_api) template is read-only in the control plane only for
+	// changes that alter what the gateway consumes at runtime: the token-extraction
+	// identifiers and per-resource mappings. Everything else — name, description,
+	// managedBy, the inline OpenAPI spec, and the metadata block (endpointUrl, auth,
+	// logoUrl, openapiSpecUrl), none of which the gateway reads at request time — stays
+	// editable.
+	if existing.Origin == constants.OriginDP {
+		if err := ensureTemplateRuntimeArtifactUnchanged(existing, m); err != nil {
+			return nil, err
+		}
+	}
+
 	if err := s.repo.Update(m); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, constants.ErrLLMProviderTemplateNotFound
@@ -331,6 +340,43 @@ func (s *LLMProviderTemplateService) Update(orgUUID, handle, updatedBy string, r
 	_ = s.auditRepo.Record("UPDATE", updated.UUID, "llm_provider_template", orgUUID, updatedBy)
 
 	return mapTemplateModelToAPI(updated), nil
+}
+
+// templateRuntimeArtifact is the subset of an LLM provider template that the gateway
+// actually consumes at request time: the token-extraction identifiers and the
+// per-resource extraction overrides (resourceMappings). The gateway's runtime
+// transformer (gateway-controller pkg/utils/llm_transformer.go) reads only these; it
+// never uses the template's metadata block (endpointUrl, auth, logoUrl, openapiSpecUrl),
+// which is authoring/reference/display data. So the metadata block — along with the
+// control-plane-only fields (name, description, managedBy, enabled, inline OpenAPI spec)
+// — stays editable on a DP-originated template; only a change to the extraction fields
+// or resource mappings is rejected.
+type templateRuntimeArtifact struct {
+	PromptTokens     *model.ExtractionIdentifier                `yaml:"promptTokens,omitempty"`
+	CompletionTokens *model.ExtractionIdentifier                `yaml:"completionTokens,omitempty"`
+	TotalTokens      *model.ExtractionIdentifier                `yaml:"totalTokens,omitempty"`
+	RemainingTokens  *model.ExtractionIdentifier                `yaml:"remainingTokens,omitempty"`
+	RequestModel     *model.ExtractionIdentifier                `yaml:"requestModel,omitempty"`
+	ResponseModel    *model.ExtractionIdentifier                `yaml:"responseModel,omitempty"`
+	ResourceMappings *model.LLMProviderTemplateResourceMappings `yaml:"resourceMappings,omitempty"`
+}
+
+func templateRuntimeArtifactOf(t *model.LLMProviderTemplate) templateRuntimeArtifact {
+	return templateRuntimeArtifact{
+		PromptTokens:     t.PromptTokens,
+		CompletionTokens: t.CompletionTokens,
+		TotalTokens:      t.TotalTokens,
+		RemainingTokens:  t.RemainingTokens,
+		RequestModel:     t.RequestModel,
+		ResponseModel:    t.ResponseModel,
+		ResourceMappings: t.ResourceMappings,
+	}
+}
+
+// ensureTemplateRuntimeArtifactUnchanged rejects an edit to a DP-originated LLM provider
+// template when it would change the gateway-consumed spec.
+func ensureTemplateRuntimeArtifactUnchanged(existing, updated *model.LLMProviderTemplate) error {
+	return compareRuntimeArtifacts(existing.Origin, templateRuntimeArtifactOf(existing), templateRuntimeArtifactOf(updated))
 }
 
 var templateVersionPattern = regexp.MustCompile(`^[vV]\d+\.\d+$`)
@@ -821,10 +867,6 @@ func (s *LLMProviderService) Update(orgUUID, handle, updatedBy string, req *api.
 	if existing == nil {
 		return nil, constants.ErrLLMProviderNotFound
 	}
-	// DP-originated artifacts are read-only in the control plane.
-	if err := ensureOriginMutable(existing.Origin); err != nil {
-		return nil, err
-	}
 	if req.DisplayName == "" || req.Version == "" || req.Template == "" {
 		return nil, constants.ErrInvalidInput
 	}
@@ -886,6 +928,20 @@ func (s *LLMProviderService) Update(orgUUID, handle, updatedBy string, req *api.
 	// Preserve stored upstream auth credential only when auth object is provided with an empty value.
 	// If auth object is omitted, treat it as explicit removal and clear stored auth.
 	m.Configuration.Upstream = preserveUpstreamAuthValue(existing.Configuration.Upstream, m.Configuration.Upstream)
+
+	// The gateway owns the runtime configuration of a DP-originated (gateway_api)
+	// provider, so preserve it verbatim from the stored copy and let ONLY the
+	// control-plane metadata from the request through (description, model catalog,
+	// OpenAPI spec). This keeps the gateway runtime artifact unchanged without depending
+	// on the update payload round-tripping every (possibly redacted) runtime field — the
+	// upstream credential and API-key security value are masked in GET responses, so a
+	// naive diff of the re-submitted payload would otherwise flag a false change.
+	if existing.Origin == constants.OriginDP {
+		m.Name = existing.Name
+		m.Version = existing.Version
+		m.TemplateUUID = existing.TemplateUUID
+		m.Configuration = existing.Configuration
+	}
 
 	if err := s.repo.Update(m); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -1235,10 +1291,6 @@ func (s *LLMProxyService) Update(orgUUID, handle, updatedBy string, req *api.LLM
 	if existing == nil {
 		return nil, constants.ErrLLMProxyNotFound
 	}
-	// DP-originated artifacts are read-only in the control plane.
-	if err := ensureOriginMutable(existing.Origin); err != nil {
-		return nil, err
-	}
 
 	// Validate provider exists
 	prov, err := s.providerRepo.GetByID(req.Provider.Id, orgUUID)
@@ -1274,6 +1326,19 @@ func (s *LLMProxyService) Update(orgUUID, handle, updatedBy string, req *api.LLM
 
 	// Preserve stored upstream auth credential when not supplied in update payload
 	m.Configuration.UpstreamAuth = preserveUpstreamAuthCredential(existing.Configuration.UpstreamAuth, m.Configuration.UpstreamAuth)
+
+	// The gateway owns the runtime configuration of a DP-originated (gateway_api) proxy,
+	// so preserve it verbatim from the stored copy and let ONLY the control-plane
+	// metadata from the request through (description, OpenAPI definition — neither is
+	// part of the gateway runtime artifact). This keeps the runtime artifact unchanged
+	// without depending on the payload round-tripping the (masked) provider credential.
+	if existing.Origin == constants.OriginDP {
+		m.Name = existing.Name
+		m.Version = existing.Version
+		m.ProviderUUID = existing.ProviderUUID
+		m.Configuration = existing.Configuration
+	}
+
 	if err := s.repo.Update(m); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, constants.ErrLLMProxyNotFound

--- a/platform-api/src/internal/service/llm.go
+++ b/platform-api/src/internal/service/llm.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	"platform-api/src/api"
+	"platform-api/src/config"
 	"platform-api/src/internal/constants"
 	"platform-api/src/internal/model"
 	"platform-api/src/internal/repository"
@@ -55,6 +56,7 @@ type LLMProviderService struct {
 	secretService        *SecretService
 	slogger              *slog.Logger
 	auditRepo            repository.AuditRepository
+	cfg                  *config.Server
 }
 
 type LLMProxyService struct {
@@ -66,6 +68,7 @@ type LLMProxyService struct {
 	gatewayEventsService *GatewayEventsService
 	slogger              *slog.Logger
 	auditRepo            repository.AuditRepository
+	cfg                  *config.Server
 }
 
 func NewLLMProviderTemplateService(repo repository.LLMProviderTemplateRepository, auditRepo repository.AuditRepository) *LLMProviderTemplateService {
@@ -82,6 +85,7 @@ func NewLLMProviderService(
 	gatewayEventsService *GatewayEventsService,
 	slogger *slog.Logger,
 	auditRepo repository.AuditRepository,
+	cfg *config.Server,
 ) *LLMProviderService {
 	return &LLMProviderService{
 		repo:                 repo,
@@ -93,6 +97,7 @@ func NewLLMProviderService(
 		gatewayEventsService: gatewayEventsService,
 		slogger:              slogger,
 		auditRepo:            auditRepo,
+		cfg:                  cfg,
 	}
 }
 
@@ -111,6 +116,7 @@ func NewLLMProxyService(
 	gatewayEventsService *GatewayEventsService,
 	slogger *slog.Logger,
 	auditRepo repository.AuditRepository,
+	cfg *config.Server,
 ) *LLMProxyService {
 	return &LLMProxyService{
 		repo:                 repo,
@@ -121,6 +127,7 @@ func NewLLMProxyService(
 		gatewayEventsService: gatewayEventsService,
 		slogger:              slogger,
 		auditRepo:            auditRepo,
+		cfg:                  cfg,
 	}
 }
 
@@ -718,7 +725,7 @@ func (s *LLMProviderService) Create(orgUUID, createdBy string, req *api.LLMProvi
 	if err != nil {
 		return nil, fmt.Errorf("failed to count providers: %w", err)
 	}
-	if err := validateLLMResourceLimit(providerCount, constants.MaxLLMProvidersPerOrganization, constants.ErrLLMProviderLimitReached); err != nil {
+	if err := validateLLMResourceLimit(providerCount, s.cfg.ArtifactLimits.MaxLLMProvidersPerOrg, constants.ErrLLMProviderLimitReached); err != nil {
 		return nil, err
 	}
 	if !tpl.Enabled {
@@ -1076,7 +1083,7 @@ func (s *LLMProxyService) Create(orgUUID, createdBy string, req *api.LLMProxy) (
 	if err != nil {
 		return nil, fmt.Errorf("failed to count proxies: %w", err)
 	}
-	if err := validateLLMResourceLimit(proxyCount, constants.MaxLLMProxiesPerOrganization, constants.ErrLLMProxyLimitReached); err != nil {
+	if err := validateLLMResourceLimit(proxyCount, s.cfg.ArtifactLimits.MaxLLMProxiesPerOrg, constants.ErrLLMProxyLimitReached); err != nil {
 		return nil, err
 	}
 
@@ -1475,8 +1482,10 @@ func preserveUpstreamAuthCredential(existing, updated *model.UpstreamAuth) *mode
 	return updated
 }
 
+// validateLLMResourceLimit returns limitErr when the org has reached maxAllowed.
+// A maxAllowed <= 0 means unlimited (see config.LimitReached), so it never errors.
 func validateLLMResourceLimit(currentCount int, maxAllowed int, limitErr error) error {
-	if currentCount >= maxAllowed {
+	if config.LimitReached(currentCount, maxAllowed) {
 		return limitErr
 	}
 	return nil

--- a/platform-api/src/internal/service/llm_test.go
+++ b/platform-api/src/internal/service/llm_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"platform-api/src/api"
+	"platform-api/src/config"
 	"platform-api/src/internal/constants"
 	"platform-api/src/internal/dto"
 	"platform-api/src/internal/model"
@@ -271,23 +272,31 @@ func TestMapProxyModelToAPI_DoesNotExposeProviderAuthValue(t *testing.T) {
 
 func TestValidateLLMResourceLimit(t *testing.T) {
 	t.Run("below limit should pass", func(t *testing.T) {
-		err := validateLLMResourceLimit(4, constants.MaxLLMProvidersPerOrganization, constants.ErrLLMProviderLimitReached)
+		err := validateLLMResourceLimit(4, 5, constants.ErrLLMProviderLimitReached)
 		if err != nil {
 			t.Fatalf("expected no error below limit, got: %v", err)
 		}
 	})
 
 	t.Run("at limit should fail", func(t *testing.T) {
-		err := validateLLMResourceLimit(5, constants.MaxLLMProvidersPerOrganization, constants.ErrLLMProviderLimitReached)
+		err := validateLLMResourceLimit(5, 5, constants.ErrLLMProviderLimitReached)
 		if err != constants.ErrLLMProviderLimitReached {
 			t.Fatalf("expected ErrLLMProviderLimitReached, got: %v", err)
 		}
 	})
 
 	t.Run("above limit should fail", func(t *testing.T) {
-		err := validateLLMResourceLimit(6, constants.MaxLLMProxiesPerOrganization, constants.ErrLLMProxyLimitReached)
+		err := validateLLMResourceLimit(6, 5, constants.ErrLLMProxyLimitReached)
 		if err != constants.ErrLLMProxyLimitReached {
 			t.Fatalf("expected ErrLLMProxyLimitReached, got: %v", err)
+		}
+	})
+
+	t.Run("unlimited (limit <= 0) should always pass", func(t *testing.T) {
+		for _, limit := range []int{0, -1} {
+			if err := validateLLMResourceLimit(1_000_000, limit, constants.ErrLLMProviderLimitReached); err != nil {
+				t.Fatalf("expected no error for unlimited (limit=%d), got: %v", limit, err)
+			}
 		}
 	})
 }
@@ -337,7 +346,6 @@ func TestGenerateLLMProviderDeploymentYAML_WithSecurityAPIKeyPolicy(t *testing.T
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
-
 
 	if out.Metadata.Name != "tt" {
 		t.Fatalf("expected metadata name tt, got: %s", out.Metadata.Name)
@@ -463,7 +471,6 @@ func TestGenerateLLMProviderDeploymentYAML_WithSecurityAndAdditionalPolicy(t *te
 		t.Fatalf("expected no error, got: %v", err)
 	}
 
-
 	if len(out.Spec.OperationPolicies) != 1 {
 		t.Fatalf("expected 1 operation policy, got: %d", len(out.Spec.OperationPolicies))
 	}
@@ -547,7 +554,6 @@ func TestGenerateLLMProviderDeploymentYAML_NormalizesPolicyVersionToMajor(t *tes
 		t.Fatalf("expected no error, got: %v", err)
 	}
 
-
 	policyA := findOperationPolicy(out.Spec.OperationPolicies, "policy-a")
 	if policyA == nil {
 		t.Fatalf("expected policy-a to be present")
@@ -606,7 +612,6 @@ func TestGenerateLLMProviderDeploymentYAML_WithProviderGlobalRateLimit(t *testin
 		t.Fatalf("expected no error, got: %v", err)
 	}
 	out = roundTripYAML(t, out)
-
 
 	if len(out.Spec.GlobalPolicies) != 2 {
 		t.Fatalf("expected 2 global policies, got: %d", len(out.Spec.GlobalPolicies))
@@ -725,7 +730,6 @@ func TestGenerateLLMProviderDeploymentYAML_WithProviderResourceWiseRateLimit(t *
 		t.Fatalf("expected no error, got: %v", err)
 	}
 	out = roundTripYAML(t, out)
-
 
 	if len(out.Spec.OperationPolicies) != 2 {
 		t.Fatalf("expected 2 operation policies, got: %d", len(out.Spec.OperationPolicies))
@@ -868,7 +872,6 @@ func TestGenerateLLMProviderDeploymentYAML_WithProviderResourceWiseRateLimitAndD
 		t.Fatalf("expected no error, got: %v", err)
 	}
 	out = roundTripYAML(t, out)
-
 
 	if len(out.Spec.OperationPolicies) != 2 {
 		t.Fatalf("expected 2 operation policies, got: %d", len(out.Spec.OperationPolicies))
@@ -1100,7 +1103,7 @@ func TestLLMProviderServiceCreateRejectsMultipleModelProvidersForNativeTemplate(
 			return &model.LLMProviderTemplate{UUID: "tpl-openai", ID: "openai", CreatedAt: now, UpdatedAt: now}, nil
 		},
 	}
-	service := NewLLMProviderService(providerRepo, templateRepo, nil, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{})
+	service := NewLLMProviderService(providerRepo, templateRepo, nil, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{})
 
 	request := validProviderRequest("openai")
 	request.ModelProviders = &[]api.LLMModelProvider{
@@ -1136,7 +1139,7 @@ func TestLLMProviderServiceCreateAllowsAggregatorTemplate(t *testing.T) {
 		},
 	}
 	orgRepo := &mockOrganizationRepo{org: &model.Organization{ID: "org-1"}}
-	service := NewLLMProviderService(providerRepo, templateRepo, orgRepo, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{})
+	service := NewLLMProviderService(providerRepo, templateRepo, orgRepo, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{})
 
 	request := validProviderRequest("awsbedrock")
 	request.ModelProviders = &[]api.LLMModelProvider{
@@ -1179,7 +1182,7 @@ func TestLLMProviderServiceCreateMigratesLegacyPolicies(t *testing.T) {
 		},
 	}
 	orgRepo := &mockOrganizationRepo{org: &model.Organization{ID: "org-1"}}
-	service := NewLLMProviderService(providerRepo, templateRepo, orgRepo, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{})
+	service := NewLLMProviderService(providerRepo, templateRepo, orgRepo, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{})
 
 	request := validProviderRequest("openai")
 	request.Policies = &[]api.LLMPolicy{
@@ -1239,7 +1242,7 @@ func TestLLMProviderServiceCreateReturnsConflictForDuplicateHandle(t *testing.T)
 			return &model.LLMProviderTemplate{UUID: "tpl-openai", ID: "openai"}, nil
 		},
 	}
-	service := NewLLMProviderService(providerRepo, templateRepo, nil, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{})
+	service := NewLLMProviderService(providerRepo, templateRepo, nil, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{})
 
 	_, err := service.Create("org-1", "alice", validProviderRequest("openai"))
 	if err != constants.ErrLLMProviderExists {
@@ -1281,7 +1284,7 @@ func TestLLMProviderServiceUpdatePreservesUpstreamAuthValue(t *testing.T) {
 			return &model.LLMProviderTemplate{UUID: "tpl-openai", ID: "openai"}, nil
 		},
 	}
-	service := NewLLMProviderService(providerRepo, templateRepo, nil, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{})
+	service := NewLLMProviderService(providerRepo, templateRepo, nil, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{})
 
 	request := validProviderRequest("openai")
 	request.DisplayName = "Updated Provider"
@@ -1311,7 +1314,7 @@ func TestLLMProxyServiceCreateFailsWhenProviderNotFound(t *testing.T) {
 		},
 	}
 	projectRepo := &mockProjectRepo{project: &model.Project{ID: "project-1", OrganizationID: "org-1"}}
-	service := NewLLMProxyService(proxyRepo, providerRepo, projectRepo, nil, nil, nil, slog.Default(), &noopAuditRepo{})
+	service := NewLLMProxyService(proxyRepo, providerRepo, projectRepo, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{})
 
 	_, err := service.Create("org-1", "alice", validProxyRequest("provider-1", "project-1"))
 	if err != constants.ErrLLMProviderNotFound {
@@ -1326,7 +1329,7 @@ func TestLLMProxyServiceCreateReturnsConflictForDuplicateHandle(t *testing.T) {
 			return &model.LLMProvider{UUID: "provider-uuid", ID: providerID}, nil
 		},
 	}
-	service := NewLLMProxyService(proxyRepo, providerRepo, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{})
+	service := NewLLMProxyService(proxyRepo, providerRepo, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{})
 
 	_, err := service.Create("org-1", "alice", validProxyRequest("provider-1", "project-1"))
 	if err != constants.ErrLLMProxyExists {
@@ -1357,7 +1360,7 @@ func TestLLMProxyServiceListByProviderUsesProviderUUID(t *testing.T) {
 			return &model.LLMProvider{UUID: "provider-uuid", ID: providerID}, nil
 		},
 	}
-	service := NewLLMProxyService(proxyRepo, providerRepo, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{})
+	service := NewLLMProxyService(proxyRepo, providerRepo, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{})
 
 	resp, err := service.ListByProvider("org-1", "provider-1", 10, 0)
 	if err != nil {
@@ -1402,7 +1405,7 @@ func TestLLMProxyServiceUpdatePreservesProviderAuthValue(t *testing.T) {
 			return &model.LLMProvider{UUID: "provider-uuid", ID: providerID}, nil
 		},
 	}
-	service := NewLLMProxyService(proxyRepo, providerRepo, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{})
+	service := NewLLMProxyService(proxyRepo, providerRepo, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{})
 
 	request := validProxyRequest("provider-1", "project-1")
 	request.DisplayName = "Updated Proxy"

--- a/platform-api/src/internal/service/mcp.go
+++ b/platform-api/src/internal/service/mcp.go
@@ -276,10 +276,6 @@ func (s *MCPProxyService) Update(orgUUID, handle, updatedBy string, req *api.MCP
 	if existing == nil {
 		return nil, constants.ErrMCPProxyNotFound
 	}
-	// DP-originated artifacts are read-only in the control plane.
-	if err := ensureOriginMutable(existing.Origin); err != nil {
-		return nil, err
-	}
 
 	// Validate {{ secret "..." }} placeholders in the upstream config
 	if s.secretService != nil {
@@ -294,6 +290,12 @@ func (s *MCPProxyService) Update(orgUUID, handle, updatedBy string, req *api.MCP
 
 	// Store existing upstream config for auth preservation
 	existingUpstreamConfig := existing.Configuration.Upstream
+
+	// Snapshot the gateway-owned runtime fields so a DP-originated proxy can preserve them
+	// (only the description is control-plane editable — restored below).
+	origName := existing.Name
+	origVersion := existing.Version
+	origConfiguration := existing.Configuration
 
 	// Update fields
 	existing.Name = req.DisplayName
@@ -314,6 +316,16 @@ func (s *MCPProxyService) Update(orgUUID, handle, updatedBy string, req *api.MCP
 	// Preserve existing upstream auth credential if not provided in update request
 	// (the auth value is redacted in GET responses, so clients send empty value on updates)
 	existing.Configuration.Upstream = *preserveMCPUpstreamAuthValue(&existingUpstreamConfig, &existing.Configuration.Upstream)
+
+	// The gateway owns the runtime configuration of a DP-originated proxy: preserve it
+	// verbatim and keep only the control-plane-editable description from the request.
+	// This keeps the gateway runtime artifact unchanged without depending on the update
+	// payload round-tripping the (masked) upstream credential.
+	if existing.Origin == constants.OriginDP {
+		existing.Name = origName
+		existing.Version = origVersion
+		existing.Configuration = origConfiguration
+	}
 
 	if err := s.repo.Update(existing); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {

--- a/platform-api/src/internal/service/mcp.go
+++ b/platform-api/src/internal/service/mcp.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"platform-api/src/api"
+	"platform-api/src/config"
 	"platform-api/src/internal/constants"
 	"platform-api/src/internal/model"
 	"platform-api/src/internal/repository"
@@ -51,12 +52,14 @@ type MCPProxyService struct {
 	secretService        *SecretService
 	slogger              *slog.Logger
 	auditRepo            repository.AuditRepository
+	cfg                  *config.Server
 }
 
 // NewMCPProxyService creates a new MCPProxyService instance
 func NewMCPProxyService(repo repository.MCPProxyRepository, projectRepo repository.ProjectRepository,
 	deploymentRepo repository.DeploymentRepository, gatewayRepo repository.GatewayRepository,
-	gatewayEventsService *GatewayEventsService, slogger *slog.Logger, auditRepo repository.AuditRepository) *MCPProxyService {
+	gatewayEventsService *GatewayEventsService, slogger *slog.Logger, auditRepo repository.AuditRepository,
+	cfg *config.Server) *MCPProxyService {
 	return &MCPProxyService{
 		repo:                 repo,
 		projectRepo:          projectRepo,
@@ -65,6 +68,7 @@ func NewMCPProxyService(repo repository.MCPProxyRepository, projectRepo reposito
 		gatewayEventsService: gatewayEventsService,
 		slogger:              slogger,
 		auditRepo:            auditRepo,
+		cfg:                  cfg,
 	}
 }
 
@@ -123,12 +127,12 @@ func (s *MCPProxyService) Create(orgUUID, createdBy string, req *api.MCPProxy) (
 	}
 	req.Id = &handle
 
-	// Temporary check for maximum MCP proxy limit per organization before creation
+	// Enforce the per-organization MCP proxy limit (unlimited when not configured).
 	proxyCount, err := s.repo.Count(orgUUID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to count existing MCP proxies: %w", err)
 	}
-	if proxyCount >= constants.MaxMCPProxiesPerOrganization {
+	if config.LimitReached(proxyCount, s.cfg.ArtifactLimits.MaxMCPProxiesPerOrg) {
 		return nil, constants.ErrMCPProxyLimitReached
 	}
 

--- a/platform-api/src/plugins/eventgateway/plugin.go
+++ b/platform-api/src/plugins/eventgateway/plugin.go
@@ -32,6 +32,7 @@ import (
 	"strings"
 
 	"platform-api/src/api"
+	"platform-api/src/config"
 	"platform-api/src/internal/constants"
 	"platform-api/src/internal/database"
 	"platform-api/src/internal/plugin"
@@ -72,6 +73,8 @@ var schemaSQLServer []byte
 
 // EventGatewayPlugin is the compile-time plugin for WebSub and WebBroker APIs.
 type EventGatewayPlugin struct {
+	cfg *config.Server
+
 	websubAPIRepo    *egrepo.WebSubAPIRepo
 	webbrokerAPIRepo *egrepo.WebBrokerAPIRepo
 	hmacSecretRepo   *egrepo.WebSubAPIHmacSecretRepo
@@ -100,6 +103,7 @@ func (p *EventGatewayPlugin) Name() string {
 func (p *EventGatewayPlugin) Init(deps *plugin.Deps) error {
 	db := deps.DB
 	cfg := deps.Config
+	p.cfg = cfg
 	logger := deps.Logger
 	apiUtil := &utils.APIUtil{}
 
@@ -138,6 +142,7 @@ func (p *EventGatewayPlugin) Init(deps *plugin.Deps) error {
 		apiUtil,
 		logger,
 		deps.AuditRepo,
+		cfg,
 	)
 
 	websubDeploymentSvc := egservice.NewWebSubAPIDeploymentService(
@@ -160,6 +165,7 @@ func (p *EventGatewayPlugin) Init(deps *plugin.Deps) error {
 		apiUtil,
 		logger,
 		deps.AuditRepo,
+		cfg,
 	)
 
 	webbrokerDeploymentSvc := egservice.NewWebBrokerAPIDeploymentService(
@@ -267,13 +273,14 @@ func (p *EventGatewayPlugin) EnrichSubscription(orgID string, sub *api.Organizat
 	if err != nil {
 		return err
 	}
-	limit := constants.MaxWebSubAPIsPerOrganization
-	remaining := max(limit-count, 0)
-	sub.Quotas.WebsubApis = &api.OrganizationQuota{
-		Used:      count,
-		Limit:     intPtr(limit),
-		Remaining: intPtr(remaining),
+	// A limit <= 0 means unlimited: report only usage, leaving Limit/Remaining
+	// unset so consumers treat the WebSub API quota as uncapped.
+	quota := &api.OrganizationQuota{Used: count}
+	if limit := p.cfg.ArtifactLimits.MaxWebSubAPIsPerOrg; limit > 0 {
+		quota.Limit = intPtr(limit)
+		quota.Remaining = intPtr(max(limit-count, 0))
 	}
+	sub.Quotas.WebsubApis = quota
 	return nil
 }
 

--- a/platform-api/src/plugins/eventgateway/service/webbroker_api.go
+++ b/platform-api/src/plugins/eventgateway/service/webbroker_api.go
@@ -26,6 +26,7 @@ import (
 	"log/slog"
 
 	"platform-api/src/api"
+	"platform-api/src/config"
 	"platform-api/src/internal/constants"
 	"platform-api/src/internal/model"
 	"platform-api/src/internal/repository"
@@ -42,6 +43,7 @@ type WebBrokerAPIService struct {
 	apiUtil              *utils.APIUtil
 	slogger              *slog.Logger
 	auditRepo            repository.AuditRepository
+	cfg                  *config.Server
 }
 
 // NewWebBrokerAPIService creates a new WebBrokerAPIService instance
@@ -53,6 +55,7 @@ func NewWebBrokerAPIService(
 	apiUtil *utils.APIUtil,
 	slogger *slog.Logger,
 	auditRepo repository.AuditRepository,
+	cfg *config.Server,
 ) *WebBrokerAPIService {
 	return &WebBrokerAPIService{
 		repo:                 repo,
@@ -62,6 +65,7 @@ func NewWebBrokerAPIService(
 		apiUtil:              apiUtil,
 		slogger:              slogger,
 		auditRepo:            auditRepo,
+		cfg:                  cfg,
 	}
 }
 
@@ -102,12 +106,12 @@ func (s *WebBrokerAPIService) Create(orgUUID, createdBy string, req *api.WebBrok
 		return nil, constants.ErrWebBrokerAPIExists
 	}
 
-	// Check org limit
+	// Enforce the per-organization WebBroker API limit (unlimited when not configured).
 	count, err := s.repo.Count(orgUUID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to count existing WebBroker APIs: %w", err)
 	}
-	if count >= constants.MaxWebBrokerAPIsPerOrganization {
+	if config.LimitReached(count, s.cfg.ArtifactLimits.MaxWebBrokerAPIsPerOrg) {
 		return nil, constants.ErrWebBrokerAPILimitReached
 	}
 

--- a/platform-api/src/plugins/eventgateway/service/websub_api.go
+++ b/platform-api/src/plugins/eventgateway/service/websub_api.go
@@ -26,6 +26,7 @@ import (
 	"log/slog"
 
 	"platform-api/src/api"
+	"platform-api/src/config"
 	"platform-api/src/internal/constants"
 	"platform-api/src/internal/model"
 	"platform-api/src/internal/repository"
@@ -42,6 +43,7 @@ type WebSubAPIService struct {
 	apiUtil              *utils.APIUtil
 	slogger              *slog.Logger
 	auditRepo            repository.AuditRepository
+	cfg                  *config.Server
 }
 
 // NewWebSubAPIService creates a new WebSubAPIService instance
@@ -53,6 +55,7 @@ func NewWebSubAPIService(
 	apiUtil *utils.APIUtil,
 	slogger *slog.Logger,
 	auditRepo repository.AuditRepository,
+	cfg *config.Server,
 ) *WebSubAPIService {
 	return &WebSubAPIService{
 		repo:                 repo,
@@ -62,6 +65,7 @@ func NewWebSubAPIService(
 		apiUtil:              apiUtil,
 		slogger:              slogger,
 		auditRepo:            auditRepo,
+		cfg:                  cfg,
 	}
 }
 
@@ -102,12 +106,12 @@ func (s *WebSubAPIService) Create(orgUUID, createdBy string, req *api.WebSubAPI)
 		return nil, constants.ErrWebSubAPIExists
 	}
 
-	// Check org limit
+	// Enforce the per-organization WebSub API limit (unlimited when not configured).
 	count, err := s.repo.Count(orgUUID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to count existing WebSub APIs: %w", err)
 	}
-	if count >= constants.MaxWebSubAPIsPerOrganization {
+	if config.LimitReached(count, s.cfg.ArtifactLimits.MaxWebSubAPIsPerOrg) {
 		return nil, constants.ErrWebSubAPILimitReached
 	}
 
@@ -138,7 +142,7 @@ func (s *WebSubAPIService) Create(orgUUID, createdBy string, req *api.WebSubAPI)
 		CreatedBy:        createdBy,
 		Version:          req.Version,
 		LifeCycleStatus:  lifeCycleStatus,
-		Origin: constants.OriginCP,
+		Origin:           constants.OriginCP,
 		Configuration: model.WebSubAPIConfiguration{
 			Name:              req.DisplayName,
 			Version:           req.Version,


### PR DESCRIPTION
This pull request introduces configurable per-organization artifact limits and improves the handling of data-plane-originated (DP) artifacts, particularly around edit permissions and error reporting. Artifact limits are now set via configuration (not hardcoded), and DP artifacts can be edited from the control plane only if the changes do not affect their gateway runtime configuration. The changes also refactor error handling and update service constructors and tests to support the new configuration.

Related to - https://github.com/wso2/api-platform/issues/2083

**Configurable Artifact Limits**

* Added the `ArtifactLimits` struct to `config.go` and integrated it into the main `Server` config. This allows operators to set maximums for LLM providers, LLM proxies, MCP proxies, WebSub APIs, and WebBroker APIs per organization, with unlimited as the default. [[1]](diffhunk://#diff-3d9d97b7e23ab9c6e77fe2b6aa9d353b34d643d87c49eb8f0101e45b47e31467R87) [[2]](diffhunk://#diff-3d9d97b7e23ab9c6e77fe2b6aa9d353b34d643d87c49eb8f0101e45b47e31467R213-R230) [[3]](diffhunk://#diff-12d11bacb8c499b267240257198192ef8c76222614bc39d318e859962d7eb251R124-R128)
* Updated environment variable mapping and documentation to support the new artifact limits, including README and `envToKoanfKey` changes. [[1]](diffhunk://#diff-99fd02378793aa762a8104825943dc18b047b4d0bda438554223166833f38bbfR351-R355) [[2]](diffhunk://#diff-3d9d97b7e23ab9c6e77fe2b6aa9d353b34d643d87c49eb8f0101e45b47e31467R531-R542)
* Removed all hardcoded artifact limits from `constants.go`—these are now configured dynamically.

**DP Artifact Edit Handling**

* Introduced a new error (`ErrArtifactRuntimeImmutable`) and enforcement logic so that DP-originated artifacts can be edited from the control plane only if the edits do not change the gateway runtime artifact (i.e., only metadata can be changed). This includes a new comparison mechanism that fingerprints and diffs runtime artifacts. [[1]](diffhunk://#diff-c419d36ed4a009ec119bf132fc0e36ceb5c1c9f0169ac31b6d7d54e8e2d5cc69R115-R122) [[2]](diffhunk://#diff-aa0dec5e64c677e38234b4eea80e90bf58607b0c9a532e183830eeebc8d5248dR62-R108)
* Updated the artifact guard response handler to return the correct HTTP status for the new error.
* Refactored the `APIService.UpdateAPI` method to allow safe metadata-only edits to DP APIs and reject runtime changes. [[1]](diffhunk://#diff-b708f9ffa32632b7541587a33ef9eeecbbc1ddb4825c7b94db8d884923e9e357L263-L267) [[2]](diffhunk://#diff-b708f9ffa32632b7541587a33ef9eeecbbc1ddb4825c7b94db8d884923e9e357R273-R288) [[3]](diffhunk://#diff-b708f9ffa32632b7541587a33ef9eeecbbc1ddb4825c7b94db8d884923e9e357R300-R321)

**Service and Test Updates**

* Updated service constructors (LLMProvider, LLMProxy, MCPProxy) and related tests to accept the new configuration struct. [[1]](diffhunk://#diff-5e894ed9fe307e169bfef527b6af74587172cd898a43fbfcd4fedef1faac2010L231-R233) [[2]](diffhunk://#diff-2fbc3896d3ca6855ec99bc68ad75df29ef6fec006c8af18e7824c9313172c91bR273) [[3]](diffhunk://#diff-2fbc3896d3ca6855ec99bc68ad75df29ef6fec006c8af18e7824c9313172c91bR315) [[4]](diffhunk://#diff-4b27b7475a7f02bfb3fe177a5d758321b120b7992193830542681d8a4575e467R817)
* Added necessary imports and wiring to support the configuration changes in tests and services. [[1]](diffhunk://#diff-2fbc3896d3ca6855ec99bc68ad75df29ef6fec006c8af18e7824c9313172c91bR27) [[2]](diffhunk://#diff-4b27b7475a7f02bfb3fe177a5d758321b120b7992193830542681d8a4575e467R26) [[3]](diffhunk://#diff-aa0dec5e64c677e38234b4eea80e90bf58607b0c9a532e183830eeebc8d5248dR21-R27)