### PR TITLE
fix(helm): render role_mapping lists as TOML arrays in config.toml

### DIFF
--- a/kubernetes/helm/event-gateway-helm-chart/templates/event-gateway/gateway-config.yaml
+++ b/kubernetes/helm/event-gateway-helm-chart/templates/event-gateway/gateway-config.yaml
@@ -81,7 +81,11 @@ data:
     {{- if $gc.auth.idp.role_mapping }}
     [controller.auth.idp.role_mapping]
     {{- range $key, $value := $gc.auth.idp.role_mapping }}
+    {{- if kindIs "slice" $value }}
+    {{ $key }} = [{{- range $i, $v := $value }}{{- if gt $i 0 }}, {{ end }}{{ $v | quote }}{{- end }}]
+    {{- else }}
     {{ $key }} = {{ $value | quote }}
+    {{- end }}
     {{- end }}
     {{- end }}
     {{- end }}

--- a/kubernetes/helm/gateway-helm-chart/Chart.yaml
+++ b/kubernetes/helm/gateway-helm-chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: gateway
 kubeVersion: ">=1.24.0-0"
 description: Helm chart for deploying the Gateway Operator components
-version: 1.1.2
+version: 1.1.5
 appVersion: "1.1.0"
 type: application
 home: https://github.com/wso2/api-platform

--- a/kubernetes/helm/gateway-helm-chart/templates/gateway/gateway-config.yaml
+++ b/kubernetes/helm/gateway-helm-chart/templates/gateway/gateway-config.yaml
@@ -161,7 +161,11 @@ data:
     {{- if $gc.auth.idp.role_mapping }}
     [controller.auth.idp.role_mapping]
     {{- range $key, $value := $gc.auth.idp.role_mapping }}
+    {{- if kindIs "slice" $value }}
+    {{ $key }} = [{{- range $i, $v := $value }}{{- if gt $i 0 }}, {{ end }}{{ $v | quote }}{{- end }}]
+    {{- else }}
     {{ $key }} = {{ $value | quote }}
+    {{- end }}
     {{- end }}
     {{- end }}
     {{- end }}


### PR DESCRIPTION
## Purpose

When `controller.auth.idp.role_mapping` values are defined as YAML lists in the Helm values file, the template's `| quote` pipeline serializes the entire Go slice as a literal string (e.g. `"[devgateway:admin]"`) instead of a valid TOML array (`["devgateway:admin"]`). This causes role-mapping comparison in the gateway controller to always fail, returning `403 Forbidden` on all Management API calls even with a fully valid, correctly-scoped IDP token.

Resolves #2329

## Approach

- Use `kindIs "slice"` in the `role_mapping` range loop to detect list values and render them as proper TOML arrays (`["item1", "item2", ...]` with each element quoted).
- Scalar string values fall through to the original `| quote` path — fully backward compatible.
- Fix applied to both `gateway-helm-chart` and `event-gateway-helm-chart`.
- Bump `gateway-helm-chart` version to `1.1.5`.

## Related Issues

Resolves #2329

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)