### PR TITLE
Add unit and gateway integration tests for DP to CP flow

### DIFF
--- a/gateway/it/Makefile
+++ b/gateway/it/Makefile
@@ -16,7 +16,7 @@
 # under the License.
 # --------------------------------------------------------------------
 
-.PHONY: all test test-postgres test-sqlserver test-vhosts-single test-vhosts-multi test-all test-verbose clean deps check-docker coverage-report build-coverage ensure-test-tags
+.PHONY: all test test-postgres test-sqlserver test-vhosts-single test-vhosts-multi test-dp-to-cp-nosync test-all test-verbose clean deps check-docker coverage-report build-coverage ensure-test-tags
 
 VERSION ?= $(shell cat ../VERSION 2>/dev/null | tr -d '[:space:]' || echo "0.0.1-SNAPSHOT")
 DOCKER_REGISTRY ?= ghcr.io/wso2/api-platform
@@ -75,6 +75,14 @@ test-vhosts-single:
 # Run vhost integration tests with multi-domain gateway vhost config
 test-vhosts-multi:
 	COMPOSE_FILE=docker-compose.test.vhosts-multi.yaml IT_FEATURE_PATHS=features/vhost-routing-multi.feature $(MAKE) test
+
+# Run the DP->CP push tests with control-plane sync DISABLED. Layers a tiny override on the
+# base compose (deployment_sync_enabled=false via COMPOSE_FILE=base:override) and asserts
+# gateway-originated artifacts are NOT pushed. Not part of the default suite (which runs with
+# sync enabled). Verifies dp-to-cp-testing.md items 1-2.
+test-dp-to-cp-nosync:
+	COMPOSE_FILE=docker-compose.test.yaml:docker-compose.test.dp-nosync.override.yaml \
+	IT_FEATURE_PATHS=features/health.feature,features/dp-to-cp-sync-disabled.feature $(MAKE) test
 
 # Run tests with verbose output
 test-verbose: ensure-test-tags

--- a/gateway/it/docker-compose.test.dp-nosync.override.yaml
+++ b/gateway/it/docker-compose.test.dp-nosync.override.yaml
@@ -1,0 +1,30 @@
+# --------------------------------------------------------------------
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# --------------------------------------------------------------------
+
+# Override layered on top of docker-compose.test.yaml to run the gateway-controller
+# with control-plane sync DISABLED. The gateway still connects to the control plane
+# (mock-platform-api) over the WebSocket, but deployment_sync_enabled=false means it
+# must NOT push gateway-originated artifacts up. Used by the dp-to-cp-sync-disabled IT
+# (dp-to-cp-testing.md items 1-2). Combine the two files via COMPOSE_FILE, e.g.:
+#   COMPOSE_FILE=docker-compose.test.yaml:docker-compose.test.dp-nosync.override.yaml
+# (see the `test-dp-to-cp-nosync` Makefile target). Docker Compose merges each
+# service's environment by key, so this only adds the one flag.
+services:
+  gateway-controller:
+    environment:
+      - APIP_GW_CONTROLLER_CONTROLPLANE_DEPLOYMENT_SYNC_ENABLED=false

--- a/gateway/it/features/dp-to-cp-sync-disabled.feature
+++ b/gateway/it/features/dp-to-cp-sync-disabled.feature
@@ -88,6 +88,7 @@ Feature: DP -> CP push is suppressed when deployment sync is disabled
     And the control plane should not receive the "LlmProvider" artifact "nosync-prov"
     And the control plane should not receive the "LlmProxy" artifact "nosync-proxy"
     And the gateway should record cp_sync_status "pending" for the "LlmProvider" artifact "nosync-prov"
+    And the gateway should record cp_sync_status "pending" for the "LlmProxy" artifact "nosync-proxy"
 
   Scenario: An MCP proxy is not pushed when sync is disabled
     When I deploy this MCP configuration:

--- a/gateway/it/features/dp-to-cp-sync-disabled.feature
+++ b/gateway/it/features/dp-to-cp-sync-disabled.feature
@@ -1,0 +1,138 @@
+Feature: DP -> CP push is suppressed when deployment sync is disabled
+  # Covers dp-to-cp-testing.md items 1-2: with deployment_sync_enabled=false the gateway
+  # still connects to the control plane (mock-platform-api) over the WebSocket, but it must
+  # NOT push gateway-originated artifacts up — they stay local with cp_sync_status=pending.
+  #
+  # This feature runs ONLY under the sync-disabled compose overlay (the controller gets
+  # APIP_GW_CONTROLLER_CONTROLPLANE_DEPLOYMENT_SYNC_ENABLED=false). Run it with:
+  #   make test-dp-to-cp-nosync
+  # It is deliberately NOT in the default suite (which runs with sync enabled to verify the
+  # push happens — see dp-to-cp.feature).
+
+  Background:
+    Given I authenticate using basic auth as "admin"
+    And I reset the control plane recorder
+
+  Scenario: An LLM provider template is not pushed when sync is disabled
+    When I create this LLM provider template:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: LlmProviderTemplate
+      metadata:
+        name: nosync-tmpl
+      spec:
+        displayName: NoSync Template
+        requestModel:
+          location: payload
+          identifier: $.model
+        responseModel:
+          location: payload
+          identifier: $.model
+      """
+    Then the response should be successful
+    And the control plane should not receive the "LlmProviderTemplate" artifact "nosync-tmpl"
+    And the gateway should record cp_sync_status "pending" for the "LlmProviderTemplate" artifact "nosync-tmpl"
+
+  Scenario: An LLM provider and proxy are not pushed when sync is disabled
+    When I create this LLM provider template:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: LlmProviderTemplate
+      metadata:
+        name: nosync-chain-tmpl
+      spec:
+        displayName: NoSync Chain Template
+        requestModel:
+          location: payload
+          identifier: $.model
+        responseModel:
+          location: payload
+          identifier: $.model
+      """
+    Then the response should be successful
+    When I create this LLM provider:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: LlmProvider
+      metadata:
+        name: nosync-prov
+      spec:
+        displayName: NoSync Provider
+        version: v1.0
+        template: nosync-chain-tmpl
+        upstream:
+          url: https://mock-openapi-https:9443/openai/v1
+          auth:
+            type: api-key
+            header: Authorization
+            value: Bearer sk-test-key
+        accessControl:
+          mode: allow_all
+      """
+    Then the response should be successful
+    When I deploy this LLM proxy configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: LlmProxy
+      metadata:
+        name: nosync-proxy
+        annotations:
+          "gateway.api-platform.wso2.com/project-id": "dp2cp-project"
+      spec:
+        displayName: NoSync Proxy
+        version: v1.0
+        provider:
+          id: nosync-prov
+      """
+    Then the response should be successful
+    And the control plane should not receive the "LlmProvider" artifact "nosync-prov"
+    And the control plane should not receive the "LlmProxy" artifact "nosync-proxy"
+    And the gateway should record cp_sync_status "pending" for the "LlmProvider" artifact "nosync-prov"
+
+  Scenario: An MCP proxy is not pushed when sync is disabled
+    When I deploy this MCP configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: Mcp
+      metadata:
+        name: nosync-mcp-v1.0
+        annotations:
+          "gateway.api-platform.wso2.com/project-id": "dp2cp-project"
+      spec:
+        displayName: NoSync MCP
+        version: v1.0
+        context: /nosync-mcp
+        specVersion: "2025-06-18"
+        upstream:
+          url: http://mcp-server-backend:3001
+        tools: []
+        resources: []
+        prompts: []
+      """
+    Then the response should be successful
+    And the control plane should not receive the "Mcp" artifact "nosync-mcp-v1.0"
+    And the gateway should record cp_sync_status "pending" for the "Mcp" artifact "nosync-mcp-v1.0"
+
+  Scenario: A REST API is not pushed when sync is disabled
+    When I deploy this API configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: RestApi
+      metadata:
+        name: nosync-rest-v1.0
+        annotations:
+          "gateway.api-platform.wso2.com/project-id": "dp2cp-project"
+      spec:
+        displayName: NoSync REST
+        version: v1.0
+        context: /nosync-rest
+        upstream:
+          main:
+            url: http://sample-backend:9080/api/v2
+        operations:
+          - method: GET
+            path: /resource
+      """
+    Then the response should be successful
+    And the control plane should not receive the "RestApi" artifact "nosync-rest-v1.0"
+    And the gateway should record cp_sync_status "pending" for the "RestApi" artifact "nosync-rest-v1.0"

