### PR TITLE
Bump developer-portal version to 1.0.0-alpha-SNAPSHOT

### DIFF
--- a/portals/developer-portal/VERSION
+++ b/portals/developer-portal/VERSION
@@ -1,1 +1,1 @@
-0.3.0-SNAPSHOT
+1.0.0-alpha-SNAPSHOT

--- a/portals/developer-portal/distribution/docker-compose.yaml
+++ b/portals/developer-portal/distribution/docker-compose.yaml
@@ -102,7 +102,7 @@ services:
   #     - devportal-network
 
   devportal:
-    image: ghcr.io/wso2/api-platform/developer-portal:0.3.0-SNAPSHOT
+    image: ghcr.io/wso2/api-platform/developer-portal:1.0.0-alpha-SNAPSHOT
     depends_on:
       platform-api:
         condition: service_healthy

--- a/portals/developer-portal/docker-compose.yaml
+++ b/portals/developer-portal/docker-compose.yaml
@@ -83,7 +83,7 @@ services:
 
   devportal:
     build: .
-    image: ghcr.io/wso2/api-platform/developer-portal:0.3.0-SNAPSHOT
+    image: ghcr.io/wso2/api-platform/developer-portal:1.0.0-alpha-SNAPSHOT
     depends_on:
       platform-api:
         condition: service_healthy

--- a/portals/developer-portal/package-lock.json
+++ b/portals/developer-portal/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "devportal-webapp",
-  "version": "0.3.0-SNAPSHOT",
+  "version": "1.0.0-alpha-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "devportal-webapp",
-      "version": "0.3.0-SNAPSHOT",
+      "version": "1.0.0-alpha-SNAPSHOT",
       "license": "ISC",
       "dependencies": {
         "applicationinsights": "2.9.7",

--- a/portals/developer-portal/package.json
+++ b/portals/developer-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devportal-webapp",
-  "version": "0.3.0-SNAPSHOT",
+  "version": "1.0.0-alpha-SNAPSHOT",
   "description": "devportal-webapp",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Purposs
Prepares for the 1.0.0-alpha release via devportal-release.yml.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes