### PR TITLE
Retry update on creation failure in dp to cp import

### DIFF
--- a/platform-api/internal/repository/errors.go
+++ b/platform-api/internal/repository/errors.go
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package repository
+
+import "strings"
+
+// IsUniqueViolation reports whether err is a database unique-constraint (or
+// primary-key) violation. It is dialect-aware across the three databases the
+// control plane supports — SQLite, PostgreSQL and SQL Server — matching on the
+// stable substrings/error codes each driver surfaces.
+//
+// Detection is by err.Error() substring, so a violation wrapped with
+// fmt.Errorf("...: %w", err) is still detected without unwrapping.
+func IsUniqueViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	switch {
+	// SQLite: "UNIQUE constraint failed: <table>.<column>"
+	case strings.Contains(s, "UNIQUE constraint failed"):
+		return true
+	// PostgreSQL (pgx): SQLSTATE 23505, "duplicate key value violates unique constraint".
+	case strings.Contains(s, "duplicate key value violates unique constraint"),
+		strings.Contains(s, "23505"):
+		return true
+	// SQL Server: error 2627 ("Violation of UNIQUE KEY constraint" / PRIMARY KEY) and
+	// error 2601 ("Cannot insert duplicate key row in object ... with unique index").
+	case strings.Contains(s, "Violation of UNIQUE KEY constraint"),
+		strings.Contains(s, "Cannot insert duplicate key"):
+		return true
+	default:
+		return false
+	}
+}