--- a/gateway/it/features/dp-to-cp.feature
+++ b/gateway/it/features/dp-to-cp.feature
@@ -1,0 +1,318 @@
+Feature: Data-plane to control-plane artifact push (DP -> CP)
+  # The gateway-controller pushes every gateway-originated artifact (LLM provider
+  # template / provider / proxy, MCP proxy, REST API) up to the control plane on
+  # create and update, tells the control plane to undeploy it on delete, and
+  # re-pushes any pending/failed artifacts on (re)connect. This is gated on
+  # deployment_sync_enabled (default true) and an active control-plane connection.
+  #
+  # These scenarios exercise the DATA-PLANE side of that flow. The control plane is
+  # stood in for by mock-platform-api, which records what the gateway pushed and
+  # mints a CP artifact UUID per artifact exactly like platform-api does; the
+  # gateway then records that UUID and the sync outcome on its own artifacts row
+  # (cp_sync_status / cp_artifact_id). We assert both the recorded push payload and
+  # the gateway's bookkeeping.
+  #
+  # Out of scope here (they need the real platform-api, not a recorder, and are
+  # covered by platform-api tests): control-plane working-copy conflict resolution,
+  # read-only / runtime-immutable enforcement of DP-origin artifacts in the AI
+  # Workspace, CP-side API-key generation, and multi-gateway deployments. The
+  # deployment_sync_enabled=false gating is covered by gateway-controller unit
+  # tests (pkg/controlplane/push_artifacts_test.go).
+
+  Background:
+    Given I authenticate using basic auth as "admin"
+    And I reset the control plane recorder
+
+  Scenario: An LLM provider template created on the gateway is pushed to the control plane
+    When I create this LLM provider template:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: LlmProviderTemplate
+      metadata:
+        name: dp2cp-tmpl-basic
+      spec:
+        displayName: DP2CP Basic Template
+        promptTokens:
+          location: payload
+          identifier: $.usage.prompt_tokens
+        completionTokens:
+          location: payload
+          identifier: $.usage.completion_tokens
+        totalTokens:
+          location: payload
+          identifier: $.usage.total_tokens
+        requestModel:
+          location: payload
+          identifier: $.model
+        responseModel:
+          location: payload
+          identifier: $.model
+      """
+    Then the response should be successful
+    And the control plane should receive the "LlmProviderTemplate" artifact "dp2cp-tmpl-basic"
+    And the control plane copy of the "LlmProviderTemplate" artifact "dp2cp-tmpl-basic" configuration should contain "DP2CP Basic Template"
+    And the control plane copy of the "LlmProviderTemplate" artifact "dp2cp-tmpl-basic" should carry a deployed timestamp
+    And the gateway should record cp_sync_status "success" for the "LlmProviderTemplate" artifact "dp2cp-tmpl-basic"
+    And the gateway should record a cp_artifact_id for the "LlmProviderTemplate" artifact "dp2cp-tmpl-basic"
+
+  Scenario: An LLM provider and proxy are pushed with their cross-references carried as handles
+    When I create this LLM provider template:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: LlmProviderTemplate
+      metadata:
+        name: dp2cp-tmpl-chain
+      spec:
+        displayName: DP2CP Chain Template
+        requestModel:
+          location: payload
+          identifier: $.model
+        responseModel:
+          location: payload
+          identifier: $.model
+      """
+    Then the response should be successful
+    When I create this LLM provider:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: LlmProvider
+      metadata:
+        name: dp2cp-prov-chain
+      spec:
+        displayName: DP2CP Chain Provider
+        version: v1.0
+        template: dp2cp-tmpl-chain
+        upstream:
+          url: https://mock-openapi-https:9443/openai/v1
+          auth:
+            type: api-key
+            header: Authorization
+            value: Bearer sk-test-key
+        accessControl:
+          mode: allow_all
+      """
+    Then the response should be successful
+    When I deploy this LLM proxy configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: LlmProxy
+      metadata:
+        name: dp2cp-proxy-chain
+        annotations:
+          "gateway.api-platform.wso2.com/project-id": "dp2cp-project"
+      spec:
+        displayName: DP2CP Chain Proxy
+        version: v1.0
+        provider:
+          id: dp2cp-prov-chain
+      """
+    Then the response should be successful
+    And the control plane should receive the "LlmProvider" artifact "dp2cp-prov-chain"
+    And the control plane copy of the "LlmProvider" artifact "dp2cp-prov-chain" should reference template "dp2cp-tmpl-chain"
+    And the gateway should record cp_sync_status "success" for the "LlmProvider" artifact "dp2cp-prov-chain"
+    And the gateway should record a cp_artifact_id for the "LlmProvider" artifact "dp2cp-prov-chain"
+    And the control plane should receive the "LlmProxy" artifact "dp2cp-proxy-chain"
+    And the control plane copy of the "LlmProxy" artifact "dp2cp-proxy-chain" should reference provider "dp2cp-prov-chain"
+    And the gateway should record cp_sync_status "success" for the "LlmProxy" artifact "dp2cp-proxy-chain"
+
+  Scenario: An MCP proxy created on the gateway is pushed to the control plane
+    When I deploy this MCP configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: Mcp
+      metadata:
+        name: dp2cp-mcp-v1.0
+        annotations:
+          "gateway.api-platform.wso2.com/project-id": "dp2cp-project"
+      spec:
+        displayName: DP2CP MCP
+        version: v1.0
+        context: /dp2cp-everything
+        specVersion: "2025-06-18"
+        upstream:
+          url: http://mcp-server-backend:3001
+        tools: []
+        resources: []
+        prompts: []
+      """
+    Then the response should be successful
+    And the control plane should receive the "Mcp" artifact "dp2cp-mcp-v1.0"
+    And the control plane copy of the "Mcp" artifact "dp2cp-mcp-v1.0" configuration should contain "/dp2cp-everything"
+    And the gateway should record cp_sync_status "success" for the "Mcp" artifact "dp2cp-mcp-v1.0"
+    And the gateway should record a cp_artifact_id for the "Mcp" artifact "dp2cp-mcp-v1.0"
+
+  Scenario: A REST API created on the gateway is pushed to the control plane
+    When I deploy this API configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: RestApi
+      metadata:
+        name: dp2cp-rest-v1.0
+        annotations:
+          "gateway.api-platform.wso2.com/project-id": "dp2cp-project"
+      spec:
+        displayName: DP2CP REST
+        version: v1.0
+        context: /dp2cp-rest
+        upstream:
+          main:
+            url: http://sample-backend:9080/api/v2
+        operations:
+          - method: GET
+            path: /resource
+      """
+    Then the response should be successful
+    And the control plane should receive the "RestApi" artifact "dp2cp-rest-v1.0"
+    And the control plane copy of the "RestApi" artifact "dp2cp-rest-v1.0" configuration should contain "/dp2cp-rest"
+    And the gateway should record cp_sync_status "success" for the "RestApi" artifact "dp2cp-rest-v1.0"
+    And the gateway should record a cp_artifact_id for the "RestApi" artifact "dp2cp-rest-v1.0"
+
+  Scenario: Updating a gateway-originated LLM provider pushes a fresh deployment to the control plane
+    When I create this LLM provider template:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: LlmProviderTemplate
+      metadata:
+        name: dp2cp-tmpl-upd
+      spec:
+        displayName: DP2CP Update Template
+        requestModel:
+          location: payload
+          identifier: $.model
+        responseModel:
+          location: payload
+          identifier: $.model
+      """
+    Then the response should be successful
+    When I create this LLM provider:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: LlmProvider
+      metadata:
+        name: dp2cp-prov-upd
+      spec:
+        displayName: DP2CP Provider Original
+        version: v1.0
+        template: dp2cp-tmpl-upd
+        upstream:
+          url: https://mock-openapi-https:9443/openai/v1
+          auth:
+            type: api-key
+            header: Authorization
+            value: Bearer sk-test-key
+        accessControl:
+          mode: allow_all
+      """
+    Then the response should be successful
+    And the control plane should receive the "LlmProvider" artifact "dp2cp-prov-upd"
+    When I update the LLM provider "dp2cp-prov-upd" with:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: LlmProvider
+      metadata:
+        name: dp2cp-prov-upd
+      spec:
+        displayName: DP2CP Provider Updated
+        version: v1.0
+        template: dp2cp-tmpl-upd
+        upstream:
+          url: https://mock-openapi-https:9443/openai/v1
+          auth:
+            type: api-key
+            header: Authorization
+            value: Bearer sk-test-key
+        accessControl:
+          mode: allow_all
+      """
+    Then the response should be successful
+    And the control plane copy of the "LlmProvider" artifact "dp2cp-prov-upd" should have been pushed at least 2 times
+    And the control plane copy of the "LlmProvider" artifact "dp2cp-prov-upd" configuration should contain "DP2CP Provider Updated"
+
+  Scenario: Updating a gateway-originated LLM provider template re-pushes it carrying a deployment watermark
+    When I create this LLM provider template:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: LlmProviderTemplate
+      metadata:
+        name: dp2cp-tmpl-updated
+      spec:
+        displayName: DP2CP Template Before
+        requestModel:
+          location: payload
+          identifier: $.model
+        responseModel:
+          location: payload
+          identifier: $.model
+      """
+    Then the response should be successful
+    And the control plane should receive the "LlmProviderTemplate" artifact "dp2cp-tmpl-updated"
+    When I update the LLM provider template "dp2cp-tmpl-updated" with:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: LlmProviderTemplate
+      metadata:
+        name: dp2cp-tmpl-updated
+      spec:
+        displayName: DP2CP Template After
+        requestModel:
+          location: payload
+          identifier: $.model
+        responseModel:
+          location: payload
+          identifier: $.model
+      """
+    Then the response should be successful
+    And the control plane copy of the "LlmProviderTemplate" artifact "dp2cp-tmpl-updated" should have been pushed at least 2 times
+    And the control plane copy of the "LlmProviderTemplate" artifact "dp2cp-tmpl-updated" configuration should contain "DP2CP Template After"
+    And the control plane copy of the "LlmProviderTemplate" artifact "dp2cp-tmpl-updated" should carry a deployed timestamp
+
+  Scenario: Deleting a gateway-originated artifact undeploys it on the control plane
+    When I deploy this MCP configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: Mcp
+      metadata:
+        name: dp2cp-mcp-del-v1.0
+        annotations:
+          "gateway.api-platform.wso2.com/project-id": "dp2cp-project"
+      spec:
+        displayName: DP2CP MCP Delete
+        version: v1.0
+        context: /dp2cp-mcp-del
+        specVersion: "2025-06-18"
+        upstream:
+          url: http://mcp-server-backend:3001
+        tools: []
+        resources: []
+        prompts: []
+      """
+    Then the response should be successful
+    And the control plane should receive the "Mcp" artifact "dp2cp-mcp-del-v1.0" with status "deployed"
+    When I delete the MCP proxy "dp2cp-mcp-del-v1.0"
+    Then the response should be successful
+    And the control plane should have undeployed the "Mcp" artifact "dp2cp-mcp-del-v1.0"
+
+  Scenario: A push rejected by the control plane is recorded as failed and re-pushed on reconnect
+    Given I make the control plane reject artifact imports
+    When I create this LLM provider template:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: LlmProviderTemplate
+      metadata:
+        name: dp2cp-tmpl-reject
+      spec:
+        displayName: DP2CP Reject Template
+        requestModel:
+          location: payload
+          identifier: $.model
+        responseModel:
+          location: payload
+          identifier: $.model
+      """
+    Then the response should be successful
+    And the gateway should record cp_sync_status "failed" for the "LlmProviderTemplate" artifact "dp2cp-tmpl-reject"
+    And the control plane should not receive the "LlmProviderTemplate" artifact "dp2cp-tmpl-reject"
+    When I make the control plane accept artifact imports
+    And I restart the "gateway-controller" service
+    Then the control plane should receive the "LlmProviderTemplate" artifact "dp2cp-tmpl-reject"
+    And the gateway should record cp_sync_status "success" for the "LlmProviderTemplate" artifact "dp2cp-tmpl-reject"

--- a/gateway/it/setup.go
+++ b/gateway/it/setup.go
@@ -107,8 +107,8 @@ func NewComposeManager(composeFiles ...string) (*ComposeManager, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve compose file path %q: %w", f, err)
 		}
-		if _, err := os.Stat(absPath); os.IsNotExist(err) {
-			return nil, fmt.Errorf("compose file not found: %s", absPath)
+		if _, err := os.Stat(absPath); err != nil {
+			return nil, fmt.Errorf("compose file %q is not accessible: %w", absPath, err)
 		}
 		absPaths = append(absPaths, absPath)
 	}

--- a/gateway/it/setup.go
+++ b/gateway/it/setup.go
@@ -81,7 +81,7 @@ type ServiceHealth struct {
 // Uses testcontainers-go compose module for reliable container management
 type ComposeManager struct {
 	compose       tc.ComposeStack
-	composeFile   string
+	composeFiles  []string
 	projectName   string
 	ctx           context.Context
 	cancel        context.CancelFunc
@@ -91,17 +91,26 @@ type ComposeManager struct {
 	isShutdown    bool
 }
 
-// NewComposeManager creates a new ComposeManager with the given compose file
-func NewComposeManager(composeFile string) (*ComposeManager, error) {
-	// Resolve absolute path
-	absPath, err := filepath.Abs(composeFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve compose file path: %w", err)
+// NewComposeManager creates a new ComposeManager from one or more compose files.
+// Multiple files are layered in order (later files override earlier ones), so a base
+// stack can be combined with a small override file (e.g. to flip a single env var)
+// without duplicating the whole compose definition.
+func NewComposeManager(composeFiles ...string) (*ComposeManager, error) {
+	if len(composeFiles) == 0 {
+		return nil, fmt.Errorf("no compose files provided")
 	}
 
-	// Check if file exists
-	if _, err := os.Stat(absPath); os.IsNotExist(err) {
-		return nil, fmt.Errorf("compose file not found: %s", absPath)
+	// Resolve and validate every file up front.
+	absPaths := make([]string, 0, len(composeFiles))
+	for _, f := range composeFiles {
+		absPath, err := filepath.Abs(f)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve compose file path %q: %w", f, err)
+		}
+		if _, err := os.Stat(absPath); os.IsNotExist(err) {
+			return nil, fmt.Errorf("compose file not found: %s", absPath)
+		}
+		absPaths = append(absPaths, absPath)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -112,7 +121,7 @@ func NewComposeManager(composeFile string) (*ComposeManager, error) {
 	// This ensures we can later query logs using the same project identifier
 	compose, err := tc.NewDockerComposeWith(
 		tc.StackIdentifier(projectName),
-		tc.WithStackFiles(absPath),
+		tc.WithStackFiles(absPaths...),
 	)
 	if err != nil {
 		cancel()
@@ -120,12 +129,12 @@ func NewComposeManager(composeFile string) (*ComposeManager, error) {
 	}
 
 	cm := &ComposeManager{
-		compose:     compose,
-		composeFile: absPath,
-		projectName: projectName,
-		ctx:         ctx,
-		cancel:      cancel,
-		signalChan:  make(chan os.Signal, 1),
+		compose:      compose,
+		composeFiles: absPaths,
+		projectName:  projectName,
+		ctx:          ctx,
+		cancel:       cancel,
+		signalChan:   make(chan os.Signal, 1),
 	}
 
 	// Setup signal handling for graceful cleanup
@@ -300,11 +309,22 @@ func (cm *ComposeManager) Cleanup() {
 	})
 }
 
+// composeFileFlags expands the manager's compose files into repeated "-f <file>"
+// arguments for direct `docker compose` invocations.
+func (cm *ComposeManager) composeFileFlags() []string {
+	flags := make([]string, 0, len(cm.composeFiles)*2)
+	for _, f := range cm.composeFiles {
+		flags = append(flags, "-f", f)
+	}
+	return flags
+}
+
 // gracefulStop sends SIGTERM to containers via docker-compose stop
 func (cm *ComposeManager) gracefulStop(ctx context.Context) error {
 	// Use docker-compose stop which sends SIGTERM and waits for graceful shutdown
 	// The -t flag specifies the timeout in seconds before sending SIGKILL
-	args := []string{"compose", "-p", cm.projectName, "-f", cm.composeFile, "stop", "-t", "15"}
+	args := append([]string{"compose", "-p", cm.projectName}, cm.composeFileFlags()...)
+	args = append(args, "stop", "-t", "15")
 	cmd := execCommandContext(ctx, "docker", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -321,7 +341,8 @@ func (cm *ComposeManager) RestartService(service string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	args := []string{"compose", "-p", cm.projectName, "-f", cm.composeFile, "restart", service}
+	args := append([]string{"compose", "-p", cm.projectName}, cm.composeFileFlags()...)
+	args = append(args, "restart", service)
 	cmd := execCommandContext(ctx, "docker", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -391,7 +412,8 @@ func (cm *ComposeManager) DumpLogs(outputFile string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	args := []string{"compose", "-p", cm.projectName, "-f", cm.composeFile, "logs", "--no-color", "--timestamps"}
+	args := append([]string{"compose", "-p", cm.projectName}, cm.composeFileFlags()...)
+	args = append(args, "logs", "--no-color", "--timestamps")
 	cmd := execCommandContext(ctx, "docker", args...)
 
 	// Give some time for containers to flush logs
@@ -432,15 +454,15 @@ func CheckPortsAvailable() error {
 		GatewayControllerPort, // 9090
 		GatewayControllerAdminPort,
 		GatewayControllerRuntimeAdminPort, // 9093
-		RouterPort,     // 8080
-		"8443",         // HTTPS
-		EnvoyAdminPort, // 9901
-		"9002",         // Policy engine
-		"9080",         // Sample backend
-		"3001",         // MCP server backend
-		"18000",        // xDS gRPC
-		"18001",        // xDS gRPC
-		"8082",         // Mock JWKS server
+		RouterPort,                        // 8080
+		"8443",                            // HTTPS
+		EnvoyAdminPort,                    // 9901
+		"9002",                            // Policy engine
+		"9080",                            // Sample backend
+		"3001",                            // MCP server backend
+		"18000",                           // xDS gRPC
+		"18001",                           // xDS gRPC
+		"8082",                            // Mock JWKS server
 	}
 
 	var conflicts []string

--- a/gateway/it/steps_dp_to_cp.go
+++ b/gateway/it/steps_dp_to_cp.go
@@ -138,16 +138,23 @@ func (d *DPToCPSteps) shouldReceiveWithStatus(kind, handle, status string) error
 }
 
 func (d *DPToCPSteps) shouldNotReceive(kind, handle string) error {
-	// Wait a grace period so an in-flight push has a fair chance to arrive, then
-	// assert the artifact is still absent.
-	deadline := time.Now().Add(cpNoPushGrace)
-	for time.Now().Before(deadline) {
-		if _, ok, err := d.findArtifact(kind, handle); err != nil {
-			return err
-		} else if ok {
-			return fmt.Errorf("control plane unexpectedly received %s %q", kind, handle)
+	// Poll for a grace period so an in-flight push has a fair chance to arrive. Stop
+	// early if the artifact is received (or a query errors); if the grace elapses with
+	// neither, conclude it was genuinely not pushed.
+	var queryErr error
+	received := pollUntil(cpNoPushGrace, func() bool {
+		_, ok, err := d.findArtifact(kind, handle)
+		if err != nil {
+			queryErr = err
+			return true // stop early; the query error is surfaced below
 		}
-		time.Sleep(cpPushPollInterval)
+		return ok
+	})
+	if queryErr != nil {
+		return queryErr
+	}
+	if received {
+		return fmt.Errorf("control plane unexpectedly received %s %q", kind, handle)
 	}
 	return nil
 }
@@ -228,29 +235,26 @@ func (d *DPToCPSteps) shouldBeUndeployed(kind, handle string) error {
 // --- gateway DB bookkeeping assertions --------------------------------------
 
 func (d *DPToCPSteps) shouldRecordSyncStatus(status, kind, handle string) error {
-	deadline := time.Now().Add(cpPushAssertTimeout)
 	var last string
-	for time.Now().Before(deadline) {
+	if pollUntil(cpPushAssertTimeout, func() bool {
 		got, err := d.queryArtifactColumn("cp_sync_status", kind, handle)
-		if err == nil {
-			last = got
-			if strings.EqualFold(got, status) {
-				return nil
-			}
+		if err != nil {
+			return false
 		}
-		time.Sleep(cpPushPollInterval)
+		last = got
+		return strings.EqualFold(got, status)
+	}) {
+		return nil
 	}
 	return fmt.Errorf("gateway did not record cp_sync_status %q for %s %q (last seen: %q)", status, kind, handle, last)
 }
 
 func (d *DPToCPSteps) shouldRecordCPArtifactID(kind, handle string) error {
-	deadline := time.Now().Add(cpPushAssertTimeout)
-	for time.Now().Before(deadline) {
+	if pollUntil(cpPushAssertTimeout, func() bool {
 		got, err := d.queryArtifactColumn("cp_artifact_id", kind, handle)
-		if err == nil && got != "" {
-			return nil
-		}
-		time.Sleep(cpPushPollInterval)
+		return err == nil && got != ""
+	}) {
+		return nil
 	}
 	return fmt.Errorf("gateway did not record a cp_artifact_id for %s %q", kind, handle)
 }
@@ -288,24 +292,43 @@ func (d *DPToCPSteps) findArtifact(kind, handle string) (cpRecordedArtifact, boo
 	return cpRecordedArtifact{}, false, nil
 }
 
+// pollUntil calls check every cpPushPollInterval until it returns true or the timeout
+// elapses, reporting whether check succeeded within the deadline. It centralizes the
+// deadline/poll loop shared by the DP->CP assertions; each caller keeps only its own
+// result-specific success/error handling (typically via variables the closure captures).
+func pollUntil(timeout time.Duration, check func() bool) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if check() {
+			return true
+		}
+		time.Sleep(cpPushPollInterval)
+	}
+	return false
+}
+
 // waitForArtifact polls the recorder until an artifact matching kind/handle
 // satisfies pred, or the timeout elapses.
 func (d *DPToCPSteps) waitForArtifact(kind, handle string, pred func(cpRecordedArtifact) bool, timeout time.Duration) (cpRecordedArtifact, error) {
-	deadline := time.Now().Add(timeout)
 	var lastErr error
 	found := false
-	var last cpRecordedArtifact
-	for time.Now().Before(deadline) {
+	var last, matched cpRecordedArtifact
+	if pollUntil(timeout, func() bool {
 		a, ok, err := d.findArtifact(kind, handle)
 		if err != nil {
 			lastErr = err
-		} else if ok {
+			return false
+		}
+		if ok {
 			found, last = true, a
 			if pred(a) {
-				return a, nil
+				matched = a
+				return true
 			}
 		}
-		time.Sleep(cpPushPollInterval)
+		return false
+	}) {
+		return matched, nil
 	}
 	if lastErr != nil {
 		return cpRecordedArtifact{}, fmt.Errorf("timed out after %s (last query error: %w)", timeout, lastErr)

--- a/gateway/it/steps_dp_to_cp.go
+++ b/gateway/it/steps_dp_to_cp.go
@@ -1,0 +1,367 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package it
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/cucumber/godog"
+)
+
+// DPToCPSteps provides step definitions for the data-plane -> control-plane
+// artifact push flow. The gateway-controller pushes every gateway-originated
+// artifact (LLM provider template/provider/proxy, MCP proxy, REST API) to the
+// control plane on create/update, undeploys them on delete, and re-pushes any
+// pending/failed ones on (re)connect. In the integration test the control plane
+// is stood in for by mock-platform-api, which records what it received; these
+// steps drive and assert against that recorder plus the gateway's own DB
+// bookkeeping (cp_sync_status / cp_artifact_id).
+type DPToCPSteps struct {
+	state *TestState
+}
+
+// NewDPToCPSteps creates a new DPToCPSteps instance.
+func NewDPToCPSteps(state *TestState) *DPToCPSteps {
+	return &DPToCPSteps{state: state}
+}
+
+const (
+	// cpPushAssertTimeout bounds how long we wait for an asynchronous push to
+	// arrive at (or be recorded by) the control plane. The create-path push for
+	// deployable kinds waits for the deployment to land first, and a rejected
+	// push is retried with backoff (~15s over 5 attempts), so this is generous.
+	cpPushAssertTimeout = 35 * time.Second
+
+	// cpPushPollInterval is how often the assertions re-poll the recorder / DB.
+	cpPushPollInterval = 500 * time.Millisecond
+
+	// cpNoPushGrace is how long a negative ("should not receive") assertion waits
+	// before concluding the artifact was genuinely not pushed.
+	cpNoPushGrace = 6 * time.Second
+)
+
+// cpRecordedArtifact mirrors the mock-platform-api recorder's per-artifact view
+// (see tests/mock-servers/mock-platform-api/main.go recordedArtifact).
+type cpRecordedArtifact struct {
+	DPID          string                 `json:"dpid"`
+	CPID          string                 `json:"cpId"`
+	Kind          string                 `json:"kind"`
+	Handle        string                 `json:"handle"`
+	Status        string                 `json:"status"`
+	Origin        string                 `json:"origin"`
+	DeployedAt    *time.Time             `json:"deployedAt,omitempty"`
+	CreatedAt     time.Time              `json:"createdAt"`
+	UpdatedAt     time.Time              `json:"updatedAt"`
+	Configuration map[string]interface{} `json:"configuration"`
+	PushCount     int                    `json:"pushCount"`
+}
+
+// RegisterDPToCPSteps registers all DP->CP Gherkin steps.
+func RegisterDPToCPSteps(ctx *godog.ScenarioContext, state *TestState) {
+	d := NewDPToCPSteps(state)
+
+	// Recorder control.
+	ctx.Step(`^I reset the control plane recorder$`, d.resetRecorder)
+	ctx.Step(`^I make the control plane reject artifact imports$`, d.rejectImports)
+	ctx.Step(`^I make the control plane accept artifact imports$`, d.acceptImports)
+
+	// Push assertions (against the mock control plane recorder).
+	ctx.Step(`^the control plane should receive the "([^"]*)" artifact "([^"]*)"$`, d.shouldReceive)
+	ctx.Step(`^the control plane should receive the "([^"]*)" artifact "([^"]*)" with status "([^"]*)"$`, d.shouldReceiveWithStatus)
+	ctx.Step(`^the control plane should not receive the "([^"]*)" artifact "([^"]*)"$`, d.shouldNotReceive)
+	ctx.Step(`^the control plane copy of the "([^"]*)" artifact "([^"]*)" should have been pushed at least (\d+) times$`, d.pushedAtLeast)
+	ctx.Step(`^the control plane copy of the "([^"]*)" artifact "([^"]*)" configuration should contain "([^"]*)"$`, d.configShouldContain)
+	ctx.Step(`^the control plane copy of the "([^"]*)" artifact "([^"]*)" should reference (provider|template) "([^"]*)"$`, d.shouldReference)
+	ctx.Step(`^the control plane copy of the "([^"]*)" artifact "([^"]*)" should carry a deployed timestamp$`, d.shouldCarryDeployedAt)
+	ctx.Step(`^the control plane should have undeployed the "([^"]*)" artifact "([^"]*)"$`, d.shouldBeUndeployed)
+
+	// Gateway-side bookkeeping assertions (against the controller DB via db-reader).
+	ctx.Step(`^the gateway should record cp_sync_status "([^"]*)" for the "([^"]*)" artifact "([^"]*)"$`, d.shouldRecordSyncStatus)
+	ctx.Step(`^the gateway should record a cp_artifact_id for the "([^"]*)" artifact "([^"]*)"$`, d.shouldRecordCPArtifactID)
+}
+
+// --- recorder control -------------------------------------------------------
+
+func (d *DPToCPSteps) resetRecorder() error {
+	return d.postJSON("/_test/reset", nil)
+}
+
+func (d *DPToCPSteps) rejectImports() error {
+	return d.postJSON("/_test/config", map[string]bool{"rejectImports": true})
+}
+
+func (d *DPToCPSteps) acceptImports() error {
+	return d.postJSON("/_test/config", map[string]bool{"rejectImports": false})
+}
+
+// --- push assertions --------------------------------------------------------
+
+func (d *DPToCPSteps) shouldReceive(kind, handle string) error {
+	_, err := d.waitForArtifact(kind, handle, func(cpRecordedArtifact) bool { return true }, cpPushAssertTimeout)
+	if err != nil {
+		return fmt.Errorf("control plane did not receive %s %q: %w", kind, handle, err)
+	}
+	return nil
+}
+
+func (d *DPToCPSteps) shouldReceiveWithStatus(kind, handle, status string) error {
+	_, err := d.waitForArtifact(kind, handle, func(a cpRecordedArtifact) bool {
+		return strings.EqualFold(a.Status, status)
+	}, cpPushAssertTimeout)
+	if err != nil {
+		return fmt.Errorf("control plane did not receive %s %q with status %q: %w", kind, handle, status, err)
+	}
+	return nil
+}
+
+func (d *DPToCPSteps) shouldNotReceive(kind, handle string) error {
+	// Wait a grace period so an in-flight push has a fair chance to arrive, then
+	// assert the artifact is still absent.
+	deadline := time.Now().Add(cpNoPushGrace)
+	for time.Now().Before(deadline) {
+		if _, ok, err := d.findArtifact(kind, handle); err != nil {
+			return err
+		} else if ok {
+			return fmt.Errorf("control plane unexpectedly received %s %q", kind, handle)
+		}
+		time.Sleep(cpPushPollInterval)
+	}
+	return nil
+}
+
+func (d *DPToCPSteps) pushedAtLeast(kind, handle string, n int) error {
+	_, err := d.waitForArtifact(kind, handle, func(a cpRecordedArtifact) bool {
+		return a.PushCount >= n
+	}, cpPushAssertTimeout)
+	if err != nil {
+		return fmt.Errorf("%s %q was not pushed at least %d times: %w", kind, handle, n, err)
+	}
+	return nil
+}
+
+func (d *DPToCPSteps) configShouldContain(kind, handle, substr string) error {
+	rec, err := d.waitForArtifact(kind, handle, func(cpRecordedArtifact) bool { return true }, cpPushAssertTimeout)
+	if err != nil {
+		return err
+	}
+	raw, err := json.Marshal(rec.Configuration)
+	if err != nil {
+		return fmt.Errorf("failed to marshal recorded configuration for %s %q: %w", kind, handle, err)
+	}
+	if !strings.Contains(string(raw), substr) {
+		return fmt.Errorf("recorded configuration for %s %q does not contain %q\nconfiguration: %s", kind, handle, substr, string(raw))
+	}
+	return nil
+}
+
+func (d *DPToCPSteps) shouldReference(kind, handle, refType, refHandle string) error {
+	rec, err := d.waitForArtifact(kind, handle, func(cpRecordedArtifact) bool { return true }, cpPushAssertTimeout)
+	if err != nil {
+		return err
+	}
+	spec, _ := rec.Configuration["spec"].(map[string]interface{})
+	if spec == nil {
+		return fmt.Errorf("recorded %s %q has no spec", kind, handle)
+	}
+	var got string
+	switch refType {
+	case "provider":
+		provider, _ := spec["provider"].(map[string]interface{})
+		got, _ = provider["id"].(string)
+	case "template":
+		got, _ = spec["template"].(string)
+	default:
+		return fmt.Errorf("unknown reference type %q", refType)
+	}
+	if got != refHandle {
+		return fmt.Errorf("recorded %s %q should reference %s %q by handle, got %q", kind, handle, refType, refHandle, got)
+	}
+	return nil
+}
+
+// shouldCarryDeployedAt asserts the recorded push carried a non-null deployedAt.
+// For LLM provider templates this guards the regression where template pushes sent
+// a nil deployedAt watermark (the CP then silently dropped template updates).
+func (d *DPToCPSteps) shouldCarryDeployedAt(kind, handle string) error {
+	_, err := d.waitForArtifact(kind, handle, func(a cpRecordedArtifact) bool {
+		return a.DeployedAt != nil
+	}, cpPushAssertTimeout)
+	if err != nil {
+		return fmt.Errorf("control plane copy of %s %q did not carry a deployed timestamp: %w", kind, handle, err)
+	}
+	return nil
+}
+
+func (d *DPToCPSteps) shouldBeUndeployed(kind, handle string) error {
+	_, err := d.waitForArtifact(kind, handle, func(a cpRecordedArtifact) bool {
+		return strings.EqualFold(a.Status, "undeployed")
+	}, cpPushAssertTimeout)
+	if err != nil {
+		return fmt.Errorf("control plane did not receive an undeploy for %s %q: %w", kind, handle, err)
+	}
+	return nil
+}
+
+// --- gateway DB bookkeeping assertions --------------------------------------
+
+func (d *DPToCPSteps) shouldRecordSyncStatus(status, kind, handle string) error {
+	deadline := time.Now().Add(cpPushAssertTimeout)
+	var last string
+	for time.Now().Before(deadline) {
+		got, err := d.queryArtifactColumn("cp_sync_status", kind, handle)
+		if err == nil {
+			last = got
+			if strings.EqualFold(got, status) {
+				return nil
+			}
+		}
+		time.Sleep(cpPushPollInterval)
+	}
+	return fmt.Errorf("gateway did not record cp_sync_status %q for %s %q (last seen: %q)", status, kind, handle, last)
+}
+
+func (d *DPToCPSteps) shouldRecordCPArtifactID(kind, handle string) error {
+	deadline := time.Now().Add(cpPushAssertTimeout)
+	for time.Now().Before(deadline) {
+		got, err := d.queryArtifactColumn("cp_artifact_id", kind, handle)
+		if err == nil && got != "" {
+			return nil
+		}
+		time.Sleep(cpPushPollInterval)
+	}
+	return fmt.Errorf("gateway did not record a cp_artifact_id for %s %q", kind, handle)
+}
+
+// queryArtifactColumn reads a single column of the gateway artifacts row for the
+// given kind/handle via the DB reader sidecar. Returns "" (no error) when the row
+// or column value is NULL/absent.
+func (d *DPToCPSteps) queryArtifactColumn(column, kind, handle string) (string, error) {
+	if !validSQLIdentifier.MatchString(column) {
+		return "", fmt.Errorf("invalid column identifier %q", column)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultDBQueryTimeout)
+	defer cancel()
+	query := fmt.Sprintf(
+		"SELECT %s FROM artifacts WHERE kind = '%s' AND handle = '%s';",
+		column, sqlLiteral(kind), sqlLiteral(handle),
+	)
+	return executeQuery(ctx, query)
+}
+
+// --- recorder HTTP helpers --------------------------------------------------
+
+// findArtifact returns the recorded artifact for kind/handle, or ok=false if the
+// control plane has not received it yet.
+func (d *DPToCPSteps) findArtifact(kind, handle string) (cpRecordedArtifact, bool, error) {
+	arts, err := d.getRecordedArtifacts()
+	if err != nil {
+		return cpRecordedArtifact{}, false, err
+	}
+	for _, a := range arts {
+		if a.Kind == kind && a.Handle == handle {
+			return a, true, nil
+		}
+	}
+	return cpRecordedArtifact{}, false, nil
+}
+
+// waitForArtifact polls the recorder until an artifact matching kind/handle
+// satisfies pred, or the timeout elapses.
+func (d *DPToCPSteps) waitForArtifact(kind, handle string, pred func(cpRecordedArtifact) bool, timeout time.Duration) (cpRecordedArtifact, error) {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	found := false
+	var last cpRecordedArtifact
+	for time.Now().Before(deadline) {
+		a, ok, err := d.findArtifact(kind, handle)
+		if err != nil {
+			lastErr = err
+		} else if ok {
+			found, last = true, a
+			if pred(a) {
+				return a, nil
+			}
+		}
+		time.Sleep(cpPushPollInterval)
+	}
+	if lastErr != nil {
+		return cpRecordedArtifact{}, fmt.Errorf("timed out after %s (last query error: %w)", timeout, lastErr)
+	}
+	if found {
+		return cpRecordedArtifact{}, fmt.Errorf("timed out after %s; artifact present but predicate unmet (last status=%q, pushCount=%d)", timeout, last.Status, last.PushCount)
+	}
+	return cpRecordedArtifact{}, fmt.Errorf("timed out after %s; artifact never received", timeout)
+}
+
+func (d *DPToCPSteps) getRecordedArtifacts() ([]cpRecordedArtifact, error) {
+	req, err := http.NewRequest(http.MethodGet, d.state.Config.MockPlatformAPIURL+"/_test/artifacts", nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := d.state.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query control plane recorder: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("control plane recorder returned status %d: %s", resp.StatusCode, string(body))
+	}
+	var out []cpRecordedArtifact
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("failed to parse recorder response: %w (body: %s)", err, string(body))
+	}
+	return out, nil
+}
+
+func (d *DPToCPSteps) postJSON(path string, payload interface{}) error {
+	var body io.Reader
+	if payload != nil {
+		b, err := json.Marshal(payload)
+		if err != nil {
+			return err
+		}
+		body = bytes.NewReader(b)
+	}
+	req, err := http.NewRequest(http.MethodPost, d.state.Config.MockPlatformAPIURL+path, body)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := d.state.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to call control plane recorder %s: %w", path, err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("control plane recorder %s returned status %d: %s", path, resp.StatusCode, string(respBody))
+	}
+	return nil
+}

--- a/gateway/it/suite_test.go
+++ b/gateway/it/suite_test.go
@@ -378,16 +378,8 @@ func getComposeFilePaths() []string {
 		}
 	}
 
-	// Default: the base compose file, resolved relative to the package directory.
-	for _, candidate := range []string{
-		"docker-compose.test.yaml",
-		filepath.Join(".", "docker-compose.test.yaml"),
-	} {
-		if _, err := os.Stat(candidate); err == nil {
-			return []string{candidate}
-		}
-	}
-
+	// Default: the base compose file. NewComposeManager resolves it to an absolute
+	// path (relative to the package working directory) and validates that it exists.
 	return []string{"docker-compose.test.yaml"}
 }
 

--- a/gateway/it/suite_test.go
+++ b/gateway/it/suite_test.go
@@ -143,6 +143,9 @@ func getFeaturePaths() []string {
 		"features/route-path-matching.feature",
 		"features/secrets.feature",
 		"features/template-functions.feature",
+		// Runs late: it restarts the gateway-controller (reject/reconnect scenario), so keep it
+		// after features that assume an uninterrupted controller. Verifies the DP->CP artifact push.
+		"features/dp-to-cp.feature",
 		// These tests require different gateway configurations and are not included in the default suite run.
 		// "features/vhost-routing-single.feature", // cd it && make test-vhosts-single
 		// "features/vhost-routing-multi.feature", // cd it && make test-vhosts-multi
@@ -199,10 +202,10 @@ func InitializeTestSuite(ctx *godog.TestSuiteContext) {
 		}
 
 		// Create and start compose manager
-		composeFile := getComposeFilePath()
-		log.Printf("Using compose file: %s", composeFile)
+		composeFiles := getComposeFilePaths()
+		log.Printf("Using compose file(s): %s", strings.Join(composeFiles, ", "))
 		var err error
-		composeManager, err = NewComposeManager(composeFile)
+		composeManager, err = NewComposeManager(composeFiles...)
 		if err != nil {
 			log.Fatalf("Failed to create compose manager: %v", err)
 		}
@@ -345,6 +348,7 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 		RegisterSubscriptionSteps(ctx, testState, httpSteps)
 		RegisterSecretSteps(ctx, testState, httpSteps)
 		RegisterTemplateSteps(ctx, testState, httpSteps)
+		RegisterDPToCPSteps(ctx, testState)
 	}
 
 	// Register common HTTP and assertion steps
@@ -356,29 +360,35 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	}
 }
 
-// getComposeFilePath returns the path to docker-compose.test.yaml
-func getComposeFilePath() string {
-	// Try to find compose file relative to this test file
-	// When running tests, the working directory is the package directory
-	candidates := []string{
-		"docker-compose.test.yaml",
-		filepath.Join(".", "docker-compose.test.yaml"),
-	}
-
-	// Also check COMPOSE_FILE env var
-	if envFile := os.Getenv("COMPOSE_FILE"); envFile != "" {
-		candidates = append([]string{envFile}, candidates...)
-	}
-
-	for _, candidate := range candidates {
-		if _, err := os.Stat(candidate); err == nil {
-			absPath, _ := filepath.Abs(candidate)
-			return absPath
+// getComposeFilePaths returns the compose file(s) for the test stack. COMPOSE_FILE may
+// name a single file or several separated by the OS path-list separator (":") — mirroring
+// docker compose's own COMPOSE_FILE handling — so a base stack (docker-compose.test.yaml)
+// can be layered with a small override file (e.g. docker-compose.test.dp-nosync.override.yaml)
+// that only changes a service's env. Falls back to the default single file.
+func getComposeFilePaths() []string {
+	if envFile := strings.TrimSpace(os.Getenv("COMPOSE_FILE")); envFile != "" {
+		var files []string
+		for _, p := range strings.Split(envFile, string(os.PathListSeparator)) {
+			if p = strings.TrimSpace(p); p != "" {
+				files = append(files, p)
+			}
+		}
+		if len(files) > 0 {
+			return files
 		}
 	}
 
-	// Default to relative path
-	return "docker-compose.test.yaml"
+	// Default: the base compose file, resolved relative to the package directory.
+	for _, candidate := range []string{
+		"docker-compose.test.yaml",
+		filepath.Join(".", "docker-compose.test.yaml"),
+	} {
+		if _, err := os.Stat(candidate); err == nil {
+			return []string{candidate}
+		}
+	}
+
+	return []string{"docker-compose.test.yaml"}
 }
 
 // checkColimaAndSetupEnv detects if colima is used and sets up environment variables

--- a/platform-api/src/internal/service/artifact_dp_apikey_test.go
+++ b/platform-api/src/internal/service/artifact_dp_apikey_test.go
@@ -1,0 +1,143 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package service
+
+// Consumer API keys can be generated for DP-originated (gateway_api) artifacts from the
+// control plane. API keys are not part of the gateway runtime artifact,
+// so — unlike metadata/runtime edits (guarded elsewhere) — key generation carries NO origin
+// guard: a DP-origin provider/proxy mints a key exactly like a control-plane one. These
+// tests pin that contract so a future origin check added to the CRUD guards can't
+// accidentally start rejecting API-key creation for DP artifacts.
+
+import (
+	"context"
+	"testing"
+
+	"platform-api/src/api"
+	"platform-api/src/internal/constants"
+	"platform-api/src/internal/model"
+	"platform-api/src/internal/repository"
+
+	"github.com/wso2/api-platform/common/eventhub"
+)
+
+// dpNoopEventHub is an eventhub.EventHub that does nothing; PublishEvent succeeds so the
+// API-key broadcast is a no-op. (The broadcast is fault-tolerant anyway — a delivery
+// failure only logs; the key is still persisted and creation still succeeds.)
+type dpNoopEventHub struct{}
+
+func (dpNoopEventHub) Initialize() error                               { return nil }
+func (dpNoopEventHub) RegisterGateway(string) error                    { return nil }
+func (dpNoopEventHub) PublishEvent(string, eventhub.Event) error       { return nil }
+func (dpNoopEventHub) Subscribe(string) (<-chan eventhub.Event, error) { return nil, nil }
+func (dpNoopEventHub) Unsubscribe(string, <-chan eventhub.Event) error { return nil }
+func (dpNoopEventHub) UnsubscribeAll(string) error                     { return nil }
+func (dpNoopEventHub) CleanUpEvents() error                            { return nil }
+func (dpNoopEventHub) Close() error                                    { return nil }
+
+// dpKeyGatewayRepo returns a single gateway for the org so API-key creation has a
+// broadcast target (an empty list would short-circuit with ErrGatewayUnavailable).
+type dpKeyGatewayRepo struct {
+	repository.GatewayRepository
+}
+
+func (dpKeyGatewayRepo) GetByOrganizationID(string) ([]*model.Gateway, error) {
+	return []*model.Gateway{{ID: "gw-1"}}, nil
+}
+
+// dpCapturingAPIKeyRepo captures the persisted API key so tests can assert it was created
+// against the artifact's own UUID.
+type dpCapturingAPIKeyRepo struct {
+	repository.APIKeyRepository
+	created *model.APIKey
+}
+
+func (c *dpCapturingAPIKeyRepo) Create(k *model.APIKey) error {
+	c.created = k
+	return nil
+}
+
+func newDPKeyEventsService() *GatewayEventsService {
+	return NewGatewayEventsService(dpNoopEventHub{}, newTestIdentityService(), newTestLogger())
+}
+
+// TestLLMProviderAPIKey_AllowedForDPOrigin verifies a consumer API key can be generated
+// for a DP-originated LLM provider (origin is not consulted by the key service).
+func TestLLMProviderAPIKey_AllowedForDPOrigin(t *testing.T) {
+	provider := &model.LLMProvider{
+		UUID:             "dp-prov-uuid",
+		ID:               "dp-prov",
+		OrganizationUUID: "org-1",
+		Name:             "DP Provider",
+		Version:          "v1.0",
+		Origin:           constants.OriginDP, // read-only for metadata/runtime edits, but keys are allowed
+	}
+	providerRepo := &mockLLMProviderRepo{
+		getByIDFunc: func(string, string) (*model.LLMProvider, error) { return provider, nil },
+	}
+	keyRepo := &dpCapturingAPIKeyRepo{}
+	svc := NewLLMProviderAPIKeyService(providerRepo, dpKeyGatewayRepo{}, keyRepo, newDPKeyEventsService(), newTestIdentityService(), newTestLogger())
+
+	resp, err := svc.CreateLLMProviderAPIKey(context.Background(), "dp-prov", "org-1", "",
+		&api.CreateLLMProviderAPIKeyRequest{DisplayName: "dp-consumer-key"})
+	if err != nil {
+		t.Fatalf("CreateLLMProviderAPIKey for DP-origin provider = %v, want success", err)
+	}
+	if resp == nil || resp.ApiKey == "" {
+		t.Fatalf("expected a generated API key, got %#v", resp)
+	}
+	if keyRepo.created == nil {
+		t.Fatalf("API key was not persisted")
+	}
+	if keyRepo.created.ArtifactUUID != provider.UUID {
+		t.Errorf("persisted key ArtifactUUID = %q, want provider UUID %q", keyRepo.created.ArtifactUUID, provider.UUID)
+	}
+}
+
+// TestLLMProxyAPIKey_AllowedForDPOrigin verifies a consumer API key can be generated for a
+// DP-originated LLM proxy.
+func TestLLMProxyAPIKey_AllowedForDPOrigin(t *testing.T) {
+	proxy := &model.LLMProxy{
+		UUID:             "dp-proxy-uuid",
+		ID:               "dp-proxy",
+		OrganizationUUID: "org-1",
+		Name:             "DP Proxy",
+		Version:          "v1.0",
+		Origin:           constants.OriginDP,
+	}
+	proxyRepo := &mockLLMProxyRepo{
+		getByIDFunc: func(string, string) (*model.LLMProxy, error) { return proxy, nil },
+	}
+	keyRepo := &dpCapturingAPIKeyRepo{}
+	svc := NewLLMProxyAPIKeyService(proxyRepo, dpKeyGatewayRepo{}, keyRepo, newDPKeyEventsService(), newTestIdentityService(), newTestLogger())
+
+	resp, err := svc.CreateLLMProxyAPIKey(context.Background(), "dp-proxy", "org-1", "",
+		&api.CreateLLMProxyAPIKeyRequest{DisplayName: "dp-consumer-key"})
+	if err != nil {
+		t.Fatalf("CreateLLMProxyAPIKey for DP-origin proxy = %v, want success", err)
+	}
+	if resp == nil || resp.ApiKey == "" {
+		t.Fatalf("expected a generated API key, got %#v", resp)
+	}
+	if keyRepo.created == nil {
+		t.Fatalf("API key was not persisted")
+	}
+	if keyRepo.created.ArtifactUUID != proxy.UUID {
+		t.Errorf("persisted key ArtifactUUID = %q, want proxy UUID %q", keyRepo.created.ArtifactUUID, proxy.UUID)
+	}
+}

--- a/tests/mock-servers/mock-platform-api/main.go
+++ b/tests/mock-servers/mock-platform-api/main.go
@@ -20,13 +20,17 @@
 package main
 
 import (
+	"archive/zip"
+	"bytes"
 	"crypto/tls"
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
+	"sort"
 	"sync"
 	"time"
 
@@ -42,6 +46,17 @@ const (
 	injectPath       = "/inject-subscription"
 	subscriptionPath = "/api/internal/v1/subscription-plans"
 	manifestPath     = "POST /api/internal/v1/gateways/{gatewayId}/manifest"
+
+	// importArtifactsPath is the generic DP->CP bulk artifact import endpoint the
+	// gateway-controller pushes to (multipart/form-data: an "artifacts" zip whose
+	// single "artifacts.json" entry is a JSON array of ImportArtifactRequest, plus a
+	// "total" field). Mirrors platform-api's real handler; used by the dp-to-cp IT.
+	importArtifactsPath = "POST /api/internal/v1/artifacts/import-gateway-artifacts"
+
+	// gatewayArtifactsZipEntry is the file name, inside the "artifacts" zip, holding
+	// the JSON array of pushed artifacts. Must match the gateway-controller constant
+	// of the same name (gateway-controller/pkg/utils/api_utils.go).
+	gatewayArtifactsZipEntry = "artifacts.json"
 )
 
 var (
@@ -91,6 +106,13 @@ func main() {
 	mux.HandleFunc(subscriptionPath, syncHandler)
 	mux.HandleFunc("/api/internal/v1/apis/", subscriptionsSyncHandler)
 	mux.HandleFunc(manifestPath, manifestHandler)
+
+	// DP->CP artifact import (what the gateway pushes) + test-inspection endpoints.
+	mux.HandleFunc(importArtifactsPath, importArtifactsHandler)
+	mux.HandleFunc("GET /_test/artifacts", testArtifactsHandler)
+	mux.HandleFunc("GET /_test/pushes", testPushesHandler)
+	mux.HandleFunc("POST /_test/reset", testResetHandler)
+	mux.HandleFunc("POST /_test/config", testConfigHandler)
 
 	// HTTP server for IT inject endpoint (port 9244)
 	go func() {
@@ -302,4 +324,273 @@ func subscriptionsSyncHandler(w http.ResponseWriter, r *http.Request) {
 // platform-api response: 204 No Content with an empty body.
 func manifestHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// -----------------------------------------------------------------------------
+// DP->CP artifact import recorder
+//
+// The gateway-controller pushes every gateway-originated artifact (LLM provider
+// template/provider/proxy, MCP proxy, REST API, ...) to the control plane via the
+// bulk import endpoint. This mock stands in for that control plane: it records
+// what was pushed so the dp-to-cp integration test can assert on it, and mints a
+// per-handle CP artifact UUID (returned as `id`) exactly like the real platform-api
+// so the gateway records a `cp_artifact_id` / `cp_sync_status=success`.
+//
+// The recorder is deliberately dependency-free (in-memory) and additive: it does
+// not touch the WebSocket/subscription behaviour the other ITs rely on.
+// -----------------------------------------------------------------------------
+
+// importArtifactRequest is one entry in the pushed artifacts.json array. It mirrors
+// the gateway-controller's ImportArtifactRequest; Configuration is kept as a generic
+// map so the mock stays decoupled from each kind's spec schema.
+type importArtifactRequest struct {
+	DPID          string                 `json:"dpid"`
+	Configuration map[string]interface{} `json:"configuration"`
+	Status        string                 `json:"status"`
+	CreatedAt     time.Time              `json:"createdAt"`
+	UpdatedAt     time.Time              `json:"updatedAt"`
+	DeployedAt    *time.Time             `json:"deployedAt,omitempty"`
+}
+
+// importArtifactResponse is the per-artifact result the gateway parses. The gateway
+// reads `id` (stored as cp_artifact_id) and `error` (empty => cp_sync_status=success).
+type importArtifactResponse struct {
+	ID         string     `json:"id,omitempty"`
+	Status     string     `json:"status"`
+	Origin     string     `json:"origin"`
+	CreatedAt  time.Time  `json:"createdAt"`
+	UpdatedAt  time.Time  `json:"updatedAt"`
+	DeployedAt *time.Time `json:"deployedAt,omitempty"`
+	Error      string     `json:"error,omitempty"`
+}
+
+// importArtifactsResponse is the bulk import reply: per-dpid results plus aggregate counts.
+type importArtifactsResponse struct {
+	Total     int                               `json:"total"`
+	Success   int                               `json:"success"`
+	Failed    int                               `json:"failed"`
+	Artifacts map[string]importArtifactResponse `json:"artifacts"`
+}
+
+// recordedArtifact is the mock's current view of a pushed artifact, keyed by
+// kind+handle (the org-scoped identity the real CP matches on). It reflects the
+// latest push for that artifact.
+type recordedArtifact struct {
+	DPID          string                 `json:"dpid"`
+	CPID          string                 `json:"cpId"`
+	Kind          string                 `json:"kind"`
+	Handle        string                 `json:"handle"`
+	Status        string                 `json:"status"` // latest pushed status (deployed|undeployed|...)
+	Origin        string                 `json:"origin"`
+	DeployedAt    *time.Time             `json:"deployedAt,omitempty"`
+	CreatedAt     time.Time              `json:"createdAt"`
+	UpdatedAt     time.Time              `json:"updatedAt"`
+	Configuration map[string]interface{} `json:"configuration"`
+	PushCount     int                    `json:"pushCount"`
+}
+
+// pushEvent is an append-only log entry: one per received artifact push. Lets the
+// test assert ordering and per-push detail (e.g. an undeploy following a deploy).
+type pushEvent struct {
+	Seq        int        `json:"seq"`
+	DPID       string     `json:"dpid"`
+	Kind       string     `json:"kind"`
+	Handle     string     `json:"handle"`
+	Status     string     `json:"status"`
+	DeployedAt *time.Time `json:"deployedAt,omitempty"`
+}
+
+var (
+	recMu         sync.Mutex
+	recByKey      = map[string]*recordedArtifact{} // key = kind + "|" + handle
+	pushLog       []pushEvent
+	pushSeq       int
+	rejectImports bool // when true, every import is rejected (per-artifact error)
+)
+
+func artifactKey(kind, handle string) string { return kind + "|" + handle }
+
+func cfgString(m map[string]interface{}, key string) string {
+	if m == nil {
+		return ""
+	}
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// cfgHandle extracts metadata.name (the artifact handle) from a configuration map.
+func cfgHandle(cfg map[string]interface{}) string {
+	md, _ := cfg["metadata"].(map[string]interface{})
+	return cfgString(md, "name")
+}
+
+// importArtifactsHandler records a DP->CP bulk artifact push and returns a
+// platform-api-shaped response (a minted CP UUID per artifact, matched by handle).
+func importArtifactsHandler(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseMultipartForm(32 << 20); err != nil {
+		http.Error(w, "invalid multipart form: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	file, _, err := r.FormFile("artifacts")
+	if err != nil {
+		http.Error(w, "missing 'artifacts' file part: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	defer file.Close()
+	zipBytes, err := io.ReadAll(file)
+	if err != nil {
+		http.Error(w, "failed to read artifacts zip: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	zr, err := zip.NewReader(bytes.NewReader(zipBytes), int64(len(zipBytes)))
+	if err != nil {
+		http.Error(w, "invalid artifacts zip: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	var listJSON []byte
+	for _, f := range zr.File {
+		if f.Name == gatewayArtifactsZipEntry {
+			rc, err := f.Open()
+			if err != nil {
+				http.Error(w, "failed to open "+gatewayArtifactsZipEntry+": "+err.Error(), http.StatusBadRequest)
+				return
+			}
+			listJSON, err = io.ReadAll(rc)
+			rc.Close()
+			if err != nil {
+				http.Error(w, "failed to read "+gatewayArtifactsZipEntry+": "+err.Error(), http.StatusBadRequest)
+				return
+			}
+			break
+		}
+	}
+	if listJSON == nil {
+		http.Error(w, gatewayArtifactsZipEntry+" not found in artifacts zip", http.StatusBadRequest)
+		return
+	}
+	var reqs []importArtifactRequest
+	if err := json.Unmarshal(listJSON, &reqs); err != nil {
+		http.Error(w, "invalid "+gatewayArtifactsZipEntry+": "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	resp := importArtifactsResponse{
+		Total:     len(reqs),
+		Artifacts: make(map[string]importArtifactResponse, len(reqs)),
+	}
+
+	recMu.Lock()
+	for _, req := range reqs {
+		kind := cfgString(req.Configuration, "kind")
+		handle := cfgHandle(req.Configuration)
+
+		if rejectImports {
+			resp.Artifacts[req.DPID] = importArtifactResponse{
+				Status: "failed",
+				Origin: "gateway_api",
+				Error:  "mock control plane: artifact import rejected",
+			}
+			resp.Failed++
+			continue
+		}
+
+		key := artifactKey(kind, handle)
+		rec, ok := recByKey[key]
+		if !ok {
+			rec = &recordedArtifact{CPID: uuid.New().String(), Kind: kind, Handle: handle}
+			recByKey[key] = rec
+		}
+		rec.DPID = req.DPID
+		rec.Status = req.Status
+		rec.Origin = "gateway_api"
+		rec.DeployedAt = req.DeployedAt
+		rec.CreatedAt = req.CreatedAt
+		rec.UpdatedAt = req.UpdatedAt
+		rec.Configuration = req.Configuration
+		rec.PushCount++
+
+		pushSeq++
+		pushLog = append(pushLog, pushEvent{
+			Seq: pushSeq, DPID: req.DPID, Kind: kind, Handle: handle,
+			Status: req.Status, DeployedAt: req.DeployedAt,
+		})
+
+		resp.Artifacts[req.DPID] = importArtifactResponse{
+			ID:         rec.CPID,
+			Status:     req.Status,
+			Origin:     "gateway_api",
+			CreatedAt:  req.CreatedAt,
+			UpdatedAt:  req.UpdatedAt,
+			DeployedAt: req.DeployedAt,
+		}
+		resp.Success++
+	}
+	recMu.Unlock()
+
+	log.Printf("Recorded DP->CP import: total=%d success=%d failed=%d", resp.Total, resp.Success, resp.Failed)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// testArtifactsHandler returns the current per-artifact view (one entry per
+// kind+handle), sorted for deterministic output.
+func testArtifactsHandler(w http.ResponseWriter, r *http.Request) {
+	recMu.Lock()
+	out := make([]recordedArtifact, 0, len(recByKey))
+	for _, rec := range recByKey {
+		out = append(out, *rec)
+	}
+	recMu.Unlock()
+	sort.Slice(out, func(i, j int) bool {
+		return artifactKey(out[i].Kind, out[i].Handle) < artifactKey(out[j].Kind, out[j].Handle)
+	})
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(out)
+}
+
+// testPushesHandler returns the append-only push log (every received push, in order).
+func testPushesHandler(w http.ResponseWriter, r *http.Request) {
+	recMu.Lock()
+	out := make([]pushEvent, len(pushLog))
+	copy(out, pushLog)
+	recMu.Unlock()
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(out)
+}
+
+// testResetHandler clears the recorder and failure toggle. Called at the start of
+// each dp-to-cp scenario so assertions see only that scenario's pushes.
+func testResetHandler(w http.ResponseWriter, r *http.Request) {
+	recMu.Lock()
+	recByKey = map[string]*recordedArtifact{}
+	pushLog = nil
+	pushSeq = 0
+	rejectImports = false
+	recMu.Unlock()
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "reset"})
+}
+
+// testConfigHandler toggles recorder behaviour for negative tests. Body:
+// {"rejectImports": true} makes every subsequent import fail per-artifact.
+func testConfigHandler(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		RejectImports *bool `json:"rejectImports"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	recMu.Lock()
+	if body.RejectImports != nil {
+		rejectImports = *body.RejectImports
+	}
+	current := rejectImports
+	recMu.Unlock()
+	log.Printf("Recorder config updated: rejectImports=%v", current)
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]bool{"rejectImports": current})
 }


### PR DESCRIPTION
This pull request adds comprehensive integration tests for the data-plane to control-plane (DP->CP) artifact push logic in the gateway, and introduces test infrastructure improvements to support layered Docker Compose files for more flexible test scenarios.

Related to - https://github.com/wso2/api-platform/issues/2083

**Integration testing for DP->CP artifact sync:**

* Added a new feature file `dp-to-cp.feature` that tests the gateway's ability to push various artifact types (LLM provider templates, providers, proxies, MCP proxies, REST APIs) to the control plane, including create, update, delete, and error/retry flows.
* Added a complementary feature file `dp-to-cp-sync-disabled.feature` that verifies artifacts are *not* pushed to the control plane when deployment sync is disabled, and that their sync status is recorded as pending.

**Test infrastructure improvements:**

* Added a `docker-compose.test.dp-nosync.override.yaml` file that disables deployment sync by setting `APIP_GW_CONTROLLER_CONTROLPLANE_DEPLOYMENT_SYNC_ENABLED=false` for the gateway-controller, allowing tests to verify sync-disabled scenarios without duplicating compose files.
* Updated the `Makefile` to add a `test-dp-to-cp-nosync` target, which runs the new sync-disabled tests using the compose override. [[1]](diffhunk://#diff-c1273cc3d756c2789a4bf95f713d682304c7d375f1d3d7d57ec91046a3decd82L19-R19) [[2]](diffhunk://#diff-c1273cc3d756c2789a4bf95f713d682304c7d375f1d3d7d57ec91046a3decd82R79-R86)
* Refactored the test setup code in `setup.go` so that `ComposeManager` now accepts multiple compose files, supporting Docker Compose file layering for flexible test configuration. [[1]](diffhunk://#diff-597edc9e02dc4a8c77f3ee04ab96b306761944fcf287097154fa23b453d51b23L84-R84) [[2]](diffhunk://#diff-597edc9e02dc4a8c77f3ee04ab96b306761944fcf287097154fa23b453d51b23L94-R114) [[3]](diffhunk://#diff-597edc9e02dc4a8c77f3ee04ab96b306761944fcf287097154fa23b453d51b23L115-R124) [[4]](diffhunk://#diff-597edc9e02dc4a8c77f3ee04ab96b306761944fcf287097154fa23b453d51b23L124-R133)