### PR TITLE
Reset cp_sync_status on update of artifacts from gateway

### DIFF
--- a/gateway/gateway-controller/pkg/storage/sql_store.go
+++ b/gateway/gateway-controller/pkg/storage/sql_store.go
@@ -648,7 +648,8 @@ func (s *sqlStore) UpsertConfig(cfg *models.StoredConfig) (bool, error) {
 
 	// Portable insert-or-update guarded by deployed_at: only overwrite when the
 	// incoming deployed_at is strictly newer (or the stored value is NULL).
-	// cp_sync_* and created_at are written on INSERT only — preserved on update.
+	// cp_artifact_id and created_at are written on INSERT only — preserved on update
+	// cp_sync_status and cp_sync_info ARE reset on update
 	didWrite, err := s.upsert(tx, upsertSpec{
 		table: "artifacts",
 		columns: []string{
@@ -667,10 +668,12 @@ func (s *sqlStore) UpsertConfig(cfg *models.StoredConfig) (bool, error) {
 			"display_name = ?", "version = ?", "data_version = ?", "kind = ?", "handle = ?",
 			"desired_state = ?", "deployment_id = ?", "origin = ?",
 			"updated_at = ?", "deployed_at = ?",
+			"cp_sync_status = ?", "cp_sync_info = ?",
 		},
 		setValues: []interface{}{
 			cfg.DisplayName, cfg.Version, cfg.DataVersion, cfg.Kind, cfg.Handle,
 			cfg.DesiredState, deploymentID, cfg.Origin, now, cfg.DeployedAt,
+			upsertCPSyncStatus, upsertCPSyncInfo,
 		},
 		guard:       "(deployed_at IS NULL OR deployed_at < ?)",
 		guardValues: []interface{}{cfg.DeployedAt},

--- a/gateway/gateway-controller/pkg/storage/sqlite_test.go
+++ b/gateway/gateway-controller/pkg/storage/sqlite_test.go
@@ -1362,6 +1362,64 @@ func TestSQLiteStorage_UpsertConfig(t *testing.T) {
 		assert.Equal(t, models.StateDeployed, retrieved.DesiredState)
 	})
 
+	t.Run("Update re-marks gateway-origin cp_sync_status pending and preserves cp_artifact_id", func(t *testing.T) {
+		// Regression for #2475: an update made while the DP->CP push is disabled must flip
+		// the row back to pending so the reconnect reconciliation re-syncs it. Previously
+		// cp_sync_status was written on INSERT only and left stale ("success") on update.
+		cfg := createTestStoredConfig() // Origin gateway_api
+		olderTime := time.Now().Add(-1 * time.Hour)
+		cfg.DeployedAt = &olderTime
+		cfg.CPSyncStatus = models.CPSyncStatusPending // cpSyncStatusForOrigin(gateway_api)
+
+		updated, err := storage.UpsertConfig(cfg)
+		assert.NilError(t, err)
+		assert.Assert(t, updated)
+
+		// Simulate a successful DP->CP push: status success, CP UUID recorded.
+		assert.NilError(t, storage.UpdateCPSyncStatus(cfg.UUID, "cp-uuid-123", models.CPSyncStatusSuccess, ""))
+
+		// A later update (newer deployed_at), as the deploy path builds it — carrying
+		// pending for a gateway-origin artifact.
+		newerTime := time.Now()
+		cfg.DeployedAt = &newerTime
+		cfg.DisplayName = "Updated Name"
+		cfg.CPSyncStatus = models.CPSyncStatusPending
+
+		updated, err = storage.UpsertConfig(cfg)
+		assert.NilError(t, err)
+		assert.Assert(t, updated)
+
+		retrieved, err := storage.GetConfig(cfg.UUID)
+		assert.NilError(t, err)
+		assert.Equal(t, models.CPSyncStatusPending, retrieved.CPSyncStatus)
+		// The CP UUID from the prior successful sync is preserved (not wiped by the update).
+		assert.Equal(t, "cp-uuid-123", retrieved.CPArtifactID)
+	})
+
+	t.Run("Update keeps cp_sync_status NULL for control-plane-origin", func(t *testing.T) {
+		cfg := createTestStoredConfig()
+		cfg.Origin = models.OriginControlPlane
+		cfg.CPSyncStatus = "" // cpSyncStatusForOrigin(control_plane) => NULL, never pushed back
+		olderTime := time.Now().Add(-1 * time.Hour)
+		cfg.DeployedAt = &olderTime
+
+		updated, err := storage.UpsertConfig(cfg)
+		assert.NilError(t, err)
+		assert.Assert(t, updated)
+
+		newerTime := time.Now()
+		cfg.DeployedAt = &newerTime
+		cfg.DisplayName = "Updated CP Name"
+
+		updated, err = storage.UpsertConfig(cfg)
+		assert.NilError(t, err)
+		assert.Assert(t, updated)
+
+		retrieved, err := storage.GetConfig(cfg.UUID)
+		assert.NilError(t, err)
+		assert.Equal(t, models.CPSyncStatus(""), retrieved.CPSyncStatus)
+	})
+
 	t.Run("Missing handle returns error", func(t *testing.T) {
 		cfg := createTestStoredConfig()
 		cfg.Handle = ""


### PR DESCRIPTION
This pull request updates the config upsert logic to ensure that `cp_sync_status` and `cp_sync_info` are always reset on update, not just on insert. This fixes an issue where these fields could become stale, especially for gateway-origin artifacts, and adds regression tests to prevent future breakage.

Fixes -
- https://github.com/wso2/api-platform/issues/2475

**Bug fix: Upsert logic for sync status fields**

* Updated the comment in `sql_store.go` to clarify that `cp_sync_status` and `cp_sync_info` are reset on update, while `cp_artifact_id` and `created_at` are only set on insert.
* Modified the SQL upsert operation in `sql_store.go` to explicitly set `cp_sync_status` and `cp_sync_info` on updates, ensuring their values are refreshed appropriately.

**Testing improvements**

* Added regression tests in `sqlite_test.go` to verify that:
  - Updating a gateway-origin config resets `cp_sync_status` to pending but preserves `cp_artifact_id`.
  - Updating a control-plane-origin config keeps `cp_sync_status` as NULL.