### PR TITLE
Fix AI Workspace pages reading stale gateway `vhost` field

### DIFF
--- a/portals/ai-workspace/src/apis/gatewayTypes.ts
+++ b/portals/ai-workspace/src/apis/gatewayTypes.ts
@@ -20,7 +20,9 @@ export interface Gateway {
   name: string;
   displayName: string;
   description?: string;
-  vhost: string;
+  endpoints?: string[];
+  /** @deprecated Use `endpoints` instead. Kept for gateways created before the `endpoints` field existed. */
+  vhost?: string;
   isCritical: boolean;
   functionalityType: string;
   isActive: boolean;

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/ExternalServersOverview.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/ExternalServersOverview.tsx
@@ -353,7 +353,7 @@ export default function ExternalServersOverview(): JSX.Element {
   );
 
   const generatedInvokeUrl = useMemo(() => {
-    const vhost = selectedGateway?.vhost?.trim();
+    const vhost = (selectedGateway?.endpoints?.[0] || selectedGateway?.vhost)?.trim();
     if (!vhost) return '';
 
     const normalizedBase = /^https?:\/\//i.test(vhost)
@@ -366,7 +366,7 @@ export default function ExternalServersOverview(): JSX.Element {
         : `/${context}`
       : '/';
     return `${normalizedBase}${normalizedContext}`;
-  }, [server?.context, selectedGateway?.vhost]);
+  }, [server?.context, selectedGateway?.endpoints, selectedGateway?.vhost]);
 
   const handleCopyInvokeUrl = async () => {
     if (!generatedInvokeUrl) return;

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyDeploymentsCard.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyDeploymentsCard.tsx
@@ -211,7 +211,7 @@ export default function LLMProxyDeploymentsCard() {
     [deployedGateways, selectedGatewayId]
   );
   const generatedInvokeUrl = useMemo(() => {
-    const vhost = selectedGateway?.vhost?.trim();
+    const vhost = (selectedGateway?.endpoints?.[0] || selectedGateway?.vhost)?.trim();
     if (!vhost) return '';
 
     const normalizedBase = /^https?:\/\//i.test(vhost)
@@ -224,7 +224,7 @@ export default function LLMProxyDeploymentsCard() {
         : `/${context}`
       : '/';
     return `${normalizedBase}${normalizedContext}`;
-  }, [proxy?.context, selectedGateway?.vhost]);
+  }, [proxy?.context, selectedGateway?.endpoints, selectedGateway?.vhost]);
 
   const handleCopyInvokeUrl = async () => {
     if (!generatedInvokeUrl) return;

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyOverviewTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyOverviewTab.tsx
@@ -141,7 +141,7 @@ export default function LLMProxyOverviewTab() {
   );
 
   const generatedGatewayUrl = useMemo(() => {
-    const vhost = selectedGateway?.vhost?.trim();
+    const vhost = (selectedGateway?.endpoints?.[0] || selectedGateway?.vhost)?.trim();
     if (!vhost) return '';
 
     const normalizedBase = /^https?:\/\//i.test(vhost)
@@ -154,7 +154,7 @@ export default function LLMProxyOverviewTab() {
         : `/${context}`
       : '/';
     return `${normalizedBase}${normalizedContext}`;
-  }, [proxy?.context, selectedGateway?.vhost]);
+  }, [proxy?.context, selectedGateway?.endpoints, selectedGateway?.vhost]);
 
   const swaggerSpecWithGatewayServer = useMemo<OpenApiSpec>(() => {
     if (!parsedOpenApiSpec) return {};

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ProviderMap/ProviderMapTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ProviderMap/ProviderMapTab.tsx
@@ -366,9 +366,11 @@ export function GatewayCard({ gateway, deployment }: GatewayCardProps) {
             <Box sx={{ mt: 0.75 }}>
               <StatusChip deployed={isDeployed} />
             </Box>
-            {(gateway.functionalityType || gateway.vhost) && (
+            {(gateway.functionalityType ||
+              gateway.endpoints?.[0] ||
+              gateway.vhost) && (
               <Stack spacing={0.5} mt={1}>
-                {gateway.vhost && (
+                {(gateway.endpoints?.[0] || gateway.vhost) && (
                   <Stack direction="row" spacing={0.75} alignItems="center">
                     <Network
                       size={13}
@@ -378,9 +380,9 @@ export function GatewayCard({ gateway, deployment }: GatewayCardProps) {
                       variant="caption"
                       color="text.secondary"
                       noWrap
-                      title={gateway.vhost}
+                      title={gateway.endpoints?.[0] || gateway.vhost}
                     >
-                      {gateway.vhost}
+                      {gateway.endpoints?.[0] || gateway.vhost}
                     </Typography>
                   </Stack>
                 )}

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderDeploymentsCard.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderDeploymentsCard.tsx
@@ -632,7 +632,7 @@ export default function ServiceProviderDeploymentsCard({
                           {gateway.displayName || gateway.name}
                         </Typography>
                         <Typography variant="body2" color="text.secondary">
-                          {gateway.vhost}
+                          {gateway.endpoints?.[0] || gateway.vhost}
                         </Typography>
                         <Chip
                           label={gateway.isActive ? 'Active' : 'Inactive'}

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverview.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverview.tsx
@@ -281,7 +281,7 @@ function ServiceProviderOverviewContent() {
     [gateways, selectedGatewayId]
   );
   const generatedInvokeUrl = useMemo(() => {
-    const vhost = selectedGateway?.vhost?.trim();
+    const vhost = (selectedGateway?.endpoints?.[0] || selectedGateway?.vhost)?.trim();
     if (!vhost) return '';
 
     const normalizedBase = /^https?:\/\//i.test(vhost)
@@ -294,7 +294,7 @@ function ServiceProviderOverviewContent() {
         : `/${context}`
       : '/';
     return `${normalizedBase}${normalizedContext}`;
-  }, [provider?.context, selectedGateway?.vhost]);
+  }, [provider?.context, selectedGateway?.endpoints, selectedGateway?.vhost]);
   const selectedProjectForProxy = useMemo(
     () =>
       projectsForCurrentOrganization.find(

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverviewTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverviewTab.tsx
@@ -178,7 +178,7 @@ export default function ServiceProviderOverviewTab({
     [gateways, selectedGatewayId]
   );
   const generatedGatewayUrl = useMemo(() => {
-    const vhost = selectedGateway?.vhost?.trim();
+    const vhost = (selectedGateway?.endpoints?.[0] || selectedGateway?.vhost)?.trim();
     if (!vhost) return '';
 
     const normalizedBase = /^https?:\/\//i.test(vhost)
@@ -191,7 +191,7 @@ export default function ServiceProviderOverviewTab({
         : `/${context}`
       : '/';
     return `${normalizedBase}${normalizedContext}`;
-  }, [provider?.context, selectedGateway?.vhost]);
+  }, [provider?.context, selectedGateway?.endpoints, selectedGateway?.vhost]);
   const swaggerSpecWithGatewayServer = useMemo<OpenApiSpec>(() => {
     const baseSpec = filteredOpenApiSpec ?? parsedOpenApiSpec;
     if (!baseSpec) return {};


### PR DESCRIPTION
## Purpose
> Fix AI Workspace pages reading stale gateway `vhost` field

The gateway API migrated `vhost` (string) to `endpoints` (string[]), but the Service Provider, External Servers, and LLM Proxy pages use a separate, unmigrated Gateway API client and still read `.vhost`, which the backend no longer returns. Add `endpoints` to the stale `Gateway` type and fall back to `endpoints?.[0] || vhost` in the affected components, matching the pattern already used by the Gateways list/view pages.


**Before (Broken):**
<img width="1770" height="962" alt="image" src="https://github.com/user-attachments/assets/ae118376-44e5-4f4d-8ef2-caadcb6af61a" />


**After:**
<img width="940" height="531" alt="Screenshot 2026-07-02 at 8 00 12 PM" src="https://github.com/user-attachments/assets/26e771f2-dde0-4729-95aa-2e8884504395" />

