### PR TITLE
Improve api key generation flow and webhook events

### DIFF
--- a/docs/rest-apis/devportal/README.md
+++ b/docs/rest-apis/devportal/README.md
@@ -47,7 +47,6 @@ Base URLs:
 - [Replace API content](api-content.md#replace-api-content)
 - [Get an API content file](api-content.md#get-an-api-content-file)
 - [Delete API content files](api-content.md#delete-api-content-files)
-- [List API document file names](api-content.md#list-api-document-file-names)
 
 ### [Subscription Plans](subscription-plans.md)
 

--- a/docs/rest-apis/devportal/api-content.md
+++ b/docs/rest-apis/devportal/api-content.md
@@ -515,4 +515,3 @@ This operation requires <strong>Basic Auth</strong> authentication.
 |---|---|
 |status|error|
 |status|error|
-

--- a/docs/rest-apis/devportal/api-keys.md
+++ b/docs/rest-apis/devportal/api-keys.md
@@ -285,7 +285,8 @@ Regenerates the secret for an existing API key identified by `keyId` in the requ
 
 ```json
 {
-  "keyId": "key-12345"
+  "keyId": "key-12345",
+  "expiresAt": "2027-01-01T00:00:00Z"
 }
 ```
 
@@ -300,8 +301,9 @@ This operation requires <strong>Basic Auth</strong> authentication.
 
 |Name|In|Type|Required|Description|
 |---|---|---|---|---|
-|body|body|object|true|Identifies the API key to regenerate by its `keyId`.|
+|body|body|object|true|Identifies the API key to regenerate by its `keyId`. `expiresAt` is optional and, if provided, updates the key's expiry; the key's `name` cannot be changed by this operation.|
 |» keyId|body|string|true|Developer Portal key ID returned by generate or list.|
+|» expiresAt|body|string|false|New expiry for the key. Can be an ISO-8601 datetime with timezone, epoch seconds, or epoch milliseconds. Omit to leave the current expiry unchanged.|
 |apiId|path|string|true|none|
 
 > Example responses

--- a/docs/rest-apis/devportal/api-keys.md
+++ b/docs/rest-apis/devportal/api-keys.md
@@ -160,7 +160,7 @@ This operation requires <strong>Basic Auth</strong> authentication.
       "name": "weather_prod_key",
       "apiId": "api-7f4c2a6b",
       "appId": "app-12345",
-      "appName": "My Mobile App",
+      "appDisplayName": "My Mobile App",
       "status": "ACTIVE",
       "expiresAt": "2026-12-31T23:59:59Z",
       "createdAt": "2019-08-24T14:15:22Z",
@@ -236,7 +236,7 @@ Status Code **200**
 |»» name|string|false|none|none|
 |»» apiId|string|false|none|Developer Portal API ID the key belongs to.|
 |»» appId|string¦null|false|none|ID of the application this key is associated with, if any. Analytics attribution only.|
-|»» appName|string¦null|false|none|Name of the associated application, if any.|
+|»» appDisplayName|string¦null|false|none|Display name of the associated application, if any.|
 |»» status|string|false|none|none|
 |»» expiresAt|string(date-time)¦null|false|none|none|
 |»» createdAt|string(date-time)|false|none|none|
@@ -517,7 +517,7 @@ This operation requires <strong>Basic Auth</strong> authentication.
   "keyId": "key-12345",
   "application": {
     "id": "app-12345",
-    "name": "My Mobile App"
+    "displayName": "My Mobile App"
   }
 }
 ```
@@ -711,7 +711,7 @@ This operation requires <strong>Basic Auth</strong> authentication.
       "name": "weather_prod_key",
       "apiId": "api-7f4c2a6b",
       "appId": "app-12345",
-      "appName": "My Mobile App",
+      "appDisplayName": "My Mobile App",
       "status": "ACTIVE",
       "expiresAt": "2026-12-31T23:59:59Z",
       "createdAt": "2019-08-24T14:15:22Z",
@@ -765,7 +765,7 @@ Status Code **200**
 |»» name|string|false|none|none|
 |»» apiId|string|false|none|Developer Portal API ID the key belongs to.|
 |»» appId|string¦null|false|none|ID of the application this key is associated with, if any. Analytics attribution only.|
-|»» appName|string¦null|false|none|Name of the associated application, if any.|
+|»» appDisplayName|string¦null|false|none|Display name of the associated application, if any.|
 |»» status|string|false|none|none|
 |»» expiresAt|string(date-time)¦null|false|none|none|
 |»» createdAt|string(date-time)|false|none|none|

--- a/docs/rest-apis/devportal/applications.md
+++ b/docs/rest-apis/devportal/applications.md
@@ -334,7 +334,7 @@ curl -X PUT https://devportal.api-platform.io/devportal/v1/applications/{applica
 
 ```
 
-Updates an application owned by the authenticated user in the specified organization. The request may be JSON, multipart form fields, or an application YAML file in the `application` multipart field. An `application.updated` webhook event is published, plus one `apikey.application_updated` event per API key currently associated with the application.
+Updates an application owned by the authenticated user in the specified organization. The request may be JSON, multipart form fields, or an application YAML file in the `application` multipart field. An `application.updated` webhook event is published.
 
 > Payload
 

--- a/docs/rest-apis/devportal/applications.md
+++ b/docs/rest-apis/devportal/applications.md
@@ -42,7 +42,7 @@ This operation requires <strong>Basic Auth</strong> authentication.
   "list": [
     {
       "id": "app-12345",
-      "name": "Weather App",
+      "displayName": "Weather App",
       "description": "Application used to call Weather APIs.",
       "appKeyMappings": [
         {
@@ -86,7 +86,8 @@ Status Code **200**
 |---|---|---|---|---|
 |» list|[[ApplicationResponse](schemas.md#schemaapplicationresponse)]|false|none|none|
 |»» id|string|false|none|none|
-|»» name|string|false|none|none|
+|»» displayName|string|false|none|none|
+|»» handle|string|false|none|none|
 |»» description|string|false|none|none|
 |»» appKeyMappings|[[ApplicationKeyMappingSummary](schemas.md#schemaapplicationkeymappingsummary)]|false|none|[OAuth client ID mapping entry attached to an application.]|
 |»»» asClientId|string|false|none|OAuth client ID, created directly in the key manager and linked to this application.|
@@ -129,13 +130,15 @@ Creates a Developer Portal application in the specified organization. The reques
 
 ```json
 {
-  "name": "Weather App",
+  "displayName": "Weather App",
+  "handle": "weather-app",
   "description": "Application used to call Weather APIs."
 }
 ```
 
 ```yaml
-name: Weather App
+displayName: Weather App
+handle: weather-app
 description: Application used to call Weather APIs.
 
 ```
@@ -151,7 +154,7 @@ This operation requires <strong>Basic Auth</strong> authentication.
 
 |Name|In|Type|Required|Description|
 |---|---|---|---|---|
-|body|body|[ApplicationRequest](schemas.md#schemaapplicationrequest)|true|Application payload. Send JSON, multipart form fields, or an application YAML file in the `application` field. When YAML is used, the service reads `spec.displayName` or `metadata.name` as the application name and `spec.description` as the description.|
+|body|body|[ApplicationRequest](schemas.md#schemaapplicationrequest)|true|Application payload. Send JSON, multipart form fields, or an application YAML file in the `application` field. When YAML is used, the service reads `spec.displayName` as the application's display name, `spec.description` as the description, and `spec.handle` or `metadata.name` as the handle.|
 
 > Example responses
 
@@ -160,7 +163,7 @@ This operation requires <strong>Basic Auth</strong> authentication.
 ```json
 {
   "id": "app-12345",
-  "name": "Weather App",
+  "displayName": "Weather App",
   "description": "Application used to call Weather APIs.",
   "appKeyMappings": []
 }
@@ -281,7 +284,8 @@ This operation requires <strong>Basic Auth</strong> authentication.
 ```json
 {
   "id": "app-12345",
-  "name": "Weather App",
+  "displayName": "Weather App",
+  "handle": "weather-app",
   "description": "Application used to call Weather APIs.",
   "appKeyMappings": []
 }
@@ -340,13 +344,15 @@ Updates an application owned by the authenticated user in the specified organiza
 
 ```json
 {
-  "name": "Weather App",
+  "displayName": "Weather App",
+  "handle": "weather-app",
   "description": "Application used to call Weather APIs."
 }
 ```
 
 ```yaml
-name: Weather App
+displayName: Weather App
+handle: weather-app
 description: Application used to call Weather APIs.
 
 ```
@@ -362,7 +368,7 @@ This operation requires <strong>Basic Auth</strong> authentication.
 
 |Name|In|Type|Required|Description|
 |---|---|---|---|---|
-|body|body|[ApplicationRequest](schemas.md#schemaapplicationrequest)|true|Application payload. Send JSON, multipart form fields, or an application YAML file in the `application` field. When YAML is used, the service reads `spec.displayName` or `metadata.name` as the application name and `spec.description` as the description.|
+|body|body|[ApplicationRequest](schemas.md#schemaapplicationrequest)|true|Application payload. Send JSON, multipart form fields, or an application YAML file in the `application` field. When YAML is used, the service reads `spec.displayName` as the application's display name, `spec.description` as the description, and `spec.handle` or `metadata.name` as the handle.|
 |applicationId|path|string|true|none|
 
 > Example responses
@@ -372,7 +378,8 @@ This operation requires <strong>Basic Auth</strong> authentication.
 ```json
 {
   "id": "app-12345",
-  "name": "Weather App",
+  "displayName": "Weather App",
+  "handle": "weather-app",
   "description": "Application used to call Weather APIs.",
   "appKeyMappings": []
 }

--- a/docs/rest-apis/devportal/schemas.md
+++ b/docs/rest-apis/devportal/schemas.md
@@ -1065,6 +1065,7 @@ xor
 
 ```json
 {
+  "apiId": "api-5f2b8c1a",
   "planId": "pol-9a3d1f7e"
 }
 
@@ -1074,6 +1075,7 @@ xor
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
+|apiId|string|false|none|Developer Portal API ID the subscription belongs to. Optional — used as a fallback when the API cannot be derived from the subscription record.|
 |planId|string|true|none|Developer Portal subscription plan ID to switch to.|
 
 <h2 id="tocS_SubscriptionResponse">SubscriptionResponse</h2>

--- a/docs/rest-apis/devportal/schemas.md
+++ b/docs/rest-apis/devportal/schemas.md
@@ -721,7 +721,8 @@ Fields are returned at the root of ApiMetadataResponse / ApiMetadataCreateRespon
 ```json
 {
   "id": "app-12345",
-  "name": "Weather App",
+  "displayName": "Weather App",
+  "handle": "weather-app",
   "description": "Application used to call Weather APIs.",
   "appKeyMappings": [
     {
@@ -739,7 +740,8 @@ Fields are returned at the root of ApiMetadataResponse / ApiMetadataCreateRespon
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |id|string|false|none|none|
-|name|string|false|none|none|
+|displayName|string|false|none|none|
+|handle|string|false|none|none|
 |description|string|false|none|none|
 |appKeyMappings|[[ApplicationKeyMappingSummary](#schemaapplicationkeymappingsummary)]|false|none|[OAuth client ID mapping entry attached to an application.]|
 
@@ -994,7 +996,8 @@ xor
 
 ```json
 {
-  "name": "Weather App",
+  "displayName": "Weather App",
+  "handle": "weather-app",
   "description": "Application used to call Weather APIs."
 }
 
@@ -1004,7 +1007,8 @@ xor
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|name|string|true|none|none|
+|displayName|string|true|none|none|
+|handle|string|false|none|Immutable, org-scoped slug for the application. Optional — defaults to the application's `displayName` when omitted.|
 |description|string|true|none|none|
 
 <h2 id="tocS_SubscriptionCreateRequest">SubscriptionCreateRequest</h2>
@@ -1170,7 +1174,7 @@ xor
   "name": "weather_prod_key",
   "apiId": "api-7f4c2a6b",
   "appId": "app-12345",
-  "appName": "My Mobile App",
+  "appDisplayName": "My Mobile App",
   "status": "ACTIVE",
   "expiresAt": "2026-12-31T23:59:59Z",
   "createdAt": "2019-08-24T14:15:22Z",
@@ -1189,7 +1193,7 @@ API key metadata returned by list operations. Secret material is omitted.
 |name|string|false|none|none|
 |apiId|string|false|none|Developer Portal API ID the key belongs to.|
 |appId|string¦null|false|none|ID of the application this key is associated with, if any. Analytics attribution only.|
-|appName|string¦null|false|none|Name of the associated application, if any.|
+|appDisplayName|string¦null|false|none|Display name of the associated application, if any.|
 |status|string|false|none|none|
 |expiresAt|string(date-time)¦null|false|none|none|
 |createdAt|string(date-time)|false|none|none|
@@ -1220,7 +1224,7 @@ API key metadata returned by list operations. Secret material is omitted.
 
 ```
 
-API key response returned by generate/regenerate only. Unlike ApiKeyMetadataResponse, this does not include apiId, appId, appName, createdAt, or revokedAt — generate/regenerate return only these five fields.
+API key response returned by generate/regenerate only. Unlike ApiKeyMetadataResponse, this does not include apiId, appId, appDisplayName, createdAt, or revokedAt — generate/regenerate return only these five fields.
 
 ### Properties
 
@@ -1251,7 +1255,7 @@ API key response returned by generate/regenerate only. Unlike ApiKeyMetadataResp
   "keyId": "key-12345",
   "application": {
     "id": "app-12345",
-    "name": "My Mobile App"
+    "displayName": "My Mobile App"
   }
 }
 
@@ -1264,7 +1268,7 @@ API key response returned by generate/regenerate only. Unlike ApiKeyMetadataResp
 |keyId|string|false|none|none|
 |application|object|false|none|none|
 |» id|string|false|none|none|
-|» name|string|false|none|none|
+|» displayName|string|false|none|none|
 
 <h2 id="tocS_KeyManagerRequest">KeyManagerRequest</h2>
 

--- a/docs/rest-apis/devportal/subscriptions.md
+++ b/docs/rest-apis/devportal/subscriptions.md
@@ -497,6 +497,7 @@ Changes the subscription plan in-place. The subscription UUID and token remain u
 
 ```json
 {
+  "apiId": "api-5f2b8c1a",
   "planId": "pol-9a3d1f7e"
 }
 ```

--- a/portals/developer-portal/configs/config.yaml.example
+++ b/portals/developer-portal/configs/config.yaml.example
@@ -179,11 +179,11 @@ telemetry:
 
 defaultOrgName: "default"
 
-# ─── Subscription Policies ─────────────────────────────────────────────────────
+# ─── Subscription Plans ─────────────────────────────────────────────────────────
 # When true, Bronze/Silver/Gold/Unlimited/AsyncUnlimited plans are auto-created
 # for every new organization.
 
-generateDefaultSubPolicies: true
+generateDefaultSubPlans: true
 
 # ─── Features ──────────────────────────────────────────────────────────────────
 

--- a/portals/developer-portal/database/schema.postgres.sql
+++ b/portals/developer-portal/database/schema.postgres.sql
@@ -99,7 +99,7 @@ CREATE TABLE IF NOT EXISTS "dp_key_managers" ("uuid" VARCHAR(40) , "org_uuid" VA
 CREATE UNIQUE INDEX IF NOT EXISTS "uq_key_manager_org_name" ON "dp_key_managers" ("org_uuid", "name");
 
 -- dp_applications
-CREATE TABLE IF NOT EXISTS "dp_applications" ("uuid" VARCHAR(40) , "org_uuid" VARCHAR(40) NOT NULL REFERENCES "dp_organizations" ("uuid") ON DELETE NO ACTION ON UPDATE CASCADE, "created_by" VARCHAR(255) NOT NULL, "name" VARCHAR(255) NOT NULL, "handle" VARCHAR(255) NOT NULL, "description" VARCHAR(1023), "created_at" TIMESTAMP WITH TIME ZONE NOT NULL, "updated_by" VARCHAR(255) NOT NULL, "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL, PRIMARY KEY ("uuid"));
+CREATE TABLE IF NOT EXISTS "dp_applications" ("uuid" VARCHAR(40) , "org_uuid" VARCHAR(40) NOT NULL REFERENCES "dp_organizations" ("uuid") ON DELETE NO ACTION ON UPDATE CASCADE, "created_by" VARCHAR(255) NOT NULL, "display_name" VARCHAR(255) NOT NULL, "handle" VARCHAR(255) NOT NULL, "description" VARCHAR(1023), "created_at" TIMESTAMP WITH TIME ZONE NOT NULL, "updated_by" VARCHAR(255) NOT NULL, "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL, PRIMARY KEY ("uuid"));
 
 CREATE INDEX IF NOT EXISTS "idx_application_org_created_by" ON "dp_applications" ("org_uuid", "created_by");
 CREATE UNIQUE INDEX IF NOT EXISTS "uq_application_org_handle" ON "dp_applications" ("org_uuid", "handle");

--- a/portals/developer-portal/docs/administer/api-token-curl.md
+++ b/portals/developer-portal/docs/administer/api-token-curl.md
@@ -129,7 +129,7 @@ curl -sk "${BASE}/applications" -H "Authorization: Bearer $TOKEN" | jq .
 curl -sk -X POST "${BASE}/applications" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"name": "My CLI App", "description": "Created via API", "type": "WEB"}' | jq .
+  -d '{"displayName": "My CLI App", "description": "Created via API"}' | jq .
 ```
 
 ---

--- a/portals/developer-portal/docs/administer/webhook-integration.md
+++ b/portals/developer-portal/docs/administer/webhook-integration.md
@@ -449,7 +449,7 @@ Fired when a developer renames an application or changes its details. `data` car
 }
 ```
 
-If the application has API keys associated with it (see [`apikey.application_updated`](#apikeyapplication_updated)), one such event is fired per associated key with the new name, alongside this event.
+Unlike `application.deleted`, this does **not** fan out to a per-key `apikey.application_updated` event — the key-to-application association is unchanged by a rename, so a subscriber that keys its own records off `application_id` can pick up the new name from this single event.
 
 ### `application.deleted`
 

--- a/portals/developer-portal/docs/administer/webhook-integration.md
+++ b/portals/developer-portal/docs/administer/webhook-integration.md
@@ -167,7 +167,8 @@ Fired when a developer generates a new API key for an API.
     },
     "application": {
       "id": "app-uuid",
-      "name": "My Mobile App"
+      "display_name": "My Mobile App",
+      "handle": "my-mobile-app"
     },
     "key": {
       "wrappedKey": "<base64>",
@@ -257,14 +258,15 @@ Fired whenever a single key's application association changes: the key is associ
     },
     "application": {
       "id": "app-uuid",
-      "name": "My App"
+      "display_name": "My App",
+      "handle": "my-app"
     }
   }
 }
 ```
 
 - `application` is `null` when the key's association was removed, or when the key's app was deleted
-- Renaming an app fires this event once per key currently associated with it, each with the app's new `name`
+- Renaming an app does **not** fire this event — the key-to-application association is unchanged, only the app's own `name`/`handle` change; see [`application.updated`](#applicationupdated)
 - Deleting an app fires this event once per key currently associated with it, each with `application: null` — there is no separate "deleted" variant
 
 ### `subscription.created`
@@ -427,11 +429,15 @@ Fired when a developer creates an application.
   "encrypted_fields": [],
   "data": {
     "application_id": "app-uuid",
-    "name": "My Mobile App",
-    "description": "Application used to call Weather APIs."
+    "display_name": "My Mobile App",
+    "handle": "my-mobile-app",
+    "description": "Application used to call Weather APIs.",
+    "type": "web"
   }
 }
 ```
+
+`type` is always `"web"` — applications no longer have a configurable type.
 
 ### `application.updated`
 
@@ -443,11 +449,15 @@ Fired when a developer renames an application or changes its details. `data` car
   "encrypted_fields": [],
   "data": {
     "application_id": "app-uuid",
-    "name": "My Mobile App (renamed)",
-    "description": "Application used to call Weather APIs."
+    "display_name": "My Mobile App (renamed)",
+    "handle": "my-mobile-app",
+    "description": "Application used to call Weather APIs.",
+    "type": "web"
   }
 }
 ```
+
+`type` is always `"web"` — applications no longer have a configurable type.
 
 Unlike `application.deleted`, this does **not** fan out to a per-key `apikey.application_updated` event — the key-to-application association is unchanged by a rename, so a subscriber that keys its own records off `application_id` can pick up the new name from this single event.
 
@@ -461,7 +471,8 @@ Fired when a developer deletes an application, after the application has been re
   "encrypted_fields": [],
   "data": {
     "application_id": "app-uuid",
-    "name": "My Mobile App"
+    "display_name": "My Mobile App",
+    "handle": "my-mobile-app"
   }
 }
 ```

--- a/portals/developer-portal/docs/consume-an-api/api-key-rest-api.md
+++ b/portals/developer-portal/docs/consume-an-api/api-key-rest-api.md
@@ -81,7 +81,7 @@ Optional query parameters:
       "status": "active",
       "apiId": "{apiId}",
       "appId": "{appId}",
-      "appName": "My App",
+      "appDisplayName": "My App",
       "expiresAt": "2027-01-01T00:00:00Z",
       "createdAt": "2026-06-30T10:00:00Z"
     }

--- a/portals/developer-portal/docs/devportal-openapi-spec-v1.yaml
+++ b/portals/developer-portal/docs/devportal-openapi-spec-v1.yaml
@@ -2498,7 +2498,9 @@ components:
                 name: weather_sandbox_key
     ApiKeyRegenerateBody:
       required: true
-      description: Identifies the API key to regenerate by its `keyId`.
+      description: >-
+        Identifies the API key to regenerate by its `keyId`. `expiresAt` is optional and, if provided,
+        updates the key's expiry; the key's `name` cannot be changed by this operation.
       content:
         application/json:
           schema:
@@ -2510,6 +2512,12 @@ components:
                 type: string
                 description: Developer Portal key ID returned by generate or list.
                 example: key-12345
+              expiresAt:
+                type: string
+                description: >-
+                  New expiry for the key. Can be an ISO-8601 datetime with timezone, epoch seconds, or
+                  epoch milliseconds. Omit to leave the current expiry unchanged.
+                example: "2027-01-01T00:00:00Z"
             additionalProperties: true
           example:
             keyId: key-12345
@@ -4200,6 +4208,12 @@ components:
       required:
         - planId
       properties:
+        apiId:
+          type: string
+          description: >-
+            Developer Portal API ID the subscription belongs to. Optional — used as a fallback when
+            the API cannot be derived from the subscription record.
+          example: api-5f2b8c1a
         planId:
           type: string
           description: Developer Portal subscription plan ID to switch to.

--- a/portals/developer-portal/docs/devportal-openapi-spec-v1.yaml
+++ b/portals/developer-portal/docs/devportal-openapi-spec-v1.yaml
@@ -813,7 +813,7 @@ paths:
                 $ref: "#/components/schemas/ApplicationResponse"
               example:
                 id: app-12345
-                name: Weather App
+                displayName: Weather App
                 description: Application used to call Weather APIs.
                 appKeyMappings: []
         "400":
@@ -2862,14 +2862,15 @@ components:
       required: true
       description: >-
         Application payload. Send JSON, multipart form fields, or an application YAML file in the `application` field.
-        When YAML is used, the service reads `spec.displayName` or `metadata.name` as the application name and
-        `spec.description` as the description.
+        When YAML is used, the service reads `spec.displayName` as the application's display name, `spec.description`
+        as the description, and `spec.handle` or `metadata.name` as the handle.
       content:
         application/json:
           schema:
             $ref: "#/components/schemas/ApplicationRequest"
           example:
-            name: Weather App
+            displayName: Weather App
+            handle: weather-app
             description: Application used to call Weather APIs.
         multipart/form-data:
           schema:
@@ -2879,16 +2880,16 @@ components:
                 type: string
                 format: binary
                 description: Application YAML file field named `application`.
-              name:
+              displayName:
                 type: string
-                description: Application name when sending form fields instead of YAML.
+                description: Application display name when sending form fields instead of YAML.
               description:
                 type: string
           examples:
             formFields:
               summary: Multipart form fields
               value:
-                name: Weather App
+                displayName: Weather App
                 description: Application used to call Weather APIs.
             yamlFile:
               summary: Application YAML upload
@@ -3302,7 +3303,8 @@ components:
             $ref: "#/components/schemas/ApplicationResponse"
           example:
             id: app-12345
-            name: Weather App
+            displayName: Weather App
+            handle: weather-app
             description: Application used to call Weather APIs.
             appKeyMappings: []
     ApplicationListResponse:
@@ -3321,7 +3323,7 @@ components:
           example:
             list:
               - id: app-12345
-                name: Weather App
+                displayName: Weather App
                 description: Application used to call Weather APIs.
                 appKeyMappings:
                   - asClientId: asgardeo-client-abc123
@@ -3985,9 +3987,12 @@ components:
         id:
           type: string
           example: app-12345
-        name:
+        displayName:
           type: string
           example: Weather App
+        handle:
+          type: string
+          example: weather-app
         description:
           type: string
           example: Application used to call Weather APIs.
@@ -4166,12 +4171,18 @@ components:
     ApplicationRequest:
       type: object
       required:
-        - name
+        - displayName
         - description
       properties:
-        name:
+        displayName:
           type: string
           example: Weather App
+        handle:
+          type: string
+          description: >-
+            Immutable, org-scoped slug for the application. Optional — defaults to the application's
+            `displayName` when omitted.
+          example: weather-app
         description:
           type: string
           example: Application used to call Weather APIs.
@@ -4300,10 +4311,10 @@ components:
           nullable: true
           description: ID of the application this key is associated with, if any. Analytics attribution only.
           example: app-12345
-        appName:
+        appDisplayName:
           type: string
           nullable: true
-          description: Name of the associated application, if any.
+          description: Display name of the associated application, if any.
           example: My Mobile App
         status:
           type: string
@@ -4328,7 +4339,7 @@ components:
       type: object
       description: >-
         API key response returned by generate/regenerate only. Unlike ApiKeyMetadataResponse, this does not include
-        apiId, appId, appName, createdAt, or revokedAt — generate/regenerate return only these five fields.
+        apiId, appId, appDisplayName, createdAt, or revokedAt — generate/regenerate return only these five fields.
       properties:
         keyId:
           type: string
@@ -4365,7 +4376,7 @@ components:
             id:
               type: string
               example: app-12345
-            name:
+            displayName:
               type: string
               example: My Mobile App
     KeyManagerRequest:

--- a/portals/developer-portal/docs/devportal-openapi-spec-v1.yaml
+++ b/portals/developer-portal/docs/devportal-openapi-spec-v1.yaml
@@ -853,8 +853,7 @@ paths:
       description: >-
         Updates an application owned by the authenticated user in the specified organization. The request may be JSON,
         multipart form fields, or an application YAML file in the `application` multipart field. An `application.updated`
-        webhook event is published, plus one `apikey.application_updated` event per API key currently associated with
-        the application.
+        webhook event is published.
       operationId: updateApplication
       requestBody:
         $ref: "#/components/requestBodies/ApplicationMultipartBody"

--- a/portals/developer-portal/src/controllers/apiKeyController.js
+++ b/portals/developer-portal/src/controllers/apiKeyController.js
@@ -47,7 +47,7 @@ function mapKey(k) {
         revokedAt: k.revoked_at || undefined,
         apiId: k.api_uuid,
         appId: app ? app.uuid : null,
-        appName: app ? app.name : null
+        appDisplayName: app ? app.display_name : null
     };
 }
 

--- a/portals/developer-portal/src/controllers/apiKeyController.js
+++ b/portals/developer-portal/src/controllers/apiKeyController.js
@@ -123,12 +123,12 @@ async function listApiKeys(req, res) {
 
 /**
  * POST /devportal/v1/apis/:apiId/api-keys/regenerate
- * Body: { keyId }
+ * Body: { keyId, expiresAt? }
  */
 async function regenerateApiKey(req, res) {
     const orgId = req.orgId;
     const apiId = req.params.apiId;
-    const { keyId } = req.body || {};
+    const { keyId, expiresAt } = req.body || {};
 
     if (!keyId || typeof keyId !== 'string' || !keyId.trim()) {
         return res.status(400).json({ code: '400', message: 'Bad Request', description: 'keyId is required' });
@@ -136,7 +136,7 @@ async function regenerateApiKey(req, res) {
 
     try {
         const result = await apiKeyService.regenerate({
-            orgId, apiId, keyId: keyId.trim(), actor: req.user.sub, userToken: req.user.accessToken,
+            orgId, apiId, keyId: keyId.trim(), expiresAt, actor: req.user.sub, userToken: req.user.accessToken,
         });
         logUserAction('API_KEY_REGENERATED', req, { orgId, apiId, keyId });
         return res.status(200).json(result);

--- a/portals/developer-portal/src/controllers/apiKeysPageController.js
+++ b/portals/developer-portal/src/controllers/apiKeysPageController.js
@@ -99,7 +99,7 @@ const loadAPIApiKeys = async (req, res, next) => {
                 revokedAt: k.revoked_at || undefined,
                 apiId: k.api_uuid,
                 appId: k.dp_api_key_app_mapping?.app_uuid || null,
-                appName: k.dp_api_key_app_mapping?.dp_application?.name || null,
+                appDisplayName: k.dp_api_key_app_mapping?.dp_application?.display_name || null,
                 maskedApiKey: '••••••••'
             }));
             apiKeysCount = apiKeys.length;
@@ -114,7 +114,7 @@ const loadAPIApiKeys = async (req, res, next) => {
 
         try {
             const apps = await applicationDao.list(orgId, req.user.sub);
-            applications = (apps || []).map((a) => ({ appId: a.uuid, name: a.name }));
+            applications = (apps || []).map((a) => ({ appId: a.uuid, displayName: a.display_name }));
         } catch (dbError) {
             logger.warn('Failed to load applications for API key association', {
                 error: dbError.message,

--- a/portals/developer-portal/src/controllers/customContentController.js
+++ b/portals/developer-portal/src/controllers/customContentController.js
@@ -16,7 +16,7 @@
  * under the License.
  */
 /* eslint-disable no-undef */
-const { renderTemplate, renderTemplateFromAPI, loadMarkdown } = require('../utils/util');
+const { renderTemplate, renderTemplateFromAPI, loadMarkdown, filePrefix } = require('../utils/util');
 const { config } = require('../config/configLoader');
 const markdown = require('marked');
 const fs = require('fs');

--- a/portals/developer-portal/src/controllers/devportalController.js
+++ b/portals/developer-portal/src/controllers/devportalController.js
@@ -50,16 +50,17 @@ function parseApplicationDataFromRequest(req) {
             throw new CustomError(400, "Bad Request", "Invalid application YAML: expected an object");
         }
         const spec = parsed.spec || {};
-        const name = spec.displayName || parsed.metadata?.name;
-        if (!name) {
-            throw new CustomError(400, "Bad Request", "Missing required application field: name");
+        const displayName = spec.displayName;
+        if (!displayName) {
+            throw new CustomError(400, "Bad Request", "Missing required application field: displayName");
         }
         if (!spec.description) {
             throw new CustomError(400, "Bad Request", "Missing required application field: description");
         }
         return {
-            name,
+            displayName,
             description: spec.description,
+            handle: spec.handle || parsed.metadata?.name,
         };
     }
     return req.body;
@@ -84,13 +85,13 @@ const saveApplication = async (req, res) => {
     const userId = req.auth?.userId || req.user?.sub;
     try {
         const applicationData = parseApplicationDataFromRequest(req);
-        trackAppCreationStart({ orgId: orgId, appName: applicationData.name, idpId: userId }, req);
+        trackAppCreationStart({ orgId: orgId, appName: applicationData.displayName, idpId: userId }, req);
         const application = await appDao.create(orgId, userId, applicationData);
-        trackAppCreationEnd({ orgId: orgId, appName: applicationData.name, idpId: userId }, req);
+        trackAppCreationEnd({ orgId: orgId, appName: applicationData.displayName, idpId: userId }, req);
         const createdApp = application.dataValues;
         try {
             await sequelize.transaction((t) => publish('application.created',
-                { application_id: createdApp.uuid, name: createdApp.name, description: createdApp.description },
+                { application_id: createdApp.uuid, display_name: createdApp.display_name, handle: createdApp.handle, description: createdApp.description, type: 'web' },
                 { transaction: t, orgId: orgId, aggregateType: 'application', aggregateId: createdApp.uuid }
             ));
         } catch (pubErr) {
@@ -119,7 +120,7 @@ const updateApplication = async (req, res) => {
             const renamedApp = updatedApp[0].dataValues;
             await sequelize.transaction(async (t) => {
                 await publish('application.updated',
-                    { application_id: appId, name: renamedApp.name, description: renamedApp.description },
+                    { application_id: appId, display_name: renamedApp.display_name, handle: renamedApp.handle, description: renamedApp.description, type: 'web' },
                     { transaction: t, orgId: orgId, aggregateType: 'application', aggregateId: appId }
                 );
             });
@@ -154,7 +155,7 @@ const publishApplicationDeletedEvents = async (orgId, applicationId, appToDelete
         await sequelize.transaction(async (t) => {
             if (appToDelete) {
                 await publish('application.deleted',
-                    { application_id: applicationId, name: appToDelete.name },
+                    { application_id: applicationId, display_name: appToDelete.display_name, handle: appToDelete.handle },
                     { transaction: t, orgId: orgId, aggregateType: 'application', aggregateId: applicationId }
                 );
             }

--- a/portals/developer-portal/src/controllers/devportalController.js
+++ b/portals/developer-portal/src/controllers/devportalController.js
@@ -122,7 +122,6 @@ const updateApplication = async (req, res) => {
                     { application_id: appId, name: renamedApp.name, description: renamedApp.description },
                     { transaction: t, orgId: orgId, aggregateType: 'application', aggregateId: appId }
                 );
-                await apiKeyService.notifyApplicationKeysChanged(orgId, appId, { id: appId, name: renamedApp.name }, t);
             });
         } catch (pubErr) {
             logger.warn('Failed to publish webhook events after app update', { orgId: orgId, appId: appId, error: pubErr.message });

--- a/portals/developer-portal/src/dao/apiKeyDao.js
+++ b/portals/developer-portal/src/dao/apiKeyDao.js
@@ -32,7 +32,7 @@ function appMappingInclude(required = false, appId = null) {
     const opts = {
         model: APIKeyAppMapping,
         required,
-        include: [{ model: Application, attributes: ['uuid', 'name'] }],
+        include: [{ model: Application, attributes: ['uuid', 'display_name', 'handle'] }],
     };
     if (appId) opts.where = { app_uuid: appId };
     return opts;

--- a/portals/developer-portal/src/dao/apiKeyDao.js
+++ b/portals/developer-portal/src/dao/apiKeyDao.js
@@ -92,4 +92,12 @@ async function setApplication(orgId, keyId, appId, updatedBy, transaction, { act
     return true;
 }
 
-module.exports = { create, get, list, revoke, setApplication };
+async function updateExpiry(orgId, keyId, expiresAt, updatedBy, transaction) {
+    const [count] = await APIKey.update(
+        { expires_at: expiresAt, updated_by: updatedBy },
+        { where: { uuid: keyId, org_uuid: orgId, status: constants.API_KEY_STATUS.ACTIVE }, transaction }
+    );
+    return count > 0;
+}
+
+module.exports = { create, get, list, revoke, setApplication, updateExpiry };

--- a/portals/developer-portal/src/dao/apiKeyDao.js
+++ b/portals/developer-portal/src/dao/apiKeyDao.js
@@ -24,6 +24,7 @@ const constants = require('../utils/constants');
 
 const API_METADATA_INCLUDE = {
     model: APIMetadata,
+    as: 'dp_api_metadata',
     attributes: ['uuid', 'name', 'version', 'handle', 'ref_id']
 };
 

--- a/portals/developer-portal/src/dao/applicationDao.js
+++ b/portals/developer-portal/src/dao/applicationDao.js
@@ -19,22 +19,10 @@ const { Application, ApplicationKeyMapping, SubscriptionMapping } = require('../
 const { Sequelize } = require('sequelize');
 const logger = require('../config/logger');
 
-// handle is an immutable, org-scoped slug; application names aren't unique,
-// so a short random suffix keeps collisions practically impossible.
-const generateHandle = (name) => {
-    const slug = String(name || '').toLowerCase().trim()
-        .replace(/[^\w\s-]/g, '')
-        .replace(/\s+/g, '-')
-        .replace(/-+/g, '-')
-        .substring(0, 100);
-    const suffix = Math.random().toString(36).slice(2, 8);
-    return slug ? `${slug}-${suffix}` : `app-${suffix}`;
-};
-
 const create = async (orgId, userId, appData) => {
     const createAppData = {
-        name: appData.name,
-        handle: generateHandle(appData.name),
+        display_name: appData.displayName,
+        handle: appData.handle || appData.displayName,
         org_uuid: orgId,
         description: appData.description,
         created_by: userId,
@@ -55,7 +43,7 @@ const update = async (orgId, appId, userId, appData) => {
     try {
         const [updatedRowsCount] = await Application.update(
             {
-                name: appData.name,
+                display_name: appData.displayName,
                 description: appData.description,
                 updated_by: userId,
                 updated_at: new Date()
@@ -101,7 +89,7 @@ const get = async (orgId, appId, userId, t) => {
     }
 }
 
-const getId = async (orgId, userId, appName) => {
+const getId = async (orgId, userId, displayName) => {
     try {
         return await Application.findOne(
             {
@@ -109,7 +97,7 @@ const getId = async (orgId, userId, appName) => {
                 where: {
                     org_uuid: orgId,
                     created_by: userId,
-                    name: appName
+                    display_name: displayName
                 }
             });
     } catch (error) {

--- a/portals/developer-portal/src/dao/subscriptionDao.js
+++ b/portals/developer-portal/src/dao/subscriptionDao.js
@@ -50,6 +50,7 @@ function decryptSubRecord(sub) {
 const INCLUDE_API_AND_PLAN = [
     {
         model: APIMetadata,
+        as: 'dp_api_metadata',
         attributes: ['uuid', 'name', 'version', 'handle', 'ref_id'],
         required: false,
     },

--- a/portals/developer-portal/src/defaultContent/pages/api-keys/partials/api-key-list.hbs
+++ b/portals/developer-portal/src/defaultContent/pages/api-keys/partials/api-key-list.hbs
@@ -10,7 +10,7 @@
   <select id="ak-app-filter" class="ak-form-input" style="width:auto;min-width:12rem;">
     <option value="">All apps</option>
     {{#each applications}}
-    <option value="{{this.appId}}" {{#if (eq this.appId @root.selectedAppId)}}selected{{/if}}>{{this.name}}</option>
+    <option value="{{this.appId}}" {{#if (eq this.appId @root.selectedAppId)}}selected{{/if}}>{{this.displayName}}</option>
     {{/each}}
   </select>
 </div>
@@ -56,15 +56,15 @@
           </span>
         </td>
         <td class="ak-expires">{{#if this.expiresAt}}{{formatExpiresAt this.expiresAt}}{{else}}Never{{/if}}</td>
-        <td class="ak-app">{{#if this.appName}}{{this.appName}}{{else}}-{{/if}}</td>
+        <td class="ak-app">{{#if this.appDisplayName}}{{this.appDisplayName}}{{else}}-{{/if}}</td>
         <td>
           {{#unless @root.isReadOnlyMode}}
           <div class="ak-actions">
             <button type="button" class="ak-btn-app btn-app-key"
               data-key-id="{{this.keyId}}" data-key-name="{{this.name}}"
-              data-app-id="{{this.appId}}" data-app-name="{{this.appName}}"
+              data-app-id="{{this.appId}}" data-app-display-name="{{this.appDisplayName}}"
               {{#unless (eq this.status 'active')}}disabled title="Key is revoked"{{/unless}}>
-              <i class="bi bi-grid"></i> {{#if this.appName}}Change app{{else}}Associate app{{/if}}
+              <i class="bi bi-grid"></i> {{#if this.appDisplayName}}Change app{{else}}Associate app{{/if}}
             </button>
             <button type="button" class="ak-btn-regen btn-regenerate-key"
               data-key-id="{{this.keyId}}" data-key-name="{{this.name}}"

--- a/portals/developer-portal/src/defaultContent/pages/api-keys/partials/api-key-list.hbs
+++ b/portals/developer-portal/src/defaultContent/pages/api-keys/partials/api-key-list.hbs
@@ -126,8 +126,8 @@
       <p style="margin:0;font-size:0.8125rem;line-height:1.5;color:#56657a;">The previous key will stop working immediately after regeneration.</p>
       <input type="hidden" id="regenerate-key-id" value="" />
       <div class="ak-form-group">
-        <label for="regenerate-api-key-name">Name <span class="ak-required">*</span></label>
-        <input type="text" id="regenerate-api-key-name" class="ak-form-input" autocomplete="off" />
+        <label for="regenerate-api-key-name">Name</label>
+        <input type="text" id="regenerate-api-key-name" class="ak-form-input" autocomplete="off" disabled />
       </div>
       <div class="ak-form-group">
         <label for="regenerate-api-key-expires">Expires at <span style="font-weight:400;color:#9aa3af;">— optional</span></label>

--- a/portals/developer-portal/src/dto/applicationDto.js
+++ b/portals/developer-portal/src/dto/applicationDto.js
@@ -19,7 +19,8 @@
 class ApplicationDTO {
     constructor(app) {
         this.id = app.uuid;
-        this.name = app.name;
+        this.displayName = app.display_name;
+        this.handle = app.handle;
         this.description = app.description;
         if (app.dp_app_key_mappings) {
             this.appKeyMappings = app.dp_app_key_mappings.map(map => new AppMappingDTO(map));

--- a/portals/developer-portal/src/models/apiKey.js
+++ b/portals/developer-portal/src/models/apiKey.js
@@ -99,7 +99,7 @@ const APIKey = sequelize.define('dp_api_key', {
 
 APIKey.belongsTo(Organization, { foreignKey: 'org_uuid' });
 Organization.hasMany(APIKey, { foreignKey: 'org_uuid' });
-APIKey.belongsTo(APIMetadata, { foreignKey: 'api_uuid' });
+APIKey.belongsTo(APIMetadata, { foreignKey: 'api_uuid', as: 'dp_api_metadata' });
 APIKey.belongsTo(SubscriptionMapping, { foreignKey: 'subscription_uuid', onDelete: 'SET NULL' });
 SubscriptionMapping.hasMany(APIKey, { foreignKey: 'subscription_uuid', onDelete: 'SET NULL' });
 

--- a/portals/developer-portal/src/models/application.js
+++ b/portals/developer-portal/src/models/application.js
@@ -40,7 +40,7 @@ const Application = sequelize.define('dp_application', {
         type: DataTypes.STRING,
         allowNull: false
     },
-    name: {
+    display_name: {
         type: DataTypes.STRING,
         allowNull: false
     },

--- a/portals/developer-portal/src/models/application.js
+++ b/portals/developer-portal/src/models/application.js
@@ -194,7 +194,7 @@ SubscriptionPlan.belongsToMany(APIMetadata, {
     otherKey: "api_uuid",
 });
 
-SubscriptionMapping.belongsTo(APIMetadata, { foreignKey: 'api_uuid' });
+SubscriptionMapping.belongsTo(APIMetadata, { foreignKey: 'api_uuid', as: 'dp_api_metadata' });
 SubscriptionMapping.belongsTo(SubscriptionPlan, { foreignKey: 'plan_uuid' });
 
 Application.belongsTo(Organization, {

--- a/portals/developer-portal/src/pages/application/partials/apis.hbs
+++ b/portals/developer-portal/src/pages/application/partials/apis.hbs
@@ -5,7 +5,7 @@
             <div class="container-header">Subscribed API Proxies</div>
             <div class='action-buttons mt-0'>
                 <a class="common-btn-primary" type="button"
-                    href="{{baseUrl}}/apis?appId={{applicationMetadata.id}}&appName={{applicationMetadata.name}}">
+                    href="{{baseUrl}}/apis?appId={{applicationMetadata.id}}&appDisplayName={{applicationMetadata.displayName}}">
                     <i class="fas fa-external-link-alt me-2"></i> Explore more
                 </a>
             </div>
@@ -77,7 +77,7 @@
             <div class="container-header">Subscribed MCP Servers</div>
             <div class='action-buttons mt-0'>
                 <a class="common-btn-primary" type="button"
-                    href="{{baseUrl}}/mcps?appId={{applicationMetadata.id}}&appName={{applicationMetadata.name}}">
+                    href="{{baseUrl}}/mcps?appId={{applicationMetadata.id}}&appDisplayName={{applicationMetadata.displayName}}">
                     <i class="fas fa-external-link-alt me-2"></i> Explore more
                 </a>
             </div>

--- a/portals/developer-portal/src/pages/application/partials/keys-token.hbs
+++ b/portals/developer-portal/src/pages/application/partials/keys-token.hbs
@@ -48,7 +48,7 @@
                                         class="common-btn-primary btn-sm me-1 {{#if @root.isReadOnlyMode}}disabled{{/if}}"
                                         id="regenerateButton_{{../name}}_{{keyType}}"
                                         style="{{#if @root.isReadOnlyMode}}pointer-events: none; opacity: 0.5;{{/if}}"
-                                        onclick="openGenerateTokenModal('applicationKeyGenerateForm-{{../id}}-{{keyType}}', '{{@root.applicationMetadata.id}}', '{{keys.keyMappingId}}', '{{../name}}', '{{@root.applicationMetadata/name}}', '{{json @root.subscriptionScopes}}', '{{keyType}}')">
+                                        onclick="openGenerateTokenModal('applicationKeyGenerateForm-{{../id}}-{{keyType}}', '{{@root.applicationMetadata.id}}', '{{keys.keyMappingId}}', '{{../name}}', '{{@root.applicationMetadata/displayName}}', '{{json @root.subscriptionScopes}}', '{{keyType}}')">
                                         <span class="button-normal-state">
                                             <i class="bi bi-arrow-clockwise"></i> Regenerate
                                         </span>

--- a/portals/developer-portal/src/pages/application/partials/manage-keys.hbs
+++ b/portals/developer-portal/src/pages/application/partials/manage-keys.hbs
@@ -4,7 +4,7 @@
 <section class="section keys-section">
     <div class="mk-header">
         <h2 class="mk-title">Manage Keys</h2>
-        <p class="mk-subtitle">Generate and govern OAuth2 credentials for <strong>{{applicationMetadata.name}}</strong>. Each key manager issues its own consumer key &amp; secret.</p>
+        <p class="mk-subtitle">Generate and govern OAuth2 credentials for <strong>{{applicationMetadata.displayName}}</strong>. Each key manager issues its own consumer key &amp; secret.</p>
     </div>
 
     {{!-- Environment selector — card-style tab triggers --}}
@@ -52,7 +52,7 @@
                 keys=keys
                 tokenEndpoint=../tokenEndpoint
                 appId=@root.applicationMetadata.id
-                appName=@root.applicationMetadata.name
+                appName=@root.applicationMetadata.displayName
                 orgId=@root.orgId
                 subscriptionScopes=@root.subscriptionScopes
                 isReadOnlyMode=@root.isReadOnlyMode
@@ -90,7 +90,7 @@
                 keys=keys
                 tokenEndpoint=../tokenEndpoint
                 appId=@root.applicationMetadata.id
-                appName=@root.applicationMetadata.name
+                appName=@root.applicationMetadata.displayName
                 orgId=@root.orgId
                 subscriptionScopes=@root.subscriptionScopes
                 isReadOnlyMode=@root.isReadOnlyMode

--- a/portals/developer-portal/src/pages/application/partials/overview.hbs
+++ b/portals/developer-portal/src/pages/application/partials/overview.hbs
@@ -5,7 +5,7 @@
 <nav class="dp-breadcrumb">
   <a class="dp-breadcrumb-item" href="{{baseUrl}}/applications">Applications</a>
   <i class="bi bi-chevron-right dp-breadcrumb-sep"></i>
-  <span class="dp-breadcrumb-current">{{applicationMetadata.name}}</span>
+  <span class="dp-breadcrumb-current">{{applicationMetadata.displayName}}</span>
 </nav>
 
 <section class="section mt-0 mb-6">
@@ -13,7 +13,7 @@
     <div class="me-5 w-75">
       {{#applicationMetadata}}
       <div class="d-flex align-items-center edit-container mb-2">
-        <h3 class="app-overview-title" id="applicationName" data-original="{{name}}">{{name}}</h3>
+        <h3 class="app-overview-title" id="applicationName" data-original="{{displayName}}">{{displayName}}</h3>
         <button class="btn btn-sm edit-inline-btn {{#if @root.isReadOnlyMode}}disabled border-0{{/if}}"
           id="editNameBtn" title="Edit name">
           <i class="bi bi-pencil"></i>

--- a/portals/developer-portal/src/pages/applications/partials/applications-listing.hbs
+++ b/portals/developer-portal/src/pages/applications/partials/applications-listing.hbs
@@ -35,13 +35,13 @@
   {{#if applicationsMetadata.length}}
   <div class="apps-grid" id="applicationsContainer">
     {{#applicationsMetadata}}
-    <div class="app-card" id="app-card-{{id}}" data-id="{{id}}" data-name="{{name}}"
+    <div class="app-card" id="app-card-{{id}}" data-id="{{id}}" data-display-name="{{displayName}}"
       style="cursor:pointer;" onclick="window.location.href='{{../baseUrl}}/applications/{{id}}'">
 
       <div class="app-card-top">
-        <span class="app-avatar" data-name="{{name}}"></span>
+        <span class="app-avatar" data-display-name="{{displayName}}"></span>
         <div class="app-card-meta">
-          <h3 class="app-card-name">{{name}}</h3>
+          <h3 class="app-card-name">{{displayName}}</h3>
         </div>
       </div>
 
@@ -51,7 +51,7 @@
         {{#unless @root.isReadOnlyMode}}
         <button type="button" class="app-delete-btn" id="trash-btn-{{id}}"
           title="Delete application"
-          onclick="event.stopPropagation(); appShowDeleteModal('{{id}}', '{{name}}')">
+          onclick="event.stopPropagation(); appShowDeleteModal('{{id}}', '{{displayName}}')">
           <i class="bi bi-trash"></i>
         </button>
         {{/unless}}
@@ -134,11 +134,11 @@
     return (x || 'AP').slice(0, 2).toUpperCase();
   }
 
-  document.querySelectorAll('.app-avatar[data-name]').forEach(function (el, i) {
+  document.querySelectorAll('.app-avatar[data-display-name]').forEach(function (el, i) {
     var c = palette[i % palette.length];
     el.style.background = c.bg;
     el.style.color = c.fg;
-    el.textContent = initials(el.getAttribute('data-name'));
+    el.textContent = initials(el.getAttribute('data-display-name'));
   });
 
   /* ── Create modal ────────────────────────────────── */

--- a/portals/developer-portal/src/scripts/add-application-form.js
+++ b/portals/developer-portal/src/scripts/add-application-form.js
@@ -159,7 +159,7 @@ applicationForm.addEventListener('submit', async (e) => {
             },
             credentials: 'include',
             body: JSON.stringify({
-                name,
+                displayName: name,
                 description,
             }),
         });

--- a/portals/developer-portal/src/scripts/api-keys-page.js
+++ b/portals/developer-portal/src/scripts/api-keys-page.js
@@ -188,7 +188,7 @@
                 applications.forEach(function (app) {
                     const opt = document.createElement('option');
                     opt.value = app.appId;
-                    opt.textContent = app.name;
+                    opt.textContent = app.displayName;
                     if (app.appId === currentAppId) opt.selected = true;
                     select.appendChild(opt);
                 });

--- a/portals/developer-portal/src/scripts/api-keys-page.js
+++ b/portals/developer-portal/src/scripts/api-keys-page.js
@@ -347,11 +347,7 @@
             const nameField = document.getElementById('regenerate-api-key-name');
             const expField = document.getElementById('regenerate-api-key-expires');
             const name = (nameField && nameField.value) ? nameField.value.trim() : '';
-            if (!namePattern.test(name)) {
-                if (typeof showAlert === 'function') await showAlert('Enter a valid name for the new key.', 'error');
-                return;
-            }
-            const body = { name: name };
+            const body = {};
             const iso = expField ? expiresToIso(expField.value) : null;
             if (iso) body.expiresAt = iso;
             submitRegenBtn.dataset.loading = 'true';

--- a/portals/developer-portal/src/scripts/application-listing.js
+++ b/portals/developer-portal/src/scripts/application-listing.js
@@ -16,8 +16,8 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
         }
         const filteredCards = allCards.filter((card) => {
-            const appName = card.getAttribute('data-name').toLowerCase();
-            return appName.includes(query);
+            const appDisplayName = card.getAttribute('data-display-name').toLowerCase();
+            return appDisplayName.includes(query);
         });
         applicationsContainer.innerHTML = '';
         filteredCards.forEach((card) => {

--- a/portals/developer-portal/src/scripts/common.js
+++ b/portals/developer-portal/src/scripts/common.js
@@ -485,7 +485,7 @@ document.addEventListener("DOMContentLoaded", function () {
                             'Content-Type': 'application/json',
                         },
                         body: JSON.stringify({
-                            name,
+                            displayName: name,
                             description,
                         }),
                     });
@@ -779,7 +779,7 @@ document.addEventListener("DOMContentLoaded", function () {
                             'Content-Type': 'application/json',
                         },
                         body: JSON.stringify({
-                            name,
+                            displayName: name,
                             description,
                         }),
                     });

--- a/portals/developer-portal/src/scripts/edit-application-form.js
+++ b/portals/developer-portal/src/scripts/edit-application-form.js
@@ -88,7 +88,7 @@ document.addEventListener('DOMContentLoaded', () => {
             cancelNameBtn.disabled = true;
 
             const result = await saveApplicationChanges(applicationId, {
-                name: newName,
+                displayName: newName,
                 description: applicationDescription.dataset.original
             }, nameEditError);
 
@@ -119,7 +119,7 @@ document.addEventListener('DOMContentLoaded', () => {
             cancelDescriptionBtn.disabled = true;
 
             const result = await saveApplicationChanges(applicationId, {
-                name: applicationName.dataset.original,
+                displayName: applicationName.dataset.original,
                 description: newDescription
             }, descriptionEditError);
 

--- a/portals/developer-portal/src/scripts/subscription.js
+++ b/portals/developer-portal/src/scripts/subscription.js
@@ -168,7 +168,7 @@ async function runPendingPlanSwitch(orgId, apiId, planName, displayName, subscri
             {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window.devportalApi.csrfToken() },
-                body: JSON.stringify({ planId }),
+                body: JSON.stringify({ apiId, planId }),
             }
         );
 

--- a/portals/developer-portal/src/services/apiKeyService.js
+++ b/portals/developer-portal/src/services/apiKeyService.js
@@ -209,13 +209,17 @@ async function generate({ orgId, apiId, subscriptionId, appId, name, expiresAt, 
  * Regenerate an existing key: same keyId, new secret, status stays ACTIVE.
  * The old secret is silently invalidated by whatever consumes the webhook event.
  */
-async function regenerate({ orgId, apiId, keyId, actor }) {
+async function regenerate({ orgId, apiId, keyId, expiresAt, actor }) {
     if (config.readOnlyMode) throw Object.assign(new Error('Read-only mode'), { status: 403 });
 
     const existing = await apiKeyDao.get(orgId, keyId);
     if (!existing) throw Object.assign(new Error('API key not found'), { status: 404 });
     if (apiId && existing.api_uuid !== apiId) throw Object.assign(new Error('API key not found'), { status: 404 });
     if (existing.status === constants.API_KEY_STATUS.REVOKED) throw Object.assign(new Error('Cannot regenerate a revoked key'), { status: 409 });
+
+    const expiry = parseExpiresAt(expiresAt);
+    if (!expiry.ok) throw Object.assign(new Error(expiry.description), { status: 400 });
+    const newExpiresAt = expiresAt === undefined ? existing.expires_at : expiry.date;
 
     const apiInfo = await resolveApiDirect(orgId, existing.api_uuid);
     let plaintext = generateSecret();
@@ -224,11 +228,16 @@ async function regenerate({ orgId, apiId, keyId, actor }) {
 
     try {
         await sequelize.transaction(async (t) => {
+            if (expiresAt !== undefined) {
+                const updated = await apiKeyDao.updateExpiry(orgId, keyId, newExpiresAt, actor, t);
+                if (!updated) throw Object.assign(new Error('Cannot regenerate a revoked key'), { status: 409 });
+            }
+
             await publish('apikey.regenerated',
                 {
                     key_id: keyId,
                     name: existing.name,
-                    expires_at: existing.expires_at ? new Date(existing.expires_at).toISOString() : null,
+                    expires_at: newExpiresAt ? new Date(newExpiresAt).toISOString() : null,
                     api: { name: apiInfo ? apiInfo.name : null, version: apiInfo ? apiInfo.version : null, ref_id: apiInfo ? apiInfo.refId : '' },
                     ...(subscription && { subscription }),
                     ...(application && { application })
@@ -243,7 +252,7 @@ async function regenerate({ orgId, apiId, keyId, actor }) {
     }
 
     logger.info('API key regenerated', { keyId, orgId, actor });
-    return { keyId, name: existing.name, key: plaintext, expiresAt: existing.expires_at, status: constants.API_KEY_STATUS.ACTIVE };
+    return { keyId, name: existing.name, key: plaintext, expiresAt: newExpiresAt, status: constants.API_KEY_STATUS.ACTIVE };
 }
 
 /**

--- a/portals/developer-portal/src/services/apiKeyService.js
+++ b/portals/developer-portal/src/services/apiKeyService.js
@@ -132,21 +132,6 @@ async function publishKeyApplicationUpdated(orgId, keyId, name, api, application
 }
 
 /**
- * Fan out an application-level change (rename or delete) to every key currently
- * associated with that app, as individual per-key apikey.application_updated events.
- * `application` is { id, name } for a rename, or null for a delete.
- */
-async function notifyApplicationKeysChanged(orgId, appId, application, transaction) {
-    if (!appId) return;
-    const keys = await apiKeyDao.list(orgId, { appId }, transaction);
-    for (const key of keys) {
-        const meta = key.dp_api_metadata;
-        const api = { name: meta.name || null, version: meta.version || null, ref_id: meta.ref_id || '' };
-        await publishKeyApplicationUpdated(orgId, key.uuid, key.name, api, application, transaction);
-    }
-}
-
-/**
  * Generate a new API key. Returns { keyId, name, plaintext, expiresAt, status }.
  * The plaintext is shown to the caller exactly once and never persisted.
  */
@@ -347,6 +332,6 @@ async function removeApplicationAssociation({ orgId, apiId, keyId, actor }) {
 
 module.exports = {
     generate, regenerate, revoke, list,
-    associateApplication, removeApplicationAssociation, notifyApplicationKeysChanged,
+    associateApplication, removeApplicationAssociation,
     publishKeyApplicationUpdated
 };

--- a/portals/developer-portal/src/services/apiKeyService.js
+++ b/portals/developer-portal/src/services/apiKeyService.js
@@ -106,18 +106,18 @@ async function resolveSubscription(orgId, subscriptionId) {
 
 /**
  * Validate that an app exists, belongs to orgId, and was created by actor.
- * Returns { id, name } or null. Throws 404 only when an appId was actually given.
+ * Returns { id, display_name, handle } or null. Throws 404 only when an appId was actually given.
  */
 async function resolveApp(orgId, appId, actor) {
     if (!appId) return null;
     const app = await applicationDao.get(orgId, appId, actor);
     if (!app) throw Object.assign(new Error('Application not found'), { status: 404 });
-    return { id: app.uuid, name: app.name };
+    return { id: app.uuid, display_name: app.display_name, handle: app.handle };
 }
 
 function applicationOf(key) {
     const app = key.dp_api_key_app_mapping?.dp_application;
-    return app ? { id: app.uuid, name: app.name } : null;
+    return app ? { id: app.uuid, display_name: app.display_name, handle: app.handle } : null;
 }
 
 /**
@@ -303,7 +303,7 @@ async function associateApplication({ orgId, apiId, keyId, appId, actor }) {
     });
 
     logger.info('API key associated to application', { keyId, orgId, appId: application.id, actor });
-    return { keyId, application };
+    return { keyId, application: { id: application.id, displayName: application.display_name, handle: application.handle } };
 }
 
 /**

--- a/portals/developer-portal/src/services/subscriptionService.js
+++ b/portals/developer-portal/src/services/subscriptionService.js
@@ -218,7 +218,7 @@ const updateSubscription = async (req, res) => {
 const changePlan = async (req, res) => {
     const orgId = req.orgId;
     const subscriptionId = req.params.subId;
-    const { planId: reqPlanId } = req.body;
+    const { apiId: reqApiId, planId: reqPlanId } = req.body;
 
     try {
         const existing = await subDao.get(orgId, subscriptionId, req.user.sub);
@@ -228,10 +228,15 @@ const changePlan = async (req, res) => {
             });
         }
 
-        const apiId = existing.dp_api_metadata ? existing.dp_api_metadata.uuid : null;
+        const apiId = existing.api_uuid || (existing.dp_api_metadata ? existing.dp_api_metadata.uuid : null) || null;
         if (!apiId) {
             return res.status(400).json({
                 code: '400', message: 'Bad Request', description: 'API not found for this subscription',
+            });
+        }
+        if (reqApiId && reqApiId !== apiId) {
+            return res.status(400).json({
+                code: '400', message: 'Bad Request', description: 'apiId does not match this subscription',
             });
         }
 

--- a/portals/developer-portal/src/utils/sampleApiLoader.js
+++ b/portals/developer-portal/src/utils/sampleApiLoader.js
@@ -275,7 +275,7 @@ function loadApplications() {
         const items = Array.isArray(doc.items) ? doc.items : [];
         return items.map(item => ({
             id: item.metadata?.name,
-            name: item.spec?.displayName || item.metadata?.name,
+            displayName: item.spec?.displayName || item.metadata?.name,
             description: item.spec?.description || '',
         }));
     } catch (_) {

--- a/portals/developer-portal/src/utils/util.js
+++ b/portals/developer-portal/src/utils/util.js
@@ -973,4 +973,5 @@ module.exports = {
     resolveApiType,
     toPaginatedList,
     resolveActor,
+    filePrefix,
 }


### PR DESCRIPTION
### Purpose
Fixing multiple bugs related to webhook events

### Approach

- Fixed API key regenerate (editable expiry, made the name unchangable)
- Fixed subscription plan change validation
- Fixed broken default subscription plans (config typo)
- Fixed API name/handle showing blank (Sequelize bug)
- Added handle to app & key events
- Renamed application name → displayName/display_name
- Added type: "web" to app created/updated events
