### PR TITLE
Allow editing connection details of LLM provider template

### DIFF
--- a/platform-api/src/api/generated.go
+++ b/platform-api/src/api/generated.go
@@ -2548,24 +2548,14 @@ type SyncCustomPolicyParams struct {
 
 // ListLLMProviderTemplatesParams defines parameters for ListLLMProviderTemplates.
 type ListLLMProviderTemplatesParams struct {
-	// Query URL-encoded search DSL. `query=groupId:<id>` lists that family's versions; adding `&version:<ver>` returns the single full template for that version. Terms are `&`-separated and the whole value is percent-encoded (e.g. groupId%3Aopenai%26version%3Av1.0). The version may instead be supplied via the standalone `version` query param.
+	// Query URL-encoded search DSL. `query=latest:true` lists only the latest version of each family; `query=groupId:<id>` lists that family's versions; adding `&version:<ver>` returns the single full template for that version. Terms are `&`-separated `key:value` pairs and the whole value is percent-encoded (e.g. groupId%3Aopenai%26version%3Av2.0).
 	Query *string `form:"query,omitempty" json:"query,omitempty" yaml:"query,omitempty"`
-
-	// Version Selects a single version within the family named by `query=groupId:<id>`, returning the full template for that (groupId, version). Alternative to packing `&version:<ver>` inside the `query` value; ignored when `query` has no groupId.
-	Version *string `form:"version,omitempty" json:"version,omitempty" yaml:"version,omitempty"`
 
 	// Limit Maximum number of LLM provider templates to return
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty" yaml:"limit,omitempty"`
 
 	// Offset Number of LLM provider templates to skip
 	Offset *int `form:"offset,omitempty" json:"offset,omitempty" yaml:"offset,omitempty"`
-
-	// Latest Which versions to include. By default (false) the response contains
-	// every version row across all templates (full history). Set to true
-	// to return only the latest version of each family (one entry per
-	// built-in/custom bucket), for the catalog listing. May also be passed
-	// inside the query DSL as `query=latest:true`.
-	Latest *bool `form:"latest,omitempty" json:"latest,omitempty" yaml:"latest,omitempty"`
 }
 
 // CopyLLMProviderTemplateVersionParams defines parameters for CopyLLMProviderTemplateVersion.

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/ProviderTemplateOverview.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/ProviderTemplateOverview.tsx
@@ -383,7 +383,9 @@ export default function ProviderTemplateOverview() {
 
   const handleSaveChanges = async () => {
     if (!template?.id || isSaving) return;
-    if (!endpointUrl.trim()) {
+    // DP-origin (gateway-created) templates carry no endpoint URL — the gateway
+    // owns the connection — so it is optional for them; only CP templates require it.
+    if (!template.readOnly && !endpointUrl.trim()) {
       showSnackbar('Endpoint URL is required.', 'error');
       return;
     }
@@ -1024,12 +1026,13 @@ export default function ProviderTemplateOverview() {
             </TabPanel>
 
             <TabPanel value={tabIndex} index={1}>
-              {isDpOrigin && !isReadOnly && (
-                <GatewayArtifactReadOnlyBanner message="Connection settings are managed by the gateway that created this template and are read-only here." />
-              )}
+              {/* Connection settings (endpoint URL, auth) are authoring/display
+                  metadata that the gateway never reads at runtime, so they stay
+                  editable even on a gateway-created (DP-origin) template. Only
+                  built-in templates lock this section. */}
               <Box
                 sx={
-                  isSectionReadOnly
+                  isReadOnly
                     ? { pointerEvents: 'none', opacity: 0.7 }
                     : undefined
                 }
@@ -1037,10 +1040,10 @@ export default function ProviderTemplateOverview() {
                 <Grid container spacing={2}>
                 <Grid size={{ xs: 12 }}>
                   <FormControl fullWidth>
-                    <FormLabel required>Endpoint URL</FormLabel>
+                    <FormLabel required={!isDpOrigin}>Endpoint URL</FormLabel>
                     <TextField
                       fullWidth
-                      required
+                      required={!isDpOrigin}
                       value={endpointUrl}
                       onChange={(e) => {
                         setEndpointUrl(e.target.value);
@@ -1049,9 +1052,9 @@ export default function ProviderTemplateOverview() {
                       }}
                       onBlur={() => setEndpointUrlTouched(true)}
                       placeholder="https://api.openai.com"
-                      error={endpointUrlTouched && (!endpointUrl.trim() || !isValidHttpUrl(endpointUrl))}
+                      error={endpointUrlTouched && ((!isDpOrigin && !endpointUrl.trim()) || !isValidHttpUrl(endpointUrl))}
                       helperText={
-                        endpointUrlTouched && !endpointUrl.trim()
+                        endpointUrlTouched && !isDpOrigin && !endpointUrl.trim()
                           ? 'Endpoint URL is required.'
                           : endpointUrlTouched && !isValidHttpUrl(endpointUrl)
                             ? 'Enter a valid URL.'
@@ -1164,7 +1167,7 @@ export default function ProviderTemplateOverview() {
                   disabled={
                     !isDirty ||
                     isSaving ||
-                    !endpointUrl.trim() ||
+                    (!isDpOrigin && !endpointUrl.trim()) ||
                     !isValidHttpUrl(endpointUrl) ||
                     !isValidHttpUrl(openapiSpecUrl) ||
                     !isValidHttpUrl(logoUrlField)


### PR DESCRIPTION
This pull request updates both backend API parameters and frontend validation logic to clarify and refine how LLM provider templates handle endpoint URLs, especially distinguishing between gateway-created (DP-origin) and custom (CP) templates. The changes ensure that endpoint URLs are only required for custom templates and remain optional for gateway-created templates, aligning both the API and UI with this logic.

**Frontend: Provider Template Form Behavior**

* The endpoint URL field is now only required for custom (CP) templates; for gateway-created (DP-origin) templates, it is optional and remains editable, reflecting that the gateway manages the connection for these templates. [[1]](diffhunk://#diff-561a9b30a4245a1eaf506696e02a22947ada15b65af82bdcc7db9748eba518f4L386-R388) [[2]](diffhunk://#diff-561a9b30a4245a1eaf506696e02a22947ada15b65af82bdcc7db9748eba518f4L1027-R1046)
* Validation and error messaging for the endpoint URL field now only trigger for custom templates, ensuring users of gateway-created templates aren't blocked by unnecessary requirements. [[1]](diffhunk://#diff-561a9b30a4245a1eaf506696e02a22947ada15b65af82bdcc7db9748eba518f4L1052-R1057) [[2]](diffhunk://#diff-561a9b30a4245a1eaf506696e02a22947ada15b65af82bdcc7db9748eba518f4L1167-R1170)

**Backend: API Parameter Simplification**

* The `ListLLMProviderTemplatesParams` struct removes the separate `version` and `latest` parameters, consolidating all filtering into the `query` parameter. The documentation for `query` is updated to clarify usage, including how to request only the latest version of each family or filter by group and version.