### PR TITLE
[Platform API] Add CORS configuration to server settings and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,6 +151,11 @@ platform-api/resources/openapi_with_binding.yaml
 platform-api/cmd/cmd
 # Compiled platform-api binary (produced by `go build` in src/)
 platform-api/main
+# Secret/key material and local working-tree checkouts that must never be committed
+platform-api/config/data/
+platform-api/src/
+**/*.key
+**/certs/*.pem
 
 # Gateway
 gateway/gateway-runtime/target

--- a/httpkit/middleware/cors.go
+++ b/httpkit/middleware/cors.go
@@ -10,6 +10,7 @@ import (
 // CORSOptions configures CORS behaviour for CORSMiddleware and WithCORS.
 type CORSOptions struct {
 	// AllowedOrigins lists origins that may access the resource.
+	// Empty (the default) denies all cross-origin access — fail closed.
 	// Use ["*"] to allow any origin (cannot be combined with AllowCredentials).
 	AllowedOrigins []string
 	// AllowedMethods lists the HTTP methods permitted for the resource.
@@ -94,8 +95,10 @@ func applyCORSHeaders(w http.ResponseWriter, r *http.Request, opts CORSOptions) 
 }
 
 func resolveOrigin(origin string, allowed []string) string {
+	// Fail closed: an empty allowlist means no cross-origin access, not "allow all".
+	// Callers must opt in to "*" explicitly.
 	if len(allowed) == 0 {
-		return "*"
+		return ""
 	}
 	if slices.Contains(allowed, "*") {
 		return "*"

--- a/httpkit/middleware/cors.go
+++ b/httpkit/middleware/cors.go
@@ -71,7 +71,11 @@ func applyCORSHeaders(w http.ResponseWriter, r *http.Request, opts CORSOptions) 
 	w.Header().Add("Vary", "Origin")
 	w.Header().Set("Access-Control-Allow-Origin", allowedOrigin)
 
-	if opts.AllowCredentials {
+	// Never pair a wildcard origin with credentials: the combination is spec-invalid
+	// (browsers reject it for credentialed requests) and, if a browser ever did honor it,
+	// would let any site read authenticated responses. Only send the credentials header
+	// when the origin was resolved to a specific, allowlisted value.
+	if opts.AllowCredentials && allowedOrigin != "*" {
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 	}
 

--- a/platform-api/config/config.go
+++ b/platform-api/config/config.go
@@ -90,6 +90,7 @@ type Server struct {
 	Deployments      Deployments      `koanf:"deployments"`
 	ArtifactLimits   ArtifactLimits   `koanf:"artifact_limits"`
 	TLS              TLS              `koanf:"tls"`
+	CORS             CORS             `koanf:"cors"`
 	APIKey           APIKey           `koanf:"api_key"`
 	Gateway          Gateway          `koanf:"gateway"`
 	EventHub         EventHub         `koanf:"event_hub"`
@@ -168,6 +169,14 @@ type Gateway struct {
 // TLS holds TLS certificate configuration.
 type TLS struct {
 	CertDir string `koanf:"cert_dir"`
+}
+
+// CORS holds cross-origin resource sharing configuration.
+type CORS struct {
+	// AllowedOrigins lists the exact origins permitted to make credentialed
+	// cross-origin requests. Must not be ["*"] outside demo mode — wildcard
+	// origins cannot be combined with credentialed requests.
+	AllowedOrigins []string `koanf:"allowed_origins"`
 }
 
 // JWT holds configuration for local HMAC JWT authentication.
@@ -705,6 +714,10 @@ func envToKoanfKey(s string) string {
 	// TLS
 	case "tls_cert_dir":
 		return "tls.cert_dir"
+
+	// CORS
+	case "cors_allowed_origins":
+		return "cors.allowed_origins"
 
 	// API Key
 	case "api_key_hashing_algorithms":

--- a/platform-api/config/config.toml
+++ b/platform-api/config/config.toml
@@ -86,6 +86,16 @@ scopes        = "ap:organization:manage ap:gateway:manage ap:gateway_custom_poli
 # cert_dir = "/app/data/certs"
 
 # ---------------------------------------------------------------------------
+# CORS
+# ---------------------------------------------------------------------------
+# Required (non-wildcard) when APIP_DEMO_MODE=false. List the exact origins
+# (scheme + host + port) that are allowed to make credentialed cross-origin
+# requests, e.g. the Developer Portal / Admin UI origins.
+# Override with the CORS_ALLOWED_ORIGINS env var (comma-separated).
+# [cors]
+# allowed_origins = ["https://devportal.example.com", "https://admin.example.com"]
+
+# ---------------------------------------------------------------------------
 # DevPortal integration — disable for standalone deployments
 # ---------------------------------------------------------------------------
 [default_devportal]

--- a/platform-api/internal/server/server.go
+++ b/platform-api/internal/server/server.go
@@ -35,6 +35,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"slices"
 	"strings"
 	"syscall"
 	"time"
@@ -86,6 +87,9 @@ func validateAuthConfig(cfg *config.Server) error {
 	}
 	if cfg.Auth.JWT.Enabled && cfg.Auth.JWT.SkipValidation {
 		return fmt.Errorf("JWT signature validation cannot be skipped (AUTH_JWT_SKIP_VALIDATION=true) when APIP_DEMO_MODE=false; set AUTH_JWT_SKIP_VALIDATION=false for production")
+	}
+	if len(cfg.CORS.AllowedOrigins) == 0 || slices.Contains(cfg.CORS.AllowedOrigins, "*") {
+		return fmt.Errorf("CORS_ALLOWED_ORIGINS must be set to an explicit, non-wildcard list of origins when APIP_DEMO_MODE=false")
 	}
 	return nil
 }
@@ -487,11 +491,20 @@ func StartPlatformAPIServer(cfg *config.Server, slogger *slog.Logger) (*Server, 
 	// Order: CORS → auth → scope enforcer → mux
 	var chain []func(http.Handler) http.Handler
 
+	// validateAuthConfig already rejected a missing/wildcard allowlist outside demo mode;
+	// this fallback only ever applies in demo mode, and never sends credentials alongside it.
+	corsOrigins := cfg.CORS.AllowedOrigins
+	allowCredentials := true
+	if len(corsOrigins) == 0 || slices.Contains(corsOrigins, "*") {
+		slogger.Warn("CORS_ALLOWED_ORIGINS not set to an explicit allowlist — allowing all origins without credentials [demo mode only]")
+		corsOrigins = []string{"*"}
+		allowCredentials = false
+	}
 	chain = append(chain, gohttpkit.CORSMiddleware(gohttpkit.CORSOptions{
-		AllowedOrigins:   []string{"*"},
+		AllowedOrigins:   corsOrigins,
 		AllowedMethods:   []string{"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"},
 		AllowedHeaders:   []string{"Origin", "Content-Length", "Content-Type", "Authorization"},
-		AllowCredentials: true,
+		AllowCredentials: allowCredentials,
 	}))
 
 	if cfg.Auth.FileBased.Enabled {

--- a/platform-api/internal/server/server.go
+++ b/platform-api/internal/server/server.go
@@ -491,20 +491,20 @@ func StartPlatformAPIServer(cfg *config.Server, slogger *slog.Logger) (*Server, 
 	// Order: CORS → auth → scope enforcer → mux
 	var chain []func(http.Handler) http.Handler
 
-	// validateAuthConfig already rejected a missing/wildcard allowlist outside demo mode;
-	// this fallback only ever applies in demo mode, and never sends credentials alongside it.
+	// validateAuthConfig already rejected a missing/wildcard allowlist outside demo mode.
+	// Cross-origin access is disabled by default (empty AllowedOrigins fails closed in the
+	// CORS middleware); operators must opt in explicitly via CORS_ALLOWED_ORIGINS.
 	corsOrigins := cfg.CORS.AllowedOrigins
-	allowCredentials := true
-	if len(corsOrigins) == 0 || slices.Contains(corsOrigins, "*") {
-		slogger.Warn("CORS_ALLOWED_ORIGINS not set to an explicit allowlist — allowing all origins without credentials [demo mode only]")
-		corsOrigins = []string{"*"}
-		allowCredentials = false
+	if len(corsOrigins) == 0 {
+		slogger.Warn("CORS_ALLOWED_ORIGINS not set — cross-origin requests are disabled")
+	} else if slices.Contains(corsOrigins, "*") {
+		slogger.Warn("CORS_ALLOWED_ORIGINS contains \"*\" — allowing all origins without credentials")
 	}
 	chain = append(chain, gohttpkit.CORSMiddleware(gohttpkit.CORSOptions{
 		AllowedOrigins:   corsOrigins,
 		AllowedMethods:   []string{"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"},
 		AllowedHeaders:   []string{"Origin", "Content-Length", "Content-Type", "Authorization"},
-		AllowCredentials: allowCredentials,
+		AllowCredentials: !slices.Contains(corsOrigins, "*"),
 	}))
 
 	if cfg.Auth.FileBased.Enabled {


### PR DESCRIPTION
- Introduced CORS struct in the server configuration to manage allowed origins for credentialed requests.
- Updated validation logic to ensure non-wildcard origins are specified when not in demo mode.
- Enhanced CORS middleware to conditionally allow credentials based on the configured origins.
- Added entries to .gitignore to exclude sensitive key material and local directories from version control.

