### PR TITLE
Remove API Key as a Mandatory Field

### DIFF
--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/AddNewProvider/ProviderTemplateFormFields.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/AddNewProvider/ProviderTemplateFormFields.tsx
@@ -311,10 +311,10 @@ export default function ProviderTemplateFormFields({
         </Grid>
       )}
 
-      {/* Auth Value - always show, user must provide their API key */}
+      {/* Auth Value - always show; optional, provider can be created without it */}
       <Grid size={{ xs: 12 }}>
         <FormControl fullWidth>
-          <FormLabel required>
+          <FormLabel>
             <FormattedMessage
               id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.AddNewProvider.ProviderTemplateFormFields.api.key"
               defaultMessage={'API Key'}
@@ -352,7 +352,7 @@ export default function ProviderTemplateFormFields({
                 ),
               },
             }}
-            placeholder="Enter your API key or token"
+            placeholder="Enter your API key or token (optional)"
             // helperText={
             //   template?.metadata?.auth?.valuePrefix
             //     ? `Will be prefixed with: ${template.metadata.auth.valuePrefix}`

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/AddNewProvider/serviceProviderTypes.ts
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/AddNewProvider/serviceProviderTypes.ts
@@ -27,6 +27,8 @@ export type FormState = {
   upstreamAuthHeader: string;
   upstreamAuthValue: string;
   valuePrefix: string;
+  securityKeyName: string;
+  securityKeyPrefix: string;
 };
 
 export type GuardrailSelection = {

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderNew.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderNew.tsx
@@ -97,6 +97,14 @@ function TemplateBasedFormFieldsContainer({
         : prev.upstreamAuthHeader,
       upstreamAuthValue: templateChanged ? '' : prev.upstreamAuthValue,
       valuePrefix: template?.metadata?.auth?.valuePrefix || '',
+      // Consumer-facing security config (how callers authenticate to our
+      // gateway) mirrors the template's upstream auth metadata, when present.
+      securityKeyName: templateChanged
+        ? template?.metadata?.auth?.header || 'X-API-Key'
+        : prev.securityKeyName,
+      securityKeyPrefix: templateChanged
+        ? template?.metadata?.auth?.valuePrefix || ''
+        : prev.securityKeyPrefix,
     }));
 
     // Resolve OpenAPI spec. Prefer the inline spec stored on the template
@@ -183,6 +191,8 @@ export default function ServiceProviderNew() {
     upstreamAuthHeader: 'Authorization',
     upstreamAuthValue: '',
     valuePrefix: '',
+    securityKeyName: 'X-API-Key',
+    securityKeyPrefix: '',
   });
   const isVersionValid = VERSION_PATTERN.test(formState.version.trim());
   const [showCredential, setShowCredential] = useState(false);
@@ -307,8 +317,7 @@ export default function ServiceProviderNew() {
       isVersionValid &&
       selectedTemplateId &&
       formState.upstreamUrl.trim() &&
-      formState.upstreamAuthType &&
-      formState.upstreamAuthValue.trim()
+      formState.upstreamAuthType
   );
 
   const toProviderId = (name: string): string =>
@@ -332,10 +341,23 @@ export default function ServiceProviderNew() {
             type: formState.upstreamAuthType,
             header: formState.upstreamAuthHeader,
 
-            value: formState.valuePrefix
-              ? `${formState.valuePrefix.trimEnd()} ${formState.upstreamAuthValue}`
-              : formState.upstreamAuthValue,
+            value:
+              formState.valuePrefix && formState.upstreamAuthValue.trim()
+                ? `${formState.valuePrefix.trimEnd()} ${formState.upstreamAuthValue}`
+                : formState.upstreamAuthValue,
           },
+        },
+      };
+
+      const security = {
+        enabled: true,
+        apiKey: {
+          enabled: true,
+          key: formState.securityKeyName || 'X-API-Key',
+          in: 'header' as const,
+          ...(formState.securityKeyPrefix
+            ? { keyPrefix: formState.securityKeyPrefix }
+            : {}),
         },
       };
 