--- a/platform-api/internal/repository/errors_test.go
+++ b/platform-api/internal/repository/errors_test.go
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package repository
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestIsUniqueViolation(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"unrelated", errors.New("connection refused"), false},
+		{"sqlite", errors.New("UNIQUE constraint failed: mcp_proxies.organization_uuid, mcp_proxies.handle"), true},
+		{"postgres message", errors.New(`ERROR: duplicate key value violates unique constraint "artifacts_org_handle_key" (SQLSTATE 23505)`), true},
+		{"postgres sqlstate only", errors.New("SQLSTATE 23505"), true},
+		{"sqlserver 2627", errors.New("mssql: Violation of UNIQUE KEY constraint 'UQ_artifacts'. Cannot insert duplicate key in object 'dbo.artifacts'."), true},
+		{"sqlserver 2601", errors.New("mssql: Cannot insert duplicate key row in object 'dbo.artifacts' with unique index 'IX_artifacts_handle'."), true},
+		// A violation wrapped with %w (as the per-kind importers do) must still be detected.
+		{"wrapped sqlite", fmt.Errorf("failed to create MCP proxy: %w", errors.New("UNIQUE constraint failed: mcp_proxies.handle")), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsUniqueViolation(tc.err); got != tc.want {
+				t.Errorf("IsUniqueViolation(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/platform-api/internal/repository/user_identity_mapping.go
+++ b/platform-api/internal/repository/user_identity_mapping.go
@@ -147,18 +147,8 @@ func dedupeNonEmpty(ids []string) []string {
 	return unique
 }
 
-// isUniqueViolation detects DB unique-constraint violations across SQLite and PostgreSQL.
+// isUniqueViolation detects DB unique-constraint violations. It delegates to the
+// shared, dialect-aware IsUniqueViolation (SQLite, PostgreSQL and SQL Server).
 func isUniqueViolation(err error) bool {
-	if err == nil {
-		return false
-	}
-	s := err.Error()
-	if strings.Contains(s, "UNIQUE constraint failed") {
-		return true
-	}
-	if strings.Contains(s, "duplicate key value violates unique constraint") ||
-		strings.Contains(s, "23505") {
-		return true
-	}
-	return false
+	return IsUniqueViolation(err)
 }

--- a/platform-api/internal/service/artifact_import.go
+++ b/platform-api/internal/service/artifact_import.go
@@ -209,6 +209,10 @@ func (s *ArtifactImportService) getGatewayForOrg(orgID, gatewayID string) (*mode
 	return gateway, nil
 }
 
+// importConflictMaxRetries bounds how many times importValidated re-resolves and retries a
+// single artifact import after a unique-constraint violation
+const importConflictMaxRetries = 3
+
 // importValidated imports a single artifact, assuming the gateway has already been resolved
 // and validated for the org (so a batch validates the gateway once instead of per artifact).
 func (s *ArtifactImportService) importValidated(orgID, gatewayID string, req dto.ImportGatewayArtifactRequest) (*dto.ImportGatewayArtifactResponse, error) {
@@ -268,57 +272,25 @@ func (s *ArtifactImportService) importValidated(orgID, gatewayID string, req dto
 		ictx.ProjectID = project.ID
 	}
 
-	// The control plane owns the artifact UUID; it does NOT reuse the data-plane UUID
-	// (the gateway mints a fresh one whenever the artifact is recreated). Match an
-	// already-imported artifact by its handle, which is unique per organization and
-	// stable across delete/recreate. When found, reuse its CP UUID (so a recreate
-	// re-attaches to the same artifact and only adds a new deployment); otherwise mint
-	// a new CP UUID. Org-level kinds (e.g. templates) are not in the artifacts table —
-	// GetByHandle returns nil and the importer resolves existence itself.
+	// Resolve the existing artifact by handle, decide the last-in-wins write mode, and run the
+	// per-kind importer — retrying on a unique-constraint violation to close a TOCTOU race.
 	handle := utils.ImportHandle(ictx.Configuration)
-	existing, err := s.artifactRepo.GetByHandle(handle, orgID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to look up existing artifact: %w", err)
-	}
-	if existing != nil {
-		// Guard against handle reuse across kinds. GetByHandle reports the artifact kind in
-		// the Type field (the artifacts.type column).
-		if existing.Type != kind {
-			return nil, fmt.Errorf("%w: artifact %q already exists with kind %s", constants.ErrArtifactExists, handle, existing.Type)
+	var result *ImportResult
+	var err error
+	for attempt := 0; ; attempt++ {
+		result, err = s.resolveAndImport(importer, ictx, handle, orgID, kind, req.DeployedAt)
+		if err == nil {
+			break
 		}
-		ictx.ID = existing.UUID
-		ictx.Existing = existing
-	} else {
-		ictx.ID = uuid.NewString()
-	}
-
-	// Decide the working-copy (metadata) write mode using last-in-wins by deployment time.
-	// The "latest deployment" watermark is derived from the artifact's existing deployment
-	// rows (deployments.created_at, set to each push's gateway deployment time): a push wins
-	// only when its deployment time is later than every recorded deployment of the artifact.
-	// Org-level kinds not backed by the artifacts table (templates) have existing == nil here
-	// and recompute the decision themselves in the importer using their own watermark.
-	var currentOrigin string
-	var currentDeployedAt *time.Time
-	if existing != nil {
-		currentOrigin = existing.Origin
-		latest, err := s.deploymentRepo.GetLatestDeploymentTime(existing.UUID, orgID)
-		if err != nil {
-			return nil, fmt.Errorf("failed to look up latest deployment time: %w", err)
+		if attempt < importConflictMaxRetries && repository.IsUniqueViolation(err) {
+			s.slogger.Info("Concurrent same-handle import detected; re-resolving and retrying as update",
+				"kind", kind, "handle", handle, "orgId", orgID, "attempt", attempt+1)
+			continue
 		}
-		currentDeployedAt = latest
-	}
-	ictx.MetadataMode = utils.DecideMetadataWrite(existing == nil, currentOrigin, currentDeployedAt, req.DeployedAt)
-
-	result, err := importer.Import(ictx)
-	if err != nil {
 		return nil, err
 	}
 
-	// Persist deployment + status for deployable kinds (everything except templates). This
-	// runs for every non-undeploy push — including a stale (utils.SkipWorkingCopy) one — so each
-	// push is recorded as a deployment (with created_at = the gateway deployment time) and
-	// each gateway's own deployment status stays accurate even when its push lost the race.
+	// Persist deployment + status for deployable kinds (everything except templates).
 	if result.Deployable {
 		if err := s.writeDeployment(ictx, result.ID); err != nil {
 			return nil, err
@@ -334,6 +306,49 @@ func (s *ArtifactImportService) importValidated(orgID, gatewayID string, req dto
 		DeployedAt:      req.DeployedAt,
 		DeployedVersion: result.DeployedVersion,
 	}, nil
+}
+
+// resolveAndImport resolves the existing artifact by handle, computes the last-in-wins
+// metadata write mode for this push, and runs the per-kind importer once.
+func (s *ArtifactImportService) resolveAndImport(
+	importer GatewayArtifactImporter,
+	ictx *ImportContext,
+	handle, orgID, kind string,
+	incomingDeployedAt *time.Time,
+) (*ImportResult, error) {
+	// The control plane owns the artifact UUID; it does NOT reuse the data-plane UUID
+	// (the gateway mints a fresh one whenever the artifact is recreated).
+	existing, err := s.artifactRepo.GetByHandle(handle, orgID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to look up existing artifact: %w", err)
+	}
+	if existing != nil {
+		// Guard against handle reuse across kinds. GetByHandle reports the artifact kind in
+		// the Type field (the artifacts.type column).
+		if existing.Type != kind {
+			return nil, fmt.Errorf("%w: artifact %q already exists with kind %s", constants.ErrArtifactExists, handle, existing.Type)
+		}
+		ictx.ID = existing.UUID
+		ictx.Existing = existing
+	} else {
+		ictx.ID = uuid.NewString()
+		ictx.Existing = nil
+	}
+
+	// Decide the working-copy (metadata) write mode using last-in-wins by deployment time.
+	var currentOrigin string
+	var currentDeployedAt *time.Time
+	if existing != nil {
+		currentOrigin = existing.Origin
+		latest, err := s.deploymentRepo.GetLatestDeploymentTime(existing.UUID, orgID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to look up latest deployment time: %w", err)
+		}
+		currentDeployedAt = latest
+	}
+	ictx.MetadataMode = utils.DecideMetadataWrite(existing == nil, currentOrigin, currentDeployedAt, incomingDeployedAt)
+
+	return importer.Import(ictx)
 }
 
 // writeDeployment records the immutable deployment artifact, upserts the current

--- a/platform-api/internal/service/artifact_import_test.go
+++ b/platform-api/internal/service/artifact_import_test.go
@@ -353,6 +353,193 @@ func TestArtifactImport_DPArtifactMetadataNotUpdatedOnStalePush(t *testing.T) {
 	}
 }
 
+// failOnceImporter wraps a real importer and returns a synthetic unique-constraint violation
+// on its first Import call, delegating to the real importer thereafter. It deterministically
+// simulates the TOCTOU race in which a concurrent same-handle push wins the create and this
+// push's INSERT is rejected by the (organization_uuid, handle) unique index.
+type failOnceImporter struct {
+	delegate GatewayArtifactImporter
+	calls    int
+}
+
+func (f *failOnceImporter) Kind() string          { return f.delegate.Kind() }
+func (f *failOnceImporter) RequiresProject() bool { return f.delegate.RequiresProject() }
+func (f *failOnceImporter) Import(ctx *ImportContext) (*ImportResult, error) {
+	f.calls++
+	if f.calls == 1 {
+		// A representative SQLite unique-violation string; IsUniqueViolation matches it.
+		return nil, errors.New("insert failed: UNIQUE constraint failed: rest_apis.organization_uuid, rest_apis.handle")
+	}
+	return f.delegate.Import(ctx)
+}
+
+// TestArtifactImport_RetriesAsUpdateOnHandleConflict verifies the TOCTOU fix: when the per-kind
+// importer's create loses a concurrent same-handle race (unique violation), the service
+// re-resolves by handle and retries as an Update — and last-in-wins still applies (the newer
+// push wins the working copy).
+func TestArtifactImport_RetriesAsUpdateOnHandleConflict(t *testing.T) {
+	d := setupImportTest(t)
+
+	const id1 = "99999999-9999-9999-9999-999999999991"
+	// The "winning" gateway creates and imports the handle first.
+	resp, err := d.svc.Import(importTestOrgID, importTestGatewayID,
+		withDeployedAt(restImportRequest(id1, "shared-handle", "First Name"), baseDeployedAt))
+	if err != nil {
+		t.Fatalf("first import: %v", err)
+	}
+	cpID := resp.ID
+
+	// Force the second (newer) push's first importer call to fail with a unique violation,
+	// as if its INSERT lost the create race.
+	real := d.svc.importers[constants.RestApi]
+	fake := &failOnceImporter{delegate: real}
+	d.svc.importers[constants.RestApi] = fake
+	t.Cleanup(func() { d.svc.importers[constants.RestApi] = real })
+
+	const id2 = "99999999-9999-9999-9999-999999999992"
+	resp2, err := d.svc.Import(importTestOrgID, importTestGatewayID,
+		withDeployedAt(restImportRequest(id2, "shared-handle", "Second Name"), newerDeployedAt))
+	if err != nil {
+		t.Fatalf("second import should recover via retry, got error: %v", err)
+	}
+	if fake.calls < 2 {
+		t.Fatalf("importer was not retried after the unique violation: calls = %d, want >= 2", fake.calls)
+	}
+	// The retry re-resolved to the existing artifact (same CP UUID, no duplicate minted).
+	if resp2.ID != cpID {
+		t.Errorf("retry returned a different artifact: got %q, want existing %q", resp2.ID, cpID)
+	}
+	// Last-in-wins preserved on the retry's Update path: the newer push wins the working copy.
+	art, _ := d.artifactRepo.GetByUUID(cpID, importTestOrgID)
+	if art == nil || art.Name != "Second Name" {
+		t.Errorf("artifact name = %v, want 'Second Name' (newer push wins on retry)", art)
+	}
+}
+
+// TestArtifactImport_RetryPreservesLastInWinsForStalePush verifies that when the losing push
+// is stale (older DeployedAt), the retry re-runs the last-in-wins decision and leaves the
+// working copy untouched (SkipWorkingCopy) rather than clobbering the newer winner.
+func TestArtifactImport_RetryPreservesLastInWinsForStalePush(t *testing.T) {
+	d := setupImportTest(t)
+
+	const id1 = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1"
+	// The winner imports with the NEWER deployment time.
+	resp, err := d.svc.Import(importTestOrgID, importTestGatewayID,
+		withDeployedAt(restImportRequest(id1, "stale-handle", "Winner Name"), newerDeployedAt))
+	if err != nil {
+		t.Fatalf("first import: %v", err)
+	}
+	cpID := resp.ID
+
+	real := d.svc.importers[constants.RestApi]
+	fake := &failOnceImporter{delegate: real}
+	d.svc.importers[constants.RestApi] = fake
+	t.Cleanup(func() { d.svc.importers[constants.RestApi] = real })
+
+	const id2 = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2"
+	// The loser pushes with an OLDER deployment time; after the forced conflict + retry it
+	// must be treated as stale and NOT overwrite the winner's metadata.
+	if _, err := d.svc.Import(importTestOrgID, importTestGatewayID,
+		withDeployedAt(restImportRequest(id2, "stale-handle", "Loser Name"), olderDeployedAt)); err != nil {
+		t.Fatalf("second import should recover via retry, got error: %v", err)
+	}
+	if fake.calls < 2 {
+		t.Fatalf("importer was not retried after the unique violation: calls = %d, want >= 2", fake.calls)
+	}
+	art, _ := d.artifactRepo.GetByUUID(cpID, importTestOrgID)
+	if art == nil || art.Name != "Winner Name" {
+		t.Errorf("artifact name = %v, want unchanged 'Winner Name' (stale loser must not win on retry)", art)
+	}
+}
+
+// TestImportersReturnUniqueViolationOnDuplicateHandle verifies the load-bearing assumption of
+// the TOCTOU retry: for EVERY artifact kind, a duplicate (organization_uuid, handle) create
+// surfaces an error that repository.IsUniqueViolation detects — so importValidated actually
+// retries as an update. It runs against the real SQLite driver.
+//
+// Deployable kinds are exercised through importer.Import with ctx.Existing == nil (the losing
+// push's view of the race) after the row already exists, so the importer takes its Create branch
+// and hits the child table's UNIQUE(organization_uuid, handle) index. LLM provider templates are
+// org-level and the template importer re-resolves existence internally (GetByID) on every call,
+// so a duplicate create is only reachable under a true concurrent race; the violation therefore
+// originates in templateRepo.Create — which the importer propagates verbatim via %w — and is
+// verified at the repo layer here.
+func TestImportersReturnUniqueViolationOnDuplicateHandle(t *testing.T) {
+	// createCtx builds the losing push's context: Existing == nil (it read before the winner
+	// committed) forces the importer's Create branch even though the row now exists.
+	createCtx := func(req dto.ImportGatewayArtifactRequest, projectID string) *ImportContext {
+		return &ImportContext{
+			OrgID:         importTestOrgID,
+			GatewayID:     importTestGatewayID,
+			DPID:          req.DPID,
+			Configuration: req.Configuration,
+			Status:        req.Status,
+			ProjectID:     projectID,
+			ID:            "cp-" + req.DPID,
+			Existing:      nil,
+		}
+	}
+	assertViolation := func(t *testing.T, err error) {
+		t.Helper()
+		if err == nil {
+			t.Fatal("expected a unique-constraint violation, got nil")
+		}
+		if !repository.IsUniqueViolation(err) {
+			t.Fatalf("error is not detected as a unique violation by repository.IsUniqueViolation: %v", err)
+		}
+	}
+
+	t.Run("RestApi", func(t *testing.T) {
+		d := setupImportTest(t)
+		mustImport(t, d, restImportRequest("dp-rest-w", "dup-rest", "Rest Winner"))
+		imp := d.svc.importers[constants.RestApi]
+		_, err := imp.Import(createCtx(restImportRequest("dp-rest-l", "dup-rest", "Rest Loser"), importTestProjectID))
+		assertViolation(t, err)
+	})
+
+	t.Run("LLMProvider", func(t *testing.T) {
+		d := setupImportTest(t)
+		mustImport(t, d, dpTemplateReq("dp-tmpl", "dup-tmpl", "Tmpl"))
+		mustImport(t, d, dpProviderReq("dp-prov-w", "dup-prov", "Prov Winner", "dup-tmpl"))
+		imp := d.svc.importers[constants.LLMProvider]
+		_, err := imp.Import(createCtx(dpProviderReq("dp-prov-l", "dup-prov", "Prov Loser", "dup-tmpl"), ""))
+		assertViolation(t, err)
+	})
+
+	t.Run("LLMProxy", func(t *testing.T) {
+		d := setupImportTest(t)
+		mustImport(t, d, dpTemplateReq("dp-tmpl2", "dup-tmpl2", "Tmpl"))
+		mustImport(t, d, dpProviderReq("dp-prov2", "dup-prov2", "Prov", "dup-tmpl2"))
+		mustImport(t, d, dpProxyReq("dp-proxy-w", "dup-proxy", "Proxy Winner", "dup-prov2"))
+		imp := d.svc.importers[constants.LLMProxy]
+		_, err := imp.Import(createCtx(dpProxyReq("dp-proxy-l", "dup-proxy", "Proxy Loser", "dup-prov2"), importTestProjectID))
+		assertViolation(t, err)
+	})
+
+	t.Run("MCPProxy", func(t *testing.T) {
+		d := setupImportTest(t)
+		mustImport(t, d, dpMCPReq("dp-mcp-w", "dup-mcp", "Mcp Winner"))
+		imp := d.svc.importers[constants.MCPProxy]
+		_, err := imp.Import(createCtx(dpMCPReq("dp-mcp-l", "dup-mcp", "Mcp Loser"), importTestProjectID))
+		assertViolation(t, err)
+	})
+
+	t.Run("LLMProviderTemplate", func(t *testing.T) {
+		d := setupImportTest(t)
+		mustImport(t, d, dpTemplateReq("dp-tmpl-t", "dup-tmpl-t", "Tmpl Winner"))
+		// The template importer re-resolves by handle internally, so a single-threaded second
+		// Import would take the Update branch. Drive the duplicate at the repo layer — this is
+		// exactly the error importer.Import wraps and returns under a genuine concurrent race.
+		err := d.templateRepo.Create(&model.LLMProviderTemplate{
+			ID:               "dup-tmpl-t",
+			OrganizationUUID: importTestOrgID,
+			Name:             "Tmpl Loser",
+			Origin:           constants.OriginDP,
+		})
+		assertViolation(t, err)
+	})
+}
+
 func TestArtifactImport_UndeployedStatus(t *testing.T) {
 	d := setupImportTest(t)
 


### PR DESCRIPTION
### Summary

When two or more gateways push an artifact with the same `metadata.name` (handle) to the control plane at the same time, the importer could fail one of the pushes with a unique-constraint error and, on the gateway's retry, leave a duplicate deployment. This PR makes the importer race-safe by catching the unique violation, re-resolving the artifact by handle, and retrying the push as an update.
### Root cause

`ArtifactImportService.importValidated` resolves an existing artifact with `GetByHandle` and then lets the per-kind importer take its Create branch when nothing was found. The read and the write are not in one critical section, so two concurrent pushes of the same (org, handle) both observe nil and both attempt an insert. The child table's `UNIQUE(organization_uuid, handle)` index lets only one commit; the loser gets a unique-constraint violation that surfaced as a failed import. It affects all artifact kinds (REST, LLM provider, LLM proxy, MCP proxy, LLM provider template) since it lives in the shared import path.

### Changes

- `repository/errors.go` (new): IsUniqueViolation(err) — a shared, dialect-aware detector for unique/primary-key violations across the three databases the CP supports (SQLite, PostgreSQL, SQL Server). Matches through %w wrapping. The existing unexported isUniqueViolation now delegates to it (and gains SQL Server coverage).
- `service/artifact_import.go`: extracted the resolve → decide → import step into `resolveAndImport(...)` and wrapped it in a bounded retry loop (`importConflictMaxRetries = 3`) in `importValidated`. On a `IsUniqueViolation` error, it re-resolves by handle (the winner's row now exists) and retries — which takes the importer's Update branch and re-runs the last-in-wins decision (`DecideMetadataWrite`).

The retried (losing) push re-enters `DecideMetadataWrite` with the now-committed watermark:
a newer deployedAt → WriteFullMetadata (it wins the working copy)
a stale one → `SkipWorkingCopy` (the winner's copy is untouched)

Only the spurious insert failure is removed. Each push still records its own immutable deployment row.

Why catch-and-retry (not ON CONFLICT / advisory locks)

The CP targets three SQL dialects, so ON CONFLICT/MERGE and Postgres advisory locks aren't portable. Catch-and-retry is portable and already idiomatic in this codebase (subscription_repository does the same). Verified that every per-kind importer/repo propagates the raw DB error via %w (no sentinel translation) and that each child table carries the UNIQUE(organization_uuid, handle) constraint, so the violation is reliably detectable for all kinds.

Testing

- repository.TestIsUniqueViolation — SQLite / Postgres (23505) / SQL Server (2627, 2601) strings, %w-wrapped, nil, and unrelated errors.
- service.TestArtifactImport_RetriesAsUpdateOnHandleConflict — a forced unique violation is recovered via retry, re-resolves to the same CP UUID (no duplicate artifact), and the newer push wins.
- service.TestArtifactImport_RetryPreservesLastInWinsForStalePush — a stale loser leaves the winner's working copy unchanged after retry.
- service.TestImportersReturnUniqueViolationOnDuplicateHandle — against the real SQLite driver, confirms a duplicate handle produces an IsUniqueViolation-detectable error for all five kinds (REST, LLM provider, LLM proxy, MCP proxy, template).