### PR TITLE
[PlatformAPI] Fix deployment error encountered for older gateways due to kind version

### DIFF
--- a/platform-api/internal/deploymenttransform/apiversion.go
+++ b/platform-api/internal/deploymenttransform/apiversion.go
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package deploymenttransform
+
+import (
+	"fmt"
+
+	"github.com/wso2/api-platform/platform-api/internal/constants"
+	"github.com/wso2/api-platform/platform-api/internal/dto"
+	"github.com/wso2/api-platform/platform-api/internal/model"
+)
+
+// init registers apiVersion down-convert transformations for the artifact kinds
+// whose generators stamp the canonical apiVersion but carry no policy-list split
+// (RestApi, WebSubApi, Mcp).
+//
+// Generators stamp the canonical apiVersion (GatewayApiVersion, i.e. ".../v1").
+// Gateways < 1.2.0 only accept the legacy ".../v1alpha1" value, so for those
+// targets we rewrite the apiVersion field. Unlike the LLM kinds, these artifacts
+// have no globalPolicies/operationPolicies split, so the apiVersion swap is the
+// only conversion needed.
+func init() {
+	minVer := ParseVersion(MinSplitPoliciesVersion)
+	isOldGateway := func(target Version) bool { return !target.GTE(minVer) }
+
+	// RestApi and WebSubApi both marshal from *dto.APIDeploymentYAML.
+	downgradeAPIDeploymentVersion := func(payload any) error {
+		artifact, ok := payload.(*dto.APIDeploymentYAML)
+		if !ok {
+			return fmt.Errorf("expected *dto.APIDeploymentYAML, got %T", payload)
+		}
+		artifact.ApiVersion = constants.GatewayApiVersionV1Alpha1
+		return nil
+	}
+
+	for _, kind := range []string{constants.RestApi, constants.WebSubApi} {
+		defaultRegistry.Register(Transformation{
+			Name:        "apiversion/downconvert-pre-1.2.0/" + kind,
+			Kind:        kind,
+			AppliesWhen: isOldGateway,
+			Apply:       downgradeAPIDeploymentVersion,
+		})
+	}
+
+	// Mcp marshals from *model.MCPProxyDeploymentYAML (a different struct).
+	defaultRegistry.Register(Transformation{
+		Name:        "apiversion/downconvert-pre-1.2.0/" + constants.MCPProxy,
+		Kind:        constants.MCPProxy,
+		AppliesWhen: isOldGateway,
+		Apply: func(payload any) error {
+			artifact, ok := payload.(*model.MCPProxyDeploymentYAML)
+			if !ok {
+				return fmt.Errorf("expected *model.MCPProxyDeploymentYAML, got %T", payload)
+			}
+			artifact.ApiVersion = constants.GatewayApiVersionV1Alpha1
+			return nil
+		},
+	})
+}

--- a/platform-api/internal/deploymenttransform/transform_test.go
+++ b/platform-api/internal/deploymenttransform/transform_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/wso2/api-platform/platform-api/api"
 	"github.com/wso2/api-platform/platform-api/internal/constants"
 	"github.com/wso2/api-platform/platform-api/internal/dto"
