### PR TITLE
[PlatformAPI] Enforce major-only policy version pattern in code

### DIFF
--- a/platform-api/internal/constants/error.go
+++ b/platform-api/internal/constants/error.go
@@ -87,6 +87,10 @@ var (
 )
 
 var (
+	ErrInvalidPolicyVersion = errors.New("policy version must be major-only, e.g. v1")
+)
+
+var (
 	ErrDeploymentNotFound            = errors.New("deployment not found")
 	ErrDeploymentNotActive           = errors.New("no active deployment found for this API on the gateway")
 	ErrDeploymentIsDeployed          = errors.New("cannot delete an active deployment - undeploy it first")

--- a/platform-api/internal/handler/api.go
+++ b/platform-api/internal/handler/api.go
@@ -155,6 +155,12 @@ func (h *APIHandler) CreateAPI(w http.ResponseWriter, r *http.Request) {
 				"Invalid transport protocol"))
 			return
 		}
+		if errors.Is(err, constants.ErrInvalidPolicyVersion) {
+			h.slogger.Error("Invalid policy version format", "organizationId", orgId, "error", err)
+			httputil.WriteJSON(w, http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request",
+				err.Error()))
+			return
+		}
 		if errors.Is(err, constants.ErrSubscriptionPlanNotFoundOrInactive) {
 			h.slogger.Error("Subscription plan not found or not active", "organizationId", orgId, "error", err)
 			httputil.WriteJSON(w, http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request",
@@ -311,6 +317,12 @@ func (h *APIHandler) UpdateAPI(w http.ResponseWriter, r *http.Request) {
 			h.slogger.Error("Invalid transport protocol", "apiId", apiId, "organizationId", orgId)
 			httputil.WriteJSON(w, http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request",
 				"Invalid transport protocol"))
+			return
+		}
+		if errors.Is(err, constants.ErrInvalidPolicyVersion) {
+			h.slogger.Error("Invalid policy version format", "apiId", apiId, "organizationId", orgId, "error", err)
+			httputil.WriteJSON(w, http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request",
+				err.Error()))
 			return
 		}
 		if errors.Is(err, constants.ErrSubscriptionPlanNotFoundOrInactive) {

--- a/platform-api/internal/handler/llm.go
+++ b/platform-api/internal/handler/llm.go
@@ -480,6 +480,9 @@ func (h *LLMHandler) CreateLLMProvider(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, constants.ErrSecretRefMissing):
 			httputil.WriteJSON(w, http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", err.Error()))
 			return
+		case errors.Is(err, constants.ErrInvalidPolicyVersion):
+			httputil.WriteJSON(w, http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", err.Error()))
+			return
 		case errors.Is(err, constants.ErrInvalidInput):
 			httputil.WriteJSON(w, http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", "Invalid input"))
 			return
@@ -598,6 +601,9 @@ func (h *LLMHandler) UpdateLLMProvider(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, constants.ErrHandleImmutable):
 			httputil.WriteJSON(w, http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", err.Error()))
 			return
+		case errors.Is(err, constants.ErrInvalidPolicyVersion):
+			httputil.WriteJSON(w, http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", err.Error()))
+			return
 		case errors.Is(err, constants.ErrInvalidInput):
 			httputil.WriteJSON(w, http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", "Invalid input"))
 			return
@@ -679,6 +685,9 @@ func (h *LLMHandler) CreateLLMProxy(w http.ResponseWriter, r *http.Request) {
 			return
 		case errors.Is(err, constants.ErrProjectNotFound):
 			httputil.WriteJSON(w, http.StatusNotFound, utils.NewErrorResponse(404, "Not Found", "Project not found"))
+			return
+		case errors.Is(err, constants.ErrInvalidPolicyVersion):
+			httputil.WriteJSON(w, http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", err.Error()))
 			return
 		case errors.Is(err, constants.ErrInvalidInput):
 			httputil.WriteJSON(w, http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", "Invalid input"))
@@ -850,6 +859,9 @@ func (h *LLMHandler) UpdateLLMProxy(w http.ResponseWriter, r *http.Request) {
 			httputil.WriteJSON(w, http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", "Referenced provider not found"))
 			return
 		case errors.Is(err, constants.ErrHandleImmutable):
+			httputil.WriteJSON(w, http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", err.Error()))
+			return
+		case errors.Is(err, constants.ErrInvalidPolicyVersion):
 			httputil.WriteJSON(w, http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", err.Error()))
 			return
 		case errors.Is(err, constants.ErrInvalidInput):

--- a/platform-api/internal/handler/mcp.go
+++ b/platform-api/internal/handler/mcp.go
@@ -268,6 +268,9 @@ func (h *MCPProxyHandler) handleServiceError(w http.ResponseWriter, err error) {
 	case errors.Is(err, constants.ErrInvalidInput):
 		h.slogger.Error("MCP request validation failed", "reason", err.Error())
 		httputil.WriteJSON(w, http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", err.Error()))
+	case errors.Is(err, constants.ErrInvalidPolicyVersion):
+		h.slogger.Error("MCP policy version validation failed", "reason", err.Error())
+		httputil.WriteJSON(w, http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", err.Error()))
 	case errors.Is(err, constants.ErrMCPProxyNotFound):
 		h.slogger.Error("MCP proxy not found", "reason", err.Error())
 		httputil.WriteJSON(w, http.StatusNotFound, utils.NewErrorResponse(404, "Not Found", "MCP proxy not found"))

--- a/platform-api/internal/service/api.go
+++ b/platform-api/internal/service/api.go
@@ -622,6 +622,10 @@ func (s *APIService) validateCreateAPIRequest(req *api.CreateRESTAPIRequest, org
 		}
 	}
 
+	if err := validateOperationAndChannelPolicyVersions(req.Operations, req.Channels); err != nil {
+		return err
+	}
+
 	// Validate subscription plans if provided
 	if err := s.validateSubscriptionPlans(req.SubscriptionPlans, orgUUID); err != nil {
 		return err
@@ -728,6 +732,10 @@ func (s *APIService) validateUpdateAPIRequest(existingAPIModel *model.API, req *
 				return constants.ErrInvalidTransport
 			}
 		}
+	}
+
+	if err := validateOperationAndChannelPolicyVersions(req.Operations, req.Channels); err != nil {
+		return err
 	}
 
 	// Validate subscription plans if provided

--- a/platform-api/internal/service/api_test.go
+++ b/platform-api/internal/service/api_test.go
@@ -63,6 +63,7 @@ func TestValidateUpdateAPIRequest(t *testing.T) {
 		mockNameVersionError      error
 		wantErr                   bool
 		expectedErr               error
+		errContains               string
 		expectedExcludeHandle     string
 		verifyExcludeHandleCalled bool
 	}{
@@ -155,6 +156,42 @@ func TestValidateUpdateAPIRequest(t *testing.T) {
 			req:     &api.RESTAPI{Transport: slicePtr([]string{"https"})},
 			wantErr: false,
 		},
+		{
+			name: "invalid operation policy version",
+			existingAPI: &model.API{
+				Handle:  "my-api",
+				Version: "v1",
+			},
+			req: &api.RESTAPI{
+				Operations: &[]api.Operation{
+					{
+						Request: api.OperationRequest{
+							Policies: &[]api.Policy{{Name: "SET_HEADER", Version: "v1.0.0"}},
+						},
+					},
+				},
+			},
+			wantErr:     true,
+			errContains: "policy version must be major-only",
+		},
+		{
+			name: "invalid channel policy version",
+			existingAPI: &model.API{
+				Handle:  "my-api",
+				Version: "v1",
+			},
+			req: &api.RESTAPI{
+				Channels: &[]api.Channel{
+					{
+						Request: api.ChannelRequest{
+							Policies: &[]api.Policy{{Name: "SET_HEADER", Version: "1"}},
+						},
+					},
+				},
+			},
+			wantErr:     true,
+			errContains: "policy version must be major-only",
+		},
 	}
 
 	for _, tt := range tests {
@@ -178,9 +215,12 @@ func TestValidateUpdateAPIRequest(t *testing.T) {
 				return
 			}
 
-			if tt.wantErr && err != nil && tt.expectedErr != nil {
-				if err != tt.expectedErr {
+			if tt.wantErr && err != nil {
+				if tt.expectedErr != nil && err != tt.expectedErr {
 					t.Errorf("validateUpdateAPIRequest() error = %v, expectedErr %v", err, tt.expectedErr)
+				}
+				if tt.errContains != "" && !contains(err.Error(), tt.errContains) {
+					t.Errorf("validateUpdateAPIRequest() error = %v, should contain %v", err, tt.errContains)
 				}
 			}
 
@@ -379,6 +419,65 @@ func TestValidateCreateAPIRequest(t *testing.T) {
 				ProjectId:   projectID,
 				Transport:   slicePtr([]string{"https"}),
 				Upstream:    api.Upstream{},
+			},
+			mockNameVersionExists:    false,
+			wantErr:                  false,
+			verifyExcludeHandleEmpty: true,
+			expectedExcludeHandle:    "",
+		},
+		{
+			name: "invalid operation policy version",
+			req: &api.CreateRESTAPIRequest{
+				DisplayName: "Test API",
+				Context:     "/test",
+				Version:     "v1",
+				ProjectId:   projectID,
+				Upstream:    api.Upstream{},
+				Operations: &[]api.Operation{
+					{
+						Request: api.OperationRequest{
+							Policies: &[]api.Policy{{Name: "SET_HEADER", Version: "v1.0.0"}},
+						},
+					},
+				},
+			},
+			wantErr:     true,
+			errContains: "policy version must be major-only",
+		},
+		{
+			name: "invalid channel policy version",
+			req: &api.CreateRESTAPIRequest{
+				DisplayName: "Test API",
+				Context:     "/test",
+				Version:     "v1",
+				ProjectId:   projectID,
+				Upstream:    api.Upstream{},
+				Channels: &[]api.Channel{
+					{
+						Request: api.ChannelRequest{
+							Policies: &[]api.Policy{{Name: "SET_HEADER", Version: "1"}},
+						},
+					},
+				},
+			},
+			wantErr:     true,
+			errContains: "policy version must be major-only",
+		},
+		{
+			name: "unspecified operation policy version is allowed (gateway resolves to latest)",
+			req: &api.CreateRESTAPIRequest{
+				DisplayName: "Test API",
+				Context:     "/test",
+				Version:     "v1",
+				ProjectId:   projectID,
+				Upstream:    api.Upstream{},
+				Operations: &[]api.Operation{
+					{
+						Request: api.OperationRequest{
+							Policies: &[]api.Policy{{Name: "SET_HEADER", Version: ""}},
+						},
+					},
+				},
 			},
 			mockNameVersionExists:    false,
 			wantErr:                  false,

--- a/platform-api/internal/service/llm.go
+++ b/platform-api/internal/service/llm.go
@@ -801,6 +801,15 @@ func (s *LLMProviderService) Create(orgUUID, createdBy string, req *api.LLMProvi
 	if req.DisplayName == "" || req.Version == "" || req.Template == "" {
 		return nil, constants.ErrInvalidInput
 	}
+	if err := validatePolicyVersions(req.GlobalPolicies); err != nil {
+		return nil, err
+	}
+	if err := validateOperationPolicyVersions(req.OperationPolicies); err != nil {
+		return nil, err
+	}
+	if err := validateLLMPolicyVersions(req.Policies); err != nil {
+		return nil, err
+	}
 	if err := validateModelProviders(req.Template, req.ModelProviders); err != nil {
 		return nil, err
 	}
@@ -1038,6 +1047,15 @@ func (s *LLMProviderService) Update(orgUUID, handle, updatedBy string, req *api.
 	if req.DisplayName == "" || req.Version == "" || req.Template == "" {
 		return nil, constants.ErrInvalidInput
 	}
+	if err := validatePolicyVersions(req.GlobalPolicies); err != nil {
+		return nil, err
+	}
+	if err := validateOperationPolicyVersions(req.OperationPolicies); err != nil {
+		return nil, err
+	}
+	if err := validateLLMPolicyVersions(req.Policies); err != nil {
+		return nil, err
+	}
 	if err := validateModelProviders(req.Template, req.ModelProviders); err != nil {
 		return nil, err
 	}
@@ -1210,6 +1228,15 @@ func (s *LLMProxyService) Create(orgUUID, createdBy string, req *api.LLMProxy) (
 	}
 	if req.DisplayName == "" || req.Version == "" || req.Provider.Id == "" || req.ProjectId == "" {
 		return nil, constants.ErrInvalidInput
+	}
+	if err := validatePolicyVersions(req.GlobalPolicies); err != nil {
+		return nil, err
+	}
+	if err := validateOperationPolicyVersions(req.OperationPolicies); err != nil {
+		return nil, err
+	}
+	if err := validateLLMPolicyVersions(req.Policies); err != nil {
+		return nil, err
 	}
 	// req.ProjectId is the project handle; resolve it to the project UUID so the
 	// proxy is stored against the same identifier List filters on.
@@ -1478,6 +1505,15 @@ func (s *LLMProxyService) Update(orgUUID, handle, updatedBy string, req *api.LLM
 	}
 	if req.DisplayName == "" || req.Version == "" || req.Provider.Id == "" {
 		return nil, constants.ErrInvalidInput
+	}
+	if err := validatePolicyVersions(req.GlobalPolicies); err != nil {
+		return nil, err
+	}
+	if err := validateOperationPolicyVersions(req.OperationPolicies); err != nil {
+		return nil, err
+	}
+	if err := validateLLMPolicyVersions(req.Policies); err != nil {
+		return nil, err
 	}
 
 	existing, err := s.repo.GetByID(handle, orgUUID)

--- a/platform-api/internal/service/llm_test.go
+++ b/platform-api/internal/service/llm_test.go
@@ -1239,6 +1239,59 @@ func TestLLMProviderServiceCreateMigratesLegacyPolicies(t *testing.T) {
 	}
 }
 
+func TestLLMProviderServiceCreateRejectsInvalidGlobalPolicyVersion(t *testing.T) {
+	service := NewLLMProviderService(&mockLLMProviderRepo{}, &mockLLMTemplateRepo{}, nil, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{}, newTestIdentityService())
+
+	request := validProviderRequest("openai")
+	request.GlobalPolicies = &[]api.Policy{{Name: "api-key-auth", Version: "v1.0.0"}}
+
+	_, err := service.Create("org-1", "alice", request)
+	if !errors.Is(err, constants.ErrInvalidPolicyVersion) {
+		t.Fatalf("expected ErrInvalidPolicyVersion, got: %v", err)
+	}
+}
+
+func TestLLMProviderServiceCreateRejectsInvalidOperationPolicyVersion(t *testing.T) {
+	service := NewLLMProviderService(&mockLLMProviderRepo{}, &mockLLMTemplateRepo{}, nil, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{}, newTestIdentityService())
+
+	request := validProviderRequest("openai")
+	request.OperationPolicies = &[]api.OperationPolicy{{Name: "token-ratelimit", Version: "1"}}
+
+	_, err := service.Create("org-1", "alice", request)
+	if !errors.Is(err, constants.ErrInvalidPolicyVersion) {
+		t.Fatalf("expected ErrInvalidPolicyVersion, got: %v", err)
+	}
+}
+
+func TestLLMProviderServiceCreateRejectsInvalidLegacyPolicyVersion(t *testing.T) {
+	service := NewLLMProviderService(&mockLLMProviderRepo{}, &mockLLMTemplateRepo{}, nil, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{}, newTestIdentityService())
+
+	request := validProviderRequest("openai")
+	request.Policies = &[]api.LLMPolicy{{Name: "basic-ratelimit", Version: "V1"}}
+
+	_, err := service.Create("org-1", "alice", request)
+	if !errors.Is(err, constants.ErrInvalidPolicyVersion) {
+		t.Fatalf("expected ErrInvalidPolicyVersion, got: %v", err)
+	}
+}
+
+func TestLLMProviderServiceUpdateRejectsInvalidPolicyVersion(t *testing.T) {
+	providerRepo := &mockLLMProviderRepo{
+		getByIDFunc: func(providerID, orgUUID string) (*model.LLMProvider, error) {
+			return &model.LLMProvider{UUID: "prov-uuid", ID: providerID, TemplateUUID: "tpl-openai"}, nil
+		},
+	}
+	service := NewLLMProviderService(providerRepo, &mockLLMTemplateRepo{}, nil, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{}, newTestIdentityService())
+
+	request := validProviderRequest("openai")
+	request.GlobalPolicies = &[]api.Policy{{Name: "api-key-auth", Version: "v1.0.0"}}
+
+	_, err := service.Update("org-1", "provider-1", "alice", request)
+	if !errors.Is(err, constants.ErrInvalidPolicyVersion) {
+		t.Fatalf("expected ErrInvalidPolicyVersion, got: %v", err)
+	}
+}
+
 func TestLLMProviderServiceCreateReturnsConflictForDuplicateHandle(t *testing.T) {
 	providerRepo := &mockLLMProviderRepo{existsResult: true}
 	templateRepo := &mockLLMTemplateRepo{
@@ -1323,6 +1376,42 @@ func TestLLMProxyServiceCreateFailsWhenProviderNotFound(t *testing.T) {
 	_, err := service.Create("org-1", "alice", validProxyRequest("provider-1", "project-1"))
 	if err != constants.ErrLLMProviderNotFound {
 		t.Fatalf("expected ErrLLMProviderNotFound, got: %v", err)
+	}
+}
+
+func TestLLMProxyServiceCreateRejectsInvalidPolicyVersion(t *testing.T) {
+	proxyRepo := &mockLLMProxyRepo{}
+	providerRepo := &mockLLMProviderRepo{
+		getByIDFunc: func(providerID, orgUUID string) (*model.LLMProvider, error) {
+			return &model.LLMProvider{UUID: "provider-uuid", ID: providerID}, nil
+		},
+	}
+	service := NewLLMProxyService(proxyRepo, providerRepo, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{}, newTestIdentityService())
+
+	request := validProxyRequest("provider-1", "project-1")
+	request.GlobalPolicies = &[]api.Policy{{Name: "api-key-auth", Version: "v1.0.0"}}
+
+	_, err := service.Create("org-1", "alice", request)
+	if !errors.Is(err, constants.ErrInvalidPolicyVersion) {
+		t.Fatalf("expected ErrInvalidPolicyVersion, got: %v", err)
+	}
+}
+
+func TestLLMProxyServiceUpdateRejectsInvalidPolicyVersion(t *testing.T) {
+	proxyRepo := &mockLLMProxyRepo{}
+	providerRepo := &mockLLMProviderRepo{
+		getByIDFunc: func(providerID, orgUUID string) (*model.LLMProvider, error) {
+			return &model.LLMProvider{UUID: "provider-uuid", ID: providerID}, nil
+		},
+	}
+	service := NewLLMProxyService(proxyRepo, providerRepo, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{}, newTestIdentityService())
+
+	request := validProxyRequest("provider-1", "project-1")
+	request.OperationPolicies = &[]api.OperationPolicy{{Name: "token-ratelimit", Version: "1"}}
+
+	_, err := service.Update("org-1", "proxy-1", "alice", request)
+	if !errors.Is(err, constants.ErrInvalidPolicyVersion) {
+		t.Fatalf("expected ErrInvalidPolicyVersion, got: %v", err)
 	}
 }
 

--- a/platform-api/internal/service/mcp.go
+++ b/platform-api/internal/service/mcp.go
@@ -116,6 +116,9 @@ func (s *MCPProxyService) Create(orgUUID, createdBy string, req *api.MCPProxy) (
 	if req.DisplayName == "" || req.Version == "" {
 		return nil, constants.ErrInvalidInput
 	}
+	if err := validatePolicyVersions(req.Policies); err != nil {
+		return nil, err
+	}
 
 	if req.Upstream.Main.Url == nil || *req.Upstream.Main.Url == "" {
 		return nil, constants.ErrInvalidInput
@@ -336,6 +339,9 @@ func (s *MCPProxyService) Update(orgUUID, handle, updatedBy string, req *api.MCP
 	}
 	if req.DisplayName == "" || req.Version == "" {
 		return nil, constants.ErrInvalidInput
+	}
+	if err := validatePolicyVersions(req.Policies); err != nil {
+		return nil, err
 	}
 
 	if req.Upstream.Main.Url == nil || *req.Upstream.Main.Url == "" {

--- a/platform-api/internal/service/mcp_test.go
+++ b/platform-api/internal/service/mcp_test.go
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package service
+
+import (
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/wso2/api-platform/platform-api/api"
+	"github.com/wso2/api-platform/platform-api/config"
+	"github.com/wso2/api-platform/platform-api/internal/constants"
+	"github.com/wso2/api-platform/platform-api/internal/model"
+	"github.com/wso2/api-platform/platform-api/internal/repository"
+)
+
+// mockMCPProxyRepository is a minimal mock of repository.MCPProxyRepository.
+type mockMCPProxyRepository struct {
+	repository.MCPProxyRepository
+	getByHandleResult *model.MCPProxy
+}
+
+func (m *mockMCPProxyRepository) GetByHandle(handle, orgUUID string) (*model.MCPProxy, error) {
+	return m.getByHandleResult, nil
+}
+
+func validMCPProxyRequest() *api.MCPProxy {
+	url := "https://example.com/mcp"
+	return &api.MCPProxy{
+		Id:          strPointer("mcp-proxy-1"),
+		DisplayName: "Test MCP Proxy",
+		Version:     "v1.0",
+		Upstream: api.Upstream{
+			Main: api.UpstreamDefinition{Url: &url},
+		},
+	}
+}
+
+func TestMCPProxyServiceCreateRejectsInvalidPolicyVersion(t *testing.T) {
+	service := NewMCPProxyService(&mockMCPProxyRepository{}, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{}, newTestIdentityService())
+
+	request := validMCPProxyRequest()
+	request.Policies = &[]api.Policy{{Name: "api-key-auth", Version: "v1.0.0"}}
+
+	_, err := service.Create("org-1", "alice", request)
+	if !errors.Is(err, constants.ErrInvalidPolicyVersion) {
+		t.Fatalf("expected ErrInvalidPolicyVersion, got: %v", err)
+	}
+}
+
+func TestMCPProxyServiceUpdateRejectsInvalidPolicyVersion(t *testing.T) {
+	repo := &mockMCPProxyRepository{getByHandleResult: &model.MCPProxy{Handle: "mcp-proxy-1"}}
+	service := NewMCPProxyService(repo, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{}, newTestIdentityService())
+
+	request := validMCPProxyRequest()
+	request.Policies = &[]api.Policy{{Name: "api-key-auth", Version: "1"}}
+
+	_, err := service.Update("org-1", "mcp-proxy-1", "alice", request)
+	if !errors.Is(err, constants.ErrInvalidPolicyVersion) {
+		t.Fatalf("expected ErrInvalidPolicyVersion, got: %v", err)
+	}
+}

--- a/platform-api/internal/service/policy_validation.go
+++ b/platform-api/internal/service/policy_validation.go
@@ -1,0 +1,103 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package service
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/wso2/api-platform/platform-api/api"
+	"github.com/wso2/api-platform/platform-api/internal/constants"
+)
+
+// policyVersionPattern mirrors the `pattern: '^v\d+$'` constraint on Policy.version,
+// LLMPolicy.version and OperationPolicy.version in openapi.yaml: only a major-only
+// version (e.g. v0, v1) is accepted, since the Gateway Controller rejects anything else.
+var policyVersionPattern = regexp.MustCompile(`^v\d+$`)
+
+// isValidPolicyVersion accepts a major-only version (e.g. v1) and also an empty/blank
+// version: the Gateway Controller's ResolvePolicyVersion treats an unspecified version as
+// "use the latest available version" rather than an error, so platform-api must not reject
+// it either. Only a non-empty value that fails the major-only pattern (e.g. v1.0.0, 1) is
+// invalid.
+func isValidPolicyVersion(version string) bool {
+	if strings.TrimSpace(version) == "" {
+		return true
+	}
+	return policyVersionPattern.MatchString(version)
+}
+
+// validatePolicyVersions checks the version of every Policy in the list.
+func validatePolicyVersions(policies *[]api.Policy) error {
+	if policies == nil {
+		return nil
+	}
+	for _, p := range *policies {
+		if !isValidPolicyVersion(p.Version) {
+			return fmt.Errorf("%w: policy %q version %q", constants.ErrInvalidPolicyVersion, p.Name, p.Version)
+		}
+	}
+	return nil
+}
+
+// validateLLMPolicyVersions checks the version of every deprecated flat LLMPolicy in the list.
+func validateLLMPolicyVersions(policies *[]api.LLMPolicy) error {
+	if policies == nil {
+		return nil
+	}
+	for _, p := range *policies {
+		if !isValidPolicyVersion(p.Version) {
+			return fmt.Errorf("%w: policy %q version %q", constants.ErrInvalidPolicyVersion, p.Name, p.Version)
+		}
+	}
+	return nil
+}
+
+// validateOperationPolicyVersions checks the version of every OperationPolicy in the list.
+func validateOperationPolicyVersions(policies *[]api.OperationPolicy) error {
+	if policies == nil {
+		return nil
+	}
+	for _, p := range *policies {
+		if !isValidPolicyVersion(p.Version) {
+			return fmt.Errorf("%w: policy %q version %q", constants.ErrInvalidPolicyVersion, p.Name, p.Version)
+		}
+	}
+	return nil
+}
+
+// validateOperationAndChannelPolicyVersions checks the policy versions attached to every
+// REST API operation and channel.
+func validateOperationAndChannelPolicyVersions(operations *[]api.Operation, channels *[]api.Channel) error {
+	if operations != nil {
+		for _, op := range *operations {
+			if err := validatePolicyVersions(op.Request.Policies); err != nil {
+				return err
+			}
+		}
+	}
+	if channels != nil {
+		for _, ch := range *channels {
+			if err := validatePolicyVersions(ch.Request.Policies); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/platform-api/internal/service/policy_validation_test.go
+++ b/platform-api/internal/service/policy_validation_test.go
@@ -1,0 +1,128 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/wso2/api-platform/platform-api/api"
+	"github.com/wso2/api-platform/platform-api/internal/constants"
+)
+
+func TestIsValidPolicyVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    bool
+	}{
+		{"major only v0", "v0", true},
+		{"major only v1", "v1", true},
+		{"major only v42", "v42", true},
+		{"full semver rejected", "v1.0.0", false},
+		{"missing v prefix", "1", false},
+		{"uppercase V rejected", "V1", false},
+		{"empty string means unspecified, resolved to latest by gateway", "", true},
+		{"whitespace-only also means unspecified", "   ", true},
+		{"v with no digits", "v", false},
+		{"non-numeric suffix", "va", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isValidPolicyVersion(tt.version); got != tt.want {
+				t.Errorf("isValidPolicyVersion(%q) = %v, want %v", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidatePolicyVersions(t *testing.T) {
+	if err := validatePolicyVersions(nil); err != nil {
+		t.Errorf("expected nil error for nil list, got %v", err)
+	}
+	valid := []api.Policy{{Name: "SET_HEADER", Version: "v1"}}
+	if err := validatePolicyVersions(&valid); err != nil {
+		t.Errorf("expected nil error for valid version, got %v", err)
+	}
+	unspecified := []api.Policy{{Name: "SET_HEADER", Version: ""}}
+	if err := validatePolicyVersions(&unspecified); err != nil {
+		t.Errorf("expected nil error for unspecified version (resolved to latest by gateway), got %v", err)
+	}
+	invalid := []api.Policy{{Name: "SET_HEADER", Version: "v1.0.0"}}
+	err := validatePolicyVersions(&invalid)
+	if !errors.Is(err, constants.ErrInvalidPolicyVersion) {
+		t.Errorf("expected ErrInvalidPolicyVersion, got %v", err)
+	}
+}
+
+func TestValidateLLMPolicyVersions(t *testing.T) {
+	if err := validateLLMPolicyVersions(nil); err != nil {
+		t.Errorf("expected nil error for nil list, got %v", err)
+	}
+	invalid := []api.LLMPolicy{{Name: "API_KEY_AUTH", Version: "1.0"}}
+	err := validateLLMPolicyVersions(&invalid)
+	if !errors.Is(err, constants.ErrInvalidPolicyVersion) {
+		t.Errorf("expected ErrInvalidPolicyVersion, got %v", err)
+	}
+}
+
+func TestValidateOperationPolicyVersions(t *testing.T) {
+	if err := validateOperationPolicyVersions(nil); err != nil {
+		t.Errorf("expected nil error for nil list, got %v", err)
+	}
+	invalid := []api.OperationPolicy{{Name: "RATE_LIMIT", Version: "v1.2"}}
+	err := validateOperationPolicyVersions(&invalid)
+	if !errors.Is(err, constants.ErrInvalidPolicyVersion) {
+		t.Errorf("expected ErrInvalidPolicyVersion, got %v", err)
+	}
+}
+
+func TestValidateOperationAndChannelPolicyVersions(t *testing.T) {
+	badPolicies := []api.Policy{{Name: "SET_HEADER", Version: "v1.0.0"}}
+	goodPolicies := []api.Policy{{Name: "SET_HEADER", Version: "v1"}}
+
+	t.Run("nil operations and channels", func(t *testing.T) {
+		if err := validateOperationAndChannelPolicyVersions(nil, nil); err != nil {
+			t.Errorf("expected nil error, got %v", err)
+		}
+	})
+
+	t.Run("bad operation policy version", func(t *testing.T) {
+		operations := []api.Operation{{Request: api.OperationRequest{Policies: &badPolicies}}}
+		err := validateOperationAndChannelPolicyVersions(&operations, nil)
+		if !errors.Is(err, constants.ErrInvalidPolicyVersion) {
+			t.Errorf("expected ErrInvalidPolicyVersion, got %v", err)
+		}
+	})
+
+	t.Run("bad channel policy version", func(t *testing.T) {
+		channels := []api.Channel{{Request: api.ChannelRequest{Policies: &badPolicies}}}
+		err := validateOperationAndChannelPolicyVersions(nil, &channels)
+		if !errors.Is(err, constants.ErrInvalidPolicyVersion) {
+			t.Errorf("expected ErrInvalidPolicyVersion, got %v", err)
+		}
+	})
+
+	t.Run("valid operation and channel policy versions", func(t *testing.T) {
+		operations := []api.Operation{{Request: api.OperationRequest{Policies: &goodPolicies}}}
+		channels := []api.Channel{{Request: api.ChannelRequest{Policies: &goodPolicies}}}
+		if err := validateOperationAndChannelPolicyVersions(&operations, &channels); err != nil {
+			t.Errorf("expected nil error, got %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Purpose

- Resolves: https://github.com/wso2/api-platform/issues/2535

PR #2332 added `pattern: '^v\d+$'` to `Policy`/`LLMPolicy`/`OperationPolicy.version` in the OpenAPI spec, but nothing enforced it in code — a client could still submit `v1.0.0` and have it accepted, only to fail later at the gateway.

This adds the missing validation in the service layer, matching the existing hand-written validator style (`isValidContext`/`isValidVersion` in `api.go`).

## Changes

- New `internal/service/policy_validation.go`: shared `^v\d+$` validator, wired into REST API operation/channel policies, LLM Provider/Proxy (global, operation, deprecated flat policies), and MCP Proxy policies — across all Create/Update paths.
- New `constants.ErrInvalidPolicyVersion`, mapped to `400` in each handler.
- An empty/unspecified version is intentionally allowed — the Gateway Controller's `ResolvePolicyVersion` treats it as "use latest", not an error, so platform-api mirrors that instead of being stricter than the gateway.
- Unit tests for the validator and every wired call site (valid, invalid, and unspecified versions).
