### PR TITLE
[Sample] Adding sample for prompt-decorator-policy

### DIFF
--- a/samples/prompt-decorator-policy/README.md
+++ b/samples/prompt-decorator-policy/README.md
@@ -25,13 +25,13 @@ By working through this sample you will understand how to:
 
 ### Scenario 1 — Chat Prompt Decoration (prepend)
 
-**What it does:** The `persona-proxy` prepends a `system` message to the `messages` array, giving the model a hotel-receptionist persona for the imaginary "Azure Horizon Resort". The caller sends only a plain user message.
+**What it does:** The `persona-proxy` prepends a `system` message to the `messages` array, giving the model a hotel-receptionist persona for the imaginary "ABC Horizon Resort". The caller sends only a plain user message.
 
 **JSONPath:** `$.messages` · **append:** `false` (prepend)
 
 ### Scenario 2 — Text Prompt Decoration (append)
 
-**What it does:** The `suffix-proxy` appends an instruction to the last message's `content`, telling the model to end every reply with the exact tag `[AZURE-HORIZON-OK]`. The caller never asks for that tag.
+**What it does:** The `suffix-proxy` appends an instruction to the last message's `content`, telling the model to end every reply with the exact tag `[ABC-HORIZON-OK]`. The caller never asks for that tag.
 
 **JSONPath:** `$.messages[-1].content` · **append:** `true`
 
@@ -41,18 +41,18 @@ By working through this sample you will understand how to:
 
 ### Scenario 1 — Chat Prompt Decoration
 
-A bare user message (`"Hi, I would like to book a room."`) is sent with **no** system message. Because the gateway injects the persona, the reply should welcome the guest to **Azure Horizon Resort** — a name the caller never typed.
+A bare user message (`"Hi, I would like to book a room."`) is sent with **no** system message. Because the gateway injects the persona, the reply should welcome the guest to **ABC Horizon Resort** — a name the caller never typed.
 
 ```
-[PASS] Chat decoration applied — persona injected ('Azure Horizon' present though the caller never sent it).
+[PASS] Chat decoration applied — persona injected ('ABC Horizon' present though the caller never sent it).
 ```
 
 ### Scenario 2 — Text Prompt Decoration
 
-A plain question (`"What is the capital of France?"`) is sent with no formatting instructions. Because the gateway appends the suffix instruction, the reply should end with the tag `[AZURE-HORIZON-OK]`.
+A plain question (`"What is the capital of France?"`) is sent with no formatting instructions. Because the gateway appends the suffix instruction, the reply should end with the tag `[ABC-HORIZON-OK]`.
 
 ```
-[PASS] Text decoration applied — appended instruction honored ('[AZURE-HORIZON-OK]' present though the caller never sent it).
+[PASS] Text decoration applied — appended instruction honored ('[ABC-HORIZON-OK]' present though the caller never sent it).
 ```
 
 ---