+	"github.com/wso2/api-platform/platform-api/internal/model"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -183,6 +184,84 @@ func TestTransform_Proxy_OldGateway_FlattensToLegacy(t *testing.T) {
 	assert.Nil(t, artifact.Spec.GlobalPolicies)
 	require.Len(t, artifact.Spec.Policies, 1)
 	assert.Equal(t, "/*", artifact.Spec.Policies[0].Paths[0].Path)
+}
+
+// ---------------------------------------------------------------------------
+// Registry.Transform — REST/WebSub apiVersion down-convert
+//
+// REST/WebSub artifacts carry no policy-list split, so the only conversion for
+// old gateways is the apiVersion field swap.
+// ---------------------------------------------------------------------------
+
+func newAPIArtifact(kind string) *dto.APIDeploymentYAML {
+	return &dto.APIDeploymentYAML{
+		ApiVersion: constants.GatewayApiVersion,
+		Kind:       kind,
+		Spec:       dto.APIYAMLData{DisplayName: "test"},
+	}
+}
+
+func TestTransform_RestAPI_NewGateway_ApiVersionPassthrough(t *testing.T) {
+	artifact := newAPIArtifact(constants.RestApi)
+	err := Default().Transform(constants.RestApi, ParseVersion(MinSplitPoliciesVersion), artifact)
+	require.NoError(t, err)
+	assert.Equal(t, constants.GatewayApiVersion, artifact.ApiVersion)
+}
+
+func TestTransform_RestAPI_OldGateway_DowngradesApiVersion(t *testing.T) {
+	artifact := newAPIArtifact(constants.RestApi)
+	err := Default().Transform(constants.RestApi, ParseVersion("1.1.0"), artifact)
+	require.NoError(t, err)
+	assert.Equal(t, constants.GatewayApiVersionV1Alpha1, artifact.ApiVersion)
+}
+
+func TestTransform_WebSubAPI_OldGateway_DowngradesApiVersion(t *testing.T) {
+	artifact := newAPIArtifact(constants.WebSubApi)
+	err := Default().Transform(constants.WebSubApi, ParseVersion(""), artifact)
+	require.NoError(t, err)
+	assert.Equal(t, constants.GatewayApiVersionV1Alpha1, artifact.ApiVersion)
+}
+
+func TestTransform_RestAPI_WrongPayloadType_ReturnsError(t *testing.T) {
+	// Passing a *dto.LLMProviderDeploymentYAML where an APIDeploymentYAML is
+	// expected triggers the type-assertion guard in Apply.
+	artifact := newProviderArtifact(sampleGlobal(), nil, nil)
+	err := Default().Transform(constants.RestApi, ParseVersion("1.1.0"), artifact)
+	assert.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// Registry.Transform — MCP apiVersion down-convert (*model.MCPProxyDeploymentYAML)
+// ---------------------------------------------------------------------------
+
+func newMCPArtifact() *model.MCPProxyDeploymentYAML {
+	return &model.MCPProxyDeploymentYAML{
+		ApiVersion: constants.GatewayApiVersion,
+		Kind:       constants.MCPProxy,
+		Spec:       model.MCPProxyDeploymentSpec{DisplayName: "test"},
+	}
+}
+
+func TestTransform_MCP_NewGateway_ApiVersionPassthrough(t *testing.T) {
+	artifact := newMCPArtifact()
+	err := Default().Transform(constants.MCPProxy, ParseVersion(MinSplitPoliciesVersion), artifact)
+	require.NoError(t, err)
+	assert.Equal(t, constants.GatewayApiVersion, artifact.ApiVersion)
+}
+
+func TestTransform_MCP_OldGateway_DowngradesApiVersion(t *testing.T) {
+	artifact := newMCPArtifact()
+	err := Default().Transform(constants.MCPProxy, ParseVersion("1.1.0"), artifact)
+	require.NoError(t, err)
+	assert.Equal(t, constants.GatewayApiVersionV1Alpha1, artifact.ApiVersion)
+}
+
+func TestTransform_MCP_WrongPayloadType_ReturnsError(t *testing.T) {
+	// Passing a *dto.APIDeploymentYAML where an MCPProxyDeploymentYAML is
+	// expected triggers the type-assertion guard in Apply.
+	artifact := newAPIArtifact(constants.RestApi)
+	err := Default().Transform(constants.MCPProxy, ParseVersion("1.1.0"), artifact)
+	assert.Error(t, err)
 }
 
 // ---------------------------------------------------------------------------

--- a/platform-api/internal/service/deployment.go
+++ b/platform-api/internal/service/deployment.go
@@ -29,6 +29,7 @@ import (
 	"github.com/wso2/api-platform/platform-api/api"
 	"github.com/wso2/api-platform/platform-api/config"
 	"github.com/wso2/api-platform/platform-api/internal/constants"
+	"github.com/wso2/api-platform/platform-api/internal/deploymenttransform"
 	"github.com/wso2/api-platform/platform-api/internal/dto"
 	"github.com/wso2/api-platform/platform-api/internal/model"
 	"github.com/wso2/api-platform/platform-api/internal/repository"
@@ -243,6 +244,14 @@ func (s *DeploymentService) DeployAPI(apiUUID string, req *api.DeployRequest, or
 		apiDeployment, err := s.apiUtil.BuildAPIDeploymentYAML(apiModel)
 		if err != nil {
 			return nil, fmt.Errorf("failed to build API deployment YAML: %w", err)
+		}
+		// Adapt the canonical artifact to the target gateway's capability.
+		// Notably, gateways < 1.2.0 only accept the legacy apiVersion
+		// (gateway.api-platform.wso2.com/v1alpha1), so the apiVersion is
+		// down-converted here based on the resolved gateway version.
+		target := deploymenttransform.ParseVersion(gateway.Version)
+		if err := deploymenttransform.Default().Transform(apiModel.Kind, target, apiDeployment); err != nil {
+			return nil, fmt.Errorf("failed to transform API deployment for gateway %s: %w", gateway.Version, err)
 		}
 		applyStructOverrides(apiDeployment, endpointURL, vhostMain, vhostSandbox)
 		contentBytes, err = yaml.Marshal(apiDeployment)

--- a/platform-api/internal/service/mcp_deployment.go
+++ b/platform-api/internal/service/mcp_deployment.go
@@ -26,6 +26,7 @@ import (
 	"github.com/wso2/api-platform/platform-api/api"
 	"github.com/wso2/api-platform/platform-api/config"
 	"github.com/wso2/api-platform/platform-api/internal/constants"
+	"github.com/wso2/api-platform/platform-api/internal/deploymenttransform"
 	"github.com/wso2/api-platform/platform-api/internal/model"
 	"github.com/wso2/api-platform/platform-api/internal/repository"
 	"github.com/wso2/api-platform/platform-api/internal/utils"
@@ -259,6 +260,14 @@ func (s *MCPDeploymentService) deployMCPProxy(proxyUUID string, req *api.DeployR
 		d, err := s.utils.BuildMCPDeploymentYAML(mcpProxy)
 		if err != nil {
 			return nil, fmt.Errorf("failed to build MCP deployment YAML: %w", err)
+		}
+		// Adapt the canonical artifact to the target gateway's capability.
+		// Gateways < 1.2.0 only accept the legacy apiVersion
+		// (gateway.api-platform.wso2.com/v1alpha1), so the apiVersion is
+		// down-converted here based on the resolved gateway version.
+		target := deploymenttransform.ParseVersion(gateway.Version)
+		if err := deploymenttransform.Default().Transform(constants.MCPProxy, target, d); err != nil {
+			return nil, fmt.Errorf("failed to transform MCP deployment for gateway %s: %w", gateway.Version, err)
 		}
 		if endpointURL != nil {
 			d.Spec.Upstream.URL = *endpointURL


### PR DESCRIPTION
## Purpose

Deploying a REST API, WebSub API, or MCP proxy to a gateway < 1.2.0 failed with "Unsupported API version (must be 'gateway.api-platform.wso2.com/v1alpha1')". Their deploy paths sent the canonical apiVersion .../v1 and never invoked the
deploymenttransform registry (only LLM provider/proxy did).

- Register apiVersion down-convert transformations for RestApi, WebSubApi, and  Mcp (< 1.2.0 → v1alpha1).
- Call Transform in DeployAPI and deployMCPProxy "current" branches.