@@ -348,6 +370,7 @@ export default function ServiceProviderNew() {
         template: selectedVersionTemplateId ?? selectedTemplateId,
         openapi: openapiSpec,
         upstream,
+        security,
         globalPolicies: [
           ...(familyHandle(selectedTemplateId) !== 'azure-openai' &&
           familyHandle(selectedTemplateId) !== 'azureai-foundry'

--- a/portals/ai-workspace/src/utils/tmpSPRequest.ts
+++ b/portals/ai-workspace/src/utils/tmpSPRequest.ts
@@ -125,7 +125,7 @@ export function buildFullProviderRequest(
     modelProviders:
       request.modelProviders ?? buildModelProvidersFromTemplate(request.template),
     rateLimiting: {},
-    security: {
+    security: request.security ?? {
       enabled: true,
       apiKey: {
         enabled: true,

--- a/portals/ai-workspace/src/utils/types.ts
+++ b/portals/ai-workspace/src/utils/types.ts
@@ -325,6 +325,7 @@ export interface ApiKeySecurity {
   enabled: boolean;
   key?: string;
   in?: 'header' | 'query';
+  keyPrefix?: string;
 }
 
 /**
@@ -408,6 +409,7 @@ export interface CreateLLMProviderRequest {
   operationPolicies?: OperationPolicy[];
   policies?: Policy[];
   openapi?: string;
+  security?: SecurityConfig;
 }
 
 /** Read-only fields from API (excluded from update requests) */


### PR DESCRIPTION
This pull request introduces support for configuring a consumer-facing API key security mechanism when creating a new service provider. It allows users to specify the API key name and an optional prefix, and makes the upstream API key optional. The changes also ensure that the security configuration is included in the provider creation payload and type definitions.

**Security configuration enhancements:**

* Added `securityKeyName` and `securityKeyPrefix` fields to the `FormState` type, and updated the form logic to initialize and update these fields based on the selected template. (`serviceProviderTypes.ts` [[1]](diffhunk://#diff-5b4fb78875a38dc2a55c4375a826cd4afdca403437fb3cee7e0ddc5d28671f2eR30-R31) `ServiceProviderNew.tsx` [[2]](diffhunk://#diff-5f3cfa9035307148cacb9a695d1cde1ebe05c3b5c50435d0f5ec42d6bfa6280dR100-R107) [[3]](diffhunk://#diff-5f3cfa9035307148cacb9a695d1cde1ebe05c3b5c50435d0f5ec42d6bfa6280dR194-R195)
* Constructed a `security` object in the provider creation payload, enabling API key security with the specified key name and prefix, and included it in the request. (`ServiceProviderNew.tsx` [[1]](diffhunk://#diff-5f3cfa9035307148cacb9a695d1cde1ebe05c3b5c50435d0f5ec42d6bfa6280dL335-R363) [[2]](diffhunk://#diff-5f3cfa9035307148cacb9a695d1cde1ebe05c3b5c50435d0f5ec42d6bfa6280dR373)

**Usability improvements:**

* Made the upstream API key field optional, updated its label and placeholder to reflect this, and relaxed the form validation to allow provider creation without an API key. (`ProviderTemplateFormFields.tsx` [[1]](diffhunk://#diff-c61b2c3da4e6d27c7596b1637afe4a2274f78c44095dec55cd0a3894a152ed7dL314-R317) [[2]](diffhunk://#diff-c61b2c3da4e6d27c7596b1637afe4a2274f78c44095dec55cd0a3894a152ed7dL355-R355) `ServiceProviderNew.tsx` [[3]](diffhunk://#diff-5f3cfa9035307148cacb9a695d1cde1ebe05c3b5c50435d0f5ec42d6bfa6280dL310-R320)

**Type and utility updates:**

* Added `keyPrefix` to the `ApiKeySecurity` interface and made the `security` field optional in the `CreateLLMProviderRequest` type. (`types.ts` [[1]](diffhunk://#diff-c6c3331227d44fb604da2f1aa7be7c552e5e408ef3094bff9c00806817f0c878R328) [[2]](diffhunk://#diff-c6c3331227d44fb604da2f1aa7be7c552e5e408ef3094bff9c00806817f0c878R412)
* Updated the `buildFullProviderRequest` utility to use the provided `security` configuration if present. (`tmpSPRequest.ts` [portals/ai-workspace/src/utils/tmpSPRequest.tsL128-R128](diffhunk://#diff-ab311c905b9f6f10a805b873c71f6d42b10c788d07392c05c7b1b4213dc78385L128-R128))