### PR TITLE
Fix logout flow by clearing the BFF session and remove SQL lock

### DIFF
--- a/portals/ai-workspace/src/App.tsx
+++ b/portals/ai-workspace/src/App.tsx
@@ -222,8 +222,7 @@ function PostSignInInit({ children }: { children: React.ReactNode }) {
               Oops! This is embarrassing
             </Typography>
             <Typography variant="body2" color="text.secondary">
-              Something went terribly wrong. Will you please refresh and try
-              again.
+              Something went wrong. Please log out and sign in again.
             </Typography>
             <Button variant="contained" onClick={onLogout}>
               Logout

--- a/portals/ai-workspace/src/App.tsx
+++ b/portals/ai-workspace/src/App.tsx
@@ -82,7 +82,8 @@ import { LLMProvidersProvider } from './contexts/llmProvider';
 import React, { useRef, useState } from 'react';
 import { ChoreoUserProvider } from './contexts/ChoreoUserContext';
 import { useAppAuth } from './contexts/AppAuthContext';
-import { Box } from '@wso2/oxygen-ui';
+import { Box, Button, Stack, Typography } from '@wso2/oxygen-ui';
+import OoopsImage from './assets/images/Ooops.svg';
 
 /**
  * Only allow same-origin relative paths as return URLs to prevent open redirects.
@@ -140,8 +141,6 @@ function PostSignInInit({ children }: { children: React.ReactNode }) {
   const navigate = useNavigate();
   const initiated = useRef(false);
   const [orgState, setOrgState] = useState<OrgInitState>('checking');
-  const [orgError, setOrgError] = useState<string | null>(null);
-  const [sessionExpired, setSessionExpired] = useState(false);
 
   React.useEffect(() => {
     if (initiated.current) return;
@@ -168,15 +167,10 @@ function PostSignInInit({ children }: { children: React.ReactNode }) {
         navigate(`/organizations/${org.handle}/home`, { replace: true });
         setOrgState('done');
       })
-      .catch((err: unknown) => {
-        // A 401 means the session is invalid/expired — retrying won't help.
-        // Surface a "session expired" screen with a logout action instead.
-        if ((err as { status?: number })?.status === 401) {
-          setSessionExpired(true);
-          setOrgState('error');
-          return;
-        }
-        setOrgError(err instanceof Error ? err.message : 'Failed to set up workspace');
+      .catch(() => {
+        // Any failure here (a 401 from an expired/invalid session, or an
+        // unexpected error) is unrecoverable without re-authenticating, so
+        // surface the error screen whose only action is to log out.
         setOrgState('error');
       });
   }, [user, navigate]);
@@ -191,14 +185,52 @@ function PostSignInInit({ children }: { children: React.ReactNode }) {
   }
 
   if (orgState === 'error') {
+    const onLogout = () => { void forceLogoutAndRedirect(); };
     return (
-      <OrgProvisioningPage
-        orgName={user?.org?.name ?? undefined}
-        error={sessionExpired ? null : orgError}
-        isSessionExpired={sessionExpired}
-        onLogout={() => { void forceLogoutAndRedirect(); }}
-        onRetry={() => { initiated.current = false; setOrgState('checking'); }}
-      />
+      <Box
+        sx={{
+          minHeight: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          px: 2,
+        }}
+      >
+        <Box
+          sx={{
+            width: 'min(560px, 100%)',
+            textAlign: 'center',
+          }}
+        >
+          <Stack spacing={1} alignItems="center">
+            <Box
+              component="img"
+              src={OoopsImage}
+              alt="Oops"
+              sx={{
+                width: 180,
+                maxWidth: '100%',
+                height: 'auto',
+              }}
+            />
+            <Typography
+              variant="h4"
+              sx={{
+                fontWeight: 700,
+              }}
+            >
+              Oops! This is embarrassing
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Something went terribly wrong. Will you please refresh and try
+              again.
+            </Typography>
+            <Button variant="contained" onClick={onLogout}>
+              Logout
+            </Button>
+          </Stack>
+        </Box>
+      </Box>
     );
   }
 

--- a/portals/ai-workspace/src/auth/logout.ts
+++ b/portals/ai-workspace/src/auth/logout.ts
@@ -24,6 +24,7 @@ import { logger } from '../utils/logger';
 type SignOutFunction = () => Promise<void>;
 
 const BFF_LOGOUT_URL = '/api/logout';
+const LOGOUT_REQUEST_TIMEOUT_MS = 5000;
 
 const AUTH_SESSION_KEYS = [
   'platform_auth_token',
@@ -94,11 +95,14 @@ export const forceLogoutAndRedirect = async (): Promise<void> => {
   };
 
   let logoutUrl: string | undefined;
+  const controller = new AbortController();
+  const timeoutId = window.setTimeout(() => controller.abort(), LOGOUT_REQUEST_TIMEOUT_MS);
   try {
     const res = await fetch(BFF_LOGOUT_URL, {
       method: 'POST',
       credentials: 'include',
       headers: { Accept: 'application/json', [CSRF_HEADER]: CSRF_VALUE },
+      signal: controller.signal,
     });
     if (res.ok) {
       const body = (await res.json().catch(() => ({}))) as { logoutUrl?: string };
@@ -106,6 +110,8 @@ export const forceLogoutAndRedirect = async (): Promise<void> => {
     }
   } catch (error) {
     logger.warn('Force logout: BFF logout call failed:', error);
+  } finally {
+    window.clearTimeout(timeoutId);
   }
 
   runStep('clear auth data', clearAuthData);

--- a/portals/ai-workspace/src/auth/logout.ts
+++ b/portals/ai-workspace/src/auth/logout.ts
@@ -18,9 +18,12 @@
 
 import { clearStoredToken } from '../clients/choreoApiClient';
 import { clearBasicAuthSession } from '../contexts/BasicAuthProvider';
+import { CSRF_HEADER, CSRF_VALUE } from '../config.env';
 import { logger } from '../utils/logger';
 
 type SignOutFunction = () => Promise<void>;
+
+const BFF_LOGOUT_URL = '/api/logout';
 
 const AUTH_SESSION_KEYS = [
   'platform_auth_token',
@@ -68,13 +71,16 @@ const clearSiteCache = async (): Promise<void> => {
 };
 
 /**
- * Force a logout without an IDP round-trip and redirect to the login page.
+ * Force a logout and redirect to the login page.
  *
  * Used when the platform API rejects a request with 401 (expired/invalid
- * session): retrying is futile, so we clear all client-side session state and
- * the site cache, then do a full-page redirect to /login. The full reload
- * (rather than a router navigation) also discards any in-memory React state
- * tied to the dead session.
+ * session): retrying is futile. We first ask the BFF to tear down the session
+ * (`POST /api/logout`) so the HttpOnly `_bff_session` cookie is cleared
+ * server-side — clearing client storage alone leaves that cookie intact, which
+ * would silently re-hydrate the dead session on the next `/login` and loop the
+ * user back to the error screen. We then clear all client-side session state and
+ * the site cache and do a full-page redirect (which also discards in-memory
+ * React state tied to the dead session).
  */
 export const forceLogoutAndRedirect = async (): Promise<void> => {
   // Each cleanup step is isolated so a failure in one doesn't skip the rest;
@@ -87,12 +93,32 @@ export const forceLogoutAndRedirect = async (): Promise<void> => {
     }
   };
 
+  let logoutUrl: string | undefined;
+  try {
+    const res = await fetch(BFF_LOGOUT_URL, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { Accept: 'application/json', [CSRF_HEADER]: CSRF_VALUE },
+    });
+    if (res.ok) {
+      const body = (await res.json().catch(() => ({}))) as { logoutUrl?: string };
+      logoutUrl = body.logoutUrl;
+    }
+  } catch (error) {
+    logger.warn('Force logout: BFF logout call failed:', error);
+  }
+
   runStep('clear auth data', clearAuthData);
   // Wipe any remaining client-side state so nothing carries over the session.
   runStep('clear sessionStorage', () => sessionStorage.clear());
   runStep('clear localStorage', () => localStorage.clear());
   await clearSiteCache();
 
-  // Replace (not assign) so the broken page isn't left in history.
+  // Prefer the IDP end-session URL (fully logs out at the IDP); otherwise fall
+  // back to /login. Replace (not assign) so the broken page isn't left in history.
+  if (logoutUrl) {
+    window.location.replace(logoutUrl);
+    return;
+  }
   window.location.replace('/login');
 };


### PR DESCRIPTION
## Purpose

Previously, when the AI Workspace portal encountered an unrecoverable authentication error, the logout flow only cleared client-side state (tokens, localStorage, sessionStorage, and site cache) before redirecting the user to /login.

However, the active BFF session is stored in an HttpOnly _bff_session cookie, which cannot be cleared from the browser. As a result, the stale session remained active, and revisiting /login immediately restored the invalid session, sending users back to the error page with no way to successfully log out.

This change updates the logout flow to properly terminate the server-side BFF session before clearing client-side state, ensuring users are fully signed out and can start a fresh authentication flow.

## UI change

<img width="544" height="441" alt="image" src="https://github.com/user-attachments/assets/f1d1ba4d-f5a5-4d58-a12b-89c00bc5bdab" />
