### PR TITLE
ci(helm): guard releases against duplicate tags and missing validation

### DIFF
--- a/.github/workflows/event-gateway-helm-release.yml
+++ b/.github/workflows/event-gateway-helm-release.yml
@@ -31,6 +31,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Check tag does not already exist
+        run: |
+          TAG="helm-event-gateway-${{ inputs.version }}"
+          if git ls-remote --tags origin "refs/tags/$TAG" | grep -q "$TAG"; then
+            echo "::error::Tag '$TAG' already exists. Bump the version or delete the tag first."
+            exit 1
+          fi
+          echo "Tag '$TAG' is free. Proceeding."
+
       - name: Validate image tags match appVersion
         working-directory: ${{ env.CHART_PATH }}
         run: |

--- a/.github/workflows/gateway-helm-release.yml
+++ b/.github/workflows/gateway-helm-release.yml
@@ -31,6 +31,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Check tag does not already exist
+        run: |
+          TAG="helm-gateway-${{ inputs.version }}"
+          if git ls-remote --tags origin "refs/tags/$TAG" | grep -q "$TAG"; then
+            echo "::error::Tag '$TAG' already exists. Bump the version or delete the tag first."
+            exit 1
+          fi
+          echo "Tag '$TAG' is free. Proceeding."
+
       - name: Validate image tags match appVersion
         working-directory: ${{ env.CHART_PATH }}
         run: |

--- a/.github/workflows/operator-helm-release.yml
+++ b/.github/workflows/operator-helm-release.yml
@@ -30,6 +30,32 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Check tag does not already exist
+        run: |
+          TAG="helm-gateway-operator-${{ inputs.version }}"
+          if git ls-remote --tags origin "refs/tags/$TAG" | grep -q "$TAG"; then
+            echo "::error::Tag '$TAG' already exists. Bump the version or delete the tag first."
+            exit 1
+          fi
+          echo "Tag '$TAG' is free. Proceeding."
+
+      - name: Validate image tag matches appVersion
+        working-directory: ${{ env.CHART_PATH }}
+        run: |
+          APP_VERSION="${{ inputs.appVersion }}"
+          OPERATOR_TAG=$(yq '.image.tag' values.yaml)
+
+          echo "App Version: $APP_VERSION"
+          echo "Operator image tag: $OPERATOR_TAG"
+
+          if [ "$OPERATOR_TAG" != "$APP_VERSION" ]; then
+            echo "::error::gateway-operator image tag '$OPERATOR_TAG' does not match appVersion '$APP_VERSION' in values.yaml"
+            echo "::error::Please update the image tag in ${{ env.CHART_PATH }}/values.yaml to match the appVersion '$APP_VERSION' before releasing."
+            exit 1
+          fi
+
+          echo "✅ Operator image tag matches appVersion '$APP_VERSION'"
+
       - name: Install Helm
         uses: azure/setup-helm@v4
         with:


### PR DESCRIPTION
## Purpose

The three Helm release workflows (gateway, operator, event-gateway) had two missing safeguards that could silently corrupt releases. Resolves #2395.

**No duplicate tag check:** Re-running a release workflow with the same version would silently overwrite the existing OCI chart in GHCR and update the existing GitHub release without any warning or error.

**Missing image tag validation in operator-helm-release:** The operator workflow did not validate that `.image.tag` in `values.yaml` matched the `appVersion` input, unlike the gateway and event-gateway workflows which already had this check. A mismatch would produce a chart that references the wrong image version.

## Approach

- Add a `Check tag does not already exist` step (using `git ls-remote --tags origin`) as the first post-checkout step in all three release workflows; fails fast with a clear error before any packaging or pushing occurs
- Add `Validate image tag matches appVersion` step to `operator-helm-release.yml`, reading `.image.tag` from `values.yaml` and comparing it against the `appVersion` input — matching the pattern already present in gateway and event-gateway workflows

## User stories

As a release engineer, I want the Helm release pipeline to fail early if a tag already exists, so that I cannot accidentally overwrite a published chart.

As a release engineer, I want the operator Helm release to validate image tags match the app version, so that the released chart always references the correct image.

## Documentation

N/A

## Automation tests

- Unit tests: N/A (CI workflow change)
- Integration tests: N/A (CI workflow change)

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

N/A

## Test environment

N/A — CI workflow-only change