### PR TITLE
Add webhook support for Platform API

### DIFF
--- a/platform-api/src/config/config.go
+++ b/platform-api/src/config/config.go
@@ -91,6 +91,7 @@ type Server struct {
 	APIKey           APIKey           `koanf:"api_key"`
 	Gateway          Gateway          `koanf:"gateway"`
 	EventHub         EventHub         `koanf:"event_hub"`
+	Webhook          Webhook          `koanf:"webhook"`
 
 	EnableScopeValidation bool `koanf:"enable_scope_validation"`
 }
@@ -132,6 +133,28 @@ type EventHub struct {
 	PollInterval    time.Duration `koanf:"poll_interval"`
 	CleanupInterval time.Duration `koanf:"cleanup_interval"`
 	RetentionPeriod time.Duration `koanf:"retention_period"`
+}
+
+// Webhook holds configuration for the control-plane webhook receiver. The Developer Portal
+// delivers signed events (API key / subscription changes) to this endpoint. See
+// docs-local/platform-api-webhook.md.
+type Webhook struct {
+	// Enabled controls whether the webhook endpoint is registered.
+	Enabled bool `koanf:"enabled"`
+	// Secret is the HMAC-SHA256 shared secret used to verify request signatures.
+	Secret string `koanf:"secret"`
+	// PrivateKeyPath points to the PEM RSA private key used to decrypt encrypted_key fields.
+	// Optional: required only for events that carry encrypted secrets (API key generate/regenerate).
+	PrivateKeyPath string `koanf:"private_key_path"`
+	// GatewayType filters events meant for this platform type. Events with a different
+	// gateway_type are accepted as a no-op.
+	GatewayType string `koanf:"gateway_type"`
+	// SignatureTolerance bounds how old a signed request may be (replay protection).
+	SignatureTolerance time.Duration `koanf:"signature_tolerance"`
+	// MaxBodySize caps the request body size in bytes.
+	MaxBodySize int64 `koanf:"max_body_size"`
+	// SignatureHeader is the header carrying the "t=...,v1=..." signature.
+	SignatureHeader string `koanf:"signature_header"`
 }
 
 // Gateway holds gateway-related configuration.
@@ -310,6 +333,9 @@ func LoadConfig(configPath string) (*Server, error) {
 		return nil, err
 	}
 	if err := validateIDPConfig(&cfg.Auth.IDP); err != nil {
+		return nil, err
+	}
+	if err := validateWebhookConfig(&cfg.Webhook); err != nil {
 		return nil, err
 	}
 	if err := validateFileBasedConfig(&cfg.Auth.FileBased); err != nil {
@@ -582,6 +608,22 @@ func envToKoanfKey(s string) string {
 	case "event_hub_retention_period":
 		return "event_hub.retention_period"
 
+	// Webhook
+	case "webhook_enabled":
+		return "webhook.enabled"
+	case "webhook_secret":
+		return "webhook.secret"
+	case "webhook_private_key_path":
+		return "webhook.private_key_path"
+	case "webhook_gateway_type":
+		return "webhook.gateway_type"
+	case "webhook_signature_tolerance":
+		return "webhook.signature_tolerance"
+	case "webhook_max_body_size":
+		return "webhook.max_body_size"
+	case "webhook_signature_header":
+		return "webhook.signature_header"
+
 	default:
 		return ""
 	}
@@ -688,6 +730,30 @@ func validateFileBasedConfig(cfg *FileBased) error {
 	}
 	if len(cfg.Users) == 0 {
 		return fmt.Errorf("auth.file_based.enabled=true requires at least one user in auth.file_based.users")
+	}
+	return nil
+}
+
+// validateWebhookConfig validates and fills defaults for the webhook receiver config.
+// It is a no-op when the webhook is disabled.
+func validateWebhookConfig(w *Webhook) error {
+	if !w.Enabled {
+		return nil
+	}
+	if w.Secret == "" {
+		return fmt.Errorf("webhook.enabled=true requires webhook.secret to be configured")
+	}
+	if w.SignatureTolerance <= 0 {
+		w.SignatureTolerance = 5 * time.Minute
+	}
+	if w.MaxBodySize <= 0 {
+		w.MaxBodySize = 1 << 20 // 1 MiB
+	}
+	if w.SignatureHeader == "" {
+		w.SignatureHeader = "X-Devportal-Signature"
+	}
+	if w.GatewayType == "" {
+		w.GatewayType = "wso2/api-platform"
 	}
 	return nil
 }

--- a/platform-api/src/config/default_config.go
+++ b/platform-api/src/config/default_config.go
@@ -17,7 +17,11 @@
 
 package config
 
-import "time"
+import (
+	"time"
+
+	"platform-api/src/internal/constants"
+)
 
 // defaultConfig returns a Server with all default values.
 func defaultConfig() *Server {
@@ -55,6 +59,7 @@ func defaultConfig() *Server {
 				"/api/internal/v1/secrets",
 				"/api/internal/v1/websub-apis",
 				"/api/internal/v1/webbroker-apis",
+				"/api/internal/" + constants.APIVersion + "/webhook/events",
 			},
 			JWT: JWT{
 				Enabled:        true,
@@ -137,6 +142,13 @@ func defaultConfig() *Server {
 			PollInterval:    3 * time.Second,
 			CleanupInterval: 10 * time.Minute,
 			RetentionPeriod: 1 * time.Hour,
+		},
+		Webhook: Webhook{
+			Enabled:            false,
+			GatewayType:        "wso2/api-platform",
+			SignatureTolerance: 5 * time.Minute,
+			MaxBodySize:        1 << 20, // 1 MiB
+			SignatureHeader:    "X-Devportal-Signature",
 		},
 	}
 }

--- a/platform-api/src/internal/constants/error.go
+++ b/platform-api/src/internal/constants/error.go
@@ -42,6 +42,7 @@ var (
 	ErrOrganizationMustHAveAtLeastOneProject = errors.New("organization must have at least one project")
 	ErrProjectHasAssociatedAPIs              = errors.New("project has associated APIs")
 	ErrProjectHasAssociatedMCPProxies        = errors.New("project has associated MCP proxies")
+	ErrProjectHasAssociatedApplications      = errors.New("project has associated applications")
 	ErrorInvalidProjectUUID                  = errors.New("invalid project UUID")
 )
 

