### PR TITLE
Bug fixes in DP to CP flow

### DIFF
--- a/gateway/gateway-controller/pkg/api/handlers/handlers.go
+++ b/gateway/gateway-controller/pkg/api/handlers/handlers.go
@@ -31,7 +31,6 @@ import (
 	"log/slog"
 	"net/http"
 
-	"gopkg.in/yaml.v3"
 	"github.com/wso2/api-platform/common/authenticators"
 	"github.com/wso2/api-platform/common/eventhub"
 	commonmodels "github.com/wso2/api-platform/common/models"
@@ -41,6 +40,7 @@ import (
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/api/middleware"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/apikeyxds"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/config"
+	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/constants"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/controlplane"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/lazyresourcexds"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/models"
@@ -51,6 +51,7 @@ import (
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/utils"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/xds"
 	"github.com/wso2/go-httpkit/httputil"
+	"gopkg.in/yaml.v3"
 )
 
 // APIServer implements the generated ServerInterface
@@ -361,16 +362,18 @@ func (s *APIServer) pushArtifactUndeploy(cfg *models.StoredConfig, log *slog.Log
 }
 
 // waitForDeploymentAndPush waits for API deployment to complete and pushes it to the control plane
-// This is only called for APIs created directly via gateway endpoint (not from platform API)
-func (s *APIServer) waitForDeploymentAndPush(configID string, correlationID string, log *slog.Logger) {
+// This is only called for APIs created directly via gateway endpoint (not from platform API).
+//
+// minDeployedAt is the DeployedAt of the deployment this push was triggered for.
+func (s *APIServer) waitForDeploymentAndPush(configID string, correlationID string, minDeployedAt *time.Time, log *slog.Logger) {
 	// Create a logger with correlation ID if provided
 	if correlationID != "" {
 		log = log.With(slog.String("correlation_id", correlationID))
 	}
 
 	// Poll for deployment status with timeout
-	timeout := time.NewTimer(30 * time.Second)       // 30 second timeout
-	ticker := time.NewTicker(500 * time.Millisecond) // Check every 500ms
+	timeout := time.NewTimer(constants.CPPushDeploymentTimeout)
+	ticker := time.NewTicker(constants.CPPushPollInterval)
 	defer timeout.Stop()
 	defer ticker.Stop()
 
@@ -389,24 +392,28 @@ func (s *APIServer) waitForDeploymentAndPush(configID string, correlationID stri
 				continue
 			}
 
-			if cfg.DeployedAt != nil {
-				log.Info("API deployed successfully, pushing to control plane",
-					slog.String("config_id", configID),
-					slog.String("displayName", cfg.DisplayName))
-
-				apiID := configID
-				deploymentID := cfg.DeploymentID
-
-				if err := s.controlPlaneClient.PushArtifact(apiID, cfg, deploymentID); err != nil {
-					log.Error("Failed to push deployment to control plane",
-						slog.String("api_id", apiID),
-						slog.Any("error", err))
-				} else {
-					log.Info("Successfully pushed deployment to control plane",
-						slog.String("api_id", apiID))
-				}
-				return
+			// Not deployed yet, or the store still holds a snapshot older than the
+			// deployment we were triggered for — keep waiting.
+			if cfg.DeployedAt == nil || (minDeployedAt != nil && cfg.DeployedAt.Before(*minDeployedAt)) {
+				continue
 			}
+
+			log.Info("API deployed successfully, pushing to control plane",
+				slog.String("config_id", configID),
+				slog.String("displayName", cfg.DisplayName))
+
+			apiID := configID
+			deploymentID := cfg.DeploymentID
+
+			if err := s.controlPlaneClient.PushArtifact(apiID, cfg, deploymentID); err != nil {
+				log.Error("Failed to push deployment to control plane",
+					slog.String("api_id", apiID),
+					slog.Any("error", err))
+			} else {
+				log.Info("Successfully pushed deployment to control plane",
+					slog.String("api_id", apiID))
+			}
+			return
 		}
 	}
 }

--- a/gateway/gateway-controller/pkg/api/handlers/handlers_test.go
+++ b/gateway/gateway-controller/pkg/api/handlers/handlers_test.go
@@ -2562,14 +2562,17 @@ func TestPopulatePropsForSystemPolicies(t *testing.T) {
 	// Props should remain empty as no action is taken
 }
 
-// TestWaitForDeploymentAndNotifyTimeout tests the timeout scenario
+// TestWaitForDeploymentAndPush_PushesWhenDeploymentCompletes verifies the waiter pushes and
+// returns promptly once the artifact's deployment completes in the store (DeployedAt set),
+// rather than blocking until constants.CPPushDeploymentTimeout.
 // Note: This test involves deliberate concurrent access patterns that trigger
-// race detector warnings but represent valid production behavior with proper locking
-func TestWaitForDeploymentAndNotifyTimeout(t *testing.T) {
+// race detector warnings but represent valid production behavior with proper locking.
+func TestWaitForDeploymentAndPush_PushesWhenDeploymentCompletes(t *testing.T) {
 	server := createTestAPIServer()
-	server.controlPlaneClient = &MockControlPlaneClient{connected: true}
+	mockCP := &MockControlPlaneClient{connected: true}
+	server.controlPlaneClient = mockCP
 
-	// Add config that starts pending and will be updated to deployed
+	// Config present but not yet deployed (DeployedAt nil).
 	cfg := createTestStoredConfig("0000-test-id-0000-000000000000", "0000-test-api-0000-000000000000", "v1.0.0", "/test")
 	cfg.DesiredState = models.StateDeployed
 	_ = server.store.Add(cfg)
@@ -2586,22 +2589,29 @@ func TestWaitForDeploymentAndNotifyTimeout(t *testing.T) {
 		}()
 
 		logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-		server.waitForDeploymentAndPush("0000-test-id-0000-000000000000", "test-correlation", logger)
+		server.waitForDeploymentAndPush("0000-test-id-0000-000000000000", "test-correlation", nil, logger)
 	}()
+
+	// The waiter must not push while the artifact is still undeployed.
+	time.Sleep(1 * time.Second)
+	require.Equal(t, 0, mockCP.PushCount(), "must not push before deployment completes")
+
+	// Deployment completes: publish a fresh snapshot with DeployedAt set (a new object,
+	// not a mutation of the stored pointer, to avoid racing the waiter's reads). The
+	// next poll should push and the waiter should return.
+	deployed := createTestStoredConfig("0000-test-id-0000-000000000000", "0000-test-api-0000-000000000000", "v1.0.0", "/test")
+	deployed.DesiredState = models.StateDeployed
+	now := time.Now()
+	deployed.DeployedAt = &now
+	require.NoError(t, server.store.Update(deployed))
 
 	select {
 	case err := <-done:
 		require.NoError(t, err)
-
-	case <-time.After(2 * time.Second):
-		// Trigger graceful exit by updating status to deployed
-		server.handleStatusUpdate("0000-test-id-0000-000000000000", true, "")
-		require.NoError(t, <-done)
-
-		retrievedCfg, err := server.store.Get("0000-test-id-0000-000000000000")
-		require.NoError(t, err)
-		assert.Equal(t, models.StateDeployed, retrievedCfg.DesiredState)
+	case <-time.After(5 * time.Second):
+		t.Fatal("waitForDeploymentAndPush did not return after deployment completed")
 	}
+	require.Equal(t, 1, mockCP.PushCount())
 }
 
 func TestWaitForDeploymentAndPush_RetriesUntilConfigAppears(t *testing.T) {
@@ -2612,7 +2622,7 @@ func TestWaitForDeploymentAndPush_RetriesUntilConfigAppears(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-		server.waitForDeploymentAndPush("0000-delayed-id-0000-000000000000", "test-correlation", logger)
+		server.waitForDeploymentAndPush("0000-delayed-id-0000-000000000000", "test-correlation", nil, logger)
 		close(done)
 	}()
 
@@ -2630,6 +2640,54 @@ func TestWaitForDeploymentAndPush_RetriesUntilConfigAppears(t *testing.T) {
 		t.Fatal("waitForDeploymentAndPush did not complete after config appeared")
 	}
 
+	require.Equal(t, 1, mockCP.PushCount())
+}
+
+// TestWaitForDeploymentAndPush_WaitsForFreshDeploymentWatermark verifies that on an
+// update the push does not send the stale (pre-update) store snapshot: it waits until
+// the store's DeployedAt has advanced to the deployment it was triggered for. Without
+// this, the DP->CP push races the async (SQL-eventhub) store refresh and pushes the old
+// spec + old watermark, which the control plane drops as not-newer.
+func TestWaitForDeploymentAndPush_WaitsForFreshDeploymentWatermark(t *testing.T) {
+	server := createTestAPIServer()
+	mockCP := &MockControlPlaneClient{connected: true}
+	server.controlPlaneClient = mockCP
+
+	// The store still holds the pre-update snapshot, deployed at t1.
+	cfg := createTestStoredConfig("0000-stale-id-0000-000000000000", "stale-api", "v1.0.0", "/stale")
+	t1 := time.Now()
+	cfg.DeployedAt = &t1
+	require.NoError(t, server.store.Add(cfg))
+
+	// This push was triggered for a newer deployment at t2 > t1.
+	t2 := t1.Add(2 * time.Second)
+
+	done := make(chan struct{})
+	go func() {
+		logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+		server.waitForDeploymentAndPush("0000-stale-id-0000-000000000000", "test-correlation", &t2, logger)
+		close(done)
+	}()
+
+	// While the store lags at t1, the stale snapshot must NOT be pushed.
+	time.Sleep(1200 * time.Millisecond)
+	require.Equal(t, 0, mockCP.PushCount(), "must not push the pre-update snapshot")
+	select {
+	case <-done:
+		t.Fatal("waitForDeploymentAndPush returned before the store caught up")
+	default:
+	}
+
+	// The EventListener refreshes the store to the t2 deployment.
+	fresh := createTestStoredConfig("0000-stale-id-0000-000000000000", "stale-api", "v1.0.0", "/stale")
+	fresh.DeployedAt = &t2
+	require.NoError(t, server.store.Update(fresh))
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("waitForDeploymentAndPush did not push after the store reached the deployment watermark")
+	}
 	require.Equal(t, 1, mockCP.PushCount())
 }
 

--- a/gateway/gateway-controller/pkg/api/handlers/mcp_proxy_handler.go
+++ b/gateway/gateway-controller/pkg/api/handlers/mcp_proxy_handler.go
@@ -26,7 +26,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/wso2/go-httpkit/httputil"
 	api "github.com/wso2/api-platform/gateway/gateway-controller/pkg/api/management"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/api/middleware"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/models"
@@ -34,6 +33,7 @@ import (
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/utils"
 	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 	policyenginev1 "github.com/wso2/api-platform/sdk/core/policyengine"
+	"github.com/wso2/go-httpkit/httputil"
 )
 
 // convertAPIPolicy converts generated api.Policy to policyenginev1.PolicyInstance.
@@ -127,7 +127,7 @@ func (s *APIServer) CreateMCPProxy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if s.controlPlaneClient != nil && s.controlPlaneClient.IsConnected() && s.systemConfig.Controller.ControlPlane.DeploymentSyncEnabled {
-		go s.waitForDeploymentAndPush(cfg.UUID, correlationID, log)
+		go s.waitForDeploymentAndPush(cfg.UUID, correlationID, cfg.DeployedAt, log)
 	}
 }
 

