### PR TITLE
[PlatformAPI] Store internal UUID for user identity fields

### DIFF
--- a/platform-api/src/api/generated.go
+++ b/platform-api/src/api/generated.go
@@ -401,8 +401,8 @@ type APIKeyItem struct {
 	// CreatedAt Timestamp when the key was created
 	CreatedAt time.Time `binding:"required" json:"createdAt" yaml:"createdAt"`
 
-	// CreatedBy User who created the key
-	CreatedBy string `binding:"required" json:"createdBy" yaml:"createdBy"`
+	// CreatedBy User identifier of the user who created this resource
+	CreatedBy *string `binding:"required" json:"createdBy,omitempty" yaml:"createdBy,omitempty"`
 
 	// DisplayName Human-readable display name of the API key
 	DisplayName string `binding:"required" json:"displayName" yaml:"displayName"`
@@ -480,7 +480,7 @@ type AddGatewayToRESTAPIRequest struct {
 type Application struct {
 	CreatedAt *time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
 
-	// CreatedBy Creator identifier
+	// CreatedBy User identifier of the user who created this resource
 	CreatedBy *string `json:"createdBy,omitempty" yaml:"createdBy,omitempty"`
 
 	// Description Description of the application
@@ -498,6 +498,9 @@ type Application struct {
 	// Type Type of the application
 	Type      ApplicationType `json:"type" yaml:"type"`
 	UpdatedAt *time.Time      `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
+
+	// UpdatedBy User identifier of the user who last updated this resource. Only present in the detail response (GET /applications/{appId}), omitted from list responses.
+	UpdatedBy *string `json:"updatedBy,omitempty" yaml:"updatedBy,omitempty"`
 }
 
 // ApplicationAssociation defines model for ApplicationAssociation.
@@ -647,9 +650,6 @@ type CreateAPIKeyResponseStatus string
 
 // CreateApplicationRequest Request body for creating an application.
 type CreateApplicationRequest struct {
-	// CreatedBy Creator identifier
-	CreatedBy *string `json:"createdBy,omitempty" yaml:"createdBy,omitempty"`
-
 	// Description Description of the application
 	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 
@@ -818,7 +818,7 @@ type CreateRESTAPIRequest struct {
 	// CreatedAt Timestamp when the api was created
 	CreatedAt *time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
 
-	// CreatedBy If the createdBy value is not given user invoking the api will be used as the createdBy.
+	// CreatedBy User identifier of the user who created this resource
 	CreatedBy   *string `json:"createdBy,omitempty" yaml:"createdBy,omitempty"`
 	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 
@@ -855,6 +855,9 @@ type CreateRESTAPIRequest struct {
 
 	// UpdatedAt Timestamp when the api was last updated
 	UpdatedAt *time.Time `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
+
+	// UpdatedBy User identifier of the user who last updated this resource. Only present in the detail response (GET /rest-apis/{apiId}), omitted from list responses.
+	UpdatedBy *string `json:"updatedBy,omitempty" yaml:"updatedBy,omitempty"`
 
 	// Upstream Upstream backend configuration with main and sandbox endpoints
 	Upstream Upstream `json:"upstream" yaml:"upstream"`
@@ -1072,6 +1075,9 @@ type GatewayResponse struct {
 	// CreatedAt Timestamp when gateway was registered
 	CreatedAt *time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
 
+	// CreatedBy User identifier of the user who created this resource
+	CreatedBy *string `json:"createdBy,omitempty" yaml:"createdBy,omitempty"`
+
 	// Description Description of the gateway
 	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 
@@ -1101,6 +1107,9 @@ type GatewayResponse struct {
 
 	// UpdatedAt Timestamp when gateway was last updated
 	UpdatedAt *time.Time `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
+
+	// UpdatedBy User identifier of the user who last updated this resource. Only present in the detail response (GET /gateways/{gatewayId}), omitted from list responses.
+	UpdatedBy *string `json:"updatedBy,omitempty" yaml:"updatedBy,omitempty"`
 
 	// Version Gateway version in `major.minor` format (e.g. `1.0`) or CalVer `YYYY.MM.DD` format (e.g. `2026.05.13`)
 	Version *string `json:"version,omitempty" yaml:"version,omitempty"`
@@ -1199,7 +1208,7 @@ type LLMProvider struct {
 	// CreatedAt Timestamp when the resource was created
 	CreatedAt *time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
 
-	// CreatedBy Username of the creator
+	// CreatedBy User identifier of the user who created this resource
 	CreatedBy *string `json:"createdBy,omitempty" yaml:"createdBy,omitempty"`
 
 	// Description Description of the LLM provider
@@ -1242,6 +1251,9 @@ type LLMProvider struct {
 	// UpdatedAt Timestamp when the resource was last updated
 	UpdatedAt *time.Time `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
 
+	// UpdatedBy User identifier of the user who last updated this resource. Only present in the detail response (GET /llm-providers/{id}), omitted from list responses.
+	UpdatedBy *string `json:"updatedBy,omitempty" yaml:"updatedBy,omitempty"`
+
 	// Upstream Upstream backend configuration with main and sandbox endpoints
 	Upstream Upstream `json:"upstream" yaml:"upstream"`
 
@@ -1263,9 +1275,11 @@ type LLMProviderAPIKeyListResponse struct {
 
 // LLMProviderListItem defines model for LLMProviderListItem.
 type LLMProviderListItem struct {
-	CreatedAt   *time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
-	CreatedBy   *string    `json:"createdBy,omitempty" yaml:"createdBy,omitempty"`
-	Description *string    `json:"description,omitempty" yaml:"description,omitempty"`
+	CreatedAt *time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
+
+	// CreatedBy User identifier of the user who created this resource
+	CreatedBy   *string `json:"createdBy,omitempty" yaml:"createdBy,omitempty"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 
 	// DisplayName Human-readable name for the LLM provider
 	DisplayName string  `binding:"required" json:"displayName" yaml:"displayName"`
@@ -1296,7 +1310,7 @@ type LLMProviderTemplate struct {
 	// CreatedAt Timestamp when the resource was created
 	CreatedAt *time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
 
-	// CreatedBy Username of the creator
+	// CreatedBy User identifier of the user who created this resource
 	CreatedBy *string `json:"createdBy,omitempty" yaml:"createdBy,omitempty"`
 
 	// Description Description of the LLM provider template
@@ -1340,7 +1354,7 @@ type LLMProviderTemplate struct {
 	// UpdatedAt Timestamp when the resource was last updated
 	UpdatedAt *time.Time `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
 
-	// UpdatedBy Username of the last user to update the template
+	// UpdatedBy User identifier of the user who last updated this resource
 	UpdatedBy *string `json:"updatedBy,omitempty" yaml:"updatedBy,omitempty"`
 
 	// Version Content version, matching the v<major>.<minor> pattern (e.g. v1.0, v2.0).
@@ -1362,9 +1376,11 @@ type LLMProviderTemplateAuth struct {
 
 // LLMProviderTemplateListItem defines model for LLMProviderTemplateListItem.
 type LLMProviderTemplateListItem struct {
-	CreatedAt   *time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
-	CreatedBy   *string    `json:"createdBy,omitempty" yaml:"createdBy,omitempty"`
-	Description *string    `json:"description,omitempty" yaml:"description,omitempty"`
+	CreatedAt *time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
+
+	// CreatedBy User identifier of the user who created this resource
+	CreatedBy   *string `json:"createdBy,omitempty" yaml:"createdBy,omitempty"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 
 	// DisplayName Human-readable name for the LLM provider template
 	DisplayName string `binding:"required" json:"displayName" yaml:"displayName"`
@@ -1446,7 +1462,7 @@ type LLMProxy struct {
 	// CreatedAt Timestamp when the resource was created
 	CreatedAt *time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
 
-	// CreatedBy Username of the creator
+	// CreatedBy User identifier of the user who created this resource
 	CreatedBy *string `json:"createdBy,omitempty" yaml:"createdBy,omitempty"`
 
 	// Description Description of the LLM proxy
@@ -1484,6 +1500,9 @@ type LLMProxy struct {
 	// UpdatedAt Timestamp when the resource was last updated
 	UpdatedAt *time.Time `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
 
+	// UpdatedBy User identifier of the user who last updated this resource. Only present in the detail response (GET /llm-proxies/{id}), omitted from list responses.
+	UpdatedBy *string `json:"updatedBy,omitempty" yaml:"updatedBy,omitempty"`
+
 	// Version Semantic version of the LLM proxy
 	Version string `binding:"required" json:"version" yaml:"version"`
 
@@ -1503,10 +1522,12 @@ type LLMProxyAPIKeyListResponse struct {
 // LLMProxyListItem defines model for LLMProxyListItem.
 type LLMProxyListItem struct {
 	// Context Context path where the proxy is exposed
-	Context     *string    `json:"context,omitempty" yaml:"context,omitempty"`
-	CreatedAt   *time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
-	CreatedBy   *string    `json:"createdBy,omitempty" yaml:"createdBy,omitempty"`
-	Description *string    `json:"description,omitempty" yaml:"description,omitempty"`
+	Context   *string    `json:"context,omitempty" yaml:"context,omitempty"`
+	CreatedAt *time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
+
+	// CreatedBy User identifier of the user who created this resource
+	CreatedBy   *string `json:"createdBy,omitempty" yaml:"createdBy,omitempty"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 
 	// DisplayName Human-readable name for the LLM proxy
 	DisplayName string  `binding:"required" json:"displayName" yaml:"displayName"`
@@ -1565,7 +1586,7 @@ type MCPProxy struct {
 	// CreatedAt Timestamp when the resource was created
 	CreatedAt *time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
 
-	// CreatedBy Username of the creator
+	// CreatedBy User identifier of the user who created this resource
 	CreatedBy *string `json:"createdBy,omitempty" yaml:"createdBy,omitempty"`
 
 	// Description Description of the MCP proxy
@@ -1595,6 +1616,9 @@ type MCPProxy struct {
 	// UpdatedAt Timestamp when the resource was last updated
 	UpdatedAt *time.Time `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
 
+	// UpdatedBy User identifier of the user who last updated this resource. Only present in the detail response (GET /mcp-proxies/{id}), omitted from list responses.
+	UpdatedBy *string `json:"updatedBy,omitempty" yaml:"updatedBy,omitempty"`
+
 	// Upstream Upstream backend configuration with main and sandbox endpoints
 	Upstream Upstream `json:"upstream" yaml:"upstream"`
 
@@ -1623,10 +1647,12 @@ type MCPProxyCapabilities struct {
 // MCPProxyListItem defines model for MCPProxyListItem.
 type MCPProxyListItem struct {
 	// Context Context path where the proxy is exposed
-	Context     *string    `json:"context,omitempty" yaml:"context,omitempty"`
-	CreatedAt   *time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
-	CreatedBy   *string    `json:"createdBy,omitempty" yaml:"createdBy,omitempty"`
-	Description *string    `json:"description,omitempty" yaml:"description,omitempty"`
+	Context   *string    `json:"context,omitempty" yaml:"context,omitempty"`
+	CreatedAt *time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
+
+	// CreatedBy User identifier of the user who created this resource
+	CreatedBy   *string `json:"createdBy,omitempty" yaml:"createdBy,omitempty"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 
 	// DisplayName Human-readable name for the MCP proxy
 	DisplayName    string  `binding:"required" json:"displayName" yaml:"displayName"`
@@ -1703,7 +1729,7 @@ type MappedAPIKey struct {
 	// UpdatedAt Timestamp when the API key was updated
 	UpdatedAt *time.Time `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
 
-	// UserId User id of the key creator
+	// UserId User identifier of the user who created this resource
 	UserId *string `json:"userId,omitempty" yaml:"userId,omitempty"`
 }
 
@@ -1770,6 +1796,9 @@ type Organization struct {
 	// CreatedAt Timestamp when the organization was created
 	CreatedAt *time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
 
+	// CreatedBy User identifier of the user who created this resource
+	CreatedBy *string `json:"createdBy,omitempty" yaml:"createdBy,omitempty"`
+
 	// DisplayName Human-readable name for the organization
 	DisplayName string `binding:"required" json:"displayName" yaml:"displayName"`
 
@@ -1781,6 +1810,9 @@ type Organization struct {
 
 	// UpdatedAt Timestamp when the organization was last updated
 	UpdatedAt *time.Time `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
+
+	// UpdatedBy User identifier of the user who last updated this resource
+	UpdatedBy *string `json:"updatedBy,omitempty" yaml:"updatedBy,omitempty"`
 }
 
 // OrganizationListResponse defines model for OrganizationListResponse.
@@ -1823,6 +1855,9 @@ type Project struct {
 	// CreatedAt Timestamp when the project was created
 	CreatedAt *time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
 
+	// CreatedBy User identifier of the user who created this resource
+	CreatedBy *string `json:"createdBy,omitempty" yaml:"createdBy,omitempty"`
+
 	// Description Description of the project
 	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 
@@ -1837,6 +1872,9 @@ type Project struct {
 
 	// UpdatedAt Timestamp when the project was last updated
 	UpdatedAt *time.Time `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
+
+	// UpdatedBy User identifier of the user who last updated this resource. Only present in the detail response (GET /projects/{projectId}), omitted from list responses.
+	UpdatedBy *string `json:"updatedBy,omitempty" yaml:"updatedBy,omitempty"`
 }
 
 // ProjectListResponse defines model for ProjectListResponse.
@@ -1856,7 +1894,7 @@ type RESTAPI struct {
 	// CreatedAt Timestamp when the api was created
 	CreatedAt *time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
 
-	// CreatedBy If the createdBy value is not given user invoking the api will be used as the createdBy.
+	// CreatedBy User identifier of the user who created this resource
 	CreatedBy   *string `json:"createdBy,omitempty" yaml:"createdBy,omitempty"`
 	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 
@@ -1893,6 +1931,9 @@ type RESTAPI struct {
 
 	// UpdatedAt Timestamp when the api was last updated
 	UpdatedAt *time.Time `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
+
+	// UpdatedBy User identifier of the user who last updated this resource. Only present in the detail response (GET /rest-apis/{apiId}), omitted from list responses.
+	UpdatedBy *string `json:"updatedBy,omitempty" yaml:"updatedBy,omitempty"`
 
 	// Upstream Upstream backend configuration with main and sandbox endpoints
 	Upstream Upstream `json:"upstream" yaml:"upstream"`
@@ -1932,6 +1973,9 @@ type RESTAPIGatewayResponse struct {
 	// CreatedAt Timestamp when gateway was registered
 	CreatedAt *time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
 
+	// CreatedBy User identifier of the user who created this resource
+	CreatedBy *string `json:"createdBy,omitempty" yaml:"createdBy,omitempty"`
+
 	// Deployment Details about API deployment to a specific gateway
 	Deployment *RESTAPIDeploymentDetails `json:"deployment,omitempty" yaml:"deployment,omitempty"`
 
@@ -1967,6 +2011,9 @@ type RESTAPIGatewayResponse struct {
 
 	// UpdatedAt Timestamp when gateway was last updated
 	UpdatedAt *time.Time `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
+
+	// UpdatedBy User identifier of the user who last updated this resource. Only present in the detail response (GET /gateways/{gatewayId}), omitted from list responses.
+	UpdatedBy *string `json:"updatedBy,omitempty" yaml:"updatedBy,omitempty"`
 
 	// Version Gateway version in `major.minor` format (e.g. `1.0`) or CalVer `YYYY.MM.DD` format (e.g. `2026.05.13`)
 	Version *string `json:"version,omitempty" yaml:"version,omitempty"`
@@ -2096,16 +2143,25 @@ type SecretListResponse struct {
 type SecretResponse struct {
 	CreatedAt *time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
 
+	// CreatedBy User identifier of the user who created this resource
+	CreatedBy *string `json:"createdBy,omitempty" yaml:"createdBy,omitempty"`
+
 	// DisplayName Human-readable name for the secret
 	DisplayName string     `binding:"required" json:"displayName" yaml:"displayName"`
 	Id          *string    `json:"id,omitempty" yaml:"id,omitempty"`
 	UpdatedAt   *time.Time `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
+
+	// UpdatedBy User identifier of the user who last updated this resource
+	UpdatedBy *string `json:"updatedBy,omitempty" yaml:"updatedBy,omitempty"`
 }
 
 // SecretSummary Secret metadata — never includes the plaintext value.
 type SecretSummary struct {
-	CreatedAt   *time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
-	Description *string    `json:"description,omitempty" yaml:"description,omitempty"`
+	CreatedAt *time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
+
+	// CreatedBy User identifier of the user who created this resource
+	CreatedBy   *string `json:"createdBy,omitempty" yaml:"createdBy,omitempty"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 
 	// DisplayName Human-readable name for the secret
 	DisplayName string                 `binding:"required" json:"displayName" yaml:"displayName"`
@@ -2158,6 +2214,9 @@ type Subscription struct {
 	ApplicationId *string    `json:"applicationId,omitempty" yaml:"applicationId,omitempty"`
 	CreatedAt     *time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
 
+	// CreatedBy User identifier of the user who created this resource
+	CreatedBy *string `json:"createdBy,omitempty" yaml:"createdBy,omitempty"`
+
 	// Id Subscription ID
 	Id *openapi_types.UUID `json:"id,omitempty" yaml:"id,omitempty"`
 
@@ -2180,6 +2239,9 @@ type Subscription struct {
 	// SubscriptionToken Opaque subscription token for API invocation via Subscription-Key header
 	SubscriptionToken *string    `json:"subscriptionToken,omitempty" yaml:"subscriptionToken,omitempty"`
 	UpdatedAt         *time.Time `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
+
+	// UpdatedBy User identifier of the user who last updated this resource. Only present in the detail response (GET /subscriptions/{subscriptionId}), omitted from list responses.
+	UpdatedBy *string `json:"updatedBy,omitempty" yaml:"updatedBy,omitempty"`
 }
 
 // SubscriptionKind Type of the subscribed artifact
@@ -2200,6 +2262,9 @@ type SubscriptionListResponse struct {
 type SubscriptionPlan struct {
 	CreatedAt *time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
 
+	// CreatedBy User identifier of the user who created this resource
+	CreatedBy *string `json:"createdBy,omitempty" yaml:"createdBy,omitempty"`
+
 	// DisplayName Human-readable name for the subscription plan
 	DisplayName string     `binding:"required" json:"displayName" yaml:"displayName"`
 	ExpiryTime  *time.Time `json:"expiryTime,omitempty" yaml:"expiryTime,omitempty"`
@@ -2214,6 +2279,9 @@ type SubscriptionPlan struct {
 	OrganizationId *string                 `json:"organizationId,omitempty" yaml:"organizationId,omitempty"`
 	Status         *SubscriptionPlanStatus `json:"status,omitempty" yaml:"status,omitempty"`
 	UpdatedAt      *time.Time              `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
+
+	// UpdatedBy User identifier of the user who last updated this resource. Only present in the detail response (GET /subscription-plans/{planId}), omitted from list responses.
+	UpdatedBy *string `json:"updatedBy,omitempty" yaml:"updatedBy,omitempty"`
 }
 
 // SubscriptionPlanStatus defines model for SubscriptionPlan.Status.
@@ -2392,8 +2460,8 @@ type UserAPIKeyItem struct {
 	// CreatedAt Timestamp when the key was created
 	CreatedAt time.Time `binding:"required" json:"createdAt" yaml:"createdAt"`
 
-	// CreatedBy User who created the key
-	CreatedBy string `binding:"required" json:"createdBy" yaml:"createdBy"`
+	// CreatedBy User identifier of the user who created this resource
+	CreatedBy *string `binding:"required" json:"createdBy,omitempty" yaml:"createdBy,omitempty"`
 
 	// DisplayName Human-readable display name of the API key
 	DisplayName string `binding:"required" json:"displayName" yaml:"displayName"`

--- a/platform-api/src/api/generated_eventgateway.go
+++ b/platform-api/src/api/generated_eventgateway.go
@@ -84,7 +84,7 @@ type WebBrokerAPI struct {
 	Context   *string    `json:"context,omitempty" yaml:"context,omitempty"`
 	CreatedAt *time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
 
-	// CreatedBy Username of the creator
+	// CreatedBy User identifier of the user who created this resource
 	CreatedBy   *string `json:"createdBy,omitempty" yaml:"createdBy,omitempty"`
 	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 
@@ -120,6 +120,9 @@ type WebBrokerAPI struct {
 	Transport *[]WebBrokerAPITransport `json:"transport,omitempty" yaml:"transport,omitempty"`
 	UpdatedAt *time.Time               `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
 
+	// UpdatedBy User identifier of the user who last updated this resource. Only present in the detail response (GET /webbroker-apis/{id}), omitted from list responses.
+	UpdatedBy *string `json:"updatedBy,omitempty" yaml:"updatedBy,omitempty"`
+
 	// Version Semantic version of the WebBroker API
 	Version string `json:"version" yaml:"version"`
 }
@@ -140,6 +143,9 @@ type WebBrokerAPITransport string
 type WebBrokerAPIListItem struct {
 	Context   *string    `json:"context,omitempty" yaml:"context,omitempty"`
 	CreatedAt *time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
+
+	// CreatedBy User identifier of the user who created this resource
+	CreatedBy *string `json:"createdBy,omitempty" yaml:"createdBy,omitempty"`
 
 	// DisplayName Human-readable name for the WebBroker API
 	DisplayName     string                               `json:"displayName" yaml:"displayName"`
@@ -215,7 +221,7 @@ type WebSubAPI struct {
 	Context   *string    `json:"context,omitempty" yaml:"context,omitempty"`
 	CreatedAt *time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
 
-	// CreatedBy Username of the creator
+	// CreatedBy User identifier of the user who created this resource
 	CreatedBy   *string `json:"createdBy,omitempty" yaml:"createdBy,omitempty"`
 	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 
@@ -243,7 +249,10 @@ type WebSubAPI struct {
 	// Transport Supported transport protocols
 	Transport *[]WebSubAPITransport `json:"transport,omitempty" yaml:"transport,omitempty"`
 	UpdatedAt *time.Time            `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
-	Upstream  Upstream              `json:"upstream" yaml:"upstream"`
+
+	// UpdatedBy User identifier of the user who last updated this resource. Only present in the detail response (GET /websub-apis/{id}), omitted from list responses.
+	UpdatedBy *string  `json:"updatedBy,omitempty" yaml:"updatedBy,omitempty"`
+	Upstream  Upstream `json:"upstream" yaml:"upstream"`
 
 	// Version Semantic version of the WebSub API
 	Version string `json:"version" yaml:"version"`
@@ -269,6 +278,9 @@ type WebSubAPIHmacSecretCreationResponse struct {
 // WebSubAPIHmacSecretInfo defines model for WebSubAPIHmacSecretInfo.
 type WebSubAPIHmacSecretInfo struct {
 	CreatedAt time.Time `json:"createdAt" yaml:"createdAt"`
+
+	// CreatedBy User identifier of the user who created this resource
+	CreatedBy *string `json:"createdBy,omitempty" yaml:"createdBy,omitempty"`
 
 	// DisplayName Human-readable name for the HMAC secret
 	DisplayName string `json:"displayName" yaml:"displayName"`
@@ -310,6 +322,9 @@ type WebSubAPIHmacSecretRequest struct {
 type WebSubAPIListItem struct {
 	Context   *string    `json:"context,omitempty" yaml:"context,omitempty"`
 	CreatedAt *time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
+
+	// CreatedBy User identifier of the user who created this resource
+	CreatedBy *string `json:"createdBy,omitempty" yaml:"createdBy,omitempty"`
 
 	// DisplayName Human-readable name for the WebSub API
 	DisplayName     string                            `json:"displayName" yaml:"displayName"`

--- a/platform-api/src/internal/constants/constants.go
+++ b/platform-api/src/internal/constants/constants.go
@@ -125,6 +125,12 @@ const APIKeyAllowedTargetsAll = "ALL"
 // AdminRole is the role name that grants administrative privileges
 const AdminRole = "admin"
 
+// DeletedUser is returned for audit-identity fields (createdBy/updatedBy/
+// revokedBy/performedBy) and external/data-plane events when the stored
+// internal UUID has no entry in user_idp_references — an anonymous write, or
+// a user whose mapping was removed.
+const DeletedUser = "deleted_user"
+
 // Deployment limit constants
 const (
 	// DeploymentLimitBuffer is the buffer added to MaxPerAPIGateway for hard limit enforcement

--- a/platform-api/src/internal/database/schema.postgres.sql
+++ b/platform-api/src/internal/database/schema.postgres.sql
@@ -581,3 +581,22 @@ CREATE INDEX IF NOT EXISTS idx_asr_org_handle
 -- Fast gateway sync lookups: which handles does this gateway need?
 CREATE INDEX IF NOT EXISTS idx_asr_org_gateway
     ON artifact_secret_refs(organization_uuid, gateway_id);
+
+-- Maps our internal user UUID to the IdP actor identity. Audit columns store the
+-- UUID; responses/events resolve it back to idp_id. No FK; no empty-idp_id rows.
+CREATE TABLE IF NOT EXISTS user_idp_references (
+    uuid       VARCHAR(40)  PRIMARY KEY,
+    idp_id     VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP    DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(idp_id)
+);
+
+-- User-to-organization membership, populated on org onboarding.
+CREATE TABLE IF NOT EXISTS user_organization_mappings (
+    user_uuid  VARCHAR(40) NOT NULL,
+    org_uuid   VARCHAR(40) NOT NULL,
+    created_at TIMESTAMP   DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (user_uuid, org_uuid),
+    FOREIGN KEY (user_uuid) REFERENCES user_idp_references(uuid) ON DELETE CASCADE,
+    FOREIGN KEY (org_uuid)  REFERENCES organizations(uuid)       ON DELETE CASCADE
+);

--- a/platform-api/src/internal/database/schema.sql
+++ b/platform-api/src/internal/database/schema.sql
@@ -572,3 +572,22 @@ CREATE INDEX IF NOT EXISTS idx_asr_org_handle
 
 CREATE INDEX IF NOT EXISTS idx_asr_org_gateway
     ON artifact_secret_refs(organization_uuid, gateway_id);
+
+-- Maps our internal user UUID to the IdP actor identity. Audit columns store the
+-- UUID; responses/events resolve it back to idp_id. No FK; no empty-idp_id rows.
+CREATE TABLE IF NOT EXISTS user_idp_references (
+    uuid       VARCHAR(40)  PRIMARY KEY,
+    idp_id     VARCHAR(255) NOT NULL,
+    created_at DATETIME     DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(idp_id)
+);
+
+-- User-to-organization membership, populated on org onboarding.
+CREATE TABLE IF NOT EXISTS user_organization_mappings (
+    user_uuid  VARCHAR(40) NOT NULL,
+    org_uuid   VARCHAR(40) NOT NULL,
+    created_at DATETIME    DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (user_uuid, org_uuid),
+    FOREIGN KEY (user_uuid) REFERENCES user_idp_references(uuid) ON DELETE CASCADE,
+    FOREIGN KEY (org_uuid)  REFERENCES organizations(uuid)       ON DELETE CASCADE
+);

--- a/platform-api/src/internal/database/schema.sqlite.sql
+++ b/platform-api/src/internal/database/schema.sqlite.sql
@@ -581,3 +581,22 @@ CREATE INDEX IF NOT EXISTS idx_asr_org_handle
 -- Fast gateway sync lookups: which handles does this gateway need?
 CREATE INDEX IF NOT EXISTS idx_asr_org_gateway
     ON artifact_secret_refs(organization_uuid, gateway_id);
+
+-- Maps our internal user UUID to the IdP actor identity. Audit columns store the
+-- UUID; responses/events resolve it back to idp_id. No FK; no empty-idp_id rows.
+CREATE TABLE IF NOT EXISTS user_idp_references (
+    uuid       VARCHAR(40)  PRIMARY KEY,
+    idp_id     VARCHAR(255) NOT NULL,
+    created_at DATETIME     DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(idp_id)
+);
+
+-- User-to-organization membership, populated on org onboarding.
+CREATE TABLE IF NOT EXISTS user_organization_mappings (
+    user_uuid  VARCHAR(40) NOT NULL,
+    org_uuid   VARCHAR(40) NOT NULL,
+    created_at DATETIME    DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (user_uuid, org_uuid),
+    FOREIGN KEY (user_uuid) REFERENCES user_idp_references(uuid) ON DELETE CASCADE,
+    FOREIGN KEY (org_uuid)  REFERENCES organizations(uuid)       ON DELETE CASCADE
+);

--- a/platform-api/src/internal/database/schema.sqlserver.sql
+++ b/platform-api/src/internal/database/schema.sqlserver.sql
@@ -690,3 +690,23 @@ CREATE INDEX idx_asr_org_handle ON dbo.artifact_secret_refs(organization_uuid, s
 
 IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = N'idx_asr_org_gateway' AND object_id = OBJECT_ID(N'dbo.artifact_secret_refs'))
 CREATE INDEX idx_asr_org_gateway ON dbo.artifact_secret_refs(organization_uuid, gateway_id);
+
+-- Maps our internal user UUID to the IdP actor identity. Audit columns store the
+-- UUID; responses/events resolve it back to idp_id. No FK; no empty-idp_id rows.
+IF OBJECT_ID(N'dbo.user_idp_references', N'U') IS NULL
+CREATE TABLE dbo.user_idp_references (
+    uuid       VARCHAR(40)  PRIMARY KEY,
+    idp_id     VARCHAR(255) NOT NULL UNIQUE,
+    created_at DATETIME2(7) DEFAULT SYSUTCDATETIME()
+);
+
+-- User-to-organization membership, populated on org onboarding.
+IF OBJECT_ID(N'dbo.user_organization_mappings', N'U') IS NULL
+CREATE TABLE dbo.user_organization_mappings (
+    user_uuid  VARCHAR(40)  NOT NULL,
+    org_uuid   VARCHAR(40)  NOT NULL,
+    created_at DATETIME2(7) DEFAULT SYSUTCDATETIME(),
+    PRIMARY KEY (user_uuid, org_uuid),
+    FOREIGN KEY (user_uuid) REFERENCES user_idp_references(uuid) ON DELETE CASCADE,
+    FOREIGN KEY (org_uuid)  REFERENCES organizations(uuid)       ON DELETE CASCADE
+);

--- a/platform-api/src/internal/dto/gateway_event.go
+++ b/platform-api/src/internal/dto/gateway_event.go
@@ -31,7 +31,10 @@ type GatewayEventDTO struct {
 	// CorrelationID provides request tracing identifier
 	CorrelationID string `json:"correlationId"`
 
-	// UserId is an optional temporary user identifier (from x-user-id header)
+	// UserId is the raw resolved actor identity (token "sub", falling back to
+	// the configured claim / user_id), or constants.DeletedUser if the actor's
+	// internal UUID has no mapping. Never the internal UUID — see
+	// service.IdentityService.SubForUUID.
 	UserId string `json:"userId,omitempty"`
 }
 

--- a/platform-api/src/internal/dto/secret.go
+++ b/platform-api/src/internal/dto/secret.go
@@ -41,6 +41,8 @@ type UpdateSecretRequest struct {
 type SecretResponse struct {
 	Handle      string    `json:"id"`
 	DisplayName string    `json:"displayName"`
+	CreatedBy   string    `json:"createdBy,omitempty"`
+	UpdatedBy   string    `json:"updatedBy,omitempty"`
 	CreatedAt   time.Time `json:"createdAt"`
 	UpdatedAt   time.Time `json:"updatedAt"`
 }
@@ -54,6 +56,7 @@ type SecretSummary struct {
 	Provider    string    `json:"provider"`
 	Status      string    `json:"status"`
 	Hash        string    `json:"hash"`
+	CreatedBy   string    `json:"createdBy,omitempty"`
 	CreatedAt   time.Time `json:"createdAt"`
 	UpdatedAt   time.Time `json:"updatedAt"`
 }

--- a/platform-api/src/internal/handler/api.go
+++ b/platform-api/src/internal/handler/api.go
@@ -34,12 +34,14 @@ import (
 
 type APIHandler struct {
 	apiService *service.APIService
+	identity   *service.IdentityService
 	slogger    *slog.Logger
 }
 
-func NewAPIHandler(apiService *service.APIService, slogger *slog.Logger) *APIHandler {
+func NewAPIHandler(apiService *service.APIService, identity *service.IdentityService, slogger *slog.Logger) *APIHandler {
 	return &APIHandler{
 		apiService: apiService,
+		identity:   identity,
 		slogger:    slogger,
 	}
 }
@@ -87,7 +89,10 @@ func (h *APIHandler) CreateAPI(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	createdBy, _ := middleware.GetUserIDFromRequest(r)
+	createdBy, ok := resolveActor(w, r, h.identity, h.slogger, "create API")
+	if !ok {
+		return
+	}
 	apiResponse, err := h.apiService.CreateAPI(&req, orgId, createdBy)
 	if err != nil {
 		if errors.Is(err, constants.ErrHandleExists) {
@@ -271,7 +276,10 @@ func (h *APIHandler) UpdateAPI(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	updatedBy, _ := middleware.GetUserIDFromRequest(r)
+	updatedBy, ok := resolveActor(w, r, h.identity, h.slogger, "update API")
+	if !ok {
+		return
+	}
 	apiResponse, err := h.apiService.UpdateAPIByHandle(apiId, &req, orgId, updatedBy)
 	if err != nil {
 		if respondArtifactGuardError(w, err) {
@@ -336,7 +344,10 @@ func (h *APIHandler) DeleteAPI(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	deletedBy, _ := middleware.GetUserIDFromRequest(r)
+	deletedBy, ok := resolveActor(w, r, h.identity, h.slogger, "delete API")
+	if !ok {
+		return
+	}
 	err := h.apiService.DeleteAPIByHandle(apiId, orgId, deletedBy)
 	if err != nil {
 		if respondArtifactGuardError(w, err) {

--- a/platform-api/src/internal/handler/api_deployment.go
+++ b/platform-api/src/internal/handler/api_deployment.go
@@ -35,12 +35,14 @@ import (
 
 type DeploymentHandler struct {
 	deploymentService *service.DeploymentService
+	identity          *service.IdentityService
 	slogger           *slog.Logger
 }
 
-func NewDeploymentHandler(deploymentService *service.DeploymentService, slogger *slog.Logger) *DeploymentHandler {
+func NewDeploymentHandler(deploymentService *service.DeploymentService, identity *service.IdentityService, slogger *slog.Logger) *DeploymentHandler {
 	return &DeploymentHandler{
 		deploymentService: deploymentService,
+		identity:          identity,
 		slogger:           slogger,
 	}
 }
@@ -85,7 +87,10 @@ func (h *DeploymentHandler) DeployAPI(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	createdBy, _ := middleware.GetUserIDFromRequest(r)
+	createdBy, ok := resolveActor(w, r, h.identity, h.slogger, "deploy API")
+	if !ok {
+		return
+	}
 	deployment, err := h.deploymentService.DeployAPIByHandle(apiId, &req, orgId, createdBy)
 	if err != nil {
 		if respondArtifactGuardError(w, err) {
@@ -168,7 +173,10 @@ func (h *DeploymentHandler) UndeployDeployment(w http.ResponseWriter, r *http.Re
 			"API ID is required"))
 		return
 	}
-	actor, _ := middleware.GetUserIDFromRequest(r)
+	actor, ok := resolveActor(w, r, h.identity, h.slogger, "undeploy API")
+	if !ok {
+		return
+	}
 	deployment, err := h.deploymentService.UndeployDeploymentByHandle(apiId, deploymentId, gatewayId, orgId, actor)
 	if err != nil {
 		// DP-originated artifacts are read-only: undeployment cannot be initiated from the CP.
@@ -241,7 +249,10 @@ func (h *DeploymentHandler) RestoreDeployment(w http.ResponseWriter, r *http.Req
 			"API ID is required"))
 		return
 	}
-	actor, _ := middleware.GetUserIDFromRequest(r)
+	actor, ok := resolveActor(w, r, h.identity, h.slogger, "restore API deployment")
+	if !ok {
+		return
+	}
 	deployment, err := h.deploymentService.RestoreDeploymentByHandle(apiId, deploymentId, gatewayId, orgId, actor)
 	if err != nil {
 		// DP-originated artifacts are read-only: restore cannot be initiated from the CP.
@@ -305,7 +316,10 @@ func (h *DeploymentHandler) DeleteDeployment(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	actor, _ := middleware.GetUserIDFromRequest(r)
+	actor, ok := resolveActor(w, r, h.identity, h.slogger, "delete API deployment")
+	if !ok {
+		return
+	}
 	err := h.deploymentService.DeleteDeploymentByHandle(apiId, deploymentId, orgId, actor)
 	if err != nil {
 		if errors.Is(err, constants.ErrAPINotFound) {

--- a/platform-api/src/internal/handler/api_key.go
+++ b/platform-api/src/internal/handler/api_key.go
@@ -36,13 +36,15 @@ import (
 // APIKeyHandler handles API key operations for external services (Cloud APIM)
 type APIKeyHandler struct {
 	apiKeyService *service.APIKeyService
+	identity      *service.IdentityService
 	slogger       *slog.Logger
 }
 
 // NewAPIKeyHandler creates a new API key handler
-func NewAPIKeyHandler(apiKeyService *service.APIKeyService, slogger *slog.Logger) *APIKeyHandler {
+func NewAPIKeyHandler(apiKeyService *service.APIKeyService, identity *service.IdentityService, slogger *slog.Logger) *APIKeyHandler {
 	return &APIKeyHandler{
 		apiKeyService: apiKeyService,
+		identity:      identity,
 		slogger:       slogger,
 	}
 }
@@ -58,8 +60,10 @@ func (h *APIKeyHandler) CreateAPIKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Extract optional x-user-id header for user identification (empty string if not present)
-	userId := r.Header.Get("x-user-id")
+	userId, ok := resolveActor(w, r, h.identity, h.slogger, "create API key")
+	if !ok {
+		return
+	}
 
 	// Extract API handle from path parameter (parameter named apiId for backward compatibility, but contains handle)
 	apiHandle := r.PathValue("restApiId")
@@ -149,8 +153,10 @@ func (h *APIKeyHandler) UpdateAPIKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Extract optional x-user-id header for user identification (empty string if not present)
-	userId := r.Header.Get("x-user-id")
+	userId, ok := resolveActor(w, r, h.identity, h.slogger, "update API key")
+	if !ok {
+		return
+	}
 
 	// Extract API ID and key name from path parameters
 	apiHandle := r.PathValue("restApiId")
@@ -248,8 +254,10 @@ func (h *APIKeyHandler) RevokeAPIKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Extract optional x-user-id header for user identification (empty string if not present)
-	userId := r.Header.Get("x-user-id")
+	userId, ok := resolveActor(w, r, h.identity, h.slogger, "revoke API key")
+	if !ok {
+		return
+	}
 
 	// Revoke the API key and broadcast to gateways
 	err := h.apiKeyService.RevokeAPIKey(r.Context(), apiHandle, constants.RestApi, orgId, keyName, userId)

--- a/platform-api/src/internal/handler/apikey_user.go
+++ b/platform-api/src/internal/handler/apikey_user.go
@@ -33,13 +33,15 @@ import (
 // APIKeyUserHandler handles listing API keys for a user across artifact types.
 type APIKeyUserHandler struct {
 	apiKeyUserService *service.APIKeyUserService
+	identity          *service.IdentityService
 	slogger           *slog.Logger
 }
 
 // NewAPIKeyUserHandler creates a new APIKeyUserHandler.
-func NewAPIKeyUserHandler(apiKeyUserService *service.APIKeyUserService, slogger *slog.Logger) *APIKeyUserHandler {
+func NewAPIKeyUserHandler(apiKeyUserService *service.APIKeyUserService, identity *service.IdentityService, slogger *slog.Logger) *APIKeyUserHandler {
 	return &APIKeyUserHandler{
 		apiKeyUserService: apiKeyUserService,
+		identity:          identity,
 		slogger:           slogger,
 	}
 }
@@ -53,7 +55,10 @@ func (h *APIKeyUserHandler) ListUserAPIKeys(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	callerUserID := r.Header.Get("x-user-id")
+	callerUserID, ok := resolveActor(w, r, h.identity, h.slogger, "list user API keys")
+	if !ok {
+		return
+	}
 
 	var types []string
 	if typeParam := r.URL.Query().Get("type"); typeParam != "" {

--- a/platform-api/src/internal/handler/application.go
+++ b/platform-api/src/internal/handler/application.go
@@ -36,11 +36,12 @@ import (
 
 type ApplicationHandler struct {
 	applicationService *service.ApplicationService
+	identity           *service.IdentityService
 	slogger            *slog.Logger
 }
 
-func NewApplicationHandler(applicationService *service.ApplicationService, slogger *slog.Logger) *ApplicationHandler {
-	return &ApplicationHandler{applicationService: applicationService, slogger: slogger}
+func NewApplicationHandler(applicationService *service.ApplicationService, identity *service.IdentityService, slogger *slog.Logger) *ApplicationHandler {
+	return &ApplicationHandler{applicationService: applicationService, identity: identity, slogger: slogger}
 }
 
 func (h *ApplicationHandler) CreateApplication(w http.ResponseWriter, r *http.Request) {
@@ -69,7 +70,10 @@ func (h *ApplicationHandler) CreateApplication(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	createdBy := h.resolveRequesterUserID(r)
+	createdBy, ok := resolveActor(w, r, h.identity, h.slogger, "create application")
+	if !ok {
+		return
+	}
 	app, err := h.applicationService.CreateApplication(&req, orgID, createdBy)
 	if err != nil {
 		h.writeApplicationError(w, r, err, "Failed to create application")
@@ -161,7 +165,10 @@ func (h *ApplicationHandler) UpdateApplication(w http.ResponseWriter, r *http.Re
 		httputil.WriteJSON(w, http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", "Application ID is required"))
 		return
 	}
-	userID := h.resolveRequesterUserID(r)
+	userID, ok := resolveActor(w, r, h.identity, h.slogger, "update application")
+	if !ok {
+		return
+	}
 
 	var req api.Application
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -190,7 +197,10 @@ func (h *ApplicationHandler) DeleteApplication(w http.ResponseWriter, r *http.Re
 		httputil.WriteJSON(w, http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", "Application ID is required"))
 		return
 	}
-	userID := h.resolveRequesterUserID(r)
+	userID, ok := resolveActor(w, r, h.identity, h.slogger, "delete application")
+	if !ok {
+		return
+	}
 
 	if err := h.applicationService.DeleteApplication(appID, orgID, userID); err != nil {
 		h.writeApplicationError(w, r, err, "Failed to delete application")
@@ -394,7 +404,10 @@ func (h *ApplicationHandler) AddApplicationAPIKeys(w http.ResponseWriter, r *htt
 	}
 
 	appID := r.PathValue("applicationId")
-	userID := h.resolveRequesterUserID(r)
+	userID, ok := resolveActor(w, r, h.identity, h.slogger, "add application API keys")
+	if !ok {
+		return
+	}
 	if strings.TrimSpace(appID) == "" {
 		httputil.WriteJSON(w, http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", "Application ID is required"))
 		return
@@ -429,7 +442,10 @@ func (h *ApplicationHandler) RemoveApplicationAPIKey(w http.ResponseWriter, r *h
 	appID := r.PathValue("applicationId")
 	keyID := r.PathValue("apiKeyId")
 	entityID := strings.TrimSpace(r.URL.Query().Get("entityID"))
-	userID := h.resolveRequesterUserID(r)
+	userID, ok := resolveActor(w, r, h.identity, h.slogger, "remove mapped application API key")
+	if !ok {
+		return
+	}
 	if strings.TrimSpace(appID) == "" {
 		httputil.WriteJSON(w, http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", "Application ID is required"))
 		return
@@ -466,19 +482,6 @@ func (h *ApplicationHandler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST "+base+"/{applicationId}/associations", h.AddApplicationAssociations)
 	mux.HandleFunc("GET "+base+"/{applicationId}/associations/{associationId}/api-keys", h.ListApplicationAssociationAPIKeys)
 	mux.HandleFunc("DELETE "+base+"/{applicationId}/associations/{associationId}", h.RemoveApplicationAssociation)
-}
-
-func (h *ApplicationHandler) resolveRequesterUserID(r *http.Request) string {
-	userID := strings.TrimSpace(r.Header.Get("x-user-id"))
-	if userID != "" {
-		return userID
-	}
-
-	if ctxUserID, ok := middleware.GetUserIDFromRequest(r); ok {
-		return strings.TrimSpace(ctxUserID)
-	}
-
-	return ""
 }
 
 func (h *ApplicationHandler) writeApplicationError(w http.ResponseWriter, r *http.Request, err error, fallback string) {

--- a/platform-api/src/internal/handler/gateway.go
+++ b/platform-api/src/internal/handler/gateway.go
@@ -44,13 +44,15 @@ var gatewayVersionPattern = regexp.MustCompile(`^([0-9]{1,6}\.[0-9]{1,6}|[0-9]{4
 // GatewayHandler handles HTTP requests for gateway operations
 type GatewayHandler struct {
 	gatewayService *service.GatewayService
+	identity       *service.IdentityService
 	slogger        *slog.Logger
 }
 
 // NewGatewayHandler creates a new gateway handler
-func NewGatewayHandler(gatewayService *service.GatewayService, slogger *slog.Logger) *GatewayHandler {
+func NewGatewayHandler(gatewayService *service.GatewayService, identity *service.IdentityService, slogger *slog.Logger) *GatewayHandler {
 	return &GatewayHandler{
 		gatewayService: gatewayService,
+		identity:       identity,
 		slogger:        slogger,
 	}
 }
@@ -105,7 +107,10 @@ func (h *GatewayHandler) CreateGateway(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	createdBy, _ := middleware.GetUserIDFromRequest(r)
+	createdBy, ok := resolveActor(w, r, h.identity, h.slogger, "register gateway")
+	if !ok {
+		return
+	}
 	gateway, err := h.gatewayService.RegisterGateway(orgId, req.Id, req.DisplayName, description, req.Endpoints,
 		isCritical, functionalityType, version, createdBy, properties)
 	if err != nil {
@@ -272,7 +277,10 @@ func (h *GatewayHandler) UpdateGateway(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	updatedBy, _ := middleware.GetUserIDFromRequest(r)
+	updatedBy, ok := resolveActor(w, r, h.identity, h.slogger, "update gateway")
+	if !ok {
+		return
+	}
 	response, err := h.gatewayService.UpdateGateway(gatewayId, orgId, updatedBy, &req)
 	if err != nil {
 		if errors.Is(err, constants.ErrGatewayNotFound) {
@@ -307,7 +315,10 @@ func (h *GatewayHandler) DeleteGateway(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	deletedBy, _ := middleware.GetUserIDFromRequest(r)
+	deletedBy, ok := resolveActor(w, r, h.identity, h.slogger, "delete gateway")
+	if !ok {
+		return
+	}
 	err := h.gatewayService.DeleteGateway(gatewayId, orgId, deletedBy)
 	if err != nil {
 		// Check for specific error types
@@ -394,7 +405,10 @@ func (h *GatewayHandler) RotateToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	createdBy, _ := middleware.GetUserIDFromRequest(r)
+	createdBy, ok := resolveActor(w, r, h.identity, h.slogger, "rotate gateway token")
+	if !ok {
+		return
+	}
 	response, err := h.gatewayService.RotateToken(gatewayId, orgId, createdBy)
 	if err != nil {
 		errMsg := err.Error()
@@ -446,7 +460,10 @@ func (h *GatewayHandler) RevokeToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	revokedBy, _ := middleware.GetUserIDFromRequest(r)
+	revokedBy, ok := resolveActor(w, r, h.identity, h.slogger, "revoke gateway token")
+	if !ok {
+		return
+	}
 	err := h.gatewayService.RevokeToken(gatewayId, tokenId, orgId, revokedBy)
 	if err != nil {
 		errMsg := err.Error()

--- a/platform-api/src/internal/handler/gateway_secret_integration_test.go
+++ b/platform-api/src/internal/handler/gateway_secret_integration_test.go
@@ -108,12 +108,12 @@ func setupGatewaySecretTestEnv(t *testing.T) (*gatewaySecretTestEnv, func()) {
 	}
 
 	secretRepo := repository.NewSecretRepo(db)
-	secretSvc := service.NewSecretService(secretRepo, v)
+	secretSvc := service.NewSecretService(secretRepo, v, service.NewIdentityService(repository.NewUserIdentityMappingRepo(db)))
 
 	deploymentRepo := repository.NewDeploymentRepo(db, repository.NewArtifactTableRegistry())
 	gatewayRepo := repository.NewGatewayRepo(db)
 
-	gatewaySvc := service.NewGatewayService(gatewayRepo, nil, nil, nil, nil, slog.Default(), false, false, nil)
+	gatewaySvc := service.NewGatewayService(gatewayRepo, nil, nil, nil, nil, slog.Default(), false, false, nil, service.NewIdentityService(repository.NewUserIdentityMappingRepo(db)))
 
 	cfg := &config.Server{}
 	gwInternalSvc := service.NewGatewayInternalAPIService(

--- a/platform-api/src/internal/handler/identity_helper.go
+++ b/platform-api/src/internal/handler/identity_helper.go
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package handler
+
+import (
+	"log/slog"
+	"net/http"
+
+	"platform-api/src/internal/service"
+	"platform-api/src/internal/utils"
+
+	"github.com/wso2/go-httpkit/httputil"
+)
+
+// resolveActor resolves the internal platform UUID for the actor behind r via
+// identity, for use in audit columns (created_by/updated_by/revoked_by/
+// performed_by). Identity is always resolved from the token claim (sub,
+// falling back to the configured claim / user_id) — a missing identity mints
+// an anonymous UUID rather than failing (see IdentityService.InternalUserID),
+// so this only fails (500) on a genuine DB error.
+func resolveActor(w http.ResponseWriter, r *http.Request, identity *service.IdentityService, slogger *slog.Logger, action string) (actor string, ok bool) {
+	actor, err := identity.InternalUserID(r)
+	if err != nil {
+		slogger.Error("Failed to resolve user identity", "action", action, "error", err)
+		httputil.WriteJSON(w, http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error",
+			"Failed to resolve user identity"))
+		return "", false
+	}
+	return actor, true
+}

--- a/platform-api/src/internal/handler/llm.go
+++ b/platform-api/src/internal/handler/llm.go
@@ -39,6 +39,7 @@ type LLMHandler struct {
 	templateService *service.LLMProviderTemplateService
 	providerService *service.LLMProviderService
 	proxyService    *service.LLMProxyService
+	identity        *service.IdentityService
 	slogger         *slog.Logger
 }
 
@@ -46,9 +47,10 @@ func NewLLMHandler(
 	templateService *service.LLMProviderTemplateService,
 	providerService *service.LLMProviderService,
 	proxyService *service.LLMProxyService,
+	identity *service.IdentityService,
 	slogger *slog.Logger,
 ) *LLMHandler {
-	return &LLMHandler{templateService: templateService, providerService: providerService, proxyService: proxyService, slogger: slogger}
+	return &LLMHandler{templateService: templateService, providerService: providerService, proxyService: proxyService, identity: identity, slogger: slogger}
 }
 
 func (h *LLMHandler) RegisterRoutes(mux *http.ServeMux) {
@@ -111,11 +113,14 @@ func (h *LLMHandler) CreateLLMProviderTemplate(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	createdBy, _ := middleware.GetUserIDFromRequest(r)
-
 	var req api.LLMProviderTemplate
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		httputil.WriteJSON(w, http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", "Invalid request body"))
+		return
+	}
+
+	createdBy, ok := resolveActor(w, r, h.identity, h.slogger, "create LLM provider template")
+	if !ok {
 		return
 	}
 
@@ -153,7 +158,10 @@ func (h *LLMHandler) CopyLLMProviderTemplateVersion(w http.ResponseWriter, r *ht
 		return
 	}
 
-	createdBy, _ := middleware.GetUserIDFromRequest(r)
+	createdBy, ok := resolveActor(w, r, h.identity, h.slogger, "copy LLM provider template version")
+	if !ok {
+		return
+	}
 
 	fromTemplateID := strings.TrimSpace(r.URL.Query().Get("fromTemplateId"))
 	toTemplateID := strings.TrimSpace(r.URL.Query().Get("toTemplateId"))
@@ -365,7 +373,10 @@ func (h *LLMHandler) UpdateLLMProviderTemplate(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	updatedBy, _ := middleware.GetUserIDFromRequest(r)
+	updatedBy, ok := resolveActor(w, r, h.identity, h.slogger, "update LLM provider template")
+	if !ok {
+		return
+	}
 	resp, err := h.templateService.Update(orgID, id, updatedBy, &req)
 	if err != nil {
 		if respondArtifactGuardError(w, err) {
@@ -443,7 +454,10 @@ func (h *LLMHandler) CreateLLMProvider(w http.ResponseWriter, r *http.Request) {
 		httputil.WriteJSON(w, http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", "Invalid request body"))
 		return
 	}
-	createdBy, _ := middleware.GetUserIDFromRequest(r)
+	createdBy, ok := resolveActor(w, r, h.identity, h.slogger, "create LLM provider")
+	if !ok {
+		return
+	}
 
 	created, err := h.providerService.Create(orgID, createdBy, &req)
 	if err != nil {
@@ -550,7 +564,10 @@ func (h *LLMHandler) UpdateLLMProvider(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	updatedBy, _ := middleware.GetUserIDFromRequest(r)
+	updatedBy, ok := resolveActor(w, r, h.identity, h.slogger, "update LLM provider")
+	if !ok {
+		return
+	}
 	resp, err := h.providerService.Update(orgID, id, updatedBy, &req)
 	if err != nil {
 		if respondArtifactGuardError(w, err) {
@@ -588,7 +605,10 @@ func (h *LLMHandler) DeleteLLMProvider(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	id := r.PathValue("llmProviderId")
-	deletedBy, _ := middleware.GetUserIDFromRequest(r)
+	deletedBy, ok := resolveActor(w, r, h.identity, h.slogger, "delete LLM provider")
+	if !ok {
+		return
+	}
 
 	if err := h.providerService.Delete(orgID, id, deletedBy); err != nil {
 		if respondArtifactGuardError(w, err) {
@@ -628,7 +648,10 @@ func (h *LLMHandler) CreateLLMProxy(w http.ResponseWriter, r *http.Request) {
 		httputil.WriteJSON(w, http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", "Project ID is required"))
 		return
 	}
-	createdBy, _ := middleware.GetUserIDFromRequest(r)
+	createdBy, ok := resolveActor(w, r, h.identity, h.slogger, "create LLM proxy")
+	if !ok {
+		return
+	}
 
 	created, err := h.proxyService.Create(orgID, createdBy, &req)
 	if err != nil {
@@ -792,7 +815,10 @@ func (h *LLMHandler) UpdateLLMProxy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	updatedBy, _ := middleware.GetUserIDFromRequest(r)
+	updatedBy, ok := resolveActor(w, r, h.identity, h.slogger, "update LLM proxy")
+	if !ok {
+		return
+	}
 	resp, err := h.proxyService.Update(orgID, id, updatedBy, &req)
 	if err != nil {
 		if respondArtifactGuardError(w, err) {
@@ -827,7 +853,10 @@ func (h *LLMHandler) DeleteLLMProxy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	id := r.PathValue("llmProxyId")
-	deletedBy, _ := middleware.GetUserIDFromRequest(r)
+	deletedBy, ok := resolveActor(w, r, h.identity, h.slogger, "delete LLM proxy")
+	if !ok {
+		return
+	}
 
 	if err := h.proxyService.Delete(orgID, id, deletedBy); err != nil {
 		if respondArtifactGuardError(w, err) {

--- a/platform-api/src/internal/handler/llm_apikey.go
+++ b/platform-api/src/internal/handler/llm_apikey.go
@@ -36,13 +36,15 @@ import (
 // LLMProviderAPIKeyHandler handles API key operations for LLM providers
 type LLMProviderAPIKeyHandler struct {
 	apiKeyService *service.LLMProviderAPIKeyService
+	identity      *service.IdentityService
 	slogger       *slog.Logger
 }
 
 // NewLLMProviderAPIKeyHandler creates a new LLM provider API key handler
-func NewLLMProviderAPIKeyHandler(apiKeyService *service.LLMProviderAPIKeyService, slogger *slog.Logger) *LLMProviderAPIKeyHandler {
+func NewLLMProviderAPIKeyHandler(apiKeyService *service.LLMProviderAPIKeyService, identity *service.IdentityService, slogger *slog.Logger) *LLMProviderAPIKeyHandler {
 	return &LLMProviderAPIKeyHandler{
 		apiKeyService: apiKeyService,
+		identity:      identity,
 		slogger:       slogger,
 	}
 }
@@ -63,7 +65,10 @@ func (h *LLMProviderAPIKeyHandler) ListAPIKeys(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	callerUserID := r.Header.Get("x-user-id")
+	callerUserID, ok := resolveActor(w, r, h.identity, h.slogger, "list LLM provider API keys")
+	if !ok {
+		return
+	}
 
 	response, err := h.apiKeyService.ListLLMProviderAPIKeys(r.Context(), providerID, orgID, callerUserID)
 	if err != nil {
@@ -104,7 +109,10 @@ func (h *LLMProviderAPIKeyHandler) DeleteAPIKey(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	callerUserID := r.Header.Get("x-user-id")
+	callerUserID, ok := resolveActor(w, r, h.identity, h.slogger, "delete LLM provider API key")
+	if !ok {
+		return
+	}
 
 	err := h.apiKeyService.DeleteLLMProviderAPIKey(r.Context(), providerID, orgID, callerUserID, keyName)
 	if err != nil {
@@ -165,7 +173,10 @@ func (h *LLMProviderAPIKeyHandler) CreateAPIKey(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	userID := r.Header.Get("x-user-id")
+	userID, ok := resolveActor(w, r, h.identity, h.slogger, "create LLM provider API key")
+	if !ok {
+		return
+	}
 
 	response, err := h.apiKeyService.CreateLLMProviderAPIKey(r.Context(), providerID, orgID, userID, &req)
 	if err != nil {

--- a/platform-api/src/internal/handler/llm_proxy_apikey.go
+++ b/platform-api/src/internal/handler/llm_proxy_apikey.go
@@ -36,13 +36,15 @@ import (
 // LLMProxyAPIKeyHandler handles API key operations for LLM proxies
 type LLMProxyAPIKeyHandler struct {
 	apiKeyService *service.LLMProxyAPIKeyService
+	identity      *service.IdentityService
 	slogger       *slog.Logger
 }
 
 // NewLLMProxyAPIKeyHandler creates a new LLM proxy API key handler
-func NewLLMProxyAPIKeyHandler(apiKeyService *service.LLMProxyAPIKeyService, slogger *slog.Logger) *LLMProxyAPIKeyHandler {
+func NewLLMProxyAPIKeyHandler(apiKeyService *service.LLMProxyAPIKeyService, identity *service.IdentityService, slogger *slog.Logger) *LLMProxyAPIKeyHandler {
 	return &LLMProxyAPIKeyHandler{
 		apiKeyService: apiKeyService,
+		identity:      identity,
 		slogger:       slogger,
 	}
 }
@@ -63,7 +65,10 @@ func (h *LLMProxyAPIKeyHandler) ListAPIKeys(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	callerUserID := r.Header.Get("x-user-id")
+	callerUserID, ok := resolveActor(w, r, h.identity, h.slogger, "list LLM proxy API keys")
+	if !ok {
+		return
+	}
 
 	response, err := h.apiKeyService.ListLLMProxyAPIKeys(r.Context(), proxyID, orgID, callerUserID)
 	if err != nil {
@@ -104,7 +109,10 @@ func (h *LLMProxyAPIKeyHandler) DeleteAPIKey(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	callerUserID := r.Header.Get("x-user-id")
+	callerUserID, ok := resolveActor(w, r, h.identity, h.slogger, "delete LLM proxy API key")
+	if !ok {
+		return
+	}
 
 	err := h.apiKeyService.DeleteLLMProxyAPIKey(r.Context(), proxyID, orgID, callerUserID, keyName)
 	if err != nil {
@@ -165,7 +173,10 @@ func (h *LLMProxyAPIKeyHandler) CreateAPIKey(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	userID := r.Header.Get("x-user-id")
+	userID, ok := resolveActor(w, r, h.identity, h.slogger, "create LLM proxy API key")
+	if !ok {
+		return
+	}
 
 	response, err := h.apiKeyService.CreateLLMProxyAPIKey(r.Context(), proxyID, orgID, userID, &req)
 	if err != nil {

--- a/platform-api/src/internal/handler/llm_template_integration_test.go
+++ b/platform-api/src/internal/handler/llm_template_integration_test.go
@@ -84,8 +84,9 @@ func setupLLMTemplateEnv(t *testing.T) (http.Handler, *database.DB, func()) {
 		t.Fatalf("seed built-ins: %v", err)
 	}
 
-	svc := service.NewLLMProviderTemplateService(repo, noopAudit{})
-	h := NewLLMHandler(svc, nil, nil, slog.Default())
+	identityService := service.NewIdentityService(repository.NewUserIdentityMappingRepo(db))
+	svc := service.NewLLMProviderTemplateService(repo, noopAudit{}, identityService)
+	h := NewLLMHandler(svc, nil, nil, identityService, slog.Default())
 	mux := http.NewServeMux()
 	h.RegisterRoutes(mux)
 

--- a/platform-api/src/internal/handler/mcp.go
+++ b/platform-api/src/internal/handler/mcp.go
@@ -35,14 +35,16 @@ import (
 )
 
 type MCPProxyHandler struct {
-	service *service.MCPProxyService
-	slogger *slog.Logger
+	service  *service.MCPProxyService
+	identity *service.IdentityService
+	slogger  *slog.Logger
 }
 
-func NewMCPProxyHandler(service *service.MCPProxyService, slogger *slog.Logger) *MCPProxyHandler {
+func NewMCPProxyHandler(service *service.MCPProxyService, identity *service.IdentityService, slogger *slog.Logger) *MCPProxyHandler {
 	return &MCPProxyHandler{
-		service: service,
-		slogger: slogger,
+		service:  service,
+		identity: identity,
+		slogger:  slogger,
 	}
 }
 
@@ -71,7 +73,10 @@ func (h *MCPProxyHandler) CreateMCPProxy(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	createdBy, _ := middleware.GetUserIDFromRequest(r)
+	createdBy, ok := resolveActor(w, r, h.identity, h.slogger, "create MCP proxy")
+	if !ok {
+		return
+	}
 
 	if req.ProjectId == nil {
 		h.slogger.Debug("No project ID provided for MCP proxy, proceeding without project association", "mcpProxyId", req.Id)
@@ -170,7 +175,10 @@ func (h *MCPProxyHandler) UpdateMCPProxy(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	updatedBy, _ := middleware.GetUserIDFromRequest(r)
+	updatedBy, ok := resolveActor(w, r, h.identity, h.slogger, "update MCP proxy")
+	if !ok {
+		return
+	}
 	resp, err := h.service.Update(orgID, id, updatedBy, &req)
 	if err != nil {
 		h.handleServiceError(w, err)
@@ -189,7 +197,10 @@ func (h *MCPProxyHandler) DeleteMCPProxy(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	id := r.PathValue("mcpProxyId")
-	deletedBy, _ := middleware.GetUserIDFromRequest(r)
+	deletedBy, ok := resolveActor(w, r, h.identity, h.slogger, "delete MCP proxy")
+	if !ok {
+		return
+	}
 
 	if err := h.service.Delete(orgID, id, deletedBy); err != nil {
 		h.handleServiceError(w, err)

--- a/platform-api/src/internal/handler/mcp_deployment.go
+++ b/platform-api/src/internal/handler/mcp_deployment.go
@@ -38,13 +38,15 @@ import (
 // MCPProxyDeploymentHandler handles MCP proxy deployment endpoints
 type MCPProxyDeploymentHandler struct {
 	deploymentService *service.MCPDeploymentService
+	identity          *service.IdentityService
 	slogger           *slog.Logger
 }
 
 // NewMCPProxyDeploymentHandler creates a new MCP proxy deployment handler
-func NewMCPProxyDeploymentHandler(deploymentService *service.MCPDeploymentService, slogger *slog.Logger) *MCPProxyDeploymentHandler {
+func NewMCPProxyDeploymentHandler(deploymentService *service.MCPDeploymentService, identity *service.IdentityService, slogger *slog.Logger) *MCPProxyDeploymentHandler {
 	return &MCPProxyDeploymentHandler{
 		deploymentService: deploymentService,
+		identity:          identity,
 		slogger:           slogger,
 	}
 }
@@ -97,7 +99,10 @@ func (h *MCPProxyDeploymentHandler) DeployMCPProxy(w http.ResponseWriter, r *htt
 		return
 	}
 
-	createdBy, _ := middleware.GetUserIDFromRequest(r)
+	createdBy, ok := resolveActor(w, r, h.identity, h.slogger, "deploy MCP proxy")
+	if !ok {
+		return
+	}
 	deployment, err := h.deploymentService.DeployMCPProxyByHandle(proxyId, &req, orgId, createdBy)
 	if err != nil {
 		if respondArtifactGuardError(w, err) {

--- a/platform-api/src/internal/handler/organization.go
+++ b/platform-api/src/internal/handler/organization.go
@@ -36,12 +36,14 @@ import (
 
 type OrganizationHandler struct {
 	orgService *service.OrganizationService
+	identity   *service.IdentityService
 	slogger    *slog.Logger
 }
 
-func NewOrganizationHandler(orgService *service.OrganizationService, slogger *slog.Logger) *OrganizationHandler {
+func NewOrganizationHandler(orgService *service.OrganizationService, identity *service.IdentityService, slogger *slog.Logger) *OrganizationHandler {
 	return &OrganizationHandler{
 		orgService: orgService,
+		identity:   identity,
 		slogger:    slogger,
 	}
 }
@@ -80,7 +82,10 @@ func (h *OrganizationHandler) RegisterOrganization(w http.ResponseWriter, r *htt
 		handle = *req.Id
 	}
 
-	performedBy, _ := middleware.GetUserIDFromRequest(r)
+	performedBy, ok := resolveActor(w, r, h.identity, h.slogger, "register organization")
+	if !ok {
+		return
+	}
 	// The IDP's organization UUID is derived server-side from the token's raw
 	// organization claim (the IDP org id), never client-supplied. This uses the
 	// unresolved claim rather than the resolved platform UUID, since the

--- a/platform-api/src/internal/handler/project.go
+++ b/platform-api/src/internal/handler/project.go
@@ -33,12 +33,14 @@ import (
 
 type ProjectHandler struct {
 	projectService *service.ProjectService
+	identity       *service.IdentityService
 	slogger        *slog.Logger
 }
 
-func NewProjectHandler(projectService *service.ProjectService, slogger *slog.Logger) *ProjectHandler {
+func NewProjectHandler(projectService *service.ProjectService, identity *service.IdentityService, slogger *slog.Logger) *ProjectHandler {
 	return &ProjectHandler{
 		projectService: projectService,
+		identity:       identity,
 		slogger:        slogger,
 	}
 }
@@ -64,7 +66,10 @@ func (h *ProjectHandler) CreateProject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	actor, _ := middleware.GetUserIDFromRequest(r)
+	actor, ok := resolveActor(w, r, h.identity, h.slogger, "create project")
+	if !ok {
+		return
+	}
 	project, err := h.projectService.CreateProject(&req, organizationID, actor)
 	if err != nil {
 		if errors.Is(err, constants.ErrProjectExists) {
@@ -179,7 +184,10 @@ func (h *ProjectHandler) UpdateProject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	actor, _ := middleware.GetUserIDFromRequest(r)
+	actor, ok := resolveActor(w, r, h.identity, h.slogger, "update project")
+	if !ok {
+		return
+	}
 	project, err := h.projectService.UpdateProject(projectId, &req, orgID, actor)
 	if err != nil {
 		if errors.Is(err, constants.ErrProjectNotFound) {
@@ -222,7 +230,10 @@ func (h *ProjectHandler) DeleteProject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	actor, _ := middleware.GetUserIDFromRequest(r)
+	actor, ok := resolveActor(w, r, h.identity, h.slogger, "delete project")
+	if !ok {
+		return
+	}
 	err := h.projectService.DeleteProject(projectId, orgID, actor)
 	if err != nil {
 		if errors.Is(err, constants.ErrProjectNotFound) {

--- a/platform-api/src/internal/handler/secret.go
+++ b/platform-api/src/internal/handler/secret.go
@@ -35,11 +35,12 @@ import (
 
 type SecretHandler struct {
 	secretService *service.SecretService
+	identity      *service.IdentityService
 	slogger       *slog.Logger
 }
 
-func NewSecretHandler(secretService *service.SecretService, slogger *slog.Logger) *SecretHandler {
-	return &SecretHandler{secretService: secretService, slogger: slogger}
+func NewSecretHandler(secretService *service.SecretService, identity *service.IdentityService, slogger *slog.Logger) *SecretHandler {
+	return &SecretHandler{secretService: secretService, identity: identity, slogger: slogger}
 }
 
 func (h *SecretHandler) RegisterRoutes(mux *http.ServeMux) {
@@ -59,7 +60,10 @@ func (h *SecretHandler) CreateSecret(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userID, _ := middleware.GetUserIDFromRequest(r)
+	userID, ok := resolveActor(w, r, h.identity, h.slogger, "create secret")
+	if !ok {
+		return
+	}
 
 	if err := r.ParseMultipartForm(32 << 20); err != nil {
 		_ = r.ParseForm()
@@ -177,7 +181,10 @@ func (h *SecretHandler) UpdateSecret(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userID, _ := middleware.GetUserIDFromRequest(r)
+	userID, ok := resolveActor(w, r, h.identity, h.slogger, "update secret")
+	if !ok {
+		return
+	}
 
 	if err := r.ParseMultipartForm(32 << 20); err != nil {
 		_ = r.ParseForm()
@@ -219,7 +226,10 @@ func (h *SecretHandler) DeleteSecret(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userID, _ := middleware.GetUserIDFromRequest(r)
+	userID, ok := resolveActor(w, r, h.identity, h.slogger, "delete secret")
+	if !ok {
+		return
+	}
 
 	err := h.secretService.Delete(orgID, handle, userID)
 	if err != nil {

--- a/platform-api/src/internal/handler/secret_integration_test.go
+++ b/platform-api/src/internal/handler/secret_integration_test.go
@@ -83,8 +83,9 @@ func setupSecretTestEnv(t *testing.T) (http.Handler, func()) {
 	}
 
 	repo := repository.NewSecretRepo(db)
-	svc := service.NewSecretService(repo, v)
-	h := NewSecretHandler(svc, slog.Default())
+	identityService := service.NewIdentityService(repository.NewUserIdentityMappingRepo(db))
+	svc := service.NewSecretService(repo, v, identityService)
+	h := NewSecretHandler(svc, identityService, slog.Default())
 
 	mux := http.NewServeMux()
 	h.RegisterRoutes(mux)
@@ -370,10 +371,11 @@ func TestSecretHandler_Update_ReactivatesDeprecatedSecret(t *testing.T) {
 
 	v, _ := vault.NewInHouseVault([]byte("12345678901234567890123456789012"))
 	repo := repository.NewSecretRepo(db)
-	svc := service.NewSecretService(repo, v)
+	identityService := service.NewIdentityService(repository.NewUserIdentityMappingRepo(db))
+	svc := service.NewSecretService(repo, v, identityService)
 
 	mux := http.NewServeMux()
-	NewSecretHandler(svc, slog.Default()).RegisterRoutes(mux)
+	NewSecretHandler(svc, identityService, slog.Default()).RegisterRoutes(mux)
 	r := middleware.NewTestContextMiddleware(mux)
 
 	// Create then soft-delete (deprecate) the secret.
@@ -477,8 +479,9 @@ func TestSecretHandler_Delete_409_ReferencedByArtifact(t *testing.T) {
 
 	v, _ := vault.NewInHouseVault([]byte("12345678901234567890123456789012"))
 	repo := repository.NewSecretRepo(db)
-	svc := service.NewSecretService(repo, v)
-	h := NewSecretHandler(svc, slog.Default())
+	identityService := service.NewIdentityService(repository.NewUserIdentityMappingRepo(db))
+	svc := service.NewSecretService(repo, v, identityService)
+	h := NewSecretHandler(svc, identityService, slog.Default())
 
 	mux2 := http.NewServeMux()
 	h.RegisterRoutes(mux2)
@@ -655,10 +658,11 @@ func TestSecretHandler_Delete_SoftDeletesRow(t *testing.T) {
 
 	v, _ := vault.NewInHouseVault([]byte("12345678901234567890123456789012"))
 	repo := repository.NewSecretRepo(db)
-	svc := service.NewSecretService(repo, v)
+	identityService := service.NewIdentityService(repository.NewUserIdentityMappingRepo(db))
+	svc := service.NewSecretService(repo, v, identityService)
 
 	mux3 := http.NewServeMux()
-	NewSecretHandler(svc, slog.Default()).RegisterRoutes(mux3)
+	NewSecretHandler(svc, identityService, slog.Default()).RegisterRoutes(mux3)
 	r := middleware.NewTestContextMiddleware(mux3)
 
 	// (a) Create and DELETE → 204
@@ -736,7 +740,7 @@ func TestSecretService_Decrypt_DeprecatedSecretReturnsError(t *testing.T) {
 
 	v, _ := vault.NewInHouseVault([]byte("12345678901234567890123456789012"))
 	repo := repository.NewSecretRepo(db)
-	svc := service.NewSecretService(repo, v)
+	svc := service.NewSecretService(repo, v, service.NewIdentityService(repository.NewUserIdentityMappingRepo(db)))
 
 	// Create and then soft-delete a secret
 	_, err = svc.Create("org-dep-it", "alice", &dto.CreateSecretRequest{
@@ -779,7 +783,7 @@ func TestSecretRepo_CiphertextStoredNotPlaintext(t *testing.T) {
 
 	v, _ := vault.NewInHouseVault([]byte("12345678901234567890123456789012"))
 	repo := repository.NewSecretRepo(db)
-	svc := service.NewSecretService(repo, v)
+	svc := service.NewSecretService(repo, v, service.NewIdentityService(repository.NewUserIdentityMappingRepo(db)))
 
 	_, err = svc.Create("org-ct-001", "alice", &dto.CreateSecretRequest{Handle: "ct-key", Value: "sk-abc123"})
 	if err != nil {
@@ -818,7 +822,7 @@ func TestSecretRepo_ProviderIsInBuilt(t *testing.T) {
 
 	v, _ := vault.NewInHouseVault([]byte("12345678901234567890123456789012"))
 	repo := repository.NewSecretRepo(db)
-	svc := service.NewSecretService(repo, v)
+	svc := service.NewSecretService(repo, v, service.NewIdentityService(repository.NewUserIdentityMappingRepo(db)))
 
 	_, err = svc.Create("org-prov-001", "alice", &dto.CreateSecretRequest{Handle: "prov-key", Value: "somevalue"})
 	if err != nil {
@@ -854,7 +858,7 @@ func TestSecretService_DecryptReturnsOriginalPlaintext(t *testing.T) {
 
 	v, _ := vault.NewInHouseVault([]byte("12345678901234567890123456789012"))
 	repo := repository.NewSecretRepo(db)
-	svc := service.NewSecretService(repo, v)
+	svc := service.NewSecretService(repo, v, service.NewIdentityService(repository.NewUserIdentityMappingRepo(db)))
 
 	_, err = svc.Create("org-dec-001", "alice", &dto.CreateSecretRequest{Handle: "dec-key", Value: "sk-original"})
 	if err != nil {
@@ -890,7 +894,7 @@ func TestSecretService_ValidateSecretRefs_DeprecatedHandleRejected(t *testing.T)
 
 	v, _ := vault.NewInHouseVault([]byte("12345678901234567890123456789012"))
 	repo := repository.NewSecretRepo(db)
-	svc := service.NewSecretService(repo, v)
+	svc := service.NewSecretService(repo, v, service.NewIdentityService(repository.NewUserIdentityMappingRepo(db)))
 
 	// Create then deprecate the secret
 	_, err = svc.Create("org-val-it", "alice", &dto.CreateSecretRequest{

--- a/platform-api/src/internal/handler/subscription_handler.go
+++ b/platform-api/src/internal/handler/subscription_handler.go
@@ -39,17 +39,19 @@ import (
 type SubscriptionHandler struct {
 	subscriptionService     *service.SubscriptionService
 	subscriptionPlanService *service.SubscriptionPlanService
+	identity                *service.IdentityService
 	slogger                 *slog.Logger
 }
 
 // NewSubscriptionHandler creates a new subscription handler
-func NewSubscriptionHandler(subscriptionService *service.SubscriptionService, subscriptionPlanService *service.SubscriptionPlanService, slogger *slog.Logger) *SubscriptionHandler {
+func NewSubscriptionHandler(subscriptionService *service.SubscriptionService, subscriptionPlanService *service.SubscriptionPlanService, identity *service.IdentityService, slogger *slog.Logger) *SubscriptionHandler {
 	if slogger == nil {
 		slogger = slog.Default()
 	}
 	return &SubscriptionHandler{
 		subscriptionService:     subscriptionService,
 		subscriptionPlanService: subscriptionPlanService,
+		identity:                identity,
 		slogger:                 slogger,
 	}
 }
@@ -101,7 +103,11 @@ func (h *SubscriptionHandler) CreateSubscription(w http.ResponseWriter, r *http.
 		httputil.WriteJSON(w, http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", "Invalid status value"))
 		return
 	}
-	sub, err := h.subscriptionService.CreateSubscription(req.APIID, req.Kind, orgId, req.SubscriberID, req.ApplicationID, req.SubscriptionPlanID, "", req.Status)
+	actor, ok := resolveActor(w, r, h.identity, h.slogger, "create subscription")
+	if !ok {
+		return
+	}
+	sub, err := h.subscriptionService.CreateSubscription(req.APIID, req.Kind, orgId, req.SubscriberID, req.ApplicationID, req.SubscriptionPlanID, "", req.Status, actor)
 	if err != nil {
 		if errors.Is(err, constants.ErrAPINotFound) {
 			httputil.WriteJSON(w, http.StatusNotFound, utils.NewErrorResponse(404, "Not Found", "API not found"))
@@ -115,7 +121,13 @@ func (h *SubscriptionHandler) CreateSubscription(w http.ResponseWriter, r *http.
 		httputil.WriteJSON(w, http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error", "Failed to create subscription"))
 		return
 	}
-	httputil.WriteJSON(w, http.StatusCreated, h.toSubscriptionResponse(sub, orgId))
+	resp, err := h.toSubscriptionResponse(sub, orgId)
+	if err != nil {
+		h.slogger.Error("Failed to resolve subscription identity", "apiId", req.APIID, "organizationId", orgId, "error", err)
+		httputil.WriteJSON(w, http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error", "Failed to create subscription"))
+		return
+	}
+	httputil.WriteJSON(w, http.StatusCreated, resp)
 }
 
 // ListSubscriptions handles GET /api/v0.9/subscriptions
@@ -215,9 +227,20 @@ func (h *SubscriptionHandler) ListSubscriptions(w http.ResponseWriter, r *http.R
 		httputil.WriteJSON(w, http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error", "Failed to list subscriptions"))
 		return
 	}
+	// Bulk-resolve createdBy UUIDs to their raw identity to avoid N+1 lookups.
+	createdByUUIDs := make([]string, 0, len(list))
+	for _, sub := range list {
+		createdByUUIDs = append(createdByUUIDs, sub.CreatedBy)
+	}
+	createdByMap, err := h.identity.SubsForUUIDs(createdByUUIDs)
+	if err != nil {
+		h.slogger.Error("Failed to resolve subscription creator identities", "organizationId", orgId, "error", err)
+		httputil.WriteJSON(w, http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error", "Failed to list subscriptions"))
+		return
+	}
 	items := make([]map[string]any, 0, len(list))
 	for _, sub := range list {
-		items = append(items, h.toSubscriptionResponseWithMaps(sub, orgId, artifactMetaMap, planNameMap))
+		items = append(items, h.toSubscriptionResponseWithMaps(sub, orgId, artifactMetaMap, planNameMap, createdByMap))
 	}
 	httputil.WriteJSON(w, http.StatusOK, map[string]any{
 		"subscriptions": items,
@@ -253,7 +276,13 @@ func (h *SubscriptionHandler) GetSubscription(w http.ResponseWriter, r *http.Req
 		httputil.WriteJSON(w, http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error", "Failed to get subscription"))
 		return
 	}
-	httputil.WriteJSON(w, http.StatusOK, h.toSubscriptionResponse(sub, orgId))
+	resp, err := h.toSubscriptionResponse(sub, orgId)
+	if err != nil {
+		h.slogger.Error("Failed to resolve subscription identity", "subscriptionId", subscriptionId, "organizationId", orgId, "error", err)
+		httputil.WriteJSON(w, http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error", "Failed to get subscription"))
+		return
+	}
+	httputil.WriteJSON(w, http.StatusOK, resp)
 }
 
 // UpdateSubscription handles PUT /api/v0.9/subscriptions/:subscriptionId
@@ -288,7 +317,11 @@ func (h *SubscriptionHandler) UpdateSubscription(w http.ResponseWriter, r *http.
 	if !ok {
 		return
 	}
-	sub, err := h.subscriptionService.UpdateSubscription(subscriptionId, orgId, subscriberID, status)
+	actor, ok := resolveActor(w, r, h.identity, h.slogger, "update subscription")
+	if !ok {
+		return
+	}
+	sub, err := h.subscriptionService.UpdateSubscription(subscriptionId, orgId, subscriberID, status, actor)
 	if err != nil {
 		if errors.Is(err, constants.ErrSubscriptionNotFound) {
 			httputil.WriteJSON(w, http.StatusNotFound, utils.NewErrorResponse(404, "Not Found", "Subscription not found"))
@@ -302,7 +335,13 @@ func (h *SubscriptionHandler) UpdateSubscription(w http.ResponseWriter, r *http.
 		httputil.WriteJSON(w, http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error", "Failed to update subscription"))
 		return
 	}
-	httputil.WriteJSON(w, http.StatusOK, h.toSubscriptionResponse(sub, orgId))
+	resp, err := h.toSubscriptionResponse(sub, orgId)
+	if err != nil {
+		h.slogger.Error("Failed to resolve subscription identity", "subscriptionId", subscriptionId, "organizationId", orgId, "error", err)
+		httputil.WriteJSON(w, http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error", "Failed to update subscription"))
+		return
+	}
+	httputil.WriteJSON(w, http.StatusOK, resp)
 }
 
 // DeleteSubscription handles DELETE /api/v0.9/subscriptions/:subscriptionId
@@ -322,7 +361,11 @@ func (h *SubscriptionHandler) DeleteSubscription(w http.ResponseWriter, r *http.
 	if !ok {
 		return
 	}
-	err := h.subscriptionService.DeleteSubscription(subscriptionId, orgId, subscriberID)
+	actor, ok := resolveActor(w, r, h.identity, h.slogger, "delete subscription")
+	if !ok {
+		return
+	}
+	err := h.subscriptionService.DeleteSubscription(subscriptionId, orgId, subscriberID, actor)
 	if err != nil {
 		if errors.Is(err, constants.ErrSubscriptionNotFound) {
 			httputil.WriteJSON(w, http.StatusNotFound, utils.NewErrorResponse(404, "Not Found", "Subscription not found"))
@@ -356,11 +399,19 @@ func (h *SubscriptionHandler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("DELETE "+constants.APIBasePath+"/subscriptions/{subscriptionId}", h.DeleteSubscription)
 }
 
-func (h *SubscriptionHandler) toSubscriptionResponse(sub *model.Subscription, orgId string) map[string]any {
+func (h *SubscriptionHandler) toSubscriptionResponse(sub *model.Subscription, orgId string) (map[string]any, error) {
 	// apiId in response should be the handle (e.g. "samp1"), not the internal UUID
 	apiIdForResponse, kind := h.subscriptionService.ResolveArtifactHandleAndKind(sub.ArtifactUUID, orgId)
 	if apiIdForResponse == "" {
 		apiIdForResponse = sub.ArtifactUUID // fallback to UUID
+	}
+	createdBy, err := h.identity.SubForUUID(sub.CreatedBy)
+	if err != nil {
+		return nil, err
+	}
+	updatedBy, err := h.identity.SubForUUID(sub.UpdatedBy)
+	if err != nil {
+		return nil, err
 	}
 	resp := map[string]any{
 		"id":             sub.UUID,
@@ -368,6 +419,8 @@ func (h *SubscriptionHandler) toSubscriptionResponse(sub *model.Subscription, or
 		"subscriberId":   sub.SubscriberID,
 		"organizationId": h.subscriptionService.ResolveOrgHandle(sub.OrganizationUUID),
 		"status":         string(sub.Status),
+		"createdBy":      createdBy,
+		"updatedBy":      updatedBy,
 		"createdAt":      sub.CreatedAt,
 		"updatedAt":      sub.UpdatedAt,
 	}
@@ -390,12 +443,12 @@ func (h *SubscriptionHandler) toSubscriptionResponse(sub *model.Subscription, or
 	if sub.SubscriptionToken != "" {
 		resp["subscriptionToken"] = sub.SubscriptionToken
 	}
-	return resp
+	return resp, nil
 }
 
 // toSubscriptionResponseWithMaps builds a subscription response using pre-fetched lookup maps.
 // Used by ListSubscriptions to avoid N+1 queries.
-func (h *SubscriptionHandler) toSubscriptionResponseWithMaps(sub *model.Subscription, orgId string, artifactMetaMap map[string]*model.APIMetadata, planNameMap map[string]string) map[string]any {
+func (h *SubscriptionHandler) toSubscriptionResponseWithMaps(sub *model.Subscription, orgId string, artifactMetaMap map[string]*model.APIMetadata, planNameMap map[string]string, createdByMap map[string]string) map[string]any {
 	apiIdForResponse := sub.ArtifactUUID // fallback to UUID
 	var kind string
 	if meta := artifactMetaMap[sub.ArtifactUUID]; meta != nil {
@@ -404,12 +457,17 @@ func (h *SubscriptionHandler) toSubscriptionResponseWithMaps(sub *model.Subscrip
 		}
 		kind = meta.Kind
 	}
+	createdBy := createdByMap[sub.CreatedBy]
+	if createdBy == "" {
+		createdBy = constants.DeletedUser
+	}
 	resp := map[string]any{
 		"id":             sub.UUID,
 		"apiId":          apiIdForResponse,
 		"subscriberId":   sub.SubscriberID,
 		"organizationId": h.subscriptionService.ResolveOrgHandle(sub.OrganizationUUID),
 		"status":         string(sub.Status),
+		"createdBy":      createdBy,
 		"createdAt":      sub.CreatedAt,
 		"updatedAt":      sub.UpdatedAt,
 	}

--- a/platform-api/src/internal/handler/subscription_plan_handler.go
+++ b/platform-api/src/internal/handler/subscription_plan_handler.go
@@ -38,16 +38,18 @@ import (
 // SubscriptionPlanHandler handles subscription plan CRUD
 type SubscriptionPlanHandler struct {
 	planService *service.SubscriptionPlanService
+	identity    *service.IdentityService
 	slogger     *slog.Logger
 }
 
 // NewSubscriptionPlanHandler creates a new subscription plan handler
-func NewSubscriptionPlanHandler(planService *service.SubscriptionPlanService, slogger *slog.Logger) *SubscriptionPlanHandler {
+func NewSubscriptionPlanHandler(planService *service.SubscriptionPlanService, identity *service.IdentityService, slogger *slog.Logger) *SubscriptionPlanHandler {
 	if slogger == nil {
 		slogger = slog.Default()
 	}
 	return &SubscriptionPlanHandler{
 		planService: planService,
+		identity:    identity,
 		slogger:     slogger,
 	}
 }
@@ -189,9 +191,15 @@ func (h *SubscriptionPlanHandler) CreateSubscriptionPlan(w http.ResponseWriter, 
 		plan.ExpiryTime = &t
 	}
 
-	actor, ok := middleware.GetUserIDFromRequest(r)
+	rawActor, ok := middleware.GetActorIdentityFromRequest(r)
 	if !ok {
 		httputil.WriteJSON(w, http.StatusUnauthorized, utils.NewErrorResponse(401, "Unauthorized", "User ID claim not found in token"))
+		return
+	}
+	actor, err := h.identity.ToInternalUUID(rawActor)
+	if err != nil {
+		h.slogger.Error("Failed to resolve user identity", "error", err)
+		httputil.WriteJSON(w, http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error", "Failed to resolve user identity"))
 		return
 	}
 	created, err := h.planService.CreatePlan(orgId, actor, plan)
@@ -204,7 +212,13 @@ func (h *SubscriptionPlanHandler) CreateSubscriptionPlan(w http.ResponseWriter, 
 		httputil.WriteJSON(w, http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error", "Failed to create subscription plan"))
 		return
 	}
-	httputil.WriteJSON(w, http.StatusCreated, h.toSubscriptionPlanResponse(created))
+	resp, err := h.toSubscriptionPlanResponse(created, true)
+	if err != nil {
+		h.slogger.Error("Failed to resolve subscription plan identity", "organizationId", orgId, "error", err)
+		httputil.WriteJSON(w, http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error", "Failed to create subscription plan"))
+		return
+	}
+	httputil.WriteJSON(w, http.StatusCreated, resp)
 }
 
 // ListSubscriptionPlans handles GET /api/v0.9/subscription-plans
@@ -247,7 +261,13 @@ func (h *SubscriptionPlanHandler) ListSubscriptionPlans(w http.ResponseWriter, r
 	}
 	items := make([]map[string]any, 0, len(list))
 	for _, p := range list {
-		items = append(items, h.toSubscriptionPlanResponse(p))
+		item, err := h.toSubscriptionPlanResponse(p, false)
+		if err != nil {
+			h.slogger.Error("Failed to resolve subscription plan identity", "organizationId", orgId, "error", err)
+			httputil.WriteJSON(w, http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error", "Failed to list subscription plans"))
+			return
+		}
+		items = append(items, item)
 	}
 	httputil.WriteJSON(w, http.StatusOK, map[string]any{"subscriptionPlans": items, "count": len(items)})
 }
@@ -276,7 +296,13 @@ func (h *SubscriptionPlanHandler) GetSubscriptionPlan(w http.ResponseWriter, r *
 		httputil.WriteJSON(w, http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error", "Failed to get subscription plan"))
 		return
 	}
-	httputil.WriteJSON(w, http.StatusOK, h.toSubscriptionPlanResponse(plan))
+	resp, err := h.toSubscriptionPlanResponse(plan, true)
+	if err != nil {
+		h.slogger.Error("Failed to resolve subscription plan identity", "planId", planId, "organizationId", orgId, "error", err)
+		httputil.WriteJSON(w, http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error", "Failed to get subscription plan"))
+		return
+	}
+	httputil.WriteJSON(w, http.StatusOK, resp)
 }
 
 // UpdateSubscriptionPlan handles PUT /api/v0.9/subscription-plans/:planId
@@ -344,9 +370,15 @@ func (h *SubscriptionPlanHandler) UpdateSubscriptionPlan(w http.ResponseWriter, 
 		}
 	}
 
-	actor, ok := middleware.GetUserIDFromRequest(r)
+	rawActor, ok := middleware.GetActorIdentityFromRequest(r)
 	if !ok {
 		httputil.WriteJSON(w, http.StatusUnauthorized, utils.NewErrorResponse(401, "Unauthorized", "User ID claim not found in token"))
+		return
+	}
+	actor, err := h.identity.ToInternalUUID(rawActor)
+	if err != nil {
+		h.slogger.Error("Failed to resolve user identity", "error", err)
+		httputil.WriteJSON(w, http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error", "Failed to resolve user identity"))
 		return
 	}
 	updated, err := h.planService.UpdatePlan(planId, orgId, actor, update)
@@ -368,7 +400,13 @@ func (h *SubscriptionPlanHandler) UpdateSubscriptionPlan(w http.ResponseWriter, 
 		httputil.WriteJSON(w, http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error", "Failed to update subscription plan"))
 		return
 	}
-	httputil.WriteJSON(w, http.StatusOK, h.toSubscriptionPlanResponse(updated))
+	resp, err := h.toSubscriptionPlanResponse(updated, true)
+	if err != nil {
+		h.slogger.Error("Failed to resolve subscription plan identity", "planId", planId, "organizationId", orgId, "error", err)
+		httputil.WriteJSON(w, http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error", "Failed to update subscription plan"))
+		return
+	}
+	httputil.WriteJSON(w, http.StatusOK, resp)
 }
 
 // DeleteSubscriptionPlan handles DELETE /api/v0.9/subscription-plans/:planId
@@ -385,12 +423,18 @@ func (h *SubscriptionPlanHandler) DeleteSubscriptionPlan(w http.ResponseWriter, 
 		return
 	}
 
-	actor, ok := middleware.GetUserIDFromRequest(r)
+	rawActor, ok := middleware.GetActorIdentityFromRequest(r)
 	if !ok {
 		httputil.WriteJSON(w, http.StatusUnauthorized, utils.NewErrorResponse(401, "Unauthorized", "User ID claim not found in token"))
 		return
 	}
-	err := h.planService.DeletePlan(planId, orgId, actor)
+	actor, err := h.identity.ToInternalUUID(rawActor)
+	if err != nil {
+		h.slogger.Error("Failed to resolve user identity", "error", err)
+		httputil.WriteJSON(w, http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error", "Failed to resolve user identity"))
+		return
+	}
+	err = h.planService.DeletePlan(planId, orgId, actor)
 	if err != nil {
 		if errors.Is(err, constants.ErrSubscriptionPlanNotFound) {
 			httputil.WriteJSON(w, http.StatusNotFound, utils.NewErrorResponse(404, "Not Found", "Subscription plan not found"))
@@ -413,17 +457,31 @@ func (h *SubscriptionPlanHandler) RegisterRoutes(mux *http.ServeMux) {
 }
 
 // toSubscriptionPlanResponse builds the API response for a plan.
+// updatedBy is only included when detail is true (GET/POST/PUT single-plan responses),
+// matching the platform-wide policy of omitting it from list responses.
 //
 // NOTE: SINGLE-LIMIT ASSUMPTION. The "limits" array holds at most one entry today
 // even though subscription_plan_limits supports many; see model.SubscriptionPlan.
-func (h *SubscriptionPlanHandler) toSubscriptionPlanResponse(plan *model.SubscriptionPlan) map[string]any {
+func (h *SubscriptionPlanHandler) toSubscriptionPlanResponse(plan *model.SubscriptionPlan, detail bool) (map[string]any, error) {
+	createdBy, err := h.identity.SubForUUID(plan.CreatedBy)
+	if err != nil {
+		return nil, err
+	}
 	resp := map[string]any{
 		"id":             plan.Handle,
 		"displayName":    plan.Name,
 		"organizationId": h.planService.ResolveOrgHandle(plan.OrganizationUUID),
 		"status":         string(plan.Status),
+		"createdBy":      createdBy,
 		"createdAt":      plan.CreatedAt,
 		"updatedAt":      plan.UpdatedAt,
+	}
+	if detail {
+		updatedBy, err := h.identity.SubForUUID(plan.UpdatedBy)
+		if err != nil {
+			return nil, err
+		}
+		resp["updatedBy"] = updatedBy
 	}
 	limits := []map[string]any{}
 	if plan.ThrottleLimitCount != nil {
@@ -439,5 +497,5 @@ func (h *SubscriptionPlanHandler) toSubscriptionPlanResponse(plan *model.Subscri
 	if plan.ExpiryTime != nil {
 		resp["expiryTime"] = plan.ExpiryTime
 	}
-	return resp
+	return resp, nil
 }

--- a/platform-api/src/internal/middleware/auth.go
+++ b/platform-api/src/internal/middleware/auth.go
@@ -444,6 +444,35 @@ func GetUserIDFromRequest(r *http.Request) (string, bool) {
 	return getStringFromCtx(r, keyUserID)
 }
 
+// GetSubClaimFromRequest extracts the token's OIDC "sub" (subject) claim from
+// the request context. This is the raw IdP subject identifier — distinct from
+// GetUserIDFromRequest, which returns the configured-claim/user_id/sub
+// precedence value used historically for audit columns. Prefer this for keying
+// the internal-UUID mapping (see service.IdentityService).
+func GetSubClaimFromRequest(r *http.Request) (string, bool) {
+	claims, ok := GetClaimsFromRequest(r)
+	if !ok || claims == nil || claims.Subject == "" {
+		return "", false
+	}
+	return claims.Subject, true
+}
+
+// GetActorIdentityFromRequest resolves the raw identity-provider identifier for
+// the actor behind r, preferring the token's "sub" claim and falling back to
+// GetUserIDFromRequest (configured-claim/user_id/sub) when sub is unavailable
+// (e.g. non-OIDC IdPs, or test/internal callers that only set the legacy
+// context key). ok is false only when neither source has a value — callers
+// that must reject unauthenticated requests should treat that as 401.
+// This mirrors the precedence used by service.IdentityService.InternalUserID;
+// use it at call sites that need the raw id before mapping (e.g. to
+// distinguish "claim missing" from "mapping failed").
+func GetActorIdentityFromRequest(r *http.Request) (string, bool) {
+	if sub, ok := GetSubClaimFromRequest(r); ok {
+		return sub, true
+	}
+	return GetUserIDFromRequest(r)
+}
+
 // GetUsernameFromRequest extracts the username from the request context.
 func GetUsernameFromRequest(r *http.Request) (string, bool) {
 	return getStringFromCtx(r, keyUsername)

--- a/platform-api/src/internal/model/organization.go
+++ b/platform-api/src/internal/model/organization.go
@@ -30,6 +30,8 @@ type Organization struct {
 	// IdpOrganizationRefUUID is the identity provider's organization UUID, sourced
 	// from the token's org_id claim. Empty for file-based auth (no external IDP).
 	IdpOrganizationRefUUID string    `json:"idpOrganizationRefUuid" db:"idp_organization_ref_uuid"`
+	CreatedBy              string    `json:"createdBy,omitempty" db:"created_by"`
+	UpdatedBy              string    `json:"updatedBy,omitempty" db:"updated_by"`
 	CreatedAt              time.Time `json:"createdAt" db:"created_at"`
 	UpdatedAt              time.Time `json:"updatedAt" db:"updated_at"`
 }

--- a/platform-api/src/internal/model/subscription_plan.go
+++ b/platform-api/src/internal/model/subscription_plan.go
@@ -59,6 +59,8 @@ type SubscriptionPlan struct {
 	ExpiryTime         *time.Time             `json:"expiryTime,omitempty" db:"expiry_time"`
 	OrganizationUUID   string                 `json:"organizationId" db:"organization_uuid"`
 	Status             SubscriptionPlanStatus `json:"status" db:"status"`
+	CreatedBy          string                 `json:"createdBy,omitempty" db:"created_by"`
+	UpdatedBy          string                 `json:"updatedBy,omitempty" db:"updated_by"`
 	CreatedAt          time.Time              `json:"createdAt" db:"created_at"`
 	UpdatedAt          time.Time              `json:"updatedAt" db:"updated_at"`
 }

--- a/platform-api/src/internal/model/user_identity_mapping.go
+++ b/platform-api/src/internal/model/user_identity_mapping.go
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package model
+
+import "time"
+
+// UserIdentityMapping maps our internal platform user UUID to the identity
+// provider's resolved actor identifier (the OIDC "sub" claim, falling back to
+// the configured claim / user_id when sub is absent — see
+// middleware.GetActorIdentityFromRequest). Audit columns
+// (created_by/updated_by/revoked_by/performed_by) store UserIdentityMapping.UUID;
+// API responses and external/data-plane events resolve it back to IdpID at
+// the boundary (see service.IdentityService).
+type UserIdentityMapping struct {
+	UUID      string    `json:"uuid" db:"uuid"`
+	IdpID     string    `json:"idpId" db:"idp_id"`
+	CreatedAt time.Time `json:"createdAt" db:"created_at"`
+}

--- a/platform-api/src/internal/model/user_organization_mapping.go
+++ b/platform-api/src/internal/model/user_organization_mapping.go
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package model
+
+import "time"
+
+// UserOrganizationMapping records that a user (identified by their internal
+// UUID) has onboarded to an organization. Populate-only today: no reader
+// depends on this table yet. There is no ON DELETE CASCADE on either FK by
+// design — deleting the referenced user or organization must delete the
+// matching rows here first, in the same transaction (see
+// repository.UserOrganizationMappingRepository).
+type UserOrganizationMapping struct {
+	UserUUID  string    `json:"userUuid" db:"user_uuid"`
+	OrgUUID   string    `json:"orgUuid" db:"org_uuid"`
+	CreatedAt time.Time `json:"createdAt" db:"created_at"`
+}

--- a/platform-api/src/internal/plugin/plugin.go
+++ b/platform-api/src/internal/plugin/plugin.go
@@ -90,6 +90,7 @@ type Deps struct {
 	// Core services shared with plugins.
 	GatewayEventsService *service.GatewayEventsService
 	APIKeyService        *service.APIKeyService
+	IdentityService      *service.IdentityService
 
 	// DBEncryptionKey is the derived hex key used for encrypted DB columns.
 	DBEncryptionKey string

--- a/platform-api/src/internal/repository/apikey.go
+++ b/platform-api/src/internal/repository/apikey.go
@@ -140,7 +140,7 @@ func (r *APIKeyRepo) ListByArtifact(artifactUUID string) ([]*model.APIKey, error
 }
 
 // ListByGatewayAndKind retrieves all API keys for artifacts of the given kind that have
-// an active deployment association on the specified gateway within the organisation
+// an active deployment association on the specified gateway within the organization
 // (status_desired in DEPLOYED or UNDEPLOYED).
 // When issuer is non-empty only keys whose issuer column matches are returned;
 // an empty issuer returns keys regardless of their issuer value.

--- a/platform-api/src/internal/repository/interfaces.go
+++ b/platform-api/src/internal/repository/interfaces.go
@@ -362,3 +362,30 @@ type CustomPolicyRepository interface {
 type AuditRepository interface {
 	Record(action, resourceUUID, resourceType, orgUUID, performedBy string) error
 }
+
+// UserIdentityMappingRepository defines the interface for internal-UUID <-> IdP-identity mapping persistence.
+type UserIdentityMappingRepository interface {
+	GetOrCreateUUID(identity string) (string, error)
+	// GetSubByUUID returns the resolved actor identity mapped to uuid, or
+	// found=false if uuid has no mapping (a "hanging" UUID).
+	GetSubByUUID(uuid string) (identity string, found bool, err error)
+	// GetSubsByUUIDs batch-resolves multiple UUIDs to their mapped identity in
+	// a single query (avoids N+1 on list endpoints). UUIDs with no mapping are
+	// absent from the returned map.
+	GetSubsByUUIDs(uuids []string) (map[string]string, error)
+}
+
+// UserOrganizationMappingRepository defines the interface for user<->organization
+// membership persistence. Populate-only today (no reader depends on it). Both
+// FKs are declared without ON DELETE CASCADE; DeleteByUser/DeleteByOrg exist so
+// callers can perform the cascade in application code, in the same transaction
+// as the parent delete.
+type UserOrganizationMappingRepository interface {
+	// AddMembership records that userUUID has onboarded to orgUUID. Idempotent:
+	// a duplicate (userUUID, orgUUID) pair is a no-op, not an error.
+	AddMembership(userUUID, orgUUID string) error
+	// DeleteByUser removes all membership rows for userUUID, within tx.
+	DeleteByUser(tx *sql.Tx, userUUID string) error
+	// DeleteByOrg removes all membership rows for orgUUID, within tx.
+	DeleteByOrg(tx *sql.Tx, orgUUID string) error
+}

--- a/platform-api/src/internal/repository/mcp.go
+++ b/platform-api/src/internal/repository/mcp.go
@@ -82,11 +82,11 @@ func (r *MCPProxyRepo) Create(p *model.MCPProxy) error {
 	// Insert into mcp_proxies table
 	query := `
 		INSERT INTO mcp_proxies (
-			uuid, handle, display_name, version, project_uuid, description, created_by, configuration, origin, created_at, updated_at, organization_uuid
+			uuid, handle, display_name, version, project_uuid, description, created_by, updated_by, configuration, origin, created_at, updated_at, organization_uuid
 		)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 	_, err = tx.Exec(r.db.Rebind(query),
-		p.UUID, p.Handle, p.Name, p.Version, p.ProjectUUID, p.Description, p.CreatedBy, configurationJSON, origin, p.CreatedAt, p.UpdatedAt,
+		p.UUID, p.Handle, p.Name, p.Version, p.ProjectUUID, p.Description, p.CreatedBy, p.UpdatedBy, configurationJSON, origin, p.CreatedAt, p.UpdatedAt,
 		p.OrganizationUUID,
 	)
 	if err != nil {
@@ -113,17 +113,17 @@ func (r *MCPProxyRepo) GetByHandle(handle, orgUUID string) (*model.MCPProxy, err
 	query := `
 		SELECT
 			uuid, handle, display_name, version, organization_uuid, origin, created_at, updated_at,
-			project_uuid, description, created_by, configuration
+			project_uuid, description, created_by, updated_by, configuration
 		FROM mcp_proxies
 		WHERE handle = ? AND organization_uuid = ?`
 	row := r.db.QueryRow(r.db.Rebind(query), handle, orgUUID)
 
 	var p model.MCPProxy
-	var createdBy sql.NullString
+	var createdBy, updatedBy sql.NullString
 	var configurationJSON []byte
 	if err := row.Scan(
 		&p.UUID, &p.Handle, &p.Name, &p.Version, &p.OrganizationUUID, &p.Origin, &p.CreatedAt, &p.UpdatedAt,
-		&p.ProjectUUID, &p.Description, &createdBy, &configurationJSON,
+		&p.ProjectUUID, &p.Description, &createdBy, &updatedBy, &configurationJSON,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
@@ -131,6 +131,7 @@ func (r *MCPProxyRepo) GetByHandle(handle, orgUUID string) (*model.MCPProxy, err
 		return nil, err
 	}
 	p.CreatedBy = createdBy.String
+	p.UpdatedBy = updatedBy.String
 
 	if len(configurationJSON) > 0 {
 		if config, err := deserializeMCPProxyConfiguration(configurationJSON); err != nil {
@@ -154,17 +155,17 @@ func (r *MCPProxyRepo) GetByUUID(uuid, orgUUID string) (*model.MCPProxy, error) 
 	query := `
 		SELECT
 			uuid, handle, display_name, version, organization_uuid, origin, created_at, updated_at,
-			project_uuid, description, created_by, configuration
+			project_uuid, description, created_by, updated_by, configuration
 		FROM mcp_proxies
 		WHERE uuid = ? AND organization_uuid = ?`
 	row := r.db.QueryRow(r.db.Rebind(query), uuid, orgUUID)
 
 	var p model.MCPProxy
-	var createdBy sql.NullString
+	var createdBy, updatedBy sql.NullString
 	var configurationJSON []byte
 	if err := row.Scan(
 		&p.UUID, &p.Handle, &p.Name, &p.Version, &p.OrganizationUUID, &p.Origin, &p.CreatedAt, &p.UpdatedAt,
-		&p.ProjectUUID, &p.Description, &createdBy, &configurationJSON,
+		&p.ProjectUUID, &p.Description, &createdBy, &updatedBy, &configurationJSON,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
@@ -172,6 +173,7 @@ func (r *MCPProxyRepo) GetByUUID(uuid, orgUUID string) (*model.MCPProxy, error) 
 		return nil, err
 	}
 	p.CreatedBy = createdBy.String
+	p.UpdatedBy = updatedBy.String
 
 	if len(configurationJSON) > 0 {
 		if config, err := deserializeMCPProxyConfiguration(configurationJSON); err != nil {
@@ -190,7 +192,7 @@ func (r *MCPProxyRepo) List(orgUUID string, limit, offset int) ([]*model.MCPProx
 	query := `
 		SELECT
 			uuid, handle, display_name, version, organization_uuid, origin, created_at, updated_at,
-			project_uuid, description, created_by, configuration
+			project_uuid, description, created_by, updated_by, configuration
 		FROM mcp_proxies
 		WHERE organization_uuid = ?
 		ORDER BY created_at DESC
@@ -204,16 +206,17 @@ func (r *MCPProxyRepo) List(orgUUID string, limit, offset int) ([]*model.MCPProx
 	var res []*model.MCPProxy
 	for rows.Next() {
 		var p model.MCPProxy
-		var createdBy sql.NullString
+		var createdBy, updatedBy sql.NullString
 		var configurationJSON []byte
 		err := rows.Scan(
 			&p.UUID, &p.Handle, &p.Name, &p.Version, &p.OrganizationUUID, &p.Origin, &p.CreatedAt, &p.UpdatedAt,
-			&p.ProjectUUID, &p.Description, &createdBy, &configurationJSON,
+			&p.ProjectUUID, &p.Description, &createdBy, &updatedBy, &configurationJSON,
 		)
 		if err != nil {
 			return nil, err
 		}
 		p.CreatedBy = createdBy.String
+		p.UpdatedBy = updatedBy.String
 		if len(configurationJSON) > 0 {
 			if config, err := deserializeMCPProxyConfiguration(configurationJSON); err != nil {
 				return nil, fmt.Errorf("unmarshal configuration for MCP proxy %s: %w", p.Handle, err)
@@ -236,7 +239,7 @@ func (r *MCPProxyRepo) ListByProject(orgUUID, projectUUID string) ([]*model.MCPP
 	query := `
 		SELECT
 			uuid, handle, display_name, version, organization_uuid, origin, created_at, updated_at,
-			project_uuid, description, created_by, configuration
+			project_uuid, description, created_by, updated_by, configuration
 		FROM mcp_proxies
 		WHERE organization_uuid = ? AND project_uuid = ?
 		ORDER BY created_at DESC
@@ -250,16 +253,17 @@ func (r *MCPProxyRepo) ListByProject(orgUUID, projectUUID string) ([]*model.MCPP
 	var res []*model.MCPProxy
 	for rows.Next() {
 		var p model.MCPProxy
-		var createdBy sql.NullString
+		var createdBy, updatedBy sql.NullString
 		var configurationJSON []byte
 		err := rows.Scan(
 			&p.UUID, &p.Handle, &p.Name, &p.Version, &p.OrganizationUUID, &p.Origin, &p.CreatedAt, &p.UpdatedAt,
-			&p.ProjectUUID, &p.Description, &createdBy, &configurationJSON,
+			&p.ProjectUUID, &p.Description, &createdBy, &updatedBy, &configurationJSON,
 		)
 		if err != nil {
 			return nil, err
 		}
 		p.CreatedBy = createdBy.String
+		p.UpdatedBy = updatedBy.String
 		if len(configurationJSON) > 0 {
 			if config, err := deserializeMCPProxyConfiguration(configurationJSON); err != nil {
 				return nil, fmt.Errorf("unmarshal configuration for MCP proxy %s: %w", p.Handle, err)

--- a/platform-api/src/internal/repository/organization.go
+++ b/platform-api/src/internal/repository/organization.go
@@ -28,12 +28,13 @@ import (
 
 // OrganizationRepo implements OrganizationRepository
 type OrganizationRepo struct {
-	db *database.DB
+	db                 *database.DB
+	userOrgMappingRepo UserOrganizationMappingRepository
 }
 
 // NewOrganizationRepo creates a new organization repository
 func NewOrganizationRepo(db *database.DB) OrganizationRepository {
-	return &OrganizationRepo{db: db}
+	return &OrganizationRepo{db: db, userOrgMappingRepo: NewUserOrganizationMappingRepo(db)}
 }
 
 // CreateOrganization inserts a new organization
@@ -42,23 +43,24 @@ func (r *OrganizationRepo) CreateOrganization(org *model.Organization) error {
 	org.UpdatedAt = time.Now()
 
 	query := `
-		INSERT INTO organizations (uuid, handle, display_name, region, idp_organization_ref_uuid, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO organizations (uuid, handle, display_name, region, idp_organization_ref_uuid, created_by, updated_by, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`
 	_, err := r.db.Exec(r.db.Rebind(query),
-		org.ID, org.Handle, org.Name, org.Region, org.IdpOrganizationRefUUID, org.CreatedAt, org.UpdatedAt)
+		org.ID, org.Handle, org.Name, org.Region, org.IdpOrganizationRefUUID, org.CreatedBy, org.UpdatedBy, org.CreatedAt, org.UpdatedAt)
 	return err
 }
 
 func (r *OrganizationRepo) GetOrganizationByIdOrHandle(id, handle string) (*model.Organization, error) {
 	org := &model.Organization{}
+	var createdBy, updatedBy sql.NullString
 	query := `
-		SELECT uuid, handle, display_name, region, idp_organization_ref_uuid, created_at, updated_at
+		SELECT uuid, handle, display_name, region, idp_organization_ref_uuid, created_by, updated_by, created_at, updated_at
 		FROM organizations
 		WHERE uuid = ? OR handle = ?
 	`
 	err := r.db.QueryRow(r.db.Rebind(query), id, handle).Scan(
-		&org.ID, &org.Handle, &org.Name, &org.Region, &org.IdpOrganizationRefUUID, &org.CreatedAt, &org.UpdatedAt,
+		&org.ID, &org.Handle, &org.Name, &org.Region, &org.IdpOrganizationRefUUID, &createdBy, &updatedBy, &org.CreatedAt, &org.UpdatedAt,
 	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -66,18 +68,21 @@ func (r *OrganizationRepo) GetOrganizationByIdOrHandle(id, handle string) (*mode
 		}
 		return nil, err
 	}
+	org.CreatedBy = createdBy.String
+	org.UpdatedBy = updatedBy.String
 	return org, nil
 }
 
 func (r *OrganizationRepo) GetOrganizationByUUID(orgId string) (*model.Organization, error) {
 	org := &model.Organization{}
+	var createdBy, updatedBy sql.NullString
 	query := `
-		SELECT uuid, handle, display_name, region, idp_organization_ref_uuid, created_at, updated_at
+		SELECT uuid, handle, display_name, region, idp_organization_ref_uuid, created_by, updated_by, created_at, updated_at
 		FROM organizations
 		WHERE uuid = ?
 	`
 	err := r.db.QueryRow(r.db.Rebind(query), orgId).Scan(
-		&org.ID, &org.Handle, &org.Name, &org.Region, &org.IdpOrganizationRefUUID, &org.CreatedAt, &org.UpdatedAt,
+		&org.ID, &org.Handle, &org.Name, &org.Region, &org.IdpOrganizationRefUUID, &createdBy, &updatedBy, &org.CreatedAt, &org.UpdatedAt,
 	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -85,18 +90,21 @@ func (r *OrganizationRepo) GetOrganizationByUUID(orgId string) (*model.Organizat
 		}
 		return nil, err
 	}
+	org.CreatedBy = createdBy.String
+	org.UpdatedBy = updatedBy.String
 	return org, nil
 }
 
 func (r *OrganizationRepo) GetOrganizationByHandle(handle string) (*model.Organization, error) {
 	org := &model.Organization{}
+	var createdBy, updatedBy sql.NullString
 	query := `
-		SELECT uuid, handle, display_name, region, idp_organization_ref_uuid, created_at, updated_at
+		SELECT uuid, handle, display_name, region, idp_organization_ref_uuid, created_by, updated_by, created_at, updated_at
 		FROM organizations
 		WHERE handle = ?
 	`
 	err := r.db.QueryRow(r.db.Rebind(query), handle).Scan(
-		&org.ID, &org.Handle, &org.Name, &org.Region, &org.IdpOrganizationRefUUID, &org.CreatedAt, &org.UpdatedAt,
+		&org.ID, &org.Handle, &org.Name, &org.Region, &org.IdpOrganizationRefUUID, &createdBy, &updatedBy, &org.CreatedAt, &org.UpdatedAt,
 	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -104,6 +112,8 @@ func (r *OrganizationRepo) GetOrganizationByHandle(handle string) (*model.Organi
 		}
 		return nil, err
 	}
+	org.CreatedBy = createdBy.String
+	org.UpdatedBy = updatedBy.String
 	return org, nil
 }
 
@@ -116,13 +126,14 @@ func (r *OrganizationRepo) GetOrganizationByIdpOrgRefUUID(idpOrgRefUUID string) 
 		return nil, nil
 	}
 	org := &model.Organization{}
+	var createdBy, updatedBy sql.NullString
 	query := `
-		SELECT uuid, handle, display_name, region, idp_organization_ref_uuid, created_at, updated_at
+		SELECT uuid, handle, display_name, region, idp_organization_ref_uuid, created_by, updated_by, created_at, updated_at
 		FROM organizations
 		WHERE idp_organization_ref_uuid = ?
 	`
 	err := r.db.QueryRow(r.db.Rebind(query), idpOrgRefUUID).Scan(
-		&org.ID, &org.Handle, &org.Name, &org.Region, &org.IdpOrganizationRefUUID, &org.CreatedAt, &org.UpdatedAt,
+		&org.ID, &org.Handle, &org.Name, &org.Region, &org.IdpOrganizationRefUUID, &createdBy, &updatedBy, &org.CreatedAt, &org.UpdatedAt,
 	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -130,6 +141,8 @@ func (r *OrganizationRepo) GetOrganizationByIdpOrgRefUUID(idpOrgRefUUID string) 
 		}
 		return nil, err
 	}
+	org.CreatedBy = createdBy.String
+	org.UpdatedBy = updatedBy.String
 	return org, nil
 }
 
@@ -137,23 +150,38 @@ func (r *OrganizationRepo) UpdateOrganization(org *model.Organization) error {
 	org.UpdatedAt = time.Now()
 	query := `
 		UPDATE organizations
-		SET handle = ?, display_name = ?, region = ?, updated_at = ?
+		SET handle = ?, display_name = ?, region = ?, updated_by = ?, updated_at = ?
 		WHERE uuid = ?
 	`
-	_, err := r.db.Exec(r.db.Rebind(query), org.Handle, org.Name, org.Region, org.UpdatedAt, org.ID)
+	_, err := r.db.Exec(r.db.Rebind(query), org.Handle, org.Name, org.Region, org.UpdatedBy, org.UpdatedAt, org.ID)
 	return err
 }
 
 func (r *OrganizationRepo) DeleteOrganization(orgId string) error {
-	query := `DELETE FROM organizations WHERE uuid = ?`
-	_, err := r.db.Exec(r.db.Rebind(query), orgId)
-	return err
+	tx, err := r.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	// user_organization_mappings has no ON DELETE CASCADE on org_uuid by
+	// design (see schema comment) — delete the membership rows first, in the
+	// same transaction, before deleting the organization itself.
+	if err := r.userOrgMappingRepo.DeleteByOrg(tx, orgId); err != nil {
+		return err
+	}
+
+	if _, err := tx.Exec(r.db.Rebind(`DELETE FROM organizations WHERE uuid = ?`), orgId); err != nil {
+		return err
+	}
+
+	return tx.Commit()
 }
 
 func (r *OrganizationRepo) ListOrganizations(limit, offset int) ([]*model.Organization, error) {
 	pageClause, pageArgs := r.db.PaginationClause(limit, offset)
 	query := `
-		SELECT uuid, handle, display_name, region, idp_organization_ref_uuid, created_at, updated_at
+		SELECT uuid, handle, display_name, region, idp_organization_ref_uuid, created_by, updated_by, created_at, updated_at
 		FROM organizations
 		ORDER BY created_at DESC
 		` + pageClause
@@ -166,9 +194,12 @@ func (r *OrganizationRepo) ListOrganizations(limit, offset int) ([]*model.Organi
 	var orgs []*model.Organization
 	for rows.Next() {
 		org := &model.Organization{}
-		if err := rows.Scan(&org.ID, &org.Handle, &org.Name, &org.Region, &org.IdpOrganizationRefUUID, &org.CreatedAt, &org.UpdatedAt); err != nil {
+		var createdBy, updatedBy sql.NullString
+		if err := rows.Scan(&org.ID, &org.Handle, &org.Name, &org.Region, &org.IdpOrganizationRefUUID, &createdBy, &updatedBy, &org.CreatedAt, &org.UpdatedAt); err != nil {
 			return nil, err
 		}
+		org.CreatedBy = createdBy.String
+		org.UpdatedBy = updatedBy.String
 		orgs = append(orgs, org)
 	}
 	return orgs, rows.Err()

--- a/platform-api/src/internal/repository/subscription_plan_repository.go
+++ b/platform-api/src/internal/repository/subscription_plan_repository.go
@@ -41,7 +41,7 @@ import (
 // improved to surface all limit rows.
 const planSelectColumns = `
 		p.uuid, p.handle, p.display_name, p.expiry_time,
-		p.organization_uuid, p.status, p.created_at, p.updated_at,
+		p.organization_uuid, p.status, p.created_by, p.updated_by, p.created_at, p.updated_at,
 		spl.limit_count, spl.time_unit, spl.stop_on_quota_reach
 	FROM subscription_plans p
 	LEFT JOIN subscription_plan_limits spl
@@ -77,11 +77,11 @@ func (r *SubscriptionPlanRepo) Create(plan *model.SubscriptionPlan) error {
 
 	if _, err := tx.Exec(r.db.Rebind(`
 		INSERT INTO subscription_plans (uuid, handle, display_name, expiry_time,
-			organization_uuid, status, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+			organization_uuid, status, created_by, updated_by, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`),
 		plan.UUID, plan.Handle, plan.Name, plan.ExpiryTime,
-		plan.OrganizationUUID, string(plan.Status), plan.CreatedAt, plan.UpdatedAt,
+		plan.OrganizationUUID, string(plan.Status), plan.CreatedBy, plan.UpdatedBy, plan.CreatedAt, plan.UpdatedAt,
 	); err != nil {
 		return fmt.Errorf("failed to insert subscription plan: %w", err)
 	}
@@ -138,17 +138,20 @@ func (r *SubscriptionPlanRepo) replaceSingleLimitTx(tx *sql.Tx, plan *model.Subs
 func scanPlan(scanner rowScanner) (*model.SubscriptionPlan, error) {
 	plan := &model.SubscriptionPlan{}
 	var (
-		limitCount  sql.NullInt64
-		timeUnit    sql.NullString
-		stopOnQuota sql.NullInt64
+		createdBy, updatedBy sql.NullString
+		limitCount           sql.NullInt64
+		timeUnit             sql.NullString
+		stopOnQuota          sql.NullInt64
 	)
 	if err := scanner.Scan(
 		&plan.UUID, &plan.Handle, &plan.Name, &plan.ExpiryTime,
-		&plan.OrganizationUUID, &plan.Status, &plan.CreatedAt, &plan.UpdatedAt,
+		&plan.OrganizationUUID, &plan.Status, &createdBy, &updatedBy, &plan.CreatedAt, &plan.UpdatedAt,
 		&limitCount, &timeUnit, &stopOnQuota,
 	); err != nil {
 		return nil, err
 	}
+	plan.CreatedBy = createdBy.String
+	plan.UpdatedBy = updatedBy.String
 	if limitCount.Valid {
 		c := int(limitCount.Int64)
 		plan.ThrottleLimitCount = &c
@@ -250,11 +253,11 @@ func (r *SubscriptionPlanRepo) Update(plan *model.SubscriptionPlan) error {
 
 	result, err := tx.Exec(r.db.Rebind(`
 		UPDATE subscription_plans
-		SET handle = ?, display_name = ?, expiry_time = ?, status = ?, updated_at = ?
+		SET handle = ?, display_name = ?, expiry_time = ?, status = ?, updated_by = ?, updated_at = ?
 		WHERE uuid = ? AND organization_uuid = ?
 	`),
 		plan.Handle, plan.Name, plan.ExpiryTime,
-		string(plan.Status), plan.UpdatedAt,
+		string(plan.Status), plan.UpdatedBy, plan.UpdatedAt,
 		plan.UUID, plan.OrganizationUUID,
 	)
 	if err != nil {

--- a/platform-api/src/internal/repository/user_identity_mapping.go
+++ b/platform-api/src/internal/repository/user_identity_mapping.go
@@ -1,0 +1,164 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package repository
+
+import (
+	"database/sql"
+	"errors"
+	"strings"
+	"time"
+
+	"platform-api/src/internal/database"
+
+	"github.com/google/uuid"
+)
+
+// UserIdentityMappingRepo persists the internal-UUID <-> IdP-identity mapping.
+type UserIdentityMappingRepo struct {
+	db *database.DB
+}
+
+// NewUserIdentityMappingRepo creates a new UserIdentityMappingRepo.
+func NewUserIdentityMappingRepo(db *database.DB) UserIdentityMappingRepository {
+	return &UserIdentityMappingRepo{db: db}
+}
+
+// GetOrCreateUUID returns the internal platform UUID mapped to the given
+// resolved actor identity, creating the mapping on first use. An empty
+// identity returns an empty UUID without creating a row — callers that must
+// never fail on a missing identity (e.g. anonymous writes) mint their own
+// standalone UUID instead (see service.IdentityService.InternalUserID); this
+// method never stores a row with an empty idp_id.
+func (r *UserIdentityMappingRepo) GetOrCreateUUID(identity string) (string, error) {
+	if identity == "" {
+		return "", nil
+	}
+
+	if existing, err := r.getUUID(identity); err != nil {
+		return "", err
+	} else if existing != "" {
+		return existing, nil
+	}
+
+	newUUID := uuid.New().String()
+	query := `INSERT INTO user_idp_references (uuid, idp_id, created_at) VALUES (?, ?, ?)`
+	_, err := r.db.Exec(r.db.Rebind(query), newUUID, identity, time.Now())
+	if err != nil {
+		if isUniqueViolation(err) {
+			// Lost the race to another concurrent request inserting the same idp_id.
+			return r.getUUID(identity)
+		}
+		return "", err
+	}
+	return newUUID, nil
+}
+
+func (r *UserIdentityMappingRepo) getUUID(identity string) (string, error) {
+	query := `SELECT uuid FROM user_idp_references WHERE idp_id = ?`
+	var mappedUUID string
+	err := r.db.QueryRow(r.db.Rebind(query), identity).Scan(&mappedUUID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", nil
+		}
+		return "", err
+	}
+	return mappedUUID, nil
+}
+
+// GetSubByUUID returns the resolved actor identity mapped to uuid, or
+// found=false if uuid has no mapping (a "hanging" UUID — e.g. an anonymous
+// write, or a mapping that was removed).
+func (r *UserIdentityMappingRepo) GetSubByUUID(uuid string) (string, bool, error) {
+	query := `SELECT idp_id FROM user_idp_references WHERE uuid = ?`
+	var identity string
+	err := r.db.QueryRow(r.db.Rebind(query), uuid).Scan(&identity)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	return identity, true, nil
+}
+
+// GetSubsByUUIDs batch-resolves multiple UUIDs to their mapped identity in a
+// single query, for list endpoints (avoids N+1). UUIDs with no mapping are
+// absent from the returned map.
+func (r *UserIdentityMappingRepo) GetSubsByUUIDs(uuids []string) (map[string]string, error) {
+	result := make(map[string]string)
+	unique := dedupeNonEmpty(uuids)
+	if len(unique) == 0 {
+		return result, nil
+	}
+
+	placeholders := make([]string, len(unique))
+	args := make([]any, len(unique))
+	for i, id := range unique {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+	query := `SELECT uuid, idp_id FROM user_idp_references WHERE uuid IN (` + strings.Join(placeholders, ",") + `)`
+	rows, err := r.db.Query(r.db.Rebind(query), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var mappedUUID, identity string
+		if err := rows.Scan(&mappedUUID, &identity); err != nil {
+			return nil, err
+		}
+		result[mappedUUID] = identity
+	}
+	return result, rows.Err()
+}
+
+// dedupeNonEmpty returns the distinct, non-empty values of ids.
+func dedupeNonEmpty(ids []string) []string {
+	seen := make(map[string]struct{}, len(ids))
+	unique := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		unique = append(unique, id)
+	}
+	return unique
+}
+
+// isUniqueViolation detects DB unique-constraint violations across SQLite and PostgreSQL.
+func isUniqueViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	if strings.Contains(s, "UNIQUE constraint failed") {
+		return true
+	}
+	if strings.Contains(s, "duplicate key value violates unique constraint") ||
+		strings.Contains(s, "23505") {
+		return true
+	}
+	return false
+}

--- a/platform-api/src/internal/repository/user_organization_mapping.go
+++ b/platform-api/src/internal/repository/user_organization_mapping.go
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package repository
+
+import (
+	"database/sql"
+	"time"
+
+	"platform-api/src/internal/database"
+)
+
+// UserOrganizationMappingRepo persists user<->organization membership rows.
+type UserOrganizationMappingRepo struct {
+	db *database.DB
+}
+
+// NewUserOrganizationMappingRepo creates a new UserOrganizationMappingRepo.
+func NewUserOrganizationMappingRepo(db *database.DB) UserOrganizationMappingRepository {
+	return &UserOrganizationMappingRepo{db: db}
+}
+
+// AddMembership records that userUUID has onboarded to orgUUID. Idempotent: a
+// duplicate (userUUID, orgUUID) pair is treated as success, not an error.
+func (r *UserOrganizationMappingRepo) AddMembership(userUUID, orgUUID string) error {
+	query := `INSERT INTO user_organization_mappings (user_uuid, org_uuid, created_at) VALUES (?, ?, ?)`
+	_, err := r.db.Exec(r.db.Rebind(query), userUUID, orgUUID, time.Now())
+	if err != nil {
+		if isUniqueViolation(err) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// DeleteByUser removes all membership rows for userUUID, within tx. Callers
+// must run this before deleting the referenced user_idp_references row (no
+// ON DELETE CASCADE on that FK by design).
+func (r *UserOrganizationMappingRepo) DeleteByUser(tx *sql.Tx, userUUID string) error {
+	_, err := tx.Exec(r.db.Rebind(`DELETE FROM user_organization_mappings WHERE user_uuid = ?`), userUUID)
+	return err
+}
+
+// DeleteByOrg removes all membership rows for orgUUID, within tx. Callers
+// must run this before deleting the referenced organizations row (no
+// ON DELETE CASCADE on that FK by design).
+func (r *UserOrganizationMappingRepo) DeleteByOrg(tx *sql.Tx, orgUUID string) error {
+	_, err := tx.Exec(r.db.Rebind(`DELETE FROM user_organization_mappings WHERE org_uuid = ?`), orgUUID)
+	return err
+}

--- a/platform-api/src/internal/server/server.go
+++ b/platform-api/src/internal/server/server.go
@@ -139,6 +139,8 @@ func StartPlatformAPIServer(cfg *config.Server, slogger *slog.Logger) (*Server, 
 	apiKeyRepo := repository.NewAPIKeyRepo(db, artifactTableRegistry)
 	auditRepo := repository.NewAuditRepo(db)
 	secretRepo := repository.NewSecretRepo(db)
+	userIdentityMappingRepo := repository.NewUserIdentityMappingRepo(db)
+	userOrgMappingRepo := repository.NewUserOrganizationMappingRepo(db)
 
 	// Seed the file-based organization on startup if file-based auth mode is enabled.
 	if cfg.Auth.FileBased.Enabled {
@@ -225,6 +227,7 @@ func StartPlatformAPIServer(cfg *config.Server, slogger *slog.Logger) (*Server, 
 	apiUtil := &utils.APIUtil{}
 
 	// Initialize services
+	identityService := service.NewIdentityService(userIdentityMappingRepo)
 	orgService := service.NewOrganizationService(
 		orgRepo,
 		projectRepo,
@@ -236,24 +239,26 @@ func StartPlatformAPIServer(cfg *config.Server, slogger *slog.Logger) (*Server, 
 		mcpProxyRepo,
 		llmTemplateSeeder,
 		auditRepo,
+		userOrgMappingRepo,
+		identityService,
 		cfg,
 		slogger,
 	)
-	projectService := service.NewProjectService(projectRepo, orgRepo, apiRepo, mcpProxyRepo, appRepo, auditRepo, slogger)
-	gatewayEventsService := service.NewGatewayEventsService(eventHub, slogger)
-	appService := service.NewApplicationService(appRepo, projectRepo, orgRepo, apiRepo, gatewayEventsService, auditRepo, slogger)
+	projectService := service.NewProjectService(projectRepo, orgRepo, apiRepo, mcpProxyRepo, appRepo, auditRepo, identityService, slogger)
+	gatewayEventsService := service.NewGatewayEventsService(eventHub, identityService, slogger)
+	appService := service.NewApplicationService(appRepo, projectRepo, orgRepo, apiRepo, gatewayEventsService, auditRepo, identityService, slogger)
 	apiService := service.NewAPIService(apiRepo, projectRepo, orgRepo, gatewayRepo, deploymentRepo,
-		subscriptionPlanRepo, customPolicyRepo, gatewayEventsService, apiUtil, slogger, auditRepo)
-	gatewayService := service.NewGatewayService(gatewayRepo, orgRepo, apiRepo, customPolicyRepo, gatewayEventsService, slogger, cfg.Gateway.EnableVersionVerification, cfg.Gateway.EnableFunctionalityTypeVerification, auditRepo)
+		subscriptionPlanRepo, customPolicyRepo, gatewayEventsService, apiUtil, slogger, auditRepo, identityService)
+	gatewayService := service.NewGatewayService(gatewayRepo, orgRepo, apiRepo, customPolicyRepo, gatewayEventsService, slogger, cfg.Gateway.EnableVersionVerification, cfg.Gateway.EnableFunctionalityTypeVerification, auditRepo, identityService)
 	subscriptionService := service.NewSubscriptionService(apiRepo, artifactRepo, subscriptionRepo, subscriptionPlanRepo, orgRepo, gatewayEventsService, auditRepo, slogger)
 	subscriptionPlanService := service.NewSubscriptionPlanService(subscriptionPlanRepo, gatewayRepo, orgRepo, gatewayEventsService, auditRepo, slogger)
 	internalGatewayService := service.NewGatewayInternalAPIService(apiRepo, subscriptionRepo, subscriptionPlanRepo, llmProviderRepo, llmProxyRepo, mcpProxyRepo, deploymentRepo, gatewayRepo, orgRepo, projectRepo, apiKeyRepo, artifactRepo, secretRepo, cfg, slogger)
 	apiKeyService := service.NewAPIKeyService(apiRepo, artifactRepo, apiKeyRepo, gatewayEventsService, auditRepo, cfg.APIKey.HashingAlgorithms, slogger)
 	deploymentService := service.NewDeploymentService(apiRepo, artifactRepo, deploymentRepo, gatewayRepo, orgRepo, gatewayEventsService, auditRepo, apiUtil, cfg, slogger)
-	llmTemplateService := service.NewLLMProviderTemplateService(llmTemplateRepo, auditRepo)
-	llmProviderService := service.NewLLMProviderService(llmProviderRepo, llmTemplateRepo, orgRepo, llmTemplateSeeder, deploymentRepo, gatewayRepo, gatewayEventsService, slogger, auditRepo, cfg)
-	llmProxyService := service.NewLLMProxyService(llmProxyRepo, llmProviderRepo, projectRepo, deploymentRepo, gatewayRepo, gatewayEventsService, slogger, auditRepo, cfg)
-	mcpProxyService := service.NewMCPProxyService(mcpProxyRepo, projectRepo, deploymentRepo, gatewayRepo, gatewayEventsService, slogger, auditRepo, cfg)
+	llmTemplateService := service.NewLLMProviderTemplateService(llmTemplateRepo, auditRepo, identityService)
+	llmProviderService := service.NewLLMProviderService(llmProviderRepo, llmTemplateRepo, orgRepo, llmTemplateSeeder, deploymentRepo, gatewayRepo, gatewayEventsService, slogger, auditRepo, cfg, identityService)
+	llmProxyService := service.NewLLMProxyService(llmProxyRepo, llmProviderRepo, projectRepo, deploymentRepo, gatewayRepo, gatewayEventsService, slogger, auditRepo, cfg, identityService)
+	mcpProxyService := service.NewMCPProxyService(mcpProxyRepo, projectRepo, deploymentRepo, gatewayRepo, gatewayEventsService, slogger, auditRepo, cfg, identityService)
 
 	// Initialize the shared database encryption key used for all encrypted DB columns.
 	// DATABASE_SUBSCRIPTION_TOKEN_ENCRYPTION_KEY is accepted as a legacy alias.
@@ -274,9 +279,9 @@ func StartPlatformAPIServer(cfg *config.Server, slogger *slog.Logger) (*Server, 
 		cfg,
 		slogger,
 	)
-	llmProviderAPIKeyService := service.NewLLMProviderAPIKeyService(llmProviderRepo, gatewayRepo, apiKeyRepo, gatewayEventsService, slogger)
-	llmProxyAPIKeyService := service.NewLLMProxyAPIKeyService(llmProxyRepo, gatewayRepo, apiKeyRepo, gatewayEventsService, slogger)
-	apiKeyUserService := service.NewAPIKeyUserService(apiKeyRepo, slogger)
+	llmProviderAPIKeyService := service.NewLLMProviderAPIKeyService(llmProviderRepo, gatewayRepo, apiKeyRepo, gatewayEventsService, identityService, slogger)
+	llmProxyAPIKeyService := service.NewLLMProxyAPIKeyService(llmProxyRepo, gatewayRepo, apiKeyRepo, gatewayEventsService, identityService, slogger)
+	apiKeyUserService := service.NewAPIKeyUserService(apiKeyRepo, identityService, slogger)
 	llmProxyDeploymentService := service.NewLLMProxyDeploymentService(
 		llmProxyRepo,
 		deploymentRepo,
@@ -325,32 +330,32 @@ func StartPlatformAPIServer(cfg *config.Server, slogger *slog.Logger) (*Server, 
 	if vaultErr != nil {
 		return nil, fmt.Errorf("failed to initialize secret vault: %w", vaultErr)
 	}
-	secretService := service.NewSecretService(secretRepo, secretVault)
+	secretService := service.NewSecretService(secretRepo, secretVault, identityService)
 
 	// Initialize handlers
-	orgHandler := handler.NewOrganizationHandler(orgService, slogger)
-	projectHandler := handler.NewProjectHandler(projectService, slogger)
-	apiHandler := handler.NewAPIHandler(apiService, slogger)
-	gatewayHandler := handler.NewGatewayHandler(gatewayService, slogger)
-	subscriptionHandler := handler.NewSubscriptionHandler(subscriptionService, subscriptionPlanService, slogger)
-	subscriptionPlanHandler := handler.NewSubscriptionPlanHandler(subscriptionPlanService, slogger)
-	appHandler := handler.NewApplicationHandler(appService, slogger)
+	orgHandler := handler.NewOrganizationHandler(orgService, identityService, slogger)
+	projectHandler := handler.NewProjectHandler(projectService, identityService, slogger)
+	apiHandler := handler.NewAPIHandler(apiService, identityService, slogger)
+	gatewayHandler := handler.NewGatewayHandler(gatewayService, identityService, slogger)
+	subscriptionHandler := handler.NewSubscriptionHandler(subscriptionService, subscriptionPlanService, identityService, slogger)
+	subscriptionPlanHandler := handler.NewSubscriptionPlanHandler(subscriptionPlanService, identityService, slogger)
+	appHandler := handler.NewApplicationHandler(appService, identityService, slogger)
 	wsHandler := handler.NewWebSocketHandler(wsManager, gatewayService, deploymentService, cfg.WebSocket.RateLimitPerMin, slogger)
 	internalGatewayHandler := handler.NewGatewayInternalAPIHandler(gatewayService, internalGatewayService, artifactImportService, secretService, slogger)
-	apiKeyHandler := handler.NewAPIKeyHandler(apiKeyService, slogger)
-	deploymentHandler := handler.NewDeploymentHandler(deploymentService, slogger)
-	llmHandler := handler.NewLLMHandler(llmTemplateService, llmProviderService, llmProxyService, slogger)
+	apiKeyHandler := handler.NewAPIKeyHandler(apiKeyService, identityService, slogger)
+	deploymentHandler := handler.NewDeploymentHandler(deploymentService, identityService, slogger)
+	llmHandler := handler.NewLLMHandler(llmTemplateService, llmProviderService, llmProxyService, identityService, slogger)
 	llmDeploymentHandler := handler.NewLLMProviderDeploymentHandler(llmProviderDeploymentService, slogger)
-	llmProviderAPIKeyHandler := handler.NewLLMProviderAPIKeyHandler(llmProviderAPIKeyService, slogger)
-	llmProxyAPIKeyHandler := handler.NewLLMProxyAPIKeyHandler(llmProxyAPIKeyService, slogger)
-	apiKeyUserHandler := handler.NewAPIKeyUserHandler(apiKeyUserService, slogger)
+	llmProviderAPIKeyHandler := handler.NewLLMProviderAPIKeyHandler(llmProviderAPIKeyService, identityService, slogger)
+	llmProxyAPIKeyHandler := handler.NewLLMProxyAPIKeyHandler(llmProxyAPIKeyService, identityService, slogger)
+	apiKeyUserHandler := handler.NewAPIKeyUserHandler(apiKeyUserService, identityService, slogger)
 	llmProxyDeploymentHandler := handler.NewLLMProxyDeploymentHandler(llmProxyDeploymentService, slogger)
-	mcpProxyHandler := handler.NewMCPProxyHandler(mcpProxyService, slogger)
-	mcpProxyDeploymentHandler := handler.NewMCPProxyDeploymentHandler(mcpDeploymentService, slogger)
+	mcpProxyHandler := handler.NewMCPProxyHandler(mcpProxyService, identityService, slogger)
+	mcpProxyDeploymentHandler := handler.NewMCPProxyDeploymentHandler(mcpDeploymentService, identityService, slogger)
 	// Wire secret placeholder validation into dependent services
 	llmProviderService.SetSecretService(secretService)
 	mcpProxyService.WithSecretService(secretService)
-	secretHandler := handler.NewSecretHandler(secretService, slogger)
+	secretHandler := handler.NewSecretHandler(secretService, identityService, slogger)
 	// Start deployment timeout background job
 	timeoutConfig := service.DeploymentTimeoutConfig{
 		Enabled:  cfg.Deployments.TimeoutEnabled,
@@ -426,6 +431,7 @@ func StartPlatformAPIServer(cfg *config.Server, slogger *slog.Logger) (*Server, 
 		APIRepo:               apiRepo,
 		GatewayEventsService:  gatewayEventsService,
 		APIKeyService:         apiKeyService,
+		IdentityService:       identityService,
 		DBEncryptionKey:       dbEncryptionKey,
 	}
 	for _, p := range plugin.All() {

--- a/platform-api/src/internal/service/api.go
+++ b/platform-api/src/internal/service/api.go
@@ -47,6 +47,7 @@ type APIService struct {
 	apiUtil              *utils.APIUtil
 	slogger              *slog.Logger
 	auditRepo            repository.AuditRepository
+	identity             *IdentityService
 }
 
 // NewAPIService creates a new API service
@@ -56,7 +57,7 @@ func NewAPIService(apiRepo repository.APIRepository, projectRepo repository.Proj
 	subscriptionPlanRepo repository.SubscriptionPlanRepository,
 	customPolicyRepo repository.CustomPolicyRepository,
 	gatewayEventsService *GatewayEventsService, apiUtil *utils.APIUtil,
-	slogger *slog.Logger, auditRepo repository.AuditRepository) *APIService {
+	slogger *slog.Logger, auditRepo repository.AuditRepository, identity *IdentityService) *APIService {
 	return &APIService{
 		apiRepo:              apiRepo,
 		projectRepo:          projectRepo,
@@ -69,7 +70,20 @@ func NewAPIService(apiRepo repository.APIRepository, projectRepo repository.Proj
 		apiUtil:              apiUtil,
 		slogger:              slogger,
 		auditRepo:            auditRepo,
+		identity:             identity,
 	}
+}
+
+// resolveRESTAPIIdentity replaces resp's createdBy/updatedBy UUIDs with the
+// raw external identity (or constants.DeletedUser), in place.
+func (s *APIService) resolveRESTAPIIdentity(resp *api.RESTAPI) error {
+	if resp == nil {
+		return nil
+	}
+	if err := s.identity.ResolveIdentityField(&resp.CreatedBy); err != nil {
+		return err
+	}
+	return s.identity.ResolveIdentityField(&resp.UpdatedBy)
 }
 
 // CreateAPI creates a new API with validation and business logic
@@ -103,10 +117,8 @@ func (s *APIService) CreateAPI(req *api.CreateRESTAPIRequest, orgUUID, createdBy
 		}
 	}
 
-	// Set default values if not provided
-	if req.CreatedBy == nil || *req.CreatedBy == "" {
-		req.CreatedBy = &createdBy
-	}
+	// createdBy is always inferred from the authenticated actor, never from the request body.
+	req.CreatedBy = &createdBy
 	if req.Kind == nil || *req.Kind == "" {
 		kind := constants.RestApi
 		req.Kind = &kind
@@ -145,7 +157,8 @@ func (s *APIService) CreateAPI(req *api.CreateRESTAPIRequest, orgUUID, createdBy
 }
 
 // modelToRESTAPI converts an internal API model to the API representation,
-// resolving the project's handle for the response's projectId field.
+// resolving the project's handle for the response's projectId field and the
+// createdBy/updatedBy UUIDs to their raw external identity.
 func (s *APIService) modelToRESTAPI(apiModel *model.API) (*api.RESTAPI, error) {
 	if apiModel == nil {
 		return nil, nil
@@ -158,7 +171,14 @@ func (s *APIService) modelToRESTAPI(apiModel *model.API) (*api.RESTAPI, error) {
 	if project != nil {
 		projectHandle = project.Handle
 	}
-	return s.apiUtil.ModelToRESTAPI(apiModel, projectHandle)
+	resp, err := s.apiUtil.ModelToRESTAPI(apiModel, projectHandle)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.resolveRESTAPIIdentity(resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
 }
 
 // GetAPIByUUID retrieves an API by its ID
@@ -249,6 +269,8 @@ func (s *APIService) GetAPIsByOrganization(orgUUID string, projectHandle string)
 			return nil, err
 		}
 		if apiResponse != nil {
+			// updatedBy is detail-only; omit it from list responses.
+			apiResponse.UpdatedBy = nil
 			apis = append(apis, *apiResponse)
 		}
 	}
@@ -652,9 +674,7 @@ func (s *APIService) applyAPIUpdates(existingAPIModel *model.API, req *api.RESTA
 	if req.Description != nil {
 		existingAPI.Description = req.Description
 	}
-	if req.CreatedBy != nil {
-		existingAPI.CreatedBy = req.CreatedBy
-	}
+	// createdBy is immutable: intentionally not copied from req, even if the client sends one.
 	if req.LifeCycleStatus != nil {
 		existingAPI.LifeCycleStatus = req.LifeCycleStatus
 	}

--- a/platform-api/src/internal/service/api_test.go
+++ b/platform-api/src/internal/service/api_test.go
@@ -167,7 +167,8 @@ func TestValidateUpdateAPIRequest(t *testing.T) {
 			}
 
 			service := &APIService{
-				apiRepo: mock,
+				apiRepo:  mock,
+				identity: newTestIdentityService(),
 			}
 
 			err := service.validateUpdateAPIRequest(tt.existingAPI, tt.req, "test-org-uuid")
@@ -396,7 +397,8 @@ func TestValidateCreateAPIRequest(t *testing.T) {
 			}
 
 			service := &APIService{
-				apiRepo: mock,
+				apiRepo:  mock,
+				identity: newTestIdentityService(),
 			}
 
 			err := service.validateCreateAPIRequest(tt.req, "test-org-uuid")
@@ -429,6 +431,7 @@ func TestApplyAPIUpdatesUpdatesPolicies(t *testing.T) {
 		apiRepo:     &mockAPIRepository{},
 		projectRepo: &mockProjectRepository{projectByUUID: &model.Project{ID: "11111111-1111-1111-1111-111111111111", Handle: "test-project"}},
 		apiUtil:     &utils.APIUtil{},
+		identity:    newTestIdentityService(),
 	}
 
 	condition := "request.path == '/pets'"

--- a/platform-api/src/internal/service/apikey_user.go
+++ b/platform-api/src/internal/service/apikey_user.go
@@ -24,21 +24,25 @@ import (
 
 	"platform-api/src/api"
 	"platform-api/src/internal/repository"
+	"platform-api/src/internal/utils"
 )
 
 // APIKeyUserService handles listing API keys across artifact types for a given user.
 type APIKeyUserService struct {
 	apiKeyRepo repository.APIKeyRepository
+	identity   *IdentityService
 	slogger    *slog.Logger
 }
 
 // NewAPIKeyUserService creates a new APIKeyUserService instance.
 func NewAPIKeyUserService(
 	apiKeyRepo repository.APIKeyRepository,
+	identity *IdentityService,
 	slogger *slog.Logger,
 ) *APIKeyUserService {
 	return &APIKeyUserService{
 		apiKeyRepo: apiKeyRepo,
+		identity:   identity,
 		slogger:    slogger,
 	}
 }
@@ -58,13 +62,17 @@ func (s *APIKeyUserService) ListAPIKeysByUser(
 
 	items := make([]api.UserAPIKeyItem, 0, len(keys))
 	for _, k := range keys {
+		createdBy := utils.StringPtrIfNotEmpty(k.CreatedBy)
+		if err := s.identity.ResolveIdentityField(&createdBy); err != nil {
+			return nil, err
+		}
 		item := api.UserAPIKeyItem{
 			Id:             &k.Name,
 			DisplayName:    k.DisplayName,
 			MaskedApiKey:   k.MaskedAPIKey,
 			Status:         api.UserAPIKeyItemStatus(k.Status),
 			CreatedAt:      k.CreatedAt,
-			CreatedBy:      k.CreatedBy,
+			CreatedBy:      createdBy,
 			UpdatedAt:      k.UpdatedAt,
 			ExpiresAt:      k.ExpiresAt,
 			Issuer:         k.Issuer,

--- a/platform-api/src/internal/service/application.go
+++ b/platform-api/src/internal/service/application.go
@@ -39,6 +39,7 @@ type ApplicationService struct {
 	apiRepo              repository.APIRepository
 	gatewayEventsService *GatewayEventsService
 	auditRepo            repository.AuditRepository
+	identity             *IdentityService
 	slogger              *slog.Logger
 }
 
@@ -73,6 +74,7 @@ func NewApplicationService(
 	apiRepo repository.APIRepository,
 	gatewayEventsService *GatewayEventsService,
 	auditRepo repository.AuditRepository,
+	identity *IdentityService,
 	slogger *slog.Logger,
 ) *ApplicationService {
 	return &ApplicationService{
@@ -82,6 +84,7 @@ func NewApplicationService(
 		apiRepo:              apiRepo,
 		gatewayEventsService: gatewayEventsService,
 		auditRepo:            auditRepo,
+		identity:             identity,
 		slogger:              slogger,
 	}
 }
@@ -145,10 +148,8 @@ func (s *ApplicationService) CreateApplication(req *api.CreateApplicationRequest
 		}
 	}
 
+	// createdBy is always inferred from the authenticated actor, never from the request body.
 	actor := strings.TrimSpace(createdBy)
-	if actor == "" {
-		actor = strings.TrimSpace(valueOrEmptyApplication(req.CreatedBy))
-	}
 	app := &model.Application{
 		UUID:             uuid.New().String(),
 		Handle:           handle,
@@ -249,6 +250,8 @@ func (s *ApplicationService) GetApplicationsByOrganization(orgID, projectHandle 
 			return nil, err
 		}
 		if mapped != nil {
+			// updatedBy is detail-only; omit it from list responses.
+			mapped.UpdatedBy = nil
 			response.List = append(response.List, *mapped)
 		}
 	}
@@ -826,7 +829,7 @@ func (s *ApplicationService) buildMappedAPIKeyListForAssociationPaginated(applic
 		}
 	}
 
-	return s.buildMappedAPIKeyResponse(filteredKeys, limit, offset), nil
+	return s.buildMappedAPIKeyResponse(filteredKeys, limit, offset)
 }
 
 func (s *ApplicationService) buildApplicationAssociationListPaginated(applicationUUID string, limit, offset int) (*ApplicationAssociationListResponse, error) {
@@ -880,10 +883,10 @@ func (s *ApplicationService) buildMappedAPIKeyListPaginated(applicationUUID stri
 		return nil, err
 	}
 
-	return s.buildMappedAPIKeyResponse(keys, limit, offset), nil
+	return s.buildMappedAPIKeyResponse(keys, limit, offset)
 }
 
-func (s *ApplicationService) buildMappedAPIKeyResponse(keys []*model.ApplicationAPIKey, limit, offset int) *api.MappedAPIKeyListResponse {
+func (s *ApplicationService) buildMappedAPIKeyResponse(keys []*model.ApplicationAPIKey, limit, offset int) (*api.MappedAPIKeyListResponse, error) {
 
 	if offset < 0 {
 		offset = 0
@@ -916,10 +919,14 @@ func (s *ApplicationService) buildMappedAPIKeyResponse(keys []*model.Application
 	}
 
 	for _, key := range pagedKeys {
-		response.List = append(response.List, s.modelToMappedAPIKeyResponse(key))
+		item, err := s.modelToMappedAPIKeyResponse(key)
+		if err != nil {
+			return nil, err
+		}
+		response.List = append(response.List, item)
 	}
 
-	return response
+	return response, nil
 }
 
 func (s *ApplicationService) modelToApplicationResponse(app *model.Application) (*api.Application, error) {
@@ -940,24 +947,32 @@ func (s *ApplicationService) modelToApplicationResponse(app *model.Application) 
 		projectHandle = project.Handle
 	}
 
-	return &api.Application{
+	resp := &api.Application{
 		Id:          app.Handle,
 		DisplayName: app.Name,
 		ProjectId:   projectHandle,
 		Type:        api.ApplicationType(app.Type),
 		Description: utils.StringPtrIfNotEmpty(app.Description),
 		CreatedBy:   utils.StringPtrIfNotEmpty(app.CreatedBy),
+		UpdatedBy:   utils.StringPtrIfNotEmpty(app.UpdatedBy),
 		CreatedAt:   utils.TimePtrIfNotZero(app.CreatedAt),
 		UpdatedAt:   utils.TimePtrIfNotZero(app.UpdatedAt),
-	}, nil
+	}
+	if err := s.identity.ResolveIdentityField(&resp.CreatedBy); err != nil {
+		return nil, err
+	}
+	if err := s.identity.ResolveIdentityField(&resp.UpdatedBy); err != nil {
+		return nil, err
+	}
+	return resp, nil
 }
 
-func (s *ApplicationService) modelToMappedAPIKeyResponse(key *model.ApplicationAPIKey) api.MappedAPIKey {
+func (s *ApplicationService) modelToMappedAPIKeyResponse(key *model.ApplicationAPIKey) (api.MappedAPIKey, error) {
 	if key == nil {
-		return api.MappedAPIKey{}
+		return api.MappedAPIKey{}, nil
 	}
 
-	return api.MappedAPIKey{
+	resp := api.MappedAPIKey{
 		KeyId: key.Name,
 		AssociatedEntity: api.AssociatedEntity{
 			Id:   key.ArtifactHandle,
@@ -969,6 +984,10 @@ func (s *ApplicationService) modelToMappedAPIKeyResponse(key *model.ApplicationA
 		UpdatedAt: utils.TimePtrIfNotZero(key.UpdatedAt),
 		ExpiresAt: key.ExpiresAt,
 	}
+	if err := s.identity.ResolveIdentityField(&resp.UserId); err != nil {
+		return api.MappedAPIKey{}, err
+	}
+	return resp, nil
 }
 
 func (s *ApplicationService) modelToApplicationAssociation(association *model.ApplicationAssociationTarget) ApplicationAssociation {

--- a/platform-api/src/internal/service/application_test.go
+++ b/platform-api/src/internal/service/application_test.go
@@ -322,7 +322,7 @@ func TestListMappedAPIKeys_ReturnsUnifiedMappingsWithMetadata(t *testing.T) {
 		},
 	}
 
-	svc := &ApplicationService{appRepo: appRepo}
+	svc := &ApplicationService{appRepo: appRepo, identity: newTestIdentityService()}
 
 	resp, err := svc.ListMappedAPIKeys("my-app", "org-1", 20, 0)
 	if err != nil {
@@ -370,7 +370,7 @@ func TestListMappedAPIKeys_AppliesPagination(t *testing.T) {
 		},
 	}
 
-	svc := &ApplicationService{appRepo: appRepo}
+	svc := &ApplicationService{appRepo: appRepo, identity: newTestIdentityService()}
 
 	resp, err := svc.ListMappedAPIKeys("my-app", "org-1", 1, 1)
 	if err != nil {
@@ -409,7 +409,7 @@ func TestListMappedAPIKeys_LimitOneReturnsFirstPage(t *testing.T) {
 		},
 	}
 
-	svc := &ApplicationService{appRepo: appRepo}
+	svc := &ApplicationService{appRepo: appRepo, identity: newTestIdentityService()}
 
 	resp, err := svc.ListMappedAPIKeys("my-app", "org-1", 1, 0)
 	if err != nil {
@@ -454,7 +454,7 @@ func TestListMappedAPIKeysForAssociation_FiltersToAssociation(t *testing.T) {
 		},
 	}
 
-	svc := &ApplicationService{appRepo: appRepo}
+	svc := &ApplicationService{appRepo: appRepo, identity: newTestIdentityService()}
 
 	resp, err := svc.ListMappedAPIKeysForAssociation("my-app", "provider-1", "org-1", 20, 0)
 	if err != nil {
@@ -490,7 +490,7 @@ func TestListMappedAPIKeysForAssociation_ErrorsWhenAssociationMissing(t *testing
 		mappedAssociations: []*model.ApplicationAssociationTarget{},
 	}
 
-	svc := &ApplicationService{appRepo: appRepo}
+	svc := &ApplicationService{appRepo: appRepo, identity: newTestIdentityService()}
 
 	_, err := svc.ListMappedAPIKeysForAssociation("my-app", "provider-1", "org-1", 20, 0)
 	if !errors.Is(err, constants.ErrArtifactNotFound) {
@@ -520,6 +520,7 @@ func TestGetApplicationsByOrganization_AppliesPagination(t *testing.T) {
 		appRepo:     appRepo,
 		projectRepo: projectRepo,
 		orgRepo:     orgRepo,
+		identity:    newTestIdentityService(),
 	}
 
 	resp, err := svc.GetApplicationsByOrganization(orgID, projectID, 1, 1)
@@ -559,7 +560,7 @@ func TestAddMappedAPIKeys_RejectsWhenRequesterIsNotCreator(t *testing.T) {
 		},
 	}
 
-	svc := &ApplicationService{appRepo: appRepo}
+	svc := &ApplicationService{appRepo: appRepo, identity: newTestIdentityService()}
 
 	_, err := svc.AddMappedAPIKeys("my-app", &api.AddApplicationAPIKeysRequest{ApiKeys: []api.APIKeyMappingSelector{{
 		KeyId: "key-1",
@@ -587,7 +588,7 @@ func TestRemoveMappedAPIKey_AllowsWhenRequesterIsNotCreator(t *testing.T) {
 		},
 	}
 
-	svc := &ApplicationService{appRepo: appRepo}
+	svc := &ApplicationService{appRepo: appRepo, identity: newTestIdentityService()}
 
 	err := svc.RemoveMappedAPIKey("my-app", "key-1", "orders-api", "org-1", "different-user")
 	if err != nil {
@@ -615,7 +616,7 @@ func TestAddMappedAPIKeys_ResolvesByAssociatedEntityID(t *testing.T) {
 		},
 	}
 
-	svc := &ApplicationService{appRepo: appRepo}
+	svc := &ApplicationService{appRepo: appRepo, identity: newTestIdentityService()}
 
 	_, err := svc.AddMappedAPIKeys("my-app", &api.AddApplicationAPIKeysRequest{ApiKeys: []api.APIKeyMappingSelector{{
 		KeyId: "shared-key",
@@ -647,7 +648,7 @@ func TestAddMappedAPIKeys_DoesNotFailWhenBroadcastResolutionFails(t *testing.T) 
 		artifactErr: errors.New("artifact lookup failed"),
 	}
 
-	svc := &ApplicationService{appRepo: appRepo, gatewayEventsService: &GatewayEventsService{}}
+	svc := &ApplicationService{appRepo: appRepo, gatewayEventsService: &GatewayEventsService{}, identity: newTestIdentityService()}
 
 	_, err := svc.AddMappedAPIKeys("my-app", &api.AddApplicationAPIKeysRequest{ApiKeys: []api.APIKeyMappingSelector{{
 		KeyId: "key-1",
@@ -685,7 +686,7 @@ func TestAddApplicationAssociations_AssociatesProviderAndProxy(t *testing.T) {
 		},
 	}
 
-	svc := &ApplicationService{appRepo: appRepo}
+	svc := &ApplicationService{appRepo: appRepo, identity: newTestIdentityService()}
 
 	_, err := svc.AddApplicationAssociations("my-app", &AddApplicationAssociationsRequest{Associations: []ApplicationAssociationSelector{
 		{Id: "provider-1", Kind: constants.LLMProvider},
@@ -719,7 +720,7 @@ func TestAddApplicationAssociations_RejectsCrossProjectProxy(t *testing.T) {
 		},
 	}
 
-	svc := &ApplicationService{appRepo: appRepo}
+	svc := &ApplicationService{appRepo: appRepo, identity: newTestIdentityService()}
 
 	_, err := svc.AddApplicationAssociations("my-app", &AddApplicationAssociationsRequest{Associations: []ApplicationAssociationSelector{{
 		Id:   "proxy-1",
@@ -741,7 +742,7 @@ func TestListApplicationAssociations_AppliesPagination(t *testing.T) {
 		},
 	}
 
-	svc := &ApplicationService{appRepo: appRepo}
+	svc := &ApplicationService{appRepo: appRepo, identity: newTestIdentityService()}
 
 	resp, err := svc.ListApplicationAssociations("my-app", "org-1", 1, 0)
 	if err != nil {
@@ -771,7 +772,7 @@ func TestRemoveApplicationAssociation_RemovesByResolvedTarget(t *testing.T) {
 		},
 	}
 
-	svc := &ApplicationService{appRepo: appRepo}
+	svc := &ApplicationService{appRepo: appRepo, identity: newTestIdentityService()}
 
 	err := svc.RemoveApplicationAssociation("my-app", "proxy-1", "org-1")
 	if err != nil {
@@ -800,7 +801,7 @@ func TestRemoveMappedAPIKey_DoesNotFailWhenBroadcastResolutionFails(t *testing.T
 		artifactErr: errors.New("artifact lookup failed"),
 	}
 
-	svc := &ApplicationService{appRepo: appRepo, gatewayEventsService: &GatewayEventsService{}}
+	svc := &ApplicationService{appRepo: appRepo, gatewayEventsService: &GatewayEventsService{}, identity: newTestIdentityService()}
 
 	err := svc.RemoveMappedAPIKey("my-app", "key-1", "orders-api", "org-1", "creator-user")
 	if err != nil {
@@ -919,6 +920,7 @@ func TestCreateApplication_AllowsMissingProjectID(t *testing.T) {
 		projectRepo: projectRepo,
 		orgRepo:     orgRepo,
 		auditRepo:   &noopAuditRepo{},
+		identity:    newTestIdentityService(),
 	}
 
 	// project_uuid is optional: creating without a project id succeeds and persists a project-less
@@ -1002,7 +1004,7 @@ func TestUpdateApplication_RejectsHandleChange(t *testing.T) {
 	appRepo := &mockApplicationRepository{
 		app: &model.Application{UUID: "uuid-1", Handle: "my-app", Name: "My App", ProjectUUID: "proj-1"},
 	}
-	svc := &ApplicationService{appRepo: appRepo}
+	svc := &ApplicationService{appRepo: appRepo, identity: newTestIdentityService()}
 
 	resp, err := svc.UpdateApplication("my-app", &api.Application{
 		Id: "renamed-app",
@@ -1028,6 +1030,7 @@ func TestCreateApplication_ValidatesProvidedProjectID(t *testing.T) {
 		appRepo:     appRepo,
 		projectRepo: projectRepo,
 		orgRepo:     orgRepo,
+		identity:    newTestIdentityService(),
 	}
 
 	_, err := svc.CreateApplication(&api.CreateApplicationRequest{

--- a/platform-api/src/internal/service/artifact_cross_origin_test.go
+++ b/platform-api/src/internal/service/artifact_cross_origin_test.go
@@ -271,6 +271,7 @@ func TestCPProviderFromDPTemplate(t *testing.T) {
 		newTestLogger(),
 		&noopAuditRepo{},
 		&config.Server{},
+		NewIdentityService(repository.NewUserIdentityMappingRepo(d.db)),
 	)
 
 	created, err := providerSvc.Create(importTestOrgID, "tester", &api.LLMProvider{
@@ -313,6 +314,7 @@ func TestCPProxyFromDPProvider(t *testing.T) {
 		newTestLogger(),
 		&noopAuditRepo{},
 		&config.Server{},
+		NewIdentityService(repository.NewUserIdentityMappingRepo(d.db)),
 	)
 
 	created, err := proxySvc.Create(importTestOrgID, "tester", &api.LLMProxy{

--- a/platform-api/src/internal/service/artifact_import_lifecycle_test.go
+++ b/platform-api/src/internal/service/artifact_import_lifecycle_test.go
@@ -815,6 +815,7 @@ func TestImport_MCPProxy_ReadOnlyInGetAndList(t *testing.T) {
 		newTestLogger(),
 		&noopAuditRepo{},
 		&config.Server{},
+		NewIdentityService(repository.NewUserIdentityMappingRepo(d.db)),
 	)
 
 	// DP-origin MCP proxy via the gateway import flow.
@@ -890,7 +891,7 @@ func TestCPSideGuard_DPOriginUpdate(t *testing.T) {
 
 	t.Run("LLMProviderTemplate", func(t *testing.T) {
 		d := setupImportTest(t)
-		svc := NewLLMProviderTemplateService(d.templateRepo, &noopAuditRepo{})
+		svc := NewLLMProviderTemplateService(d.templateRepo, &noopAuditRepo{}, NewIdentityService(repository.NewUserIdentityMappingRepo(d.db)))
 		mustImport(t, d, dpTemplateReq("dp-t", "blk-tmpl", "T"))
 
 		// Changing a gateway-consumed field (a token-extraction identifier) is rejected.
@@ -915,7 +916,7 @@ func TestCPSideGuard_DPOriginUpdate(t *testing.T) {
 	t.Run("LLMProvider", func(t *testing.T) {
 		d := setupImportTest(t)
 		svc := NewLLMProviderService(repository.NewLLMProviderRepo(d.db), d.templateRepo,
-			repository.NewOrganizationRepo(d.db), nil, d.deployment, repository.NewGatewayRepo(d.db), nil, logger, &noopAuditRepo{}, &config.Server{})
+			repository.NewOrganizationRepo(d.db), nil, d.deployment, repository.NewGatewayRepo(d.db), nil, logger, &noopAuditRepo{}, &config.Server{}, NewIdentityService(repository.NewUserIdentityMappingRepo(d.db)))
 		mustImport(t, d, dpTemplateReq("dp-t", "p-tmpl", "T"))
 		provReq := dpProviderReq("dp-p", "blk-prov", "P", "p-tmpl")
 		provReq.Configuration.Spec["upstream"] = map[string]interface{}{"url": "https://api.example.com"}
@@ -943,7 +944,7 @@ func TestCPSideGuard_DPOriginUpdate(t *testing.T) {
 	t.Run("LLMProxy", func(t *testing.T) {
 		d := setupImportTest(t)
 		svc := NewLLMProxyService(repository.NewLLMProxyRepo(d.db), repository.NewLLMProviderRepo(d.db),
-			repository.NewProjectRepo(d.db), d.deployment, repository.NewGatewayRepo(d.db), nil, logger, &noopAuditRepo{}, &config.Server{})
+			repository.NewProjectRepo(d.db), d.deployment, repository.NewGatewayRepo(d.db), nil, logger, &noopAuditRepo{}, &config.Server{}, NewIdentityService(repository.NewUserIdentityMappingRepo(d.db)))
 		mustImport(t, d, dpTemplateReq("dp-t", "px-tmpl", "T"))
 		mustImport(t, d, dpProviderReq("dp-p", "px-prov", "P", "px-tmpl"))
 		mustImport(t, d, dpProxyReq("dp-x", "blk-proxy", "X", "px-prov"))
@@ -966,7 +967,7 @@ func TestCPSideGuard_DPOriginUpdate(t *testing.T) {
 	t.Run("MCPProxy", func(t *testing.T) {
 		d := setupImportTest(t)
 		svc := NewMCPProxyService(repository.NewMCPProxyRepo(d.db), repository.NewProjectRepo(d.db),
-			d.deployment, repository.NewGatewayRepo(d.db), nil, logger, &noopAuditRepo{}, &config.Server{})
+			d.deployment, repository.NewGatewayRepo(d.db), nil, logger, &noopAuditRepo{}, &config.Server{}, NewIdentityService(repository.NewUserIdentityMappingRepo(d.db)))
 		mustImport(t, d, dpMCPReq("dp-m", "blk-mcp", "M"))
 
 		updated, err := svc.Update(importTestOrgID, "blk-mcp", "tester", &api.MCPProxy{

--- a/platform-api/src/internal/service/artifact_runtime_immutable_test.go
+++ b/platform-api/src/internal/service/artifact_runtime_immutable_test.go
@@ -77,7 +77,7 @@ func baseRESTAPI(origin string) *model.API {
 }
 
 func TestRESTRuntimeArtifactGuard(t *testing.T) {
-	svc := &APIService{apiUtil: &utils.APIUtil{}}
+	svc := &APIService{apiUtil: &utils.APIUtil{}, identity: newTestIdentityService()}
 
 	t.Run("metadata-only edit allowed", func(t *testing.T) {
 		existing := baseRESTAPI(constants.OriginDP)

--- a/platform-api/src/internal/service/custom_policy_test.go
+++ b/platform-api/src/internal/service/custom_policy_test.go
@@ -160,6 +160,7 @@ func newTestGatewayService(gwRepo repository.GatewayRepository, cpRepo repositor
 		gatewayRepo:      gwRepo,
 		customPolicyRepo: cpRepo,
 		slogger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+		identity:         newTestIdentityService(),
 	}
 }
 

--- a/platform-api/src/internal/service/gateway.go
+++ b/platform-api/src/internal/service/gateway.go
@@ -78,6 +78,7 @@ type GatewayService struct {
 	enableVersionVerification           bool
 	enableFunctionalityTypeVerification bool
 	auditRepo                           repository.AuditRepository
+	identity                            *IdentityService
 }
 
 // NewGatewayService creates a new gateway service
@@ -85,7 +86,7 @@ func NewGatewayService(gatewayRepo repository.GatewayRepository, orgRepo reposit
 	apiRepo repository.APIRepository, customPolicyRepo repository.CustomPolicyRepository,
 	gatewayEventsService *GatewayEventsService, slogger *slog.Logger,
 	enableVersionVerification bool, enableFunctionalityTypeVerification bool,
-	auditRepo repository.AuditRepository) *GatewayService {
+	auditRepo repository.AuditRepository, identity *IdentityService) *GatewayService {
 	return &GatewayService{
 		gatewayRepo:                         gatewayRepo,
 		orgRepo:                             orgRepo,
@@ -96,6 +97,7 @@ func NewGatewayService(gatewayRepo repository.GatewayRepository, orgRepo reposit
 		enableVersionVerification:           enableVersionVerification,
 		enableFunctionalityTypeVerification: enableFunctionalityTypeVerification,
 		auditRepo:                           auditRepo,
+		identity:                            identity,
 	}
 }
 
@@ -611,7 +613,7 @@ func (s *GatewayService) RegisterGateway(orgID string, id *string, displayName, 
 	}
 
 	// 7. Return GatewayResponse
-	return s.gatewayModelToAPI(gateway), nil
+	return s.gatewayModelToAPI(gateway)
 }
 
 // ListGateways retrieves all gateways with constitution-compliant envelope structure
@@ -633,7 +635,13 @@ func (s *GatewayService) ListGateways(orgID *string) (*api.GatewayListResponse, 
 	// Convert to API types
 	responses := make([]api.GatewayResponse, 0, len(gateways))
 	for _, gw := range gateways {
-		if resp := s.gatewayModelToAPI(gw); resp != nil {
+		resp, err := s.gatewayModelToAPI(gw)
+		if err != nil {
+			return nil, err
+		}
+		if resp != nil {
+			// updatedBy is detail-only; omit it from list responses.
+			resp.UpdatedBy = nil
 			responses = append(responses, *resp)
 		}
 	}
@@ -661,7 +669,7 @@ func (s *GatewayService) GetGateway(gatewayId, orgId string) (*api.GatewayRespon
 		return nil, errors.New("gateway not found")
 	}
 
-	return s.gatewayModelToAPI(gateway), nil
+	return s.gatewayModelToAPI(gateway)
 }
 
 // UpdateGateway updates gateway details
@@ -700,7 +708,7 @@ func (s *GatewayService) UpdateGateway(gatewayId, orgId, updatedBy string, req *
 		_ = s.auditRepo.Record("UPDATE", gateway.ID, "gateway", orgId, updatedBy)
 	}
 
-	return s.gatewayModelToAPI(gateway), nil
+	return s.gatewayModelToAPI(gateway)
 }
 
 // DeleteGateway deletes a gateway and all associated tokens (CASCADE)
@@ -1020,9 +1028,9 @@ func hashToken(plainToken string) string {
 // Mapping functions
 
 // gatewayModelToAPI converts a Gateway model to GatewayResponse API type
-func (s *GatewayService) gatewayModelToAPI(gateway *model.Gateway) *api.GatewayResponse {
+func (s *GatewayService) gatewayModelToAPI(gateway *model.Gateway) (*api.GatewayResponse, error) {
 	if gateway == nil {
-		return nil
+		return nil, nil
 	}
 
 	orgHandle := ""
@@ -1031,7 +1039,7 @@ func (s *GatewayService) gatewayModelToAPI(gateway *model.Gateway) *api.GatewayR
 	}
 	functionalityType := api.GatewayResponseFunctionalityType(gateway.FunctionalityType)
 
-	return &api.GatewayResponse{
+	resp := &api.GatewayResponse{
 		Id:                &gateway.Handle,
 		OrganizationId:    &orgHandle,
 		DisplayName:       gateway.Name,
@@ -1042,9 +1050,18 @@ func (s *GatewayService) gatewayModelToAPI(gateway *model.Gateway) *api.GatewayR
 		FunctionalityType: &functionalityType,
 		Version:           &gateway.Version,
 		IsActive:          &gateway.IsActive,
+		CreatedBy:         utils.StringPtrIfNotEmpty(gateway.CreatedBy),
+		UpdatedBy:         utils.StringPtrIfNotEmpty(gateway.UpdatedBy),
 		CreatedAt:         &gateway.CreatedAt,
 		UpdatedAt:         &gateway.UpdatedAt,
 	}
+	if err := s.identity.ResolveIdentityField(&resp.CreatedBy); err != nil {
+		return nil, err
+	}
+	if err := s.identity.ResolveIdentityField(&resp.UpdatedBy); err != nil {
+		return nil, err
+	}
+	return resp, nil
 }
 
 // gatewayStatusModelToAPI converts a Gateway model to GatewayStatusResponse API type

--- a/platform-api/src/internal/service/gateway_endpoints_test.go
+++ b/platform-api/src/internal/service/gateway_endpoints_test.go
@@ -43,6 +43,7 @@ func TestRegisterGatewayEndpoints(t *testing.T) {
 			gatewayRepo: repo,
 			orgRepo:     &mockOrganizationRepository{org: &model.Organization{ID: orgID}},
 			auditRepo:   &noopAuditRepo{},
+			identity:    newTestIdentityService(),
 		}
 		return svc, repo
 	}
@@ -178,6 +179,7 @@ func TestUpdateGatewayEndpoints(t *testing.T) {
 			gatewayRepo: repo,
 			orgRepo:     &mockOrganizationRepository{org: &model.Organization{ID: orgID, Handle: "test-org"}},
 			auditRepo:   &noopAuditRepo{},
+			identity:    newTestIdentityService(),
 		}
 		return svc, repo
 	}

--- a/platform-api/src/internal/service/gateway_events.go
+++ b/platform-api/src/internal/service/gateway_events.go
@@ -85,15 +85,17 @@ const (
 // Publishing to the EventHub persists the event to the shared DB so any platform-api
 // replica can pick it up and deliver it to the gateway WebSocket it holds.
 type GatewayEventsService struct {
-	hub     eventhub.EventHub
-	slogger *slog.Logger
+	hub      eventhub.EventHub
+	identity *IdentityService
+	slogger  *slog.Logger
 }
 
 // NewGatewayEventsService creates a new gateway events service backed by the EventHub.
-func NewGatewayEventsService(hub eventhub.EventHub, slogger *slog.Logger) *GatewayEventsService {
+func NewGatewayEventsService(hub eventhub.EventHub, identity *IdentityService, slogger *slog.Logger) *GatewayEventsService {
 	return &GatewayEventsService{
-		hub:     hub,
-		slogger: slogger,
+		hub:      hub,
+		identity: identity,
+		slogger:  slogger,
 	}
 }
 
@@ -262,6 +264,14 @@ func (s *GatewayEventsService) broadcastEvent(gatewayID, eventType string, paylo
 // broadcastEventWithUserID serializes the payload into a GatewayEventDTO and publishes it
 // to the EventHub. The EventHub persists it to the shared DB; the EventDispatcher on
 // whichever replica holds the gateway WebSocket will pick it up and deliver it.
+//
+// userId is expected to be the internal UUID stored in the triggering audit column (or
+// empty when the event has no associated actor, e.g. system-triggered deployment events).
+// This is the single sink for every actor-bearing gateway event, so it is also the single
+// place the internal UUID is unwrapped to the raw external identity (constants.DeletedUser
+// if the UUID has no mapping) before the event leaves the process — the internal UUID must
+// never reach the data plane. An empty userId is left empty (no actor to resolve), not
+// turned into constants.DeletedUser.
 func (s *GatewayEventsService) broadcastEventWithUserID(gatewayID, userId, eventType string, payload interface{}) error {
 	correlationID := uuid.New().String()
 
@@ -276,12 +286,21 @@ func (s *GatewayEventsService) broadcastEventWithUserID(gatewayID, userId, event
 		}
 	}
 
+	resolvedUserId := userId
+	if userId != "" && s.identity != nil {
+		if resolved, err := s.identity.SubForUUID(userId); err != nil {
+			s.slogger.Error("Failed to resolve actor identity for gateway event", "eventType", eventType, "error", err)
+		} else {
+			resolvedUserId = resolved
+		}
+	}
+
 	eventDTO := dto.GatewayEventDTO{
 		Type:          eventType,
 		Payload:       payload,
 		Timestamp:     time.Now().Format(time.RFC3339),
 		CorrelationID: correlationID,
-		UserId:        userId,
+		UserId:        resolvedUserId,
 	}
 
 	eventJSON, err := json.Marshal(eventDTO)

--- a/platform-api/src/internal/service/gateway_properties_test.go
+++ b/platform-api/src/internal/service/gateway_properties_test.go
@@ -97,6 +97,7 @@ func TestRegisterGatewayProperties(t *testing.T) {
 		gatewayRepo: mockGatewayRepo,
 		orgRepo:     mockOrgRepo,
 		auditRepo:   &noopAuditRepo{},
+		identity:    newTestIdentityService(),
 	}
 
 	gatewayID := "prod-gateway-01"
@@ -157,6 +158,7 @@ func TestUpdateGatewayProperties(t *testing.T) {
 			gatewayRepo: mockGatewayRepo,
 			orgRepo:     &mockOrganizationRepository{org: &model.Organization{ID: orgID, Handle: "test-org"}},
 			auditRepo:   &noopAuditRepo{},
+			identity:    newTestIdentityService(),
 		}
 
 		newDescription := "New description"
@@ -196,6 +198,7 @@ func TestUpdateGatewayProperties(t *testing.T) {
 			gatewayRepo: mockGatewayRepo,
 			orgRepo:     &mockOrganizationRepository{org: &model.Organization{ID: orgID, Handle: "test-org"}},
 			auditRepo:   &noopAuditRepo{},
+			identity:    newTestIdentityService(),
 		}
 
 		newProperties := map[string]interface{}{

--- a/platform-api/src/internal/service/gateway_test.go
+++ b/platform-api/src/internal/service/gateway_test.go
@@ -24,7 +24,7 @@ import (
 
 // TestValidateGatewayInput tests input validation logic
 func TestValidateGatewayInput(t *testing.T) {
-	service := &GatewayService{}
+	service := &GatewayService{identity: newTestIdentityService()}
 
 	tests := []struct {
 		name              string

--- a/platform-api/src/internal/service/identity.go
+++ b/platform-api/src/internal/service/identity.go
@@ -1,0 +1,158 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package service
+
+import (
+	"net/http"
+
+	"platform-api/src/internal/constants"
+	"platform-api/src/internal/middleware"
+	"platform-api/src/internal/repository"
+	"platform-api/src/internal/utils"
+)
+
+// IdentityService resolves the internal platform UUID for the actor behind a
+// request, translating the identity-provider's resolved actor identifier
+// (the OIDC "sub" claim, falling back to the configured claim / user_id via
+// middleware.GetActorIdentityFromRequest) into our own stable UUID. This UUID
+// is what gets stored in audit columns
+// (created_by/updated_by/revoked_by/performed_by).
+//
+// The internal UUID never leaves the process: API responses and
+// external/data-plane consumers (e.g. gateway events) must resolve it back to
+// the raw identity via SubForUUID / SubsForUUIDs before it is emitted —
+// falling back to constants.DeletedUser when the UUID has no mapping.
+type IdentityService struct {
+	repo repository.UserIdentityMappingRepository
+}
+
+// NewIdentityService creates a new IdentityService.
+func NewIdentityService(repo repository.UserIdentityMappingRepository) *IdentityService {
+	return &IdentityService{repo: repo}
+}
+
+// ToInternalUUID maps a raw resolved actor identity (or header-supplied actor
+// id) to our internal platform UUID, creating the mapping on first use. An
+// empty identity returns an empty string and creates no row — see
+// InternalUserID for the anonymous-write path, which never fails.
+func (s *IdentityService) ToInternalUUID(identity string) (string, error) {
+	return s.repo.GetOrCreateUUID(identity)
+}
+
+// InternalUserID resolves the internal platform UUID for the actor making the
+// given request, preferring the token's "sub" claim and falling back through
+// the configured claim / user_id. When the request carries no resolvable
+// identity, a fresh standalone UUID is minted so the write never fails; no
+// mapping row is created for it, so it reads back as constants.DeletedUser
+// (see SubForUUID) — it can never be confused with a real user.
+func (s *IdentityService) InternalUserID(r *http.Request) (string, error) {
+	identity, ok := middleware.GetActorIdentityFromRequest(r)
+	if !ok || identity == "" {
+		return utils.GenerateUUID()
+	}
+	return s.ToInternalUUID(identity)
+}
+
+// SubForUUID resolves an internal UUID stored in an audit column back to the
+// raw identity that should be shown to external consumers (API responses,
+// gateway events), or constants.DeletedUser if uuid has no mapping (an
+// anonymous write, or a user whose mapping was removed).
+func (s *IdentityService) SubForUUID(uuid string) (string, error) {
+	if uuid == "" {
+		return constants.DeletedUser, nil
+	}
+	identity, found, err := s.repo.GetSubByUUID(uuid)
+	if err != nil {
+		return "", err
+	}
+	if !found || identity == "" {
+		return constants.DeletedUser, nil
+	}
+	return identity, nil
+}
+
+// SubsForUUIDs batch-resolves multiple UUIDs (e.g. across a list response) to
+// their raw identity in a single lookup, avoiding N+1 queries. Every non-empty
+// input UUID is present in the result, resolving to constants.DeletedUser if
+// it has no mapping.
+func (s *IdentityService) SubsForUUIDs(uuids []string) (map[string]string, error) {
+	resolved, err := s.repo.GetSubsByUUIDs(uuids)
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string]string, len(uuids))
+	for _, id := range uuids {
+		if id == "" {
+			continue
+		}
+		if identity, ok := resolved[id]; ok && identity != "" {
+			result[id] = identity
+		} else {
+			result[id] = constants.DeletedUser
+		}
+	}
+	return result, nil
+}
+
+// ResolveIdentityField replaces the UUID held in *field (a generated API
+// response's createdBy/updatedBy/revokedBy/performedBy pointer, which holds
+// our internal UUID immediately after a model→API mapper runs) with the raw
+// external identity, in place. No-op if field is nil or points to nil/empty.
+//
+// This is the single place a detail response's audit-identity field is
+// unwrapped before being returned to the caller — see ResolveIdentityFields
+// for the batch/list equivalent.
+func (s *IdentityService) ResolveIdentityField(field **string) error {
+	if field == nil || *field == nil || **field == "" {
+		return nil
+	}
+	resolved, err := s.SubForUUID(**field)
+	if err != nil {
+		return err
+	}
+	*field = &resolved
+	return nil
+}
+
+// ResolveIdentityFields batch-resolves multiple createdBy/updatedBy-style
+// pointer fields (e.g. across every record in a list response) in a single
+// lookup, avoiding N+1 queries. Each entry is a pointer to a *string field
+// (e.g. &resp.CreatedBy); nil entries, and fields that are nil or empty, are
+// skipped.
+func (s *IdentityService) ResolveIdentityFields(fields []**string) error {
+	uuids := make([]string, 0, len(fields))
+	for _, f := range fields {
+		if f != nil && *f != nil && **f != "" {
+			uuids = append(uuids, **f)
+		}
+	}
+	resolved, err := s.SubsForUUIDs(uuids)
+	if err != nil {
+		return err
+	}
+	for _, f := range fields {
+		if f == nil || *f == nil || **f == "" {
+			continue
+		}
+		if identity, ok := resolved[**f]; ok {
+			v := identity
+			*f = &v
+		}
+	}
+	return nil
+}

--- a/platform-api/src/internal/service/identity_test_helpers_test.go
+++ b/platform-api/src/internal/service/identity_test_helpers_test.go
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package service
+
+// passthroughIdentityRepo is a repository.UserIdentityMappingRepository test
+// double that returns the input identity unchanged (no real
+// user_idp_references table). It lets unit tests that assert exact
+// createdBy/updatedBy values (e.g. "alice") keep passing without needing a
+// real DB-backed mapping.
+type passthroughIdentityRepo struct{}
+
+func (passthroughIdentityRepo) GetOrCreateUUID(identity string) (string, error) {
+	return identity, nil
+}
+
+func (passthroughIdentityRepo) GetSubByUUID(uuid string) (string, bool, error) {
+	if uuid == "" {
+		return "", false, nil
+	}
+	return uuid, true, nil
+}
+
+func (passthroughIdentityRepo) GetSubsByUUIDs(uuids []string) (map[string]string, error) {
+	result := make(map[string]string, len(uuids))
+	for _, id := range uuids {
+		if id != "" {
+			result[id] = id
+		}
+	}
+	return result, nil
+}
+
+// newTestIdentityService returns an *IdentityService backed by
+// passthroughIdentityRepo, for unit tests that need to satisfy the
+// IdentityService constructor param without a real database.
+func newTestIdentityService() *IdentityService {
+	return NewIdentityService(passthroughIdentityRepo{})
+}

--- a/platform-api/src/internal/service/llm.go
+++ b/platform-api/src/internal/service/llm.go
@@ -44,6 +44,7 @@ const (
 type LLMProviderTemplateService struct {
 	repo      repository.LLMProviderTemplateRepository
 	auditRepo repository.AuditRepository
+	identity  *IdentityService
 }
 
 type LLMProviderService struct {
@@ -58,6 +59,7 @@ type LLMProviderService struct {
 	slogger              *slog.Logger
 	auditRepo            repository.AuditRepository
 	cfg                  *config.Server
+	identity             *IdentityService
 }
 
 type LLMProxyService struct {
@@ -70,10 +72,37 @@ type LLMProxyService struct {
 	slogger              *slog.Logger
 	auditRepo            repository.AuditRepository
 	cfg                  *config.Server
+	identity             *IdentityService
 }
 
-func NewLLMProviderTemplateService(repo repository.LLMProviderTemplateRepository, auditRepo repository.AuditRepository) *LLMProviderTemplateService {
-	return &LLMProviderTemplateService{repo: repo, auditRepo: auditRepo}
+func NewLLMProviderTemplateService(repo repository.LLMProviderTemplateRepository, auditRepo repository.AuditRepository, identity *IdentityService) *LLMProviderTemplateService {
+	return &LLMProviderTemplateService{repo: repo, auditRepo: auditRepo, identity: identity}
+}
+
+// toTemplateAPI converts m via mapTemplateModelToAPI and resolves its
+// createdBy/updatedBy UUIDs to their raw external identity.
+func (s *LLMProviderTemplateService) toTemplateAPI(m *model.LLMProviderTemplate) (*api.LLMProviderTemplate, error) {
+	resp := mapTemplateModelToAPI(m)
+	if resp == nil {
+		return nil, nil
+	}
+	if err := s.identity.ResolveIdentityField(&resp.CreatedBy); err != nil {
+		return nil, err
+	}
+	if err := s.identity.ResolveIdentityField(&resp.UpdatedBy); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// templateListItemResolved converts t via templateListItem and resolves its
+// createdBy UUID to its raw external identity.
+func (s *LLMProviderTemplateService) templateListItemResolved(t *model.LLMProviderTemplate) (api.LLMProviderTemplateListItem, error) {
+	item := templateListItem(t)
+	if err := s.identity.ResolveIdentityField(&item.CreatedBy); err != nil {
+		return item, err
+	}
+	return item, nil
 }
 
 func NewLLMProviderService(
@@ -87,6 +116,7 @@ func NewLLMProviderService(
 	slogger *slog.Logger,
 	auditRepo repository.AuditRepository,
 	cfg *config.Server,
+	identity *IdentityService,
 ) *LLMProviderService {
 	return &LLMProviderService{
 		repo:                 repo,
@@ -99,6 +129,7 @@ func NewLLMProviderService(
 		slogger:              slogger,
 		auditRepo:            auditRepo,
 		cfg:                  cfg,
+		identity:             identity,
 	}
 }
 
@@ -106,6 +137,22 @@ func NewLLMProviderService(
 // Called after both services are constructed to avoid circular dependency.
 func (s *LLMProviderService) SetSecretService(ss *SecretService) {
 	s.secretService = ss
+}
+
+// toProviderAPI converts m via mapProviderModelToAPI and resolves its
+// createdBy/updatedBy UUIDs to their raw external identity.
+func (s *LLMProviderService) toProviderAPI(m *model.LLMProvider, templateHandle string) (*api.LLMProvider, error) {
+	resp := mapProviderModelToAPI(m, templateHandle)
+	if resp == nil {
+		return nil, nil
+	}
+	if err := s.identity.ResolveIdentityField(&resp.CreatedBy); err != nil {
+		return nil, err
+	}
+	if err := s.identity.ResolveIdentityField(&resp.UpdatedBy); err != nil {
+		return nil, err
+	}
+	return resp, nil
 }
 
 func NewLLMProxyService(
@@ -118,6 +165,7 @@ func NewLLMProxyService(
 	slogger *slog.Logger,
 	auditRepo repository.AuditRepository,
 	cfg *config.Server,
+	identity *IdentityService,
 ) *LLMProxyService {
 	return &LLMProxyService{
 		repo:                 repo,
@@ -129,7 +177,24 @@ func NewLLMProxyService(
 		slogger:              slogger,
 		auditRepo:            auditRepo,
 		cfg:                  cfg,
+		identity:             identity,
 	}
+}
+
+// toProxyAPI converts m via mapProxyModelToAPI and resolves its
+// createdBy/updatedBy UUIDs to their raw external identity.
+func (s *LLMProxyService) toProxyAPI(m *model.LLMProxy) (*api.LLMProxy, error) {
+	resp := mapProxyModelToAPI(m)
+	if resp == nil {
+		return nil, nil
+	}
+	if err := s.identity.ResolveIdentityField(&resp.CreatedBy); err != nil {
+		return nil, err
+	}
+	if err := s.identity.ResolveIdentityField(&resp.UpdatedBy); err != nil {
+		return nil, err
+	}
+	return resp, nil
 }
 
 func (s *LLMProviderTemplateService) Create(orgUUID, createdBy string, req *api.LLMProviderTemplate) (*api.LLMProviderTemplate, error) {
@@ -205,7 +270,7 @@ func (s *LLMProviderTemplateService) Create(orgUUID, createdBy string, req *api.
 
 	_ = s.auditRepo.Record("CREATE", m.UUID, "llm_provider_template", orgUUID, createdBy)
 
-	return mapTemplateModelToAPI(m), nil
+	return s.toTemplateAPI(m)
 }
 
 func (s *LLMProviderTemplateService) List(orgUUID string, limit, offset int, latestOnly bool) (*api.LLMProviderTemplateListResponse, error) {
@@ -233,7 +298,11 @@ func (s *LLMProviderTemplateService) List(orgUUID string, limit, offset int, lat
 	}
 	resp.List = make([]api.LLMProviderTemplateListItem, 0, len(items))
 	for _, t := range items {
-		resp.List = append(resp.List, templateListItem(t))
+		item, err := s.templateListItemResolved(t)
+		if err != nil {
+			return nil, err
+		}
+		resp.List = append(resp.List, item)
 	}
 	return resp, nil
 }
@@ -249,7 +318,7 @@ func (s *LLMProviderTemplateService) Get(orgUUID, handle string) (*api.LLMProvid
 	if m == nil {
 		return nil, constants.ErrLLMProviderTemplateNotFound
 	}
-	return mapTemplateModelToAPI(m), nil
+	return s.toTemplateAPI(m)
 }
 
 func (s *LLMProviderTemplateService) Update(orgUUID, handle, updatedBy string, req *api.LLMProviderTemplate) (*api.LLMProviderTemplate, error) {
@@ -351,7 +420,7 @@ func (s *LLMProviderTemplateService) Update(orgUUID, handle, updatedBy string, r
 
 	_ = s.auditRepo.Record("UPDATE", updated.UUID, "llm_provider_template", orgUUID, updatedBy)
 
-	return mapTemplateModelToAPI(updated), nil
+	return s.toTemplateAPI(updated)
 }
 
 // templateRuntimeArtifact is the subset of an LLM provider template that the gateway
@@ -475,7 +544,7 @@ func (s *LLMProviderTemplateService) CreateVersion(orgUUID, groupID, createdBy s
 		}
 	}
 
-	return mapTemplateModelToAPI(m), nil
+	return s.toTemplateAPI(m)
 }
 
 func (s *LLMProviderTemplateService) CopyVersion(orgUUID, fromTemplateID, toTemplateID, toVersion, createdBy string, req *api.CreateLLMProviderTemplateVersionRequest) (*api.LLMProviderTemplate, error) {
@@ -581,7 +650,11 @@ func (s *LLMProviderTemplateService) ListVersions(orgUUID, groupID string, limit
 	}
 	resp.List = make([]api.LLMProviderTemplateListItem, 0, len(items))
 	for _, t := range items {
-		resp.List = append(resp.List, templateListItem(t))
+		item, err := s.templateListItemResolved(t)
+		if err != nil {
+			return nil, err
+		}
+		resp.List = append(resp.List, item)
 	}
 	return resp, nil
 }
@@ -603,7 +676,7 @@ func (s *LLMProviderTemplateService) GetVersion(orgUUID, groupID, version string
 	if m == nil {
 		return nil, constants.ErrLLMProviderTemplateNotFound
 	}
-	return mapTemplateModelToAPI(m), nil
+	return s.toTemplateAPI(m)
 }
 
 func (s *LLMProviderTemplateService) SetVersionEnabled(orgUUID, groupID, version string, enabled bool) (*api.LLMProviderTemplate, error) {
@@ -654,7 +727,7 @@ func (s *LLMProviderTemplateService) SetVersionEnabled(orgUUID, groupID, version
 	if m == nil {
 		return nil, constants.ErrLLMProviderTemplateNotFound
 	}
-	return mapTemplateModelToAPI(m), nil
+	return s.toTemplateAPI(m)
 }
 
 func (s *LLMProviderTemplateService) DeleteVersion(orgUUID, groupID, version string) error {
@@ -874,7 +947,7 @@ func (s *LLMProviderService) Create(orgUUID, createdBy string, req *api.LLMProvi
 
 	_ = s.auditRepo.Record("CREATE", created.UUID, "llm_provider", orgUUID, createdBy)
 
-	return mapProviderModelToAPI(created, tpl.ID), nil
+	return s.toProviderAPI(created, tpl.ID)
 }
 
 func (s *LLMProviderService) List(orgUUID string, limit, offset int) (*api.LLMProviderListResponse, error) {
@@ -911,6 +984,9 @@ func (s *LLMProviderService) List(orgUUID string, limit, offset int) (*api.LLMPr
 		name := p.Name
 		desc := utils.StringPtrIfNotEmpty(p.Description)
 		createdBy := utils.StringPtrIfNotEmpty(p.CreatedBy)
+		if err := s.identity.ResolveIdentityField(&createdBy); err != nil {
+			return nil, err
+		}
 		version := p.Version
 		template := utils.StringPtrIfNotEmpty(tplHandle)
 		resp.List = append(resp.List, api.LLMProviderListItem{
@@ -950,7 +1026,7 @@ func (s *LLMProviderService) Get(orgUUID, handle string) (*api.LLMProvider, erro
 			tplHandle = tpl.ID
 		}
 	}
-	return mapProviderModelToAPI(m, tplHandle), nil
+	return s.toProviderAPI(m, tplHandle)
 }
 
 func (s *LLMProviderService) Update(orgUUID, handle, updatedBy string, req *api.LLMProvider) (*api.LLMProvider, error) {
@@ -1074,7 +1150,7 @@ func (s *LLMProviderService) Update(orgUUID, handle, updatedBy string, req *api.
 
 	_ = s.auditRepo.Record("UPDATE", updated.UUID, "llm_provider", orgUUID, updatedBy)
 
-	return mapProviderModelToAPI(updated, tpl.ID), nil
+	return s.toProviderAPI(updated, tpl.ID)
 }
 
 func (s *LLMProviderService) Delete(orgUUID, handle, deletedBy string) error {
@@ -1246,7 +1322,7 @@ func (s *LLMProxyService) Create(orgUUID, createdBy string, req *api.LLMProxy) (
 	if created == nil {
 		return nil, constants.ErrLLMProxyNotFound
 	}
-	return mapProxyModelToAPI(created), nil
+	return s.toProxyAPI(created)
 }
 
 func (s *LLMProxyService) List(orgUUID string, projectHandle *string, limit, offset int) (*api.LLMProxyListResponse, error) {
@@ -1298,6 +1374,9 @@ func (s *LLMProxyService) List(orgUUID string, projectHandle *string, limit, off
 		name := p.Name
 		desc := utils.StringPtrIfNotEmpty(p.Description)
 		createdBy := utils.StringPtrIfNotEmpty(p.CreatedBy)
+		if err := s.identity.ResolveIdentityField(&createdBy); err != nil {
+			return nil, err
+		}
 		contextValue := (*string)(nil)
 		if p.Configuration.Context != nil {
 			v := *p.Configuration.Context
@@ -1360,6 +1439,9 @@ func (s *LLMProxyService) ListByProvider(orgUUID, providerID string, limit, offs
 		name := p.Name
 		desc := utils.StringPtrIfNotEmpty(p.Description)
 		createdBy := utils.StringPtrIfNotEmpty(p.CreatedBy)
+		if err := s.identity.ResolveIdentityField(&createdBy); err != nil {
+			return nil, err
+		}
 		contextValue := (*string)(nil)
 		if p.Configuration.Context != nil {
 			v := *p.Configuration.Context
@@ -1396,7 +1478,7 @@ func (s *LLMProxyService) Get(orgUUID, handle string) (*api.LLMProxy, error) {
 	if m == nil {
 		return nil, constants.ErrLLMProxyNotFound
 	}
-	return mapProxyModelToAPI(m), nil
+	return s.toProxyAPI(m)
 }
 
 func (s *LLMProxyService) Update(orgUUID, handle, updatedBy string, req *api.LLMProxy) (*api.LLMProxy, error) {
@@ -1494,7 +1576,7 @@ func (s *LLMProxyService) Update(orgUUID, handle, updatedBy string, req *api.LLM
 		return nil, constants.ErrLLMProxyNotFound
 	}
 	_ = s.auditRepo.Record("UPDATE", existing.UUID, "llm_proxy", orgUUID, updatedBy)
-	return mapProxyModelToAPI(updated), nil
+	return s.toProxyAPI(updated)
 }
 
 func (s *LLMProxyService) Delete(orgUUID, handle, deletedBy string) error {
@@ -2464,6 +2546,7 @@ func mapProviderModelToAPI(m *model.LLMProvider, templateHandle string) *api.LLM
 		ReadOnly:          utils.BoolPtr(m.Origin == constants.OriginDP),
 		CreatedAt:         utils.TimePtr(m.CreatedAt),
 		UpdatedAt:         utils.TimePtr(m.UpdatedAt),
+		UpdatedBy:         utils.StringPtrIfNotEmpty(m.UpdatedBy),
 	}
 	if associated := mapAssociatedGatewaysModelToAPI(m.AssociatedGateways); associated != nil {
 		out.AssociatedGateways = associated
@@ -2814,6 +2897,7 @@ func mapProxyModelToAPI(m *model.LLMProxy) *api.LLMProxy {
 		ReadOnly:  utils.BoolPtr(m.Origin == constants.OriginDP),
 		CreatedAt: createdAt,
 		UpdatedAt: updatedAt,
+		UpdatedBy: utils.StringPtrIfNotEmpty(m.UpdatedBy),
 	}
 	if m.Configuration.UpstreamAuth != nil {
 		authType := (*api.UpstreamAuthType)(nil)

--- a/platform-api/src/internal/service/llm_apikey.go
+++ b/platform-api/src/internal/service/llm_apikey.go
@@ -37,6 +37,7 @@ type LLMProviderAPIKeyService struct {
 	gatewayRepo          repository.GatewayRepository
 	apiKeyRepo           repository.APIKeyRepository
 	gatewayEventsService *GatewayEventsService
+	identity             *IdentityService
 	slogger              *slog.Logger
 }
 
@@ -46,6 +47,7 @@ func NewLLMProviderAPIKeyService(
 	gatewayRepo repository.GatewayRepository,
 	apiKeyRepo repository.APIKeyRepository,
 	gatewayEventsService *GatewayEventsService,
+	identity *IdentityService,
 	slogger *slog.Logger,
 ) *LLMProviderAPIKeyService {
 	return &LLMProviderAPIKeyService{
@@ -53,6 +55,7 @@ func NewLLMProviderAPIKeyService(
 		gatewayRepo:          gatewayRepo,
 		apiKeyRepo:           apiKeyRepo,
 		gatewayEventsService: gatewayEventsService,
+		identity:             identity,
 		slogger:              slogger,
 	}
 }
@@ -83,13 +86,17 @@ func (s *LLMProviderAPIKeyService) ListLLMProviderAPIKeys(
 		if k.CreatedBy != userID {
 			continue
 		}
+		createdBy := utils.StringPtrIfNotEmpty(k.CreatedBy)
+		if err := s.identity.ResolveIdentityField(&createdBy); err != nil {
+			return nil, err
+		}
 		item := api.APIKeyItem{
 			Id:             &k.Name,
 			DisplayName:    k.DisplayName,
 			MaskedApiKey:   k.MaskedAPIKey,
 			Status:         api.APIKeyItemStatus(k.Status),
 			CreatedAt:      k.CreatedAt,
-			CreatedBy:      k.CreatedBy,
+			CreatedBy:      createdBy,
 			UpdatedAt:      k.UpdatedAt,
 			ExpiresAt:      k.ExpiresAt,
 			Issuer:         k.Issuer,

--- a/platform-api/src/internal/service/llm_provider_template_test.go
+++ b/platform-api/src/internal/service/llm_provider_template_test.go
@@ -183,7 +183,7 @@ func validTemplateRequest(name string) *api.LLMProviderTemplate {
 
 func TestLLMProviderTemplateServiceCreate_Success(t *testing.T) {
 	repo := &mockLLMProviderTemplateCRUDRepo{}
-	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{}, newTestIdentityService())
 
 	resp, err := svc.Create("org-1", "alice", validTemplateRequest("My Custom Provider"))
 	if err != nil {
@@ -202,7 +202,7 @@ func TestLLMProviderTemplateServiceCreate_Success(t *testing.T) {
 
 func TestLLMProviderTemplateServiceCreate_RejectsMissingEndpoint(t *testing.T) {
 	repo := &mockLLMProviderTemplateCRUDRepo{}
-	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{}, newTestIdentityService())
 
 	// No metadata at all.
 	req := &api.LLMProviderTemplate{DisplayName: "No Endpoint", Version: "v1.0"}
@@ -227,7 +227,7 @@ func TestLLMProviderTemplateServiceCreate_RejectsMissingEndpoint(t *testing.T) {
 
 func TestLLMProviderTemplateServiceCreate_RejectsEmptyName(t *testing.T) {
 	repo := &mockLLMProviderTemplateCRUDRepo{}
-	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{}, newTestIdentityService())
 
 	req := validTemplateRequest("")
 	_, err := svc.Create("org-1", "alice", req)
@@ -241,7 +241,7 @@ func TestLLMProviderTemplateServiceCreate_RejectsEmptyName(t *testing.T) {
 
 func TestLLMProviderTemplateServiceCreate_RejectsInvalidVersion(t *testing.T) {
 	repo := &mockLLMProviderTemplateCRUDRepo{}
-	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{}, newTestIdentityService())
 
 	req := validTemplateRequest("My Provider")
 	req.Version = "not-a-version"
@@ -256,7 +256,7 @@ func TestLLMProviderTemplateServiceCreate_RejectsInvalidVersion(t *testing.T) {
 
 func TestLLMProviderTemplateServiceCreate_RejectsReservedManagedBy(t *testing.T) {
 	repo := &mockLLMProviderTemplateCRUDRepo{}
-	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{}, newTestIdentityService())
 
 	wso2 := "wso2"
 	req := validTemplateRequest("My Provider")
@@ -272,7 +272,7 @@ func TestLLMProviderTemplateServiceCreate_RejectsReservedManagedBy(t *testing.T)
 
 func TestLLMProviderTemplateServiceCreate_ReturnsConflictForDuplicateHandle(t *testing.T) {
 	repo := &mockLLMProviderTemplateCRUDRepo{existsResult: true}
-	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{}, newTestIdentityService())
 
 	_, err := svc.Create("org-1", "alice", validTemplateRequest("My Provider"))
 	if !errors.Is(err, constants.ErrLLMProviderTemplateExists) {
@@ -287,7 +287,7 @@ func TestLLMProviderTemplateServiceCreate_ReturnsConflictForDuplicateHandle(t *t
 
 func TestLLMProviderTemplateServiceUpdate_RejectsReservedManagedBy(t *testing.T) {
 	repo := &mockLLMProviderTemplateCRUDRepo{}
-	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{}, newTestIdentityService())
 
 	wso2 := "wso2"
 	req := validTemplateRequest("My Provider")
@@ -306,7 +306,7 @@ func TestLLMProviderTemplateServiceUpdate_RejectsReadOnlyBuiltin(t *testing.T) {
 	repo.getByIDFunc = func(templateID, orgUUID string) (*model.LLMProviderTemplate, error) {
 		return &model.LLMProviderTemplate{ID: templateID, OrganizationUUID: orgUUID, ManagedBy: "wso2"}, nil
 	}
-	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{}, newTestIdentityService())
 
 	_, err := svc.Update("org-1", "openai", "alice", validTemplateRequest("OpenAI"))
 	if !errors.Is(err, constants.ErrLLMProviderTemplateReadOnly) {
@@ -319,7 +319,7 @@ func TestLLMProviderTemplateServiceUpdate_RejectsReadOnlyBuiltin(t *testing.T) {
 
 func TestLLMProviderTemplateServiceUpdate_ReturnsNotFoundWhenTemplateMissing(t *testing.T) {
 	repo := &mockLLMProviderTemplateCRUDRepo{}
-	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{}, newTestIdentityService())
 
 	_, err := svc.Update("org-1", "does-not-exist", "alice", validTemplateRequest("Name"))
 	if !errors.Is(err, constants.ErrLLMProviderTemplateNotFound) {
@@ -338,7 +338,7 @@ func TestLLMProviderTemplateServiceUpdate_PreservesOpenAPISpecWhenOmitted(t *tes
 			Version:          "v1.0",
 		}, nil
 	}
-	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{}, newTestIdentityService())
 
 	req := validTemplateRequest("Renamed")
 	req.Openapi = nil
@@ -362,7 +362,7 @@ func TestLLMProviderTemplateServiceUpdate_PropagatesNameToFamily(t *testing.T) {
 	repo.getByIDFunc = func(templateID, orgUUID string) (*model.LLMProviderTemplate, error) {
 		return &model.LLMProviderTemplate{ID: templateID, OrganizationUUID: orgUUID, Name: "Mistral Updated", Version: "v1.0"}, nil
 	}
-	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{}, newTestIdentityService())
 
 	req := validTemplateRequest("Mistral Updated")
 	resp, err := svc.Update("org-1", "mistralai", "alice", req)
@@ -380,7 +380,7 @@ func TestLLMProviderTemplateServiceUpdate_PropagatesNameToFamily(t *testing.T) {
 
 func TestLLMProviderTemplateServiceUpdate_RejectsMismatchedID(t *testing.T) {
 	repo := &mockLLMProviderTemplateCRUDRepo{managedByForHandleResult: "customer"}
-	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{}, newTestIdentityService())
 
 	req := validTemplateRequest("Name")
 	otherHandle := "some-other-handle"
@@ -395,7 +395,7 @@ func TestLLMProviderTemplateServiceUpdate_RejectsMismatchedID(t *testing.T) {
 
 func TestLLMProviderTemplateServiceCreateVersion_Success(t *testing.T) {
 	repo := &mockLLMProviderTemplateCRUDRepo{countVersionsResult: 1}
-	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{}, newTestIdentityService())
 
 	req := &api.CreateLLMProviderTemplateVersionRequest{DisplayName: stringPtr("Mistral"), Version: "v2.0"}
 	resp, err := svc.CreateVersion("org-1", "mistralai", "test-user", req)
@@ -415,7 +415,7 @@ func TestLLMProviderTemplateServiceCreateVersion_Success(t *testing.T) {
 
 func TestLLMProviderTemplateServiceCreateVersion_ForkFromBuiltinSetsCustomerManagedBy(t *testing.T) {
 	repo := &mockLLMProviderTemplateCRUDRepo{countVersionsResult: 1}
-	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{}, newTestIdentityService())
 
 	wso2 := "wso2"
 	req := &api.CreateLLMProviderTemplateVersionRequest{DisplayName: stringPtr("Mistral"), Version: "v2.0", ManagedBy: &wso2}
@@ -436,7 +436,7 @@ func TestLLMProviderTemplateServiceCreateVersion_ForkFromBuiltinSetsCustomerMana
 
 func TestLLMProviderTemplateServiceCreateVersion_NotFoundWhenFamilyMissing(t *testing.T) {
 	repo := &mockLLMProviderTemplateCRUDRepo{countVersionsResult: 0}
-	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{}, newTestIdentityService())
 
 	req := &api.CreateLLMProviderTemplateVersionRequest{DisplayName: stringPtr("Mistral"), Version: "v2.0"}
 	_, err := svc.CreateVersion("org-1", "does-not-exist", "test-user", req)
@@ -450,7 +450,7 @@ func TestLLMProviderTemplateServiceCreateVersion_ConflictWhenVersionExists(t *te
 		countVersionsResult: 1,
 		createNewVersionErr: constants.ErrLLMProviderTemplateVersionExists,
 	}
-	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{}, newTestIdentityService())
 
 	req := &api.CreateLLMProviderTemplateVersionRequest{DisplayName: stringPtr("Mistral"), Version: "v1.0"}
 	_, err := svc.CreateVersion("org-1", "mistralai", "test-user", req)
@@ -461,7 +461,7 @@ func TestLLMProviderTemplateServiceCreateVersion_ConflictWhenVersionExists(t *te
 
 func TestLLMProviderTemplateServiceCreateVersion_RejectsInvalidVersionFormat(t *testing.T) {
 	repo := &mockLLMProviderTemplateCRUDRepo{countVersionsResult: 1}
-	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{}, newTestIdentityService())
 
 	req := &api.CreateLLMProviderTemplateVersionRequest{DisplayName: stringPtr("Mistral"), Version: "2.0"}
 	_, err := svc.CreateVersion("org-1", "mistralai", "test-user", req)
@@ -475,7 +475,7 @@ func TestLLMProviderTemplateServiceCreateVersion_RejectsInvalidVersionFormat(t *
 
 func TestLLMProviderTemplateServiceCreateVersion_RejectsV0(t *testing.T) {
 	repo := &mockLLMProviderTemplateCRUDRepo{countVersionsResult: 1}
-	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{}, newTestIdentityService())
 
 	// Versions start at v1.0; v0.x is not creatable.
 	req := &api.CreateLLMProviderTemplateVersionRequest{DisplayName: stringPtr("Mistral"), Version: "v0.0"}
@@ -504,7 +504,7 @@ func TestLLMProviderTemplateServiceCopyVersion_ClonesSourceAndOverrides(t *testi
 			OpenAPISpec: "openapi: 3.0.0",
 		}, nil
 	}
-	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{}, newTestIdentityService())
 
 	newDesc := "copied for v2"
 	overrides := &api.CreateLLMProviderTemplateVersionRequest{Description: &newDesc}
@@ -535,7 +535,7 @@ func TestLLMProviderTemplateServiceCopyVersion_NotFoundWhenSourceMissing(t *test
 	repo.getByIDFunc = func(templateID, orgUUID string) (*model.LLMProviderTemplate, error) {
 		return nil, nil
 	}
-	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{}, newTestIdentityService())
 
 	_, err := svc.CopyVersion("org-1", "nope-v1-0", "nope-v2-0", "v2.0", "test-user", nil)
 	if !errors.Is(err, constants.ErrLLMProviderTemplateNotFound) {
@@ -548,7 +548,7 @@ func TestLLMProviderTemplateServiceCopyVersion_RejectsMismatchedToTemplateID(t *
 	repo.getByIDFunc = func(templateID, orgUUID string) (*model.LLMProviderTemplate, error) {
 		return &model.LLMProviderTemplate{ID: "mistralai-v1-0", GroupID: "mistralai", Name: "Mistral", Version: "v1.0"}, nil
 	}
-	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{}, newTestIdentityService())
 
 	_, err := svc.CopyVersion("org-1", "mistralai-v1-0", "other-family-v2-0", "v2.0", "test-user", nil)
 	if !errors.Is(err, constants.ErrInvalidInput) {
@@ -563,7 +563,7 @@ func TestLLMProviderTemplateServiceCopyVersion_RejectsMismatchedToTemplateID(t *
 
 func TestLLMProviderTemplateServiceListVersions_NotFoundWhenNoVersions(t *testing.T) {
 	repo := &mockLLMProviderTemplateCRUDRepo{countVersionsResult: 0}
-	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{}, newTestIdentityService())
 
 	_, err := svc.ListVersions("org-1", "does-not-exist", 10, 0)
 	if !errors.Is(err, constants.ErrLLMProviderTemplateNotFound) {
@@ -579,7 +579,7 @@ func TestLLMProviderTemplateServiceListVersions_Success(t *testing.T) {
 			{ID: "mistralai-v2-0", Version: "v2.0"},
 		},
 	}
-	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{}, newTestIdentityService())
 
 	resp, err := svc.ListVersions("org-1", "mistralai", 10, 0)
 	if err != nil {
@@ -596,7 +596,7 @@ func TestLLMProviderTemplateServiceGetVersion_NotFound(t *testing.T) {
 			return nil, nil
 		},
 	}
-	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{}, newTestIdentityService())
 
 	_, err := svc.GetVersion("org-1", "mistralai", "v9.0")
 	if !errors.Is(err, constants.ErrLLMProviderTemplateNotFound) {
@@ -612,7 +612,7 @@ func TestLLMProviderTemplateServiceGetVersion_NormalizesVersionCasing(t *testing
 			return &model.LLMProviderTemplate{ID: templateID, Version: version}, nil
 		},
 	}
-	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{}, newTestIdentityService())
 
 	resp, err := svc.GetVersion("org-1", "mistralai", "V2.0")
 	if err != nil {
@@ -634,7 +634,7 @@ func TestLLMProviderTemplateServiceSetVersionEnabled_Success(t *testing.T) {
 			return &model.LLMProviderTemplate{ID: templateID, Version: version, ManagedBy: "wso2", Enabled: false}, nil
 		},
 	}
-	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{}, newTestIdentityService())
 
 	resp, err := svc.SetVersionEnabled("org-1", "openai", "v1.0", false)
 	if err != nil {
@@ -650,7 +650,7 @@ func TestLLMProviderTemplateServiceSetVersionEnabled_Success(t *testing.T) {
 
 func TestLLMProviderTemplateServiceSetVersionEnabled_NotFound(t *testing.T) {
 	repo := &mockLLMProviderTemplateCRUDRepo{setEnabledErr: sql.ErrNoRows}
-	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{}, newTestIdentityService())
 
 	_, err := svc.SetVersionEnabled("org-1", "does-not-exist", "v1.0", true)
 	if !errors.Is(err, constants.ErrLLMProviderTemplateNotFound) {
@@ -665,7 +665,7 @@ func TestLLMProviderTemplateServiceSetVersionEnabled_DisableBlocksWhenInUse(t *t
 			return &model.LLMProviderTemplate{ID: templateID, Version: version, ManagedBy: "wso2"}, nil
 		},
 	}
-	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{}, newTestIdentityService())
 
 	_, err := svc.SetVersionEnabled("org-1", "openai", "v1.0", false)
 	if !errors.Is(err, constants.ErrLLMProviderTemplateInUse) {
@@ -686,7 +686,7 @@ func TestLLMProviderTemplateServiceSetVersionEnabled_EnableIgnoresUsage(t *testi
 			return &model.LLMProviderTemplate{ID: templateID, Version: version, ManagedBy: "wso2", Enabled: true}, nil
 		},
 	}
-	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{}, newTestIdentityService())
 
 	resp, err := svc.SetVersionEnabled("org-1", "openai", "v1.0", true)
 	if err != nil {
@@ -706,7 +706,7 @@ func TestLLMProviderTemplateServiceSetVersionEnabled_RejectsCustomTemplate(t *te
 			return &model.LLMProviderTemplate{ID: templateID, Version: version, ManagedBy: "customer"}, nil
 		},
 	}
-	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{}, newTestIdentityService())
 
 	// Enable/disable is reserved for built-in ('wso2') templates; a custom
 	// ('customer') template must be rejected and never touch SetEnabled.
@@ -727,7 +727,7 @@ func TestLLMProviderTemplateServiceDeleteVersion_NotFoundWhenVersionMissing(t *t
 			return nil, nil
 		},
 	}
-	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{}, newTestIdentityService())
 
 	err := svc.DeleteVersion("org-1", "mistralai", "v9.0")
 	if !errors.Is(err, constants.ErrLLMProviderTemplateNotFound) {
@@ -741,7 +741,7 @@ func TestLLMProviderTemplateServiceDeleteVersion_BlocksReadOnlyBuiltin(t *testin
 			return &model.LLMProviderTemplate{ID: templateID, Version: version, ManagedBy: "wso2"}, nil
 		},
 	}
-	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{}, newTestIdentityService())
 
 	err := svc.DeleteVersion("org-1", "openai", "v1.0")
 	if !errors.Is(err, constants.ErrLLMProviderTemplateReadOnly) {
@@ -759,7 +759,7 @@ func TestLLMProviderTemplateServiceDeleteVersion_BlocksWhenInUse(t *testing.T) {
 		},
 		countProvidersUsingTemplateResult: 1,
 	}
-	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{}, newTestIdentityService())
 
 	err := svc.DeleteVersion("org-1", "mistralai-v2-0", "v2.0")
 	if !errors.Is(err, constants.ErrLLMProviderTemplateInUse) {
@@ -780,7 +780,7 @@ func TestLLMProviderTemplateServiceDeleteVersion_Success(t *testing.T) {
 		},
 		countProvidersUsingTemplateResult: 0,
 	}
-	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{})
+	svc := NewLLMProviderTemplateService(repo, &noopAuditRepo{}, newTestIdentityService())
 
 	if err := svc.DeleteVersion("org-1", "mistralai-v2-0", "v2.0"); err != nil {
 		t.Fatalf("expected no error, got: %v", err)

--- a/platform-api/src/internal/service/llm_proxy_apikey.go
+++ b/platform-api/src/internal/service/llm_proxy_apikey.go
@@ -37,6 +37,7 @@ type LLMProxyAPIKeyService struct {
 	gatewayRepo          repository.GatewayRepository
 	apiKeyRepo           repository.APIKeyRepository
 	gatewayEventsService *GatewayEventsService
+	identity             *IdentityService
 	slogger              *slog.Logger
 }
 
@@ -46,6 +47,7 @@ func NewLLMProxyAPIKeyService(
 	gatewayRepo repository.GatewayRepository,
 	apiKeyRepo repository.APIKeyRepository,
 	gatewayEventsService *GatewayEventsService,
+	identity *IdentityService,
 	slogger *slog.Logger,
 ) *LLMProxyAPIKeyService {
 	return &LLMProxyAPIKeyService{
@@ -53,6 +55,7 @@ func NewLLMProxyAPIKeyService(
 		gatewayRepo:          gatewayRepo,
 		apiKeyRepo:           apiKeyRepo,
 		gatewayEventsService: gatewayEventsService,
+		identity:             identity,
 		slogger:              slogger,
 	}
 }
@@ -83,13 +86,17 @@ func (s *LLMProxyAPIKeyService) ListLLMProxyAPIKeys(
 		if k.CreatedBy != userID {
 			continue
 		}
+		createdBy := utils.StringPtrIfNotEmpty(k.CreatedBy)
+		if err := s.identity.ResolveIdentityField(&createdBy); err != nil {
+			return nil, err
+		}
 		item := api.APIKeyItem{
 			Id:             &k.Name,
 			DisplayName:    k.DisplayName,
 			MaskedApiKey:   k.MaskedAPIKey,
 			Status:         api.APIKeyItemStatus(k.Status),
 			CreatedAt:      k.CreatedAt,
-			CreatedBy:      k.CreatedBy,
+			CreatedBy:      createdBy,
 			UpdatedAt:      k.UpdatedAt,
 			ExpiresAt:      k.ExpiresAt,
 			Issuer:         k.Issuer,

--- a/platform-api/src/internal/service/llm_secret_validation_test.go
+++ b/platform-api/src/internal/service/llm_secret_validation_test.go
@@ -79,7 +79,7 @@ func setupLLMSecretTestEnv(t *testing.T, orgID string) (*SecretService, func()) 
 	}
 
 	secretRepo := repository.NewSecretRepo(db)
-	secretSvc := NewSecretService(secretRepo, v)
+	secretSvc := NewSecretService(secretRepo, v, NewIdentityService(repository.NewUserIdentityMappingRepo(db)))
 
 	cleanup := func() { sqlDB.Close() }
 	return secretSvc, cleanup

--- a/platform-api/src/internal/service/llm_test.go
+++ b/platform-api/src/internal/service/llm_test.go
@@ -1107,7 +1107,7 @@ func TestLLMProviderServiceCreateRejectsMultipleModelProvidersForNativeTemplate(
 			return &model.LLMProviderTemplate{UUID: "tpl-openai", ID: "openai", CreatedAt: now, UpdatedAt: now}, nil
 		},
 	}
-	service := NewLLMProviderService(providerRepo, templateRepo, nil, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{})
+	service := NewLLMProviderService(providerRepo, templateRepo, nil, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{}, newTestIdentityService())
 
 	request := validProviderRequest("openai")
 	request.ModelProviders = &[]api.LLMModelProvider{
@@ -1143,7 +1143,7 @@ func TestLLMProviderServiceCreateAllowsAggregatorTemplate(t *testing.T) {
 		},
 	}
 	orgRepo := &mockOrganizationRepo{org: &model.Organization{ID: "org-1"}}
-	service := NewLLMProviderService(providerRepo, templateRepo, orgRepo, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{})
+	service := NewLLMProviderService(providerRepo, templateRepo, orgRepo, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{}, newTestIdentityService())
 
 	request := validProviderRequest("awsbedrock")
 	request.ModelProviders = &[]api.LLMModelProvider{
@@ -1186,7 +1186,7 @@ func TestLLMProviderServiceCreateMigratesLegacyPolicies(t *testing.T) {
 		},
 	}
 	orgRepo := &mockOrganizationRepo{org: &model.Organization{ID: "org-1"}}
-	service := NewLLMProviderService(providerRepo, templateRepo, orgRepo, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{})
+	service := NewLLMProviderService(providerRepo, templateRepo, orgRepo, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{}, newTestIdentityService())
 
 	request := validProviderRequest("openai")
 	request.Policies = &[]api.LLMPolicy{
@@ -1246,7 +1246,7 @@ func TestLLMProviderServiceCreateReturnsConflictForDuplicateHandle(t *testing.T)
 			return &model.LLMProviderTemplate{UUID: "tpl-openai", ID: "openai"}, nil
 		},
 	}
-	service := NewLLMProviderService(providerRepo, templateRepo, nil, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{})
+	service := NewLLMProviderService(providerRepo, templateRepo, nil, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{}, newTestIdentityService())
 
 	_, err := service.Create("org-1", "alice", validProviderRequest("openai"))
 	if err != constants.ErrLLMProviderExists {
@@ -1288,7 +1288,7 @@ func TestLLMProviderServiceUpdatePreservesUpstreamAuthValue(t *testing.T) {
 			return &model.LLMProviderTemplate{UUID: "tpl-openai", ID: "openai"}, nil
 		},
 	}
-	service := NewLLMProviderService(providerRepo, templateRepo, nil, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{})
+	service := NewLLMProviderService(providerRepo, templateRepo, nil, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{}, newTestIdentityService())
 
 	request := validProviderRequest("openai")
 	request.DisplayName = "Updated Provider"
@@ -1318,7 +1318,7 @@ func TestLLMProxyServiceCreateFailsWhenProviderNotFound(t *testing.T) {
 		},
 	}
 	projectRepo := &mockProjectRepo{project: &model.Project{ID: "project-1", OrganizationID: "org-1"}}
-	service := NewLLMProxyService(proxyRepo, providerRepo, projectRepo, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{})
+	service := NewLLMProxyService(proxyRepo, providerRepo, projectRepo, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{}, newTestIdentityService())
 
 	_, err := service.Create("org-1", "alice", validProxyRequest("provider-1", "project-1"))
 	if err != constants.ErrLLMProviderNotFound {
@@ -1333,7 +1333,7 @@ func TestLLMProxyServiceCreateReturnsConflictForDuplicateHandle(t *testing.T) {
 			return &model.LLMProvider{UUID: "provider-uuid", ID: providerID}, nil
 		},
 	}
-	service := NewLLMProxyService(proxyRepo, providerRepo, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{})
+	service := NewLLMProxyService(proxyRepo, providerRepo, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{}, newTestIdentityService())
 
 	_, err := service.Create("org-1", "alice", validProxyRequest("provider-1", "project-1"))
 	if err != constants.ErrLLMProxyExists {
@@ -1364,7 +1364,7 @@ func TestLLMProxyServiceListByProviderUsesProviderUUID(t *testing.T) {
 			return &model.LLMProvider{UUID: "provider-uuid", ID: providerID}, nil
 		},
 	}
-	service := NewLLMProxyService(proxyRepo, providerRepo, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{})
+	service := NewLLMProxyService(proxyRepo, providerRepo, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{}, newTestIdentityService())
 
 	resp, err := service.ListByProvider("org-1", "provider-1", 10, 0)
 	if err != nil {
@@ -1409,7 +1409,7 @@ func TestLLMProxyServiceUpdatePreservesProviderAuthValue(t *testing.T) {
 			return &model.LLMProvider{UUID: "provider-uuid", ID: providerID}, nil
 		},
 	}
-	service := NewLLMProxyService(proxyRepo, providerRepo, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{})
+	service := NewLLMProxyService(proxyRepo, providerRepo, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{}, newTestIdentityService())
 
 	request := validProxyRequest("provider-1", "project-1")
 	request.DisplayName = "Updated Proxy"

--- a/platform-api/src/internal/service/mcp.go
+++ b/platform-api/src/internal/service/mcp.go
@@ -53,13 +53,14 @@ type MCPProxyService struct {
 	slogger              *slog.Logger
 	auditRepo            repository.AuditRepository
 	cfg                  *config.Server
+	identity             *IdentityService
 }
 
 // NewMCPProxyService creates a new MCPProxyService instance
 func NewMCPProxyService(repo repository.MCPProxyRepository, projectRepo repository.ProjectRepository,
 	deploymentRepo repository.DeploymentRepository, gatewayRepo repository.GatewayRepository,
 	gatewayEventsService *GatewayEventsService, slogger *slog.Logger, auditRepo repository.AuditRepository,
-	cfg *config.Server) *MCPProxyService {
+	cfg *config.Server, identity *IdentityService) *MCPProxyService {
 	return &MCPProxyService{
 		repo:                 repo,
 		projectRepo:          projectRepo,
@@ -69,7 +70,37 @@ func NewMCPProxyService(repo repository.MCPProxyRepository, projectRepo reposito
 		slogger:              slogger,
 		auditRepo:            auditRepo,
 		cfg:                  cfg,
+		identity:             identity,
 	}
+}
+
+// toMCPProxyAPI converts m via mapMCPProxyModelToAPI and resolves its
+// createdBy/updatedBy UUIDs to their raw external identity.
+func (s *MCPProxyService) toMCPProxyAPI(m *model.MCPProxy) (*api.MCPProxy, error) {
+	resp := mapMCPProxyModelToAPI(m)
+	if resp == nil {
+		return nil, nil
+	}
+	if err := s.identity.ResolveIdentityField(&resp.CreatedBy); err != nil {
+		return nil, err
+	}
+	if err := s.identity.ResolveIdentityField(&resp.UpdatedBy); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// mcpProxyListItemResolved converts m via mapMCPProxyModelToListItem and
+// resolves its createdBy UUID to its raw external identity.
+func (s *MCPProxyService) mcpProxyListItemResolved(m *model.MCPProxy) (*api.MCPProxyListItem, error) {
+	item := mapMCPProxyModelToListItem(m)
+	if item == nil {
+		return nil, nil
+	}
+	if err := s.identity.ResolveIdentityField(&item.CreatedBy); err != nil {
+		return nil, err
+	}
+	return item, nil
 }
 
 // WithSecretService injects the SecretService for secret-ref validation.
@@ -167,6 +198,7 @@ func (s *MCPProxyService) Create(orgUUID, createdBy string, req *api.MCPProxy) (
 		Name:             req.DisplayName,
 		Description:      utils.ValueOrEmpty(req.Description),
 		CreatedBy:        createdBy,
+		UpdatedBy:        createdBy,
 		Version:          req.Version,
 		Configuration: model.MCPProxyConfiguration{
 			Name:         req.DisplayName,
@@ -216,7 +248,13 @@ func (s *MCPProxyService) List(orgUUID string, limit, offset int) (*api.MCPProxy
 
 	resp.List = make([]api.MCPProxyListItem, 0, len(proxies))
 	for _, p := range proxies {
-		resp.List = append(resp.List, *mapMCPProxyModelToListItem(p))
+		item, err := s.mcpProxyListItemResolved(p)
+		if err != nil {
+			return nil, err
+		}
+		if item != nil {
+			resp.List = append(resp.List, *item)
+		}
 	}
 
 	return resp, nil
@@ -262,7 +300,13 @@ func (s *MCPProxyService) ListByProject(orgUUID, projectHandle string, limit, of
 
 	resp.List = make([]api.MCPProxyListItem, 0, len(proxies))
 	for _, p := range proxies {
-		resp.List = append(resp.List, *mapMCPProxyModelToListItem(p))
+		item, err := s.mcpProxyListItemResolved(p)
+		if err != nil {
+			return nil, err
+		}
+		if item != nil {
+			resp.List = append(resp.List, *item)
+		}
 	}
 
 	return resp, nil
@@ -282,7 +326,7 @@ func (s *MCPProxyService) Get(orgUUID, handle string) (*api.MCPProxy, error) {
 		return nil, constants.ErrMCPProxyNotFound
 	}
 
-	return mapMCPProxyModelToAPI(m), nil
+	return s.toMCPProxyAPI(m)
 }
 
 // Update updates an existing MCP proxy
@@ -570,6 +614,7 @@ func mapMCPProxyModelToAPI(m *model.MCPProxy) *api.MCPProxy {
 		ReadOnly:       utils.BoolPtr(m.Origin == constants.OriginDP),
 		CreatedAt:      utils.TimePtr(m.CreatedAt),
 		UpdatedAt:      utils.TimePtr(m.UpdatedAt),
+		UpdatedBy:      utils.StringPtrIfNotEmpty(m.UpdatedBy),
 	}
 	if associated := mapAssociatedGatewaysModelToAPI(m.AssociatedGateways); associated != nil {
 		out.AssociatedGateways = associated

--- a/platform-api/src/internal/service/organization.go
+++ b/platform-api/src/internal/service/organization.go
@@ -30,18 +30,20 @@ import (
 )
 
 type OrganizationService struct {
-	orgRepo           repository.OrganizationRepository
-	projectRepo       repository.ProjectRepository
-	applicationRepo   repository.ApplicationRepository
-	apiRepo           repository.APIRepository
-	gatewayRepo       repository.GatewayRepository
-	llmProviderRepo   repository.LLMProviderRepository
-	llmProxyRepo      repository.LLMProxyRepository
-	mcpProxyRepo      repository.MCPProxyRepository
-	llmTemplateSeeder *LLMTemplateSeeder
-	auditRepo         repository.AuditRepository
-	config            *config.Server
-	slogger           *slog.Logger
+	orgRepo            repository.OrganizationRepository
+	projectRepo        repository.ProjectRepository
+	applicationRepo    repository.ApplicationRepository
+	apiRepo            repository.APIRepository
+	gatewayRepo        repository.GatewayRepository
+	llmProviderRepo    repository.LLMProviderRepository
+	llmProxyRepo       repository.LLMProxyRepository
+	mcpProxyRepo       repository.MCPProxyRepository
+	llmTemplateSeeder  *LLMTemplateSeeder
+	auditRepo          repository.AuditRepository
+	userOrgMappingRepo repository.UserOrganizationMappingRepository
+	identity           *IdentityService
+	config             *config.Server
+	slogger            *slog.Logger
 }
 
 func NewOrganizationService(orgRepo repository.OrganizationRepository,
@@ -54,22 +56,26 @@ func NewOrganizationService(orgRepo repository.OrganizationRepository,
 	mcpProxyRepo repository.MCPProxyRepository,
 	llmTemplateSeeder *LLMTemplateSeeder,
 	auditRepo repository.AuditRepository,
+	userOrgMappingRepo repository.UserOrganizationMappingRepository,
+	identity *IdentityService,
 	cfg *config.Server,
 	slogger *slog.Logger,
 ) *OrganizationService {
 	return &OrganizationService{
-		orgRepo:           orgRepo,
-		projectRepo:       projectRepo,
-		applicationRepo:   applicationRepo,
-		apiRepo:           apiRepo,
-		gatewayRepo:       gatewayRepo,
-		llmProviderRepo:   llmProviderRepo,
-		llmProxyRepo:      llmProxyRepo,
-		mcpProxyRepo:      mcpProxyRepo,
-		llmTemplateSeeder: llmTemplateSeeder,
-		auditRepo:         auditRepo,
-		config:            cfg,
-		slogger:           slogger,
+		orgRepo:            orgRepo,
+		projectRepo:        projectRepo,
+		applicationRepo:    applicationRepo,
+		apiRepo:            apiRepo,
+		gatewayRepo:        gatewayRepo,
+		llmProviderRepo:    llmProviderRepo,
+		llmProxyRepo:       llmProxyRepo,
+		mcpProxyRepo:       mcpProxyRepo,
+		llmTemplateSeeder:  llmTemplateSeeder,
+		auditRepo:          auditRepo,
+		userOrgMappingRepo: userOrgMappingRepo,
+		identity:           identity,
+		config:             cfg,
+		slogger:            slogger,
 	}
 }
 
@@ -124,11 +130,23 @@ func (s *OrganizationService) RegisterOrganization(id string, handle string, nam
 	// The IDP organization reference is derived server-side from the token's
 	// organization claim; it is stored internally and not exposed via the API.
 	orgModel.IdpOrganizationRefUUID = idpOrgRefUUID
+	orgModel.CreatedBy = performedBy
+	orgModel.UpdatedBy = performedBy
 	err = s.orgRepo.CreateOrganization(orgModel)
 	if err != nil {
 		return nil, err
 	}
 	_ = s.auditRepo.Record("CREATE", orgModel.ID, "organization", orgModel.ID, performedBy)
+
+	// Record that the registering user has onboarded to this organization.
+	// Best-effort: user_organization_mappings.user_uuid FKs to
+	// user_idp_references, so an anonymous actor (no mapping row, per
+	// D-ANON-KEY) cannot be org-mapped — that is expected, not an error.
+	if s.userOrgMappingRepo != nil {
+		if membershipErr := s.userOrgMappingRepo.AddMembership(performedBy, orgModel.ID); membershipErr != nil {
+			s.slogger.Warn("Failed to record organization membership", "organization", orgModel.ID, "error", membershipErr)
+		}
+	}
 
 	// Seed default LLM provider templates for the new organization (best-effort)
 	if s.llmTemplateSeeder != nil {
@@ -262,13 +280,22 @@ func (s *OrganizationService) modelToAPI(orgModel *model.Organization) (*api.Org
 		return nil, nil
 	}
 
-	return &api.Organization{
+	resp := &api.Organization{
 		Id:          &orgModel.Handle,
 		DisplayName: orgModel.Name,
 		Region:      orgModel.Region,
+		CreatedBy:   utils.StringPtrIfNotEmpty(orgModel.CreatedBy),
+		UpdatedBy:   utils.StringPtrIfNotEmpty(orgModel.UpdatedBy),
 		CreatedAt:   utils.TimePtrIfNotZero(orgModel.CreatedAt),
 		UpdatedAt:   utils.TimePtrIfNotZero(orgModel.UpdatedAt),
-	}, nil
+	}
+	if err := s.identity.ResolveIdentityField(&resp.CreatedBy); err != nil {
+		return nil, err
+	}
+	if err := s.identity.ResolveIdentityField(&resp.UpdatedBy); err != nil {
+		return nil, err
+	}
+	return resp, nil
 }
 
 func intPtr(value int) *int {

--- a/platform-api/src/internal/service/project.go
+++ b/platform-api/src/internal/service/project.go
@@ -42,13 +42,14 @@ type ProjectService struct {
 	appRepo        repository.ApplicationRepository
 	deletionGuards []ProjectDeletionGuard
 	auditRepo      repository.AuditRepository
+	identity       *IdentityService
 	slogger        *slog.Logger
 }
 
 func NewProjectService(projectRepo repository.ProjectRepository, orgRepo repository.OrganizationRepository,
 	apiRepo repository.APIRepository, mcpProxyRepo repository.MCPProxyRepository,
 	appRepo repository.ApplicationRepository, auditRepo repository.AuditRepository,
-	slogger *slog.Logger) *ProjectService {
+	identity *IdentityService, slogger *slog.Logger) *ProjectService {
 	return &ProjectService{
 		projectRepo:  projectRepo,
 		orgRepo:      orgRepo,
@@ -56,6 +57,7 @@ func NewProjectService(projectRepo repository.ProjectRepository, orgRepo reposit
 		mcpProxyRepo: mcpProxyRepo,
 		appRepo:      appRepo,
 		auditRepo:    auditRepo,
+		identity:     identity,
 		slogger:      slogger,
 	}
 }
@@ -141,7 +143,7 @@ func (s *ProjectService) CreateProject(req *api.CreateProjectRequest, organizati
 	}
 	_ = s.auditRepo.Record("CREATE", projectModel.ID, "project", organizationID, actor)
 
-	return s.modelToAPI(projectModel, org.Handle), nil
+	return s.modelToAPI(projectModel, org.Handle)
 }
 
 func (s *ProjectService) GetProjectByHandle(handle, orgId string) (*api.Project, error) {
@@ -162,7 +164,7 @@ func (s *ProjectService) GetProjectByHandle(handle, orgId string) (*api.Project,
 		orgHandle = org.Handle
 	}
 
-	return s.modelToAPI(projectModel, orgHandle), nil
+	return s.modelToAPI(projectModel, orgHandle)
 }
 
 func (s *ProjectService) GetProjectsByOrganization(organizationID string) ([]api.Project, error) {
@@ -181,11 +183,16 @@ func (s *ProjectService) GetProjectsByOrganization(organizationID string) ([]api
 
 	projects := make([]api.Project, 0)
 	for _, projectModel := range projectModels {
-		apiProj := s.modelToAPI(projectModel, org.Handle)
+		apiProj, err := s.modelToAPI(projectModel, org.Handle)
+		if err != nil {
+			return nil, err
+		}
 		if apiProj == nil {
 			s.slogger.Warn("Failed to convert project model to API", "organizationId", organizationID)
 			continue
 		}
+		// updatedBy is detail-only; omit it from list responses.
+		apiProj.UpdatedBy = nil
 		projects = append(projects, *apiProj)
 	}
 	return projects, nil
@@ -238,7 +245,7 @@ func (s *ProjectService) UpdateProject(handle string, req *api.Project, orgId, a
 		orgHandle = org.Handle
 	}
 
-	return s.modelToAPI(project, orgHandle), nil
+	return s.modelToAPI(project, orgHandle)
 }
 
 func (s *ProjectService) DeleteProject(handle, orgId, actor string) error {
@@ -332,9 +339,9 @@ func (s *ProjectService) apiToModel(project *api.Project) *model.Project {
 	}
 }
 
-func (s *ProjectService) modelToAPI(projectModel *model.Project, orgHandle string) *api.Project {
+func (s *ProjectService) modelToAPI(projectModel *model.Project, orgHandle string) (*api.Project, error) {
 	if projectModel == nil {
-		return nil
+		return nil, nil
 	}
 
 	var description *string
@@ -343,12 +350,21 @@ func (s *ProjectService) modelToAPI(projectModel *model.Project, orgHandle strin
 	}
 
 	handle := projectModel.Handle
-	return &api.Project{
+	resp := &api.Project{
 		Id:             &handle,
 		DisplayName:    projectModel.Name,
 		OrganizationId: &orgHandle,
 		Description:    description,
+		CreatedBy:      utils.StringPtrIfNotEmpty(projectModel.CreatedBy),
+		UpdatedBy:      utils.StringPtrIfNotEmpty(projectModel.UpdatedBy),
 		CreatedAt:      utils.TimePtrIfNotZero(projectModel.CreatedAt),
 		UpdatedAt:      utils.TimePtrIfNotZero(projectModel.UpdatedAt),
 	}
+	if err := s.identity.ResolveIdentityField(&resp.CreatedBy); err != nil {
+		return nil, err
+	}
+	if err := s.identity.ResolveIdentityField(&resp.UpdatedBy); err != nil {
+		return nil, err
+	}
+	return resp, nil
 }

--- a/platform-api/src/internal/service/secret_service.go
+++ b/platform-api/src/internal/service/secret_service.go
@@ -32,7 +32,6 @@ import (
 	"platform-api/src/internal/vault"
 )
 
-
 type SecretInUseError struct {
 	References []model.SecretReference
 }
@@ -42,12 +41,48 @@ func (e *SecretInUseError) Error() string {
 }
 
 type SecretService struct {
-	repo  repository.SecretRepository
-	vault vault.SecretVault
+	repo     repository.SecretRepository
+	vault    vault.SecretVault
+	identity *IdentityService
 }
 
-func NewSecretService(repo repository.SecretRepository, v vault.SecretVault) *SecretService {
-	return &SecretService{repo: repo, vault: v}
+func NewSecretService(repo repository.SecretRepository, v vault.SecretVault, identity *IdentityService) *SecretService {
+	return &SecretService{repo: repo, vault: v, identity: identity}
+}
+
+// toSecretResponse converts secret via secretToResponse and resolves its
+// createdBy/updatedBy UUIDs to their raw external identity.
+func (s *SecretService) toSecretResponse(secret *model.Secret) (*dto.SecretResponse, error) {
+	resp := secretToResponse(secret)
+	if resp == nil {
+		return nil, nil
+	}
+	createdBy, err := s.identity.SubForUUID(resp.CreatedBy)
+	if err != nil {
+		return nil, err
+	}
+	resp.CreatedBy = createdBy
+	updatedBy, err := s.identity.SubForUUID(resp.UpdatedBy)
+	if err != nil {
+		return nil, err
+	}
+	resp.UpdatedBy = updatedBy
+	return resp, nil
+}
+
+// toSecretSummary converts secret via secretToSummary and resolves its
+// createdBy UUID to its raw external identity.
+func (s *SecretService) toSecretSummary(secret *model.Secret) (*dto.SecretSummary, error) {
+	resp := secretToSummary(secret)
+	if resp == nil {
+		return nil, nil
+	}
+	createdBy, err := s.identity.SubForUUID(resp.CreatedBy)
+	if err != nil {
+		return nil, err
+	}
+	resp.CreatedBy = createdBy
+	return resp, nil
 }
 
 func (s *SecretService) Create(orgID, createdBy string, req *dto.CreateSecretRequest) (*dto.SecretResponse, error) {
@@ -92,7 +127,7 @@ func (s *SecretService) Create(orgID, createdBy string, req *dto.CreateSecretReq
 		return nil, fmt.Errorf("failed to persist secret: %w", err)
 	}
 
-	return secretToResponse(secret), nil
+	return s.toSecretResponse(secret)
 }
 
 func (s *SecretService) List(orgID string, limit, offset int, updatedAfter *time.Time) (*dto.SecretListResponse, error) {
@@ -108,7 +143,11 @@ func (s *SecretService) List(orgID string, limit, offset int, updatedAfter *time
 
 	summaries := make([]*dto.SecretSummary, 0, len(secrets))
 	for _, sec := range secrets {
-		summaries = append(summaries, secretToSummary(sec))
+		summary, err := s.toSecretSummary(sec)
+		if err != nil {
+			return nil, err
+		}
+		summaries = append(summaries, summary)
 	}
 
 	return &dto.SecretListResponse{
@@ -126,7 +165,7 @@ func (s *SecretService) Get(orgID, handle string) (*dto.SecretSummary, error) {
 	if err != nil {
 		return nil, err
 	}
-	return secretToSummary(secret), nil
+	return s.toSecretSummary(secret)
 }
 
 func (s *SecretService) Update(orgID, handle, updatedBy string, req *dto.UpdateSecretRequest) (*dto.SecretResponse, error) {
@@ -156,7 +195,7 @@ func (s *SecretService) Update(orgID, handle, updatedBy string, req *dto.UpdateS
 		return nil, fmt.Errorf("failed to update secret: %w", err)
 	}
 
-	return secretToResponse(existing), nil
+	return s.toSecretResponse(existing)
 }
 
 func (s *SecretService) Delete(orgID, handle, updatedBy string) error {
@@ -235,6 +274,8 @@ func secretToResponse(s *model.Secret) *dto.SecretResponse {
 	return &dto.SecretResponse{
 		Handle:      s.Handle,
 		DisplayName: s.DisplayName,
+		CreatedBy:   s.CreatedBy,
+		UpdatedBy:   s.UpdatedBy,
 		CreatedAt:   s.CreatedAt,
 		UpdatedAt:   s.UpdatedAt,
 	}
@@ -249,6 +290,7 @@ func secretToSummary(s *model.Secret) *dto.SecretSummary {
 		Provider:    s.Provider,
 		Status:      s.Status,
 		Hash:        s.Hash,
+		CreatedBy:   s.CreatedBy,
 		CreatedAt:   s.CreatedAt,
 		UpdatedAt:   s.UpdatedAt,
 	}

--- a/platform-api/src/internal/service/secret_service_test.go
+++ b/platform-api/src/internal/service/secret_service_test.go
@@ -177,7 +177,7 @@ func (m *mockSecretRepo) Count(orgID string) (int, error) {
 
 func TestSecretService_Create_SetsOrgSharedValueScope(t *testing.T) {
 	repo := newMockRepo()
-	svc := NewSecretService(repo, &mockVault{})
+	svc := NewSecretService(repo, &mockVault{}, newTestIdentityService())
 
 	_, err := svc.Create("org1", "alice", &dto.CreateSecretRequest{
 		Handle:      "my-secret",
@@ -200,7 +200,7 @@ func TestSecretService_Create_SetsOrgSharedValueScope(t *testing.T) {
 
 func TestSecretService_Create_ReturnsCleartextValue(t *testing.T) {
 	repo := newMockRepo()
-	svc := NewSecretService(repo, &mockVault{})
+	svc := NewSecretService(repo, &mockVault{}, newTestIdentityService())
 
 	_, err := svc.Create("org1", "alice", &dto.CreateSecretRequest{
 		Handle: "secret-with-value",
@@ -216,7 +216,7 @@ func TestSecretService_Create_DuplicateHandle_ReturnsError(t *testing.T) {
 	// Pre-populate so Exists returns true
 	repo.secrets["dup"] = &model.Secret{Handle: "dup", Status: model.SecretStatusActive}
 
-	svc := NewSecretService(repo, &mockVault{})
+	svc := NewSecretService(repo, &mockVault{}, newTestIdentityService())
 	_, err := svc.Create("org1", "alice", &dto.CreateSecretRequest{
 		Handle: "dup",
 		Value:  "val",
@@ -233,7 +233,7 @@ func TestSecretService_Create_EncryptionError_PropagatesError(t *testing.T) {
 			return nil, errors.New("vault unavailable")
 		},
 	}
-	svc := NewSecretService(repo, v)
+	svc := NewSecretService(repo, v, newTestIdentityService())
 
 	_, err := svc.Create("org1", "alice", &dto.CreateSecretRequest{
 		Handle: "new-secret",
@@ -246,7 +246,7 @@ func TestSecretService_Create_EncryptionError_PropagatesError(t *testing.T) {
 
 func TestSecretService_Create_DefaultsTypeToGeneric(t *testing.T) {
 	repo := newMockRepo()
-	svc := NewSecretService(repo, &mockVault{})
+	svc := NewSecretService(repo, &mockVault{}, newTestIdentityService())
 
 	_, err := svc.Create("org1", "alice", &dto.CreateSecretRequest{
 		Handle: "typed-secret",
@@ -264,7 +264,7 @@ func TestSecretService_Create_DefaultsTypeToGeneric(t *testing.T) {
 
 func TestSecretService_Create_InvalidType_ReturnsError(t *testing.T) {
 	repo := newMockRepo()
-	svc := NewSecretService(repo, &mockVault{})
+	svc := NewSecretService(repo, &mockVault{}, newTestIdentityService())
 
 	_, err := svc.Create("org1", "alice", &dto.CreateSecretRequest{
 		Handle: "bad-type-secret",
@@ -283,7 +283,7 @@ func TestSecretService_List_ReturnsPagination(t *testing.T) {
 		repo.secrets[h] = &model.Secret{Handle: h, Status: model.SecretStatusActive}
 	}
 
-	svc := NewSecretService(repo, &mockVault{})
+	svc := NewSecretService(repo, &mockVault{}, newTestIdentityService())
 	resp, err := svc.List("org1", 10, 0, nil)
 	if err != nil {
 		t.Fatalf("List: %v", err)
@@ -302,7 +302,7 @@ func TestSecretService_List_ReturnsPagination(t *testing.T) {
 
 func TestSecretService_List_PaginationReflectsOffset(t *testing.T) {
 	repo := newMockRepo()
-	svc := NewSecretService(repo, &mockVault{})
+	svc := NewSecretService(repo, &mockVault{}, newTestIdentityService())
 
 	resp, err := svc.List("org1", 5, 10, nil)
 	if err != nil {
@@ -320,7 +320,7 @@ func TestSecretService_List_PaginationReflectsOffset(t *testing.T) {
 
 func TestSecretService_Get_NotFound(t *testing.T) {
 	repo := newMockRepo()
-	svc := NewSecretService(repo, &mockVault{})
+	svc := NewSecretService(repo, &mockVault{}, newTestIdentityService())
 
 	_, err := svc.Get("org1", "missing")
 	if !errors.Is(err, constants.ErrSecretNotFound) {
@@ -336,7 +336,7 @@ func TestSecretService_Get_ReturnsSecret(t *testing.T) {
 		Status:      model.SecretStatusActive,
 	}
 
-	svc := NewSecretService(repo, &mockVault{})
+	svc := NewSecretService(repo, &mockVault{}, newTestIdentityService())
 	summary, err := svc.Get("org1", "s1")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
@@ -350,7 +350,7 @@ func TestSecretService_Get_ReturnsSecret(t *testing.T) {
 
 func TestSecretService_Update_NotFound(t *testing.T) {
 	repo := newMockRepo()
-	svc := NewSecretService(repo, &mockVault{})
+	svc := NewSecretService(repo, &mockVault{}, newTestIdentityService())
 
 	_, err := svc.Update("org1", "ghost", "alice", &dto.UpdateSecretRequest{Value: "v"})
 	if !errors.Is(err, constants.ErrSecretNotFound) {
@@ -364,7 +364,7 @@ func TestSecretService_Update_EncryptsNewValue(t *testing.T) {
 		Handle: "upd",
 		Status: model.SecretStatusActive,
 	}
-	svc := NewSecretService(repo, &mockVault{})
+	svc := NewSecretService(repo, &mockVault{}, newTestIdentityService())
 
 	_, err := svc.Update("org1", "upd", "bob", &dto.UpdateSecretRequest{Value: "new-value"})
 	if err != nil {
@@ -386,7 +386,7 @@ func TestSecretService_Delete_BlockedWhenInUse(t *testing.T) {
 		}, nil
 	}
 
-	svc := NewSecretService(repo, &mockVault{})
+	svc := NewSecretService(repo, &mockVault{}, newTestIdentityService())
 	err := svc.Delete("org1", "in-use", "alice")
 	if err == nil {
 		t.Fatal("expected error when secret is in use")
@@ -411,7 +411,7 @@ func TestSecretService_Delete_BlockedByArtifactLevelRef(t *testing.T) {
 		}, nil
 	}
 
-	svc := NewSecretService(repo, &mockVault{})
+	svc := NewSecretService(repo, &mockVault{}, newTestIdentityService())
 	err := svc.Delete("org1", "config-secret", "alice")
 	if err == nil {
 		t.Fatal("should block deletion even for undeployed artifacts")
@@ -422,7 +422,7 @@ func TestSecretService_Delete_SucceedsWhenNotInUse(t *testing.T) {
 	repo := newMockRepo()
 	repo.secrets["unused"] = &model.Secret{Handle: "unused", Status: model.SecretStatusActive}
 
-	svc := NewSecretService(repo, &mockVault{})
+	svc := NewSecretService(repo, &mockVault{}, newTestIdentityService())
 	if err := svc.Delete("org1", "unused", "alice"); err != nil {
 		t.Errorf("Delete: %v", err)
 	}
@@ -433,7 +433,7 @@ func TestSecretService_Delete_SucceedsWhenNotInUse(t *testing.T) {
 
 func TestSecretService_Delete_NotFound(t *testing.T) {
 	repo := newMockRepo()
-	svc := NewSecretService(repo, &mockVault{})
+	svc := NewSecretService(repo, &mockVault{}, newTestIdentityService())
 
 	err := svc.Delete("org1", "ghost", "alice")
 	if !errors.Is(err, constants.ErrSecretNotFound) {
@@ -445,7 +445,7 @@ func TestSecretService_Delete_NotFound(t *testing.T) {
 
 func TestSecretService_ValidateSecretRefs_NoPlaceholders(t *testing.T) {
 	repo := newMockRepo()
-	svc := NewSecretService(repo, &mockVault{})
+	svc := NewSecretService(repo, &mockVault{}, newTestIdentityService())
 
 	if err := svc.ValidateSecretRefs("org1", `{"plain": "config"}`); err != nil {
 		t.Errorf("unexpected error for config without placeholders: %v", err)
@@ -457,7 +457,7 @@ func TestSecretService_ValidateSecretRefs_AllExist(t *testing.T) {
 	repo.secrets["key1"] = &model.Secret{Handle: "key1", Status: model.SecretStatusActive}
 	repo.secrets["key2"] = &model.Secret{Handle: "key2", Status: model.SecretStatusActive}
 
-	svc := NewSecretService(repo, &mockVault{})
+	svc := NewSecretService(repo, &mockVault{}, newTestIdentityService())
 	config := `{{ secret "key1" }} {{ secret "key2" }}`
 	if err := svc.ValidateSecretRefs("org1", config); err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -466,7 +466,7 @@ func TestSecretService_ValidateSecretRefs_AllExist(t *testing.T) {
 
 func TestSecretService_ValidateSecretRefs_MissingHandle(t *testing.T) {
 	repo := newMockRepo()
-	svc := NewSecretService(repo, &mockVault{})
+	svc := NewSecretService(repo, &mockVault{}, newTestIdentityService())
 
 	config := `{{ secret "missing-key" }}`
 	err := svc.ValidateSecretRefs("org1", config)
@@ -482,7 +482,7 @@ func TestSecretService_ValidateSecretRefs_JSONEscapedForm(t *testing.T) {
 	repo := newMockRepo()
 	repo.secrets["my-key"] = &model.Secret{Handle: "my-key", Status: model.SecretStatusActive}
 
-	svc := NewSecretService(repo, &mockVault{})
+	svc := NewSecretService(repo, &mockVault{}, newTestIdentityService())
 	// Simulates what Go's json.Marshal produces when the placeholder is inside a string field:
 	// the surrounding quotes are escaped as \", giving {{ secret \"my-key\" }}.
 	config := `{{ secret \"my-key\" }}`
@@ -493,7 +493,7 @@ func TestSecretService_ValidateSecretRefs_JSONEscapedForm(t *testing.T) {
 
 func TestSecretService_ValidateSecretRefs_JSONEscapedForm_Missing(t *testing.T) {
 	repo := newMockRepo()
-	svc := NewSecretService(repo, &mockVault{})
+	svc := NewSecretService(repo, &mockVault{}, newTestIdentityService())
 
 	config := `{{ secret \"nonexistent-key\" }}`
 	err := svc.ValidateSecretRefs("org1", config)
@@ -513,7 +513,7 @@ func TestSecretService_ValidateSecretRefs_DeduplicatesHandles(t *testing.T) {
 		return true, nil
 	}
 
-	svc := NewSecretService(repo, &mockVault{})
+	svc := NewSecretService(repo, &mockVault{}, newTestIdentityService())
 	config := `{{ secret "key1" }} {{ secret "key1" }} {{ secret "key1" }}`
 	if err := svc.ValidateSecretRefs("org1", config); err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -533,7 +533,7 @@ func TestSecretService_Decrypt_ReturnsPlaintext(t *testing.T) {
 		Status:     model.SecretStatusActive,
 	}
 
-	svc := NewSecretService(repo, &mockVault{})
+	svc := NewSecretService(repo, &mockVault{}, newTestIdentityService())
 	plain, err := svc.Decrypt("org1", "enc-secret")
 	if err != nil {
 		t.Fatalf("Decrypt: %v", err)
@@ -551,7 +551,7 @@ func TestSecretService_Decrypt_DeprecatedSecret_ReturnsError(t *testing.T) {
 		Status:     model.SecretStatusDeprecated,
 	}
 
-	svc := NewSecretService(repo, &mockVault{})
+	svc := NewSecretService(repo, &mockVault{}, newTestIdentityService())
 	_, err := svc.Decrypt("org1", "dep-secret")
 	if err == nil {
 		t.Fatal("expected error decrypting deprecated secret")

--- a/platform-api/src/internal/service/subscription_plan_service.go
+++ b/platform-api/src/internal/service/subscription_plan_service.go
@@ -96,6 +96,8 @@ func (s *SubscriptionPlanService) CreatePlan(orgUUID, actor string, plan *model.
 	}
 
 	plan.OrganizationUUID = orgUUID
+	plan.CreatedBy = actor
+	plan.UpdatedBy = actor
 	if plan.Status == "" {
 		plan.Status = model.SubscriptionPlanStatusActive
 	}
@@ -201,6 +203,7 @@ func (s *SubscriptionPlanService) UpdatePlan(handle, orgUUID, actor string, upda
 		}
 	}
 
+	existing.UpdatedBy = actor
 	if err := s.planRepo.Update(existing); err != nil {
 		return nil, err
 	}

--- a/platform-api/src/internal/service/subscription_service.go
+++ b/platform-api/src/internal/service/subscription_service.go
@@ -152,7 +152,11 @@ func (s *SubscriptionService) GetArtifactMetadataMap(uuids []string, orgUUID str
 
 // CreateSubscription creates a new subscription for an artifact of the given kind.
 // apiId is the artifact handle; kind selects the artifact table it is resolved against.
-func (s *SubscriptionService) CreateSubscription(apiId, kind, orgUUID string, subscriberID string, applicationId *string, subscriptionPlanId *string, subscriptionToken string, status string) (*model.Subscription, error) {
+// subscriberID identifies who the subscription is for (client-supplied, not a token
+// identity); subscriptionToken, when non-empty, is the token imported from the
+// Developer Portal (empty means generate one); actor is the authenticated caller's
+// internal UUID, used for created_by/updated_by/audit.
+func (s *SubscriptionService) CreateSubscription(apiId, kind, orgUUID string, subscriberID string, applicationId *string, subscriptionPlanId *string, subscriptionToken string, status string, actor string) (*model.Subscription, error) {
 	apiUUID, err := s.resolveArtifactUUIDByKind(apiId, kind, orgUUID)
 	if err != nil {
 		return nil, err
@@ -205,13 +209,13 @@ func (s *SubscriptionService) CreateSubscription(apiId, kind, orgUUID string, su
 		SubscriptionToken:  subscriptionToken,
 		OrganizationUUID:   orgUUID,
 		Status:             st,
-		CreatedBy:          subscriberID,
-		UpdatedBy:          subscriberID,
+		CreatedBy:          actor,
+		UpdatedBy:          actor,
 	}
 	if err := s.subscriptionRepo.Create(sub); err != nil {
 		return nil, err
 	}
-	_ = s.auditRepo.Record("CREATE", sub.UUID, "subscription", sub.OrganizationUUID, subscriberID)
+	_ = s.auditRepo.Record("CREATE", sub.UUID, "subscription", sub.OrganizationUUID, actor)
 
 	if s.gatewayEvents != nil {
 		gateways, err := s.apiRepo.GetAPIGatewaysWithDetails(apiUUID, orgUUID)
@@ -305,8 +309,10 @@ func (s *SubscriptionService) FindByArtifactKindAndSubscriber(orgUUID, apiHandle
 	return list[0], nil
 }
 
-// UpdateSubscription updates a subscription (e.g. status). subscriberID must match the stored subscriber_id.
-func (s *SubscriptionService) UpdateSubscription(subscriptionId, orgUUID, subscriberID, status string) (*model.Subscription, error) {
+// UpdateSubscription updates a subscription (e.g. status). subscriberID must match the
+// stored subscriber_id; actor is the authenticated caller's internal UUID, used for
+// updated_by/audit.
+func (s *SubscriptionService) UpdateSubscription(subscriptionId, orgUUID, subscriberID, status, actor string) (*model.Subscription, error) {
 	sub, err := s.subscriptionRepo.GetByID(subscriptionId, orgUUID)
 	if err != nil {
 		if errors.Is(err, constants.ErrSubscriptionNotFound) {
@@ -329,11 +335,11 @@ func (s *SubscriptionService) UpdateSubscription(subscriptionId, orgUUID, subscr
 			return nil, fmt.Errorf("invalid status: %s", status)
 		}
 	}
-	sub.UpdatedBy = subscriberID
+	sub.UpdatedBy = actor
 	if err := s.subscriptionRepo.Update(sub); err != nil {
 		return nil, err
 	}
-	_ = s.auditRepo.Record("UPDATE", sub.UUID, "subscription", sub.OrganizationUUID, subscriberID)
+	_ = s.auditRepo.Record("UPDATE", sub.UUID, "subscription", sub.OrganizationUUID, actor)
 
 	if s.gatewayEvents != nil {
 		gateways, err := s.apiRepo.GetAPIGatewaysWithDetails(sub.ArtifactUUID, orgUUID)
@@ -491,8 +497,9 @@ func (s *SubscriptionService) RegenerateToken(subscriptionId, orgUUID, subscribe
 	return sub, nil
 }
 
-// DeleteSubscription removes a subscription. subscriberID must match the stored subscriber_id.
-func (s *SubscriptionService) DeleteSubscription(subscriptionId, orgUUID, subscriberID string) error {
+// DeleteSubscription removes a subscription. subscriberID must match the stored
+// subscriber_id; actor is the authenticated caller's internal UUID, used for audit.
+func (s *SubscriptionService) DeleteSubscription(subscriptionId, orgUUID, subscriberID, actor string) error {
 	sub, err := s.subscriptionRepo.GetByID(subscriptionId, orgUUID)
 	if err != nil {
 		if errors.Is(err, constants.ErrSubscriptionNotFound) {
@@ -510,7 +517,7 @@ func (s *SubscriptionService) DeleteSubscription(subscriptionId, orgUUID, subscr
 	if err := s.subscriptionRepo.Delete(subscriptionId, orgUUID); err != nil {
 		return err
 	}
-	_ = s.auditRepo.Record("DELETE", subscriptionId, "subscription", orgUUID, subscriberID)
+	_ = s.auditRepo.Record("DELETE", subscriptionId, "subscription", orgUUID, actor)
 
 	if s.gatewayEvents != nil {
 		gateways, err := s.apiRepo.GetAPIGatewaysWithDetails(sub.ArtifactUUID, orgUUID)

--- a/platform-api/src/internal/utils/api.go
+++ b/platform-api/src/internal/utils/api.go
@@ -135,6 +135,7 @@ func (u *APIUtil) ModelToRESTAPI(modelAPI *model.API, projectHandle string) (*ap
 		SubscriptionPlans: stringSlicePtr(modelAPI.Configuration.SubscriptionPlans),
 		Transport:         stringSlicePtr(modelAPI.Configuration.Transport),
 		UpdatedAt:         TimePtrIfNotZero(modelAPI.UpdatedAt),
+		UpdatedBy:         StringPtrIfNotEmpty(modelAPI.UpdatedBy),
 		Upstream:          u.UpstreamConfigModelToAPI(&modelAPI.Configuration.Upstream),
 		Version:           modelAPI.Version,
 	}, nil

--- a/platform-api/src/internal/webhook/handlers_subscription.go
+++ b/platform-api/src/internal/webhook/handlers_subscription.go
@@ -109,7 +109,9 @@ func (r *Receiver) handleSubscriptionCreated(ctx context.Context, env *Envelope)
 		token = decrypted
 	}
 
-	_, err := r.subs.CreateSubscription(d.API.RefID, d.API.kind(), env.OrgID, d.SubscriberID, d.applicationIDPtr(), &d.SubscriptionPlan.RefID, token, d.Status)
+	// Developer Portal sync events have no interactive platform user, so the audit
+	// actor is left empty (there is no internal-UUID identity to attribute).
+	_, err := r.subs.CreateSubscription(d.API.RefID, d.API.kind(), env.OrgID, d.SubscriberID, d.applicationIDPtr(), &d.SubscriptionPlan.RefID, token, d.Status, "")
 	if err != nil {
 		// Domain-level idempotency: a duplicate delivery whose subscription already exists is success.
 		if errors.Is(err, constants.ErrSubscriptionAlreadyExists) {
@@ -142,7 +144,7 @@ func (r *Receiver) handleSubscriptionUpdated(ctx context.Context, env *Envelope)
 		return constants.ErrSubscriptionNotFound
 	}
 
-	_, err = r.subs.UpdateSubscription(sub.UUID, env.OrgID, d.SubscriberID, d.Status)
+	_, err = r.subs.UpdateSubscription(sub.UUID, env.OrgID, d.SubscriberID, d.Status, "")
 	return err
 }
 
@@ -221,7 +223,7 @@ func (r *Receiver) handleSubscriptionDeleted(ctx context.Context, env *Envelope)
 		return nil
 	}
 
-	if err := r.subs.DeleteSubscription(sub.UUID, env.OrgID, d.SubscriberID); err != nil {
+	if err := r.subs.DeleteSubscription(sub.UUID, env.OrgID, d.SubscriberID, ""); err != nil {
 		if errors.Is(err, constants.ErrSubscriptionNotFound) {
 			return nil
 		}

--- a/platform-api/src/internal/webhook/receiver.go
+++ b/platform-api/src/internal/webhook/receiver.go
@@ -50,11 +50,11 @@ type apiKeyService interface {
 
 // subscriptionService is the subset of *service.SubscriptionService the receiver depends on.
 type subscriptionService interface {
-	CreateSubscription(apiID, kind, orgUUID, subscriberID string, applicationID, subscriptionPlanID *string, subscriptionToken, status string) (*model.Subscription, error)
-	UpdateSubscription(subscriptionID, orgUUID, subscriberID, status string) (*model.Subscription, error)
+	CreateSubscription(apiID, kind, orgUUID, subscriberID string, applicationID, subscriptionPlanID *string, subscriptionToken, status, actor string) (*model.Subscription, error)
+	UpdateSubscription(subscriptionID, orgUUID, subscriberID, status, actor string) (*model.Subscription, error)
 	ChangePlan(subscriptionID, orgUUID, subscriberID, planUUID string) (*model.Subscription, error)
 	RegenerateToken(subscriptionID, orgUUID, subscriberID, newToken string) (*model.Subscription, error)
-	DeleteSubscription(subscriptionID, orgUUID, subscriberID string) error
+	DeleteSubscription(subscriptionID, orgUUID, subscriberID, actor string) error
 	FindByArtifactKindAndSubscriber(orgUUID, apiHandle, kind, subscriberID string) (*model.Subscription, error)
 }
 

--- a/platform-api/src/plugins/eventgateway/handler/identity_helper.go
+++ b/platform-api/src/plugins/eventgateway/handler/identity_helper.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package handler
+
+import (
+	"log/slog"
+	"net/http"
+
+	"platform-api/src/internal/service"
+	"platform-api/src/internal/utils"
+
+	"github.com/wso2/go-httpkit/httputil"
+)
+
+// resolveActor resolves the internal platform UUID for the actor behind r via
+// identity, for use in audit columns (created_by/updated_by/revoked_by/
+// performed_by). Identity is always resolved from the token claim (sub,
+// falling back to the configured claim / user_id) — a missing identity mints
+// an anonymous UUID rather than failing (see IdentityService.InternalUserID),
+// so this only fails (500) on a genuine DB error.
+func resolveActor(w http.ResponseWriter, r *http.Request, identity *service.IdentityService, slogger *slog.Logger, action string) (actor string, ok bool) {
+	actor, err := identity.InternalUserID(r)
+	if err != nil {
+		slogger.Error("Failed to resolve user identity", "action", action, "error", err)
+		httputil.WriteJSON(w, http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error",
+			"Failed to resolve user identity"))
+		return "", false
+	}
+	return actor, true
+}

--- a/platform-api/src/plugins/eventgateway/handler/webbroker_api.go
+++ b/platform-api/src/plugins/eventgateway/handler/webbroker_api.go
@@ -30,6 +30,7 @@ import (
 	"platform-api/src/api"
 	"platform-api/src/internal/constants"
 	"platform-api/src/internal/middleware"
+	"platform-api/src/internal/service"
 	"platform-api/src/internal/utils"
 	egservice "platform-api/src/plugins/eventgateway/service"
 
@@ -39,13 +40,15 @@ import (
 // WebBrokerAPIHandler handles CRUD and auxiliary routes for WebBroker APIs
 type WebBrokerAPIHandler struct {
 	webbrokerAPIService *egservice.WebBrokerAPIService
+	identity            *service.IdentityService
 	slogger             *slog.Logger
 }
 
 // NewWebBrokerAPIHandler creates a new WebBrokerAPIHandler instance
-func NewWebBrokerAPIHandler(webbrokerAPIService *egservice.WebBrokerAPIService, slogger *slog.Logger) *WebBrokerAPIHandler {
+func NewWebBrokerAPIHandler(webbrokerAPIService *egservice.WebBrokerAPIService, identity *service.IdentityService, slogger *slog.Logger) *WebBrokerAPIHandler {
 	return &WebBrokerAPIHandler{
 		webbrokerAPIService: webbrokerAPIService,
+		identity:            identity,
 		slogger:             slogger,
 	}
 }
@@ -74,7 +77,10 @@ func (h *WebBrokerAPIHandler) CreateWebBrokerAPI(w http.ResponseWriter, r *http.
 		return
 	}
 
-	createdBy, _ := middleware.GetUserIDFromRequest(r)
+	createdBy, ok := resolveActor(w, r, h.identity, h.slogger, "create WebBroker API")
+	if !ok {
+		return
+	}
 
 	resp, err := h.webbrokerAPIService.Create(orgID, createdBy, &req)
 	if err != nil {
@@ -164,7 +170,10 @@ func (h *WebBrokerAPIHandler) UpdateWebBrokerAPI(w http.ResponseWriter, r *http.
 		return
 	}
 
-	updatedBy, _ := middleware.GetUserIDFromRequest(r)
+	updatedBy, ok := resolveActor(w, r, h.identity, h.slogger, "update WebBroker API")
+	if !ok {
+		return
+	}
 	resp, err := h.webbrokerAPIService.Update(orgID, id, updatedBy, &req)
 	if err != nil {
 		h.handleServiceError(w, err)
@@ -183,7 +192,10 @@ func (h *WebBrokerAPIHandler) DeleteWebBrokerAPI(w http.ResponseWriter, r *http.
 	}
 
 	id := r.PathValue("webBrokerApiId")
-	deletedBy, _ := middleware.GetUserIDFromRequest(r)
+	deletedBy, ok := resolveActor(w, r, h.identity, h.slogger, "delete WebBroker API")
+	if !ok {
+		return
+	}
 
 	if err := h.webbrokerAPIService.Delete(orgID, id, deletedBy); err != nil {
 		h.handleServiceError(w, err)

--- a/platform-api/src/plugins/eventgateway/handler/webbroker_api_deployment.go
+++ b/platform-api/src/plugins/eventgateway/handler/webbroker_api_deployment.go
@@ -29,6 +29,7 @@ import (
 	"platform-api/src/api"
 	"platform-api/src/internal/constants"
 	"platform-api/src/internal/middleware"
+	"platform-api/src/internal/service"
 	"platform-api/src/internal/utils"
 	egservice "platform-api/src/plugins/eventgateway/service"
 
@@ -38,13 +39,15 @@ import (
 // WebBrokerAPIDeploymentHandler handles deployment routes for WebBroker APIs
 type WebBrokerAPIDeploymentHandler struct {
 	webbrokerAPIDeploymentService *egservice.WebBrokerAPIDeploymentService
+	identity                      *service.IdentityService
 	slogger                       *slog.Logger
 }
 
 // NewWebBrokerAPIDeploymentHandler creates a new WebBrokerAPIDeploymentHandler
-func NewWebBrokerAPIDeploymentHandler(webbrokerAPIDeploymentService *egservice.WebBrokerAPIDeploymentService, slogger *slog.Logger) *WebBrokerAPIDeploymentHandler {
+func NewWebBrokerAPIDeploymentHandler(webbrokerAPIDeploymentService *egservice.WebBrokerAPIDeploymentService, identity *service.IdentityService, slogger *slog.Logger) *WebBrokerAPIDeploymentHandler {
 	return &WebBrokerAPIDeploymentHandler{
 		webbrokerAPIDeploymentService: webbrokerAPIDeploymentService,
+		identity:                      identity,
 		slogger:                       slogger,
 	}
 }
@@ -92,7 +95,10 @@ func (h *WebBrokerAPIDeploymentHandler) DeployWebBrokerAPI(w http.ResponseWriter
 		return
 	}
 
-	createdBy, _ := middleware.GetUserIDFromRequest(r)
+	createdBy, ok := resolveActor(w, r, h.identity, h.slogger, "deploy WebBroker API")
+	if !ok {
+		return
+	}
 	deployment, err := h.webbrokerAPIDeploymentService.DeployWebBrokerAPIByHandle(apiId, &req, orgId, createdBy)
 	if err != nil {
 		if respondArtifactGuardError(w, err) {

--- a/platform-api/src/plugins/eventgateway/handler/webbroker_apikey.go
+++ b/platform-api/src/plugins/eventgateway/handler/webbroker_apikey.go
@@ -40,14 +40,16 @@ import (
 type WebBrokerAPIKeyHandler struct {
 	webbrokerAPIService *egservice.WebBrokerAPIService
 	apiKeyService       *service.APIKeyService
+	identity            *service.IdentityService
 	slogger             *slog.Logger
 }
 
 // NewWebBrokerAPIKeyHandler creates a new WebBrokerAPIKeyHandler instance
-func NewWebBrokerAPIKeyHandler(webbrokerAPIService *egservice.WebBrokerAPIService, apiKeyService *service.APIKeyService, slogger *slog.Logger) *WebBrokerAPIKeyHandler {
+func NewWebBrokerAPIKeyHandler(webbrokerAPIService *egservice.WebBrokerAPIService, apiKeyService *service.APIKeyService, identity *service.IdentityService, slogger *slog.Logger) *WebBrokerAPIKeyHandler {
 	return &WebBrokerAPIKeyHandler{
 		webbrokerAPIService: webbrokerAPIService,
 		apiKeyService:       apiKeyService,
+		identity:            identity,
 		slogger:             slogger,
 	}
 }
@@ -79,7 +81,10 @@ func (h *WebBrokerAPIKeyHandler) CreateAPIKey(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	userId := r.Header.Get("x-user-id")
+	userId, ok := resolveActor(w, r, h.identity, h.slogger, "create WebBroker API key")
+	if !ok {
+		return
+	}
 
 	var req api.CreateAPIKeyRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -152,7 +157,10 @@ func (h *WebBrokerAPIKeyHandler) UpdateAPIKey(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	userId := r.Header.Get("x-user-id")
+	userId, ok := resolveActor(w, r, h.identity, h.slogger, "update WebBroker API key")
+	if !ok {
+		return
+	}
 
 	var req api.UpdateAPIKeyRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -216,7 +224,10 @@ func (h *WebBrokerAPIKeyHandler) DeleteAPIKey(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	userId := r.Header.Get("x-user-id")
+	userId, ok := resolveActor(w, r, h.identity, h.slogger, "revoke WebBroker API key")
+	if !ok {
+		return
+	}
 
 	if err := h.apiKeyService.RevokeAPIKey(r.Context(), apiHandle, constants.WebBrokerApi, orgID, keyName, userId); err != nil {
 		if errors.Is(err, constants.ErrAPINotFound) {

--- a/platform-api/src/plugins/eventgateway/handler/websub_api.go
+++ b/platform-api/src/plugins/eventgateway/handler/websub_api.go
@@ -30,6 +30,7 @@ import (
 	"platform-api/src/api"
 	"platform-api/src/internal/constants"
 	"platform-api/src/internal/middleware"
+	"platform-api/src/internal/service"
 	"platform-api/src/internal/utils"
 	egservice "platform-api/src/plugins/eventgateway/service"
 
@@ -39,13 +40,15 @@ import (
 // WebSubAPIHandler handles CRUD and auxiliary routes for WebSub APIs
 type WebSubAPIHandler struct {
 	websubAPIService *egservice.WebSubAPIService
+	identity         *service.IdentityService
 	slogger          *slog.Logger
 }
 
 // NewWebSubAPIHandler creates a new WebSubAPIHandler instance
-func NewWebSubAPIHandler(websubAPIService *egservice.WebSubAPIService, slogger *slog.Logger) *WebSubAPIHandler {
+func NewWebSubAPIHandler(websubAPIService *egservice.WebSubAPIService, identity *service.IdentityService, slogger *slog.Logger) *WebSubAPIHandler {
 	return &WebSubAPIHandler{
 		websubAPIService: websubAPIService,
+		identity:         identity,
 		slogger:          slogger,
 	}
 }
@@ -74,7 +77,10 @@ func (h *WebSubAPIHandler) CreateWebSubAPI(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	createdBy, _ := middleware.GetUserIDFromRequest(r)
+	createdBy, ok := resolveActor(w, r, h.identity, h.slogger, "create WebSub API")
+	if !ok {
+		return
+	}
 
 	resp, err := h.websubAPIService.Create(orgID, createdBy, &req)
 	if err != nil {
@@ -155,7 +161,10 @@ func (h *WebSubAPIHandler) UpdateWebSubAPI(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	updatedBy, _ := middleware.GetUserIDFromRequest(r)
+	updatedBy, ok := resolveActor(w, r, h.identity, h.slogger, "update WebSub API")
+	if !ok {
+		return
+	}
 	resp, err := h.websubAPIService.Update(orgID, id, updatedBy, &req)
 	if err != nil {
 		h.handleServiceError(w, err)
@@ -174,7 +183,10 @@ func (h *WebSubAPIHandler) DeleteWebSubAPI(w http.ResponseWriter, r *http.Reques
 	}
 
 	id := r.PathValue("webSubApiId")
-	deletedBy, _ := middleware.GetUserIDFromRequest(r)
+	deletedBy, ok := resolveActor(w, r, h.identity, h.slogger, "delete WebSub API")
+	if !ok {
+		return
+	}
 
 	if err := h.websubAPIService.Delete(orgID, id, deletedBy); err != nil {
 		h.handleServiceError(w, err)

--- a/platform-api/src/plugins/eventgateway/handler/websub_api_deployment.go
+++ b/platform-api/src/plugins/eventgateway/handler/websub_api_deployment.go
@@ -29,6 +29,7 @@ import (
 	"platform-api/src/api"
 	"platform-api/src/internal/constants"
 	"platform-api/src/internal/middleware"
+	"platform-api/src/internal/service"
 	"platform-api/src/internal/utils"
 	egservice "platform-api/src/plugins/eventgateway/service"
 
@@ -38,13 +39,15 @@ import (
 // WebSubAPIDeploymentHandler handles deployment routes for WebSub APIs
 type WebSubAPIDeploymentHandler struct {
 	websubAPIDeploymentService *egservice.WebSubAPIDeploymentService
+	identity                   *service.IdentityService
 	slogger                    *slog.Logger
 }
 
 // NewWebSubAPIDeploymentHandler creates a new WebSubAPIDeploymentHandler
-func NewWebSubAPIDeploymentHandler(websubAPIDeploymentService *egservice.WebSubAPIDeploymentService, slogger *slog.Logger) *WebSubAPIDeploymentHandler {
+func NewWebSubAPIDeploymentHandler(websubAPIDeploymentService *egservice.WebSubAPIDeploymentService, identity *service.IdentityService, slogger *slog.Logger) *WebSubAPIDeploymentHandler {
 	return &WebSubAPIDeploymentHandler{
 		websubAPIDeploymentService: websubAPIDeploymentService,
+		identity:                   identity,
 		slogger:                    slogger,
 	}
 }
@@ -92,7 +95,10 @@ func (h *WebSubAPIDeploymentHandler) DeployWebSubAPI(w http.ResponseWriter, r *h
 		return
 	}
 
-	createdBy, _ := middleware.GetUserIDFromRequest(r)
+	createdBy, ok := resolveActor(w, r, h.identity, h.slogger, "deploy WebSub API")
+	if !ok {
+		return
+	}
 	deployment, err := h.websubAPIDeploymentService.DeployWebSubAPIByHandle(apiId, &req, orgId, createdBy)
 	if err != nil {
 		if respondArtifactGuardError(w, err) {

--- a/platform-api/src/plugins/eventgateway/handler/websub_api_hmac_secret.go
+++ b/platform-api/src/plugins/eventgateway/handler/websub_api_hmac_secret.go
@@ -30,6 +30,7 @@ import (
 	"platform-api/src/internal/constants"
 	"platform-api/src/internal/middleware"
 	"platform-api/src/internal/model"
+	"platform-api/src/internal/service"
 	"platform-api/src/internal/utils"
 	egservice "platform-api/src/plugins/eventgateway/service"
 
@@ -39,13 +40,15 @@ import (
 // WebSubAPIHmacSecretHandler handles HMAC secret CRUD for WebSub APIs.
 type WebSubAPIHmacSecretHandler struct {
 	secretService *egservice.WebSubAPIHmacSecretService
+	identity      *service.IdentityService
 	slogger       *slog.Logger
 }
 
 // NewWebSubAPIHmacSecretHandler creates a new WebSubAPIHmacSecretHandler.
-func NewWebSubAPIHmacSecretHandler(secretService *egservice.WebSubAPIHmacSecretService, slogger *slog.Logger) *WebSubAPIHmacSecretHandler {
+func NewWebSubAPIHmacSecretHandler(secretService *egservice.WebSubAPIHmacSecretService, identity *service.IdentityService, slogger *slog.Logger) *WebSubAPIHmacSecretHandler {
 	return &WebSubAPIHmacSecretHandler{
 		secretService: secretService,
+		identity:      identity,
 		slogger:       slogger,
 	}
 }
@@ -100,7 +103,10 @@ func (h *WebSubAPIHmacSecretHandler) CreateHmacSecret(w http.ResponseWriter, r *
 		externalSecret = *req.Secret
 	}
 
-	userID, _ := middleware.GetUserIDFromRequest(r)
+	userID, ok := resolveActor(w, r, h.identity, h.slogger, "generate WebSub HMAC secret")
+	if !ok {
+		return
+	}
 	secret, plaintext, err := h.secretService.Generate(orgID, apiHandle, req.DisplayName, externalSecret, userID)
 	if err != nil {
 		h.handleServiceError(w, err)
@@ -111,9 +117,15 @@ func (h *WebSubAPIHmacSecretHandler) CreateHmacSecret(w http.ResponseWriter, r *
 	if externalSecret != "" {
 		msg = "HMAC secret stored successfully."
 	}
+	info, err := h.toSecretInfo(secret)
+	if err != nil {
+		h.slogger.Error("Failed to resolve HMAC secret identity", "error", err)
+		httputil.WriteJSON(w, http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error", "Failed to generate HMAC secret"))
+		return
+	}
 	httputil.WriteJSON(w, http.StatusCreated, api.WebSubAPIHmacSecretCreationResponse{
 		Secret:        plaintext,
-		WebhookSecret: secretToInfo(secret),
+		WebhookSecret: info,
 		Message:       msg,
 	})
 }
@@ -143,7 +155,13 @@ func (h *WebSubAPIHmacSecretHandler) ListHmacSecrets(w http.ResponseWriter, r *h
 
 	items := make([]api.WebSubAPIHmacSecretInfo, 0, len(secrets))
 	for _, s := range secrets {
-		items = append(items, *secretToInfo(s))
+		info, err := h.toSecretInfo(s)
+		if err != nil {
+			h.slogger.Error("Failed to resolve HMAC secret identity", "error", err)
+			httputil.WriteJSON(w, http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error", "Failed to list HMAC secrets"))
+			return
+		}
+		items = append(items, *info)
 	}
 	httputil.WriteJSON(w, http.StatusOK, api.WebSubAPIHmacSecretListResponse{Secrets: items})
 }
@@ -208,7 +226,10 @@ func (h *WebSubAPIHmacSecretHandler) RegenerateHmacSecret(w http.ResponseWriter,
 		externalSecret = *req.Secret
 	}
 
-	userID, _ := middleware.GetUserIDFromRequest(r)
+	userID, ok := resolveActor(w, r, h.identity, h.slogger, "regenerate WebSub HMAC secret")
+	if !ok {
+		return
+	}
 	secret, plaintext, err := h.secretService.Regenerate(orgID, apiHandle, secretName, externalSecret, userID)
 	if err != nil {
 		h.handleServiceError(w, err)
@@ -219,9 +240,15 @@ func (h *WebSubAPIHmacSecretHandler) RegenerateHmacSecret(w http.ResponseWriter,
 	if externalSecret != "" {
 		msg = "HMAC secret rotated to the provided value successfully."
 	}
+	info, err := h.toSecretInfo(secret)
+	if err != nil {
+		h.slogger.Error("Failed to resolve HMAC secret identity", "error", err)
+		httputil.WriteJSON(w, http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error", "Failed to regenerate HMAC secret"))
+		return
+	}
 	httputil.WriteJSON(w, http.StatusOK, api.WebSubAPIHmacSecretCreationResponse{
 		Secret:        plaintext,
-		WebhookSecret: secretToInfo(secret),
+		WebhookSecret: info,
 		Message:       msg,
 	})
 }
@@ -254,7 +281,21 @@ func secretToInfo(s *model.WebSubAPIHmacSecret) *api.WebSubAPIHmacSecretInfo {
 		Name:        s.Handle,
 		DisplayName: s.Name,
 		Status:      s.Status,
+		CreatedBy:   utils.StringPtrIfNotEmpty(s.CreatedBy),
 		CreatedAt:   s.CreatedAt,
 		UpdatedAt:   s.UpdatedAt,
 	}
+}
+
+// toSecretInfo converts s via secretToInfo and resolves its createdBy UUID to
+// its raw external identity.
+func (h *WebSubAPIHmacSecretHandler) toSecretInfo(s *model.WebSubAPIHmacSecret) (*api.WebSubAPIHmacSecretInfo, error) {
+	info := secretToInfo(s)
+	if info == nil {
+		return nil, nil
+	}
+	if err := h.identity.ResolveIdentityField(&info.CreatedBy); err != nil {
+		return nil, err
+	}
+	return info, nil
 }

--- a/platform-api/src/plugins/eventgateway/handler/websub_apikey.go
+++ b/platform-api/src/plugins/eventgateway/handler/websub_apikey.go
@@ -40,14 +40,16 @@ import (
 type WebSubAPIKeyHandler struct {
 	websubAPIService *egservice.WebSubAPIService
 	apiKeyService    *service.APIKeyService
+	identity         *service.IdentityService
 	slogger          *slog.Logger
 }
 
 // NewWebSubAPIKeyHandler creates a new WebSubAPIKeyHandler instance
-func NewWebSubAPIKeyHandler(websubAPIService *egservice.WebSubAPIService, apiKeyService *service.APIKeyService, slogger *slog.Logger) *WebSubAPIKeyHandler {
+func NewWebSubAPIKeyHandler(websubAPIService *egservice.WebSubAPIService, apiKeyService *service.APIKeyService, identity *service.IdentityService, slogger *slog.Logger) *WebSubAPIKeyHandler {
 	return &WebSubAPIKeyHandler{
 		websubAPIService: websubAPIService,
 		apiKeyService:    apiKeyService,
+		identity:         identity,
 		slogger:          slogger,
 	}
 }
@@ -79,7 +81,10 @@ func (h *WebSubAPIKeyHandler) CreateAPIKey(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	userId := r.Header.Get("x-user-id")
+	userId, ok := resolveActor(w, r, h.identity, h.slogger, "create WebSub API key")
+	if !ok {
+		return
+	}
 
 	var req api.CreateAPIKeyRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -152,7 +157,10 @@ func (h *WebSubAPIKeyHandler) UpdateAPIKey(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	userId := r.Header.Get("x-user-id")
+	userId, ok := resolveActor(w, r, h.identity, h.slogger, "update WebSub API key")
+	if !ok {
+		return
+	}
 
 	var req api.UpdateAPIKeyRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -217,7 +225,10 @@ func (h *WebSubAPIKeyHandler) DeleteAPIKey(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	userId := r.Header.Get("x-user-id")
+	userId, ok := resolveActor(w, r, h.identity, h.slogger, "revoke WebSub API key")
+	if !ok {
+		return
+	}
 
 	if err := h.apiKeyService.RevokeAPIKey(r.Context(), apiHandle, constants.WebSubApi, orgID, keyName, userId); err != nil {
 		if errors.Is(err, constants.ErrAPINotFound) {

--- a/platform-api/src/plugins/eventgateway/openapi.yaml
+++ b/platform-api/src/plugins/eventgateway/openapi.yaml
@@ -815,9 +815,14 @@ components:
           example: false
         createdBy:
           type: string
-          description: Username of the creator
+          description: User identifier of the user who created this resource
           readOnly: true
-          example: jane.doe
+          example: "john.doe@example.com"
+        updatedBy:
+          type: string
+          readOnly: true
+          description: User identifier of the user who last updated this resource. Only present in the detail response (GET /websub-apis/{id}), omitted from list responses.
+          example: "john.doe@example.com"
         createdAt:
           type: string
           format: date-time
@@ -864,6 +869,11 @@ components:
           type: boolean
           description: True when the artifact originated from a data-plane gateway (origin gateway_api) and is read-only in the control plane.
           example: false
+        createdBy:
+          type: string
+          readOnly: true
+          description: User identifier of the user who created this resource
+          example: "john.doe@example.com"
         createdAt:
           type: string
           format: date-time
@@ -985,6 +995,11 @@ components:
           type: string
           description: Status of the HMAC secret.
           example: active
+        createdBy:
+          type: string
+          readOnly: true
+          description: User identifier of the user who created this resource
+          example: "john.doe@example.com"
         createdAt:
           type: string
           format: date-time
@@ -1141,9 +1156,14 @@ components:
           example: false
         createdBy:
           type: string
-          description: Username of the creator
+          description: User identifier of the user who created this resource
           readOnly: true
-          example: jane.doe
+          example: "john.doe@example.com"
+        updatedBy:
+          type: string
+          readOnly: true
+          description: User identifier of the user who last updated this resource. Only present in the detail response (GET /webbroker-apis/{id}), omitted from list responses.
+          example: "john.doe@example.com"
         createdAt:
           type: string
           format: date-time
@@ -1190,6 +1210,11 @@ components:
           type: boolean
           description: True when the artifact originated from a data-plane gateway (origin gateway_api) and is read-only in the control plane.
           example: false
+        createdBy:
+          type: string
+          readOnly: true
+          description: User identifier of the user who created this resource
+          example: "john.doe@example.com"
         createdAt:
           type: string
           format: date-time

--- a/platform-api/src/plugins/eventgateway/plugin.go
+++ b/platform-api/src/plugins/eventgateway/plugin.go
@@ -143,6 +143,7 @@ func (p *EventGatewayPlugin) Init(deps *plugin.Deps) error {
 		logger,
 		deps.AuditRepo,
 		cfg,
+		deps.IdentityService,
 	)
 
 	websubDeploymentSvc := egservice.NewWebSubAPIDeploymentService(
@@ -166,6 +167,7 @@ func (p *EventGatewayPlugin) Init(deps *plugin.Deps) error {
 		logger,
 		deps.AuditRepo,
 		cfg,
+		deps.IdentityService,
 	)
 
 	webbrokerDeploymentSvc := egservice.NewWebBrokerAPIDeploymentService(
@@ -196,13 +198,13 @@ func (p *EventGatewayPlugin) Init(deps *plugin.Deps) error {
 	p.hmacSecretSvc = hmacSecretSvc
 
 	// Handlers.
-	p.websubAPIHandler = eghandler.NewWebSubAPIHandler(websubAPISvc, logger)
-	p.websubAPIDeploymentHandler = eghandler.NewWebSubAPIDeploymentHandler(websubDeploymentSvc, logger)
-	p.websubAPIHmacSecretHandler = eghandler.NewWebSubAPIHmacSecretHandler(hmacSecretSvc, logger)
-	p.websubAPIKeyHandler = eghandler.NewWebSubAPIKeyHandler(websubAPISvc, deps.APIKeyService, logger)
-	p.webbrokerAPIHandler = eghandler.NewWebBrokerAPIHandler(webbrokerAPISvc, logger)
-	p.webbrokerDeploymentHandler = eghandler.NewWebBrokerAPIDeploymentHandler(webbrokerDeploymentSvc, logger)
-	p.webbrokerAPIKeyHandler = eghandler.NewWebBrokerAPIKeyHandler(webbrokerAPISvc, deps.APIKeyService, logger)
+	p.websubAPIHandler = eghandler.NewWebSubAPIHandler(websubAPISvc, deps.IdentityService, logger)
+	p.websubAPIDeploymentHandler = eghandler.NewWebSubAPIDeploymentHandler(websubDeploymentSvc, deps.IdentityService, logger)
+	p.websubAPIHmacSecretHandler = eghandler.NewWebSubAPIHmacSecretHandler(hmacSecretSvc, deps.IdentityService, logger)
+	p.websubAPIKeyHandler = eghandler.NewWebSubAPIKeyHandler(websubAPISvc, deps.APIKeyService, deps.IdentityService, logger)
+	p.webbrokerAPIHandler = eghandler.NewWebBrokerAPIHandler(webbrokerAPISvc, deps.IdentityService, logger)
+	p.webbrokerDeploymentHandler = eghandler.NewWebBrokerAPIDeploymentHandler(webbrokerDeploymentSvc, deps.IdentityService, logger)
+	p.webbrokerAPIKeyHandler = eghandler.NewWebBrokerAPIKeyHandler(webbrokerAPISvc, deps.APIKeyService, deps.IdentityService, logger)
 
 	return nil
 }

--- a/platform-api/src/plugins/eventgateway/service/webbroker_api.go
+++ b/platform-api/src/plugins/eventgateway/service/webbroker_api.go
@@ -44,6 +44,7 @@ type WebBrokerAPIService struct {
 	slogger              *slog.Logger
 	auditRepo            repository.AuditRepository
 	cfg                  *config.Server
+	identity             *coreservice.IdentityService
 }
 
 // NewWebBrokerAPIService creates a new WebBrokerAPIService instance
@@ -56,6 +57,7 @@ func NewWebBrokerAPIService(
 	slogger *slog.Logger,
 	auditRepo repository.AuditRepository,
 	cfg *config.Server,
+	identity *coreservice.IdentityService,
 ) *WebBrokerAPIService {
 	return &WebBrokerAPIService{
 		repo:                 repo,
@@ -66,7 +68,37 @@ func NewWebBrokerAPIService(
 		slogger:              slogger,
 		auditRepo:            auditRepo,
 		cfg:                  cfg,
+		identity:             identity,
 	}
+}
+
+// toWebBrokerAPI converts m via mapWebBrokerAPIModelToAPI and resolves its
+// createdBy/updatedBy UUIDs to their raw external identity.
+func (s *WebBrokerAPIService) toWebBrokerAPI(m *model.WebBrokerAPI) (*api.WebBrokerAPI, error) {
+	resp := mapWebBrokerAPIModelToAPI(m, s.apiUtil)
+	if resp == nil {
+		return nil, nil
+	}
+	if err := s.identity.ResolveIdentityField(&resp.CreatedBy); err != nil {
+		return nil, err
+	}
+	if err := s.identity.ResolveIdentityField(&resp.UpdatedBy); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// webBrokerAPIListItemResolved converts m via mapWebBrokerAPIModelToListItem
+// and resolves its createdBy UUID to its raw external identity.
+func (s *WebBrokerAPIService) webBrokerAPIListItemResolved(m *model.WebBrokerAPI) (*api.WebBrokerAPIListItem, error) {
+	item := mapWebBrokerAPIModelToListItem(m)
+	if item == nil {
+		return nil, nil
+	}
+	if err := s.identity.ResolveIdentityField(&item.CreatedBy); err != nil {
+		return nil, err
+	}
+	return item, nil
 }
 
 // Create creates a new WebBroker API
@@ -183,7 +215,7 @@ func (s *WebBrokerAPIService) Get(orgUUID, handle string) (*api.WebBrokerAPI, er
 		return nil, constants.ErrWebBrokerAPINotFound
 	}
 
-	return mapWebBrokerAPIModelToAPI(m, s.apiUtil), nil
+	return s.toWebBrokerAPI(m)
 }
 
 // List retrieves WebBroker APIs for an organization filtered by project
@@ -214,7 +246,13 @@ func (s *WebBrokerAPIService) List(orgUUID, projectUUID string, limit, offset in
 
 	resp.List = make([]api.WebBrokerAPIListItem, 0, len(apis))
 	for _, a := range apis {
-		resp.List = append(resp.List, *mapWebBrokerAPIModelToListItem(a))
+		item, err := s.webBrokerAPIListItemResolved(a)
+		if err != nil {
+			return nil, err
+		}
+		if item != nil {
+			resp.List = append(resp.List, *item)
+		}
 	}
 
 	return resp, nil
@@ -398,6 +436,7 @@ func mapWebBrokerAPIModelToAPI(m *model.WebBrokerAPI, apiUtil *utils.APIUtil) *a
 		ReadOnly:          utils.BoolPtr(m.Origin == constants.OriginDP),
 		CreatedAt:         utils.TimePtr(m.CreatedAt),
 		UpdatedAt:         utils.TimePtr(m.UpdatedAt),
+		UpdatedBy:         utils.StringPtrIfNotEmpty(m.UpdatedBy),
 	}
 
 	return result
@@ -597,6 +636,7 @@ func mapWebBrokerAPIModelToListItem(m *model.WebBrokerAPI) *api.WebBrokerAPIList
 		Context:         m.Configuration.Context,
 		LifeCycleStatus: &lifeCycleStatus,
 		ReadOnly:        utils.BoolPtr(m.Origin == constants.OriginDP),
+		CreatedBy:       utils.StringPtrIfNotEmpty(m.CreatedBy),
 		CreatedAt:       utils.TimePtr(m.CreatedAt),
 		UpdatedAt:       utils.TimePtr(m.UpdatedAt),
 	}

--- a/platform-api/src/plugins/eventgateway/service/websub_api.go
+++ b/platform-api/src/plugins/eventgateway/service/websub_api.go
@@ -44,6 +44,7 @@ type WebSubAPIService struct {
 	slogger              *slog.Logger
 	auditRepo            repository.AuditRepository
 	cfg                  *config.Server
+	identity             *coreservice.IdentityService
 }
 
 // NewWebSubAPIService creates a new WebSubAPIService instance
@@ -56,6 +57,7 @@ func NewWebSubAPIService(
 	slogger *slog.Logger,
 	auditRepo repository.AuditRepository,
 	cfg *config.Server,
+	identity *coreservice.IdentityService,
 ) *WebSubAPIService {
 	return &WebSubAPIService{
 		repo:                 repo,
@@ -66,7 +68,37 @@ func NewWebSubAPIService(
 		slogger:              slogger,
 		auditRepo:            auditRepo,
 		cfg:                  cfg,
+		identity:             identity,
 	}
+}
+
+// toWebSubAPI converts m via mapWebSubAPIModelToAPI and resolves its
+// createdBy/updatedBy UUIDs to their raw external identity.
+func (s *WebSubAPIService) toWebSubAPI(m *model.WebSubAPI) (*api.WebSubAPI, error) {
+	resp := mapWebSubAPIModelToAPI(m, s.apiUtil)
+	if resp == nil {
+		return nil, nil
+	}
+	if err := s.identity.ResolveIdentityField(&resp.CreatedBy); err != nil {
+		return nil, err
+	}
+	if err := s.identity.ResolveIdentityField(&resp.UpdatedBy); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// webSubAPIListItemResolved converts m via mapWebSubAPIModelToListItem and
+// resolves its createdBy UUID to its raw external identity.
+func (s *WebSubAPIService) webSubAPIListItemResolved(m *model.WebSubAPI) (*api.WebSubAPIListItem, error) {
+	item := mapWebSubAPIModelToListItem(m)
+	if item == nil {
+		return nil, nil
+	}
+	if err := s.identity.ResolveIdentityField(&item.CreatedBy); err != nil {
+		return nil, err
+	}
+	return item, nil
 }
 
 // Create creates a new WebSub API
@@ -182,7 +214,7 @@ func (s *WebSubAPIService) Get(orgUUID, handle string) (*api.WebSubAPI, error) {
 		return nil, constants.ErrWebSubAPINotFound
 	}
 
-	return mapWebSubAPIModelToAPI(m, s.apiUtil), nil
+	return s.toWebSubAPI(m)
 }
 
 // List retrieves WebSub APIs for an organization filtered by project
@@ -213,7 +245,13 @@ func (s *WebSubAPIService) List(orgUUID, projectUUID string, limit, offset int) 
 
 	resp.List = make([]api.WebSubAPIListItem, 0, len(apis))
 	for _, a := range apis {
-		resp.List = append(resp.List, *mapWebSubAPIModelToListItem(a))
+		item, err := s.webSubAPIListItemResolved(a)
+		if err != nil {
+			return nil, err
+		}
+		if item != nil {
+			resp.List = append(resp.List, *item)
+		}
 	}
 
 	return resp, nil
@@ -395,6 +433,7 @@ func mapWebSubAPIModelToAPI(m *model.WebSubAPI, apiUtil *utils.APIUtil) *api.Web
 		ReadOnly:          utils.BoolPtr(m.Origin == constants.OriginDP),
 		CreatedAt:         utils.TimePtr(m.CreatedAt),
 		UpdatedAt:         utils.TimePtr(m.UpdatedAt),
+		UpdatedBy:         utils.StringPtrIfNotEmpty(m.UpdatedBy),
 	}
 
 	return result
@@ -540,6 +579,7 @@ func mapWebSubAPIModelToListItem(m *model.WebSubAPI) *api.WebSubAPIListItem {
 		Context:         m.Configuration.Context,
 		LifeCycleStatus: &lifeCycleStatus,
 		ReadOnly:        utils.BoolPtr(m.Origin == constants.OriginDP),
+		CreatedBy:       utils.StringPtrIfNotEmpty(m.CreatedBy),
 		CreatedAt:       utils.TimePtr(m.CreatedAt),
 		UpdatedAt:       utils.TimePtr(m.UpdatedAt),
 	}

--- a/platform-api/src/resources/openapi.yaml
+++ b/platform-api/src/resources/openapi.yaml
@@ -4976,7 +4976,9 @@ components:
           description: Timestamp when the key was created
         createdBy:
           type: string
-          description: User who created the key
+          readOnly: true
+          description: User identifier of the user who created this resource
+          example: "john.doe"
         updatedAt:
           type: string
           format: date-time
@@ -5080,6 +5082,16 @@ components:
           type: string
           description: Geographic region where the organization operates
           example: "us"
+        createdBy:
+          type: string
+          readOnly: true
+          description: User identifier of the user who created this resource
+          example: "john.doe"
+        updatedBy:
+          type: string
+          readOnly: true
+          description: User identifier of the user who last updated this resource
+          example: "john.doe"
         createdAt:
           type: string
           format: date-time
@@ -5150,6 +5162,16 @@ components:
           description: Handle (URL-friendly slug) of the organization this project belongs to
           readOnly: true
           example: "acme"
+        createdBy:
+          type: string
+          readOnly: true
+          description: User identifier of the user who created this resource
+          example: "john.doe"
+        updatedBy:
+          type: string
+          readOnly: true
+          description: User identifier of the user who last updated this resource. Only present in the detail response (GET /projects/{projectId}), omitted from list responses.
+          example: "john.doe"
         createdAt:
           type: string
           format: date-time
@@ -5203,10 +5225,6 @@ components:
           type: string
           description: Description of the application
           example: "Sample GenAI application"
-        createdBy:
-          type: string
-          description: Creator identifier
-          example: "admin"
 
     Application:
       type: object
@@ -5243,8 +5261,14 @@ components:
           example: "Sample GenAI application"
         createdBy:
           type: string
-          description: Creator identifier
-          example: "admin"
+          readOnly: true
+          description: User identifier of the user who created this resource
+          example: "john.doe"
+        updatedBy:
+          type: string
+          readOnly: true
+          description: User identifier of the user who last updated this resource. Only present in the detail response (GET /applications/{appId}), omitted from list responses.
+          example: "john.doe"
         createdAt:
           type: string
           format: date-time
@@ -5429,8 +5453,9 @@ components:
           example: "ACTIVE"
         userId:
           type: string
-          description: User id of the key creator
-          example: "user-123"
+          readOnly: true
+          description: User identifier of the user who created this resource
+          example: "john.doe"
         createdAt:
           type: string
           format: date-time
@@ -5506,9 +5531,15 @@ components:
         createdBy:
           maxLength: 200
           type: string
-          description: |
-            If the createdBy value is not given user invoking the api will be used as the createdBy.
-          example: admin
+          readOnly: true
+          description: User identifier of the user who created this resource
+          example: "john.doe"
+        updatedBy:
+          maxLength: 200
+          type: string
+          readOnly: true
+          description: User identifier of the user who last updated this resource. Only present in the detail response (GET /rest-apis/{apiId}), omitted from list responses.
+          example: "john.doe"
         projectId:
           type: string
           pattern: '^[a-z0-9-]+$'
@@ -6022,6 +6053,16 @@ components:
           type: boolean
           description: Indicates if the gateway is currently connected to the platform via WebSocket
           example: true
+        createdBy:
+          type: string
+          readOnly: true
+          description: User identifier of the user who created this resource
+          example: "john.doe"
+        updatedBy:
+          type: string
+          readOnly: true
+          description: User identifier of the user who last updated this resource. Only present in the detail response (GET /gateways/{gatewayId}), omitted from list responses.
+          example: "john.doe"
         createdAt:
           type: string
           format: date-time
@@ -6479,6 +6520,16 @@ components:
         status:
           type: string
           enum: [ACTIVE, INACTIVE]
+        createdBy:
+          type: string
+          readOnly: true
+          description: User identifier of the user who created this resource
+          example: "john.doe"
+        updatedBy:
+          type: string
+          readOnly: true
+          description: User identifier of the user who last updated this resource. Only present in the detail response (GET /subscription-plans/{planId}), omitted from list responses.
+          example: "john.doe"
         createdAt:
           type: string
           format: date-time
@@ -6575,6 +6626,16 @@ components:
         status:
           type: string
           enum: [ACTIVE, INACTIVE, REVOKED]
+        createdBy:
+          type: string
+          readOnly: true
+          description: User identifier of the user who created this resource
+          example: "john.doe"
+        updatedBy:
+          type: string
+          readOnly: true
+          description: User identifier of the user who last updated this resource. Only present in the detail response (GET /subscriptions/{subscriptionId}), omitted from list responses.
+          example: "john.doe"
         createdAt:
           type: string
           format: date-time
@@ -6904,16 +6965,16 @@ components:
           example: Default OpenAI template
         createdBy:
           type: string
-          description: Username of the creator
+          description: User identifier of the user who created this resource
           readOnly: true
           maxLength: 200
-          example: jane.doe
+          example: "john.doe"
         updatedBy:
           type: string
-          description: Username of the last user to update the template
+          description: User identifier of the user who last updated this resource
           readOnly: true
           maxLength: 200
-          example: jane.doe
+          example: "john.doe"
         readOnly:
           type: boolean
           readOnly: true
@@ -7069,7 +7130,9 @@ components:
           example: Default OpenAI template
         createdBy:
           type: string
-          example: jane.doe
+          readOnly: true
+          description: User identifier of the user who created this resource
+          example: "john.doe"
         version:
           type: string
           description: Content version, matching the v<major>.<minor> pattern (e.g. v1.0, v2.0).
@@ -7448,14 +7511,19 @@ components:
           example: Primary OpenAI provider
         createdBy:
           type: string
-          description: Username of the creator
+          description: User identifier of the user who created this resource
           readOnly: true
-          example: jane.doe
+          example: "john.doe"
         readOnly:
           type: boolean
           readOnly: true
           description: True if the artifact originated from a data-plane gateway (origin gateway_api) and is read-only in the control plane; false for control-plane created artifacts.
           example: false
+        updatedBy:
+          type: string
+          readOnly: true
+          description: User identifier of the user who last updated this resource. Only present in the detail response (GET /llm-providers/{id}), omitted from list responses.
+          example: "john.doe"
         version:
           type: string
           description: Semantic version of the LLM Provider
@@ -7594,7 +7662,9 @@ components:
           example: Primary OpenAI provider
         createdBy:
           type: string
-          example: jane.doe
+          readOnly: true
+          description: User identifier of the user who created this resource
+          example: "john.doe"
         readOnly:
           type: boolean
           description: True when the artifact originated from a data-plane gateway (origin gateway_api) and is read-only in the control plane.
@@ -7711,14 +7781,19 @@ components:
           example: Customer support assistant
         createdBy:
           type: string
-          description: Username of the creator
+          description: User identifier of the user who created this resource
           readOnly: true
-          example: jane.doe
+          example: "john.doe"
         readOnly:
           type: boolean
           readOnly: true
           description: True if the artifact originated from a data-plane gateway (origin gateway_api) and is read-only in the control plane; false for control-plane created artifacts.
           example: false
+        updatedBy:
+          type: string
+          readOnly: true
+          description: User identifier of the user who last updated this resource. Only present in the detail response (GET /llm-proxies/{id}), omitted from list responses.
+          example: "john.doe"
         version:
           type: string
           description: Semantic version of the LLM proxy
@@ -7820,7 +7895,9 @@ components:
           example: Customer support assistant
         createdBy:
           type: string
-          example: jane.doe
+          readOnly: true
+          description: User identifier of the user who created this resource
+          example: "john.doe"
         context:
           type: string
           description: Context path where the proxy is exposed
@@ -8033,14 +8110,19 @@ components:
           example: An MCP server which provides weather information
         createdBy:
           type: string
-          description: Username of the creator
+          description: User identifier of the user who created this resource
           readOnly: true
-          example: jane.doe
+          example: "john.doe"
         readOnly:
           type: boolean
           readOnly: true
           description: True if the artifact originated from a data-plane gateway (origin gateway_api) and is read-only in the control plane; false for control-plane created artifacts.
           example: false
+        updatedBy:
+          type: string
+          readOnly: true
+          description: User identifier of the user who last updated this resource. Only present in the detail response (GET /mcp-proxies/{id}), omitted from list responses.
+          example: "john.doe"
         version:
           type: string
           description: Semantic version of the MCP proxy
@@ -8134,7 +8216,9 @@ components:
           example: An MCP server which provides weather information
         createdBy:
           type: string
-          example: jane.doe
+          readOnly: true
+          description: User identifier of the user who created this resource
+          example: "john.doe"
         context:
           type: string
           description: Context path where the proxy is exposed
@@ -8317,6 +8401,16 @@ components:
           minLength: 1
           maxLength: 128
           example: WSO2 OpenAI API Key
+        createdBy:
+          type: string
+          readOnly: true
+          description: User identifier of the user who created this resource
+          example: "john.doe"
+        updatedBy:
+          type: string
+          readOnly: true
+          description: User identifier of the user who last updated this resource
+          example: "john.doe"
         createdAt:
           type: string
           format: date-time
@@ -8355,6 +8449,11 @@ components:
         hash:
           type: string
           example: hmac-sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe04294e576d4b3d4c57e3f428a
+        createdBy:
+          type: string
+          readOnly: true
+          description: User identifier of the user who created this resource
+          example: "john.doe"
         createdAt:
           type: string
           format: date-time


### PR DESCRIPTION
## Purpose

- Resolves: https://github.com/wso2/api-platform/issues/2370

**1. Internal UUID for user identity fields**  
Every place that stored the identity-provider's token subject directly (`created_by`, `updated_by`, `revoked_by`, `performed_by`) now stores our own internal, platform-generated UUID instead. A new `user_sub_mappings` table (`uuid` ↔ `idp_sub`, no FK) maps the OIDC `sub` claim to that UUID, created lazily on first use via `IdentityService`. This applies uniformly across REST APIs, Applications, Projects, Gateways, Subscriptions, LLM Providers/Proxies, MCP Proxies, WebSub/WebBroker APIs, Secrets, Organizations, Subscription Plans, and all API-key variants (including the `x-user-id` header path used by API-key/service-to-service endpoints).

`createdBy` is now always server-inferred (never accepted from a request body) and immutable on update.

**2. Standardized list vs. detail audit fields**  
Applied one policy everywhere: `createdBy` appears in both list and detail responses; `updatedBy` appears in detail responses only. Added the missing fields where resources were previously inconsistent (e.g. `Project`, `Gateway`, `Subscription` had neither; `SubscriptionPlan`/`Organization` needed new model + repository columns wired up).

## Why

- Responses should never leak the raw IdP subject/token claim to API consumers — only our own stable, internal identifier.
- List/detail responses had inconsistent, ad-hoc audit field exposure across resources; this establishes and applies one policy platform-wide.

## Key design points

- **Mapping table keys on the OIDC `sub` claim** (`middleware.GetSubClaimFromRequest`), falling back to the legacy configured-claim/`user_id`/sub precedence (`GetUserIDFromRequest`) when a token has no `sub` — e.g. non-OIDC IdPs, or the `x-user-id` header path used by internal/service callers.
- **No backfill**: existing rows keep their raw IdP identifier until next write; only new writes get the internal UUID.
- **External consumers also get the internal UUID** — gateway broadcast events (`APIKeyCreated/Updated/Revoked`, etc.) carry the same UUID as the DB and API responses, not the raw IdP identifier. This closes an inconsistency where LLM provider/proxy API keys were still storing/comparing/broadcasting the raw `x-user-id` header value while REST API keys had already moved to the internal UUID.
- **`subscriptions.subscriber_id`** is intentionally excluded from this mapping — it's a client-supplied business identifier (who the subscription is for), not a token identity. However, `subscriptions.created_by`/`updated_by` were incorrectly derived from it; they now come from the authenticated caller's internal UUID instead.
- **`gateway_custom_policies.created_by`/`updated_by`** are intentionally left unchanged — they store the syncing *gateway's* UUID (data-plane to control-plane sync), not a user identity.

## Notable fixes found during implementation

- `GET /me/api-keys` was filtering `api_keys.created_by` against the raw `x-user-id` header — silently broken once `created_by` started holding internal UUIDs. Fixed by routing the header through the same identity-resolution helper as every other endpoint.
- MCP Proxy's `updated_by` was written on update but never read back by any `SELECT` query — fixed alongside adding it to the API response.