### PR TITLE
Persist secret encryption key in demo mode

### DIFF
--- a/platform-api/src/config/config.go
+++ b/platform-api/src/config/config.go
@@ -21,9 +21,11 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"sync"
@@ -205,6 +207,12 @@ type Database struct {
 	EncryptionKey                  string `koanf:"encryption_key"`
 	SubscriptionTokenEncryptionKey string `koanf:"subscription_token_encryption_key"`
 	SecretEncryptionKey            string `koanf:"secret_encryption_key"`
+	// SecretEncryptionKeyFile is the path to a 32-byte binary key file used for secret encryption.
+	// Honoured in both demo and non-demo mode when neither SecretEncryptionKey nor
+	// EncryptionKey is set. In demo mode the file is auto-generated on first startup and
+	// reused on subsequent restarts; in non-demo mode the file must already exist (a missing
+	// or unreadable file is fatal). Matches the gateway controller key-management pattern.
+	SecretEncryptionKeyFile string `koanf:"secret_encryption_key_file"`
 }
 
 // DefaultDevPortal holds default DevPortal configuration for new organizations.
@@ -361,27 +369,54 @@ func LoadConfig(configPath string) (*Server, error) {
 			slog.String("AUTH_JWT_SECRET_KEY", key))
 	}
 
+	// Resolve the secret key file path: explicit config → default alongside the DB file.
+	if cfg.Database.SecretEncryptionKeyFile == "" && cfg.Database.Path != "" {
+		cfg.Database.SecretEncryptionKeyFile = filepath.Join(filepath.Dir(cfg.Database.Path), "secret-encryption.key")
+	}
+
 	// SecretEncryptionKey is optional when the shared DATABASE_ENCRYPTION_KEY is configured;
-	// server.go resolves the final key via: SecretEncryptionKey → EncryptionKey → JWT secret.
-	// Only fail (or warn in demo mode) when no key source is available at all.
+	// server.go resolves the final key via: SecretEncryptionKey → EncryptionKey.
+	// Only fail (or auto-generate in demo mode) when no key source is available at all.
+	if cfg.Database.SecretEncryptionKey == "" && cfg.Database.EncryptionKey == "" {
+		// Try the key file first — valid in both demo and non-demo mode.
+		if cfg.Database.SecretEncryptionKeyFile != "" {
+			hexKey, err := loadOrGenerateSecretKeyFile(cfg.Database.SecretEncryptionKeyFile)
+			if err == nil {
+				cfg.Database.SecretEncryptionKey = hexKey
+			} else {
+				// Key file is inaccessible or unwritable.
+				// In non-demo mode this is fatal; in demo mode fall through to ephemeral.
+				demoMode := strings.ToLower(strings.TrimSpace(os.Getenv("APIP_DEMO_MODE")))
+				if demoMode == "false" || demoMode == "0" {
+					return nil, fmt.Errorf("failed to load secret key file: %w", err)
+				}
+				slog.Warn("APIP_DEMO_MODE: could not initialise secret key file, falling back to ephemeral key",
+					slog.String("path", cfg.Database.SecretEncryptionKeyFile), slog.Any("err", err))
+			}
+		}
+	}
+
 	if cfg.Database.SecretEncryptionKey == "" && cfg.Database.EncryptionKey == "" {
 		// APIP_DEMO_MODE defaults to enabled when unset; only an explicit
 		// "false"/"0" opts out and requires a configured encryption key.
 		demoMode := strings.ToLower(strings.TrimSpace(os.Getenv("APIP_DEMO_MODE")))
 		if demoMode == "false" || demoMode == "0" {
 			return nil, fmt.Errorf("no encryption key configured for secrets management. " +
-				"Set PLATFORM_SECRET_ENCRYPTION_KEY (secret-specific) or DATABASE_ENCRYPTION_KEY (shared). " +
+				"Set PLATFORM_SECRET_ENCRYPTION_KEY (secret-specific), DATABASE_ENCRYPTION_KEY (shared), " +
+				"or DATABASE_SECRET_ENCRYPTION_KEY_FILE (key file). " +
 				"Generate one with: openssl rand -hex 32. " +
 				"To allow an ephemeral key in a single-node dev environment, set APIP_DEMO_MODE=true")
 		}
+
+		// Demo mode with no usable key file — fall back to an ephemeral key.
+		// Secrets will not survive restarts.
 		key, err := generateRandomSecret()
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate secret encryption key: %w", err)
 		}
 		cfg.Database.SecretEncryptionKey = key
