### PR TITLE
Add optional UUID field for organizations and update registration logic

### DIFF
--- a/platform-api/src/api/generated.go
+++ b/platform-api/src/api/generated.go
@@ -1831,6 +1831,10 @@ type Organization struct {
 
 	// UpdatedAt Timestamp when the organization was last updated
 	UpdatedAt *time.Time `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
+
+	// Uuid Stable unique identifier for the organization. Optional on creation;
+	// server-generated if omitted.
+	Uuid *string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
 }
 
 // Pagination defines model for Pagination.

--- a/platform-api/src/internal/handler/organization.go
+++ b/platform-api/src/internal/handler/organization.go
@@ -65,11 +65,22 @@ func (h *OrganizationHandler) RegisterOrganization(w http.ResponseWriter, r *htt
 		return
 	}
 
-	// UUID is always server-generated
-	id, genErr := utils.GenerateUUID()
-	if genErr != nil {
-		httputil.WriteJSON(w, http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error", "Failed to generate organization ID"))
-		return
+	// UUID is optional in the request: use the client-provided value if present
+	// (e.g. the IdP org_id claim), otherwise server-generate one.
+	var id string
+	if req.Uuid != nil && *req.Uuid != "" {
+		if err := utils.ValidateUUID(*req.Uuid); err != nil {
+			httputil.WriteJSON(w, http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", "uuid must be a valid UUID"))
+			return
+		}
+		id = *req.Uuid
+	} else {
+		genID, genErr := utils.GenerateUUID()
+		if genErr != nil {
+			httputil.WriteJSON(w, http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error", "Failed to generate organization ID"))
+			return
+		}
+		id = genID
 	}
 
 	// Extract handle from id field (optional — auto-generated from displayName if absent)

--- a/platform-api/src/internal/service/organization.go
+++ b/platform-api/src/internal/service/organization.go
@@ -236,6 +236,7 @@ func (s *OrganizationService) modelToAPI(orgModel *model.Organization) (*api.Org
 
 	return &api.Organization{
 		Id:          &orgModel.Handle,
+		Uuid:        &orgModel.ID,
 		DisplayName: orgModel.Name,
 		Region:      orgModel.Region,
 		CreatedAt:   utils.TimePtrIfNotZero(orgModel.CreatedAt),

--- a/platform-api/src/internal/utils/common.go
+++ b/platform-api/src/internal/utils/common.go
@@ -391,6 +391,14 @@ func GenerateUUID() (string, error) {
 	return u.String(), nil
 }
 
+// ValidateUUID returns an error if the given string is not a valid UUID.
+func ValidateUUID(id string) error {
+	if _, err := uuid.Parse(id); err != nil {
+		return fmt.Errorf("invalid UUID: %w", err)
+	}
+	return nil
+}
+
 // ValidateURL validates a URL with additional checks
 func ValidateURL(rawURL string) error {
 	if rawURL == "" {

--- a/platform-api/src/resources/openapi.yaml
+++ b/platform-api/src/resources/openapi.yaml
@@ -5153,6 +5153,14 @@ components:
           maxLength: 40
           readOnly: true
           example: "acme"
+        uuid:
+          type: string
+          format: uuid
+          description: >-
+            Stable unique identifier for the organization. Optional on creation:
+            if provided it is used as-is, otherwise
+            the server generates one. Immutable once set.
+          example: "01890a5d-ac96-774b-bcce-b302099a8057"
         displayName:
           type: string
           description: Human-readable name for the organization

--- a/portals/ai-workspace/src/App.tsx
+++ b/portals/ai-workspace/src/App.tsx
@@ -161,6 +161,8 @@ function PostSignInInit({ children }: { children: React.ReactNode }) {
           setOrgState('provisioning');
           await registerOrganization({
             id: org.handle,
+            // org_id claim → stable uuid; omit if absent so the server generates one.
+            uuid: org.id || undefined,
             displayName: org.name || org.handle,
             region: DEFAULT_ORG_REGION,
           });

--- a/portals/ai-workspace/src/apis/platformApis.ts
+++ b/portals/ai-workspace/src/apis/platformApis.ts
@@ -33,6 +33,11 @@ import { logger } from '../utils/logger';
 export interface PlatformOrganization {
   /** Handle (URL-friendly slug), pattern: ^[a-z0-9-]+$ — readOnly, server-assigned */
   id: string;
+  /**
+   * Stable unique identifier (from the IdP org_id claim). Optional on creation —
+   * the server generates one when omitted.
+   */
+  uuid?: string;
   /** Display name */
   displayName: string;
   /** Geographic region, e.g. "us", "eu", "ap" */
@@ -43,7 +48,7 @@ export interface PlatformOrganization {
 
 export type RegisterOrganizationRequest = Pick<
   PlatformOrganization,
-  'id' | 'displayName' | 'region'
+  'id' | 'uuid' | 'displayName' | 'region'
 >;
 
 // ============================================================================

--- a/portals/ai-workspace/src/contexts/AppShellContext.tsx
+++ b/portals/ai-workspace/src/contexts/AppShellContext.tsx
@@ -135,7 +135,7 @@ export const AppShellProvider: React.FC<AppShellProviderProps> = ({
 
   const toOrganization = (p: PlatformOrganization): Organization => ({
     id: p.id,
-    uuid: p.id,
+    uuid: p.uuid ?? p.id,
     handle: p.id,
     name: p.displayName,
     region: p.region,
@@ -159,6 +159,8 @@ export const AppShellProvider: React.FC<AppShellProviderProps> = ({
           try {
             await registerOrganization({
               id: tokenOrg.handle,
+              // org_id claim → stable uuid; omit if absent so the server generates one.
+              uuid: tokenOrg.id || undefined,
               displayName,
               region: DEFAULT_ORG_REGION,
             });


### PR DESCRIPTION
- Introduced a new `Uuid` field in the `Organization` model to allow for a stable unique identifier during organization creation.
- Updated the `RegisterOrganization` handler to accept a client-provided UUID or generate one if omitted.
- Enhanced the OpenAPI documentation to reflect the new UUID field and its usage.
- Adjusted related API interfaces and contexts to support the new UUID functionality.