--- a/platform-api/src/internal/database/schema.postgres.sql
+++ b/platform-api/src/internal/database/schema.postgres.sql
@@ -50,7 +50,7 @@ CREATE TABLE IF NOT EXISTS projects (
 CREATE TABLE IF NOT EXISTS applications (
     uuid VARCHAR(40) PRIMARY KEY,
     handle VARCHAR(40) NOT NULL,
-    project_uuid VARCHAR(40) NOT NULL,
+    project_uuid VARCHAR(40),
     organization_uuid VARCHAR(40) NOT NULL,
     display_name VARCHAR(255) NOT NULL,
     description VARCHAR(1023),
@@ -60,7 +60,6 @@ CREATE TABLE IF NOT EXISTS applications (
     created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
     updated_by VARCHAR(200),
     updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY (project_uuid) REFERENCES projects(uuid) ON DELETE CASCADE,
     FOREIGN KEY (organization_uuid) REFERENCES organizations(uuid) ON DELETE CASCADE,
     UNIQUE(organization_uuid, handle)
 );

--- a/platform-api/src/internal/database/schema.sql
+++ b/platform-api/src/internal/database/schema.sql
@@ -50,7 +50,7 @@ CREATE TABLE IF NOT EXISTS projects (
 CREATE TABLE IF NOT EXISTS applications (
     uuid VARCHAR(40) PRIMARY KEY,
     handle VARCHAR(40) NOT NULL,
-    project_uuid VARCHAR(40) NOT NULL,
+    project_uuid VARCHAR(40),
     organization_uuid VARCHAR(40) NOT NULL,
     display_name VARCHAR(255) NOT NULL,
     description VARCHAR(1023),
@@ -60,7 +60,6 @@ CREATE TABLE IF NOT EXISTS applications (
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     updated_by VARCHAR(200),
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY (project_uuid) REFERENCES projects(uuid) ON DELETE CASCADE,
     FOREIGN KEY (organization_uuid) REFERENCES organizations(uuid) ON DELETE CASCADE,
     UNIQUE(organization_uuid, handle)
 );

--- a/platform-api/src/internal/database/schema.sqlite.sql
+++ b/platform-api/src/internal/database/schema.sqlite.sql
@@ -50,7 +50,7 @@ CREATE TABLE IF NOT EXISTS projects (
 CREATE TABLE IF NOT EXISTS applications (
     uuid VARCHAR(40) PRIMARY KEY,
     handle VARCHAR(40) NOT NULL,
-    project_uuid VARCHAR(40) NOT NULL,
+    project_uuid VARCHAR(40),
     organization_uuid VARCHAR(40) NOT NULL,
     display_name VARCHAR(255) NOT NULL,
     description VARCHAR(1023),
@@ -60,7 +60,6 @@ CREATE TABLE IF NOT EXISTS applications (
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     updated_by VARCHAR(200),
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY (project_uuid) REFERENCES projects(uuid) ON DELETE CASCADE,
     FOREIGN KEY (organization_uuid) REFERENCES organizations(uuid) ON DELETE CASCADE,
     UNIQUE(organization_uuid, handle)
 );

--- a/platform-api/src/internal/database/schema.sqlserver.sql
+++ b/platform-api/src/internal/database/schema.sqlserver.sql
@@ -52,7 +52,7 @@ IF OBJECT_ID(N'dbo.applications', N'U') IS NULL
 CREATE TABLE dbo.applications (
     uuid VARCHAR(40) PRIMARY KEY,
     handle VARCHAR(40) NOT NULL,
-    project_uuid VARCHAR(40) NOT NULL,
+    project_uuid VARCHAR(40),
     organization_uuid VARCHAR(40) NOT NULL,
     display_name VARCHAR(255) NOT NULL,
     description VARCHAR(1023),
@@ -62,12 +62,7 @@ CREATE TABLE dbo.applications (
     created_at DATETIME2(7) DEFAULT SYSUTCDATETIME(),
     updated_by VARCHAR(200),
     updated_at DATETIME2(7) DEFAULT SYSUTCDATETIME(),
-    FOREIGN KEY (project_uuid) REFERENCES projects(uuid) ON DELETE CASCADE,
-    -- NO ACTION (not CASCADE) to avoid the SQL Server multiple-cascade-paths
-    -- restriction (error 1785). Deleting an organization still removes its
-    -- applications via organizations -> projects -> applications, so no
-    -- cleanup behavior is lost relative to the Postgres schema.
-    FOREIGN KEY (organization_uuid) REFERENCES organizations(uuid) ON DELETE NO ACTION,
+    FOREIGN KEY (organization_uuid) REFERENCES organizations(uuid) ON DELETE CASCADE,
     UNIQUE(organization_uuid, handle)
 );
 

--- a/platform-api/src/internal/handler/api_key.go
+++ b/platform-api/src/internal/handler/api_key.go
@@ -100,7 +100,7 @@ func (h *APIKeyHandler) CreateAPIKey(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create the API key and broadcast to gateways
-	err := h.apiKeyService.CreateAPIKey(r.Context(), apiHandle, orgId, userId, &req)
+	err := h.apiKeyService.CreateAPIKey(r.Context(), apiHandle, constants.RestApi, orgId, userId, &req)
 	if err != nil {
 		// Handle specific error cases
 		if errors.Is(err, constants.ErrAPINotFound) {
@@ -192,7 +192,7 @@ func (h *APIKeyHandler) UpdateAPIKey(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Update the API key and broadcast to gateways
-	err := h.apiKeyService.UpdateAPIKey(r.Context(), apiHandle, orgId, keyName, userId, &req)
+	err := h.apiKeyService.UpdateAPIKey(r.Context(), apiHandle, constants.RestApi, orgId, keyName, userId, &req)
 	if err != nil {
 		// Handle specific error cases
 		if errors.Is(err, constants.ErrAPINotFound) {
@@ -252,7 +252,7 @@ func (h *APIKeyHandler) RevokeAPIKey(w http.ResponseWriter, r *http.Request) {
 	userId := r.Header.Get("x-user-id")
 
 	// Revoke the API key and broadcast to gateways
-	err := h.apiKeyService.RevokeAPIKey(r.Context(), apiHandle, orgId, keyName, userId)
+	err := h.apiKeyService.RevokeAPIKey(r.Context(), apiHandle, constants.RestApi, orgId, keyName, userId)
 	if err != nil {
 		// Handle specific error cases
 		if errors.Is(err, constants.ErrAPINotFound) {

--- a/platform-api/src/internal/handler/project.go
+++ b/platform-api/src/internal/handler/project.go
@@ -245,6 +245,11 @@ func (h *ProjectHandler) DeleteProject(w http.ResponseWriter, r *http.Request) {
 				"Project has associated MCP proxies"))
 			return
 		}
+		if errors.Is(err, constants.ErrProjectHasAssociatedApplications) {
+			httputil.WriteJSON(w, http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request",
+				"Project has associated applications"))
+			return
+		}
 		h.slogger.Error("Failed to delete project", "error", err)
 		httputil.WriteJSON(w, http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error",
 			"Failed to delete project"))

--- a/platform-api/src/internal/handler/subscription_handler.go
+++ b/platform-api/src/internal/handler/subscription_handler.go
@@ -101,7 +101,7 @@ func (h *SubscriptionHandler) CreateSubscription(w http.ResponseWriter, r *http.
 		httputil.WriteJSON(w, http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", "Invalid status value"))
 		return
 	}
-	sub, err := h.subscriptionService.CreateSubscription(req.APIID, req.Kind, orgId, req.SubscriberID, req.ApplicationID, req.SubscriptionPlanID, req.Status)
+	sub, err := h.subscriptionService.CreateSubscription(req.APIID, req.Kind, orgId, req.SubscriberID, req.ApplicationID, req.SubscriptionPlanID, "", req.Status)
 	if err != nil {
 		if errors.Is(err, constants.ErrAPINotFound) {
 			httputil.WriteJSON(w, http.StatusNotFound, utils.NewErrorResponse(404, "Not Found", "API not found"))

--- a/platform-api/src/internal/integration/cascade_test.go
+++ b/platform-api/src/internal/integration/cascade_test.go
@@ -148,25 +148,6 @@ func TestCascade_DeleteApplicationRemovesMappings(t *testing.T) {
 	}
 }
 
-// TestCascade_DeleteProjectRemovesApplications verifies the kept projects ->
-// applications CASCADE (the org-direct application edge is now NO ACTION on
-// SQL Server, so applications must be cleaned via the project edge). Project
-// deletion is guarded against associated APIs in the service layer, so we
-// remove the API artifacts first to mirror a legitimate project delete.
-func TestCascade_DeleteProjectRemovesApplications(t *testing.T) {
-	it := openITDB(t)
-	defer it.db.Close()
-	g := seedOrgGraph(t, it)
-
-	// Remove API-side rows first (as the service guard requires no APIs).
-	it.exec(t, `DELETE FROM artifacts WHERE uuid = ?`, g.apiArtifact)
-
-	it.exec(t, `DELETE FROM projects WHERE uuid = ?`, g.project)
-	if got := it.count(t, "applications", "uuid", g.app); got != 0 {
-		t.Fatalf("[%s] application not removed after project delete: %d remain", it.driver, got)
-	}
-}
-
 // TestCascade_DeleteSubscriptionPlanRemovesLimits verifies that deleting a
 // subscription plan cascade-removes its subscription_plan_limits rows. On SQL
 // Server the limit's organization/composite edges are NO ACTION (to avoid the

--- a/platform-api/src/internal/repository/application.go
+++ b/platform-api/src/internal/repository/application.go
@@ -517,6 +517,43 @@ func (r *ApplicationRepo) RemoveApplicationAPIKey(applicationUUID, apiKeyID stri
 	return err
 }
 
+// GetApplicationsByAPIKeyID returns the applications the given API key is currently mapped to within
+// the organization. Used to broadcast a mapping update to the affected gateways when a key is
+// dissociated — the previously-owning application must be captured before the mapping is removed.
+func (r *ApplicationRepo) GetApplicationsByAPIKeyID(apiKeyID, orgID string) ([]*model.Application, error) {
+	rows, err := r.db.Query(r.db.Rebind(`
+		SELECT a.uuid, a.handle, a.project_uuid, a.organization_uuid, a.created_by, a.updated_by, a.display_name, a.description, a.type, a.created_at, a.updated_at
+		FROM applications a
+		INNER JOIN application_api_key_mappings m ON m.application_uuid = a.uuid
+		WHERE m.api_key_id = ? AND a.organization_uuid = ?
+	`), apiKeyID, orgID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var apps []*model.Application
+	for rows.Next() {
+		app, err := scanApplication(rows)
+		if err != nil {
+			return nil, err
+		}
+		apps = append(apps, app)
+	}
+	return apps, rows.Err()
+}
+
+// RemoveAPIKeyFromAllApplications removes the given API key from every application it is mapped to.
+// Used to reconcile a Developer Portal apikey.application_updated event (a key belongs to at most
+// one application), where the previous application is not carried in the event.
+func (r *ApplicationRepo) RemoveAPIKeyFromAllApplications(apiKeyID string) error {
+	_, err := r.db.Exec(r.db.Rebind(`
+		DELETE FROM application_api_key_mappings
+		WHERE api_key_id = ?
+	`), apiKeyID)
+	return err
+}
+
 func (r *ApplicationRepo) RemoveApplicationAssociation(applicationUUID, targetUUID string) error {
 	_, err := r.db.Exec(r.db.Rebind(`
 		DELETE FROM application_artifact_mappings
@@ -531,6 +568,7 @@ type rowScanner interface {
 
 func scanApplication(scanner rowScanner) (*model.Application, error) {
 	var app model.Application
+	var projectUUID sql.NullString
 	var createdBy sql.NullString
 	var updatedBy sql.NullString
 	var description sql.NullString
@@ -538,7 +576,7 @@ func scanApplication(scanner rowScanner) (*model.Application, error) {
 	err := scanner.Scan(
 		&app.UUID,
 		&app.Handle,
-		&app.ProjectUUID,
+		&projectUUID,
 		&app.OrganizationUUID,
 		&createdBy,
 		&updatedBy,
@@ -552,6 +590,9 @@ func scanApplication(scanner rowScanner) (*model.Application, error) {
 		return nil, err
 	}
 
+	if projectUUID.Valid {
+		app.ProjectUUID = projectUUID.String
+	}
 	if createdBy.Valid {
 		app.CreatedBy = createdBy.String
 	}

--- a/platform-api/src/internal/repository/interfaces.go
+++ b/platform-api/src/internal/repository/interfaces.go
@@ -89,7 +89,9 @@ type ApplicationRepository interface {
 	ListApplicationAssociations(applicationUUID string) ([]*model.ApplicationAssociationTarget, error)
 	AddApplicationAPIKeys(applicationUUID string, apiKeyIDs []string) error
 	AddApplicationAssociations(applicationUUID string, targetUUIDs []string) error
+	GetApplicationsByAPIKeyID(apiKeyID, orgID string) ([]*model.Application, error)
 	RemoveApplicationAPIKey(applicationUUID, apiKeyID string) error
+	RemoveAPIKeyFromAllApplications(apiKeyID string) error
 	RemoveApplicationAssociation(applicationUUID, targetUUID string) error
 }
 
@@ -203,6 +205,7 @@ type SubscriptionRepository interface {
 	// CountByFilters returns the total count of subscriptions matching the same filters as ListByFilters.
 	CountByFilters(orgUUID string, apiUUID *string, subscriberID *string, applicationID *string, status *string) (int, error)
 	Update(sub *model.Subscription) error
+	UpdateToken(subscriptionID, orgUUID, newToken string) error
 	Delete(subscriptionID, orgUUID string) error
 	ExistsByAPIAndSubscriber(apiUUID, subscriberID, orgUUID string) (bool, error)
 }

--- a/platform-api/src/internal/repository/subscription_repository.go
+++ b/platform-api/src/internal/repository/subscription_repository.go
@@ -329,6 +329,43 @@ func (r *SubscriptionRepo) Update(sub *model.Subscription) error {
 	return nil
 }
 
+// UpdateToken rotates a subscription's token: the new value is hashed (for the uniqueness/lookup
+// column) and encrypted (for at-rest storage), mirroring Create. Returns ErrSubscriptionNotFound
+// when no row matches.
+func (r *SubscriptionRepo) UpdateToken(subscriptionID, orgUUID, newToken string) error {
+	if newToken == "" {
+		return fmt.Errorf("subscription token cannot be empty")
+	}
+	hashedToken := hashSubscriptionToken(newToken)
+
+	key, err := getSubscriptionTokenEncryptionKey()
+	if err != nil {
+		return fmt.Errorf("subscription token encryption: %w", err)
+	}
+	encryptedToken, err := utils.EncryptSubscriptionToken(key, newToken)
+	if err != nil {
+		return fmt.Errorf("failed to encrypt subscription token: %w", err)
+	}
+
+	query := `
+		UPDATE subscriptions
+		SET subscription_token = ?, subscription_token_hash = ?, updated_at = ?
+		WHERE uuid = ? AND organization_uuid = ?
+	`
+	result, err := r.db.Exec(r.db.Rebind(query), encryptedToken, hashedToken, time.Now(), subscriptionID, orgUUID)
+	if err != nil {
+		if isSubscriptionUniqueViolation(err) {
+			return constants.ErrSubscriptionAlreadyExists
+		}
+		return fmt.Errorf("failed to update subscription token: %w", err)
+	}
+	n, _ := result.RowsAffected()
+	if n == 0 {
+		return constants.ErrSubscriptionNotFound
+	}
+	return nil
+}
+
 // Delete removes a subscription by ID and organization
 func (r *SubscriptionRepo) Delete(subscriptionID, orgUUID string) error {
 	query := `DELETE FROM subscriptions WHERE uuid = ? AND organization_uuid = ?`

--- a/platform-api/src/internal/server/server.go
+++ b/platform-api/src/internal/server/server.go
@@ -49,6 +49,7 @@ import (
 	"platform-api/src/internal/service"
 	"platform-api/src/internal/utils"
 	internalvault "platform-api/src/internal/vault"
+	"platform-api/src/internal/webhook"
 	"platform-api/src/internal/websocket"
 
 	"github.com/wso2/api-platform/common/authenticators"
@@ -238,7 +239,7 @@ func StartPlatformAPIServer(cfg *config.Server, slogger *slog.Logger) (*Server, 
 		cfg,
 		slogger,
 	)
-	projectService := service.NewProjectService(projectRepo, orgRepo, apiRepo, mcpProxyRepo, auditRepo, slogger)
+	projectService := service.NewProjectService(projectRepo, orgRepo, apiRepo, mcpProxyRepo, appRepo, auditRepo, slogger)
 	gatewayEventsService := service.NewGatewayEventsService(eventHub, slogger)
 	appService := service.NewApplicationService(appRepo, projectRepo, orgRepo, apiRepo, gatewayEventsService, auditRepo, slogger)
 	apiService := service.NewAPIService(apiRepo, projectRepo, orgRepo, gatewayRepo, deploymentRepo,
@@ -451,6 +452,29 @@ func StartPlatformAPIServer(cfg *config.Server, slogger *slog.Logger) (*Server, 
 			projectService.RegisterDeletionGuard(guard)
 		}
 	}
+	slogger.Info("Registered API routes successfully")
+
+	// Register the control-plane webhook receiver (Developer Portal -> Platform API) when enabled.
+	// Authenticity is established by HMAC signature; the route is excluded from JWT/IDP auth via
+	// cfg.Auth.SkipPaths (see config defaults).
+	if cfg.Webhook.Enabled {
+		webhookDecryptor, err := webhook.NewDecryptor(cfg.Webhook.PrivateKeyPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize webhook decryptor: %w", err)
+		}
+		webhookReceiver := webhook.NewReceiver(
+			cfg.Webhook,
+			webhookDecryptor,
+			apiKeyService,
+			subscriptionService,
+			appService,
+			orgRepo,
+			slogger,
+		)
+		webhookReceiver.RegisterRoutes(mux)
+		slogger.Info("Webhook receiver enabled", "path", webhook.RoutePath, "gatewayType", cfg.Webhook.GatewayType)
+	}
+
 	slogger.Info("Registered API routes successfully")
 
 	// Build the middleware chain that wraps the mux.

--- a/platform-api/src/internal/service/apikey.go
+++ b/platform-api/src/internal/service/apikey.go
@@ -277,11 +277,12 @@ func (s *APIKeyService) resolveUniqueKeyName(artifactUUID string, req *api.Creat
 
 // CreateAPIKey hashes an external API key and broadcasts it to gateways where the API is deployed.
 // This method is used when external platforms inject API keys to hybrid gateways.
-func (s *APIKeyService) CreateAPIKey(ctx context.Context, apiHandle, orgId, userId string, req *api.CreateAPIKeyRequest) error {
-	// Resolve API handle to UUID
-	apiMetadata, err := s.artifactRepo.GetAPIMetadataByHandle(apiHandle, orgId)
+func (s *APIKeyService) CreateAPIKey(ctx context.Context, apiHandle, kind, orgId, userId string, req *api.CreateAPIKeyRequest) error {
+	// Resolve API handle to UUID within the artifact table backing kind, so a handle shared across
+	// kinds resolves to exactly one artifact.
+	apiMetadata, err := s.artifactRepo.GetAPIMetadataByHandleAndKind(apiHandle, kind, orgId)
 	if err != nil {
-		s.slogger.Error("Failed to get API metadata for API key creation", "apiHandle", apiHandle, "error", err)
+		s.slogger.Error("Failed to get API metadata for API key creation", "apiHandle", apiHandle, "kind", kind, "error", err)
 		return fmt.Errorf("failed to get API by handle: %w", err)
 	}
 	if apiMetadata == nil {
@@ -402,11 +403,12 @@ func (s *APIKeyService) CreateAPIKey(ctx context.Context, apiHandle, orgId, user
 
 // UpdateAPIKey updates/regenerates an API key and broadcasts it to all gateways where the API is deployed.
 // This method is used when external platforms rotates/regenerates API keys on hybrid gateways.
-func (s *APIKeyService) UpdateAPIKey(ctx context.Context, apiHandle, orgId, keyName, userId string, req *api.UpdateAPIKeyRequest) error {
-	// Resolve API handle to UUID
-	apiMetadata, err := s.artifactRepo.GetAPIMetadataByHandle(apiHandle, orgId)
+func (s *APIKeyService) UpdateAPIKey(ctx context.Context, apiHandle, kind, orgId, keyName, userId string, req *api.UpdateAPIKeyRequest) error {
+	// Resolve API handle to UUID within the artifact table backing kind, so a handle shared across
+	// kinds resolves to exactly one artifact.
+	apiMetadata, err := s.artifactRepo.GetAPIMetadataByHandleAndKind(apiHandle, kind, orgId)
 	if err != nil {
-		s.slogger.Error("Failed to get API metadata for API key update", "apiHandle", apiHandle, "error", err)
+		s.slogger.Error("Failed to get API metadata for API key update", "apiHandle", apiHandle, "kind", kind, "error", err)
 		return fmt.Errorf("failed to get API by handle: %w", err)
 	}
 	if apiMetadata == nil {
@@ -512,11 +514,12 @@ func (s *APIKeyService) UpdateAPIKey(ctx context.Context, apiHandle, orgId, keyN
 }
 
 // RevokeAPIKey broadcasts API key revocation to all gateways where the API is deployed
-func (s *APIKeyService) RevokeAPIKey(ctx context.Context, apiHandle, orgId, keyName, userId string) error {
-	// Resolve API handle to UUID
-	apiMetadata, err := s.artifactRepo.GetAPIMetadataByHandle(apiHandle, orgId)
+func (s *APIKeyService) RevokeAPIKey(ctx context.Context, apiHandle, kind, orgId, keyName, userId string) error {
+	// Resolve API handle to UUID within the artifact table backing kind, so a handle shared across
+	// kinds resolves to exactly one artifact.
+	apiMetadata, err := s.artifactRepo.GetAPIMetadataByHandleAndKind(apiHandle, kind, orgId)
 	if err != nil {
-		s.slogger.Error("Failed to get API metadata for API key revocation", "apiHandle", apiHandle, "error", err)
+		s.slogger.Error("Failed to get API metadata for API key revocation", "apiHandle", apiHandle, "kind", kind, "error", err)
 		return fmt.Errorf("failed to get API by handle: %w", err)
 	}
 	if apiMetadata == nil {

--- a/platform-api/src/internal/service/application.go
+++ b/platform-api/src/internal/service/application.go
@@ -103,26 +103,27 @@ func (s *ApplicationService) CreateApplication(req *api.CreateApplicationRequest
 		return nil, constants.ErrOrganizationNotFound
 	}
 
+	// project_uuid is optional. When a project handle is supplied it must resolve, and name
+	// uniqueness is scoped to that project; when absent the application is created without a project.
 	projectHandle := strings.TrimSpace(req.ProjectId)
-	if projectHandle == "" {
-		return nil, constants.ErrProjectNotFound
-	}
+	var projectID string
+	if projectHandle != "" {
+		project, err := s.projectRepo.GetProjectByHandleAndOrgID(projectHandle, orgID)
+		if err != nil {
+			return nil, err
+		}
+		if project == nil {
+			return nil, constants.ErrProjectNotFound
+		}
+		projectID = project.ID
 
-	project, err := s.projectRepo.GetProjectByHandleAndOrgID(projectHandle, orgID)
-	if err != nil {
-		return nil, err
-	}
-	if project == nil {
-		return nil, constants.ErrProjectNotFound
-	}
-	projectID := project.ID
-
-	existingByName, err := s.appRepo.GetApplicationByNameInProject(strings.TrimSpace(req.DisplayName), projectID, orgID)
-	if err != nil {
-		return nil, err
-	}
-	if existingByName != nil {
-		return nil, constants.ErrApplicationExists
+		existingByName, err := s.appRepo.GetApplicationByNameInProject(strings.TrimSpace(req.DisplayName), projectID, orgID)
+		if err != nil {
+			return nil, err
+		}
+		if existingByName != nil {
+			return nil, constants.ErrApplicationExists
+		}
 	}
 
 	handle := strings.TrimSpace(valueOrEmptyApplication(req.Id))
@@ -324,10 +325,36 @@ func (s *ApplicationService) DeleteApplication(appIDOrHandle, orgID, actor strin
 		return constants.ErrApplicationNotFound
 	}
 
+	// Capture the mapped keys before deletion so we can tell the gateways to drop them. Deleting the
+	// application row cascades the application_api_key_mappings rows away in the Platform API DB, but
+	// nothing is broadcast to the gateways, so without this they keep the key→application mappings
+	// until the controller's next pull-sync.
+	mappedKeys, keysErr := s.listMappedAPIKeysForBroadcast(app.UUID)
+	if keysErr != nil && s.slogger != nil {
+		s.slogger.Warn("Failed to list mapped API keys before application delete",
+			"applicationId", app.Handle, "error", keysErr)
+	}
+
 	if err := s.appRepo.DeleteApplication(app.UUID, orgID); err != nil {
 		return err
 	}
 	_ = s.auditRepo.Record("DELETE", app.UUID, "application", orgID, actor)
+
+	// Broadcast an empty mapping set so the gateways clear every key for this application. The
+	// removed keys' artifacts are passed as hints so the correct gateways are targeted (the
+	// application is gone, so there are no remaining keys to derive targets from).
+	if len(mappedKeys) > 0 {
+		hints := make([]string, 0, len(mappedKeys))
+		for _, key := range mappedKeys {
+			if key != nil && strings.TrimSpace(key.ArtifactID) != "" {
+				hints = append(hints, key.ArtifactID)
+			}
+		}
+		if berr := s.broadcastApplicationMappingUpdateWithArtifactHints(app, actor, nil, hints); berr != nil && s.slogger != nil {
+			s.slogger.Warn("Application delete succeeded but failed to broadcast mapping clear",
+				"applicationId", app.Handle, "error", berr)
+		}
+	}
 	return nil
 }
 
@@ -414,6 +441,106 @@ func (s *ApplicationService) AddMappedAPIKeys(appIDOrHandle string, req *api.Add
 	}
 
 	return keys, nil
+}
+
+// CreateApplicationFromWebhook creates an application reconciled from a Developer Portal
+// application.created/updated event. DP applications carry no project.
+func (s *ApplicationService) CreateApplicationFromWebhook(handle, name, description, appType, orgID string) (*api.Application, error) {
+	id := strings.TrimSpace(handle)
+	desc := strings.TrimSpace(description)
+	// ProjectId is intentionally left empty: webhook-reconciled applications have no project.
+	req := &api.CreateApplicationRequest{
+		DisplayName: name,
+		Id:          &id,
+		Type:        api.ApplicationType(strings.TrimSpace(appType)),
+		Description: &desc,
+	}
+	return s.CreateApplication(req, orgID, "")
+}
+
+// SetAPIKeyApplication reconciles which application an API key belongs to, from a Developer Portal
+// apikey.application_updated event. keyName + artifactRef (artifact UUID or handle) + kind identify
+// the key; kind scopes the resolution to the artifact table backing that kind, so a handle shared
+// across kinds resolves unambiguously. Because a Developer Portal key belongs to at most one
+// application, this first removes the key from any application it is currently mapped to, then —
+// when appIDOrHandle is non-empty — maps it to that application and broadcasts the change to the
+// deployed gateways. A blank appIDOrHandle dissociates the key.
+func (s *ApplicationService) SetAPIKeyApplication(keyName, artifactRef, kind, appIDOrHandle, orgID, userID string) error {
+	// Resolve artifactRef (artifact UUID or handle) to the artifact handle used by the key lookup.
+	artifactHandle := strings.TrimSpace(artifactRef)
+	if art, err := s.appRepo.GetAssociationTargetByUUID(artifactHandle, orgID); err == nil && art != nil {
+		artifactHandle = art.Handle
+	}
+
+	key, err := s.resolveAPIKey(api.APIKeyMappingSelector{
+		KeyId:            keyName,
+		AssociatedEntity: api.APIKeyMappingAssociatedEntity{Id: artifactHandle},
+	}, orgID)
+	if err != nil {
+		return err
+	}
+	if key == nil {
+		return constants.ErrAPIKeyNotFound
+	}
+	// Enforce kind scoping: the resolved key must belong to an artifact of the requested kind. A
+	// handle can collide across kinds, so a key found under a same-named handle of another kind is
+	// treated as not found for this event.
+	if kind != "" && key.ArtifactType != kind {
+		return constants.ErrAPIKeyNotFound
+	}
+
+	// Capture the applications the key currently belongs to before removing the mapping, so a
+	// dissociation can broadcast the (key-removed) mapping to the gateways that had the key.
+	priorApps, lookupErr := s.appRepo.GetApplicationsByAPIKeyID(key.ID, orgID)
+	if lookupErr != nil && s.slogger != nil {
+		s.slogger.Warn("Failed to look up applications for API key before dissociation",
+			"keyId", key.ID, "error", lookupErr)
+	}
+
+	if err := s.appRepo.RemoveAPIKeyFromAllApplications(key.ID); err != nil {
+		return err
+	}
+
+	if strings.TrimSpace(appIDOrHandle) == "" {
+		// Dissociated: the key no longer belongs to any application. Broadcast an updated mapping for
+		// each previously-owning application so the gateways drop the key. listMappedAPIKeysForBroadcast
+		// now excludes the removed key (the mapping row is already gone), and the removed key's artifact
+		// is passed as a hint so the correct gateways are targeted even when no keys remain.
+		for _, app := range priorApps {
+			if app == nil {
+				continue
+			}
+			remaining, err := s.listMappedAPIKeysForBroadcast(app.UUID)
+			if err != nil {
+				if s.slogger != nil {
+					s.slogger.Warn("Failed to list mapped API keys after dissociation",
+						"applicationId", app.Handle, "error", err)
+				}
+				continue
+			}
+			if berr := s.broadcastApplicationMappingUpdateWithArtifactHints(app, userID, remaining, []string{key.ArtifactID}); berr != nil && s.slogger != nil {
+				s.slogger.Warn("Dissociation succeeded but failed to broadcast application mapping update",
+					"applicationId", app.Handle, "error", berr)
+			}
+		}
+		return nil
+	}
+
+	app, err := s.getApplication(appIDOrHandle, orgID)
+	if err != nil {
+		return err
+	}
+	if err := s.appRepo.AddApplicationAPIKeys(app.UUID, []string{key.ID}); err != nil {
+		return err
+	}
+	broadcastKeys, err := s.listMappedAPIKeysForBroadcast(app.UUID)
+	if err == nil {
+		if berr := s.broadcastApplicationMappingUpdateWithArtifactHints(app, userID, broadcastKeys, []string{key.ArtifactID}); berr != nil && s.slogger != nil {
+			s.slogger.Warn("Set API key application succeeded but failed to broadcast application mapping update",
+				"applicationId", app.Handle, "error", berr)
+		}
+	}
+	return nil
 }
 
 func (s *ApplicationService) AddApplicationAssociations(appIDOrHandle string, req *AddApplicationAssociationsRequest, orgID string) (*ApplicationAssociationListResponse, error) {
@@ -799,18 +926,24 @@ func (s *ApplicationService) modelToApplicationResponse(app *model.Application) 
 	if app == nil {
 		return nil, nil
 	}
-	project, err := s.projectRepo.GetProjectByUUID(app.ProjectUUID)
-	if err != nil {
-		return nil, err
-	}
-	if project == nil {
-		return nil, constants.ErrProjectNotFound
+	// project_uuid is optional: only resolve the project handle when one is set, otherwise the
+	// response carries an empty projectId.
+	projectHandle := ""
+	if strings.TrimSpace(app.ProjectUUID) != "" {
+		project, err := s.projectRepo.GetProjectByUUID(app.ProjectUUID)
+		if err != nil {
+			return nil, err
+		}
+		if project == nil {
+			return nil, constants.ErrProjectNotFound
+		}
+		projectHandle = project.Handle
 	}
 
 	return &api.Application{
 		Id:          app.Handle,
 		DisplayName: app.Name,
-		ProjectId:   project.Handle,
+		ProjectId:   projectHandle,
 		Type:        api.ApplicationType(app.Type),
 		Description: utils.StringPtrIfNotEmpty(app.Description),
 		CreatedBy:   utils.StringPtrIfNotEmpty(app.CreatedBy),
@@ -871,6 +1004,9 @@ func normalizeApplicationType(appType string) (string, error) {
 	if strings.EqualFold(trimmed, "genai") {
 		return "genai", nil
 	}
+	if strings.EqualFold(trimmed, "web") {
+		return "web", nil
+	}
 	return "", constants.ErrUnsupportedApplicationType
 }
 
@@ -922,7 +1058,7 @@ func (s *ApplicationService) broadcastApplicationMappingUpdateWithArtifactHints(
 		}
 
 		switch artifact.Type {
-		case constants.LLMProvider, constants.LLMProxy:
+		case constants.LLMProvider, constants.LLMProxy, constants.RestApi:
 			// Supported artifact types for gateway association lookups.
 		default:
 			if s.slogger != nil {

--- a/platform-api/src/internal/service/application_test.go
+++ b/platform-api/src/internal/service/application_test.go
@@ -48,6 +48,13 @@ type mockApplicationRepository struct {
 	handleExists            bool
 	handleExistsErr         error
 	createErr               error
+	appsByAPIKey            []*model.Application
+	appsByAPIKeyErr         error
+	getAppsByKeyCalled      bool
+	removeAllCalled         bool
+	removedAllAPIKeyID      string
+	deleteCalled            bool
+	deployedGatewayLookups  []string
 	addMappedCalled         bool
 	removeMappedCalled      bool
 	createCalled            bool
@@ -212,7 +219,24 @@ func (m *mockApplicationRepository) RemoveApplicationAssociation(applicationUUID
 	return nil
 }
 
+func (m *mockApplicationRepository) GetApplicationsByAPIKeyID(apiKeyID, orgID string) ([]*model.Application, error) {
+	m.getAppsByKeyCalled = true
+	return m.appsByAPIKey, m.appsByAPIKeyErr
+}
+
+func (m *mockApplicationRepository) DeleteApplication(appID, orgID string) error {
+	m.deleteCalled = true
+	return nil
+}
+
+func (m *mockApplicationRepository) RemoveAPIKeyFromAllApplications(apiKeyID string) error {
+	m.removeAllCalled = true
+	m.removedAllAPIKeyID = apiKeyID
+	return nil
+}
+
 func (m *mockApplicationRepository) GetDeployedGatewayIDsByArtifactUUID(artifactID, orgID string) ([]string, error) {
+	m.deployedGatewayLookups = append(m.deployedGatewayLookups, artifactID)
 	if m.deployedGatewayErr != nil {
 		return nil, m.deployedGatewayErr
 	}
@@ -787,7 +811,101 @@ func TestRemoveMappedAPIKey_DoesNotFailWhenBroadcastResolutionFails(t *testing.T
 	}
 }
 
-func TestCreateApplication_RequiresProjectID(t *testing.T) {
+// TestSetAPIKeyApplication_DissociateBroadcastsToPriorApp verifies that dissociating a key (the
+// apikey.application_updated event with a null application) captures the previously-owning
+// application before removing the mapping and broadcasts a mapping update to that application's
+// gateways — otherwise the gateway would keep the stale key→application mapping until pull-sync.
+func TestSetAPIKeyApplication_DissociateBroadcastsToPriorApp(t *testing.T) {
+	orgID := "org-1"
+
+	appRepo := &mockApplicationRepository{
+		apiKeysByLookupKey: map[string]*model.ApplicationAPIKey{
+			apiKeyLookupKey("my-key", "order-api"): {
+				ID:           "key-1",
+				APIKeyUUID:   "key-uuid-1",
+				Name:         "my-key",
+				ArtifactID:   "artifact-1",
+				ArtifactType: constants.RestApi,
+			},
+		},
+		artifactByID: map[string]*model.Artifact{
+			// Resolves the api ref_id to the artifact handle, and (as the broadcast hint) to a
+			// supported artifact type so gateway targeting runs.
+			"artifact-1": {UUID: "artifact-1", Handle: "order-api", Type: constants.RestApi},
+		},
+		// The key currently belongs to this application; the dissociation must broadcast for it.
+		appsByAPIKey: []*model.Application{
+			{UUID: "app-1", Handle: "my-app", OrganizationUUID: orgID},
+		},
+	}
+
+	svc := &ApplicationService{appRepo: appRepo, gatewayEventsService: &GatewayEventsService{}}
+
+	// appIDOrHandle empty => dissociation.
+	if err := svc.SetAPIKeyApplication("my-key", "artifact-1", constants.RestApi, "", orgID, ""); err != nil {
+		t.Fatalf("expected nil error on dissociation, got %v", err)
+	}
+
+	if !appRepo.getAppsByKeyCalled {
+		t.Fatalf("expected GetApplicationsByAPIKeyID to be called before removing the mapping")
+	}
+	if !appRepo.removeAllCalled || appRepo.removedAllAPIKeyID != "key-1" {
+		t.Fatalf("expected RemoveAPIKeyFromAllApplications for key-1, got called=%v id=%q",
+			appRepo.removeAllCalled, appRepo.removedAllAPIKeyID)
+	}
+	// The broadcast must target the removed key's artifact so the right gateways are notified even
+	// though the application now has no keys left.
+	found := false
+	for _, a := range appRepo.deployedGatewayLookups {
+		if a == "artifact-1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected dissociation to broadcast for the removed key's artifact (artifact-1); gateway lookups=%v",
+			appRepo.deployedGatewayLookups)
+	}
+}
+
+// TestDeleteApplication_BroadcastsMappingClear verifies that deleting an application broadcasts an
+// empty mapping set to the gateways that held its keys, so they drop the key→application mappings
+// (the Platform API DB clears them via cascade, but nothing else notifies the gateways).
+func TestDeleteApplication_BroadcastsMappingClear(t *testing.T) {
+	orgID := "org-1"
+
+	appRepo := &mockApplicationRepository{
+		app: &model.Application{UUID: "app-1", Handle: "my-app", Name: "My App", Type: "web", OrganizationUUID: orgID},
+		mappedKeys: []*model.ApplicationAPIKey{
+			{ID: "key-1", APIKeyUUID: "key-uuid-1", ArtifactID: "artifact-1"},
+		},
+		artifactByID: map[string]*model.Artifact{
+			"artifact-1": {UUID: "artifact-1", Handle: "order-api", Type: constants.RestApi},
+		},
+	}
+
+	svc := &ApplicationService{appRepo: appRepo, gatewayEventsService: &GatewayEventsService{}, auditRepo: &noopAuditRepo{}}
+
+	if err := svc.DeleteApplication("my-app", orgID, ""); err != nil {
+		t.Fatalf("expected nil error deleting application, got %v", err)
+	}
+	if !appRepo.deleteCalled {
+		t.Fatalf("expected the application to be deleted")
+	}
+	// The mapping-clear broadcast must target the deleted app's key artifact so the right gateways
+	// are notified even though the application (and its remaining keys) are gone.
+	found := false
+	for _, a := range appRepo.deployedGatewayLookups {
+		if a == "artifact-1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected delete to broadcast for the removed key's artifact (artifact-1); gateway lookups=%v",
+			appRepo.deployedGatewayLookups)
+	}
+}
+
+func TestCreateApplication_AllowsMissingProjectID(t *testing.T) {
 	orgID := "org-1"
 
 	appRepo := &mockApplicationRepository{}
@@ -800,20 +918,81 @@ func TestCreateApplication_RequiresProjectID(t *testing.T) {
 		appRepo:     appRepo,
 		projectRepo: projectRepo,
 		orgRepo:     orgRepo,
+		auditRepo:   &noopAuditRepo{},
 	}
 
+	// project_uuid is optional: creating without a project id succeeds and persists a project-less
+	// application rather than erroring.
 	resp, err := svc.CreateApplication(&api.CreateApplicationRequest{
 		DisplayName: "Sample App",
 		Type:        api.ApplicationType("genai"),
 	}, orgID, "")
-	if !errors.Is(err, constants.ErrProjectNotFound) {
-		t.Fatalf("expected ErrProjectNotFound, got %v", err)
+	if err != nil {
+		t.Fatalf("expected no error when project id is missing, got %v", err)
 	}
-	if resp != nil {
-		t.Fatalf("expected nil response when project id is missing")
+	if !appRepo.createCalled {
+		t.Fatalf("expected repository create to be called when project id is missing")
 	}
-	if appRepo.createCalled {
-		t.Fatalf("expected repository create not to be called when project id is missing")
+	if appRepo.createdApplication == nil || appRepo.createdApplication.ProjectUUID != "" {
+		t.Fatalf("expected created application to have an empty project uuid, got %+v", appRepo.createdApplication)
+	}
+	if resp == nil {
+		t.Fatalf("expected a non-nil response")
+	}
+	if resp.ProjectId != "" {
+		t.Fatalf("expected an empty projectId in the response, got %q", resp.ProjectId)
+	}
+}
+
+func TestCreateApplication_AcceptsWebType(t *testing.T) {
+	orgID := "org-1"
+
+	appRepo := &mockApplicationRepository{}
+	projectRepo := &mockProjectRepository{}
+	orgRepo := &mockApplicationOrganizationRepository{
+		org: &model.Organization{ID: orgID},
+	}
+
+	svc := &ApplicationService{
+		appRepo:     appRepo,
+		projectRepo: projectRepo,
+		orgRepo:     orgRepo,
+		auditRepo:   &noopAuditRepo{},
+	}
+
+	// "web" is an accepted application type (alongside "genai"): webhook-reconciled applications
+	// carry their own type, so creation must not be hardcoded to genai.
+	resp, err := svc.CreateApplication(&api.CreateApplicationRequest{
+		DisplayName: "My Mobile App",
+		Type:        api.ApplicationType("web"),
+	}, orgID, "")
+	if err != nil {
+		t.Fatalf("expected no error for web type, got %v", err)
+	}
+	if appRepo.createdApplication == nil || appRepo.createdApplication.Type != "web" {
+		t.Fatalf("expected created application type 'web', got %+v", appRepo.createdApplication)
+	}
+	if resp == nil || resp.Type != api.ApplicationType("web") {
+		t.Fatalf("expected response type 'web', got %+v", resp)
+	}
+}
+
+func TestCreateApplication_RejectsUnsupportedType(t *testing.T) {
+	orgID := "org-1"
+
+	svc := &ApplicationService{
+		appRepo:     &mockApplicationRepository{},
+		projectRepo: &mockProjectRepository{},
+		orgRepo:     &mockApplicationOrganizationRepository{org: &model.Organization{ID: orgID}},
+		auditRepo:   &noopAuditRepo{},
+	}
+
+	_, err := svc.CreateApplication(&api.CreateApplicationRequest{
+		DisplayName: "Bad Type App",
+		Type:        api.ApplicationType("mobile"),
+	}, orgID, "")
+	if !errors.Is(err, constants.ErrUnsupportedApplicationType) {
+		t.Fatalf("expected ErrUnsupportedApplicationType, got %v", err)
 	}
 }
 

--- a/platform-api/src/internal/service/project.go
+++ b/platform-api/src/internal/service/project.go
@@ -39,6 +39,7 @@ type ProjectService struct {
 	orgRepo        repository.OrganizationRepository
 	apiRepo        repository.APIRepository
 	mcpProxyRepo   repository.MCPProxyRepository
+	appRepo        repository.ApplicationRepository
 	deletionGuards []ProjectDeletionGuard
 	auditRepo      repository.AuditRepository
 	slogger        *slog.Logger
@@ -46,12 +47,14 @@ type ProjectService struct {
 
 func NewProjectService(projectRepo repository.ProjectRepository, orgRepo repository.OrganizationRepository,
 	apiRepo repository.APIRepository, mcpProxyRepo repository.MCPProxyRepository,
-	auditRepo repository.AuditRepository, slogger *slog.Logger) *ProjectService {
+	appRepo repository.ApplicationRepository, auditRepo repository.AuditRepository,
+	slogger *slog.Logger) *ProjectService {
 	return &ProjectService{
 		projectRepo:  projectRepo,
 		orgRepo:      orgRepo,
 		apiRepo:      apiRepo,
 		mcpProxyRepo: mcpProxyRepo,
+		appRepo:      appRepo,
 		auditRepo:    auditRepo,
 		slogger:      slogger,
 	}
@@ -269,6 +272,17 @@ func (s *ProjectService) DeleteProject(handle, orgId, actor string) error {
 	}
 	if mcpProxiesCount > 0 {
 		return constants.ErrProjectHasAssociatedMCPProxies
+	}
+
+	// applications no longer cascade-delete with the project (the project_uuid foreign key was
+	// removed), so refuse deletion while any application still references this project. The caller
+	// must reassign or delete those applications first.
+	appCount, err := s.appRepo.CountApplicationsByProjectID(project.ID, orgId)
+	if err != nil {
+		return err
+	}
+	if appCount > 0 {
+		return constants.ErrProjectHasAssociatedApplications
 	}
 
 	for _, guard := range s.deletionGuards {

--- a/platform-api/src/internal/service/subscription_service.go
+++ b/platform-api/src/internal/service/subscription_service.go
@@ -18,6 +18,7 @@
 package service
 
 import (
+	"database/sql"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -151,7 +152,7 @@ func (s *SubscriptionService) GetArtifactMetadataMap(uuids []string, orgUUID str
 
 // CreateSubscription creates a new subscription for an artifact of the given kind.
 // apiId is the artifact handle; kind selects the artifact table it is resolved against.
-func (s *SubscriptionService) CreateSubscription(apiId, kind, orgUUID string, subscriberID string, applicationId *string, subscriptionPlanId *string, status string) (*model.Subscription, error) {
+func (s *SubscriptionService) CreateSubscription(apiId, kind, orgUUID string, subscriberID string, applicationId *string, subscriptionPlanId *string, subscriptionToken string, status string) (*model.Subscription, error) {
 	apiUUID, err := s.resolveArtifactUUIDByKind(apiId, kind, orgUUID)
 	if err != nil {
 		return nil, err
@@ -177,21 +178,31 @@ func (s *SubscriptionService) CreateSubscription(apiId, kind, orgUUID string, su
 		return nil, constants.ErrSubscriptionAlreadyExists
 	}
 
+	// subscriptionPlanId carries the Developer Portal subscription plan handle. Resolve it to the
+	// plan's UUID, which is what the subscriptions.subscription_plan_uuid foreign key references.
 	if subscriptionPlanId != nil && *subscriptionPlanId != "" {
 		plan, err := s.planRepo.GetByHandleAndOrg(*subscriptionPlanId, orgUUID)
 		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return nil, constants.ErrSubscriptionPlanNotFound
+			}
 			return nil, err
 		}
 		if plan == nil {
 			return nil, constants.ErrSubscriptionPlanNotFound
 		}
+		subscriptionPlanId = &plan.UUID
 	}
 
+	// A non-empty subscriptionToken is the token imported from the Developer Portal (the
+	// value shown to the user); the repository persists it as-is. When empty (interactive
+	// creation), the repository generates a fresh token.
 	sub := &model.Subscription{
 		ArtifactUUID:       apiUUID,
 		SubscriberID:       subscriberID,
 		ApplicationID:      applicationId,
 		SubscriptionPlanID: subscriptionPlanId,
+		SubscriptionToken:  subscriptionToken,
 		OrganizationUUID:   orgUUID,
 		Status:             st,
 		CreatedBy:          subscriberID,
@@ -274,6 +285,26 @@ func (s *SubscriptionService) ListSubscriptionsByFilters(orgUUID string, apiId *
 	return list, total, nil
 }
 
+// FindByArtifactKindAndSubscriber locates a single subscription by (API, subscriber) within the org,
+// resolving the API by handle + kind so the lookup is scoped to the artifact table backing that kind
+// (a handle shared across kinds resolves unambiguously). Returns (nil, nil) when none exists and
+// ErrAPINotFound when the artifact itself cannot be resolved.
+func (s *SubscriptionService) FindByArtifactKindAndSubscriber(orgUUID, apiHandle, kind, subscriberID string) (*model.Subscription, error) {
+	apiUUID, err := s.resolveArtifactUUIDByKind(apiHandle, kind, orgUUID)
+	if err != nil {
+		return nil, err
+	}
+	sub := subscriberID
+	list, err := s.subscriptionRepo.ListByFilters(orgUUID, &apiUUID, &sub, nil, nil, 1, 0)
+	if err != nil {
+		return nil, err
+	}
+	if len(list) == 0 {
+		return nil, nil
+	}
+	return list[0], nil
+}
+
 // UpdateSubscription updates a subscription (e.g. status). subscriberID must match the stored subscriber_id.
 func (s *SubscriptionService) UpdateSubscription(subscriptionId, orgUUID, subscriberID, status string) (*model.Subscription, error) {
 	sub, err := s.subscriptionRepo.GetByID(subscriptionId, orgUUID)
@@ -330,6 +361,127 @@ func (s *SubscriptionService) UpdateSubscription(subscriptionId, orgUUID, subscr
 				}
 				if err := s.gatewayEvents.BroadcastSubscriptionUpdatedEvent(gw.ID, event); err != nil {
 					s.slogger.Warn("Failed to broadcast subscription.updated event",
+						"gatewayId", gw.ID, "subscriptionId", sub.UUID, "error", err)
+				}
+			}
+		}
+	}
+
+	return sub, nil
+}
+
+// ChangePlan switches the subscription plan of an existing subscription and broadcasts the change
+// to the gateways where the API is deployed. subscriberID must match the stored subscriber_id.
+func (s *SubscriptionService) ChangePlan(subscriptionId, orgUUID, subscriberID, planHandle string) (*model.Subscription, error) {
+	sub, err := s.subscriptionRepo.GetByID(subscriptionId, orgUUID)
+	if err != nil {
+		if errors.Is(err, constants.ErrSubscriptionNotFound) {
+			return nil, constants.ErrSubscriptionNotFound
+		}
+		return nil, err
+	}
+	if sub == nil {
+		return nil, constants.ErrSubscriptionNotFound
+	}
+	if sub.SubscriberID != subscriberID {
+		return nil, constants.ErrSubscriptionSubscriberMismatch
+	}
+
+	// planHandle carries the Developer Portal subscription plan handle. Resolve it to the plan's
+	// UUID, which is what the subscriptions.subscription_plan_uuid foreign key references.
+	planRecord, err := s.planRepo.GetByHandleAndOrg(planHandle, orgUUID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, constants.ErrSubscriptionPlanNotFound
+		}
+		return nil, err
+	}
+	if planRecord == nil {
+		return nil, constants.ErrSubscriptionPlanNotFound
+	}
+	plan := planRecord.UUID
+	sub.SubscriptionPlanID = &plan
+	if err := s.subscriptionRepo.Update(sub); err != nil {
+		return nil, err
+	}
+
+	if s.gatewayEvents != nil {
+		gateways, err := s.apiRepo.GetAPIGatewaysWithDetails(sub.ArtifactUUID, orgUUID)
+		if err != nil {
+			s.slogger.Warn("Failed to load gateways for subscription plan change broadcast",
+				"apiId", sub.ArtifactUUID, "subscriptionId", sub.UUID, "error", err)
+		} else {
+			event := &model.SubscriptionUpdatedEvent{
+				ApiId:              sub.ArtifactUUID,
+				SubscriptionId:     sub.UUID,
+				ApplicationId:      derefString(sub.ApplicationID),
+				SubscriptionToken:  sub.SubscriptionToken,
+				SubscriptionPlanId: derefString(sub.SubscriptionPlanID),
+				Status:             string(sub.Status),
+			}
+			for _, gw := range gateways {
+				if gw == nil || gw.ID == "" {
+					continue
+				}
+				if err := s.gatewayEvents.BroadcastSubscriptionUpdatedEvent(gw.ID, event); err != nil {
+					s.slogger.Warn("Failed to broadcast subscription plan change event",
+						"gatewayId", gw.ID, "subscriptionId", sub.UUID, "error", err)
+				}
+			}
+		}
+	}
+
+	return sub, nil
+}
+
+// RegenerateToken rotates the subscription's token to the value provided by the Developer Portal
+// (delivered encrypted in the subscription.token_regenerated event). The old token is invalidated;
+// the new token is persisted (hashed + encrypted) and broadcast to the gateways where the API is
+// deployed. subscriberID must match the stored subscriber_id.
+func (s *SubscriptionService) RegenerateToken(subscriptionId, orgUUID, subscriberID, newToken string) (*model.Subscription, error) {
+	if newToken == "" {
+		return nil, fmt.Errorf("subscription token is required")
+	}
+	sub, err := s.subscriptionRepo.GetByID(subscriptionId, orgUUID)
+	if err != nil {
+		if errors.Is(err, constants.ErrSubscriptionNotFound) {
+			return nil, constants.ErrSubscriptionNotFound
+		}
+		return nil, err
+	}
+	if sub == nil {
+		return nil, constants.ErrSubscriptionNotFound
+	}
+	if sub.SubscriberID != subscriberID {
+		return nil, constants.ErrSubscriptionSubscriberMismatch
+	}
+
+	if err := s.subscriptionRepo.UpdateToken(subscriptionId, orgUUID, newToken); err != nil {
+		return nil, err
+	}
+	sub.SubscriptionToken = newToken
+	_ = s.auditRepo.Record("UPDATE", sub.UUID, "subscription", sub.OrganizationUUID, subscriberID)
+
+	if s.gatewayEvents != nil {
+		gateways, err := s.apiRepo.GetAPIGatewaysWithDetails(sub.ArtifactUUID, orgUUID)
+		if err != nil {
+			s.slogger.Warn("Failed to load gateways for subscription token regeneration broadcast",
+				"apiUUID", sub.ArtifactUUID, "subscriptionId", sub.UUID, "error", err)
+		} else {
+			event := &model.SubscriptionUpdatedEvent{
+				ApiId:              sub.ArtifactUUID,
+				SubscriptionId:     sub.UUID,
+				ApplicationId:      derefString(sub.ApplicationID),
+				SubscriptionToken:  sub.SubscriptionToken,
+				SubscriptionPlanId: derefString(sub.SubscriptionPlanID),
+				Status:             string(sub.Status),
+			}
+			for _, gw := range gateways {
+				if gw == nil || gw.ID == "" {
+					continue
+				}
+				if err := s.gatewayEvents.BroadcastSubscriptionUpdatedEvent(gw.ID, event); err != nil {
+					s.slogger.Warn("Failed to broadcast subscription token regeneration event",
 						"gatewayId", gw.ID, "subscriptionId", sub.UUID, "error", err)
 				}
 			}

--- a/platform-api/src/internal/utils/error_mapper.go
+++ b/platform-api/src/internal/utils/error_mapper.go
@@ -127,6 +127,8 @@ func GetErrorResponse(err error) (int, interface{}) {
 		return makeError(http.StatusBadRequest, "Organization must have at least one project")
 	case errors.Is(err, constants.ErrProjectHasAssociatedAPIs):
 		return makeError(http.StatusBadRequest, "Project has associated APIs")
+	case errors.Is(err, constants.ErrProjectHasAssociatedApplications):
+		return makeError(http.StatusBadRequest, "Project has associated applications")
 
 	// API errors
 	case errors.Is(err, constants.ErrAPINotFound):

--- a/platform-api/src/internal/webhook/crypto_test.go
+++ b/platform-api/src/internal/webhook/crypto_test.go
@@ -1,0 +1,187 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package webhook
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// hybridEncrypt mirrors the producer side: AES-256-GCM body + RSA-OAEP(SHA-256)-wrapped content key.
+func hybridEncrypt(t *testing.T, pub *rsa.PublicKey, plaintext string) *EncryptedKey {
+	t.Helper()
+	contentKey := make([]byte, 32)
+	if _, err := rand.Read(contentKey); err != nil {
+		t.Fatalf("content key: %v", err)
+	}
+	block, err := aes.NewCipher(contentKey)
+	if err != nil {
+		t.Fatalf("aes: %v", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		t.Fatalf("gcm: %v", err)
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		t.Fatalf("nonce: %v", err)
+	}
+	sealed := gcm.Seal(nil, nonce, []byte(plaintext), nil)
+	ciphertext := sealed[:len(sealed)-16]
+	tag := sealed[len(sealed)-16:]
+
+	wrapped, err := rsa.EncryptOAEP(sha256.New(), rand.Reader, pub, contentKey, nil)
+	if err != nil {
+		t.Fatalf("wrap: %v", err)
+	}
+	return &EncryptedKey{
+		WrappedKey: base64.StdEncoding.EncodeToString(wrapped),
+		IV:         base64.StdEncoding.EncodeToString(nonce),
+		Tag:        base64.StdEncoding.EncodeToString(tag),
+		Ciphertext: base64.StdEncoding.EncodeToString(ciphertext),
+	}
+}
+
+func writeKeyPEM(t *testing.T, key *rsa.PrivateKey) string {
+	t.Helper()
+	der := x509.MarshalPKCS1PrivateKey(key)
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: der})
+	path := filepath.Join(t.TempDir(), "wh.pem")
+	if err := os.WriteFile(path, pemBytes, 0600); err != nil {
+		t.Fatalf("write pem: %v", err)
+	}
+	return path
+}
+
+func TestDecryptor_RoundTrip(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("genkey: %v", err)
+	}
+	path := writeKeyPEM(t, key)
+
+	d, err := NewDecryptor(path)
+	if err != nil {
+		t.Fatalf("NewDecryptor: %v", err)
+	}
+
+	const secret = "ap-key-9f8b7c6d5e4f3a2b1c0d"
+	enc := hybridEncrypt(t, &key.PublicKey, secret)
+
+	got, err := d.Decrypt(enc)
+	if err != nil {
+		t.Fatalf("Decrypt: %v", err)
+	}
+	if got != secret {
+		t.Fatalf("plaintext mismatch: got %q want %q", got, secret)
+	}
+}
+
+func TestDecryptor_TamperedTagFails(t *testing.T) {
+	key, _ := rsa.GenerateKey(rand.Reader, 2048)
+	d, err := NewDecryptor(writeKeyPEM(t, key))
+	if err != nil {
+		t.Fatalf("NewDecryptor: %v", err)
+	}
+	enc := hybridEncrypt(t, &key.PublicKey, "secret-value")
+	enc.Tag = base64.StdEncoding.EncodeToString(make([]byte, 16)) // zeroed tag
+	if _, err := d.Decrypt(enc); err == nil {
+		t.Fatal("expected decryption to fail with a tampered tag")
+	}
+}
+
+func TestDecryptor_NilWhenNoKeyPath(t *testing.T) {
+	d, err := NewDecryptor("")
+	if err != nil {
+		t.Fatalf("NewDecryptor(\"\"): %v", err)
+	}
+	if _, err := d.Decrypt(&EncryptedKey{WrappedKey: "x", Ciphertext: "y"}); err != ErrDecryptorUnavailable {
+		t.Fatalf("expected ErrDecryptorUnavailable, got %v", err)
+	}
+}
+
+// sign reproduces the producer's HMAC scheme for tests.
+func sign(secret string, ts int64, body []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(strconv.FormatInt(ts, 10) + "." + string(body)))
+	return "t=" + strconv.FormatInt(ts, 10) + ",v1=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func TestLooksLikeUniqueViolation(t *testing.T) {
+	cases := []struct {
+		err  error
+		want bool
+	}{
+		{nil, false},
+		{errorString("UNIQUE constraint failed: api_keys.artifact_uuid, api_keys.name"), true},
+		{errorString("ERROR: duplicate key value violates unique constraint \"api_keys_pkey\""), true},
+		{errorString("Violation of UNIQUE KEY constraint 'UQ_api_keys'."), true},
+		{errorString("connection refused"), false},
+	}
+	for _, c := range cases {
+		if got := looksLikeUniqueViolation(c.err); got != c.want {
+			t.Errorf("looksLikeUniqueViolation(%v) = %v, want %v", c.err, got, c.want)
+		}
+	}
+}
+
+type errorString string
+
+func (e errorString) Error() string { return string(e) }
+
+func TestVerifier_Verify(t *testing.T) {
+	const secret = "shared-secret"
+	v := NewVerifier(secret, 5*time.Minute)
+	now := time.Unix(1_700_000_000, 0)
+	body := []byte(`{"event_id":"e1"}`)
+
+	t.Run("valid", func(t *testing.T) {
+		if err := v.Verify(sign(secret, now.Unix(), body), body, now); err != nil {
+			t.Fatalf("expected valid signature, got %v", err)
+		}
+	})
+	t.Run("missing header", func(t *testing.T) {
+		if err := v.Verify("", body, now); err != ErrSignatureMissing {
+			t.Fatalf("want ErrSignatureMissing, got %v", err)
+		}
+	})
+	t.Run("tampered body", func(t *testing.T) {
+		if err := v.Verify(sign(secret, now.Unix(), body), []byte(`{"event_id":"e2"}`), now); err != ErrSignatureInvalid {
+			t.Fatalf("want ErrSignatureInvalid, got %v", err)
+		}
+	})
+	t.Run("stale timestamp", func(t *testing.T) {
+		old := now.Add(-10 * time.Minute)
+		if err := v.Verify(sign(secret, old.Unix(), body), body, now); err != ErrTimestampOutOfTolerance {
+			t.Fatalf("want ErrTimestampOutOfTolerance, got %v", err)
+		}
+	})
+}

--- a/platform-api/src/internal/webhook/decryptor.go
+++ b/platform-api/src/internal/webhook/decryptor.go
@@ -1,0 +1,135 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package webhook
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"os"
+)
+
+// Decryptor recovers a plaintext secret from the hybrid-encrypted EncryptedKey field.
+//
+// The producer (Developer Portal) encrypts the secret with a one-time AES-256 content key,
+// then wraps that content key with this receiver's RSA public key (RSA-OAEP). Decryption is
+// therefore two stages:
+//  1. RSA-OAEP unwrap `wrappedKey` with the configured RSA private key -> AES content key.
+//  2. AES-256-GCM decrypt `ciphertext` (with `iv` as nonce and `tag` appended) -> plaintext.
+//
+// Interop note: this assumes RSA-OAEP with SHA-256 and no OAEP label, a 12-byte GCM nonce, and
+// a separate 16-byte GCM tag. These must match the producer; they are documented in
+// docs-local/platform-api-webhook.md as parameters to confirm with the Developer Portal team.
+type Decryptor struct {
+	priv *rsa.PrivateKey
+}
+
+// NewDecryptor loads a PEM-encoded RSA private key (PKCS#1 or PKCS#8) from pemPath.
+// A nil Decryptor is valid and means "no key configured"; Decrypt then returns
+// ErrDecryptorUnavailable so events carrying encrypted fields fail loudly rather than silently.
+func NewDecryptor(pemPath string) (*Decryptor, error) {
+	if pemPath == "" {
+		return nil, nil
+	}
+	raw, err := os.ReadFile(pemPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read webhook private key %q: %w", pemPath, err)
+	}
+	block, _ := pem.Decode(raw)
+	if block == nil {
+		return nil, fmt.Errorf("webhook private key %q is not valid PEM", pemPath)
+	}
+
+	priv, err := parseRSAPrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse webhook private key %q: %w", pemPath, err)
+	}
+	return &Decryptor{priv: priv}, nil
+}
+
+// parseRSAPrivateKey accepts both PKCS#1 ("RSA PRIVATE KEY") and PKCS#8 ("PRIVATE KEY") DER.
+func parseRSAPrivateKey(der []byte) (*rsa.PrivateKey, error) {
+	if key, err := x509.ParsePKCS1PrivateKey(der); err == nil {
+		return key, nil
+	}
+	keyAny, err := x509.ParsePKCS8PrivateKey(der)
+	if err != nil {
+		return nil, err
+	}
+	rsaKey, ok := keyAny.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("private key is not an RSA key")
+	}
+	return rsaKey, nil
+}
+
+// Decrypt returns the plaintext secret for the given encrypted field. The caller must clear the
+// returned plaintext from memory as soon as the gateway-side representation (e.g. a hash) is derived.
+func (d *Decryptor) Decrypt(ek *EncryptedKey) (string, error) {
+	if ek == nil || ek.Empty() {
+		return "", fmt.Errorf("%w: encrypted field is empty", ErrDecryptionFailed)
+	}
+	if d == nil || d.priv == nil {
+		return "", ErrDecryptorUnavailable
+	}
+
+	wrappedKey, err := base64.StdEncoding.DecodeString(ek.WrappedKey)
+	if err != nil {
+		return "", fmt.Errorf("%w: wrappedKey is not valid base64: %v", ErrDecryptionFailed, err)
+	}
+	iv, err := base64.StdEncoding.DecodeString(ek.IV)
+	if err != nil {
+		return "", fmt.Errorf("%w: iv is not valid base64: %v", ErrDecryptionFailed, err)
+	}
+	ciphertext, err := base64.StdEncoding.DecodeString(ek.Ciphertext)
+	if err != nil {
+		return "", fmt.Errorf("%w: ciphertext is not valid base64: %v", ErrDecryptionFailed, err)
+	}
+	tag, err := base64.StdEncoding.DecodeString(ek.Tag)
+	if err != nil {
+		return "", fmt.Errorf("%w: tag is not valid base64: %v", ErrDecryptionFailed, err)
+	}
+
+	// Stage 1: RSA-OAEP unwrap the AES content key.
+	contentKey, err := rsa.DecryptOAEP(sha256.New(), rand.Reader, d.priv, wrappedKey, nil)
+	if err != nil {
+		return "", fmt.Errorf("%w: RSA-OAEP unwrap failed: %v", ErrDecryptionFailed, err)
+	}
+
+	// Stage 2: AES-256-GCM decrypt the ciphertext. Go's GCM expects the tag appended to the ciphertext.
+	block, err := aes.NewCipher(contentKey)
+	if err != nil {
+		return "", fmt.Errorf("%w: invalid AES content key: %v", ErrDecryptionFailed, err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", fmt.Errorf("%w: %v", ErrDecryptionFailed, err)
+	}
+	sealed := append(append([]byte{}, ciphertext...), tag...)
+	plaintext, err := gcm.Open(nil, iv, sealed, nil)
+	if err != nil {
+		return "", fmt.Errorf("%w: AES-GCM open failed: %v", ErrDecryptionFailed, err)
+	}
+	return string(plaintext), nil
+}

--- a/platform-api/src/internal/webhook/envelope.go
+++ b/platform-api/src/internal/webhook/envelope.go
@@ -1,0 +1,131 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+// Package webhook implements the Platform API control-plane webhook receiver.
+//
+// It is the receiver-side counterpart to the Developer Portal producer described in
+// docs-local/devportal-webhook-integration.md. The Developer Portal commits a domain
+// change, writes it to a transactional outbox, and delivers signed webhooks (at-least-once)
+// to this endpoint. Platform API verifies the request, decrypts any sensitive fields,
+// reconciles its own state by reusing the existing API-key / subscription services, and
+// lets the existing EventHub -> WebSocket sync propagate the change to gateway replicas.
+package webhook
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// CurrentSchemaVersion is assumed when an event omits schema_version. The producer lists
+// schema_version as forward-compat work, so a missing value must be tolerated (not rejected).
+const CurrentSchemaVersion = "1.0"
+
+// EncryptedKey is the hybrid-encrypted (AES-256-GCM + RSA-OAEP) representation of a sensitive
+// value (an API key secret, etc.). wrappedKey is the AES content key wrapped with the receiver's
+// RSA public key; iv/tag/ciphertext are the AES-GCM parts. See Decryptor.
+type EncryptedKey struct {
+	WrappedKey string `json:"wrappedKey"`
+	IV         string `json:"iv"`
+	Tag        string `json:"tag"`
+	Ciphertext string `json:"ciphertext"`
+}
+
+// Empty reports whether the encrypted field is unset.
+func (e *EncryptedKey) Empty() bool {
+	return e == nil || (e.WrappedKey == "" && e.Ciphertext == "")
+}
+
+// orgRef identifies the organization an event targets. ref_id is the control-plane org
+// reference (the Platform API organization UUID); the Developer Portal falls back to its own
+// org UUID when the org has not been linked to the control plane.
+type orgRef struct {
+	RefID string `json:"ref_id"`
+}
+
+// Envelope is the common webhook event envelope. It mirrors the Developer Portal DP_EVENT
+// outbox row. Data carries the event-type-specific payload and is decoded by each handler.
+type Envelope struct {
+	EventID    string `json:"event_id"`
+	EventType  string `json:"event_type"`
+	OccurredAt string `json:"occurred_at"`
+	Org        orgRef `json:"org"`
+	// OrgID is the legacy flat org identifier, superseded by Org.RefID. DecodeEnvelope copies
+	// Org.RefID into it when present, so downstream handlers can keep reading env.OrgID.
+	OrgID         string `json:"org_id"`
+	GatewayType   string `json:"gateway_type"`
+	AggregateType string `json:"aggregate_type"`
+	AggregateID   string `json:"aggregate_id"`
+	SchemaVersion string `json:"schema_version"`
+	// EncryptedFields lists which fields inside Data carry an encrypted envelope. Always present
+	// in the new contract — empty when no fields are encrypted.
+	EncryptedFields []string        `json:"encrypted_fields"`
+	Data            json.RawMessage `json:"data"`
+}
+
+// IsEncrypted reports whether the named Data field carries an encrypted envelope, per the
+// envelope's encrypted_fields list.
+func (e *Envelope) IsEncrypted(field string) bool {
+	for _, f := range e.EncryptedFields {
+		if f == field {
+			return true
+		}
+	}
+	return false
+}
+
+// DecodeEnvelope parses the raw request body into an Envelope. A decode failure maps to 400.
+func DecodeEnvelope(body []byte) (*Envelope, error) {
+	var env Envelope
+	if err := json.Unmarshal(body, &env); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidEnvelope, err)
+	}
+	// Prefer the nested org.ref_id; fall back to the legacy flat org_id. Downstream handlers
+	// read env.OrgID, so normalize onto it.
+	if env.Org.RefID != "" {
+		env.OrgID = env.Org.RefID
+	}
+	return &env, nil
+}
+
+// Validate checks that the mandatory envelope fields are present. schema_version is optional;
+// when absent it is treated as CurrentSchemaVersion rather than rejected.
+func (e *Envelope) Validate() error {
+	if e.EventID == "" {
+		return fmt.Errorf("%w: event_id is required", ErrInvalidEnvelope)
+	}
+	if e.EventType == "" {
+		return fmt.Errorf("%w: event_type is required", ErrInvalidEnvelope)
+	}
+	if e.OrgID == "" {
+		return fmt.Errorf("%w: org.ref_id is required", ErrInvalidEnvelope)
+	}
+	if e.SchemaVersion == "" {
+		e.SchemaVersion = CurrentSchemaVersion
+	}
+	return nil
+}
+
+// decodeData unmarshals the event-specific data payload into out.
+func (e *Envelope) decodeData(out interface{}) error {
+	if len(e.Data) == 0 {
+		return fmt.Errorf("%w: data is required for event %s", ErrInvalidEnvelope, e.EventType)
+	}
+	if err := json.Unmarshal(e.Data, out); err != nil {
+		return fmt.Errorf("%w: invalid data for event %s: %v", ErrInvalidEnvelope, e.EventType, err)
+	}
+	return nil
+}

--- a/platform-api/src/internal/webhook/errors.go
+++ b/platform-api/src/internal/webhook/errors.go
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package webhook
+
+import "errors"
+
+var (
+	// ErrSignatureMissing indicates the signature header was absent. -> 401
+	ErrSignatureMissing = errors.New("webhook signature header missing")
+	// ErrSignatureInvalid indicates the HMAC did not match. -> 401
+	ErrSignatureInvalid = errors.New("webhook signature invalid")
+	// ErrTimestampOutOfTolerance indicates a possible replay. -> 401
+	ErrTimestampOutOfTolerance = errors.New("webhook signature timestamp outside tolerance")
+
+	// ErrInvalidEnvelope indicates a malformed body or missing required field. -> 400
+	ErrInvalidEnvelope = errors.New("invalid webhook envelope")
+	// ErrUnsupportedEvent indicates an unknown event_type. -> 400
+	ErrUnsupportedEvent = errors.New("unsupported webhook event type")
+	// ErrBodyTooLarge indicates the body exceeded max_body_size. -> 400
+	ErrBodyTooLarge = errors.New("webhook request body too large")
+
+	// ErrDecryptionFailed indicates the encrypted field could not be decrypted. -> 400
+	ErrDecryptionFailed = errors.New("failed to decrypt webhook payload field")
+	// ErrDecryptorUnavailable indicates an encrypted field was received but no private key is configured. -> 500
+	ErrDecryptorUnavailable = errors.New("webhook decryptor is not configured")
+)

--- a/platform-api/src/internal/webhook/handlers_apikey.go
+++ b/platform-api/src/internal/webhook/handlers_apikey.go
@@ -1,0 +1,267 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"platform-api/src/api"
+	"platform-api/src/internal/constants"
+)
+
+// looksLikeUniqueViolation reports whether err is a database unique-constraint violation, across the
+// supported drivers (SQLite "UNIQUE constraint failed", PostgreSQL "duplicate key value violates
+// unique constraint", SQL Server "Violation of UNIQUE KEY constraint"). Used only to make an
+// already-injected key an idempotent success on a duplicate webhook delivery.
+func looksLikeUniqueViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := strings.ToLower(err.Error())
+	return strings.Contains(s, "unique constraint") ||
+		strings.Contains(s, "duplicate key") ||
+		strings.Contains(s, "unique key")
+}
+
+// API key event types.
+const (
+	EventAPIKeyGenerated          = "apikey.generated"
+	EventAPIKeyRegenerated        = "apikey.regenerated"
+	EventAPIKeyRevoked            = "apikey.revoked"
+	EventAPIKeyApplicationUpdated = "apikey.application_updated"
+)
+
+// apiRef identifies the API an event targets. ref_id is the Platform API artifact handle (the
+// Developer Portal's REFERENCE_ID); the API-key/subscription services resolve it to the API.
+// type is the artifact kind (e.g. RestApi, LlmProvider) and scopes the handle lookup to exactly
+// one artifact table, so every API resolution passes kind alongside the handle.
+type apiRef struct {
+	RefID   string `json:"ref_id"`
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	Type    string `json:"type"`
+}
+
+// kind returns the trimmed artifact kind carried by the event.
+func (a *apiRef) kind() string {
+	return strings.TrimSpace(a.Type)
+}
+
+// validate checks the API reference an event carries: ref_id must be present and type must be a
+// recognised artifact kind, since it scopes every downstream API lookup to one artifact table.
+func (a *apiRef) validate() error {
+	if strings.TrimSpace(a.RefID) == "" {
+		return fmt.Errorf("%w: data.api.ref_id is required", ErrInvalidEnvelope)
+	}
+	if a.kind() == "" {
+		return fmt.Errorf("%w: data.api.type (kind) is required", ErrInvalidEnvelope)
+	}
+	if !constants.ValidArtifactKinds[a.kind()] {
+		return fmt.Errorf("%w: invalid data.api.type (kind) %q", ErrInvalidEnvelope, a.kind())
+	}
+	return nil
+}
+
+// apiKeyData is the data payload for all apikey.* events. key carries the encrypted secret and is
+// present only for generate/regenerate (events that carry a new secret, listed in
+// encrypted_fields as "key"); revoke omits it.
+type apiKeyData struct {
+	KeyID     string        `json:"key_id"`
+	Name      string        `json:"name"`
+	ExpiresAt string        `json:"expires_at"`
+	API       apiRef        `json:"api"`
+	Key       *EncryptedKey `json:"key"`
+}
+
+func (d *apiKeyData) validate() error {
+	return d.API.validate()
+}
+
+// namePtr returns the key name as a pointer, or nil when absent. When present, the same name is
+// the stable identity used by regenerate/revoke (api_keys uniqueness is artifact + name).
+func (d *apiKeyData) namePtr() *string {
+	if strings.TrimSpace(d.Name) == "" {
+		return nil
+	}
+	v := strings.TrimSpace(d.Name)
+	return &v
+}
+
+func (d *apiKeyData) externalRefPtr() *string {
+	if strings.TrimSpace(d.KeyID) == "" {
+		return nil
+	}
+	v := strings.TrimSpace(d.KeyID)
+	return &v
+}
+
+// parseExpiresAt converts the optional RFC3339 expires_at into a *time.Time.
+func parseExpiresAt(s string) (*time.Time, error) {
+	if strings.TrimSpace(s) == "" {
+		return nil, nil
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid expires_at %q: %v", ErrInvalidEnvelope, s, err)
+	}
+	return &t, nil
+}
+
+// handleAPIKeyGenerated decrypts the new key secret and injects it via the existing API-key service,
+// which hashes it, persists it, and broadcasts to the gateways where the API is deployed.
+//
+// The key is identified by (api, name), so name is required and the operation is idempotent by that
+// identity: a duplicate delivery whose key already exists is treated as success rather than failing
+// on the (artifact_uuid, name) unique constraint.
+func (r *Receiver) handleAPIKeyGenerated(ctx context.Context, env *Envelope) error {
+	var d apiKeyData
+	if err := env.decodeData(&d); err != nil {
+		return err
+	}
+	if err := d.validate(); err != nil {
+		return err
+	}
+	if d.namePtr() == nil {
+		return fmt.Errorf("%w: data.name is required to identify the generated key", ErrInvalidEnvelope)
+	}
+	if d.Key == nil {
+		return fmt.Errorf("%w: data.key (encrypted secret) is required for %s", ErrInvalidEnvelope, env.EventType)
+	}
+
+	plaintext, err := r.decryptor.Decrypt(d.Key)
+	if err != nil {
+		return err
+	}
+
+	expiresAt, err := parseExpiresAt(d.ExpiresAt)
+	if err != nil {
+		return err
+	}
+
+	req := &api.CreateAPIKeyRequest{
+		ApiKey:        plaintext,
+		DisplayName:   *d.namePtr(),
+		ExternalRefId: d.externalRefPtr(),
+		ExpiresAt:     expiresAt,
+	}
+	// userID is empty: webhook events are system-originated, not tied to an interactive user.
+	if err := r.apiKeys.CreateAPIKey(ctx, d.API.RefID, d.API.kind(), env.OrgID, "", req); err != nil {
+		// Domain-level idempotency: a key already injected under this (api, name) means a prior
+		// delivery succeeded. The underlying Create surfaces a raw unique-constraint error, so match
+		// on the constraint phrasing rather than a typed error.
+		if looksLikeUniqueViolation(err) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// handleAPIKeyRegenerated rotates an existing key. The key is identified by its name within the API.
+func (r *Receiver) handleAPIKeyRegenerated(ctx context.Context, env *Envelope) error {
+	var d apiKeyData
+	if err := env.decodeData(&d); err != nil {
+		return err
+	}
+	if err := d.validate(); err != nil {
+		return err
+	}
+	if d.namePtr() == nil {
+		return fmt.Errorf("%w: data.name is required to identify the key to regenerate", ErrInvalidEnvelope)
+	}
+	if d.Key == nil {
+		return fmt.Errorf("%w: data.key (encrypted secret) is required for %s", ErrInvalidEnvelope, env.EventType)
+	}
+
+	plaintext, err := r.decryptor.Decrypt(d.Key)
+	if err != nil {
+		return err
+	}
+
+	// Carry the Developer Portal's expiry through. The Developer Portal is authoritative for the
+	// key's expiry, so a regeneration reflects data.expires_at (and clears it only when the DP
+	// sends a non-expiring key). Omitting it here would reset every regenerated key to no-expiry.
+	expiresAt, err := parseExpiresAt(d.ExpiresAt)
+	if err != nil {
+		return err
+	}
+
+	req := &api.UpdateAPIKeyRequest{
+		ApiKey:        plaintext,
+		ExternalRefId: d.externalRefPtr(),
+		ExpiresAt:     expiresAt,
+	}
+	return r.apiKeys.UpdateAPIKey(ctx, d.API.RefID, d.API.kind(), env.OrgID, *d.namePtr(), "", req)
+}
+
+// handleAPIKeyRevoked revokes an existing key, identified by its name within the API.
+func (r *Receiver) handleAPIKeyRevoked(ctx context.Context, env *Envelope) error {
+	var d apiKeyData
+	if err := env.decodeData(&d); err != nil {
+		return err
+	}
+	if err := d.validate(); err != nil {
+		return err
+	}
+	if d.namePtr() == nil {
+		return fmt.Errorf("%w: data.name is required to identify the key to revoke", ErrInvalidEnvelope)
+	}
+	return r.apiKeys.RevokeAPIKey(ctx, d.API.RefID, d.API.kind(), env.OrgID, *d.namePtr(), "")
+}
+
+// appRef is the optional application reference on apikey.application_updated. It is null when the
+// key was dissociated from its application. handle is the Developer Portal application handle, which
+// the Platform API stores as the application handle and uses to resolve the application; id (the
+// Developer Portal's internal id) is received but not used for resolution.
+type appRef struct {
+	ID          string `json:"id"`
+	DisplayName string `json:"display_name"`
+	Handle      string `json:"handle"`
+}
+
+// apiKeyApplicationData is the data payload for apikey.application_updated. The key is resolved the
+// same way as the other apikey.* events — by (api.ref_id, name) — so it embeds apiKeyData for that
+// identity. application is the new owning application, or null to dissociate the key.
+type apiKeyApplicationData struct {
+	apiKeyData
+	Application *appRef `json:"application"`
+}
+
+// handleAPIKeyApplicationUpdated reconciles a change to which application an API key belongs to.
+// The key is resolved exactly like revoke — by (api.ref_id, name); application is the new owner, or
+// null to dissociate. SetAPIKeyApplication is idempotent, so a redelivery re-applies the same owner.
+func (r *Receiver) handleAPIKeyApplicationUpdated(ctx context.Context, env *Envelope) error {
+	var d apiKeyApplicationData
+	if err := env.decodeData(&d); err != nil {
+		return err
+	}
+	if err := d.validate(); err != nil {
+		return err
+	}
+	if d.namePtr() == nil {
+		return fmt.Errorf("%w: data.name is required to identify the key", ErrInvalidEnvelope)
+	}
+	appHandle := ""
+	if d.Application != nil {
+		appHandle = strings.TrimSpace(d.Application.Handle)
+	}
+	return r.apps.SetAPIKeyApplication(*d.namePtr(), d.API.RefID, d.API.kind(), appHandle, env.OrgID, "")
+}

--- a/platform-api/src/internal/webhook/handlers_application.go
+++ b/platform-api/src/internal/webhook/handlers_application.go
@@ -1,0 +1,128 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package webhook
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"platform-api/src/api"
+	"platform-api/src/internal/constants"
+)
+
+// Application event types. apikey.application_updated is intentionally handled with the other
+// apikey.* events (see handlers_apikey.go): it targets an API key, not an application.
+const (
+	EventApplicationCreated = "application.created"
+	EventApplicationUpdated = "application.updated"
+	EventApplicationDeleted = "application.deleted"
+)
+
+// applicationData is the data payload for application.* events. description and type are absent on
+// application.deleted. handle is the Developer Portal application handle, which the Platform API
+// stores as the application handle and uses as the resolution key across all application events.
+// application_id (the Developer Portal's internal id) is received but not used for resolution. type
+// is the application type (e.g. "genai", "web"), validated by the service layer.
+type applicationData struct {
+	ApplicationID string `json:"application_id"`
+	DisplayName   string `json:"display_name"`
+	Handle        string `json:"handle"`
+	Description   string `json:"description"`
+	Type          string `json:"type"`
+}
+
+// handleApplicationCreated reconciles an application created in the Developer Portal.
+func (r *Receiver) handleApplicationCreated(ctx context.Context, env *Envelope) error {
+	var d applicationData
+	if err := env.decodeData(&d); err != nil {
+		return err
+	}
+	if strings.TrimSpace(d.Handle) == "" {
+		return fmt.Errorf("%w: data.handle is required", ErrInvalidEnvelope)
+	}
+	if strings.TrimSpace(d.DisplayName) == "" {
+		return fmt.Errorf("%w: data.display_name is required", ErrInvalidEnvelope)
+	}
+	_, err := r.apps.CreateApplicationFromWebhook(d.Handle, d.DisplayName, d.Description, d.Type, env.OrgID)
+	if err != nil {
+		// Domain-level idempotency: a duplicate delivery whose application already exists is success.
+		if errors.Is(err, constants.ErrApplicationExists) || errors.Is(err, constants.ErrHandleExists) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// handleApplicationUpdated reconciles an application renamed/updated in the Developer Portal.
+// Deliveries are at-least-once and fired once, so if the create event was missed this upserts.
+func (r *Receiver) handleApplicationUpdated(ctx context.Context, env *Envelope) error {
+	var d applicationData
+	if err := env.decodeData(&d); err != nil {
+		return err
+	}
+	handle := strings.TrimSpace(d.Handle)
+	if handle == "" {
+		return fmt.Errorf("%w: data.handle is required", ErrInvalidEnvelope)
+	}
+	name := strings.TrimSpace(d.DisplayName)
+	desc := strings.TrimSpace(d.Description)
+	// handle is the application handle and is immutable: it must match the application being updated,
+	// so it is both the lookup key and the body id. Type is applied only when present
+	// (UpdateApplication ignores an empty type).
+	req := &api.Application{
+		Id:          handle,
+		DisplayName: name,
+		Description: &desc,
+		Type:        api.ApplicationType(strings.TrimSpace(d.Type)),
+	}
+	_, err := r.apps.UpdateApplication(handle, req, env.OrgID, "")
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, constants.ErrApplicationNotFound) || name == "" {
+		return err
+	}
+	// Upsert: the create event was likely missed.
+	if _, cerr := r.apps.CreateApplicationFromWebhook(handle, name, d.Description, d.Type, env.OrgID); cerr != nil &&
+		!errors.Is(cerr, constants.ErrApplicationExists) && !errors.Is(cerr, constants.ErrHandleExists) {
+		return cerr
+	}
+	return nil
+}
+
+// handleApplicationDeleted reconciles an application deleted in the Developer Portal.
+func (r *Receiver) handleApplicationDeleted(ctx context.Context, env *Envelope) error {
+	var d applicationData
+	if err := env.decodeData(&d); err != nil {
+		return err
+	}
+	if strings.TrimSpace(d.Handle) == "" {
+		return fmt.Errorf("%w: data.handle is required", ErrInvalidEnvelope)
+	}
+	if err := r.apps.DeleteApplication(d.Handle, env.OrgID, ""); err != nil {
+		// Domain-level idempotency: already gone is success.
+		if errors.Is(err, constants.ErrApplicationNotFound) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}

--- a/platform-api/src/internal/webhook/handlers_subscription.go
+++ b/platform-api/src/internal/webhook/handlers_subscription.go
@@ -1,0 +1,231 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package webhook
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"platform-api/src/internal/constants"
+	"platform-api/src/internal/model"
+)
+
+// Subscription event types.
+const (
+	EventSubscriptionCreated          = "subscription.created"
+	EventSubscriptionUpdated          = "subscription.updated"           // status change (ACTIVE ↔ INACTIVE)
+	EventSubscriptionPlanChanged      = "subscription.plan_changed"      // plan switched; token unchanged
+	EventSubscriptionTokenRegenerated = "subscription.token_regenerated" // token rotated (encrypted)
+	EventSubscriptionDeleted          = "subscription.deleted"
+)
+
+// subscriptionPlanRef identifies a subscription plan. ref_id is the Platform API subscription plan
+// handle (unique per organization), which the service layer resolves to the plan's UUID.
+type subscriptionPlanRef struct {
+	RefID    string `json:"ref_id"`
+	PlanName string `json:"plan_name"`
+	Status   string `json:"status"`
+}
+
+// subscriptionData is the data payload for subscription.* events.
+//
+// subscriber_id is required: a Platform API subscription belongs to a subscriber (the subscriptions
+// table enforces NOT NULL). application_id is optional.
+//
+// token carries the subscription token issued by the Developer Portal — the value shown to the user
+// and presented to the gateway for validation. It arrives as an encrypted envelope (listed in the
+// envelope's encrypted_fields as "token"); once decrypted it is persisted as-is so the same token
+// validates end to end. When absent, the Platform API generates its own.
+type subscriptionData struct {
+	SubscriberID     string              `json:"subscriber_id"`
+	ApplicationID    string              `json:"application_id"`
+	Token            *EncryptedKey       `json:"token"`
+	SubscriptionPlan subscriptionPlanRef `json:"subscription_plan"`
+	API              apiRef              `json:"api"`
+	Status           string              `json:"status"`
+}
+
+func (d *subscriptionData) validate() error {
+	if err := d.API.validate(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(d.SubscriberID) == "" {
+		return fmt.Errorf("%w: data.subscriber_id is required", ErrInvalidEnvelope)
+	}
+	return nil
+}
+
+func (d *subscriptionData) applicationIDPtr() *string {
+	if strings.TrimSpace(d.ApplicationID) == "" {
+		return nil
+	}
+	v := strings.TrimSpace(d.ApplicationID)
+	return &v
+}
+
+// findSubscription locates an existing subscription by API (handle + kind) and subscriber within
+// the org. kind scopes the API resolution to the artifact table backing that kind, so a handle
+// shared across kinds resolves unambiguously. Returns (nil, nil) when none exists.
+func (r *Receiver) findSubscription(orgID, apiRefID, kind, subscriberID string) (*model.Subscription, error) {
+	return r.subs.FindByArtifactKindAndSubscriber(orgID, apiRefID, kind, subscriberID)
+}
+
+// handleSubscriptionCreated reconciles a subscription created in the Developer Portal. The existing
+// service generates the subscription's token, persists it, and broadcasts to deployed gateways.
+func (r *Receiver) handleSubscriptionCreated(ctx context.Context, env *Envelope) error {
+	var d subscriptionData
+	if err := env.decodeData(&d); err != nil {
+		return err
+	}
+	if err := d.validate(); err != nil {
+		return err
+	}
+
+	// Import the Developer Portal token (encrypted under data.token) so the value the user sees
+	// validates at the gateway. When absent, the service generates its own.
+	var token string
+	if d.Token != nil {
+		decrypted, err := r.decryptor.Decrypt(d.Token)
+		if err != nil {
+			return err
+		}
+		token = decrypted
+	}
+
+	_, err := r.subs.CreateSubscription(d.API.RefID, d.API.kind(), env.OrgID, d.SubscriberID, d.applicationIDPtr(), &d.SubscriptionPlan.RefID, token, d.Status)
+	if err != nil {
+		// Domain-level idempotency: a duplicate delivery whose subscription already exists is success.
+		if errors.Is(err, constants.ErrSubscriptionAlreadyExists) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// handleSubscriptionUpdated applies a subscription status change (subscription.updated). The event
+// carries the new status; the plan and token are unchanged, and no encrypted fields are present.
+func (r *Receiver) handleSubscriptionUpdated(ctx context.Context, env *Envelope) error {
+	var d subscriptionData
+	if err := env.decodeData(&d); err != nil {
+		return err
+	}
+	if err := d.validate(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(d.Status) == "" {
+		return fmt.Errorf("%w: data.status is required for %s", ErrInvalidEnvelope, env.EventType)
+	}
+
+	sub, err := r.findSubscription(env.OrgID, d.API.RefID, d.API.kind(), d.SubscriberID)
+	if err != nil {
+		return err
+	}
+	if sub == nil {
+		return constants.ErrSubscriptionNotFound
+	}
+
+	_, err = r.subs.UpdateSubscription(sub.UUID, env.OrgID, d.SubscriberID, d.Status)
+	return err
+}
+
+// handleSubscriptionPlanChanged switches the plan of an existing subscription (subscription.plan_changed).
+// data.subscription_plan.ref_id is the new plan; data.previous_plan (if present) is informational and
+// ignored. The subscription's token is not rotated by this event.
+func (r *Receiver) handleSubscriptionPlanChanged(ctx context.Context, env *Envelope) error {
+	var d subscriptionData
+	if err := env.decodeData(&d); err != nil {
+		return err
+	}
+	if err := d.validate(); err != nil {
+		return err
+	}
+
+	sub, err := r.findSubscription(env.OrgID, d.API.RefID, d.API.kind(), d.SubscriberID)
+	if err != nil {
+		return err
+	}
+	if sub == nil {
+		return constants.ErrSubscriptionNotFound
+	}
+
+	_, err = r.subs.ChangePlan(sub.UUID, env.OrgID, d.SubscriberID, d.SubscriptionPlan.RefID)
+	return err
+}
+
+// handleSubscriptionTokenRegenerated rotates an existing subscription's token
+// (subscription.token_regenerated). The new token arrives encrypted under data.token (listed in
+// encrypted_fields as "token"); we decrypt it and persist it, invalidating the old token.
+func (r *Receiver) handleSubscriptionTokenRegenerated(ctx context.Context, env *Envelope) error {
+	var d subscriptionData
+	if err := env.decodeData(&d); err != nil {
+		return err
+	}
+	if err := d.validate(); err != nil {
+		return err
+	}
+	if d.Token == nil {
+		return fmt.Errorf("%w: data.token (encrypted) is required for %s", ErrInvalidEnvelope, env.EventType)
+	}
+
+	token, err := r.decryptor.Decrypt(d.Token)
+	if err != nil {
+		return err
+	}
+
+	sub, err := r.findSubscription(env.OrgID, d.API.RefID, d.API.kind(), d.SubscriberID)
+	if err != nil {
+		return err
+	}
+	if sub == nil {
+		return constants.ErrSubscriptionNotFound
+	}
+
+	_, err = r.subs.RegenerateToken(sub.UUID, env.OrgID, d.SubscriberID, token)
+	return err
+}
+
+// handleSubscriptionDeleted removes a subscription deleted in the Developer Portal.
+func (r *Receiver) handleSubscriptionDeleted(ctx context.Context, env *Envelope) error {
+	var d subscriptionData
+	if err := env.decodeData(&d); err != nil {
+		return err
+	}
+	if err := d.validate(); err != nil {
+		return err
+	}
+
+	sub, err := r.findSubscription(env.OrgID, d.API.RefID, d.API.kind(), d.SubscriberID)
+	if err != nil {
+		return err
+	}
+	if sub == nil {
+		// Domain-level idempotency: already gone is success.
+		return nil
+	}
+
+	if err := r.subs.DeleteSubscription(sub.UUID, env.OrgID, d.SubscriberID); err != nil {
+		if errors.Is(err, constants.ErrSubscriptionNotFound) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}

--- a/platform-api/src/internal/webhook/receiver.go
+++ b/platform-api/src/internal/webhook/receiver.go
@@ -1,0 +1,241 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package webhook
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/wso2/go-httpkit/httputil"
+
+	"platform-api/src/api"
+	"platform-api/src/config"
+	"platform-api/src/internal/constants"
+	"platform-api/src/internal/model"
+	"platform-api/src/internal/utils"
+)
+
+// RoutePath is the webhook endpoint under the resource API version prefix (constants.APIVersion,
+// currently "v0.9"). It lives under the internal/control-plane prefix and is excluded from JWT/IDP
+// auth via config.Auth.SkipPaths (authenticity comes from the HMAC signature).
+const RoutePath = "/api/internal/" + constants.APIVersion + "/webhook/events"
+
+// apiKeyService is the subset of *service.APIKeyService the receiver depends on. The existing
+// CreateAPIKey/UpdateAPIKey/RevokeAPIKey already hash an externally provisioned key, persist it,
+// and broadcast to the gateways where the API is deployed — exactly what the webhook needs.
+type apiKeyService interface {
+	CreateAPIKey(ctx context.Context, apiHandle, kind, orgID, userID string, req *api.CreateAPIKeyRequest) error
+	UpdateAPIKey(ctx context.Context, apiHandle, kind, orgID, keyName, userID string, req *api.UpdateAPIKeyRequest) error
+	RevokeAPIKey(ctx context.Context, apiHandle, kind, orgID, keyName, userID string) error
+}
+
+// subscriptionService is the subset of *service.SubscriptionService the receiver depends on.
+type subscriptionService interface {
+	CreateSubscription(apiID, kind, orgUUID, subscriberID string, applicationID, subscriptionPlanID *string, subscriptionToken, status string) (*model.Subscription, error)
+	UpdateSubscription(subscriptionID, orgUUID, subscriberID, status string) (*model.Subscription, error)
+	ChangePlan(subscriptionID, orgUUID, subscriberID, planUUID string) (*model.Subscription, error)
+	RegenerateToken(subscriptionID, orgUUID, subscriberID, newToken string) (*model.Subscription, error)
+	DeleteSubscription(subscriptionID, orgUUID, subscriberID string) error
+	FindByArtifactKindAndSubscriber(orgUUID, apiHandle, kind, subscriberID string) (*model.Subscription, error)
+}
+
+// organizationResolver resolves the Developer Portal organization handle (delivered as org.ref_id)
+// to the Platform API organization UUID that every downstream service and table is keyed by.
+type organizationResolver interface {
+	GetOrganizationByHandle(handle string) (*model.Organization, error)
+}
+
+// applicationService is the subset of *service.ApplicationService the receiver depends on to
+// reconcile Developer Portal application events. The webhook-specific create/reconcile logic (default
+// project, "genai" type, DP-id-as-handle, single-app key mapping) lives in the service.
+type applicationService interface {
+	CreateApplicationFromWebhook(handle, name, description, appType, orgID string) (*api.Application, error)
+	UpdateApplication(appIDOrHandle string, req *api.Application, orgID, userID string) (*api.Application, error)
+	DeleteApplication(appIDOrHandle, orgID, actor string) error
+	SetAPIKeyApplication(keyName, artifactRef, kind, appIDOrHandle, orgID, userID string) error
+}
+
+// Receiver is the gin handler implementing the webhook processing flow.
+type Receiver struct {
+	cfg       config.Webhook
+	verifier  *Verifier
+	decryptor *Decryptor
+	apiKeys   apiKeyService
+	subs      subscriptionService
+	apps      applicationService
+	orgs      organizationResolver
+	slogger   *slog.Logger
+
+	handlers map[string]func(ctx context.Context, env *Envelope) error
+}
+
+// NewReceiver wires the receiver and its event-type dispatch table.
+func NewReceiver(
+	cfg config.Webhook,
+	decryptor *Decryptor,
+	apiKeys apiKeyService,
+	subs subscriptionService,
+	apps applicationService,
+	orgs organizationResolver,
+	slogger *slog.Logger,
+) *Receiver {
+	r := &Receiver{
+		cfg:       cfg,
+		verifier:  NewVerifier(cfg.Secret, cfg.SignatureTolerance),
+		decryptor: decryptor,
+		apiKeys:   apiKeys,
+		subs:      subs,
+		apps:      apps,
+		orgs:      orgs,
+		slogger:   slogger,
+	}
+	r.handlers = map[string]func(ctx context.Context, env *Envelope) error{
+		EventAPIKeyGenerated:              r.handleAPIKeyGenerated,
+		EventAPIKeyRegenerated:            r.handleAPIKeyRegenerated,
+		EventAPIKeyRevoked:                r.handleAPIKeyRevoked,
+		EventSubscriptionCreated:          r.handleSubscriptionCreated,
+		EventSubscriptionUpdated:          r.handleSubscriptionUpdated,
+		EventSubscriptionPlanChanged:      r.handleSubscriptionPlanChanged,
+		EventSubscriptionTokenRegenerated: r.handleSubscriptionTokenRegenerated,
+		EventSubscriptionDeleted:          r.handleSubscriptionDeleted,
+		EventApplicationCreated:           r.handleApplicationCreated,
+		EventApplicationUpdated:           r.handleApplicationUpdated,
+		EventApplicationDeleted:           r.handleApplicationDeleted,
+		EventAPIKeyApplicationUpdated:     r.handleAPIKeyApplicationUpdated,
+	}
+	return r
+}
+
+// RegisterRoutes registers the webhook endpoint on the mux. Only called when the webhook is enabled.
+func (r *Receiver) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("POST "+RoutePath, r.ReceiveEvent)
+}
+
+// ReceiveEvent runs the full webhook flow: size-limited read -> signature verify -> envelope
+// decode/validate -> gateway_type filter -> idempotency -> dispatch -> mark processed.
+func (r *Receiver) ReceiveEvent(w http.ResponseWriter, req *http.Request) {
+	if !r.cfg.Enabled {
+		httputil.WriteJSON(w, http.StatusNotFound, utils.NewErrorResponse(http.StatusNotFound, "Not Found", "Webhook endpoint is disabled"))
+		return
+	}
+
+	// Read the raw body with a size cap. The raw bytes are needed verbatim for HMAC verification.
+	limited := http.MaxBytesReader(w, req.Body, r.cfg.MaxBodySize)
+	body, err := io.ReadAll(limited)
+	if err != nil {
+		r.slogger.Warn("Webhook body read failed (possibly too large)", "limit", r.cfg.MaxBodySize, "error", err)
+		httputil.WriteJSON(w, http.StatusBadRequest, utils.NewErrorResponse(http.StatusBadRequest, "Bad Request", "Request body too large or unreadable"))
+		return
+	}
+
+	// 1. Verify HMAC signature over the raw body.
+	if err := r.verifier.Verify(req.Header.Get(r.cfg.SignatureHeader), body, time.Now()); err != nil {
+		r.slogger.Warn("Webhook signature verification failed", "clientIP", req.RemoteAddr, "error", err)
+		httputil.WriteJSON(w, http.StatusUnauthorized, utils.NewErrorResponse(http.StatusUnauthorized, "Unauthorized", "Signature verification failed"))
+		return
+	}
+
+	// 2. Decode + validate the envelope.
+	env, err := DecodeEnvelope(body)
+	if err == nil {
+		err = env.Validate()
+	}
+	if err != nil {
+		r.slogger.Warn("Webhook envelope invalid", "error", err)
+		httputil.WriteJSON(w, http.StatusBadRequest, utils.NewErrorResponse(http.StatusBadRequest, "Bad Request", "Invalid event envelope"))
+		return
+	}
+
+	log := r.slogger.With("eventId", env.EventID, "eventType", env.EventType, "orgHandle", env.OrgID)
+
+	// 3. Resolve the organization handle (org.ref_id) to the Platform API organization UUID that all
+	//    downstream persistence is keyed by. The Developer Portal sends the handle; the services expect
+	//    the UUID. An unknown handle is a terminal 404 (not retryable) since the event references an
+	//    organization that does not exist in the control plane.
+	if err := r.resolveOrgUUID(env); err != nil {
+		status := statusForError(err)
+		log.Warn("Webhook organization resolution failed", "status", status, "error", err)
+		httputil.WriteJSON(w, status, utils.NewErrorResponse(status, http.StatusText(status), "Unknown organization"))
+		return
+	}
+	log = log.With("orgId", env.OrgID)
+
+	// 4. gateway_type filter — events for other gateway types are a no-op (accepted, not processed).
+	if r.cfg.GatewayType != "" && env.GatewayType != "" && env.GatewayType != r.cfg.GatewayType {
+		log.Info("Webhook event for a different gateway_type; accepting as no-op", "eventGatewayType", env.GatewayType)
+		httputil.WriteJSON(w, http.StatusAccepted, map[string]string{"status": "ignored", "reason": "gateway_type mismatch"})
+		return
+	}
+
+	// 5. Dispatch to the matching handler. Duplicate (at-least-once) deliveries are made safe by
+	//    each handler being idempotent by domain identity, so no envelope-level dedup is needed.
+	handle, ok := r.handlers[env.EventType]
+	if !ok {
+		log.Warn("Unsupported webhook event type")
+		httputil.WriteJSON(w, http.StatusBadRequest, utils.NewErrorResponse(http.StatusBadRequest, "Bad Request", "Unsupported event type"))
+		return
+	}
+
+	if err := handle(req.Context(), env); err != nil {
+		status := statusForError(err)
+		log.Error("Webhook event handling failed", "status", status, "error", err)
+		httputil.WriteJSON(w, status, utils.NewErrorResponse(status, http.StatusText(status), "Failed to process event"))
+		return
+	}
+
+	log.Info("Webhook event processed")
+	httputil.WriteJSON(w, http.StatusOK, map[string]string{"status": "processed"})
+}
+
+// resolveOrgUUID converts the organization handle carried in the envelope (org.ref_id, normalized
+// onto env.OrgID by DecodeEnvelope) into the Platform API organization UUID and writes it back onto
+// env.OrgID, so downstream handlers key their persistence by the UUID. An unknown handle returns
+// ErrOrganizationNotFound.
+func (r *Receiver) resolveOrgUUID(env *Envelope) error {
+	org, err := r.orgs.GetOrganizationByHandle(env.OrgID)
+	if err != nil {
+		return err
+	}
+	if org == nil {
+		return constants.ErrOrganizationNotFound
+	}
+	env.OrgID = org.ID
+	return nil
+}
+
+// statusForError maps domain errors returned by the reused services to HTTP status codes.
+func statusForError(err error) int {
+	switch {
+	case errors.Is(err, ErrInvalidEnvelope), errors.Is(err, ErrUnsupportedEvent), errors.Is(err, ErrDecryptionFailed):
+		return http.StatusBadRequest
+	case errors.Is(err, constants.ErrAPINotFound),
+		errors.Is(err, constants.ErrOrganizationNotFound),
+		errors.Is(err, constants.ErrSubscriptionNotFound),
+		errors.Is(err, constants.ErrSubscriptionPlanNotFound),
+		errors.Is(err, constants.ErrSubscriptionPlanNotFoundOrInactive),
+		errors.Is(err, constants.ErrAPIKeyNotFound):
+		return http.StatusNotFound
+	default:
+		// Storage/EventHub failures and unexpected errors are retryable.
+		return http.StatusInternalServerError
+	}
+}

--- a/platform-api/src/internal/webhook/verifier.go
+++ b/platform-api/src/internal/webhook/verifier.go
@@ -1,0 +1,108 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package webhook
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Verifier validates the HMAC-SHA256 signature of an incoming webhook request.
+//
+// The Developer Portal signs each request with a per-subscriber shared secret. The signature
+// header has the form "t=<unix-seconds>,v1=<hex-hmac>" and the signed payload is
+// "<timestamp>.<raw_body>". This matches the producer scheme documented in
+// docs-local/platform-api-webhook.md.
+type Verifier struct {
+	secret    []byte
+	tolerance time.Duration
+}
+
+// NewVerifier builds a Verifier. tolerance bounds how old a signed request may be (replay guard).
+func NewVerifier(secret string, tolerance time.Duration) *Verifier {
+	return &Verifier{secret: []byte(secret), tolerance: tolerance}
+}
+
+// Verify checks the signature header against the raw request body. It returns nil when the
+// request is authentic and a sentinel error (ErrSignature*/ErrTimestampOutOfTolerance) otherwise.
+// now is injected for testability; callers pass time.Now().
+func (v *Verifier) Verify(header string, body []byte, now time.Time) error {
+	if strings.TrimSpace(header) == "" {
+		return ErrSignatureMissing
+	}
+
+	ts, sig, err := parseSignatureHeader(header)
+	if err != nil {
+		return err
+	}
+
+	// Reject stale (or future-dated) signatures to prevent replay.
+	if v.tolerance > 0 {
+		delta := now.Sub(time.Unix(ts, 0))
+		if delta < 0 {
+			delta = -delta
+		}
+		if delta > v.tolerance {
+			return ErrTimestampOutOfTolerance
+		}
+	}
+
+	signedPayload := strconv.FormatInt(ts, 10) + "." + string(body)
+	mac := hmac.New(sha256.New, v.secret)
+	mac.Write([]byte(signedPayload))
+	expected := mac.Sum(nil)
+
+	got, err := hex.DecodeString(sig)
+	if err != nil {
+		return ErrSignatureInvalid
+	}
+	if !hmac.Equal(expected, got) {
+		return ErrSignatureInvalid
+	}
+	return nil
+}
+
+// parseSignatureHeader extracts the t and v1 components from a header like "t=123,v1=abcdef".
+func parseSignatureHeader(header string) (timestamp int64, signature string, err error) {
+	var tsStr, sigStr string
+	for _, part := range strings.Split(header, ",") {
+		kv := strings.SplitN(strings.TrimSpace(part), "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		switch strings.TrimSpace(kv[0]) {
+		case "t":
+			tsStr = strings.TrimSpace(kv[1])
+		case "v1":
+			sigStr = strings.TrimSpace(kv[1])
+		}
+	}
+	if tsStr == "" || sigStr == "" {
+		return 0, "", fmt.Errorf("%w: malformed signature header", ErrSignatureInvalid)
+	}
+	ts, parseErr := strconv.ParseInt(tsStr, 10, 64)
+	if parseErr != nil {
+		return 0, "", fmt.Errorf("%w: invalid timestamp", ErrSignatureInvalid)
+	}
+	return ts, sigStr, nil
+}

--- a/platform-api/src/plugins/eventgateway/handler/webbroker_apikey.go
+++ b/platform-api/src/plugins/eventgateway/handler/webbroker_apikey.go
@@ -105,7 +105,7 @@ func (h *WebBrokerAPIKeyHandler) CreateAPIKey(w http.ResponseWriter, r *http.Req
 		req.Id = &name
 	}
 
-	if err := h.apiKeyService.CreateAPIKey(r.Context(), apiHandle, orgID, userId, &req); err != nil {
+	if err := h.apiKeyService.CreateAPIKey(r.Context(), apiHandle, constants.WebBrokerApi, orgID, userId, &req); err != nil {
 		if errors.Is(err, constants.ErrAPINotFound) {
 			httputil.WriteJSON(w, http.StatusNotFound, utils.NewErrorResponse(404, "Not Found", "WebBroker API not found"))
 			return
@@ -174,7 +174,7 @@ func (h *WebBrokerAPIKeyHandler) UpdateAPIKey(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	if err := h.apiKeyService.UpdateAPIKey(r.Context(), apiHandle, orgID, keyName, userId, &req); err != nil {
+	if err := h.apiKeyService.UpdateAPIKey(r.Context(), apiHandle, constants.WebBrokerApi, orgID, keyName, userId, &req); err != nil {
 		if errors.Is(err, constants.ErrAPINotFound) {
 			httputil.WriteJSON(w, http.StatusNotFound, utils.NewErrorResponse(404, "Not Found", "WebBroker API not found"))
 			return
@@ -218,7 +218,7 @@ func (h *WebBrokerAPIKeyHandler) DeleteAPIKey(w http.ResponseWriter, r *http.Req
 
 	userId := r.Header.Get("x-user-id")
 
-	if err := h.apiKeyService.RevokeAPIKey(r.Context(), apiHandle, orgID, keyName, userId); err != nil {
+	if err := h.apiKeyService.RevokeAPIKey(r.Context(), apiHandle, constants.WebBrokerApi, orgID, keyName, userId); err != nil {
 		if errors.Is(err, constants.ErrAPINotFound) {
 			httputil.WriteJSON(w, http.StatusNotFound, utils.NewErrorResponse(404, "Not Found", "WebBroker API not found"))
 			return

--- a/platform-api/src/plugins/eventgateway/handler/websub_apikey.go
+++ b/platform-api/src/plugins/eventgateway/handler/websub_apikey.go
@@ -105,7 +105,7 @@ func (h *WebSubAPIKeyHandler) CreateAPIKey(w http.ResponseWriter, r *http.Reques
 		req.Id = &name
 	}
 
-	if err := h.apiKeyService.CreateAPIKey(r.Context(), apiHandle, orgID, userId, &req); err != nil {
+	if err := h.apiKeyService.CreateAPIKey(r.Context(), apiHandle, constants.WebSubApi, orgID, userId, &req); err != nil {
 		if errors.Is(err, constants.ErrAPINotFound) {
 			httputil.WriteJSON(w, http.StatusNotFound, utils.NewErrorResponse(404, "Not Found", "WebSub API not found"))
 			return
@@ -174,7 +174,7 @@ func (h *WebSubAPIKeyHandler) UpdateAPIKey(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	if err := h.apiKeyService.UpdateAPIKey(r.Context(), apiHandle, orgID, keyName, userId, &req); err != nil {
+	if err := h.apiKeyService.UpdateAPIKey(r.Context(), apiHandle, constants.WebSubApi, orgID, keyName, userId, &req); err != nil {
 		if errors.Is(err, constants.ErrAPINotFound) {
 			httputil.WriteJSON(w, http.StatusNotFound, utils.NewErrorResponse(404, "Not Found", "WebSub API not found"))
 			return
@@ -219,7 +219,7 @@ func (h *WebSubAPIKeyHandler) DeleteAPIKey(w http.ResponseWriter, r *http.Reques
 
 	userId := r.Header.Get("x-user-id")
 
-	if err := h.apiKeyService.RevokeAPIKey(r.Context(), apiHandle, orgID, keyName, userId); err != nil {
+	if err := h.apiKeyService.RevokeAPIKey(r.Context(), apiHandle, constants.WebSubApi, orgID, keyName, userId); err != nil {
 		if errors.Is(err, constants.ErrAPINotFound) {
 			httputil.WriteJSON(w, http.StatusNotFound, utils.NewErrorResponse(404, "Not Found", "WebSub API not found"))
 			return


### PR DESCRIPTION
## Description

This pull request introduces several important updates to the platform API, primarily focused on enhancing webhook configurability, improving application and API key management, and refining database schema constraints. The changes are grouped below by theme.
Fixes https://github.com/wso2/api-platform/issues/2342

**Webhook Configuration Enhancements:**

- Introduced a new `Webhook` struct in the configuration, allowing fine-grained control over webhook behavior (enabling/disabling, secrets, signature validation, request size, etc.), with appropriate default values and validation logic. This includes environment variable mapping and documentation references. [[1]](diffhunk://#diff-3d9d97b7e23ab9c6e77fe2b6aa9d353b34d643d87c49eb8f0101e45b47e31467R94) [[2]](diffhunk://#diff-3d9d97b7e23ab9c6e77fe2b6aa9d353b34d643d87c49eb8f0101e45b47e31467R138-R159) [[3]](diffhunk://#diff-3d9d97b7e23ab9c6e77fe2b6aa9d353b34d643d87c49eb8f0101e45b47e31467R338-R340) [[4]](diffhunk://#diff-3d9d97b7e23ab9c6e77fe2b6aa9d353b34d643d87c49eb8f0101e45b47e31467R611-R626) [[5]](diffhunk://#diff-3d9d97b7e23ab9c6e77fe2b6aa9d353b34d643d87c49eb8f0101e45b47e31467R737-R760) [[6]](diffhunk://#diff-12d11bacb8c499b267240257198192ef8c76222614bc39d318e859962d7eb251L20-R24) [[7]](diffhunk://#diff-12d11bacb8c499b267240257198192ef8c76222614bc39d318e859962d7eb251R146-R152)

**Database Schema Updates:**

- Modified the `applications` table in all supported databases to make `project_uuid` nullable and removed the foreign key constraint on `project_uuid`, allowing applications to exist without being tied to a specific project. [[1]](diffhunk://#diff-783488c6dcec9868cca4a56575e7d6746d9badda1b8190a6fce104e3b151516fL53-R53) [[2]](diffhunk://#diff-783488c6dcec9868cca4a56575e7d6746d9badda1b8190a6fce104e3b151516fL63) [[3]](diffhunk://#diff-76aefc7d49da8a3159326b7cce9b02a3ca152af7dfd9188c57b3fa0f255f6bddL53-R53) [[4]](diffhunk://#diff-76aefc7d49da8a3159326b7cce9b02a3ca152af7dfd9188c57b3fa0f255f6bddL63) [[5]](diffhunk://#diff-9397a352d53c46689acdfff54c6250a5413edbfa50ec1077a1d2ef51706692aaL53-R53) [[6]](diffhunk://#diff-9397a352d53c46689acdfff54c6250a5413edbfa50ec1077a1d2ef51706692aaL63) [[7]](diffhunk://#diff-d1a75efa6678690fc874122fd84844ae5c6680b08e3d0153f854f1d99204c871L55-R55) [[8]](diffhunk://#diff-d1a75efa6678690fc874122fd84844ae5c6680b08e3d0153f854f1d99204c871L65-R65)

**Application and API Key Management:**

- Added repository methods to fetch applications by API key, and to remove API keys from all applications, supporting more robust event handling and synchronization with external systems. Updated the application scanning logic to handle nullable `project_uuid`. [[1]](diffhunk://#diff-fb1ca2a5a27243d8b8c5c018c2337cebf70dfce50783c976987a9a5ad851d52aR520-R556) [[2]](diffhunk://#diff-fb1ca2a5a27243d8b8c5c018c2337cebf70dfce50783c976987a9a5ad851d52aR571-R579) [[3]](diffhunk://#diff-fb1ca2a5a27243d8b8c5c018c2337cebf70dfce50783c976987a9a5ad851d52aR593-R595) [[4]](diffhunk://#diff-074f5f4f6c3225342030a3ff77c407762c95334a899b29a7caf7483445a63801R92-R94)

**Handler and Service Adjustments:**

- Updated API key and subscription handlers to pass additional parameters and handle new cases, such as enforcing that projects with associated applications cannot be deleted and supporting new subscription token update logic. [[1]](diffhunk://#diff-e24fa7c91b6626c334d0b9a1a11a9aac58a910a2a830635455bc4d733ebbebc1L103-R103) [[2]](diffhunk://#diff-e24fa7c91b6626c334d0b9a1a11a9aac58a910a2a830635455bc4d733ebbebc1L195-R195) [[3]](diffhunk://#diff-e24fa7c91b6626c334d0b9a1a11a9aac58a910a2a830635455bc4d733ebbebc1L255-R255) [[4]](diffhunk://#diff-d9991644a0172a0e434bc118684e1c150509a54c926164f6fc22d692f35061f2R248-R252) [[5]](diffhunk://#diff-2925ed71ef512ad0420b646f3e352f7a974e61939b8498cb7d180359fea8d927L104-R104) [[6]](diffhunk://#diff-074f5f4f6c3225342030a3ff77c407762c95334a899b29a7caf7483445a63801R208)

**Error Handling Improvements:**

- Added a new error constant for projects with associated applications, and improved error reporting in the project deletion handler to return a clear error message when deletion is blocked by existing applications. [[1]](diffhunk://#diff-c419d36ed4a009ec119bf132fc0e36ceb5c1c9f0169ac31b6d7d54e8e2d5cc69R45) [[2]](diffhunk://#diff-d9991644a0172a0e434bc118684e1c150509a54c926164f6fc22d692f35061f2R248-R252)

These changes collectively improve the flexibility, maintainability, and robustness of the platform's configuration, data model, and operational logic.

## Configuring webhook

Generate the shared secret and key pair
Platform API keeps the private key; the Portal gets the public key and the same HMAC secret.

```shell
# HMAC shared secret — give the same value to the Portal
openssl rand -hex 32

# RSA key pair — used to encrypt API-key secrets in transit
openssl genrsa -out devportal-webhook.pem 2048
openssl rsa -in devportal-webhook.pem -pubout -out devportal-webhook.pub
```

Enable the receiver
Set these env vars (paste the secret from step 1), then start the server:

```shell
export WEBHOOK_ENABLED=true
export WEBHOOK_SECRET=<hex-secret-from-step-1>
export WEBHOOK_PRIVATE_KEY_PATH=./data/certs/devportal-webhook.pem
go run ./cmd/main.go
```