--- a/gateway/gateway-controller/pkg/api/handlers/webbroker_api_handler.go
+++ b/gateway/gateway-controller/pkg/api/handlers/webbroker_api_handler.go
@@ -25,13 +25,13 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/wso2/go-httpkit/httputil"
 	"github.com/wso2/api-platform/common/eventhub"
 	api "github.com/wso2/api-platform/gateway/gateway-controller/pkg/api/management"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/api/middleware"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/models"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/storage"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/utils"
+	"github.com/wso2/go-httpkit/httputil"
 )
 
 // CreateWebBrokerApi handles POST /webbroker-apis
@@ -87,7 +87,7 @@ func (s *APIServer) CreateWebBrokerApi(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if s.controlPlaneClient != nil && s.controlPlaneClient.IsConnected() && s.systemConfig.Controller.ControlPlane.DeploymentSyncEnabled {
-		go s.waitForDeploymentAndPush(cfg.UUID, correlationID, log)
+		go s.waitForDeploymentAndPush(cfg.UUID, correlationID, cfg.DeployedAt, log)
 	}
 }
 

--- a/gateway/gateway-controller/pkg/api/handlers/websub_api_handler.go
+++ b/gateway/gateway-controller/pkg/api/handlers/websub_api_handler.go
@@ -27,13 +27,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/wso2/go-httpkit/httputil"
 	"github.com/wso2/api-platform/common/eventhub"
 	api "github.com/wso2/api-platform/gateway/gateway-controller/pkg/api/management"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/api/middleware"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/models"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/storage"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/utils"
