### PR TITLE
Add gateway handle resolution for deployment filtering

### DIFF
--- a/platform-api/src/internal/service/application.go
+++ b/platform-api/src/internal/service/application.go
@@ -52,12 +52,12 @@ type AddApplicationAssociationsRequest struct {
 }
 
 type ApplicationAssociation struct {
-	Id        string     `json:"id"`
-	Name      string     `json:"name"`
-	Version   string     `json:"version"`
-	Kind      string     `json:"kind"`
-	CreatedAt *time.Time `json:"createdAt,omitempty"`
-	UpdatedAt *time.Time `json:"updatedAt,omitempty"`
+	Id          string     `json:"id"`
+	DisplayName string     `json:"displayName"`
+	Version     string     `json:"version"`
+	Kind        string     `json:"kind"`
+	CreatedAt   *time.Time `json:"createdAt,omitempty"`
+	UpdatedAt   *time.Time `json:"updatedAt,omitempty"`
 }
 
 type ApplicationAssociationListResponse struct {
@@ -844,11 +844,11 @@ func (s *ApplicationService) modelToApplicationAssociation(association *model.Ap
 	}
 
 	return ApplicationAssociation{
-		Id:        association.TargetHandle,
-		Name:      association.TargetName,
-		Version:   association.TargetVersion,
-		Kind:      association.Type,
-		CreatedAt: utils.TimePtrIfNotZero(association.CreatedAt),
+		Id:          association.TargetHandle,
+		DisplayName: association.TargetName,
+		Version:     association.TargetVersion,
+		Kind:        association.Type,
+		CreatedAt:   utils.TimePtrIfNotZero(association.CreatedAt),
 	}
 }
 

--- a/platform-api/src/internal/service/deployment.go
+++ b/platform-api/src/internal/service/deployment.go
@@ -999,6 +999,31 @@ func (s *DeploymentService) GetDeploymentContentByHandle(apiHandle, deploymentID
 	return s.GetDeploymentContent(apiUUID, deploymentID, orgUUID)
 }
 
+// resolveGatewayFilter resolves an optional gatewayId filter — supplied by clients
+// as a gateway handle — to the internal gateway UUID stored in
+// deployments.gateway_uuid. Deploy/undeploy identify the target gateway by handle,
+// so the deployment listing must resolve the same way for the gatewayId filter to
+// match any rows. Returns (uuidPtr, true, nil) when resolved (uuidPtr is nil when no
+// filter was requested), or (nil, false, nil) when a handle was given but no gateway
+// with that handle exists in the organization.
+func resolveGatewayFilter(gatewayRepo repository.GatewayRepository, gatewayHandle *string, orgUUID string) (*string, bool, error) {
+	if gatewayHandle == nil {
+		return nil, true, nil
+	}
+	handle := strings.TrimSpace(*gatewayHandle)
+	if handle == "" {
+		return nil, true, nil
+	}
+	gateway, err := gatewayRepo.GetByHandleAndOrgID(handle, orgUUID)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to resolve gateway handle: %w", err)
+	}
+	if gateway == nil {
+		return nil, false, nil
+	}
+	return &gateway.ID, true, nil
+}
+
 func toAPIDeploymentResponse(
 	gatewayRepo repository.GatewayRepository,
 	deploymentID string,

--- a/platform-api/src/internal/service/llm_deployment.go
+++ b/platform-api/src/internal/service/llm_deployment.go
@@ -507,10 +507,21 @@ func (s *LLMProviderDeploymentService) GetLLMProviderDeployments(providerID, org
 		}
 	}
 
+	// The gatewayId filter is a gateway handle (matching deploy/undeploy); resolve it
+	// to the internal gateway UUID stored in deployments.gateway_uuid before filtering.
+	gatewayUUID, found, err := resolveGatewayFilter(s.gatewayRepo, gatewayID, orgUUID)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		// The filter names a gateway that does not exist in this org: no deployment matches.
+		return &api.DeploymentListResponse{Count: 0, List: []api.DeploymentResponse{}}, nil
+	}
+
 	if s.cfg.Deployments.MaxPerAPIGateway < 1 {
 		return nil, fmt.Errorf("MaxPerAPIGateway config value must be at least 1, got %d", s.cfg.Deployments.MaxPerAPIGateway)
 	}
-	deployments, err := s.deploymentRepo.GetDeploymentsWithState(provider.UUID, orgUUID, gatewayID, status, s.cfg.Deployments.MaxPerAPIGateway)
+	deployments, err := s.deploymentRepo.GetDeploymentsWithState(provider.UUID, orgUUID, gatewayUUID, status, s.cfg.Deployments.MaxPerAPIGateway)
 	if err != nil {
 		return nil, err
 	}
@@ -1642,10 +1653,21 @@ func (s *LLMProxyDeploymentService) GetLLMProxyDeployments(proxyID, orgUUID stri
 		}
 	}
 
+	// The gatewayId filter is a gateway handle (matching deploy/undeploy); resolve it
+	// to the internal gateway UUID stored in deployments.gateway_uuid before filtering.
+	gatewayUUID, found, err := resolveGatewayFilter(s.gatewayRepo, gatewayID, orgUUID)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		// The filter names a gateway that does not exist in this org: no deployment matches.
+		return &api.DeploymentListResponse{Count: 0, List: []api.DeploymentResponse{}}, nil
+	}
+
 	if s.cfg.Deployments.MaxPerAPIGateway < 1 {
 		return nil, fmt.Errorf("MaxPerAPIGateway config value must be at least 1, got %d", s.cfg.Deployments.MaxPerAPIGateway)
 	}
-	deployments, err := s.deploymentRepo.GetDeploymentsWithState(proxy.UUID, orgUUID, gatewayID, status, s.cfg.Deployments.MaxPerAPIGateway)
+	deployments, err := s.deploymentRepo.GetDeploymentsWithState(proxy.UUID, orgUUID, gatewayUUID, status, s.cfg.Deployments.MaxPerAPIGateway)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Implemented a new function to resolve gateway handles to internal UUIDs, ensuring that deployment queries can accurately filter by gateway. Updated relevant service methods to utilize this resolution, improving the handling of gatewayId filters in deployment listings.
