### PR TITLE
Refactor version handling and update query parameters in LLM templates

### DIFF
--- a/platform-api/src/internal/handler/llm.go
+++ b/platform-api/src/internal/handler/llm.go
@@ -236,9 +236,6 @@ func (h *LLMHandler) ListLLMProviderTemplates(w http.ResponseWriter, r *http.Req
 			return
 		}
 		version := q.Version
-		if version == "" {
-			version = strings.TrimSpace(r.URL.Query().Get("version"))
-		}
 		if version != "" {
 			resp, err := h.templateService.GetVersion(orgID, groupID, version)
 			if err != nil {
@@ -277,9 +274,7 @@ func (h *LLMHandler) ListLLMProviderTemplates(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	// latest may be given inside the query DSL (?query=latest:true) or as a
-	// standalone param (?latest=true); both mean "latest version per family".
-	latestOnly := q.Latest || strings.EqualFold(r.URL.Query().Get("latest"), "true")
+	latestOnly := q.Latest
 
 	resp, err := h.templateService.List(orgID, limit, offset, latestOnly)
 	if err != nil {

--- a/platform-api/src/internal/handler/llm_template_integration_test.go
+++ b/platform-api/src/internal/handler/llm_template_integration_test.go
@@ -301,21 +301,6 @@ func TestLLMTemplateHTTP_GetVersionByQuery(t *testing.T) {
 		t.Errorf("expected version v1.0, got %v", m["version"])
 	}
 
-	// Same selection via the standalone ?version= param (query holds only the
-	// groupId) -> the single full template, not the family's version list.
-	standalone := tmplBase + "?query=" + url.QueryEscape("groupId:"+groupID) + "&version=v1.0"
-	w = doJSON(t, r, http.MethodGet, standalone, "", true)
-	if w.Code != http.StatusOK {
-		t.Fatalf("get version (standalone param): expected 200, got %d: %s", w.Code, w.Body.String())
-	}
-	m = bodyMap(t, w)
-	if _, isList := m["list"]; isList {
-		t.Errorf("standalone version: expected a single template object, got a list response: %s", w.Body.String())
-	}
-	if m["version"] != "v1.0" {
-		t.Errorf("standalone version: expected version v1.0, got %v", m["version"])
-	}
-
 	// Unknown version within an existing family -> 404.
 	if w := doJSON(t, r, http.MethodGet, queryVersionPath(groupID, "v9.9"), "", true); w.Code != http.StatusNotFound {
 		t.Errorf("unknown version: expected 404, got %d: %s", w.Code, w.Body.String())

--- a/platform-api/src/internal/handler/parse_template_query_test.go
+++ b/platform-api/src/internal/handler/parse_template_query_test.go
@@ -24,28 +24,30 @@ func TestParseTemplateQuery(t *testing.T) {
 		raw         string
 		wantGroupID string
 		wantVersion string
+		wantLatest  bool
 		wantFound   bool
 	}{
-		{"empty", "", "", "", false},
-		{"groupId only", "groupId:openai", "openai", "", true},
-		{"slug groupId", "groupId:deep-seek", "deep-seek", "", true},
-		{"groupId and version", "groupId:openai&version:v1.0", "openai", "v1.0", true},
-		{"order independent", "version:v2.0&groupId:openai", "openai", "v2.0", true},
-		{"unknown key ignored", "displayName:ab&groupId:openai", "openai", "", true},
-		{"whitespace trimmed", " groupId : openai & version : v1.0 ", "openai", "v1.0", true},
-		{"malformed token skipped", "garbage&groupId:openai&version:v3.0", "openai", "v3.0", true},
-		{"version without groupId is not found", "version:v2.0", "", "v2.0", false},
-		{"blank groupId value", "groupId:", "", "", true},
-		{"blank groupId whitespace", "groupId:   ", "", "", true},
-		{"blank groupId with version", "version:v2.0&groupId:", "", "v2.0", true},
+		{"empty", "", "", "", false, false},
+		{"groupId only", "groupId:openai", "openai", "", false, true},
+		{"slug groupId", "groupId:deep-seek", "deep-seek", "", false, true},
+		{"groupId and version", "groupId:openai&version:v1.0", "openai", "v1.0", false, true},
+		{"order independent", "version:v2.0&groupId:openai", "openai", "v2.0", false, true},
+		{"latest only", "latest:true", "", "", true, false},
+		{"latest false", "latest:false", "", "", false, false},
+		{"unknown key ignored", "displayName:ab&groupId:openai", "openai", "", false, true},
+		{"whitespace trimmed", " groupId : openai & version : v1.0 ", "openai", "v1.0", false, true},
+		{"malformed token skipped", "garbage&groupId:openai&version:v3.0", "openai", "v3.0", false, true},
+		{"version without groupId is not found", "version:v2.0", "", "v2.0", false, false},
+		{"blank groupId value", "groupId:", "", "", false, true},
+		{"blank groupId whitespace", "groupId:   ", "", "", false, true},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			q, found := parseTemplateQuery(tc.raw)
-			if q.GroupID != tc.wantGroupID || q.Version != tc.wantVersion || found != tc.wantFound {
-				t.Fatalf("parseTemplateQuery(%q) = (%+v, %t), want (groupId=%q version=%q, %t)",
-					tc.raw, q, found, tc.wantGroupID, tc.wantVersion, tc.wantFound)
+			if q.GroupID != tc.wantGroupID || q.Version != tc.wantVersion || q.Latest != tc.wantLatest || found != tc.wantFound {
+				t.Fatalf("parseTemplateQuery(%q) = (%+v, %t), want (groupId=%q version=%q latest=%t, %t)",
+					tc.raw, q, found, tc.wantGroupID, tc.wantVersion, tc.wantLatest, tc.wantFound)
 			}
 		})
 	}

--- a/platform-api/src/internal/repository/llm.go
+++ b/platform-api/src/internal/repository/llm.go
@@ -121,6 +121,8 @@ func (r *LLMProviderTemplateRepo) Create(t *model.LLMProviderTemplate) error {
 	return err
 }
 
+const maxCreateNewVersionRetries = 3
+
 func (r *LLMProviderTemplateRepo) CreateNewVersion(t *model.LLMProviderTemplate) error {
 	configJSON, err := json.Marshal(&llmProviderTemplateConfig{
 		ManagedBy:        t.ManagedBy,
@@ -136,21 +138,31 @@ func (r *LLMProviderTemplateRepo) CreateNewVersion(t *model.LLMProviderTemplate)
 	if err != nil {
 		return err
 	}
+
+	var lastErr error
+	for attempt := 0; attempt < maxCreateNewVersionRetries; attempt++ {
+		lastErr = r.createNewVersionOnce(t, configJSON)
+		if lastErr == nil {
+			return nil
+		}
+		if !r.db.IsDuplicateKeyError(lastErr) {
+			return lastErr
+		}
+	}
+	return lastErr
+}
+
+func (r *LLMProviderTemplateRepo) createNewVersionOnce(t *model.LLMProviderTemplate, configJSON []byte) error {
 	tx, err := r.db.Begin()
 	if err != nil {
 		return err
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	lockSQL := `SELECT uuid FROM llm_provider_templates WHERE group_id = ? AND organization_uuid = ? AND is_latest = ?`
-	switch r.db.Driver() {
-	case database.DriverPostgres, database.DriverPostgreSQL, database.DriverPGX:
-		lockSQL += " FOR UPDATE"
-	case database.DriverSQLServer, database.DriverMSSQL:
-		lockSQL = `SELECT uuid FROM llm_provider_templates WITH (UPDLOCK, HOLDLOCK) WHERE group_id = ? AND organization_uuid = ? AND is_latest = ?`
-	}
-	var lockedUUID string
-	err = tx.QueryRow(r.db.Rebind(lockSQL), t.GroupID, t.OrganizationUUID, 1).Scan(&lockedUUID)
+	var latestUUID string
+	err = tx.QueryRow(r.db.Rebind(`
+		SELECT uuid FROM llm_provider_templates WHERE group_id = ? AND organization_uuid = ? AND is_latest = ?
+	`), t.GroupID, t.OrganizationUUID, 1).Scan(&latestUUID)
 	if errors.Is(err, sql.ErrNoRows) {
 		return sql.ErrNoRows
 	}

--- a/platform-api/src/resources/openapi.yaml
+++ b/platform-api/src/resources/openapi.yaml
@@ -1054,17 +1054,17 @@ paths:
     get:
       summary: List templates, list a family's versions, or get a single version
       description: |
-        Behavior depends on query params:
-          - no `query` (or `query=latest:true`) -> list templates. By default every version of every family (full history, e.g. all 5 openai + all 9 deepseek); with `latest=true` only the latest version of each family (built-in and custom)
-          - `query=groupId:<id>`              -> list all versions of that family
-          - `query=groupId:<id>&version:<ver>` -> return the single full template for that (groupId, version)
-        The `query` value is URL-encoded so its `:` and `&` survive query
-        parsing (?query=groupId%3Aopenai%26version%3Av1.0). Organization is
-        identified via the JWT token.
+        Retrieves LLM provider templates based on the `query` parameter:
+          - no `query`                         -> list all template versions
+          - `query=latest:true`                -> list the latest version of each template
+          - `query=groupId:<id>`               -> list all versions for the template
+          - `query=groupId:<id>&version:<ver>` -> retrieve a specific template version
 
-        Note: with `version`, the response is a single `LLMProviderTemplate`
-        object (the same body as `GET /llm-provider-templates/{llmProviderTemplateId}`); otherwise
-        it is an `LLMProviderTemplateListResponse`.
+        All filters are provided via the URL-encoded `query` parameter (e.g.
+        `?query=groupId%3Aopenai%26version%3Av2.0`).
+
+        Returns a single `LLMProviderTemplate` only when both `groupId` and `version` are specified; 
+        otherwise returns an `LLMProviderTemplateListResponse`.
       operationId: listLLMProviderTemplates
       security:
         - OAuth2Security:
@@ -1077,25 +1077,15 @@ paths:
           in: query
           required: false
           description: >-
-            URL-encoded search DSL. `query=groupId:<id>` lists that family's
+            URL-encoded search DSL. `query=latest:true` lists only the latest
+            version of each family; `query=groupId:<id>` lists that family's
             versions; adding `&version:<ver>` returns the single full template
-            for that version. Terms are `&`-separated and the whole value is
-            percent-encoded (e.g. groupId%3Aopenai%26version%3Av1.0). The version
-            may instead be supplied via the standalone `version` query param.
+            for that version. Terms are `&`-separated `key:value` pairs and the
+            whole value is percent-encoded (e.g.
+            groupId%3Aopenai%26version%3Av2.0).
           schema:
             type: string
-          example: groupId:openai&version:v1.0
-        - name: version
-          in: query
-          required: false
-          description: >-
-            Selects a single version within the family named by `query=groupId:<id>`,
-            returning the full template for that (groupId, version). Alternative to
-            packing `&version:<ver>` inside the `query` value; ignored when `query`
-            has no groupId.
-          schema:
-            type: string
-          example: v1.0
+          example: groupId:openai&version:v2.0
         - name: limit
           in: query
           description: Maximum number of LLM provider templates to return
@@ -1111,24 +1101,14 @@ paths:
             type: integer
             minimum: 0
             default: 0
-        - name: latest
-          in: query
-          description: |
-            Which versions to include. By default (false) the response contains
-            every version row across all templates (full history). Set to true
-            to return only the latest version of each family (one entry per
-            built-in/custom bucket), for the catalog listing. May also be passed
-            inside the query DSL as `query=latest:true`.
-          schema:
-            type: boolean
-            default: false
       responses:
         '200':
           description: >-
-            Without `version`: a list response — either templates (all versions
-            by default, or the latest of each family when `latest=true`) or
-            a family's versions. With `groupId`+`version`: the single full
-            template for that version.
+            Without a `version` term: a list response — either templates (all
+            versions by default, or the latest of each family when
+            `query=latest:true`) or a family's versions. With
+            `query=groupId:<id>&version:<ver>`: the single full template for that
+            version.
           content:
             application/json:
               schema:

--- a/portals/ai-workspace/src/apis/providerTemplateApis.ts
+++ b/portals/ai-workspace/src/apis/providerTemplateApis.ts
@@ -77,7 +77,7 @@ export async function createProviderTemplate(
 /**
  * Get Provider Templates for the catalog listing.
  *
- * Requests `latest=true` so the backend returns only the latest version
+ * Requests `query=latest:true` so the backend returns only the latest version
  * of each family (one entry per family) rather than the full version history.
  *
  * @returns Promise with the list of provider templates (latest per family)
@@ -91,7 +91,7 @@ export async function createProviderTemplate(
 export async function getProviderTemplates(baseUrl: string): Promise<ProviderTemplatesResponse> {
   try {
     const response = await get<ProviderTemplatesResponse>(
-      `/llm-provider-templates?latest=true`,
+      `/llm-provider-templates?query=${encodeURIComponent('latest:true')}`,
       undefined,
       baseUrl
     );


### PR DESCRIPTION
## Purpose


- GET /llm-provider-templates now accepts groupId, version, and latest only through the single query DSL param — the redundant standalone ?version= and ?latest= params are removed.

Query | Result 
-- | -- 
 ?query=latest:true |  latest version of each family │
 ?query=groupId:openai |  all versions of that family
?query=groupId:openai&version:v2.0| the single v2.0 template

- Remove SQLLock. 