-		slog.Warn("APIP_DEMO_MODE: no encryption key configured for secrets — using an ephemeral random key. " +
-			"Encrypted secrets will be unreadable after restart and WILL NOT be shared across replicas. " +
-			"Set PLATFORM_SECRET_ENCRYPTION_KEY or DATABASE_ENCRYPTION_KEY for any persistent or multi-replica deployment.")
+		slog.Warn("APIP_DEMO_MODE: using an ephemeral random key — encrypted secrets will be unreadable after restart. " +
+			"Set DATABASE_SECRET_ENCRYPTION_KEY_FILE, PLATFORM_SECRET_ENCRYPTION_KEY, or DATABASE_ENCRYPTION_KEY.")
 	}
 
 	return cfg, nil
@@ -405,6 +440,80 @@ func demoMode() bool {
 	return v == "true" || v == "1"
 }
 
+const secretKeySize = 32 // AES-256
+
+// loadOrGenerateSecretKeyFile loads a 32-byte binary key file from filePath, creating it
+// (and any missing parent directories) on first run. This mirrors the gateway controller's
+// KeyManager pattern: raw binary key file, 0600 permissions, validate size on load.
+// Returns the key as a 64-char hex string for use with DeriveEncryptionKey.
+//
+// Concurrent first-time callers are safe: generateSecretKeyFile uses O_CREATE|O_EXCL so
+// only one writer succeeds; others see os.ErrExist and fall through to loadSecretKeyFile.
+func loadOrGenerateSecretKeyFile(filePath string) (string, error) {
+	err := generateSecretKeyFile(filePath)
+	switch {
+	case err == nil:
+		slog.Info("APIP_DEMO_MODE: generated and persisted secret encryption key — encrypted secrets will survive restarts",
+			slog.String("path", filePath),
+			slog.String("hint", "Set PLATFORM_SECRET_ENCRYPTION_KEY or DATABASE_ENCRYPTION_KEY for production or multi-replica deployments"))
+	case errors.Is(err, os.ErrExist):
+		// Another initializer already created the file — load the winner's key.
+	default:
+		return "", err
+	}
+	return loadSecretKeyFile(filePath)
+}
+
+// generateSecretKeyFile creates parent directories and writes 32 cryptographically
+// random bytes to filePath with permissions 0600. Uses O_CREATE|O_EXCL so concurrent
+// first-time callers are safe: only one writer succeeds, others get os.ErrExist.
+// Mirrors gateway-controller's generateKeyFile.
+func generateSecretKeyFile(filePath string) error {
+	if err := os.MkdirAll(filepath.Dir(filePath), 0700); err != nil {
+		return fmt.Errorf("failed to create key directory: %w", err)
+	}
+	key := make([]byte, secretKeySize)
+	if _, err := rand.Read(key); err != nil {
+		return fmt.Errorf("failed to generate random key: %w", err)
+	}
+	f, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		// Propagate os.ErrExist so the caller can distinguish "already created" from other errors.
+		return err
+	}
+	_, err = f.Write(key)
+	if closeErr := f.Close(); closeErr != nil && err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		os.Remove(filePath) // best-effort cleanup of a partial write
+		return fmt.Errorf("failed to write key file %s: %w", filePath, err)
+	}
+	return nil
+}
+
+// loadSecretKeyFile reads the key file, validates its size, warns if world-readable,
+// and returns the key as a 64-char hex string.
+func loadSecretKeyFile(filePath string) (string, error) {
+	info, err := os.Stat(filePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to stat secret key file %s: %w", filePath, err)
+	}
+	if info.Mode().Perm()&0004 != 0 {
+		slog.Warn("Secret encryption key file is world-readable — consider restricting permissions to 0600",
+			slog.String("path", filePath),
+			slog.String("permissions", info.Mode().Perm().String()))
+	}
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read secret key file %s: %w", filePath, err)
+	}
+	if len(data) != secretKeySize {
+		return "", fmt.Errorf("secret key file %s has wrong size: expected %d bytes, got %d", filePath, secretKeySize, len(data))
+	}
+	slog.Info("APIP_DEMO_MODE: loaded persisted secret encryption key", slog.String("path", filePath))
+	return hex.EncodeToString(data), nil
+}
 
 // envToKoanfKey maps a lowercased environment variable name to its koanf dot-notation key.
 // Returns "" for unknown variables, which causes koanf to skip them.