--- a/samples/prompt-decorator-policy/README.md
+++ b/samples/prompt-decorator-policy/README.md
@@ -1,0 +1,174 @@
+# LLM Gateway — Prompt Decorator Sample
+
+> Companion sample for the [Prompt Decorator](https://wso2.com/api-platform/docs/ai-gateway/llm-proxy/prompt-management/prompt-decorator/) policy docs.
+
+## Overview
+
+This sample stands up a local WSO2 AI Gateway and shows the **Prompt Decorator** policy modifying prompts *before* they reach the LLM — without changing any application code. You run one script to set everything up, then one script per scenario to see the results.
+
+The upstream is Anthropic's **OpenAI-compatible** endpoint (`https://api.anthropic.com/v1`), so the gateway's `openai` provider template works unchanged and the model used is a Claude model (`claude-sonnet-4-6`).
+
+The Prompt Decorator policy prepends or appends content to fields in the request payload. This sample demonstrates both decoration modes against an OpenAI-compatible endpoint, giving you a reproducible environment to understand each behavior.
+
+---
+
+## What You Will Learn
+
+By working through this sample you will understand how to:
+
+- Apply **chat prompt decoration** — prepend a system message (a persona / standing instructions) to the `messages` array so the model behaves consistently, even when the caller sends no system message.
+- Apply **text prompt decoration** — append an instruction to a message's `content` string so every reply follows a required format.
+
+---
+
+## Scenarios Covered
+
+### Scenario 1 — Chat Prompt Decoration (prepend)
+
+**What it does:** The `persona-proxy` prepends a `system` message to the `messages` array, giving the model a hotel-receptionist persona for the imaginary "Azure Horizon Resort". The caller sends only a plain user message.
+
+**JSONPath:** `$.messages` · **append:** `false` (prepend)
+
+### Scenario 2 — Text Prompt Decoration (append)
+
+**What it does:** The `suffix-proxy` appends an instruction to the last message's `content`, telling the model to end every reply with the exact tag `[AZURE-HORIZON-OK]`. The caller never asks for that tag.
+
+**JSONPath:** `$.messages[-1].content` · **append:** `true`
+
+---
+
+## Expected Results
+
+### Scenario 1 — Chat Prompt Decoration
+
+A bare user message (`"Hi, I would like to book a room."`) is sent with **no** system message. Because the gateway injects the persona, the reply should welcome the guest to **Azure Horizon Resort** — a name the caller never typed.
+
+```
+[PASS] Chat decoration applied — persona injected ('Azure Horizon' present though the caller never sent it).
+```
+
+### Scenario 2 — Text Prompt Decoration
+
+A plain question (`"What is the capital of France?"`) is sent with no formatting instructions. Because the gateway appends the suffix instruction, the reply should end with the tag `[AZURE-HORIZON-OK]`.
+
+```
+[PASS] Text decoration applied — appended instruction honored ('[AZURE-HORIZON-OK]' present though the caller never sent it).
+```
+
+---
+
+## Prerequisites
+
+| Tool | Purpose |
+|---|---|
+| Docker + Docker Compose | Runs the gateway stack |
+| `wget` | Downloads the gateway distribution |
+| `unzip` | Extracts the distribution |
+| `python3` + `pyyaml` | Used by `teardown.sh` to read resource names from YAML (`pip install pyyaml`) |
+| `curl` | Calls the gateway management API and proxy endpoint |
+| `jq` | Used by the test scripts to build/parse JSON (`brew install jq`) |
+
+---
+
+## Required Configuration
+
+### Anthropic API Key
+
+The setup script injects the key into the LLM provider at deploy time. The
+Anthropic account must have available credits, or requests return HTTP 400
+(`Your credit balance is too low`). Provide the key via:
+
+```bash
+# Option A — environment variable (recommended)
+export ANTHROPIC_API_KEY="sk-ant-..."
+
+# Option B — script argument
+./setup.sh sk-ant-...
+
+# Option C — interactive prompt (key is hidden)
+./setup.sh
+```
+
+The key is never written to disk; it is substituted into the provider payload at runtime and discarded.
+
+---
+
+## Files
+
+```
+llm-provider.yaml          LLM provider definition (Anthropic OpenAI-compatible upstream, access control)
+llm-proxy-persona.yaml     Proxy with chat prompt decoration (prepend system persona)
+llm-proxy-suffix.yaml      Proxy with text prompt decoration (append suffix instruction)
+setup.sh                   Automated setup (download → start → deploy provider + proxies)
+teardown.sh                Automated teardown (delete resources → stop stack)
+test-chat-decoration.sh    Verifies the system persona is prepended
+test-text-decoration.sh    Verifies the suffix instruction is appended
+```
+
+---
+
+## Setup
+
+```bash
+./setup.sh
+```
+
+The script performs these steps in order:
+
+1. Downloads `wso2apip-ai-gateway-1.1.0.zip`
+2. Extracts the distribution
+3. Starts the Docker Compose stack
+4. Waits for the gateway to become healthy (polls up to 150 s)
+5. Deploys the LLM provider
+6. Deploys both LLM proxies
+
+All steps are idempotent — re-running the script on an already-configured environment is safe.
+
+### Endpoints After Setup
+
+| Endpoint | URL |
+|---|---|
+| Chat decoration proxy | `http://localhost:8080/persona-proxy/chat/completions` |
+| Text decoration proxy | `http://localhost:8080/suffix-proxy/chat/completions` |
+| Gateway health | `http://localhost:9094/health` |
+| Management API | `http://localhost:9090/api/management/v0.9` |
+
+---
+
+## Running the Tests
+
+Each scenario has its own script and can be run independently. No API key is needed at test time — the gateway uses its stored credentials.
+
+```bash
+# Scenario 1 — chat prompt decoration (system persona)
+./test-chat-decoration.sh
+
+# Scenario 2 — text prompt decoration (appended suffix)
+./test-text-decoration.sh
+```
+
+---
+
+## Teardown
+
+```bash
+# Stop the stack and delete deployed resources
+./teardown.sh
+
+# Also remove the extracted directory and downloaded zip
+./teardown.sh --clean
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| `setup.sh` fails at health check | Docker images are still pulling — wait and retry |
+| Scenario 1: persona not detected | The model paraphrased away the hotel name — re-run; or verify the `prompt-decorator` policy in `llm-proxy-persona.yaml` |
+| Scenario 2: tag not detected | The model dropped the tag — re-run; or verify the `prompt-decorator` policy in `llm-proxy-suffix.yaml` |
+| HTTP 401 on management API | Basic auth header mismatch; default credentials are `admin:admin` |
+| Request errors with auth failure | Check that your Anthropic API key is valid |
+| `HTTP 400` — `credit balance is too low` | The Anthropic account has no credits — add credits in the Anthropic console |
+| Proxy returns `HTTP 500` — `Internal Server Error` | The `prompt-decorator` config is invalid; its `promptDecoratorConfig` must use `text` or `messages` (check the gateway-runtime logs) |

--- a/samples/prompt-decorator-policy/llm-provider.yaml
+++ b/samples/prompt-decorator-policy/llm-provider.yaml
@@ -1,0 +1,30 @@
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: wso2-openai-provider
+spec:
+  displayName: Anthropic Provider (OpenAI-compatible)
+  version: v1.0
+  template: openai
+  context: /openai/latest
+  upstream:
+    # Anthropic exposes an OpenAI-compatible endpoint, so the `openai` template
+    # and the standard /chat/completions path work unchanged. Auth is still a
+    # Bearer token (your sk-ant-... key), injected by setup.sh.
+    url: https://api.anthropic.com/v1
+    auth:
+      type: api-key
+      header: Authorization
+      value: <API_KEY>
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods:
+          - POST
+      - path: /models
+        methods:
+          - GET
+      - path: /models/{modelId}
+        methods:
+          - GET

--- a/samples/prompt-decorator-policy/llm-proxy-persona.yaml
+++ b/samples/prompt-decorator-policy/llm-proxy-persona.yaml
@@ -1,0 +1,25 @@
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProxy
+metadata:
+  name: persona-proxy
+spec:
+  displayName: Persona Proxy (Chat Decoration)
+  version: v1.0
+  context: /persona-proxy
+  provider:
+    id: wso2-openai-provider
+  policies:
+    # Mode 2 — Chat Prompt Decoration (prepend).
+    # The JSONPath targets the messages array, so the decoration must be an
+    # array of message objects. The gateway PREPENDS this system message to
+    # every request before it reaches OpenAI, giving the model a persona the
+    # caller never has to send.
+    - name: prompt-decorator
+      version: v1
+      paths:
+        - path: /chat/completions
+          methods: ["*"]
+          params:
+            promptDecoratorConfig: '{"messages": [{"role": "system", "content": "You are a booking receptionist for the imaginary hotel Azure Horizon Resort. Always welcome the guest to Azure Horizon Resort and mention the hotel name Azure Horizon Resort in every reply."}]}'
+            jsonPath: "$.messages"
+            append: false

--- a/samples/prompt-decorator-policy/llm-proxy-persona.yaml
+++ b/samples/prompt-decorator-policy/llm-proxy-persona.yaml
@@ -20,6 +20,6 @@ spec:
         - path: /chat/completions
           methods: ["*"]
           params:
-            promptDecoratorConfig: '{"messages": [{"role": "system", "content": "You are a booking receptionist for the imaginary hotel Azure Horizon Resort. Always welcome the guest to Azure Horizon Resort and mention the hotel name Azure Horizon Resort in every reply."}]}'
+            promptDecoratorConfig: '{"messages": [{"role": "system", "content": "You are a booking receptionist for the imaginary hotel ABC Horizon Resort. Always welcome the guest to ABC Horizon Resort and mention the hotel name ABC Horizon Resort in every reply."}]}'
             jsonPath: "$.messages"
             append: false

--- a/samples/prompt-decorator-policy/llm-proxy-suffix.yaml
+++ b/samples/prompt-decorator-policy/llm-proxy-suffix.yaml
@@ -1,0 +1,24 @@
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProxy
+metadata:
+  name: suffix-proxy
+spec:
+  displayName: Suffix Proxy (Text Decoration)
+  version: v1.0
+  context: /suffix-proxy
+  provider:
+    id: wso2-openai-provider
+  policies:
+    # Mode 1 — Text Prompt Decoration (append).
+    # The JSONPath targets a string field (the last message's content), so the
+    # decoration is a plain string. With append: true the gateway APPENDS this
+    # instruction to the end of the user's message before it reaches OpenAI.
+    - name: prompt-decorator
+      version: v1
+      paths:
+        - path: /chat/completions
+          methods: ["*"]
+          params:
+            promptDecoratorConfig: '{"text": "\n\nImportant: end your entire response with the exact tag [AZURE-HORIZON-OK] on its own line."}'
+            jsonPath: "$.messages[-1].content"
+            append: true

--- a/samples/prompt-decorator-policy/llm-proxy-suffix.yaml
+++ b/samples/prompt-decorator-policy/llm-proxy-suffix.yaml
@@ -19,6 +19,6 @@ spec:
         - path: /chat/completions
           methods: ["*"]
           params:
-            promptDecoratorConfig: '{"text": "\n\nImportant: end your entire response with the exact tag [AZURE-HORIZON-OK] on its own line."}'
+            promptDecoratorConfig: '{"text": "\n\nImportant: end your entire response with the exact tag [ABC-HORIZON-OK] on its own line."}'
             jsonPath: "$.messages[-1].content"
             append: true

--- a/samples/prompt-decorator-policy/setup.sh
+++ b/samples/prompt-decorator-policy/setup.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+DIST_VERSION="1.1.0"
+DIST_NAME="wso2apip-ai-gateway-${DIST_VERSION}"
+DIST_ZIP="${DIST_NAME}.zip"
+DIST_URL="https://github.com/wso2/api-platform/releases/download/ai-gateway/v${DIST_VERSION}/${DIST_ZIP}"
+
+GATEWAY_MGMT_URL="http://localhost:9090/api/management/v0.9"
+GATEWAY_HEALTH_URL="http://localhost:9094/health"
+AUTH_HEADER="Authorization: Basic YWRtaW46YWRtaW4="   # admin:admin
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROVIDER_YAML="${SCRIPT_DIR}/llm-provider.yaml"
+PROXY_YAMLS=("${SCRIPT_DIR}/llm-proxy-persona.yaml" "${SCRIPT_DIR}/llm-proxy-suffix.yaml")
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+info()    { echo "[INFO]  $*"; }
+success() { echo "[OK]    $*"; }
+error()   { echo "[ERROR] $*" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Resolve Anthropic API key — arg > env var > interactive prompt (required).
+# OPENAI_API_KEY is still honored for backward compatibility.
+# ---------------------------------------------------------------------------
+API_KEY="${1:-${ANTHROPIC_API_KEY:-${OPENAI_API_KEY:-}}}"
+if [[ -z "${API_KEY}" ]]; then
+  read -rsp "Enter your Anthropic API key (sk-ant-...): " API_KEY
+  echo
+fi
+[[ -n "${API_KEY}" ]] || error "Anthropic API key is required."
+
+wait_for_health() {
+  local url="$1"
+  local max_attempts=30
+  local interval=5
+  info "Waiting for gateway to be healthy at ${url} ..."
+  for i in $(seq 1 "${max_attempts}"); do
+    if curl -sf "${url}" > /dev/null 2>&1; then
+      success "Gateway is healthy."
+      return 0
+    fi
+    echo "  attempt ${i}/${max_attempts} — retrying in ${interval}s ..."
+    sleep "${interval}"
+  done
+  error "Gateway did not become healthy after $((max_attempts * interval))s."
+}
+
+# ---------------------------------------------------------------------------
+# Step 1 — Download distribution
+# ---------------------------------------------------------------------------
+info "Downloading ${DIST_ZIP} ..."
+if [[ -f "${DIST_ZIP}" ]]; then
+  info "Archive already exists, skipping download."
+else
+  wget -q --show-progress "${DIST_URL}" -O "${DIST_ZIP}"
+  success "Downloaded ${DIST_ZIP}."
+fi
+
+# ---------------------------------------------------------------------------
+# Step 2 — Unzip
+# ---------------------------------------------------------------------------
+if [[ -d "${DIST_NAME}" ]]; then
+  info "Distribution directory '${DIST_NAME}' already exists, skipping unzip."
+else
+  info "Unzipping ${DIST_ZIP} ..."
+  unzip -q "${DIST_ZIP}"
+  success "Extracted to ${DIST_NAME}/."
+fi
+
+# ---------------------------------------------------------------------------
+# Step 3 — Start the stack
+# ---------------------------------------------------------------------------
+info "Starting Docker Compose stack in ${DIST_NAME}/ ..."
+(cd "${DIST_NAME}" && docker compose up -d)
+success "Docker Compose stack started."
+
+# ---------------------------------------------------------------------------
+# Step 4 — Health check
+# ---------------------------------------------------------------------------
+wait_for_health "${GATEWAY_HEALTH_URL}"
+
+# ---------------------------------------------------------------------------
+# Step 5 — Deploy LLM provider
+# ---------------------------------------------------------------------------
+info "Deploying LLM provider from ${PROVIDER_YAML} ..."
+[[ -f "${PROVIDER_YAML}" ]] || error "llm-provider.yaml not found at ${PROVIDER_YAML}"
+
+PROVIDER_YAML_TMP=$(mktemp)
+trap 'rm -f "${PROVIDER_YAML_TMP}"' EXIT
+sed "s|<API_KEY>|Bearer ${API_KEY}|g" "${PROVIDER_YAML}" > "${PROVIDER_YAML_TMP}"
+
+HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X POST "${GATEWAY_MGMT_URL}/llm-providers" \
+  -H "Content-Type: application/yaml" \
+  -H "${AUTH_HEADER}" \
+  --data-binary "@${PROVIDER_YAML_TMP}")
+
+if [[ "${HTTP_STATUS}" =~ ^2 ]]; then
+  success "LLM provider deployed (HTTP ${HTTP_STATUS})."
+else
+  error "Failed to deploy LLM provider (HTTP ${HTTP_STATUS})."
+fi
+
+# ---------------------------------------------------------------------------
+# Step 6 — Deploy LLM proxies (one per decoration mode)
+# ---------------------------------------------------------------------------
+for PROXY_YAML in "${PROXY_YAMLS[@]}"; do
+  info "Deploying LLM proxy from ${PROXY_YAML} ..."
+  [[ -f "${PROXY_YAML}" ]] || error "Proxy file not found at ${PROXY_YAML}"
+
+  HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X POST "${GATEWAY_MGMT_URL}/llm-proxies" \
+    -H "Content-Type: application/yaml" \
+    -H "${AUTH_HEADER}" \
+    --data-binary "@${PROXY_YAML}")
+
+  if [[ "${HTTP_STATUS}" =~ ^2 ]]; then
+    success "LLM proxy deployed (HTTP ${HTTP_STATUS})."
+  else
+    error "Failed to deploy LLM proxy from ${PROXY_YAML} (HTTP ${HTTP_STATUS})."
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+echo ""
+echo "============================================================"
+echo " Setup complete!"
+echo "  Gateway health : ${GATEWAY_HEALTH_URL}"
+echo "  Management API : ${GATEWAY_MGMT_URL}"
+echo ""
+echo " Proxy endpoints:"
+echo "   Chat decoration : http://localhost:8080/persona-proxy/chat/completions"
+echo "   Text decoration : http://localhost:8080/suffix-proxy/chat/completions"
+echo ""
+echo " Run the tests:"
+echo "   ./test-chat-decoration.sh"
+echo "   ./test-text-decoration.sh"
+echo "============================================================"

--- a/samples/prompt-decorator-policy/teardown.sh
+++ b/samples/prompt-decorator-policy/teardown.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration — must match setup.sh
+# ---------------------------------------------------------------------------
+DIST_VERSION="1.1.0"
+DIST_NAME="wso2apip-ai-gateway-${DIST_VERSION}"
+DIST_ZIP="${DIST_NAME}.zip"
+
+GATEWAY_MGMT_URL="http://localhost:9090/api/management/v0.9"
+AUTH_HEADER="Authorization: Basic YWRtaW46YWRtaW4="   # admin:admin
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROVIDER_YAML="${SCRIPT_DIR}/llm-provider.yaml"
+PROXY_YAMLS=("${SCRIPT_DIR}/llm-proxy-persona.yaml" "${SCRIPT_DIR}/llm-proxy-suffix.yaml")
+
+# Pass --clean to also remove the extracted directory and zip archive.
+CLEAN=false
+for arg in "$@"; do
+  [[ "${arg}" == "--clean" ]] && CLEAN=true
+done
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+info()    { echo "[INFO]  $*"; }
+success() { echo "[OK]    $*"; }
+warn()    { echo "[WARN]  $*"; }
+error()   { echo "[ERROR] $*" >&2; exit 1; }
+
+yaml_name() {
+  python3 -c "import yaml,sys; d=yaml.safe_load(open(sys.argv[1])); print(d['metadata']['name'])" "$1"
+}
+
+delete_resource() {
+  local kind="$1"   # llm-providers or llm-proxies
+  local name="$2"
+  info "Deleting ${kind}/${name} ..."
+  HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X DELETE "${GATEWAY_MGMT_URL}/${kind}/${name}" \
+    -H "${AUTH_HEADER}")
+  if [[ "${HTTP_STATUS}" =~ ^2 ]]; then
+    success "Deleted ${kind}/${name} (HTTP ${HTTP_STATUS})."
+  elif [[ "${HTTP_STATUS}" == "404" ]]; then
+    warn "${kind}/${name} not found — already deleted?"
+  else
+    error "Failed to delete ${kind}/${name} (HTTP ${HTTP_STATUS})."
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Step 1 — Delete LLM proxies
+# ---------------------------------------------------------------------------
+for PROXY_YAML in "${PROXY_YAMLS[@]}"; do
+  [[ -f "${PROXY_YAML}" ]] || error "Proxy file not found at ${PROXY_YAML}"
+  PROXY_NAME=$(yaml_name "${PROXY_YAML}")
+  delete_resource "llm-proxies" "${PROXY_NAME}"
+done
+
+# ---------------------------------------------------------------------------
+# Step 2 — Delete LLM provider
+# ---------------------------------------------------------------------------
+[[ -f "${PROVIDER_YAML}" ]] || error "llm-provider.yaml not found at ${PROVIDER_YAML}"
+PROVIDER_NAME=$(yaml_name "${PROVIDER_YAML}")
+delete_resource "llm-providers" "${PROVIDER_NAME}"
+
+# ---------------------------------------------------------------------------
+# Step 3 — Stop Docker Compose stack
+# ---------------------------------------------------------------------------
+COMPOSE_FILE="${DIST_NAME}/docker-compose.yaml"
+[[ -f "${COMPOSE_FILE}" ]] || COMPOSE_FILE="${DIST_NAME}/docker-compose.yml"
+
+if [[ -f "${COMPOSE_FILE}" ]]; then
+  info "Stopping Docker Compose stack ..."
+  (cd "${DIST_NAME}" && docker compose down --volumes)
+  success "Stack stopped and volumes removed."
+else
+  warn "docker-compose file not found in ${DIST_NAME}/ — stack may not be running."
+fi
+
+# ---------------------------------------------------------------------------
+# Step 4 — Optional cleanup of distribution files
+# ---------------------------------------------------------------------------
+if [[ "${CLEAN}" == true ]]; then
+  if [[ -d "${DIST_NAME}" ]]; then
+    info "Removing extracted directory ${DIST_NAME}/ ..."
+    rm -rf "${DIST_NAME}"
+    success "Removed ${DIST_NAME}/."
+  fi
+  if [[ -f "${DIST_ZIP}" ]]; then
+    info "Removing archive ${DIST_ZIP} ..."
+    rm -f "${DIST_ZIP}"
+    success "Removed ${DIST_ZIP}."
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+echo ""
+echo "============================================================"
+echo " Teardown complete!"
+if [[ "${CLEAN}" == false ]]; then
+  echo " Tip: run with --clean to also remove ${DIST_NAME}/ and ${DIST_ZIP}"
+fi
+echo "============================================================"

--- a/samples/prompt-decorator-policy/teardown.sh
+++ b/samples/prompt-decorator-policy/teardown.sh
@@ -45,7 +45,7 @@ delete_resource() {
   elif [[ "${HTTP_STATUS}" == "404" ]]; then
     warn "${kind}/${name} not found — already deleted?"
   else
-    error "Failed to delete ${kind}/${name} (HTTP ${HTTP_STATUS})."
+    warn "Failed to delete ${kind}/${name} (HTTP ${HTTP_STATUS}); continuing teardown."
   fi
 }
 

--- a/samples/prompt-decorator-policy/test-chat-decoration.sh
+++ b/samples/prompt-decorator-policy/test-chat-decoration.sh
@@ -2,14 +2,14 @@
 # Test: Chat Prompt Decoration (Mode 2 — prepend)
 #   Sends a bare user message with NO system message. The persona-proxy
 #   prepends a system message that gives the model a hotel-receptionist
-#   persona for "Azure Horizon Resort". Because the caller never mentions
+#   persona for "ABC Horizon Resort". Because the caller never mentions
 #   the hotel, the only way its name can appear in the reply is if the
 #   gateway injected the system message before forwarding to OpenAI.
 set -uo pipefail
 
 CHAT_URL="http://localhost:8080/persona-proxy/chat/completions"
 HEALTH_URL="http://localhost:9094/health"
-MARKER="Azure Horizon"
+MARKER="ABC Horizon"
 
 GREEN="\033[0;32m"; RED="\033[0;31m"; BLUE="\033[0;34m"; NC="\033[0m"
 # Use printf, not `echo -e`: some shells' echo prints "-e" literally and/or

--- a/samples/prompt-decorator-policy/test-chat-decoration.sh
+++ b/samples/prompt-decorator-policy/test-chat-decoration.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Test: Chat Prompt Decoration (Mode 2 — prepend)
+#   Sends a bare user message with NO system message. The persona-proxy
+#   prepends a system message that gives the model a hotel-receptionist
+#   persona for "Azure Horizon Resort". Because the caller never mentions
+#   the hotel, the only way its name can appear in the reply is if the
+#   gateway injected the system message before forwarding to OpenAI.
+set -uo pipefail
+
+CHAT_URL="http://localhost:8080/persona-proxy/chat/completions"
+HEALTH_URL="http://localhost:9094/health"
+MARKER="Azure Horizon"
+
+GREEN="\033[0;32m"; RED="\033[0;31m"; BLUE="\033[0;34m"; NC="\033[0m"
+# Use printf, not `echo -e`: some shells' echo prints "-e" literally and/or
+# interprets backslash escapes, which corrupts JSON piped to jq.
+pass() { printf '%b[PASS]%b %s\n' "${GREEN}" "${NC}" "$*"; }
+fail() { printf '%b[FAIL]%b %s\n' "${RED}" "${NC}" "$*"; }
+info() { printf '%b[INFO]%b %s\n' "${BLUE}" "${NC}" "$*"; }
+
+chat_req() {
+  local msg="$1"
+  local body
+  body=$(jq -n --arg m "${msg}" \
+    '{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":$m}],"max_tokens":150}')
+  # Append the HTTP status on its own trailing line so the caller can tell a
+  # gateway/upstream failure from a real answer.
+  curl -s -w $'\n%{http_code}' -X POST "${CHAT_URL}" \
+    -H "Content-Type: application/json" \
+    -d "${body}"
+}
+
+echo ""
+echo "══════════════════════════════════════════════════"
+echo " Pre-flight checks"
+echo "══════════════════════════════════════════════════"
+
+if ! command -v jq >/dev/null 2>&1; then
+  printf '%b[ERROR]%b jq is required: brew install jq\n' "${RED}" "${NC}" >&2; exit 1
+fi
+
+info "Checking gateway health at ${HEALTH_URL} ..."
+if ! curl -sf "${HEALTH_URL}" >/dev/null 2>&1; then
+  printf '%b[ERROR]%b Gateway is not running. Run ./setup.sh first.\n' "${RED}" "${NC}" >&2; exit 1
+fi
+printf '%b[OK]%b    Gateway is healthy.\n' "${GREEN}" "${NC}"
+
+echo ""
+echo "══════════════════════════════════════════════════"
+echo " Test: Chat Prompt Decoration (system persona)"
+echo "══════════════════════════════════════════════════"
+
+USER_MSG="Hi, I would like to book a room."
+info "Sending bare user message (no system message): \"${USER_MSG}\""
+
+RAW=$(chat_req "${USER_MSG}")
+HTTP_CODE="${RAW##*$'\n'}"   # last line
+RESP="${RAW%$'\n'*}"        # everything before it
+
+echo ""
+echo "══════════════════════════════════════════════════"
+if [[ "${HTTP_CODE}" != 2* ]] || jq -e 'type=="object" and has("error")' >/dev/null 2>&1 <<< "${RESP}"; then
+  # The gateway returns {"error":"..."} (string); upstream APIs return
+  # {"error":{"message":"..."}} (object). Handle both, else show the raw body.
+  ERR=$(jq -r '
+    if (.error|type)=="object" then (.error.message // "unknown error")
+    elif (.error|type)=="string" then .error
+    else "unknown error" end' 2>/dev/null <<< "${RESP}")
+  [[ -z "${ERR}" || "${ERR}" == "null" ]] && ERR="${RESP}"
+  fail "Request failed (HTTP ${HTTP_CODE}): ${ERR}"
+  echo "══════════════════════════════════════════════════"; echo ""; exit 1
+fi
+
+CONTENT=$(jq -r '.choices[0].message.content // ""' <<< "${RESP}")
+info "AI response: ${CONTENT}"
+echo ""
+
+if printf '%s' "${CONTENT}" | grep -qiF "${MARKER}"; then
+  pass "Chat decoration applied — persona injected ('${MARKER}' present though the caller never sent it)."
+  echo "══════════════════════════════════════════════════"; echo ""; exit 0
+else
+  fail "Persona not detected — '${MARKER}' absent. The system message may not have been prepended."
+  echo "══════════════════════════════════════════════════"; echo ""; exit 1
+fi

--- a/samples/prompt-decorator-policy/test-text-decoration.sh
+++ b/samples/prompt-decorator-policy/test-text-decoration.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Test: Text Prompt Decoration (Mode 1 — append)
+#   Sends a plain question. The suffix-proxy APPENDS an instruction to the
+#   user's message telling the model to end its reply with the exact tag
+#   [AZURE-HORIZON-OK]. The caller never asks for that tag, so its presence
+#   in the reply proves the gateway appended the decoration before
+#   forwarding the request to OpenAI.
+set -uo pipefail
+
+CHAT_URL="http://localhost:8080/suffix-proxy/chat/completions"
+HEALTH_URL="http://localhost:9094/health"
+MARKER="[AZURE-HORIZON-OK]"
+
+GREEN="\033[0;32m"; RED="\033[0;31m"; BLUE="\033[0;34m"; NC="\033[0m"
+# Use printf, not `echo -e`: some shells' echo prints "-e" literally and/or
+# interprets backslash escapes, which corrupts JSON piped to jq.
+pass() { printf '%b[PASS]%b %s\n' "${GREEN}" "${NC}" "$*"; }
+fail() { printf '%b[FAIL]%b %s\n' "${RED}" "${NC}" "$*"; }
+info() { printf '%b[INFO]%b %s\n' "${BLUE}" "${NC}" "$*"; }
+
+chat_req() {
+  local msg="$1"
+  local body
+  body=$(jq -n --arg m "${msg}" \
+    '{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":$m}],"max_tokens":150}')
+  # Append the HTTP status on its own trailing line so the caller can tell a
+  # gateway/upstream failure from a real answer.
+  curl -s -w $'\n%{http_code}' -X POST "${CHAT_URL}" \
+    -H "Content-Type: application/json" \
+    -d "${body}"
+}
+
+echo ""
+echo "══════════════════════════════════════════════════"
+echo " Pre-flight checks"
+echo "══════════════════════════════════════════════════"
+
+if ! command -v jq >/dev/null 2>&1; then
+  printf '%b[ERROR]%b jq is required: brew install jq\n' "${RED}" "${NC}" >&2; exit 1
+fi
+
+info "Checking gateway health at ${HEALTH_URL} ..."
+if ! curl -sf "${HEALTH_URL}" >/dev/null 2>&1; then
+  printf '%b[ERROR]%b Gateway is not running. Run ./setup.sh first.\n' "${RED}" "${NC}" >&2; exit 1
+fi
+printf '%b[OK]%b    Gateway is healthy.\n' "${GREEN}" "${NC}"
+
+echo ""
+echo "══════════════════════════════════════════════════"
+echo " Test: Text Prompt Decoration (appended suffix)"
+echo "══════════════════════════════════════════════════"
+
+USER_MSG="What is the capital of France? Answer in one short sentence."
+info "Sending plain question (no formatting instructions): \"${USER_MSG}\""
+
+RAW=$(chat_req "${USER_MSG}")
+HTTP_CODE="${RAW##*$'\n'}"   # last line
+RESP="${RAW%$'\n'*}"        # everything before it
+
+echo ""
+echo "══════════════════════════════════════════════════"
+if [[ "${HTTP_CODE}" != 2* ]] || jq -e 'type=="object" and has("error")' >/dev/null 2>&1 <<< "${RESP}"; then
+  # The gateway returns {"error":"..."} (string); upstream APIs return
+  # {"error":{"message":"..."}} (object). Handle both, else show the raw body.
+  ERR=$(jq -r '
+    if (.error|type)=="object" then (.error.message // "unknown error")
+    elif (.error|type)=="string" then .error
+    else "unknown error" end' 2>/dev/null <<< "${RESP}")
+  [[ -z "${ERR}" || "${ERR}" == "null" ]] && ERR="${RESP}"
+  fail "Request failed (HTTP ${HTTP_CODE}): ${ERR}"
+  echo "══════════════════════════════════════════════════"; echo ""; exit 1
+fi
+
+CONTENT=$(jq -r '.choices[0].message.content // ""' <<< "${RESP}")
+info "AI response: ${CONTENT}"
+echo ""
+
+if printf '%s' "${CONTENT}" | grep -qF "${MARKER}"; then
+  pass "Text decoration applied — appended instruction honored ('${MARKER}' present though the caller never sent it)."
+  echo "══════════════════════════════════════════════════"; echo ""; exit 0
+else
+  fail "Tag not detected — '${MARKER}' absent. The suffix may not have been appended."
+  echo "══════════════════════════════════════════════════"; echo ""; exit 1
+fi

--- a/samples/prompt-decorator-policy/test-text-decoration.sh
+++ b/samples/prompt-decorator-policy/test-text-decoration.sh
@@ -2,14 +2,14 @@
 # Test: Text Prompt Decoration (Mode 1 — append)
 #   Sends a plain question. The suffix-proxy APPENDS an instruction to the
 #   user's message telling the model to end its reply with the exact tag
-#   [AZURE-HORIZON-OK]. The caller never asks for that tag, so its presence
+#   [ABC-HORIZON-OK]. The caller never asks for that tag, so its presence
 #   in the reply proves the gateway appended the decoration before
 #   forwarding the request to OpenAI.
 set -uo pipefail
 
 CHAT_URL="http://localhost:8080/suffix-proxy/chat/completions"
 HEALTH_URL="http://localhost:9094/health"
-MARKER="[AZURE-HORIZON-OK]"
+MARKER="[ABC-HORIZON-OK]"
 
 GREEN="\033[0;32m"; RED="\033[0;31m"; BLUE="\033[0;34m"; NC="\033[0m"
 # Use printf, not `echo -e`: some shells' echo prints "-e" literally and/or


### PR DESCRIPTION
## Purpose
$subject

# Add Prompt Decorator policy sample for the AI Gateway

## Summary

Adds a new, self-contained sample under `samples/prompt-decorator-policy/` that demonstrates the WSO2 AI Gateway's **Prompt Decorator** policy. The sample stands up a local gateway stack against Anthropic's OpenAI-compatible endpoint (`claude-sonnet-4-6`) and shows how prompts are modified *before* reaching the LLM — with no application code changes. It serves as the companion sample for the [Prompt Decorator policy docs](https://wso2.com/api-platform/docs/ai-gateway/llm-proxy/prompt-management/prompt-decorator/).

## What's included

| File | Purpose |
|---|---|
| `README.md` | Full walkthrough: overview, scenarios, expected results, prerequisites, setup/teardown, troubleshooting |
| `llm-provider.yaml` | LLM provider definition (Anthropic OpenAI-compatible upstream + access control) |
| `llm-proxy-persona.yaml` | Proxy with **chat** decoration — prepends a system persona to `$.messages` (`append: false`) |
| `llm-proxy-suffix.yaml` | Proxy with **text** decoration — appends an instruction to `$.messages[-1].content` (`append: true`) |
| `setup.sh` | Idempotent setup: download → extract → start Docker stack → wait for health → deploy provider + both proxies |
| `teardown.sh` | Deletes resources and stops the stack; `--clean` also removes the extracted dist + zip |
| `test-chat-decoration.sh` | Verifies the system persona was prepended (hotel name appears though the caller never sent it) |
| `test-text-decoration.sh` | Verifies the suffix instruction was appended (required tag appears though the caller never sent it) |

## Scenarios demonstrated

1. **Chat prompt decoration (prepend)** — The `persona-proxy` injects a `system` message giving the model a hotel-receptionist persona for the imaginary "ABC Horizon Resort". A bare user message produces a reply referencing the hotel name the caller never typed — proving the gateway injected the persona.
2. **Text prompt decoration (append)** — The `suffix-proxy` appends an instruction telling the model to end every reply with the exact tag `[ABC-HORIZON-OK]`. The tag's presence proves the gateway appended the decoration.

## Notes

- The Anthropic API key is injected at deploy time (env var, script arg, or hidden interactive prompt) and never written to disk.
- All setup steps are idempotent — safe to re-run against an already-configured environment.
- Test scripts require no API key at runtime; they use the gateway's stored credentials.

## Testing

Run `./setup.sh`, then `./test-chat-decoration.sh` and `./test-text-decoration.sh`; both should report `[PASS]`.


Related : https://github.com/wso2-enterprise/apim-gtm/issues/474

## Goals
> Describe **what solutions** this feature or fix introduces to address the problems outlined above.

## Approach
> Describe **how** you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
