### PR TITLE
Refactor ServiceProvider components to use 'displayName' instead of 'name'

### DIFF
--- a/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/ProviderTemplatesList.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/ProviderTemplatesList.tsx
@@ -242,7 +242,7 @@ export default function ProviderTemplatesList({
             <Stack direction="row" spacing={0.5} alignItems="center">
               <Clock size={14} />
               <Typography variant="body2" color="text.secondary">
-                {formatRelativeTime(template.createdAt ?? template.updatedAt)}
+                {formatRelativeTime(template.updatedAt ?? template.createdAt)}
               </Typography>
             </Stack>
             {template.enabled === false ? (

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderModelsTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderModelsTab.tsx
@@ -312,7 +312,7 @@ export default function ServiceProviderModelsTab() {
     const alreadyExists = existingModels.some(
       (model) =>
         model.id.toLowerCase() === normalizedModelName ||
-        model.displayName.toLowerCase() === normalizedModelName
+        (model.displayName ?? '').toLowerCase() === normalizedModelName
     );
 
     if (alreadyExists) {

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderModelsTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderModelsTab.tsx
@@ -281,10 +281,10 @@ export default function ServiceProviderModelsTab() {
       ...baseProviders,
       {
         id: selectedOption.id,
-        name: selectedOption.name,
+        displayName: selectedOption.name,
         models: modelsForProvider.map((modelId) => ({
           id: modelId,
-          name: modelId,
+          displayName: modelId,
           description: '',
         })),
       },
@@ -312,7 +312,7 @@ export default function ServiceProviderModelsTab() {
     const alreadyExists = existingModels.some(
       (model) =>
         model.id.toLowerCase() === normalizedModelName ||
-        model.name.toLowerCase() === normalizedModelName
+        model.displayName.toLowerCase() === normalizedModelName
     );
 
     if (alreadyExists) {
@@ -331,7 +331,7 @@ export default function ServiceProviderModelsTab() {
               ...existingModels,
               {
                 id: trimmedName,
-                name: trimmedName,
+                displayName: trimmedName,
                 description: '',
               },
             ],
@@ -422,7 +422,7 @@ export default function ServiceProviderModelsTab() {
                     {providers.map((p) => (
                       <ProviderRow
                         key={p.id}
-                        name={p.name}
+                        name={p.displayName || p.id}
                         selected={p.id === selectedProviderId}
                         onClick={() => setSelectedProviderId(p.id)}
                         removeDisabled={isSaving || isReadOnlyProvider}
@@ -433,7 +433,7 @@ export default function ServiceProviderModelsTab() {
                               }
                             : undefined
                         }
-                        removeAriaLabel={`Remove model provider ${p.name}`}
+                        removeAriaLabel={`Remove model provider ${p.displayName}`}
                       />
                     ))}
                   </Stack>
@@ -528,7 +528,9 @@ export default function ServiceProviderModelsTab() {
                     id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderModelsTab.models.available"
                     defaultMessage={'Models Available'}
                   />
-                  {selectedProvider?.name ? ` — ${selectedProvider.name}` : ''}
+                  {selectedProvider?.displayName
+                    ? ` — ${selectedProvider.displayName}`
+                    : ''}
                 </Typography>
               </Box>
 
@@ -574,14 +576,14 @@ export default function ServiceProviderModelsTab() {
                     selectedProvider.models.map((m) => (
                       <ModelPill
                         key={m.id}
-                        label={m.name}
+                        label={m.displayName || m.id}
                         removeDisabled={isSaving || isReadOnlyProvider}
                         onRemove={() => {
                           if (!isReadOnlyProvider) {
                             void removeModel(m.id);
                           }
                         }}
-                        removeAriaLabel={`Remove model ${m.name}`}
+                        removeAriaLabel={`Remove model ${m.displayName || m.id}`}
                       />
                     ))
                   ) : (

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverview.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverview.tsx
@@ -1150,7 +1150,7 @@ function ServiceProviderOverviewContent() {
                                   variant="body2"
                                   color="primary.main"
                                 >
-                                  {model.name || model.id}
+                                  {model.displayName || model.id}
                                 </Typography>
                               </Box>
                             ))}

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverview.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverview.tsx
@@ -793,7 +793,8 @@ function ServiceProviderOverviewContent() {
     descriptionText.length > 200
       ? `${descriptionText.slice(0, 200).trim()}…`
       : descriptionText;
-  const lastUpdated = provider.createdAt ?? provider.lastUpdated;
+  const lastUpdated =
+    provider.updatedAt ?? provider.lastUpdated ?? provider.createdAt;
   const modelProviders = provider.modelProviders ?? [];
   const providerModels = modelProviders.flatMap((modelProvider) =>
     (modelProvider.models ?? []).map((model) => ({

--- a/portals/ai-workspace/src/utils/tmpSPRequest.ts
+++ b/portals/ai-workspace/src/utils/tmpSPRequest.ts
@@ -78,12 +78,12 @@ function buildModelProvidersFromTemplate(templateId?: string): ModelProvider[] {
   return [
     {
       id: normalizedTemplateId,
-      name:
+      displayName:
         TEMPLATE_PROVIDER_NAME_BY_ID[normalizedTemplateId] ??
         normalizedTemplateId,
       models: modelIds.map((modelId) => ({
         id: modelId,
-        name: modelId,
+        displayName: modelId,
       })),
     },
   ];

--- a/portals/ai-workspace/src/utils/types.ts
+++ b/portals/ai-workspace/src/utils/types.ts
@@ -175,7 +175,7 @@ export type LLMProviderType =
  */
 export interface LLMModel {
   id: string;
-  name: string;
+  displayName: string;
   description?: string;
 }
 
@@ -184,7 +184,7 @@ export interface LLMModel {
  */
 export interface ModelProvider {
   id: string;
-  name: string;
+  displayName: string;
   models: LLMModel[];
 }
 


### PR DESCRIPTION
## Purpose
Refactor ServiceProvider components to use 'displayName' instead of 'name'. this will fix the loading issue of the models.

## UI changes
<img width="1440" height="731" alt="image" src="https://github.com/user-attachments/assets/f1bbb461-9d6b-460d-af70-e8a4c4303f91" />