+	"github.com/wso2/go-httpkit/httputil"
 )
 
 // CreateWebSubAPI implements ServerInterface.CreateWebSubAPI
@@ -90,7 +90,7 @@ func (s *APIServer) CreateWebSubAPI(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if s.controlPlaneClient != nil && s.controlPlaneClient.IsConnected() && s.systemConfig.Controller.ControlPlane.DeploymentSyncEnabled {
-		go s.waitForDeploymentAndPush(cfg.UUID, correlationID, log)
+		go s.waitForDeploymentAndPush(cfg.UUID, correlationID, cfg.DeployedAt, log)
 	}
 }
 

--- a/gateway/gateway-controller/pkg/constants/constants.go
+++ b/gateway/gateway-controller/pkg/constants/constants.go
@@ -18,7 +18,10 @@
 
 package constants
 
-import "regexp"
+import (
+	"regexp"
+	"time"
+)
 
 // SecretPlaceholderRe matches {{ secret "handle" }} placeholders embedded in YAML
 // or JSON content. The quotes may be JSON-escaped (\") so both forms are matched.
@@ -172,6 +175,16 @@ const (
 	// System policy constants
 	ANALYTICS_SYSTEM_POLICY_NAME    = "wso2_apip_sys_analytics"
 	ANALYTICS_SYSTEM_POLICY_VERSION = "v1"
+)
+
+// DP->CP artifact push timing. The bottom-up (DP->CP) push waits for the local deployment
+// to be reflected in the in-memory store before pushing to the control plane.
+const (
+	// CPPushDeploymentTimeout is the maximum time to wait for a gateway-originated artifact
+	// to finish deploying before abandoning the DP->CP push.
+	CPPushDeploymentTimeout = 60 * time.Second
+	// CPPushPollInterval is how often the in-memory store is re-checked while waiting.
+	CPPushPollInterval = 500 * time.Millisecond
 )
 
 var WILDCARD_HTTP_METHODS = []string{

--- a/gateway/gateway-controller/pkg/controlplane/api_deleted_test.go
+++ b/gateway/gateway-controller/pkg/controlplane/api_deleted_test.go
@@ -1005,6 +1005,36 @@ func TestClient_findAPIConfig(t *testing.T) {
 		}
 	})
 
