### PR TITLE
[Gateway] Fix: reject LLM provider/proxy deploys with unresolvable policies

### DIFF
--- a/gateway/gateway-controller/pkg/config/policy_validator.go
+++ b/gateway/gateway-controller/pkg/config/policy_validator.go
@@ -100,31 +100,58 @@ func (pv *PolicyValidator) ValidateRestAPIPolicies(apiConfig *api.RestAPI) []Val
 	return errors
 }
 
-// validatePolicy validates a single policy reference
-func (pv *PolicyValidator) validatePolicy(policy api.Policy, fieldPath string) []ValidationError {
+// ValidateLLMProviderPolicies validates all policy references in an LLM provider configuration.
+// Mirrors ValidateRestAPIPolicies: it checks the user-authored global, operation and (deprecated)
+// policy references against the loaded policy definitions. Policies injected later by the
+// LLM->RestAPI transform (e.g. upstream auth) are intentionally not validated here so the
+// semantics match the REST API path, which only validates user-authored policies.
+func (pv *PolicyValidator) ValidateLLMProviderPolicies(cfg *api.LLMProviderConfiguration) []ValidationError {
+	return pv.validateLLMPolicyRefs(cfg.Spec.GlobalPolicies, cfg.Spec.OperationPolicies, cfg.Spec.Policies)
+}
+
+// ValidateLLMProxyPolicies validates all policy references in an LLM proxy configuration.
+// See ValidateLLMProviderPolicies for the rationale on validating the source configuration.
+func (pv *PolicyValidator) ValidateLLMProxyPolicies(cfg *api.LLMProxyConfiguration) []ValidationError {
+	return pv.validateLLMPolicyRefs(cfg.Spec.GlobalPolicies, cfg.Spec.OperationPolicies, cfg.Spec.Policies)
+}
+
+// validateLLMPolicyRefs validates the three policy collections shared by LLM providers and
+// proxies: api-level (global) policies, operation-level policies, and the deprecated policies
+// list. An empty version resolves to the latest available version (handled by ResolvePolicyVersion).
+func (pv *PolicyValidator) validateLLMPolicyRefs(globalPolicies *[]api.Policy, operationPolicies *[]api.OperationPolicy, legacyPolicies *[]api.LLMPolicy) []ValidationError {
 	var errors []ValidationError
 
-	// Resolve policy version:
-	// - Accept full semantic versions as-is (vX.Y.Z)
-	// - Allow major-only versions (vX) and resolve them to a single matching
-	//   full version (vX.Y.Z) from the loaded policy definitions.
-	resolvedVersion, err := pv.resolvePolicyVersion(policy.Name, policy.Version)
-	if err != nil {
-		errors = append(errors, ValidationError{
-			Field:   fieldPath + ".version",
-			Message: err.Error(),
-		})
-		return errors
+	// Global (api-level) policies carry params, so reuse validatePolicy to also validate them.
+	if globalPolicies != nil {
+		for i, policy := range *globalPolicies {
+			errors = append(errors, pv.validatePolicy(policy, fmt.Sprintf("spec.globalPolicies[%d]", i))...)
+		}
 	}
 
-	// Check if policy definition exists
-	key := policy.Name + "|" + resolvedVersion
-	policyDef, exists := pv.policyDefinitions[key]
-	if !exists {
-		errors = append(errors, ValidationError{
-			Field:   fieldPath + ".name",
-			Message: fmt.Sprintf("Policy '%s' version '%s' not found in loaded policy definitions", policy.Name, resolvedVersion),
-		})
+	// Operation-level policies: validate name + version existence.
+	if operationPolicies != nil {
+		for i, policy := range *operationPolicies {
+			_, errs := pv.validatePolicyRef(policy.Name, policy.Version, fmt.Sprintf("spec.operationPolicies[%d]", i))
+			errors = append(errors, errs...)
+		}
+	}
+
+	// Deprecated policies list (still honoured): validate name + version existence.
+	if legacyPolicies != nil {
+		for i, policy := range *legacyPolicies {
+			_, errs := pv.validatePolicyRef(policy.Name, policy.Version, fmt.Sprintf("spec.policies[%d]", i))
+			errors = append(errors, errs...)
+		}
+	}
+
+	return errors
+}
+
+// validatePolicy validates a single policy reference (name + version existence) and, when the
+// definition declares a parameter schema, the policy's params against that schema.
+func (pv *PolicyValidator) validatePolicy(policy api.Policy, fieldPath string) []ValidationError {
+	policyDef, errors := pv.validatePolicyRef(policy.Name, policy.Version, fieldPath)
+	if len(errors) > 0 {
 		return errors
 	}
 
@@ -137,11 +164,36 @@ func (pv *PolicyValidator) validatePolicy(policy api.Policy, fieldPath string) [
 		}
 		schemaErrs := pv.validatePolicyParams(params, *policyDef.Parameters, fieldPath+".params")
 		errors = append(errors, schemaErrs...)
-	} else {
-
 	}
 
 	return errors
+}
+
+// validatePolicyRef resolves and confirms a policy reference (name + version) exists in the
+// loaded policy definitions, returning the resolved definition when found. Version resolution:
+// - Accept full semantic versions as-is (vX.Y.Z)
+// - Allow major-only versions (vX) and resolve them to a single matching full version
+// - An empty version resolves to the latest available version for that policy name
+func (pv *PolicyValidator) validatePolicyRef(name, version, fieldPath string) (*models.PolicyDefinition, []ValidationError) {
+	resolvedVersion, err := pv.resolvePolicyVersion(name, version)
+	if err != nil {
+		return nil, []ValidationError{{
+			Field:   fieldPath + ".version",
+			Message: err.Error(),
+		}}
+	}
+
+	// Check if policy definition exists
+	key := name + "|" + resolvedVersion
+	policyDef, exists := pv.policyDefinitions[key]
+	if !exists {
+		return nil, []ValidationError{{
+			Field:   fieldPath + ".name",
+			Message: fmt.Sprintf("Policy '%s' version '%s' not found in loaded policy definitions", name, resolvedVersion),
+		}}
+	}
+
+	return &policyDef, nil
 }
 
 var (

--- a/gateway/gateway-controller/pkg/config/policy_validator_llm_test.go
+++ b/gateway/gateway-controller/pkg/config/policy_validator_llm_test.go
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	api "github.com/wso2/api-platform/gateway/gateway-controller/pkg/api/management"
+	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/models"
+)
+
+// ratelimitDefs is a small set of loaded policy definitions used across the LLM tests.
+func ratelimitDefs() map[string]models.PolicyDefinition {
+	return map[string]models.PolicyDefinition{
+		"basic-ratelimit|v1.0.0":       {Name: "basic-ratelimit", Version: "v1.0.0"},
+		"basic-ratelimit|v2.0.0":       {Name: "basic-ratelimit", Version: "v2.0.0"},
+		"token-based-ratelimit|v1.0.0": {Name: "token-based-ratelimit", Version: "v1.0.0"},
+	}
+}
+
+func TestPolicyValidator_ValidateLLMProviderPolicies_Valid(t *testing.T) {
+	validator := NewPolicyValidator(ratelimitDefs())
+
+	cfg := &api.LLMProviderConfiguration{
+		Spec: api.LLMProviderConfigData{
+			GlobalPolicies: &[]api.Policy{
+				{Name: "basic-ratelimit", Version: "v1"},
+			},
+			OperationPolicies: &[]api.OperationPolicy{
+				{Name: "token-based-ratelimit", Version: "v1"},
+			},
+		},
+	}
+
+	errors := validator.ValidateLLMProviderPolicies(cfg)
+	assert.Empty(t, errors, "expected no errors for valid LLM provider policies")
+}
+
+func TestPolicyValidator_ValidateLLMProviderPolicies_NonExistentName(t *testing.T) {
+	validator := NewPolicyValidator(ratelimitDefs())
+
+	cfg := &api.LLMProviderConfiguration{
+		Spec: api.LLMProviderConfigData{
+			GlobalPolicies: &[]api.Policy{
+				{Name: "this-policy-does-not-exist", Version: "v1"},
+			},
+		},
+	}
+
+	errors := validator.ValidateLLMProviderPolicies(cfg)
+	assert.Len(t, errors, 1, "expected one error for a non-existent policy name")
+	assert.Contains(t, errors[0].Field, "spec.globalPolicies[0]")
+	assert.Contains(t, errors[0].Message, "not found")
+}
+
+func TestPolicyValidator_ValidateLLMProviderPolicies_NonExistentMajorVersion(t *testing.T) {
+	validator := NewPolicyValidator(ratelimitDefs())
+
+	// The reproduction from issue #2466: a policy that exists but at a non-existent major version.
+	cfg := &api.LLMProviderConfiguration{
+		Spec: api.LLMProviderConfigData{
+			GlobalPolicies: &[]api.Policy{
+				{Name: "basic-ratelimit", Version: "v999"},
+			},
+		},
+	}
+
+	errors := validator.ValidateLLMProviderPolicies(cfg)
+	assert.Len(t, errors, 1, "expected one error for a non-existent major version")
+	assert.Contains(t, errors[0].Field, "spec.globalPolicies[0].version")
+	assert.Contains(t, errors[0].Message, "major version 'v999' not found")
+}
+
+func TestPolicyValidator_ValidateLLMProviderPolicies_EmptyVersionResolvesToLatest(t *testing.T) {
+	validator := NewPolicyValidator(ratelimitDefs())
+
+	// An empty version is a valid input: it resolves to the latest available version.
+	cfg := &api.LLMProviderConfiguration{
+		Spec: api.LLMProviderConfigData{
+			GlobalPolicies: &[]api.Policy{
+				{Name: "basic-ratelimit", Version: ""},
+			},
+		},
+	}
+
+	errors := validator.ValidateLLMProviderPolicies(cfg)
+	assert.Empty(t, errors, "expected empty version to resolve to latest without errors")
+}
+
+func TestPolicyValidator_ValidateLLMProviderPolicies_LegacyAndOperationErrors(t *testing.T) {
+	validator := NewPolicyValidator(ratelimitDefs())
+
+	cfg := &api.LLMProviderConfiguration{
+		Spec: api.LLMProviderConfigData{
+			OperationPolicies: &[]api.OperationPolicy{
+				{Name: "missing-op-policy", Version: "v1"},
+			},
+			// Deprecated policies list is still honoured and must be validated.
+			Policies: &[]api.LLMPolicy{
+				{Name: "missing-legacy-policy", Version: "v1"},
+			},
+		},
+	}
+
+	errors := validator.ValidateLLMProviderPolicies(cfg)
+	assert.Len(t, errors, 2, "expected errors for both operation and legacy policies")
+	fields := []string{errors[0].Field, errors[1].Field}
+	assert.Contains(t, fields, "spec.operationPolicies[0].version")
+	assert.Contains(t, fields, "spec.policies[0].version")
+}
+
+func TestPolicyValidator_ValidateLLMProxyPolicies_Valid(t *testing.T) {
+	validator := NewPolicyValidator(ratelimitDefs())
+
+	cfg := &api.LLMProxyConfiguration{
+		Spec: api.LLMProxyConfigData{
+			GlobalPolicies: &[]api.Policy{
+				{Name: "basic-ratelimit", Version: "v2"},
+			},
+		},
+	}
+
+	errors := validator.ValidateLLMProxyPolicies(cfg)
+	assert.Empty(t, errors, "expected no errors for a valid LLM proxy policy")
+}
+
+func TestPolicyValidator_ValidateLLMProxyPolicies_NonExistentMajorVersion(t *testing.T) {
+	validator := NewPolicyValidator(ratelimitDefs())
+
+	cfg := &api.LLMProxyConfiguration{
+		Spec: api.LLMProxyConfigData{
+			GlobalPolicies: &[]api.Policy{
+				{Name: "basic-ratelimit", Version: "v999"},
+			},
+		},
+	}
+
+	errors := validator.ValidateLLMProxyPolicies(cfg)
+	assert.Len(t, errors, 1, "expected one error for a non-existent major version")
+	assert.Contains(t, errors[0].Message, "major version 'v999' not found")
+}

--- a/gateway/gateway-controller/pkg/utils/llm_deployment.go
+++ b/gateway/gateway-controller/pkg/utils/llm_deployment.go
@@ -290,20 +290,19 @@ func (s *LLMDeploymentService) DeployLLMProviderConfiguration(params LLMDeployme
 		return nil, fmt.Errorf("failed to transform LLM provider to API configuration: %w", err)
 	}
 
-	// Validate policies against loaded policy definitions
-	// if s.policyValidator != nil {
-	// 	policyErrors := s.policyValidator.ValidatePolicies(&apiConfig)
-	// 	if len(policyErrors) > 0 {
-	// 		errs := make([]string, 0, len(policyErrors))
-	// 		for i, e := range policyErrors {
-	// 			if params.Logger != nil {
-	// 				params.Logger.Warn("Policy validation error", slog.String("field", e.Field), slog.String("message", e.Message))
-	// 			}
-	// 			errs = append(errs, fmt.Sprintf("%d. %s: %s", i+1, e.Field, e.Message))
-	// 		}
-	// 		return nil, fmt.Errorf("policy validation failed with %d error(s): %s", len(policyErrors), strings.Join(errs, "; "))
-	// 	}
-	// }
+	// Validate policy references (name + version) against the loaded policy definitions.
+	// Mirrors the REST API path (ValidateRestAPIPolicies); an unresolvable policy name or
+	// version fails the deploy instead of being silently dropped by the runtime transform.
+	if s.policyValidator != nil {
+		if policyErrors := s.policyValidator.ValidateLLMProviderPolicies(&renderedProvider); len(policyErrors) > 0 {
+			errs := make([]string, 0, len(policyErrors))
+			for i, e := range policyErrors {
+				params.Logger.Warn("Policy validation error", slog.String("field", e.Field), slog.String("message", e.Message))
+				errs = append(errs, fmt.Sprintf("%d. %s: %s", i+1, e.Field, e.Message))
+			}
+			return nil, fmt.Errorf("provider policy validation failed with %d error(s): %s", len(policyErrors), strings.Join(errs, "; "))
+		}
+	}
 
 	// Generate API ID if not provided
 	apiID := params.ID
@@ -463,20 +462,19 @@ func (s *LLMDeploymentService) DeployLLMProxyConfiguration(params LLMDeploymentP
 		return nil, fmt.Errorf("failed to transform LLM proxy to API configuration: %w", err)
 	}
 
-	// Validate policies against loaded policy definitions
-	// if s.policyValidator != nil {
-	// 	policyErrors := s.policyValidator.ValidatePolicies(&apiConfig)
-	// 	if len(policyErrors) > 0 {
-	// 		errs := make([]string, 0, len(policyErrors))
-	// 		for i, e := range policyErrors {
-	// 			if params.Logger != nil {
-	// 				params.Logger.Warn("Policy validation error", slog.String("field", e.Field), slog.String("message", e.Message))
-	// 			}
-	// 			errs = append(errs, fmt.Sprintf("%d. %s: %s", i+1, e.Field, e.Message))
-	// 		}
-	// 		return nil, fmt.Errorf("policy validation failed with %d error(s): %s", len(policyErrors), strings.Join(errs, "; "))
-	// 	}
-	// }
+	// Validate policy references (name + version) against the loaded policy definitions.
+	// Mirrors the REST API path (ValidateRestAPIPolicies); an unresolvable policy name or
+	// version fails the deploy instead of being silently dropped by the runtime transform.
+	if s.policyValidator != nil {
+		if policyErrors := s.policyValidator.ValidateLLMProxyPolicies(&renderedProxy); len(policyErrors) > 0 {
+			errs := make([]string, 0, len(policyErrors))
+			for i, e := range policyErrors {
+				params.Logger.Warn("Policy validation error", slog.String("field", e.Field), slog.String("message", e.Message))
+				errs = append(errs, fmt.Sprintf("%d. %s: %s", i+1, e.Field, e.Message))
+			}
+			return nil, fmt.Errorf("%w: %d policy error(s): %s", ErrLLMProxyValidation, len(policyErrors), strings.Join(errs, "; "))
+		}
+	}
 
 	// Generate API ID if not provided
 	apiID := params.ID

--- a/gateway/gateway-controller/pkg/utils/llm_deployment_policy_test.go
+++ b/gateway/gateway-controller/pkg/utils/llm_deployment_policy_test.go
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package utils
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	api "github.com/wso2/api-platform/gateway/gateway-controller/pkg/api/management"
+	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/config"
+	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/models"
+	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/storage"
+	"gopkg.in/yaml.v3"
+)
+
+// ratelimitPolicyValidator returns a PolicyValidator loaded with a single basic-ratelimit
+// definition, so that references to a non-existent major version (e.g. v999) do not resolve.
+func ratelimitPolicyValidator() *config.PolicyValidator {
+	return config.NewPolicyValidator(map[string]models.PolicyDefinition{
+		"basic-ratelimit|v1.0.0": {Name: "basic-ratelimit", Version: "v1.0.0"},
+	})
+}
+
+// TestLLMDeploymentService_DeployLLMProviderConfiguration_RejectsUnresolvablePolicy reproduces
+// issue #2466 for LLM providers: a global policy referencing a non-existent major version must
+// fail the deploy rather than being silently dropped.
+func TestLLMDeploymentService_DeployLLMProviderConfiguration_RejectsUnresolvablePolicy(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	store := storage.NewConfigStore()
+	db := newTestMockDB()
+	routerConfig := &config.RouterConfig{ListenerPort: 8080}
+	require.NoError(t, db.SaveLLMProviderTemplate(testStoredLLMTemplate("template-openai-id", "openai", "OpenAI Template")))
+
+	apiDeploymentService := newTestAPIDeploymentService(store, db, nil, nil, nil)
+	service := NewLLMDeploymentService(store, db, nil, nil, nil, apiDeploymentService, routerConfig, nil, ratelimitPolicyValidator())
+
+	providerCfg := api.LLMProviderConfiguration{
+		ApiVersion: api.LLMProviderConfigurationApiVersionGatewayApiPlatformWso2Comv1,
+		Kind:       api.LLMProviderConfigurationKindLlmProvider,
+		Metadata:   api.Metadata{Name: "policy-provider"},
+		Spec: api.LLMProviderConfigData{
+			DisplayName:    "Policy Provider",
+			Version:        "1.0.0",
+			Template:       "openai",
+			Upstream:       api.LLMProviderConfigData_Upstream{Url: stringPtr("https://example.com")},
+			AccessControl:  api.LLMAccessControl{Mode: api.AllowAll},
+			GlobalPolicies: &[]api.Policy{{Name: "basic-ratelimit", Version: "v999"}},
+		},
+	}
+	data, err := yaml.Marshal(providerCfg)
+	require.NoError(t, err)
+
+	_, err = service.DeployLLMProviderConfiguration(LLMDeploymentParams{
+		Data:          data,
+		ContentType:   "application/yaml",
+		CorrelationID: "test-corr",
+		Logger:        logger,
+		Origin:        models.OriginGatewayAPI,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "policy validation failed")
+	assert.Contains(t, err.Error(), "v999")
+}
+
+// TestLLMDeploymentService_DeployLLMProxyConfiguration_RejectsUnresolvablePolicy reproduces
+// issue #2466 for LLM proxies.
+func TestLLMDeploymentService_DeployLLMProxyConfiguration_RejectsUnresolvablePolicy(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	store := storage.NewConfigStore()
+	db := newTestMockDB()
+	routerConfig := &config.RouterConfig{ListenerPort: 8080}
+	require.NoError(t, db.SaveLLMProviderTemplate(testStoredLLMTemplate("template-openai-id", "openai", "OpenAI Template")))
+	require.NoError(t, db.SaveConfig(&models.StoredConfig{
+		UUID:        "provider-a-id",
+		Kind:        string(api.LLMProviderConfigurationKindLlmProvider),
+		Handle:      "provider-a",
+		DisplayName: "Provider A",
+		Version:     "1.0.0",
+		SourceConfiguration: api.LLMProviderConfiguration{
+			ApiVersion: api.LLMProviderConfigurationApiVersionGatewayApiPlatformWso2Comv1,
+			Kind:       api.LLMProviderConfigurationKindLlmProvider,
+			Metadata:   api.Metadata{Name: "provider-a"},
+			Spec: api.LLMProviderConfigData{
+				DisplayName:   "Provider A",
+				Version:       "1.0.0",
+				Template:      "openai",
+				Upstream:      api.LLMProviderConfigData_Upstream{Url: stringPtr("https://example.com")},
+				AccessControl: api.LLMAccessControl{Mode: api.AllowAll},
+			},
+		},
+	}))
+
+	apiDeploymentService := newTestAPIDeploymentService(store, db, nil, nil, nil)
+	service := NewLLMDeploymentService(store, db, nil, nil, nil, apiDeploymentService, routerConfig, nil, ratelimitPolicyValidator())
+
+	proxyCfg := api.LLMProxyConfiguration{
+		ApiVersion: api.LLMProxyConfigurationApiVersionGatewayApiPlatformWso2Comv1,
+		Kind:       api.LLMProxyConfigurationKindLlmProxy,
+		Metadata:   api.Metadata{Name: "policy-proxy"},
+		Spec: api.LLMProxyConfigData{
+			DisplayName:    "Policy Proxy",
+			Version:        "1.0.0",
+			Context:        stringPtr("/chat"),
+			Provider:       api.LLMProxyProvider{Id: "provider-a"},
+			GlobalPolicies: &[]api.Policy{{Name: "basic-ratelimit", Version: "v999"}},
+		},
+	}
+	data, err := yaml.Marshal(proxyCfg)
+	require.NoError(t, err)
+
+	_, err = service.DeployLLMProxyConfiguration(LLMDeploymentParams{
+		Data:          data,
+		ContentType:   "application/yaml",
+		CorrelationID: "test-corr",
+		Logger:        logger,
+		Origin:        models.OriginGatewayAPI,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "v999")
+}

--- a/gateway/it/features/llm-provider.feature
+++ b/gateway/it/features/llm-provider.feature
@@ -406,6 +406,99 @@ Feature: LLM Provider Management
     And the response should be valid JSON
     And the JSON response field "status" should be "error"
 
+  Scenario: Create LLM provider referencing a non-existent policy is rejected
+    Given I authenticate using basic auth as "admin"
+    When I create this LLM provider:
+        """
+        apiVersion: gateway.api-platform.wso2.com/v1
+        kind: LlmProvider
+        metadata:
+          name: bad-policy-name-provider
+        spec:
+          displayName: Bad Policy Name Provider
+          version: v1.0
+          template: openai
+          upstream:
+            url: https://mock-openapi-https:9443/openai/v1
+            auth:
+              type: api-key
+              header: Authorization
+              value: Bearer sk-test
+          accessControl:
+            mode: allow_all
+          globalPolicies:
+            - name: this-policy-does-not-exist
+              version: v1
+        """
+    Then the response status code should be 400
+    And the response should be valid JSON
+    And the JSON response field "status" should be "error"
+
+  Scenario: Create LLM provider referencing a non-existent policy version is rejected
+    Given I authenticate using basic auth as "admin"
+    When I create this LLM provider:
+        """
+        apiVersion: gateway.api-platform.wso2.com/v1
+        kind: LlmProvider
+        metadata:
+          name: bad-policy-version-provider
+        spec:
+          displayName: Bad Policy Version Provider
+          version: v1.0
+          template: openai
+          upstream:
+            url: https://mock-openapi-https:9443/openai/v1
+            auth:
+              type: api-key
+              header: Authorization
+              value: Bearer sk-test
+          accessControl:
+            mode: allow_all
+          globalPolicies:
+            - name: basic-ratelimit
+              version: v999
+        """
+    Then the response status code should be 400
+    And the response should be valid JSON
+    And the JSON response field "status" should be "error"
+
+  # An empty policy version is a valid input: it resolves to the latest loaded version.
+  Scenario: Create LLM provider with an empty policy version resolves to the latest
+    Given I authenticate using basic auth as "admin"
+    When I create this LLM provider:
+        """
+        apiVersion: gateway.api-platform.wso2.com/v1
+        kind: LlmProvider
+        metadata:
+          name: empty-version-policy-provider
+        spec:
+          displayName: Empty Version Policy Provider
+          version: v1.0
+          template: openai
+          upstream:
+            url: https://mock-openapi-https:9443/openai/v1
+            auth:
+              type: api-key
+              header: Authorization
+              value: Bearer sk-test
+          accessControl:
+            mode: allow_all
+          globalPolicies:
+            - name: basic-ratelimit
+              version: ""
+              params:
+                limits:
+                  - requests: 10
+                    duration: "1h"
+        """
+    Then the response status code should be 201
+    And the response should be valid JSON
+    And the JSON response field "status" should be "success"
+    # Cleanup
+    Given I authenticate using basic auth as "admin"
+    When I delete the LLM provider "empty-version-policy-provider"
+    Then the response status code should be 200
+
   Scenario: Retrieve non-existent LLM provider
     Given I authenticate using basic auth as "admin"
     When I retrieve the LLM provider "non-existent-provider"

--- a/gateway/it/features/llm-proxies.feature
+++ b/gateway/it/features/llm-proxies.feature
@@ -267,6 +267,49 @@ Feature: LLM Proxy Management Operations
     Then the response should be a client error
     And the response should be valid JSON
 
+  Scenario: Create LLM proxy referencing a non-existent policy version is rejected
+    # First create the provider the proxy references
+    When I create this LLM provider:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: LlmProvider
+      metadata:
+        name: proxy-policy-provider
+      spec:
+        displayName: Proxy Policy Provider
+        version: v1.0
+        template: openai
+        upstream:
+          url: https://mock-openapi-https:9443/openai/v1
+          auth:
+            type: api-key
+            header: Authorization
+            value: Bearer sk-test-key
+        accessControl:
+          mode: allow_all
+      """
+    Then the response status code should be 201
+    When I deploy this LLM proxy configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: LlmProxy
+      metadata:
+        name: bad-policy-version-proxy
+      spec:
+        displayName: Bad Policy Version Proxy
+        version: v1.0
+        provider:
+          id: proxy-policy-provider
+        globalPolicies:
+          - name: basic-ratelimit
+            version: v999
+      """
+    Then the response should be a client error
+    And the response should be valid JSON
+    # Cleanup
+    When I delete the LLM provider "proxy-policy-provider"
+    Then the response status code should be 200
+
   Scenario: Update LLM proxy with invalid JSON body returns error
     When I send a PUT request to the "gateway-controller" service at "/llm-proxies/some-proxy" with body:
       """


### PR DESCRIPTION
## Purpose

- Resolves: #2466

This pull request enhances validation for LLM provider and proxy policy references, ensuring that unresolvable policy names or versions are caught early and deployment fails with clear error messages. It introduces new validation logic, updates the deployment service to enforce these checks, and adds comprehensive unit and integration tests to cover key scenarios, including error handling for non-existent policies and version resolution.

**Validation improvements for LLM provider/proxy policies:**

* Added `ValidateLLMProviderPolicies` and `ValidateLLMProxyPolicies` methods to `PolicyValidator`, which validate all user-authored policy references (global, operation, and legacy) in LLM provider and proxy configurations, ensuring names and versions exist in the loaded policy definitions.
* Refactored policy validation to resolve empty versions to the latest available version and to provide specific error messages for missing policies or versions.

**Deployment service enforcement:**

* Updated `DeployLLMProviderConfiguration` and `DeployLLMProxyConfiguration` to invoke the new policy validation methods, causing deployment to fail with a clear error if any policy reference is unresolvable, rather than silently dropping invalid policies. [[1]](diffhunk://#diff-b3f64afaed909c3a2c8fa8275420844564577bba469a116f493687b6fee670c4L293-R305) [[2]](diffhunk://#diff-b3f64afaed909c3a2c8fa8275420844564577bba469a116f493687b6fee670c4L466-R477)

**Testing:**

* Added unit tests for LLM provider/proxy policy validation, covering valid policies, non-existent policy names, non-existent major versions, empty version resolution, and validation of legacy and operation policies.
* Added integration tests to verify that creating LLM providers with non-existent policy names or versions is rejected, and that empty policy versions correctly resolve to the latest available version.
* Added deployment service tests to ensure that deployments are rejected if they reference unresolvable policies.