### PR TITLE
Bug fixes in policy viewing and dp to cp sync

### DIFF
--- a/gateway/gateway-controller/pkg/api/handlers/mcp_proxy_handler.go
+++ b/gateway/gateway-controller/pkg/api/handlers/mcp_proxy_handler.go
@@ -121,14 +121,6 @@ func (s *APIServer) CreateMCPProxy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	httputil.WriteJSON(w, http.StatusCreated, buildResourceResponseFromStored(mcp, cfg))
-
-	if result.IsStale {
-		return
-	}
-
-	if s.controlPlaneClient != nil && s.controlPlaneClient.IsConnected() && s.systemConfig.Controller.ControlPlane.DeploymentSyncEnabled {
-		go s.waitForDeploymentAndPush(cfg.UUID, correlationID, cfg.DeployedAt, log)
-	}
 }
 
 // ListMCPProxies implements ServerInterface.ListMCPProxies

--- a/platform-api/src/internal/service/artifact_import_llm_policies.go
+++ b/platform-api/src/internal/service/artifact_import_llm_policies.go
@@ -41,17 +41,28 @@ const (
 // plane's first-class Security and RateLimiting structures, and returns the
 // remaining (genuine) policies in their original order.
 //
+// liftRateLimits controls whether rate-limit policies (token/advanced/cost) are lifted
+// into the returned RateLimitingConfig.
 // Notes / known lossiness (inherent to the forward conversion):
 //   - Reset windows are recovered in canonical minute/hour units, because the forward
 //     formatting collapses day/week/month into hours.
 //   - Provider Global and Provider ResourceWise.Default both serialize to the "/*"
 //     path, so a "/*" entry is reconstructed as Global.
-func liftLLMPolicies(policies []model.LLMPolicy) (*model.SecurityConfig, *model.LLMRateLimitingConfig, []model.LLMPolicy) {
+func liftLLMPolicies(policies []model.LLMPolicy, liftRateLimits bool) (*model.SecurityConfig, *model.LLMRateLimitingConfig, []model.LLMPolicy) {
 	var security *model.SecurityConfig
 	rl := &rateLimitBuilder{}
 	remaining := make([]model.LLMPolicy, 0, len(policies))
 
 	for _, p := range policies {
+		// When the caller has no rate-limiting field to store into (proxies),
+		// keep rate-limit policies as ordinary policies
+		if !liftRateLimits &&
+			(p.Name == importPolicyTokenRateLimit ||
+				p.Name == importPolicyAdvancedRateLimit ||
+				p.Name == importPolicyCostRateLimit) {
+			remaining = append(remaining, p)
+			continue
+		}
 		switch p.Name {
 		case importPolicyAPIKeyAuth:
 			if s := liftAPIKeySecurity(p); s != nil {

--- a/platform-api/src/internal/service/artifact_import_llm_policies_test.go
+++ b/platform-api/src/internal/service/artifact_import_llm_policies_test.go
@@ -167,7 +167,7 @@ func TestLiftLLMPolicies_NoSpecialPolicies(t *testing.T) {
 		{Name: "custom-a"},
 		{Name: "custom-b"},
 	}
-	sec, rl, remaining := liftLLMPolicies(in)
+	sec, rl, remaining := liftLLMPolicies(in, true)
 	if sec != nil {
 		t.Errorf("security = %+v, want nil", sec)
 	}
@@ -176,5 +176,39 @@ func TestLiftLLMPolicies_NoSpecialPolicies(t *testing.T) {
 	}
 	if len(remaining) != 2 {
 		t.Errorf("remaining = %d, want 2", len(remaining))
+	}
+}
+
+// TestLiftLLMPolicies_ProxyKeepsRateLimits verifies that with rate-limit lifting
+// disabled (LLM proxies have no rate-limiting field) rate-limit policies are preserved
+// as ordinary policies instead of being dropped, while security is still lifted. This
+// guards the fix for gateway-pushed proxies losing e.g. llm-cost-based-ratelimit.
+func TestLiftLLMPolicies_ProxyKeepsRateLimits(t *testing.T) {
+	in := []model.LLMPolicy{
+		{Name: importPolicyAPIKeyAuth, Paths: []model.LLMPolicyPath{{Path: "/*", Methods: []string{"*"},
+			Params: map[string]interface{}{"key": "X-API-Key", "in": "header"}}}},
+		{Name: importPolicyCostRateLimit, Paths: []model.LLMPolicyPath{{Path: "/*", Methods: []string{"*"},
+			Params: map[string]interface{}{"budgetLimits": []interface{}{map[string]interface{}{"amount": 100, "duration": "1h"}}}}}},
+		{Name: "content-length-guardrail", Paths: []model.LLMPolicyPath{{Path: "/chat/completions", Methods: []string{"POST"}}}},
+	}
+	sec, rl, remaining := liftLLMPolicies(in, false)
+	if sec == nil || sec.APIKey == nil {
+		t.Fatalf("security not lifted: %+v", sec)
+	}
+	if rl != nil {
+		t.Errorf("rateLimiting = %+v, want nil (proxies have no rate-limiting field)", rl)
+	}
+	names := make(map[string]bool, len(remaining))
+	for _, p := range remaining {
+		names[p.Name] = true
+	}
+	if !names[importPolicyCostRateLimit] {
+		t.Errorf("remaining = %+v, want %q preserved for proxies", remaining, importPolicyCostRateLimit)
+	}
+	if !names["content-length-guardrail"] {
+		t.Errorf("remaining = %+v, want content-length-guardrail preserved", remaining)
+	}
+	if names[importPolicyAPIKeyAuth] {
+		t.Errorf("api-key-auth leaked into remaining; it should be lifted to Security")
 	}
 }

--- a/platform-api/src/internal/service/artifact_import_llm_provider.go
+++ b/platform-api/src/internal/service/artifact_import_llm_provider.go
@@ -152,7 +152,7 @@ func mapLLMProviderSpecToConfig(spec dto.LLMProviderDeploymentSpec) model.LLMPro
 	liftInput := mapGlobalPoliciesAPIToLLMPolicies(&spec.GlobalPolicies)
 	liftInput = append(liftInput, mapOperationPoliciesAPIToLLMPolicies(&spec.OperationPolicies)...)
 	liftInput = append(liftInput, mapPoliciesAPIToModel(&spec.Policies)...)
-	cfg.Security, cfg.RateLimiting, cfg.Policies = liftLLMPolicies(liftInput)
+	cfg.Security, cfg.RateLimiting, cfg.Policies = liftLLMPolicies(liftInput, true)
 	return cfg
 }
 

--- a/platform-api/src/internal/service/artifact_import_llm_proxy.go
+++ b/platform-api/src/internal/service/artifact_import_llm_proxy.go
@@ -134,8 +134,9 @@ func (i *llmProxyImporter) resolveProviderUUID(providerHandle, orgID string) (st
 // generateLLMProxyDeploymentYAML: the provider object ({id, auth}) is flattened into the
 // provider handle plus the gateway-specific upstream auth, and the policy list (which
 // carries security on the wire) is lifted back into the first-class Security field.
-// (LLM proxies have no rate-limiting field, so the lifted rate-limiting — which the proxy
-// flow never emits — is discarded.)
+// LLM proxies have no rate-limiting field, so rate-limit policies are NOT lifted
+// (liftRateLimits=false) and are kept as ordinary policies so a gateway-pushed proxy
+// that carries them (e.g. llm-cost-based-ratelimit) still surfaces them in the response.
 func mapLLMProxySpecToConfig(spec dto.LLMProxyDeploymentSpec) model.LLMProxyConfig {
 	cfg := model.LLMProxyConfig{
 		Name:     spec.DisplayName,
@@ -159,7 +160,7 @@ func mapLLMProxySpecToConfig(spec dto.LLMProxyDeploymentSpec) model.LLMProxyConf
 	liftInput := mapGlobalPoliciesAPIToLLMPolicies(&spec.GlobalPolicies)
 	liftInput = append(liftInput, mapOperationPoliciesAPIToLLMPolicies(&spec.OperationPolicies)...)
 	liftInput = append(liftInput, mapPoliciesAPIToModel(&spec.Policies)...)
-	security, _, remaining := liftLLMPolicies(liftInput)
+	security, _, remaining := liftLLMPolicies(liftInput, false)
 	cfg.Security, cfg.Policies = security, remaining
 	return cfg
 }

--- a/portals/ai-workspace/src/pages/appShell/PolicyParameterEditor/PolicyParameterEditor.tsx
+++ b/portals/ai-workspace/src/pages/appShell/PolicyParameterEditor/PolicyParameterEditor.tsx
@@ -136,6 +136,10 @@ interface PolicyParameterEditorProps {
   onCancel: () => void;
   onSubmit: (values: ParameterValues) => void;
   disabled?: boolean;
+  // readOnly renders the parameters for viewing only: every field is
+  // non-editable and the submit action is hidden, but the values remain visible
+  // and the close/cancel action stays enabled.
+  readOnly?: boolean;
 }
 
 /**
@@ -318,6 +322,7 @@ const PolicyParameterEditor: React.FC<PolicyParameterEditorProps> = ({
   onCancel,
   onSubmit,
   disabled = false,
+  readOnly = false,
 }) => {
   const classes = useStyles();
   const { name, description, parameters } = policyDefinition;
@@ -481,7 +486,7 @@ const PolicyParameterEditor: React.FC<PolicyParameterEditorProps> = ({
         onAddArrayItem={handleAddArrayItem}
         onDeleteArrayItem={handleDeleteArrayItem}
         errors={errors}
-        disabled={disabled}
+        disabled={disabled || readOnly}
       />
 
       {/* Action Buttons */}
@@ -493,17 +498,19 @@ const PolicyParameterEditor: React.FC<PolicyParameterEditorProps> = ({
           data-testid="policy-param-cancel"
           disabled={disabled}
         >
-          Cancel
+          {readOnly ? 'Close' : 'Cancel'}
         </Button>
-        <Button
-          variant="contained"
-          color="primary"
-          onClick={handleSubmit}
-          data-testid="policy-param-submit"
-          disabled={disabled || !isLevelOneValid}
-        >
-          {existingValues ? 'Update' : 'Add'}
-        </Button>
+        {!readOnly && (
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={handleSubmit}
+            data-testid="policy-param-submit"
+            disabled={disabled || !isLevelOneValid}
+          >
+            {existingValues ? 'Update' : 'Add'}
+          </Button>
+        )}
       </Box>
     </Box>
   );

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/PolicyMapper.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/PolicyMapper.tsx
@@ -172,7 +172,6 @@ export default function PolicyMapper({
   };
 
   const handleEditPolicyItem = async (item: SelectedPolicy) => {
-    if (readOnly) return;
     setEditingInstanceId(item.instanceId);
     setIsDrawerOpen(true);
     setIsFetchingPolicies(true);
@@ -404,7 +403,9 @@ export default function PolicyMapper({
                   return (
                     <DisabledActionTooltip
                       key={item.instanceId}
-                      disabled={readOnly}
+                      // The card is always clickable to VIEW the policy's
+                      // details (read-only just disables edit/remove/reorder)
+                      disabled={false}
                       title={GATEWAY_MANAGED_ARTIFACT_TOOLTIP}
                     >
                       <Box
@@ -444,16 +445,15 @@ export default function PolicyMapper({
                         boxShadow: isDragOver
                           ? '0 0 0 3px rgba(29, 78, 216, 0.12)'
                           : '0 1px 3px rgba(0, 0, 0, 0.04)',
-                        cursor: readOnly ? 'default' : 'pointer',
+                        // Clickable to view details even when read-only.
+                        cursor: 'pointer',
                         opacity:
                           draggedInstanceId === item.instanceId ? 0.5 : 1,
                         transition: 'all 0.15s ease',
-                        '&:hover': readOnly
-                          ? undefined
-                          : {
-                              borderColor: '#D1D5DB',
-                              boxShadow: '0 2px 6px rgba(0, 0, 0, 0.08)',
-                            },
+                        '&:hover': {
+                          borderColor: '#D1D5DB',
+                          boxShadow: '0 2px 6px rgba(0, 0, 0, 0.08)',
+                        },
                       }}
                     >
                       <DragHandle />
@@ -699,6 +699,7 @@ export default function PolicyMapper({
                                 existingValues={editingInstanceId ? policySettings : undefined}
                                 onCancel={() => setIsDetailView(false)}
                                 onSubmit={handlePolicySubmit}
+                                readOnly={readOnly}
                               />
                             ) : (
                               <Typography

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/ProviderTemplateOverview.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/ProviderTemplateOverview.tsx
@@ -1113,25 +1113,21 @@ export default function ProviderTemplateOverview() {
               {isDpOrigin && !isReadOnly && (
                 <GatewayArtifactReadOnlyBanner message="Token mapping is managed by the gateway that created this template and is read-only here." />
               )}
-              <Box
-                sx={
-                  isSectionReadOnly
-                    ? { pointerEvents: 'none', opacity: 0.7 }
-                    : undefined
-                }
-              >
-                <TemplateTokenMapping
-                  defaultTokens={defaultTokens}
-                  onChangeDefaultToken={updateToken}
-                  resourceMappings={resourceMappings}
-                  onChangeResourceMappings={(next) => {
-                    setResourceMappings(next);
-                    setIsDirty(true);
-                  }}
-                  spec={parsedSpec}
-                  hidePerResource={isSectionReadOnly}
-                />
-              </Box>
+              {/* Read-only sections stay fully viewable: TemplateTokenMapping
+                  disables its editable fields via readOnly while keeping the
+                  scope toggle, search, per-resource list and expansion working
+                  (no pointerEvents:none, and per-resource is not hidden). */}
+              <TemplateTokenMapping
+                defaultTokens={defaultTokens}
+                onChangeDefaultToken={updateToken}
+                resourceMappings={resourceMappings}
+                onChangeResourceMappings={(next) => {
+                  setResourceMappings(next);
+                  setIsDirty(true);
+                }}
+                spec={parsedSpec}
+                readOnly={isSectionReadOnly}
+              />
             </TabPanel>
           </Box>
         </Card>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/TemplateTokenMapping.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/TemplateTokenMapping.tsx
@@ -84,9 +84,11 @@ function extractResources(spec: Record<string, unknown> | null): DiscoveredResou
 function TokenFieldsEditor({
   tokens,
   onChange,
+  disabled = false,
 }: {
   tokens: TokenConfig;
   onChange: (field: TokenFieldKey, key: 'identifier' | 'location', value: string) => void;
+  disabled?: boolean;
 }) {
   return (
     <Box
@@ -104,11 +106,13 @@ function TokenFieldsEditor({
               fullWidth
               size="small"
               value={tokens[key].identifier}
+              disabled={disabled}
               onChange={(e) => onChange(key, 'identifier', e.target.value)}
             />
             <Select
               size="small"
               value={tokens[key].location}
+              disabled={disabled}
               onChange={(e) => onChange(key, 'location', e.target.value as string)}
               sx={{ minWidth: 130, flexShrink: 0 }}
             >
@@ -136,6 +140,10 @@ interface TemplateTokenMappingProps {
   onChangeResourceMappings: (next: ResourceMapping[]) => void;
   spec: Record<string, unknown> | null;
   hidePerResource?: boolean;
+  // readOnly keeps the mapping fully viewable (scope toggle, search and
+  // expand still work) but disables the editable controls (token identifier/
+  // location fields and the per-resource Override switch).
+  readOnly?: boolean;
 }
 
 export default function TemplateTokenMapping({
@@ -145,6 +153,7 @@ export default function TemplateTokenMapping({
   onChangeResourceMappings,
   spec,
   hidePerResource = false,
+  readOnly = false,
 }: TemplateTokenMappingProps) {
   const [scope, setScope] = useState<'default' | 'resource'>('default');
   const [search, setSearch] = useState('');
@@ -223,7 +232,11 @@ export default function TemplateTokenMapping({
               Applies to all resources unless overridden per resource.
             </Typography>
           </Stack>
-          <TokenFieldsEditor tokens={defaultTokens} onChange={onChangeDefaultToken} />
+          <TokenFieldsEditor
+            tokens={defaultTokens}
+            onChange={onChangeDefaultToken}
+            disabled={readOnly}
+          />
         </>
       ) : (
         <Stack spacing={1.5}>
@@ -270,6 +283,7 @@ export default function TemplateTokenMapping({
                               <Switch
                                 size="small"
                                 checked={overridden}
+                                disabled={readOnly}
                                 onChange={(e) =>
                                   toggleOverride(r.path, key, e.target.checked)
                                 }
@@ -306,6 +320,7 @@ export default function TemplateTokenMapping({
                             onChange={(field, k, value) =>
                               updateResourceToken(r.path, field, k, value)
                             }
+                            disabled={readOnly}
                           />
                         ) : (
                           <Typography variant="body2" color="text.secondary">

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyGuardrailsTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyGuardrailsTab.tsx
@@ -655,13 +655,10 @@ export default function LLMProxyGuardrailsTab() {
               <GuardrailPill
                 key={g.id}
                 label={`${g.displayName} (${g.version.replace(/^v/, '')})`}
-                onClick={
-                  isReadOnlyProxy
-                    ? undefined
-                    : () =>
-                        handleEditGuardrailPill(g.policyIndex, g.pathIndex, {
-                            scope: 'global',
-                        }, g.source)
+                onClick={() =>
+                  handleEditGuardrailPill(g.policyIndex, g.pathIndex, {
+                    scope: 'global',
+                  }, g.source)
                 }
                 onRemove={
                   isReadOnlyProxy
@@ -972,20 +969,17 @@ export default function LLMProxyGuardrailsTab() {
                                           label={`${
                                             g.displayName
                                           } (${g.version.replace(/^v/, '')})`}
-                                          onClick={
-                                            isReadOnlyProxy
-                                              ? undefined
-                                              : () =>
-                                                handleEditGuardrailPill(
-                                                  g.policyIndex,
-                                                  g.pathIndex,
-                                                  {
-                                                    scope: 'resource',
-                                                    method,
-                                                    path: resource.path,
-                                                  },
-                                                  g.source
-                                                )
+                                          onClick={() =>
+                                            handleEditGuardrailPill(
+                                              g.policyIndex,
+                                              g.pathIndex,
+                                              {
+                                                scope: 'resource',
+                                                method,
+                                                path: resource.path,
+                                              },
+                                              g.source
+                                            )
                                           }
                                           onRemove={
                                             isReadOnlyProxy
@@ -1253,6 +1247,7 @@ export default function LLMProxyGuardrailsTab() {
                               existingValues={editingTarget ? guardrailSettings : undefined}
                               onCancel={() => setIsDetailView(false)}
                               onSubmit={handlePolicySubmit}
+                              readOnly={isReadOnlyProxy}
                             />
                           ) : (
                             <Typography variant="body2" color="text.secondary">

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyGuardrailsTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyGuardrailsTab.tsx
@@ -293,10 +293,36 @@ export default function LLMProxyGuardrailsTab() {
     return items;
   }, [proxy?.globalPolicies, policies, displayNameMap]);
 
-  const resources = useMemo(
-    () => parseOpenApiText(proxy?.openapi || ''),
-    [proxy?.openapi]
-  );
+  const resources = useMemo(() => {
+    const specResources = parseOpenApiText(proxy?.openapi || '');
+    // A gateway-pushed proxy has no OpenAPI spec, so specResources is empty.
+    // Derive a resource row for every concrete (method, path) referenced by an
+    // operation/legacy policy so its guardrails are still shown and viewable in
+    // the resource-wise section. Wildcard method ('*') / path ('/*') entries are
+    // provider-wide (handled elsewhere) and are skipped here.
+    const seen = new Set(
+      specResources.map((r) => `${r.method.toUpperCase()} ${r.path}`)
+    );
+    const derived: ResourceItem[] = [];
+    const addPaths = (
+      paths?: Array<{ methods?: string[]; path: string }>
+    ) => {
+      (paths ?? []).forEach((pc) => {
+        if (!pc?.path || pc.path === '/*') return;
+        (pc.methods ?? []).forEach((m) => {
+          const method = (m || '').toUpperCase();
+          if (!method || method === '*') return;
+          const dedupeKey = `${method} ${pc.path}`;
+          if (seen.has(dedupeKey)) return;
+          seen.add(dedupeKey);
+          derived.push({ method, path: pc.path });
+        });
+      });
+    };
+    (proxy?.operationPolicies ?? []).forEach((p) => addPaths(p.paths));
+    policies.forEach((p) => addPaths(p.paths));
+    return [...specResources, ...derived];
+  }, [proxy?.openapi, proxy?.operationPolicies, policies]);
 
   const selectedGuardrailPolicy =
     drawerGuardrails.find((p) => p.name === selectedGuardrail) ??
@@ -327,20 +353,21 @@ export default function LLMProxyGuardrailsTab() {
     scope: DrawerContext,
     source: 'global' | 'operation' | 'legacy'
   ) => {
-    if (isReadOnlyProxy) return;
-
     let policyName: string;
+    let policyVersion: string | undefined;
     let existingParams: ParameterValues = {};
 
     if (source === 'global') {
       const policy = (proxy?.globalPolicies ?? [])[policyIndex];
       if (!policy) return;
       policyName = policy.name;
+      policyVersion = policy.version;
       existingParams = (policy.params as ParameterValues) ?? {};
     } else if (source === 'operation') {
       const policy = (proxy?.operationPolicies ?? [])[policyIndex];
       if (!policy) return;
       policyName = policy.name;
+      policyVersion = policy.version;
       existingParams =
         pathIndex !== null
           ? ((policy.paths[pathIndex]?.params as ParameterValues) ?? {})
@@ -349,6 +376,7 @@ export default function LLMProxyGuardrailsTab() {
       const policy = policies[policyIndex];
       if (!policy) return;
       policyName = policy.name;
+      policyVersion = policy.version;
       existingParams =
         pathIndex !== null
           ? ((policy.paths?.[pathIndex]?.params as ParameterValues) ?? {})
@@ -364,16 +392,22 @@ export default function LLMProxyGuardrailsTab() {
     setDefinitionError(null);
     setDrawerOpen(true);
 
+    // Prefer the policy-hub version, but fall back to the applied policy's own
+    // version so non-guardrail policies shown as pills (e.g. rate-limit policies,
+    // which the guardrails hub list doesn't include) can still load their
+    // definition. getGuardrailDefinition hits the generic policy-definition
+    // endpoint, so it resolves any policy by name+version.
     const guardrailMeta = availableGuardrails.find(
       (g) => g.name === policyName
     );
-    if (!guardrailMeta?.version) {
-      setDefinitionError('No version available for this guardrail.');
+    const definitionVersion = guardrailMeta?.version ?? policyVersion;
+    if (!definitionVersion) {
+      setDefinitionError('No version available for this policy.');
       return;
     }
 
     setDefinitionLoading(true);
-    getGuardrailDefinition(guardrailMeta.name, guardrailMeta.version)
+    getGuardrailDefinition(policyName, definitionVersion)
       .then((response) => {
         const parsedDefinition = parsePolicyYaml(response);
         setPolicyDefinition(parsedDefinition);

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderGuardrailsTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderGuardrailsTab.tsx
@@ -693,13 +693,10 @@ export default function ServiceProviderGuardrailsTab() {
               <GuardrailPill
                 key={g.id}
                 label={`${g.displayName} (${g.version})`}
-                onClick={
-                  isReadOnlyProvider
-                    ? undefined
-                    : () =>
-                      handleEditGuardrailPill(g.policyIndex, g.pathIndex, {
-                        scope: 'global',
-                      }, g.source)
+                onClick={() =>
+                  handleEditGuardrailPill(g.policyIndex, g.pathIndex, {
+                    scope: 'global',
+                  }, g.source)
                 }
                 onRemove={
                   isReadOnlyProvider
@@ -985,20 +982,17 @@ export default function ServiceProviderGuardrailsTab() {
                                           /^v/,
                                           ''
                                         )})`}
-                                        onClick={
-                                          isReadOnlyProvider
-                                            ? undefined
-                                            : () =>
-                                              handleEditGuardrailPill(
-                                                guardrail.policyIndex,
-                                                guardrail.pathIndex,
-                                                {
-                                                  scope: 'resource',
-                                                  method,
-                                                  path: resource.path,
-                                                },
-                                                guardrail.source
-                                              )
+                                        onClick={() =>
+                                          handleEditGuardrailPill(
+                                            guardrail.policyIndex,
+                                            guardrail.pathIndex,
+                                            {
+                                              scope: 'resource',
+                                              method,
+                                              path: resource.path,
+                                            },
+                                            guardrail.source
+                                          )
                                         }
                                         onRemove={
                                           isReadOnlyProvider
@@ -1254,6 +1248,7 @@ export default function ServiceProviderGuardrailsTab() {
                               existingValues={editingTarget ? guardrailSettings : undefined}
                               onCancel={() => setIsDetailView(false)}
                               onSubmit={handlePolicySubmit}
+                              readOnly={isReadOnlyProvider}
                             />
                           ) : (
                             <Typography variant="body2" color="text.secondary">

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderGuardrailsTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderGuardrailsTab.tsx
@@ -309,10 +309,44 @@ export default function ServiceProviderGuardrailsTab() {
     return items;
   }, [provider?.globalPolicies, policies, displayNameMap]);
 
-  const resources = useMemo(
-    () => parseOpenApiText(provider?.openapi || '', provider?.accessControl),
-    [provider?.openapi, provider?.accessControl]
-  );
+  const resources = useMemo(() => {
+    const specResources = parseOpenApiText(
+      provider?.openapi || '',
+      provider?.accessControl
+    );
+    // A gateway-pushed provider has no OpenAPI spec, so specResources is empty.
+    // Derive a resource row for every concrete (method, path) referenced by an
+    // operation/legacy policy so its guardrails are still shown and viewable in
+    // the resource-wise section. Wildcard method ('*') / path ('/*') entries are
+    // provider-wide (handled elsewhere) and are skipped here.
+    const seen = new Set(
+      specResources.map((r) => `${r.method.toUpperCase()} ${r.path}`)
+    );
+    const derived: ResourceItem[] = [];
+    const addPaths = (
+      paths?: Array<{ methods?: string[]; path: string }>
+    ) => {
+      (paths ?? []).forEach((pc) => {
+        if (!pc?.path || pc.path === '/*') return;
+        (pc.methods ?? []).forEach((m) => {
+          const method = (m || '').toUpperCase();
+          if (!method || method === '*') return;
+          const dedupeKey = `${method} ${pc.path}`;
+          if (seen.has(dedupeKey)) return;
+          seen.add(dedupeKey);
+          derived.push({ method, path: pc.path });
+        });
+      });
+    };
+    (provider?.operationPolicies ?? []).forEach((p) => addPaths(p.paths));
+    policies.forEach((p) => addPaths(p.paths));
+    return [...specResources, ...derived];
+  }, [
+    provider?.openapi,
+    provider?.accessControl,
+    provider?.operationPolicies,
+    policies,
+  ]);
 
   const selectedGuardrailPolicy =
     drawerGuardrails.find((policy) => policy.name === selectedGuardrail) ??
@@ -340,17 +374,20 @@ export default function ServiceProviderGuardrailsTab() {
     source: 'global' | 'operation' | 'legacy'
   ) => {
     let policyName: string;
+    let policyVersion: string | undefined;
     let existingParams: ParameterValues = {};
 
     if (source === 'global') {
       const policy = (provider?.globalPolicies ?? [])[policyIndex];
       if (!policy) return;
       policyName = policy.name;
+      policyVersion = policy.version;
       existingParams = (policy.params as ParameterValues) ?? {};
     } else if (source === 'operation') {
       const policy = (provider?.operationPolicies ?? [])[policyIndex];
       if (!policy) return;
       policyName = policy.name;
+      policyVersion = policy.version;
       existingParams =
         pathIndex !== null
           ? ((policy.paths[pathIndex]?.params as ParameterValues) ?? {})
@@ -359,6 +396,7 @@ export default function ServiceProviderGuardrailsTab() {
       const policy = policies[policyIndex];
       if (!policy) return;
       policyName = policy.name;
+      policyVersion = policy.version;
       existingParams =
         pathIndex !== null
           ? ((policy.paths?.[pathIndex]?.params as ParameterValues) ?? {})
@@ -374,16 +412,22 @@ export default function ServiceProviderGuardrailsTab() {
     setDefinitionError(null);
     setDrawerOpen(true);
 
+    // Prefer the policy-hub version, but fall back to the applied policy's own
+    // version so non-guardrail policies shown as pills (e.g. the llm-cost tracker,
+    // which the guardrails hub list doesn't include) can still load their
+    // definition. getGuardrailDefinition hits the generic policy-definition
+    // endpoint, so it resolves any policy by name+version.
     const guardrailMeta = availableGuardrails.find(
       (g) => g.name === policyName
     );
-    if (!guardrailMeta?.version) {
-      setDefinitionError('No version available for this guardrail.');
+    const definitionVersion = guardrailMeta?.version ?? policyVersion;
+    if (!definitionVersion) {
+      setDefinitionError('No version available for this policy.');
       return;
     }
 
     setDefinitionLoading(true);
-    getGuardrailDefinition(guardrailMeta.name, guardrailMeta.version)
+    getGuardrailDefinition(policyName, definitionVersion)
       .then((response) => {
         const parsedDefinition = parsePolicyYaml(response);
         setPolicyDefinition(parsedDefinition);

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderRateLimitingTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderRateLimitingTab.tsx
@@ -234,7 +234,7 @@ function CriteriaRows({
                 />
                 <IconButton
                   size="small"
-                  disabled={!item.enabled || disabled}
+                  disabled={!item.enabled}
                   onClick={() => toggleOpen(item.label)}
                 >
                   {openMap[item.label] ? (


### PR DESCRIPTION
This pull request introduces important improvements to how LLM proxy and provider policy configurations are handled, ensuring rate-limit policies are preserved for proxies, and enhances the UI to support fully viewable read-only states for policy and token mapping editors. The changes address a bug where rate-limit policies were dropped from gateway-pushed proxies and improve the user experience by allowing details to be viewed even when editing is disabled.

Related to - https://github.com/wso2/api-platform/issues/2444

**Backend: LLM Policy Handling**

* Ensured that when mapping LLM proxy specs, rate-limit policies are no longer lifted and dropped, but instead are preserved as ordinary policies, fixing the loss of such policies in proxy responses (`liftLLMPolicies` now takes a `liftRateLimits` parameter, and is used appropriately in proxy/provider mapping) [[1]](diffhunk://#diff-845a80dbf9c29f5b436ba948afc9c8b9b70b90ded23b816397ea5936b93e4f7bR44-R65) [[2]](diffhunk://#diff-6eac19f4cef21089f8d96e6bf1d928c5cb889fab78b40a91c677747a202423d9L137-R139) [[3]](diffhunk://#diff-6eac19f4cef21089f8d96e6bf1d928c5cb889fab78b40a91c677747a202423d9L162-R163) [[4]](diffhunk://#diff-5e684cd14731c344959636e4fe4f04381721e6edb8c507d53533cf0ecd179a59L155-R155).
* Added a targeted unit test to verify that when rate-limit lifting is disabled, rate-limit policies are preserved for proxies, guarding against regressions.

**Frontend: Read-Only UI Improvements**

* Updated the `PolicyParameterEditor` and `TemplateTokenMapping` components to support a `readOnly` mode, making all fields non-editable while keeping values visible and the close/cancel action enabled [[1]](diffhunk://#diff-cc527cb6c16be22058c42740efbe002c2bf0e574d3470f05b4d975bedcbda77fR139-R142) [[2]](diffhunk://#diff-cc527cb6c16be22058c42740efbe002c2bf0e574d3470f05b4d975bedcbda77fR325) [[3]](diffhunk://#diff-cc527cb6c16be22058c42740efbe002c2bf0e574d3470f05b4d975bedcbda77fL484-R489) [[4]](diffhunk://#diff-cc527cb6c16be22058c42740efbe002c2bf0e574d3470f05b4d975bedcbda77fL496-R503) [[5]](diffhunk://#diff-cc527cb6c16be22058c42740efbe002c2bf0e574d3470f05b4d975bedcbda77fR513) [[6]](diffhunk://#diff-b6610712c30159507dbfca03e16a12b0d241bb81efd00023442ecc6ff0aa5b30R143-R146) [[7]](diffhunk://#diff-b6610712c30159507dbfca03e16a12b0d241bb81efd00023442ecc6ff0aa5b30R156) [[8]](diffhunk://#diff-b6610712c30159507dbfca03e16a12b0d241bb81efd00023442ecc6ff0aa5b30L226-R239) [[9]](diffhunk://#diff-b6610712c30159507dbfca03e16a12b0d241bb81efd00023442ecc6ff0aa5b30R286) [[10]](diffhunk://#diff-b6610712c30159507dbfca03e16a12b0d241bb81efd00023442ecc6ff0aa5b30R323).
* Modified `PolicyMapper` to always allow viewing policy details (even when read-only), while disabling edit/remove/reorder actions, improving discoverability and consistency in the UI [[1]](diffhunk://#diff-c3718ec9144b7d884e15851a6a566e014f182111dde5dc4a3ea3c8c6196db74aL175) [[2]](diffhunk://#diff-c3718ec9144b7d884e15851a6a566e014f182111dde5dc4a3ea3c8c6196db74aL407-R408) [[3]](diffhunk://#diff-c3718ec9144b7d884e15851a6a566e014f182111dde5dc4a3ea3c8c6196db74aL447-R453) [[4]](diffhunk://#diff-c3718ec9144b7d884e15851a6a566e014f182111dde5dc4a3ea3c8c6196db74aR702).
* Refactored `ProviderTemplateOverview` to pass the new `readOnly` prop to `TemplateTokenMapping`, removing the previous approach of disabling pointer events and opacity, so that read-only sections remain fully viewable and interactive for navigation [[1]](diffhunk://#diff-561a9b30a4245a1eaf506696e02a22947ada15b65af82bdcc7db9748eba518f4L1116-R1119) [[2]](diffhunk://#diff-561a9b30a4245a1eaf506696e02a22947ada15b65af82bdcc7db9748eba518f4L1132-L1134).

**Other**

* Cleaned up unused code and improved comments for clarity regarding rate-limit policy handling and UI behavior [[1]](diffhunk://#diff-61d72c4ca763a213619f30f70d80e117df930edd92b33550e90aff348d21bab4L124-L131) [[2]](diffhunk://#diff-6eac19f4cef21089f8d96e6bf1d928c5cb889fab78b40a91c677747a202423d9L137-R139).