+	t.Run("Falls back to cp_artifact_id for bottom-up synced artifact", func(t *testing.T) {
+		logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+		store := storage.NewConfigStore()
+		db := newMockStorageForDeletion()
+
+		// A gateway-originated (bottom-up / DP->CP synced) artifact keeps its
+		// locally-generated UUID and records the control-plane UUID as
+		// cp_artifact_id. The control plane refers to it by that CP UUID.
+		localUUID := "local-dp-uuid"
+		cpUUID := "019f2628-c926-7f0d-9822-c22c0563be73"
+		cfg := createTestAPIConfigForDeletion(localUUID)
+		cfg.CPArtifactID = cpUUID
+		db.SaveConfig(cfg)
+
+		client := &Client{
+			logger: logger,
+			store:  store,
+			db:     db,
+		}
+
+		// Looking up by the CP UUID must resolve to the local row, not miss.
+		got, err := client.findAPIConfig(cpUUID)
+		if err != nil {
+			t.Fatalf("expected cp_artifact_id fallback to resolve, got error: %v", err)
+		}
+		if got.UUID != localUUID {
+			t.Errorf("expected local UUID %s, got %s", localUUID, got.UUID)
+		}
+	})
+
 	t.Run("Returns database errors without falling back", func(t *testing.T) {
 		logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 		store := storage.NewConfigStore()

--- a/gateway/gateway-controller/pkg/controlplane/client.go
+++ b/gateway/gateway-controller/pkg/controlplane/client.go
@@ -1676,8 +1676,14 @@ func (c *Client) findAPIConfig(apiID string) (*models.StoredConfig, error) {
 // artifacts, but a bottom-up (DP->CP) synced artifact keeps its locally-generated
 // UUID and records the control-plane UUID as cp_artifact_id.
 func (c *Client) resolveLocalArtifactID(id string) string {
-	if existing, err := c.findAPIConfig(id); err == nil && existing != nil {
+	existing, err := c.findAPIConfig(id)
+	switch {
+	case err == nil && existing != nil:
 		return existing.UUID
+	case err != nil && !storage.IsNotFoundError(err):
+		c.logger.Error("Failed to resolve local artifact ID; falling back to control-plane UUID",
+			slog.String("artifact_id", id),
+			slog.Any("error", err))
 	}
 	return id
 }

--- a/gateway/gateway-controller/pkg/controlplane/client.go
+++ b/gateway/gateway-controller/pkg/controlplane/client.go
@@ -111,37 +111,37 @@ type secretSyncer interface {
 
 // Client manages the WebSocket connection to the control plane
 type Client struct {
-	config                      config.ControlPlaneConfig
-	logger                      *slog.Logger
-	state                       *ConnectionState
-	ctx                         context.Context
-	cancel                      context.CancelFunc
-	stopChan                    chan struct{}
-	wg                          sync.WaitGroup
-	writeMu                     sync.Mutex // serializes writes to the WebSocket connection
-	store                       *storage.ConfigStore
-	db                          storage.Storage
-	snapshotManager             *xds.SnapshotManager
-	parser                      *config.Parser
-	validator                   config.Validator
-	deploymentService           *utils.APIDeploymentService
-	apiUtilsService             *utils.APIUtilsService
-	apiKeyService               *utils.APIKeyService
-	llmDeploymentService        *utils.LLMDeploymentService
-	mcpDeploymentService        *utils.MCPDeploymentService
-	apiKeyXDSManager            utils.XDSManager
-	apiKeyStore                 *storage.APIKeyStore
-	routerConfig                *config.RouterConfig
-	policyManager               *policyxds.PolicyManager
-	systemConfig                *config.Config
-	policyDefinitions           map[string]models.PolicyDefinition
-	subscriptionSnapshotUpdater utils.SubscriptionSnapshotUpdater
-	subscriptionResourceService *utils.SubscriptionResourceService
-	eventHub                    eventhub.EventHub
-	gatewayID                   string
-	gatewayPath                 string      // cached gateway path from well-known discovery
-	syncOnce                    sync.Once   // ensures deployment sync runs only on first connect
-	isFirstConnect              atomic.Bool // true on first connect, flipped to false after
+	config                       config.ControlPlaneConfig
+	logger                       *slog.Logger
+	state                        *ConnectionState
+	ctx                          context.Context
+	cancel                       context.CancelFunc
+	stopChan                     chan struct{}
+	wg                           sync.WaitGroup
+	writeMu                      sync.Mutex // serializes writes to the WebSocket connection
+	store                        *storage.ConfigStore
+	db                           storage.Storage
+	snapshotManager              *xds.SnapshotManager
+	parser                       *config.Parser
+	validator                    config.Validator
+	deploymentService            *utils.APIDeploymentService
+	apiUtilsService              *utils.APIUtilsService
+	apiKeyService                *utils.APIKeyService
+	llmDeploymentService         *utils.LLMDeploymentService
+	mcpDeploymentService         *utils.MCPDeploymentService
+	apiKeyXDSManager             utils.XDSManager
+	apiKeyStore                  *storage.APIKeyStore
+	routerConfig                 *config.RouterConfig
+	policyManager                *policyxds.PolicyManager
+	systemConfig                 *config.Config
+	policyDefinitions            map[string]models.PolicyDefinition
+	subscriptionSnapshotUpdater  utils.SubscriptionSnapshotUpdater
+	subscriptionResourceService  *utils.SubscriptionResourceService
+	eventHub                     eventhub.EventHub
+	gatewayID                    string
+	gatewayPath                  string      // cached gateway path from well-known discovery
+	syncOnce                     sync.Once   // ensures deployment sync runs only on first connect
+	isFirstConnect               atomic.Bool // true on first connect, flipped to false after
 	webhookSecretStore           *webhooksecret.WebhookSecretStore
 	webhookSecretSnapshotManager *webhooksecretxds.SnapshotManager
 	secretSyncer                 secretSyncer
@@ -1402,8 +1402,11 @@ func (c *Client) fetchAndDeployAPI(apiID, deploymentID string, deployedAt *time.
 	// storage before rendering.
 	c.syncSecretRefsFromYAML(yamlData, correlationID)
 
-	// Create API configuration from YAML using the deployment service
-	result, err := c.apiUtilsService.CreateAPIFromYAML(yamlData, apiID, deploymentID, deployedAt, correlationID, c.deploymentService)
+	// Create API configuration from YAML using the deployment service. Reuse the
+	// existing local UUID for a bottom-up (DP->CP) synced API so the control-plane
+	// deploy is an in-place update; the fetch above still addresses the definition
+	// by the control-plane UUID (apiID).
+	result, err := c.apiUtilsService.CreateAPIFromYAML(yamlData, c.resolveLocalArtifactID(apiID), deploymentID, deployedAt, correlationID, c.deploymentService)
 	if err != nil {
 		c.logger.Error("Failed to create API from YAML",
 			slog.String("api_id", apiID),
@@ -1642,15 +1645,41 @@ func (c *Client) handleAPIUndeployedEvent(event map[string]interface{}) {
 }
 
 // findAPIConfig checks if an API exists in the database.
+//
+// The incoming apiID is a control-plane UUID. For control-plane-originated
+// artifacts it matches the local UUID directly. For bottom-up (DP->CP) synced
+// artifacts — Fall back to that CP UUID and the gateway UUID mapping so events
+// addressed by the control-plane UUID resolve to the local row. Mirrors
+// APIKeyService.getArtifactConfigByID.
 func (c *Client) findAPIConfig(apiID string) (*models.StoredConfig, error) {
 	config, err := c.db.GetConfig(apiID)
+	if err == nil {
+		return config, nil
+	}
+	if !storage.IsNotFoundError(err) {
+		return nil, fmt.Errorf("database error while fetching config: %w", err)
+	}
+	// Fallback: incoming UUID may be the control-plane UUID for a bottom-up
+	// synced artifact. Look it up by cp_artifact_id.
+	config, err = c.db.GetConfigByCPArtifactID(apiID)
 	if err == nil {
 		return config, nil
 	}
 	if storage.IsNotFoundError(err) {
 		return nil, storage.ErrNotFound
 	}
-	return nil, fmt.Errorf("database error while fetching config: %w", err)
+	return nil, fmt.Errorf("database error while fetching config by cp id: %w", err)
+}
+
+// resolveLocalArtifactID maps a control-plane artifact UUID to the local UUID the
+// gateway stores it under. They are identical for control-plane-originated
+// artifacts, but a bottom-up (DP->CP) synced artifact keeps its locally-generated
+// UUID and records the control-plane UUID as cp_artifact_id.
+func (c *Client) resolveLocalArtifactID(id string) string {
+	if existing, err := c.findAPIConfig(id); err == nil && existing != nil {
+		return existing.UUID
+	}
+	return id
 }
 
 // removePolicyConfiguration removes runtime config from the policy engine.
@@ -1967,12 +1996,16 @@ func (c *Client) handleLLMProxyDeployedEvent(event map[string]interface{}) {
 	// storage before rendering.
 	c.syncSecretRefsFromYAML(yamlData, deployedEvent.CorrelationID)
 
+	// Reuse the existing local UUID for a bottom-up (DP->CP) synced proxy so the
+	// control-plane deploy is an in-place update
+	deployProxyID := c.resolveLocalArtifactID(proxyID)
+
 	// Create LLM proxy configuration from YAML using the deployment service
 	llmProxyPerformedAt := deployedEvent.Payload.PerformedAt.Truncate(time.Millisecond)
 	if llmProxyPerformedAt.IsZero() {
 		llmProxyPerformedAt = time.Now().Truncate(time.Millisecond)
 	}
-	result, err := c.apiUtilsService.CreateLLMProxyFromYAML(yamlData, proxyID, deployedEvent.Payload.DeploymentID, &llmProxyPerformedAt, deployedEvent.CorrelationID, c.llmDeploymentService)
+	result, err := c.apiUtilsService.CreateLLMProxyFromYAML(yamlData, deployProxyID, deployedEvent.Payload.DeploymentID, &llmProxyPerformedAt, deployedEvent.CorrelationID, c.llmDeploymentService)
 	if err != nil {
 		c.logger.Error("Failed to create LLM proxy from YAML",
 			slog.String("proxy_id", proxyID),
@@ -2076,12 +2109,16 @@ func (c *Client) handleLLMProviderDeployedEvent(event map[string]interface{}) {
 	// sync are not yet cached, so we fetch them on demand here.
 	c.syncSecretRefsFromYAML(yamlData, deployedEvent.CorrelationID)
 
+	// Reuse the existing local UUID for a bottom-up (DP->CP) synced provider so
+	// the control-plane deploy is an in-place update
+	deployProviderID := c.resolveLocalArtifactID(providerID)
+
 	// Create LLM provider configuration from YAML using the deployment service
 	llmProviderPerformedAt := deployedEvent.Payload.PerformedAt.Truncate(time.Millisecond)
 	if llmProviderPerformedAt.IsZero() {
 		llmProviderPerformedAt = time.Now().Truncate(time.Millisecond)
 	}
-	result, err := c.apiUtilsService.CreateLLMProviderFromYAML(yamlData, providerID, deployedEvent.Payload.DeploymentID, &llmProviderPerformedAt, deployedEvent.CorrelationID, c.llmDeploymentService)
+	result, err := c.apiUtilsService.CreateLLMProviderFromYAML(yamlData, deployProviderID, deployedEvent.Payload.DeploymentID, &llmProviderPerformedAt, deployedEvent.CorrelationID, c.llmDeploymentService)
 	if err != nil {
 		c.logger.Error("Failed to create LLM provider from YAML",
 			slog.String("provider_id", providerID),
@@ -2670,7 +2707,9 @@ func (c *Client) handleWebSubAPIDeployedEvent(event map[string]any) {
 	if performedAt.IsZero() {
 		performedAt = time.Now().Truncate(time.Millisecond)
 	}
-	result, err := c.apiUtilsService.CreateAPIFromYAML(yamlData, apiID, deployedEvent.Payload.DeploymentID, &performedAt, deployedEvent.CorrelationID, c.deploymentService)
+	// Reuse the existing local UUID for a bottom-up (DP->CP) synced API so the
+	// control-plane deploy is an in-place update
+	result, err := c.apiUtilsService.CreateAPIFromYAML(yamlData, c.resolveLocalArtifactID(apiID), deployedEvent.Payload.DeploymentID, &performedAt, deployedEvent.CorrelationID, c.deploymentService)
 	if err != nil {
 		c.logger.Error("Failed to create WebSub API from YAML",
 			slog.String("api_id", apiID),
@@ -2926,7 +2965,9 @@ func (c *Client) handleWebBrokerAPIDeployedEvent(event map[string]any) {
 	if performedAt.IsZero() {
 		performedAt = time.Now().Truncate(time.Millisecond)
 	}
-	result, err := c.apiUtilsService.CreateAPIFromYAML(yamlData, apiID, deployedEvent.Payload.DeploymentID, &performedAt, deployedEvent.CorrelationID, c.deploymentService)
+	// Reuse the existing local UUID for a bottom-up (DP->CP) synced API so the
+	// control-plane deploy is an in-place update
+	result, err := c.apiUtilsService.CreateAPIFromYAML(yamlData, c.resolveLocalArtifactID(apiID), deployedEvent.Payload.DeploymentID, &performedAt, deployedEvent.CorrelationID, c.deploymentService)
 	if err != nil {
 		c.logger.Error("Failed to create WebBroker API from YAML",
 			slog.String("api_id", apiID),
@@ -3184,12 +3225,16 @@ func (c *Client) handleMCPProxyDeploymentEvent(event map[string]any) {
 	// storage before rendering.
 	c.syncSecretRefsFromYAML(yamlData, deployedEvent.CorrelationID)
 
+	// Reuse the existing local UUID for a bottom-up (DP->CP) synced proxy so the
+	// control-plane deploy is an in-place update
+	deployProxyID := c.resolveLocalArtifactID(proxyID)
+
 	// Create MCP proxy configuration from YAML using the deployment service
 	mcpPerformedAt := deployedEvent.Payload.PerformedAt.Truncate(time.Millisecond)
 	if mcpPerformedAt.IsZero() {
 		mcpPerformedAt = time.Now().Truncate(time.Millisecond)
 	}
-	result, err := c.apiUtilsService.CreateMCPProxyFromYAML(yamlData, proxyID, deployedEvent.Payload.DeploymentID, &mcpPerformedAt, deployedEvent.CorrelationID, c.mcpDeploymentService)
+	result, err := c.apiUtilsService.CreateMCPProxyFromYAML(yamlData, deployProxyID, deployedEvent.Payload.DeploymentID, &mcpPerformedAt, deployedEvent.CorrelationID, c.mcpDeploymentService)
 	if err != nil {
 		c.logger.Error("Failed to create MCP proxy from YAML",
 			slog.String("proxy_id", proxyID),

--- a/gateway/gateway-controller/pkg/service/restapi/service.go
+++ b/gateway/gateway-controller/pkg/service/restapi/service.go
@@ -32,6 +32,7 @@ import (
 	api "github.com/wso2/api-platform/gateway/gateway-controller/pkg/api/management"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/apikeyxds"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/config"
+	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/constants"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/controlplane"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/models"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/policyxds"
@@ -187,7 +188,7 @@ func (s *RestAPIService) Create(params CreateParams) (*CreateResult, error) {
 
 		// Push to control plane asynchronously if connected
 		if s.controlPlaneClient != nil && s.controlPlaneClient.IsConnected() && s.systemConfig.Controller.ControlPlane.DeploymentSyncEnabled {
-			go s.waitForDeploymentAndPush(result.StoredConfig.UUID, params.CorrelationID, log)
+			go s.waitForDeploymentAndPush(result.StoredConfig.UUID, params.CorrelationID, result.StoredConfig.DeployedAt, log)
 		}
 	}
 
@@ -328,15 +329,14 @@ func (s *RestAPIService) Update(params UpdateParams) (*UpdateResult, error) {
 
 	// Update stored configuration
 	now := time.Now()
+	truncatedNow := now.Truncate(time.Millisecond)
 	existing.DisplayName = renderedConfig.Spec.DisplayName
 	existing.Version = renderedConfig.Spec.Version
 	existing.DesiredState = desiredState
 	existing.UpdatedAt = now
+	existing.DeployedAt = &truncatedNow
 
 	if desiredState == models.StateUndeployed {
-		// Undeployment: update DeployedAt to mark when this state change happened
-		truncatedNow := now.Truncate(time.Millisecond)
-		existing.DeployedAt = &truncatedNow
 		log.Info("Undeploying API configuration",
 			slog.String("id", existing.UUID),
 			slog.String("handle", params.Handle))
@@ -367,7 +367,7 @@ func (s *RestAPIService) Update(params UpdateParams) (*UpdateResult, error) {
 	// Push to control plane asynchronously if connected
 	if existing.Origin == models.OriginGatewayAPI && s.controlPlaneClient != nil &&
 		s.controlPlaneClient.IsConnected() && s.systemConfig.Controller.ControlPlane.DeploymentSyncEnabled {
-		go s.waitForDeploymentAndPush(existing.UUID, params.CorrelationID, log)
+		go s.waitForDeploymentAndPush(existing.UUID, params.CorrelationID, existing.DeployedAt, log)
 	}
 
 	log.Info("API configuration updated",
@@ -481,13 +481,15 @@ func (s *RestAPIService) updatePolicyForConfig(cfg *models.StoredConfig, log *sl
 }
 
 // waitForDeploymentAndPush waits for API deployment to complete and pushes it to the control plane.
-func (s *RestAPIService) waitForDeploymentAndPush(configID string, correlationID string, log *slog.Logger) {
+//
+// minDeployedAt is the DeployedAt of the deployment this push was triggered for.
+func (s *RestAPIService) waitForDeploymentAndPush(configID string, correlationID string, minDeployedAt *time.Time, log *slog.Logger) {
 	if correlationID != "" {
 		log = log.With(slog.String("correlation_id", correlationID))
 	}
 
-	timeout := time.NewTimer(30 * time.Second)
-	ticker := time.NewTicker(500 * time.Millisecond)
+	timeout := time.NewTimer(constants.CPPushDeploymentTimeout)
+	ticker := time.NewTicker(constants.CPPushPollInterval)
 	defer timeout.Stop()
 	defer ticker.Stop()
 
@@ -506,24 +508,28 @@ func (s *RestAPIService) waitForDeploymentAndPush(configID string, correlationID
 				continue
 			}
 
-			if cfg.DeployedAt != nil {
-				log.Info("API deployed successfully, pushing to control plane",
-					slog.String("config_id", configID),
-					slog.String("displayName", cfg.DisplayName))
-
-				apiID := configID
-				deploymentID := cfg.DeploymentID
-
-				if err := s.controlPlaneClient.PushArtifact(apiID, cfg, deploymentID); err != nil {
-					log.Error("Failed to push deployment to control plane",
-						slog.String("api_id", apiID),
-						slog.Any("error", err))
-				} else {
-					log.Info("Successfully pushed deployment to control plane",
-						slog.String("api_id", apiID))
-				}
-				return
+			// Not deployed yet, or the store still holds a snapshot older than the
+			// deployment we were triggered for — keep waiting.
+			if cfg.DeployedAt == nil || (minDeployedAt != nil && cfg.DeployedAt.Before(*minDeployedAt)) {
+				continue
 			}
+
+			log.Info("API deployed successfully, pushing to control plane",
+				slog.String("config_id", configID),
+				slog.String("displayName", cfg.DisplayName))
+
+			apiID := configID
+			deploymentID := cfg.DeploymentID
+
+			if err := s.controlPlaneClient.PushArtifact(apiID, cfg, deploymentID); err != nil {
+				log.Error("Failed to push deployment to control plane",
+					slog.String("api_id", apiID),
+					slog.Any("error", err))
+			} else {
+				log.Info("Successfully pushed deployment to control plane",
+					slog.String("api_id", apiID))
+			}
+			return
 		}
 	}
 }

--- a/gateway/gateway-controller/pkg/utils/api_utils.go
+++ b/gateway/gateway-controller/pkg/utils/api_utils.go
@@ -1205,6 +1205,10 @@ func (s *APIUtilsService) buildImportArtifactRequest(artifact *models.StoredConf
 	if artifact.DeployedAt != nil {
 		utc := artifact.DeployedAt.UTC()
 		deployedAt = &utc
+	} else if artifact.Kind == models.KindLlmProviderTemplate {
+		// UpdatedAt is the template's effective deployment time
+		utc := artifact.UpdatedAt.UTC()
+		deployedAt = &utc
 	}
 	return ImportArtifactRequest{
 		DPID:          artifact.UUID,

--- a/gateway/gateway-controller/pkg/utils/api_utils_test.go
+++ b/gateway/gateway-controller/pkg/utils/api_utils_test.go
@@ -334,6 +334,33 @@ func TestAPIUtilsService_PushArtifact(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("Template push carries UpdatedAt as the deployedAt watermark", func(t *testing.T) {
+		// Templates have no deployment lifecycle so DeployedAt is nil; the push must
+		// still send a non-nil deployedAt (= UpdatedAt), otherwise the CP treats
+		// every template UPDATE as stale (IsNewerDeployment(nil, …) == false) and
+		// silently skips it.
+		var got ImportArtifactRequest
+		server := newHTTPTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			reqs := readPushedArtifacts(t, r)
+			require.Len(t, reqs, 1)
+			got = reqs[0]
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"total":1,"success":1,"failed":0,"artifacts":{"0000-test-api-0000-000000000000":{"id":"cp-tmpl-1","origin":"gateway_api","status":"deployed"}}}`))
+		}))
+		defer server.Close()
+
+		cfg := createTestStoredConfig(models.KindLlmProviderTemplate)
+		cfg.DeployedAt = nil // templates never set DeployedAt
+
+		svc := NewAPIUtilsService(PlatformAPIConfig{BaseURL: server.URL, Token: "test-token"}, logger)
+		_, err := svc.PushArtifact(cfg.UUID, cfg, "")
+		require.NoError(t, err)
+
+		require.NotNil(t, got.DeployedAt, "template push must carry a deployedAt watermark")
+		assert.True(t, got.DeployedAt.Equal(cfg.UpdatedAt.UTC()),
+			"template deployedAt should equal UpdatedAt; got %v want %v", got.DeployedAt, cfg.UpdatedAt.UTC())
+	})
+
 	t.Run("HTTP error response", func(t *testing.T) {
 		server := newHTTPTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusInternalServerError)

--- a/gateway/gateway-controller/pkg/utils/cp_push.go
+++ b/gateway/gateway-controller/pkg/utils/cp_push.go
@@ -22,6 +22,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/constants"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/models"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/storage"
 )
@@ -35,11 +36,6 @@ type ArtifactPusher interface {
 	IsConnected() bool
 	PushArtifact(artifactID string, artifact *models.StoredConfig, deploymentID string) error
 }
-
-const (
-	cpPushDeploymentTimeout = 30 * time.Second
-	cpPushPollInterval      = 500 * time.Millisecond
-)
 
 // cpSyncStatusForOrigin returns the initial cp_sync_status for a newly created/updated
 // artifact row in the gateway DB: "pending" for gateway-originated artifacts (those created
@@ -55,11 +51,11 @@ func cpSyncStatusForOrigin(origin models.Origin) models.CPSyncStatus {
 }
 
 // waitForDeploymentAndPush waits for the artifact identified by configID to finish deploying
-// (its DeployedAt is set in the store) and then pushes it to the control plane (DP->CP). It is
-// the gateway-create counterpart of the control plane's deployment callback and mirrors the
-// REST API push path; it is meant to be run in a goroutine. The caller is responsible for
-// gating on connectivity/push-enabled and gateway origin before invoking it.
-func waitForDeploymentAndPush(store *storage.ConfigStore, pusher ArtifactPusher, configID, correlationID string, log *slog.Logger) {
+// and then pushes it to the control plane (DP->CP). This is meant to be run in a goroutine.
+// The caller is responsible for gating on connectivity/push-enabled and gateway origin before invoking it.
+//
+// minDeployedAt is the DeployedAt of the deployment this push was triggered for.
+func waitForDeploymentAndPush(store *storage.ConfigStore, pusher ArtifactPusher, configID, correlationID string, minDeployedAt *time.Time, log *slog.Logger) {
 	if log == nil {
 		log = slog.Default()
 	}
@@ -67,8 +63,8 @@ func waitForDeploymentAndPush(store *storage.ConfigStore, pusher ArtifactPusher,
 		log = log.With(slog.String("correlation_id", correlationID))
 	}
 
-	timeout := time.NewTimer(cpPushDeploymentTimeout)
-	ticker := time.NewTicker(cpPushPollInterval)
+	timeout := time.NewTimer(constants.CPPushDeploymentTimeout)
+	ticker := time.NewTicker(constants.CPPushPollInterval)
 	defer timeout.Stop()
 	defer ticker.Stop()
 
@@ -87,21 +83,25 @@ func waitForDeploymentAndPush(store *storage.ConfigStore, pusher ArtifactPusher,
 				continue
 			}
 
-			if cfg.DeployedAt != nil {
-				log.Info("Artifact deployed successfully, pushing to control plane",
-					slog.String("config_id", configID),
-					slog.String("displayName", cfg.DisplayName))
-
-				if err := pusher.PushArtifact(configID, cfg, cfg.DeploymentID); err != nil {
-					log.Error("Failed to push deployment to control plane",
-						slog.String("artifact_id", configID),
-						slog.Any("error", err))
-				} else {
-					log.Info("Successfully pushed deployment to control plane",
-						slog.String("artifact_id", configID))
-				}
-				return
+			// Not deployed yet, or the store still holds a snapshot older than the
+			// deployment we were triggered for — keep waiting.
+			if cfg.DeployedAt == nil || (minDeployedAt != nil && cfg.DeployedAt.Before(*minDeployedAt)) {
+				continue
 			}
+
+			log.Info("Artifact deployed successfully, pushing to control plane",
+				slog.String("config_id", configID),
+				slog.String("displayName", cfg.DisplayName))
+
+			if err := pusher.PushArtifact(configID, cfg, cfg.DeploymentID); err != nil {
+				log.Error("Failed to push deployment to control plane",
+					slog.String("artifact_id", configID),
+					slog.Any("error", err))
+			} else {
+				log.Info("Successfully pushed deployment to control plane",
+					slog.String("artifact_id", configID))
+			}
+			return
 		}
 	}
 }

--- a/gateway/gateway-controller/pkg/utils/llm_deployment.go
+++ b/gateway/gateway-controller/pkg/utils/llm_deployment.go
@@ -1327,7 +1327,7 @@ func (s *LLMDeploymentService) pushDeployableArtifact(result *APIDeploymentResul
 		return
 	}
 	if result.StoredConfig.Origin == models.OriginGatewayAPI && s.canPushToControlPlane() {
-		go waitForDeploymentAndPush(s.store, s.controlPlaneClient, result.StoredConfig.UUID, correlationID, log)
+		go waitForDeploymentAndPush(s.store, s.controlPlaneClient, result.StoredConfig.UUID, correlationID, result.StoredConfig.DeployedAt, log)
 	}
 }
 

--- a/gateway/gateway-controller/pkg/utils/mcp_deployment.go
+++ b/gateway/gateway-controller/pkg/utils/mcp_deployment.go
@@ -536,7 +536,7 @@ func (s *MCPDeploymentService) pushDeployableArtifact(result *APIDeploymentResul
 		return
 	}
 	if result.StoredConfig.Origin == models.OriginGatewayAPI && s.canPushToControlPlane() {
-		go waitForDeploymentAndPush(s.store, s.controlPlaneClient, result.StoredConfig.UUID, correlationID, log)
+		go waitForDeploymentAndPush(s.store, s.controlPlaneClient, result.StoredConfig.UUID, correlationID, result.StoredConfig.DeployedAt, log)
 	}
 }
 


### PR DESCRIPTION
### CP→DP deploy of a bottom-up-synced artifact conflicted

- Root cause: The gateway keeps its own local UUID for a bottom-up-synced artifact and stores the CP's UUID as cp_artifact_id. The CP-deploy handlers passed the raw CP UUID into Create…FromYAML, which tried to insert a second row → validateArtifactConflicts fired on the same name/version/handle under a different UUID.
- Fix: Added a cp_artifact_id fallback to findAPIConfig (mirroring the existing getArtifactConfigByID pattern) and a shared resolveLocalArtifactID helper; every CP-deploy handler now resolves to the existing local UUID → in-place update instead of a conflicting insert.
- File: pkg/controlplane/client.go. Test: TestClient_findAPIConfig cp_artifact_id subtest.

### LLM provider template updates never reached the CP

- Root cause: The template push left DeployedAt nil, and buildImportArtifactRequest derived the request's deployedAt only from that → every template push sent deployedAt: null. The CP's IsNewerDeployment(nil, …) returns false → SkipWorkingCopy → the whole update block skipped. Create worked only because isNew short-circuits before that check.
- Fix: buildImportArtifactRequest now sends deployedAt = UpdatedAt for templates (their effective deploy watermark, which advances on each PUT).
- File: pkg/utils/api_utils.go. Test: TestAPIUtilsService_PushArtifact "Template push carries UpdatedAt…".

### Updates to DP-origin deployable artifacts never reached the CP

  a. Stale snapshot: waitForDeploymentAndPush read the artifact from the eventually-consistent in-memory store (refreshed by the 2–3s SQL-eventhub poll) but gated only on DeployedAt != nil — already true on an update from the create-time snapshot. So at its 500ms tick it pushed the pre-update config + old watermark, which the CP dropped as not-newer.
  b. REST-only: RestAPIService.UpdateAPI advanced DeployedAt only on undeploy, so the CP watermark never moved for REST updates.
- Fix: Added a minDeployedAt floor to all three waitForDeploymentAndPush copies (push only once the store's DeployedAt reaches the deployment we triggered), and made REST's UpdateAPI advance DeployedAt on every update (matching LLM provider/proxy/MCP).
- Files: pkg/utils/cp_push.go, pkg/api/handlers/handlers.go, pkg/service/restapi/service.go (+ callers). Test: TestWaitForDeploymentAndPush_WaitsForFreshDeploymentWatermark.

Moved the push timeout/poll to gateway-controller-wide constants — constants.CPPushDeploymentTimeout = 60s, constants.CPPushPollInterval = 500ms - used by all three helpers (this also raised the handlers/REST copies from 30s → 60s). Rewrote a timeout-bound test that was silently running the full timeout (30s → would've been 60s) into a fast (~1.5s) deploy-completion test.