### PR TITLE
fix(it): add xDS readiness waits to prevent 500 race in 4 IT scenarios

### DIFF
--- a/gateway/it/features/analytics-basic.feature
+++ b/gateway/it/features/analytics-basic.feature
@@ -52,6 +52,7 @@ Feature: Analytics - Basic Event Capture
           - method: POST
             path: /data
       """
+    And I wait for policy snapshot sync
     When I send a POST request to "http://localhost:8080/metadata-test/v2/data" with body:
       """
       {"test": "data"}
@@ -82,6 +83,7 @@ Feature: Analytics - Basic Event Capture
           - method: GET
             path: /ping
       """
+    And I wait for policy snapshot sync
     When I send a GET request to "http://localhost:8080/multi-test/v1/ping"
     And I send a GET request to "http://localhost:8080/multi-test/v1/ping"
     And I send a GET request to "http://localhost:8080/multi-test/v1/ping"

--- a/gateway/it/features/api-management.feature
+++ b/gateway/it/features/api-management.feature
@@ -315,6 +315,7 @@ Feature: API Management Handler Operations
     Then the response should be successful
     And the response should be valid JSON
     # Verify it's accessible at /api/v2.0
+    And I wait for the endpoint "http://localhost:8080/api/v2.0/data" to be ready
     When I send a GET request to "http://localhost:8080/api/v2.0/data"
     Then the response should be successful
     # Verify the list endpoint returns the resolved context (not the $version placeholder)

--- a/gateway/it/features/sandbox-routing.feature
+++ b/gateway/it/features/sandbox-routing.feature
@@ -409,6 +409,7 @@ Feature: Sandbox Routing
             path: /whoami
       """
     Then the response should be successful
+    And I wait for policy snapshot sync
     And I record the current time as "request_start"
     When I clear all headers
     And I set request host to "sandbox-sandbox-timeout.local"


### PR DESCRIPTION
## Purpose

Four gateway integration test scenarios were failing intermittently (and consistently under CI load) with HTTP 500 responses from the gateway router. The root cause is a race between test execution and xDS propagation: when no policy chain exists yet for a route, the policy engine returns an immediate 500 (`extproc.go:156-177`). The gateway controller propagates xDS updates asynchronously via an event-hub with a 200 ms poll interval, so the fixed 1-second sleep in `deployAPI()` is not a reliable barrier — particularly in CI where machines are under load.

Failing scenarios:
- `api-management.feature` — "Create API with context containing version placeholder" (got 500, expected 2xx)
- `analytics-basic.feature` — "Analytics event contains API metadata" (got 500, expected 200)
- `analytics-basic.feature` — "Multiple requests generate multiple analytics events" (got 500, expected 200)
- `sandbox-routing.feature` — "Sandbox ref should honor upstreamDefinitions connect timeout" (got 500, expected 503)

## Approach

- **`api-management.feature`**: add `I wait for the endpoint … to be ready` before the routing assertion for the `$version` context scenario — polls end-to-end until 200, then verifies snapshot sync.
- **`analytics-basic.feature` scenarios 2 & 3**: add `I wait for policy snapshot sync` before the POST/GET requests — snapshot sync is used (rather than endpoint polling) to avoid generating extra analytics events that would skew event-count assertions.
- **`sandbox-routing.feature` timeout scenario**: add `I wait for policy snapshot sync` after deployment and before `I record the current time` — the upstream endpoint intentionally times out and returns 503, so endpoint-ready polling (which waits for 200) would itself time out.

## Related Issues

N/A

## Automation tests

- Integration tests: fixes four failing BDD scenarios in `gateway/it/features/`

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (test-only change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Documentation

N/A — test-only change, no user-facing behaviour modified.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)