@@ -457,6 +566,8 @@ func envToKoanfKey(s string) string {
 		return "database.subscription_token_encryption_key"
 	case "platform_secret_encryption_key":
 		return "database.secret_encryption_key"
+	case "database_secret_encryption_key_file":
+		return "database.secret_encryption_key_file"
 
 	// Auth
 	case "auth_skip_paths":

--- a/platform-api/src/config/config.go
+++ b/platform-api/src/config/config.go
@@ -378,20 +378,25 @@ func LoadConfig(configPath string) (*Server, error) {
 	// server.go resolves the final key via: SecretEncryptionKey → EncryptionKey.
 	// Only fail (or auto-generate in demo mode) when no key source is available at all.
 	if cfg.Database.SecretEncryptionKey == "" && cfg.Database.EncryptionKey == "" {
-		// Try the key file first — valid in both demo and non-demo mode.
 		if cfg.Database.SecretEncryptionKeyFile != "" {
-			hexKey, err := loadOrGenerateSecretKeyFile(cfg.Database.SecretEncryptionKeyFile)
-			if err == nil {
-				cfg.Database.SecretEncryptionKey = hexKey
+			demoMode := strings.ToLower(strings.TrimSpace(os.Getenv("APIP_DEMO_MODE")))
+			isDemoMode := demoMode != "false" && demoMode != "0"
+			if isDemoMode {
+				// Demo mode: auto-generate the key file on first start, reload on subsequent starts.
+				hexKey, err := loadOrGenerateSecretKeyFile(cfg.Database.SecretEncryptionKeyFile)
+				if err == nil {
+					cfg.Database.SecretEncryptionKey = hexKey
+				} else {
+					slog.Warn("APIP_DEMO_MODE: could not initialise secret key file, falling back to ephemeral key",
+						slog.String("path", cfg.Database.SecretEncryptionKeyFile), slog.Any("err", err))
+				}
 			} else {
-				// Key file is inaccessible or unwritable.
-				// In non-demo mode this is fatal; in demo mode fall through to ephemeral.
-				demoMode := strings.ToLower(strings.TrimSpace(os.Getenv("APIP_DEMO_MODE")))
-				if demoMode == "false" || demoMode == "0" {
+				// Non-demo mode: the key file must already exist — never auto-generate.
+				hexKey, err := loadSecretKeyFile(cfg.Database.SecretEncryptionKeyFile)
+				if err != nil {
 					return nil, fmt.Errorf("failed to load secret key file: %w", err)
 				}
-				slog.Warn("APIP_DEMO_MODE: could not initialise secret key file, falling back to ephemeral key",
-					slog.String("path", cfg.Database.SecretEncryptionKeyFile), slog.Any("err", err))
+				cfg.Database.SecretEncryptionKey = hexKey
 			}
 		}
 	}

--- a/platform-api/src/config/config_test.go
+++ b/platform-api/src/config/config_test.go
@@ -20,6 +20,7 @@ package config
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -33,6 +34,8 @@ func TestLoadConfig_MissingSecretEncryptionKey_DemoMode_GeneratesEphemeralKey(t 
 	t.Setenv("PLATFORM_SECRET_ENCRYPTION_KEY", "")
 	// Ensure the koanf env-var alias doesn't accidentally provide a value.
 	t.Setenv("APIP_DATABASE_SECRET_ENCRYPTION_KEY", "")
+	t.Setenv("DATABASE_ENCRYPTION_KEY", "")
+	t.Setenv("AUTH_JWT_SECRET_KEY", "")
 
 	cfg, err := LoadConfig("")
 	require.NoError(t, err, "LoadConfig must succeed in DEMO_MODE even without a secret encryption key")
@@ -41,18 +44,23 @@ func TestLoadConfig_MissingSecretEncryptionKey_DemoMode_GeneratesEphemeralKey(t 
 }
 
 // TC-35 (negative): Missing key WITHOUT demo mode → fatal error returned.
+// JWT auth is disabled so the JWT-key check doesn't fire before the encryption-key check.
 func TestLoadConfig_MissingSecretEncryptionKey_NonDemoMode_ReturnsError(t *testing.T) {
 	t.Setenv("APIP_DEMO_MODE", "false")
 	t.Setenv("PLATFORM_SECRET_ENCRYPTION_KEY", "")
 	t.Setenv("APIP_DATABASE_SECRET_ENCRYPTION_KEY", "")
 	t.Setenv("DATABASE_ENCRYPTION_KEY", "")
-	// Provide a JWT secret so LoadConfig passes JWT validation and reaches the
-	// encryption-key check this test is asserting on.
-	t.Setenv("AUTH_JWT_SECRET_KEY", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+	t.Setenv("AUTH_JWT_SECRET_KEY", "")
+	t.Setenv("AUTH_JWT_ENABLED", "false")
+	// Use a blocking file as parent so the key file path resolves but can't be
+	// created, ensuring LoadConfig reaches the missing-key error path.
+	blockingFile := filepath.Join(t.TempDir(), "not-a-dir")
+	require.NoError(t, os.WriteFile(blockingFile, []byte("block"), 0600))
+	t.Setenv("DATABASE_SECRET_ENCRYPTION_KEY_FILE", filepath.Join(blockingFile, "secret-encryption.key"))
 
 	_, err := LoadConfig("")
 	assert.Error(t, err, "LoadConfig must return an error when no encryption key is configured and DEMO_MODE is off")
-	assert.Contains(t, err.Error(), "no encryption key configured for secrets management")
+	assert.Contains(t, err.Error(), "failed to load secret key file")
 }
 
 // Missing key with APIP_DEMO_MODE unset → demo mode is the default, so an
@@ -62,6 +70,7 @@ func TestLoadConfig_MissingSecretEncryptionKey_UnsetDemoMode_DefaultsToDemo(t *t
 	t.Setenv("PLATFORM_SECRET_ENCRYPTION_KEY", "")
 	t.Setenv("APIP_DATABASE_SECRET_ENCRYPTION_KEY", "")
 	t.Setenv("DATABASE_ENCRYPTION_KEY", "")
+	t.Setenv("AUTH_JWT_SECRET_KEY", "")
 
 	cfg, err := LoadConfig("")
 	require.NoError(t, err, "LoadConfig must succeed when APIP_DEMO_MODE is unset (demo is the default)")
@@ -70,10 +79,19 @@ func TestLoadConfig_MissingSecretEncryptionKey_UnsetDemoMode_DefaultsToDemo(t *t
 }
 
 // TC-35: Ephemeral key must be unique each LoadConfig call (i.e. truly random, not a constant).
-func TestLoadConfig_EphemeralKey_IsRandomPerCall(t *testing.T) {
+// Without an explicit key file path (e.g. postgres with no DATABASE_SECRET_ENCRYPTION_KEY_FILE and no DB path),
+// no persistence is possible and the key is still ephemeral — each LoadConfig call produces a different value.
+func TestLoadConfig_EphemeralKey_IsRandomPerCall_NoDatabasePath(t *testing.T) {
+	// Use a temp file as the "parent directory" — os.MkdirAll can't create a
+	// directory where a file already exists, so persistence always fails.
+	blockingFile := filepath.Join(t.TempDir(), "not-a-dir")
+	require.NoError(t, os.WriteFile(blockingFile, []byte("block"), 0600))
+	t.Setenv("DATABASE_SECRET_ENCRYPTION_KEY_FILE", filepath.Join(blockingFile, "secret-encryption.key"))
 	t.Setenv("APIP_DEMO_MODE", "true")
 	t.Setenv("PLATFORM_SECRET_ENCRYPTION_KEY", "")
 	t.Setenv("APIP_DATABASE_SECRET_ENCRYPTION_KEY", "")
+	t.Setenv("DATABASE_ENCRYPTION_KEY", "")
+	t.Setenv("AUTH_JWT_SECRET_KEY", "")
 
 	cfg1, err := LoadConfig("")
 	require.NoError(t, err)
@@ -81,7 +99,36 @@ func TestLoadConfig_EphemeralKey_IsRandomPerCall(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.NotEqual(t, cfg1.Database.SecretEncryptionKey, cfg2.Database.SecretEncryptionKey,
-		"ephemeral keys must differ between independent LoadConfig calls")
+		"without a database path, ephemeral keys must differ between independent LoadConfig calls")
+}
+
+// With a key file path configured, the first LoadConfig generates and persists a 32-byte
+// binary key file; subsequent calls load the same key — secrets survive restarts.
+func TestLoadConfig_DemoMode_PersistsAndReloadsKey(t *testing.T) {
+	dir := t.TempDir()
+	keyFile := filepath.Join(dir, "secret-encryption.key")
+
+	t.Setenv("APIP_DEMO_MODE", "true")
+	t.Setenv("PLATFORM_SECRET_ENCRYPTION_KEY", "")
+	t.Setenv("APIP_DATABASE_SECRET_ENCRYPTION_KEY", "")
+	t.Setenv("DATABASE_ENCRYPTION_KEY", "")
+	t.Setenv("AUTH_JWT_SECRET_KEY", "")
+	t.Setenv("DATABASE_SECRET_ENCRYPTION_KEY_FILE", keyFile)
+
+	cfg1, err := LoadConfig("")
+	require.NoError(t, err)
+	require.NotEmpty(t, cfg1.Database.SecretEncryptionKey)
+
+	// Key file must be a 32-byte binary file.
+	data, readErr := os.ReadFile(keyFile)
+	require.NoError(t, readErr, "key file must exist after first LoadConfig")
+	assert.Len(t, data, 32, "key file must contain exactly 32 bytes")
+
+	// Second call must load the same key.
+	cfg2, err := LoadConfig("")
+	require.NoError(t, err)
+	assert.Equal(t, cfg1.Database.SecretEncryptionKey, cfg2.Database.SecretEncryptionKey,
+		"second LoadConfig must reuse the persisted key so secrets remain readable after restart")
 }
 
 // TestLoadConfig_ExplicitSecretEncryptionKey verifies the normal path where the
@@ -90,8 +137,7 @@ func TestLoadConfig_ExplicitSecretEncryptionKey_UsedAsIs(t *testing.T) {
 	const stableKey = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 	t.Setenv("PLATFORM_SECRET_ENCRYPTION_KEY", stableKey)
 	t.Setenv("APIP_DEMO_MODE", "false")
-	// Non-demo mode requires an explicit JWT secret; set one so LoadConfig succeeds.
-	t.Setenv("AUTH_JWT_SECRET_KEY", stableKey)
+	t.Setenv("AUTH_JWT_ENABLED", "false")
 
 	cfg, err := LoadConfig("")
 	require.NoError(t, err)


### PR DESCRIPTION
## Purpose
This PR persist the secret encryption key in demo mode to avoid regenerating a new key at every platform api restart.