### PR TITLE
Refactor organization ID validation method and fix AI Workspace error handling

### DIFF
--- a/platform-api/internal/handler/organization.go
+++ b/platform-api/internal/handler/organization.go
@@ -20,7 +20,6 @@ package handler
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -83,11 +82,12 @@ func (h *OrganizationHandler) RegisterOrganization(w http.ResponseWriter, r *htt
 	if err != nil {
 		return err
 	}
-	// The IDP's organization UUID is derived server-side from the token's raw
-	// organization claim (the IDP org id), never client-supplied. This uses the
-	// unresolved claim rather than the resolved platform UUID, since the
-	// organization being created does not exist yet. Empty in file-based mode.
-	idpOrgRefUUID, _ := middleware.GetIdpOrgRefFromRequest(r)
+	// The IDP's organization UUID is derived server-side from the token's
+	// organization claim, never client-supplied. Since the organization being
+	// created does not exist yet, OrganizationResolverMiddleware has nothing to
+	// resolve the claim against, so this still reflects the raw IDP org id.
+	// Empty in file-based mode.
+	idpOrgRefUUID, _ := middleware.GetOrganizationFromRequest(r)
 	org, err := h.orgService.RegisterOrganization(id, handle, req.DisplayName, req.Region, idpOrgRefUUID, performedBy)
 	if err != nil {
 		var appErr *apperror.Error
@@ -103,30 +103,46 @@ func (h *OrganizationHandler) RegisterOrganization(w http.ResponseWriter, r *htt
 	return nil
 }
 
-// HeadOrganization handles HEAD /api/v0.9/organizations/{organizationId}
-func (h *OrganizationHandler) HeadOrganization(w http.ResponseWriter, r *http.Request) error {
+// resolveOrganizationForRequest resolves the organization strictly from the trusted
+// token/context organization ID (a UUID), never from the user-supplied path handle,
+// then verifies the path handle refers to that same organization. Comparing a handle
+// field against the context's UUID directly is always false and would forbid every
+// request, so the lookup must go through the UUID first.
+//
+// Returns apperror.Unauthorized if the token has no organization claim,
+// apperror.OrganizationNotFound (404) if the token's organization no longer exists,
+// and apperror.Forbidden (403) if pathHandle does not match the caller's organization.
+func (h *OrganizationHandler) resolveOrganizationForRequest(r *http.Request, pathHandle string) (*api.Organization, error) {
 	organizationIdFromContext, exists := middleware.GetOrganizationFromRequest(r)
 	if !exists {
-		return apperror.Unauthorized.New().
+		return nil, apperror.Unauthorized.New().
 			WithLogMessage("organization claim not found in token")
 	}
-	handle := r.PathValue("organizationId")
 
-	h.slogger.Debug("Organization from token", "organizationId", organizationIdFromContext)
-
-	org, err := h.orgService.GetOrganizationByHandle(handle)
+	org, err := h.orgService.GetOrganizationByUUID(organizationIdFromContext)
 	if err != nil {
 		var appErr *apperror.Error
 		if errors.As(err, &appErr) {
-			return err
+			return nil, err
 		}
-		return apperror.Internal.Wrap(err).
-			WithLogMessage(fmt.Sprintf("failed to get organization by handle %s", handle))
+		return nil, apperror.Internal.Wrap(err).
+			WithLogMessage("failed to get organization from token context")
 	}
 
-	if *org.Id != organizationIdFromContext {
-		return apperror.Forbidden.New().
-			WithLogMessage("Organization ID in token does not match the requested organization ID")
+	if org.Id == nil || *org.Id != pathHandle {
+		return nil, apperror.Forbidden.New().
+			WithLogMessage("organization in token does not match the requested organization")
+	}
+
+	return org, nil
+}
+
+// HeadOrganization handles HEAD /api/v0.9/organizations/{organizationId}
+func (h *OrganizationHandler) HeadOrganization(w http.ResponseWriter, r *http.Request) error {
+	handle := r.PathValue("organizationId")
+
+	if _, err := h.resolveOrganizationForRequest(r, handle); err != nil {
+		return err
 	}
 
 	w.WriteHeader(http.StatusOK)
@@ -137,14 +153,9 @@ func (h *OrganizationHandler) HeadOrganization(w http.ResponseWriter, r *http.Re
 func (h *OrganizationHandler) GetOrganizationByID(w http.ResponseWriter, r *http.Request) error {
 	handle := r.PathValue("organizationId")
 
-	org, err := h.orgService.GetOrganizationByHandle(handle)
+	org, err := h.resolveOrganizationForRequest(r, handle)
 	if err != nil {
-		var appErr *apperror.Error
-		if errors.As(err, &appErr) {
-			return err
-		}
-		return apperror.Internal.Wrap(err).
-			WithLogMessage(fmt.Sprintf("failed to get organization by handle %s", handle))
+		return err
 	}
 
 	httputil.WriteJSON(w, http.StatusOK, org)

--- a/platform-api/internal/handler/organization.go
+++ b/platform-api/internal/handler/organization.go
@@ -114,12 +114,7 @@ func (h *OrganizationHandler) HeadOrganization(w http.ResponseWriter, r *http.Re
 
 	h.slogger.Debug("Organization from token", "organizationId", organizationIdFromContext)
 
-	if handle != organizationIdFromContext {
-		return apperror.Forbidden.New().
-			WithLogMessage("Organization ID in token does not match the requested organization ID")
-	}
-
-	_, err := h.orgService.GetOrganizationByHandle(handle)
+	org, err := h.orgService.GetOrganizationByHandle(handle)
 	if err != nil {
 		var appErr *apperror.Error
 		if errors.As(err, &appErr) {
@@ -127,6 +122,11 @@ func (h *OrganizationHandler) HeadOrganization(w http.ResponseWriter, r *http.Re
 		}
 		return apperror.Internal.Wrap(err).
 			WithLogMessage(fmt.Sprintf("failed to get organization by handle %s", handle))
+	}
+
+	if *org.Id != organizationIdFromContext {
+		return apperror.Forbidden.New().
+			WithLogMessage("Organization ID in token does not match the requested organization ID")
 	}
 
 	w.WriteHeader(http.StatusOK)

--- a/platform-api/internal/middleware/auth.go
+++ b/platform-api/internal/middleware/auth.go
@@ -43,7 +43,6 @@ const (
 	keyOrganization  contextKey = "organization"
 	keyOrgName       contextKey = "org_name"
 	keyOrgHandle     contextKey = "org_handle"
-	keyIdpOrgRef     contextKey = "idp_org_ref"
 	keyScope         contextKey = "scope"
 	keyAudience      contextKey = "audience"
 	keyClaims        contextKey = "claims"
@@ -422,14 +421,6 @@ func GetOrgHandleFromRequest(r *http.Request) (string, bool) {
 	return getStringFromCtx(r, keyOrgHandle)
 }
 
-// GetIdpOrgRefFromRequest extracts the raw organization claim carried by the
-// token (the IDP's organization id in IDP mode). Unlike the organization key —
-// which OrganizationResolverMiddleware rewrites to the platform UUID — this
-// always reflects the value the token asserted. Returns false when unset.
-func GetIdpOrgRefFromRequest(r *http.Request) (string, bool) {
-	return getStringFromCtx(r, keyIdpOrgRef)
-}
-
 // OrgUUIDResolver maps a token's organization claim to the platform
 // organization UUID, returning true when a matching organization exists.
 type OrgUUIDResolver func(orgClaim string) (string, bool)
@@ -440,9 +431,10 @@ type OrgUUIDResolver func(orgClaim string) (string, bool)
 // scope their queries by the correct UUID regardless of whether the token carries
 // the platform UUID (file-based auth) or the IDP's organization id (IDP auth).
 //
-// The raw claim is preserved under a separate key (see GetIdpOrgRefFromRequest)
-// for callers that need the original IDP reference — notably organization
-// registration, where no organization exists yet to resolve against.
+// When the claim does not resolve to an existing organization (e.g. during
+// registration of a brand-new organization), the context is left holding the
+// raw claim, so GetOrganizationFromRequest still returns the IDP's original
+// organization reference in that case.
 func OrganizationResolverMiddleware(resolve OrgUUIDResolver) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -451,7 +443,7 @@ func OrganizationResolverMiddleware(resolve OrgUUIDResolver) func(http.Handler) 
 				next.ServeHTTP(w, r)
 				return
 			}
-			ctx := context.WithValue(r.Context(), keyIdpOrgRef, claim)
+			ctx := r.Context()
 			if uuid, found := resolve(claim); found {
 				ctx = context.WithValue(ctx, keyOrganization, uuid)
 			}

--- a/platform-api/internal/middleware/organization_resolver_test.go
+++ b/platform-api/internal/middleware/organization_resolver_test.go
@@ -41,8 +41,7 @@ func TestOrganizationResolverMiddleware(t *testing.T) {
 		name       string
 		claim      string
 		setClaim   bool
-		wantOrg    string // resolved organization the handler should see
-		wantIdpRef string // raw claim preserved for registration
+		wantOrg    string // organization the handler should see (resolved, or raw claim if unresolved)
 		wantHasOrg bool
 	}{
 		{
@@ -50,7 +49,6 @@ func TestOrganizationResolverMiddleware(t *testing.T) {
 			claim:      "idp-123",
 			setClaim:   true,
 			wantOrg:    "plat-uuid-1",
-			wantIdpRef: "idp-123",
 			wantHasOrg: true,
 		},
 		{
@@ -58,7 +56,6 @@ func TestOrganizationResolverMiddleware(t *testing.T) {
 			claim:      "plat-uuid-1",
 			setClaim:   true,
 			wantOrg:    "plat-uuid-1",
-			wantIdpRef: "plat-uuid-1",
 			wantHasOrg: true,
 		},
 		{
@@ -66,25 +63,22 @@ func TestOrganizationResolverMiddleware(t *testing.T) {
 			claim:      "brand-new-idp-org",
 			setClaim:   true,
 			wantOrg:    "brand-new-idp-org",
-			wantIdpRef: "brand-new-idp-org",
 			wantHasOrg: true,
 		},
 		{
 			name:       "no organization claim passes through untouched",
 			setClaim:   false,
 			wantOrg:    "",
-			wantIdpRef: "",
 			wantHasOrg: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var gotOrg, gotIdpRef string
+			var gotOrg string
 			var gotHasOrg bool
 			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				gotOrg, gotHasOrg = GetOrganizationFromRequest(r)
-				gotIdpRef, _ = GetIdpOrgRefFromRequest(r)
 			})
 
 			r := httptest.NewRequest(http.MethodGet, "/api/v0.9/rest-apis", nil)
@@ -99,9 +93,6 @@ func TestOrganizationResolverMiddleware(t *testing.T) {
 			}
 			if gotOrg != tt.wantOrg {
 				t.Errorf("resolved organization = %q, want %q", gotOrg, tt.wantOrg)
-			}
-			if gotIdpRef != tt.wantIdpRef {
-				t.Errorf("raw idp org ref = %q, want %q", gotIdpRef, tt.wantIdpRef)
 			}
 		})
 	}

--- a/platform-api/resources/openapi.yaml
+++ b/platform-api/resources/openapi.yaml
@@ -8534,7 +8534,8 @@ components:
           example:
             status: error
             code: SERVICE_UNAVAILABLE
-            message: Secrets management is not configured. Set PLATFORM_SECRET_ENCRYPTION_KEY.
+            message: Secrets management is not configured.
+            trackingId: 4f1c6f2e-8a4b-4c93-b1de-9f2f6f0c2a11
 
     GatewayConnectionUnavailable:
       description: Service Unavailable. No gateway connections are currently available to service this request.
@@ -8546,6 +8547,7 @@ components:
             status: error
             code: GATEWAY_CONNECTION_UNAVAILABLE
             message: No gateway connections are currently available.
+            trackingId: 4f1c6f2e-8a4b-4c93-b1de-9f2f6f0c2a11
 
   examples:
     GatewayNotFoundExample:

--- a/portals/ai-workspace/bff/internal/server/composite_handlers.go
+++ b/portals/ai-workspace/bff/internal/server/composite_handlers.go
@@ -135,7 +135,7 @@ func (s *Server) deleteSecretAsync(jwt, handle, apiBase string) {
 func (s *Server) handleCreateWithSecretCompensation(w http.ResponseWriter, r *http.Request, resourcePath, apiBasePath string) {
 	jwt, ok := s.tokenFromCookie(r)
 	if !ok {
-		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "not authenticated"})
+		writeErrorJSON(w, http.StatusUnauthorized, "NOT_AUTHENTICATED", "not authenticated")
 		return
 	}
 
@@ -143,7 +143,7 @@ func (s *Server) handleCreateWithSecretCompensation(w http.ResponseWriter, r *ht
 	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "failed to read request body"})
+		writeErrorJSON(w, http.StatusBadRequest, "INVALID_REQUEST_BODY", "failed to read request body")
 		return
 	}
 
@@ -155,7 +155,7 @@ func (s *Server) handleCreateWithSecretCompensation(w http.ResponseWriter, r *ht
 	resp, err := s.platformDo(r.Context(), jwt, http.MethodPost, path, r.Header, body)
 	if err != nil {
 		slog.Error("bff: platform API call failed", "path", resourcePath, "err", err)
-		writeJSON(w, http.StatusBadGateway, map[string]string{"error": "upstream request failed"})
+		writeServerErrorJSON(w, http.StatusBadGateway, "UPSTREAM_REQUEST_FAILED", "upstream request failed", w.Header().Get("X-Request-Id"))
 		return
 	}
 	defer resp.Body.Close()

--- a/portals/ai-workspace/bff/internal/server/handlers.go
+++ b/portals/ai-workspace/bff/internal/server/handlers.go
@@ -44,7 +44,7 @@ type loginRequest struct {
 // handleLogin (POST /api/login) — file-based credentials → server-side session.
 func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 	if s.fileBased == nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "file-based auth is not enabled"})
+		writeErrorJSON(w, http.StatusBadRequest, "AUTH_METHOD_DISABLED", "file-based auth is not enabled")
 		return
 	}
 
@@ -52,7 +52,7 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 	ct := r.Header.Get("Content-Type")
 	if strings.HasPrefix(ct, "application/json") {
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+			writeErrorJSON(w, http.StatusBadRequest, "INVALID_REQUEST_BODY", "invalid request body")
 			return
 		}
 	} else {
@@ -61,7 +61,7 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 		req.Password = r.PostForm.Get("password")
 	}
 	if req.Username == "" || req.Password == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "username and password are required"})
+		writeErrorJSON(w, http.StatusBadRequest, "MISSING_CREDENTIALS", "username and password are required")
 		return
 	}
 
@@ -69,11 +69,11 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		var bad auth.ErrInvalidCredentials
 		if errors.As(err, &bad) {
-			writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "invalid credentials"})
+			writeErrorJSON(w, http.StatusUnauthorized, "INVALID_CREDENTIALS", "invalid credentials")
 			return
 		}
 		slog.Error("file-based login failed", "err", err)
-		writeJSON(w, http.StatusBadGateway, map[string]string{"error": "login failed"})
+		writeServerErrorJSON(w, http.StatusBadGateway, "LOGIN_FAILED", "login failed", w.Header().Get("X-Request-Id"))
 		return
 	}
 
@@ -125,14 +125,14 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 // handleOIDCLogin (GET /api/auth/login) — redirect to the IDP authorize endpoint.
 func (s *Server) handleOIDCLogin(w http.ResponseWriter, r *http.Request) {
 	if s.oidc == nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "oidc auth is not enabled"})
+		writeErrorJSON(w, http.StatusBadRequest, "AUTH_METHOD_DISABLED", "oidc auth is not enabled")
 		return
 	}
 	ret := sanitizeReturn(r.URL.Query().Get("return"))
 	authURL, txID, err := s.oidc.AuthCodeURL(ret)
 	if err != nil {
 		slog.Error("oidc authorize url failed", "err", err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "login init failed"})
+		writeServerErrorJSON(w, http.StatusInternalServerError, "LOGIN_INIT_FAILED", "login init failed", w.Header().Get("X-Request-Id"))
 		return
 	}
 	s.setTxCookie(w, txID)
@@ -142,7 +142,7 @@ func (s *Server) handleOIDCLogin(w http.ResponseWriter, r *http.Request) {
 // handleOIDCCallback (GET /api/auth/callback) — exchange code, create session.
 func (s *Server) handleOIDCCallback(w http.ResponseWriter, r *http.Request) {
 	if s.oidc == nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "oidc auth is not enabled"})
+		writeErrorJSON(w, http.StatusBadRequest, "AUTH_METHOD_DISABLED", "oidc auth is not enabled")
 		return
 	}
 	q := r.URL.Query()
@@ -184,7 +184,7 @@ func (s *Server) handleOIDCCallback(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleProxy(w http.ResponseWriter, r *http.Request) {
 	jwt, ok := s.tokenFromCookie(r)
 	if !ok {
-		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "not authenticated"})
+		writeErrorJSON(w, http.StatusUnauthorized, "NOT_AUTHENTICATED", "not authenticated")
 		return
 	}
 
@@ -199,7 +199,7 @@ func (s *Server) handleProxy(w http.ResponseWriter, r *http.Request) {
 				slog.Warn("token refresh failed", "err", err)
 				_ = s.store.Delete(r.Context(), jwt)
 				s.clearSessionCookie(w)
-				writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "session expired"})
+				writeErrorJSON(w, http.StatusUnauthorized, "SESSION_EXPIRED", "session expired")
 				return
 			}
 			jwt = refreshed.AccessToken
@@ -347,6 +347,30 @@ func writeJSON(w http.ResponseWriter, status int, body any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(body)
+}
+
+// errorBody mirrors the Platform API's standard error shape (see
+// platform-api/resources/openapi.yaml "Error" schema) so the frontend can
+// parse every error response — proxied or BFF-originated — the same way.
+type errorBody struct {
+	Status     string `json:"status"`
+	Code       string `json:"code"`
+	Message    string `json:"message"`
+	TrackingID string `json:"trackingId,omitempty"`
+}
+
+// writeErrorJSON writes a BFF-originated error (auth/session/CSRF failures
+// that never reach the Platform API) in the same shape as Platform API
+// errors. code must match ^[A-Z][A-Z0-9_]*$.
+func writeErrorJSON(w http.ResponseWriter, status int, code, message string) {
+	writeJSON(w, status, errorBody{Status: "error", Code: code, Message: message})
+}
+
+// writeServerErrorJSON writes a 5xx BFF-originated error, echoing the
+// request's correlation id as trackingId — matching the Platform API
+// contract that trackingId is present on server-side failures.
+func writeServerErrorJSON(w http.ResponseWriter, status int, code, message, trackingID string) {
+	writeJSON(w, status, errorBody{Status: "error", Code: code, Message: message, TrackingID: trackingID})
 }
 
 // sanitizeReturn ensures redirect targets are local paths (no open redirect).

--- a/portals/ai-workspace/bff/internal/server/middleware.go
+++ b/portals/ai-workspace/bff/internal/server/middleware.go
@@ -66,7 +66,7 @@ func recoverPanic(next http.Handler) http.Handler {
 		defer func() {
 			if rec := recover(); rec != nil {
 				slog.Error("panic recovered", "err", rec, "path", r.URL.Path)
-				http.Error(w, `{"error":"internal server error"}`, http.StatusInternalServerError)
+				writeServerErrorJSON(w, http.StatusInternalServerError, "INTERNAL_ERROR", "internal server error", w.Header().Get("X-Request-Id"))
 			}
 		}()
 		next.ServeHTTP(w, r)
@@ -82,7 +82,7 @@ func (s *Server) requireCSRF(next http.Handler) http.Handler {
 			// Safe methods: no CSRF token required.
 		default:
 			if r.Header.Get(s.cfg.CSRFHeader) == "" {
-				writeJSON(w, http.StatusForbidden, map[string]string{"error": "missing CSRF header"})
+				writeErrorJSON(w, http.StatusForbidden, "MISSING_CSRF_HEADER", "missing CSRF header")
 				return
 			}
 		}

--- a/portals/ai-workspace/src/Components/common/ErrorAlert.tsx
+++ b/portals/ai-workspace/src/Components/common/ErrorAlert.tsx
@@ -19,6 +19,7 @@
 import { Alert, Button } from '@wso2/oxygen-ui';
 import { LogOut, RefreshCcw } from '@wso2/oxygen-ui-icons-react';
 import { forceLogoutAndRedirect } from '../../auth/logout';
+import { getErrorMessage as getShortErrorMessage, getTrackingId } from '../../utils/apiError';
 
 /**
  * Extract HTTP status code from various error shapes:
@@ -41,24 +42,6 @@ function getHttpStatusCode(error?: Error | null): number | null {
   return null;
 }
 
-function getErrorMessage(error?: Error | null): string {
-  if (!error) return 'Something went wrong.';
-
-  const status = getHttpStatusCode(error);
-
-  if (status !== null && status >= 400) {
-    return 'Something went wrong.';
-  }
-
-  const description = (error as any)?.response?.data?.description;
-  if (description) return description;
-
-  const dataMessage = (error as any)?.response?.data?.message;
-  if (dataMessage) return dataMessage;
-
-  return error.message || 'Something went wrong.';
-}
-
 interface ErrorAlertProps {
   error?: Error | null;
   onRetry: () => void;
@@ -66,7 +49,8 @@ interface ErrorAlertProps {
 
 export default function ErrorAlert({ error, onRetry }: ErrorAlertProps) {
   const status = getHttpStatusCode(error);
-  const isServerOrClientError = status !== null && status >= 400;
+  const isServerError = status !== null && status >= 500;
+  const isClientOrServerError = status !== null && status >= 400;
 
   // A 401 means the session is expired/invalid — retrying re-fires the same
   // doomed request (the spinner never resolves). Offer a logout that clears the
@@ -91,7 +75,15 @@ export default function ErrorAlert({ error, onRetry }: ErrorAlertProps) {
     );
   }
 
-  if (isServerOrClientError) {
+  if (isClientOrServerError) {
+    // 5xx: don't surface the (possibly unhelpful) backend message — show a
+    // generic notice with the trackingId so the user can quote it to support.
+    // 4xx: the backend message is short, user-facing, and safe to show as-is.
+    const trackingId = getTrackingId(error);
+    const message = isServerError
+      ? 'Something went wrong.'
+      : getShortErrorMessage(error, 'Something went wrong.');
+
     return (
       <Alert
         severity="error"
@@ -106,14 +98,20 @@ export default function ErrorAlert({ error, onRetry }: ErrorAlertProps) {
           </Button>
         }
       >
-        Something went wrong.
+        {message}
+        {trackingId && (
+          <>
+            {' '}
+            <em>(Reference ID: {trackingId})</em>
+          </>
+        )}
       </Alert>
     );
   }
 
   return (
     <Alert severity="error">
-      {getErrorMessage(error)}
+      {getShortErrorMessage(error)}
     </Alert>
   );
 }

--- a/portals/ai-workspace/src/apis/platformApis.ts
+++ b/portals/ai-workspace/src/apis/platformApis.ts
@@ -18,6 +18,7 @@
 
 import { PLATFORM_API_BASE_URL, CSRF_HEADER, CSRF_VALUE } from '../config.env';
 import { logger } from '../utils/logger';
+import { ApiError, buildApiError } from '../utils/apiError';
 
 // ============================================================================
 // Platform API Types
@@ -72,24 +73,18 @@ const mutatingHeaders = (): Record<string, string> => ({
   [CSRF_HEADER]: CSRF_VALUE,
 });
 
-const parseErrorMessage = async (res: Response): Promise<string> => {
-  try {
-    const body = await res.json();
-    return body?.message ?? body?.error ?? `HTTP ${res.status}`;
-  } catch {
-    return `HTTP ${res.status}`;
-  }
-};
-
 /**
- * Build an Error that carries the originating HTTP status, so callers can
- * branch on it (e.g. surface a "session expired" logout flow on 401) instead
- * of string-matching the message.
+ * Parse the Platform API's standard error body from a failed Response into
+ * an `ApiError` carrying `status`, `code`, `errors`, `details`, and
+ * `trackingId` — so callers can branch on `code` (as the spec requires)
+ * instead of string-matching the message.
  */
-const httpError = (message: string, status: number): Error & { status: number } => {
-  const err = new Error(message) as Error & { status: number };
-  err.status = status;
-  return err;
+const parseApiError = async (res: Response): Promise<ApiError> => {
+  let body: unknown;
+  try {
+    body = await res.json();
+  } catch { /* body not JSON */ }
+  return buildApiError(res.status, body, `HTTP ${res.status}`);
 };
 
 // ============================================================================
@@ -115,16 +110,15 @@ export async function registerOrganization(
   });
 
   if (!response.ok) {
-    const message = await parseErrorMessage(response);
-    logger.error('registerOrganization failed:', response.status, message);
+    const err = await parseApiError(response);
+    logger.error('registerOrganization failed:', response.status, err.code, err.message, err.trackingId);
 
-    if (response.status === 409) {
-      throw httpError(`Organization with handle "${org.id}" already exists.`, 409);
+    // Fall back to a friendlier message only when the backend didn't already
+    // supply one keyed to the specific failure (e.g. an older gateway).
+    if (err.code === 'ORGANIZATION_ALREADY_EXISTS' || (response.status === 409 && !err.code)) {
+      err.message = `Organization with handle "${org.id}" already exists.`;
     }
-    if (response.status === 400) {
-      throw httpError(`Invalid organization data: ${message}`, 400);
-    }
-    throw httpError(`Failed to register organization: ${message}`, response.status);
+    throw err;
   }
 
   const created: PlatformOrganization = await response.json();
@@ -146,9 +140,9 @@ export async function getOrganization(): Promise<PlatformOrganization> {
   });
 
   if (!response.ok) {
-    const message = await parseErrorMessage(response);
-    logger.error('getOrganization failed:', response.status, message);
-    throw new Error(`Failed to get organization: ${message}`);
+    const err = await parseApiError(response);
+    logger.error('getOrganization failed:', response.status, err.code, err.message, err.trackingId);
+    throw err;
   }
 
   return response.json();
@@ -173,9 +167,9 @@ export async function getOrganizationById(
 
   if (response.status === 404) return null;
   if (!response.ok) {
-    const message = await parseErrorMessage(response);
-    logger.error('getOrganizationById failed:', response.status, message);
-    throw new Error(`Failed to get organization: ${message}`);
+    const err = await parseApiError(response);
+    logger.error('getOrganizationById failed:', response.status, err.code, err.message, err.trackingId);
+    throw err;
   }
   return response.json();
 }
@@ -198,9 +192,9 @@ export async function getOrganizationByHandle(
 
   if (response.status === 404) return null;
   if (!response.ok) {
-    const message = await parseErrorMessage(response);
-    logger.error('getOrganizationByHandle failed:', response.status, message);
-    throw new Error(`Failed to get organization: ${message}`);
+    const err = await parseApiError(response);
+    logger.error('getOrganizationByHandle failed:', response.status, err.code, err.message, err.trackingId);
+    throw err;
   }
   return response.json();
 }
@@ -224,6 +218,5 @@ export async function checkOrganizationExists(
   if (response.status === 404) return false;
   if (response.ok) return true;
 
-  const message = await parseErrorMessage(response);
-  throw httpError(`Failed to check organization: ${message}`, response.status);
+  throw await parseApiError(response);
 }

--- a/portals/ai-workspace/src/apis/secretApis.ts
+++ b/portals/ai-workspace/src/apis/secretApis.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { get, del, postForm, putForm } from '../clients/choreoApiClient';
+import { get, del, postForm, putForm, ApiError } from '../clients/choreoApiClient';
 
 // ============================================================================
 // Types
@@ -70,7 +70,7 @@ export interface SecretReference {
 }
 
 export interface DeleteSecretConflict {
-  error: string;
+  message: string;
   references: SecretReference[];
 }
 
@@ -78,7 +78,7 @@ export class SecretConflictError extends Error {
   readonly status = 409;
   readonly conflict: DeleteSecretConflict;
   constructor(conflict: DeleteSecretConflict) {
-    super(conflict.error);
+    super(conflict.message);
     this.name = 'SecretConflictError';
     this.conflict = conflict;
   }
@@ -145,11 +145,10 @@ export async function deleteSecret(handle: string): Promise<void> {
   try {
     return await del<void>(`/secrets/${handle}`);
   } catch (err: unknown) {
-    if (err instanceof Error && (err as { status?: number }).status === 409) {
-      const data = (err as { data?: unknown }).data as DeleteSecretConflict | undefined;
-      if (data?.references) {
-        throw new SecretConflictError(data);
-      }
+    const apiErr = err as ApiError;
+    if (apiErr?.code === 'SECRET_IN_USE') {
+      const references = (apiErr.details?.references as SecretReference[] | undefined) ?? [];
+      throw new SecretConflictError({ message: apiErr.message, references });
     }
     throw err;
   }

--- a/portals/ai-workspace/src/clients/choreoApiClient.ts
+++ b/portals/ai-workspace/src/clients/choreoApiClient.ts
@@ -32,8 +32,10 @@
 import { PLATFORM_API_BASE_URL, CSRF_HEADER, CSRF_VALUE } from '../config.env';
 import { logger } from '../utils/logger';
 import { HttpMethod, ApiRequestConfig, GQLResponse } from '../utils/types';
+import { buildApiError } from '../utils/apiError';
 
 export type { HttpMethod, ApiRequestConfig, GQLResponse };
+export type { ApiError, FieldError } from '../utils/apiError';
 
 // ---------------------------------------------------------------------------
 // Token shims — tokens now live server-side in the BFF session, never in the
@@ -98,19 +100,15 @@ export const request = async <T>(config: ApiRequestConfig): Promise<T> => {
   });
 
   if (!res.ok) {
-    let message = `HTTP ${res.status}`;
     let data: unknown;
     try {
       data = await res.json();
-      const d = data as Record<string, unknown>;
-      message = (d?.description ?? d?.message ?? d?.error ?? message) as string;
     } catch { /* body not JSON */ }
-    logger.error(`[platformApiClient] ${method} ${url} → ${res.status}: ${message}`);
-    // Attach status and raw parsed body so callers can inspect structured error
-    // payloads (e.g. 409 DeleteSecretConflict) without re-fetching.
-    const err = new Error(message) as Error & { status?: number; data?: unknown };
-    err.status = res.status;
-    err.data = data;
+    const err = buildApiError(res.status, data, `HTTP ${res.status}`);
+    logger.error(
+      `[platformApiClient] ${method} ${url} → ${res.status} [${err.code ?? 'UNKNOWN'}]: ${err.message}`
+      + (err.trackingId ? ` (trackingId: ${err.trackingId})` : ''),
+    );
     throw err;
   }
 
@@ -151,13 +149,15 @@ const sendForm = async <T>(
   const res = await fetch(url, { method, credentials: 'include', headers, body: form });
 
   if (!res.ok) {
-    let message = `HTTP ${res.status}`;
+    let data: unknown;
     try {
-      const body = await res.json();
-      message = body?.description ?? body?.message ?? body?.error ?? message;
+      data = await res.json();
     } catch { /* body not JSON */ }
-    const err = new Error(message) as Error & { status?: number };
-    err.status = res.status;
+    const err = buildApiError(res.status, data, `HTTP ${res.status}`);
+    logger.error(
+      `[platformApiClient] ${method} ${url} → ${res.status} [${err.code ?? 'UNKNOWN'}]: ${err.message}`
+      + (err.trackingId ? ` (trackingId: ${err.trackingId})` : ''),
+    );
     throw err;
   }
 

--- a/portals/ai-workspace/src/contexts/ApplicationAssociationsContext.tsx
+++ b/portals/ai-workspace/src/contexts/ApplicationAssociationsContext.tsx
@@ -37,6 +37,7 @@ import { applicationApis } from '../apis/applicationApis';
 import { useAppShell } from './AppShellContext';
 import { PLATFORM_API_BASE_URL } from '../config.env';
 import { logger } from '../utils/logger';
+import { getErrorMessage } from '../utils/apiError';
 
 const EMPTY_ASSOCIATIONS_RESPONSE: ApplicationAssociationListResponse = {
   count: 0,
@@ -134,11 +135,7 @@ export function ApplicationAssociationsProvider({
         `Failed to fetch associations for application ${applicationId}:`,
         err
       );
-      setError(
-        (err as any)?.response?.data?.description ||
-          (err instanceof Error ? err.message : null) ||
-          'Failed to load associations.'
-      );
+      setError(getErrorMessage(err, 'Failed to load associations.'));
     } finally {
       setIsLoading(false);
     }

--- a/portals/ai-workspace/src/hooks/useGateway.ts
+++ b/portals/ai-workspace/src/hooks/useGateway.ts
@@ -34,6 +34,7 @@ import {
   trackHybridGatewayUpdate,
   trackHybridGatewayDelete,
 } from '../utils/app-insights';
+import { getErrorMessage } from '../utils/apiError';
 
 interface UseGatewayListReturn {
   gateways: HybridGateway[];
@@ -287,11 +288,7 @@ export function useGatewayList(
         // Track gateway delete
         trackHybridGatewayDelete(organizationId, gatewayToDelete?.id || id);
       } catch (err: any) {
-        const errorMessage =
-          err?.response?.data?.description ??
-          err?.response?.data?.message ??
-          err?.message ??
-          'Failed to delete gateway';
+        const errorMessage = getErrorMessage(err, 'Failed to delete gateway');
         showSnackbar(errorMessage, 'error');
         throw err;
       } finally {

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/applications/ApplicationNew.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/applications/ApplicationNew.tsx
@@ -38,10 +38,17 @@ import {
   buildProjectPath,
 } from '../../../../utils/projectRouting';
 import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
+import { getErrorMessage, getFieldErrors } from '../../../../utils/apiError';
 
 type FormState = {
   name: string;
   description: string;
+};
+
+// Backend field names (from CreateApplicationRequest) mapped onto this form's state keys.
+const FIELD_NAME_MAP: Record<string, keyof FormState> = {
+  displayName: 'name',
+  description: 'description',
 };
 
 function buildApplicationHandle(name: string, takenIds: Set<string>): string {
@@ -83,6 +90,7 @@ export default function ApplicationNew() {
     description: '',
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [fieldErrors, setFieldErrors] = useState<Partial<Record<keyof FormState, string>>>({});
 
   const handleCreate = async () => {
     const trimmedName = formState.name.trim();
@@ -91,6 +99,7 @@ export default function ApplicationNew() {
 
     try {
       setIsSubmitting(true);
+      setFieldErrors({});
 
       const newApplication = await createApplication({
         id: appHandle,
@@ -117,12 +126,24 @@ export default function ApplicationNew() {
         }
       );
     } catch (error) {
-      const description =
-        (error as any)?.response?.data?.description ||
-        (error as any)?.response?.data?.message ||
-        (error instanceof Error ? error.message : null) ||
-        'Failed to create application.';
-      showSnackbar(description, 'error');
+      const backendFieldErrors = getFieldErrors(error);
+      const mappedErrors: Partial<Record<keyof FormState, string>> = {};
+      let hasUnmapped = false;
+      backendFieldErrors?.forEach(({ field, message }) => {
+        const formField = FIELD_NAME_MAP[field];
+        if (formField) {
+          mappedErrors[formField] = message;
+        } else {
+          hasUnmapped = true;
+        }
+      });
+      if (Object.keys(mappedErrors).length > 0) {
+        setFieldErrors(mappedErrors);
+      }
+      if (hasUnmapped || Object.keys(mappedErrors).length === 0) {
+        const description = getErrorMessage(error, 'Failed to create application.');
+        showSnackbar(description, 'error');
+      }
     } finally {
       setIsSubmitting(false);
     }
@@ -154,12 +175,15 @@ export default function ApplicationNew() {
                 fullWidth
                 placeholder="Documentation Assistant"
                 value={formState.name}
-                onChange={(event) =>
+                onChange={(event) => {
                   setFormState((prev) => ({
                     ...prev,
                     name: event.target.value,
-                  }))
-                }
+                  }));
+                  setFieldErrors((prev) => ({ ...prev, name: undefined }));
+                }}
+                error={Boolean(fieldErrors.name)}
+                helperText={fieldErrors.name}
               />
             </FormControl>
           </Grid>
@@ -173,12 +197,15 @@ export default function ApplicationNew() {
                 minRows={3}
                 placeholder="Short description of the application."
                 value={formState.description}
-                onChange={(event) =>
+                onChange={(event) => {
                   setFormState((prev) => ({
                     ...prev,
                     description: event.target.value,
-                  }))
-                }
+                  }));
+                  setFieldErrors((prev) => ({ ...prev, description: undefined }));
+                }}
+                error={Boolean(fieldErrors.description)}
+                helperText={fieldErrors.description}
               />
             </FormControl>
           </Grid>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/applications/ApplicationOverview.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/applications/ApplicationOverview.tsx
@@ -52,18 +52,14 @@ import { applicationApis } from '../../../../apis/applicationApis';
 import type { Application } from '../../../../utils/types';
 import { ApplicationAssociationsProvider } from '../../../../contexts/ApplicationAssociationsContext';
 import AssociationsTab from './OverviewTabs/AssociationsTab';
+import { getErrorMessage } from '../../../../utils/apiError';
 
 type LocationState = {
   applicationAdded?: boolean;
 };
 
 function getErrorDescription(error: unknown, fallback: string): string {
-  return (
-    (error as any)?.response?.data?.description ||
-    (error as any)?.response?.data?.message ||
-    (error instanceof Error ? error.message : null) ||
-    fallback
-  );
+  return getErrorMessage(error, fallback);
 }
 
 

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/applications/ApplicationsList.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/applications/ApplicationsList.tsx
@@ -58,6 +58,7 @@ import type { Application } from '../../../../utils/types';
 import ErrorAlert from '../../../../Components/common/ErrorAlert';
 import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
 import NoApplications from '../../../../assets/images/NoApplications.svg';
+import { getErrorCode } from '../../../../utils/apiError';
 
 function getInitials(name: string): string {
   const words = name.trim().split(/\s+/);
@@ -316,9 +317,7 @@ export default function ApplicationsList() {
     }
 
     if (error) {
-      const is404ProjectNotFound =
-        (error as any)?.response?.status === 404 &&
-        (error as any)?.response?.data?.description === 'Project not found';
+      const is404ProjectNotFound = getErrorCode(error) === 'PROJECT_NOT_FOUND';
 
       if (is404ProjectNotFound) {
         return (

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/applications/OverviewTabs/APIKeyTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/applications/OverviewTabs/APIKeyTab.tsx
@@ -46,18 +46,14 @@ import useAIWorkspaceSnackbar from '../../../../../hooks/aiWorkspaceSnackbar';
 import { PLATFORM_API_BASE_URL } from '../../../../../config.env';
 import { keyManagementApis } from '../../../../../apis/keyManagementApis';
 import type { MappedAPIKey, UserAPIKey } from '../../../../../utils/types';
+import { getErrorMessage } from '../../../../../utils/apiError';
 
 type APIKeyTabProps = {
   applicationId: string;
 };
 
 function getErrorDescription(error: unknown, fallback: string): string {
-  return (
-    (error as any)?.response?.data?.description ||
-    (error as any)?.response?.data?.message ||
-    (error instanceof Error ? error.message : null) ||
-    fallback
-  );
+  return getErrorMessage(error, fallback);
 }
 
 function formatDate(value?: string): string {

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/applications/OverviewTabs/AssociationsTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/applications/OverviewTabs/AssociationsTab.tsx
@@ -69,6 +69,7 @@ import AssociationSelectionDrawer, {
   SelectableKeyList,
 } from './AssociationSelectionDrawer';
 import AssociationsTable from './AssociationsTable';
+import { getErrorMessage } from '../../../../../utils/apiError';
 import {
   dedupeMappedKeys,
   getInitials,
@@ -112,12 +113,7 @@ function getTemplateLogo(template?: string): string | undefined {
 }
 
 function getErrorDescription(error: unknown, fallback: string): string {
-  return (
-    (error as any)?.response?.data?.description ||
-    (error as any)?.response?.data?.message ||
-    (error instanceof Error ? error.message : null) ||
-    fallback
-  );
+  return getErrorMessage(error, fallback);
 }
 
 function resolveEntityId(key: MappedAPIKey): string | undefined {

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/EditExternalServer.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/EditExternalServer.tsx
@@ -40,6 +40,7 @@ import { PLATFORM_API_BASE_URL } from '../../../../config.env';
 import { mcpProxiesApis } from '../../../../apis/MCP/mcpProxiesApis';
 import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
 import type { MCPServer } from '../../../../utils/types';
+import { getErrorMessage, getFieldErrors } from '../../../../utils/apiError';
 import { useMemo } from 'react';
 
 const MAX_NAME_LENGTH = 255;
@@ -47,34 +48,17 @@ const MAX_DESCRIPTION_LENGTH = 1023;
 const MAX_VERSION_LENGTH = 50;
 const MAX_CONTEXT_LENGTH = 255;
 
-type ErrorResponse = {
-  response?: {
-    data?: {
-      description?: unknown;
-      message?: unknown;
-    };
-  };
-};
-
 function getErrorDescription(error: unknown, fallback: string): string {
-  const responseData = (error as ErrorResponse)?.response?.data;
-  const description = responseData?.description;
-  const message = responseData?.message;
-
-  if (typeof description === 'string' && description.trim()) {
-    return description;
-  }
-
-  if (typeof message === 'string' && message.trim()) {
-    return message;
-  }
-
-  if (error instanceof Error && error.message) {
-    return error.message;
-  }
-
-  return fallback;
+  return getErrorMessage(error, fallback);
 }
+
+// Backend field names (from MCPServer's update payload) mapped onto this form's state keys.
+const FIELD_NAME_MAP: Record<string, 'name' | 'description' | 'version' | 'context'> = {
+  displayName: 'name',
+  description: 'description',
+  version: 'version',
+  context: 'context',
+};
 
 export default function EditExternalServer() {
   const navigate = useNavigate();
@@ -112,6 +96,7 @@ export default function EditExternalServer() {
   const [version, setVersion] = useState('');
   const [context, setContext] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const isReadOnlyServer = Boolean(server?.readOnly);
 
   useEffect(() => {
@@ -165,6 +150,7 @@ export default function EditExternalServer() {
     if (!serverId || !server) return;
 
     setIsSubmitting(true);
+    setFieldErrors({});
     try {
       const fullPayload = {
         ...server,
@@ -188,10 +174,26 @@ export default function EditExternalServer() {
       const viewPath = `${listPath}/${serverId}`;
       navigate(viewPath);
     } catch (err) {
-      showSnackbar(
-        getErrorDescription(err, 'Failed to update MCP Proxy'),
-        'error'
-      );
+      const backendFieldErrors = getFieldErrors(err);
+      const mappedErrors: Record<string, string> = {};
+      let hasUnmapped = false;
+      backendFieldErrors?.forEach(({ field, message }) => {
+        const formField = FIELD_NAME_MAP[field];
+        if (formField) {
+          mappedErrors[formField] = message;
+        } else {
+          hasUnmapped = true;
+        }
+      });
+      if (Object.keys(mappedErrors).length > 0) {
+        setFieldErrors(mappedErrors);
+      }
+      if (hasUnmapped || Object.keys(mappedErrors).length === 0) {
+        showSnackbar(
+          getErrorDescription(err, 'Failed to update MCP Proxy'),
+          'error'
+        );
+      }
     } finally {
       setIsSubmitting(false);
     }
@@ -282,13 +284,17 @@ export default function EditExternalServer() {
                   required
                   value={name}
                   disabled={isReadOnlyServer}
-                  onChange={(e) => setName(e.target.value)}
+                  onChange={(e) => {
+                    setName(e.target.value);
+                    setFieldErrors((prev) => ({ ...prev, name: '' }));
+                  }}
                   placeholder="Enter server name"
-                  error={name.length > MAX_NAME_LENGTH}
+                  error={name.length > MAX_NAME_LENGTH || Boolean(fieldErrors.name)}
                   helperText={
-                    name.length > MAX_NAME_LENGTH
+                    fieldErrors.name ||
+                    (name.length > MAX_NAME_LENGTH
                       ? `Name must not exceed ${MAX_NAME_LENGTH} characters (${name.length}/${MAX_NAME_LENGTH})`
-                      : ''
+                      : '')
                   }
                 />
               </FormControl>
@@ -299,13 +305,17 @@ export default function EditExternalServer() {
                   fullWidth
                   value={version}
                   disabled={isReadOnlyServer}
-                  onChange={(e) => setVersion(e.target.value)}
+                  onChange={(e) => {
+                    setVersion(e.target.value);
+                    setFieldErrors((prev) => ({ ...prev, version: '' }));
+                  }}
                   placeholder="e.g., 1.0"
-                  error={version.length > MAX_VERSION_LENGTH}
+                  error={version.length > MAX_VERSION_LENGTH || Boolean(fieldErrors.version)}
                   helperText={
-                    version.length > MAX_VERSION_LENGTH
+                    fieldErrors.version ||
+                    (version.length > MAX_VERSION_LENGTH
                       ? `Version must not exceed ${MAX_VERSION_LENGTH} characters (${version.length}/${MAX_VERSION_LENGTH})`
-                      : ''
+                      : '')
                   }
                 />
               </FormControl>
@@ -316,15 +326,19 @@ export default function EditExternalServer() {
               <TextField
                 fullWidth
                 value={description}
-                onChange={(e) => setDescription(e.target.value)}
+                onChange={(e) => {
+                  setDescription(e.target.value);
+                  setFieldErrors((prev) => ({ ...prev, description: '' }));
+                }}
                 placeholder="Enter description"
                 multiline
                 minRows={2}
-                error={description.length > MAX_DESCRIPTION_LENGTH}
+                error={description.length > MAX_DESCRIPTION_LENGTH || Boolean(fieldErrors.description)}
                 helperText={
-                  description.length > MAX_DESCRIPTION_LENGTH
+                  fieldErrors.description ||
+                  (description.length > MAX_DESCRIPTION_LENGTH
                     ? `Description must not exceed ${MAX_DESCRIPTION_LENGTH} characters (${description.length}/${MAX_DESCRIPTION_LENGTH})`
-                    : ''
+                    : '')
                 }
               />
             </FormControl>
@@ -335,13 +349,17 @@ export default function EditExternalServer() {
                 fullWidth
                 value={context}
                 disabled={isReadOnlyServer}
-                onChange={(e) => setContext(e.target.value)}
+                onChange={(e) => {
+                  setContext(e.target.value);
+                  setFieldErrors((prev) => ({ ...prev, context: '' }));
+                }}
                 placeholder="Enter context path"
-                error={context.length > MAX_CONTEXT_LENGTH}
+                error={context.length > MAX_CONTEXT_LENGTH || Boolean(fieldErrors.context)}
                 helperText={
-                  context.length > MAX_CONTEXT_LENGTH
+                  fieldErrors.context ||
+                  (context.length > MAX_CONTEXT_LENGTH
                     ? `Context must not exceed ${MAX_CONTEXT_LENGTH} characters (${context.length}/${MAX_CONTEXT_LENGTH})`
-                    : ''
+                    : '')
                 }
               />
             </FormControl>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/ExternalServersCreateForm.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/ExternalServersCreateForm.tsx
@@ -27,6 +27,14 @@ import {
 } from '@wso2/oxygen-ui';
 import { FormattedMessage } from 'react-intl';
 
+type FieldErrors = {
+  name?: string;
+  version?: string;
+  description?: string;
+  context?: string;
+  target?: string;
+};
+
 type Props = {
   isCreateDisabled: boolean;
   serverContext: string;
@@ -34,6 +42,7 @@ type Props = {
   serverName: string;
   serverTarget: string;
   serverVersion: string;
+  fieldErrors?: FieldErrors;
   onCancel: () => void;
   onCreate: () => void;
   onContextChange: (value: string) => void;
@@ -50,6 +59,7 @@ export default function ExternalServersCreateForm({
   serverName,
   serverTarget,
   serverVersion,
+  fieldErrors = {},
   onCancel,
   onCreate,
   onContextChange,
@@ -74,6 +84,8 @@ export default function ExternalServersCreateForm({
               placeholder="WSO2 MCP Proxy"
               value={serverName}
               onChange={(event) => onNameChange(event.target.value)}
+              error={Boolean(fieldErrors.name)}
+              helperText={fieldErrors.name}
             />
           </FormControl>
         </Grid>
@@ -90,6 +102,8 @@ export default function ExternalServersCreateForm({
               placeholder="v1.0"
               value={serverVersion}
               onChange={(event) => onVersionChange(event.target.value)}
+              error={Boolean(fieldErrors.version)}
+              helperText={fieldErrors.version}
             />
           </FormControl>
         </Grid>
@@ -108,6 +122,8 @@ export default function ExternalServersCreateForm({
               placeholder="Primary MCP Proxy"
               value={serverDescription}
               onChange={(event) => onDescriptionChange(event.target.value)}
+              error={Boolean(fieldErrors.description)}
+              helperText={fieldErrors.description}
             />
           </FormControl>
         </Grid>
@@ -123,6 +139,8 @@ export default function ExternalServersCreateForm({
               fullWidth
               value={serverContext}
               onChange={(event) => onContextChange(event.target.value)}
+              error={Boolean(fieldErrors.context)}
+              helperText={fieldErrors.context}
             />
           </FormControl>
         </Grid>
@@ -139,6 +157,8 @@ export default function ExternalServersCreateForm({
               placeholder="https://example.com/mcp"
               value={serverTarget}
               onChange={(event) => onTargetChange(event.target.value)}
+              error={Boolean(fieldErrors.target)}
+              helperText={fieldErrors.target}
             />
           </FormControl>
         </Grid>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/ExternalServersList.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/ExternalServersList.tsx
@@ -61,14 +61,10 @@ import { PLATFORM_API_BASE_URL } from '../../../../config.env';
 import { mcpProxiesApis } from '../../../../apis/MCP/mcpProxiesApis';
 import type { MCPServer } from '../../../../utils/types';
 import NoMCPServers from '../../../../assets/images/NoMCPServers.svg';
+import { getErrorMessage } from '../../../../utils/apiError';
 
 function getErrorDescription(error: unknown, fallbackMessage: string): string {
-  return (
-    (error as any)?.response?.data?.description ||
-    (error as any)?.response?.data?.message ||
-    (error instanceof Error ? error.message : null) ||
-    fallbackMessage
-  );
+  return getErrorMessage(error, fallbackMessage);
 }
 
 export default function ExternalServersList(): React.JSX.Element {

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/ExternalServersNew.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/ExternalServersNew.tsx
@@ -64,6 +64,16 @@ import type { MCPServerInfoFetchRequest, CreateMCPServerRequest } from '../../..
 import ExternalServersCreateForm from './ExternalServersCreateForm';
 import ExternalServersValidationDetails from './ExternalServersValidationDetails';
 import type { EndpointValidationResponse } from './externalServersValidationTypes';
+import { getErrorMessage, getFieldErrors } from '../../../../utils/apiError';
+
+// Backend field names (from CreateMCPServerRequest) mapped onto this form's state keys.
+// "displayName" maps to the server name field; the rest match one-to-one.
+const FIELD_NAME_MAP: Record<string, 'name' | 'version' | 'description' | 'context' | 'target'> = {
+  displayName: 'name',
+  version: 'version',
+  description: 'description',
+  context: 'context',
+};
 
 const SAMPLE_MCP_SERVER_URL = 'https://db720294-98fd-40f4-85a1-cc6a3b65bc9a-prod.e1-us-east-azure.choreoapis.dev/godzilla/mcp-everything-server/v1.0/mcp';
 
@@ -87,33 +97,8 @@ function normalizeVersion(version: string): string {
   return `v${major}.${minor}`;
 }
 
-type ErrorResponse = {
-  response?: {
-    data?: {
-      description?: unknown;
-      message?: unknown;
-    };
-  };
-};
-
 function getErrorDescription(error: unknown, fallback: string): string {
-  const responseData = (error as ErrorResponse)?.response?.data;
-  const description = responseData?.description;
-  const message = responseData?.message;
-
-  if (typeof description === 'string' && description.trim()) {
-    return description;
-  }
-
-  if (typeof message === 'string' && message.trim()) {
-    return message;
-  }
-
-  if (error instanceof Error && error.message) {
-    return error.message;
-  }
-
-  return fallback;
+  return getErrorMessage(error, fallback);
 }
 
 export default function ExternalServersNew(): JSX.Element {
@@ -134,6 +119,7 @@ export default function ExternalServersNew(): JSX.Element {
   } = useMCPServerValidation();
   const showSnackbar = useAIWorkspaceSnackbar();
   const [isCreating, setIsCreating] = useState(false);
+  const [createFieldErrors, setCreateFieldErrors] = useState<Record<string, string>>({});
   const routeProject = useMemo(
     () =>
       projectsForCurrentOrganization.find(
@@ -306,6 +292,7 @@ export default function ExternalServersNew(): JSX.Element {
 
     try {
       setIsCreating(true);
+      setCreateFieldErrors({});
       const created = await mcpProxiesApis.createMCPServer(payload, PLATFORM_API_BASE_URL);
       showSnackbar('Successfully created MCP Proxy.', 'success');
       navigate(
@@ -316,10 +303,26 @@ export default function ExternalServersNew(): JSX.Element {
         )
       );
     } catch (err) {
-      showSnackbar(
-        getErrorDescription(err, 'Failed to create MCP Proxy'),
-        'error'
-      );
+      const backendFieldErrors = getFieldErrors(err);
+      const mappedErrors: Record<string, string> = {};
+      let hasUnmapped = false;
+      backendFieldErrors?.forEach(({ field, message }) => {
+        const formField = FIELD_NAME_MAP[field];
+        if (formField) {
+          mappedErrors[formField] = message;
+        } else {
+          hasUnmapped = true;
+        }
+      });
+      if (Object.keys(mappedErrors).length > 0) {
+        setCreateFieldErrors(mappedErrors);
+      }
+      if (hasUnmapped || Object.keys(mappedErrors).length === 0) {
+        showSnackbar(
+          getErrorDescription(err, 'Failed to create MCP Proxy'),
+          'error'
+        );
+      }
     } finally {
       setIsCreating(false);
     }
@@ -371,6 +374,7 @@ export default function ExternalServersNew(): JSX.Element {
           serverName={serverName}
           serverTarget={serverTarget}
           serverVersion={serverVersion}
+          fieldErrors={createFieldErrors}
           onCancel={handleCancelCreate}
           onCreate={handleCreate}
           onContextChange={setServerContextOverride}

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/projects/AddNewProject.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/projects/AddNewProject.tsx
@@ -35,6 +35,13 @@ import { ProjectsProvider, useProjects } from '../../../../contexts/ProjectsCont
 import { useAppShell } from '../../../../contexts/AppShellContext';
 import { buildOrgPath } from '../../../../utils/projectRouting';
 import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
+import { getErrorMessage, getFieldErrors, fieldErrorsToMap } from '../../../../utils/apiError';
+
+// Backend field names (from CreateProjectRequest) mapped onto this form's state keys.
+const FIELD_NAME_MAP: Record<string, 'name' | 'description'> = {
+  displayName: 'name',
+  description: 'description',
+};
 
 function AddNewProjectForm() {
   const navigate = useNavigate();
@@ -47,6 +54,7 @@ function AddNewProjectForm() {
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
 
   const handleCreate = async () => {
     const trimmedName = name.trim();
@@ -54,6 +62,7 @@ function AddNewProjectForm() {
 
     try {
       setIsSubmitting(true);
+      setFieldErrors({});
       await createProject({
         displayName: trimmedName,
         ...(description.trim() ? { description: description.trim() } : {}),
@@ -61,12 +70,24 @@ function AddNewProjectForm() {
       showSnackbar('Project created successfully.', 'success');
       if (projectsListPath) navigate(projectsListPath);
     } catch (error) {
-      const message =
-        (error as any)?.response?.data?.description ||
-        (error as any)?.response?.data?.message ||
-        (error instanceof Error ? error.message : null) ||
-        'Failed to create project.';
-      showSnackbar(message, 'error');
+      const backendFieldErrors = getFieldErrors(error);
+      const mappedErrors: Record<string, string> = {};
+      let hasUnmapped = false;
+      backendFieldErrors?.forEach(({ field, message }) => {
+        const formField = FIELD_NAME_MAP[field];
+        if (formField) {
+          mappedErrors[formField] = message;
+        } else {
+          hasUnmapped = true;
+        }
+      });
+      if (Object.keys(mappedErrors).length > 0) {
+        setFieldErrors(mappedErrors);
+      }
+      if (hasUnmapped || Object.keys(mappedErrors).length === 0) {
+        const message = getErrorMessage(error, 'Failed to create project.');
+        showSnackbar(message, 'error');
+      }
     } finally {
       setIsSubmitting(false);
     }
@@ -98,8 +119,13 @@ function AddNewProjectForm() {
                 fullWidth
                 placeholder="My AI Project"
                 value={name}
-                onChange={(e) => setName(e.target.value)}
+                onChange={(e) => {
+                  setName(e.target.value);
+                  setFieldErrors((prev) => ({ ...prev, name: '' }));
+                }}
                 autoFocus
+                error={Boolean(fieldErrors.name)}
+                helperText={fieldErrors.name}
                 data-cyid="project-name-input"
               />
             </FormControl>
@@ -114,7 +140,12 @@ function AddNewProjectForm() {
                 minRows={3}
                 placeholder="Short description of the project."
                 value={description}
-                onChange={(e) => setDescription(e.target.value)}
+                onChange={(e) => {
+                  setDescription(e.target.value);
+                  setFieldErrors((prev) => ({ ...prev, description: '' }));
+                }}
+                error={Boolean(fieldErrors.description)}
+                helperText={fieldErrors.description}
                 data-cyid="project-description-input"
               />
             </FormControl>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/projects/EditProject.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/projects/EditProject.tsx
@@ -35,6 +35,13 @@ import { ProjectsProvider, useProjects } from '../../../../contexts/ProjectsCont
 import { useAppShell } from '../../../../contexts/AppShellContext';
 import { buildOrgPath } from '../../../../utils/projectRouting';
 import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
+import { getErrorMessage, getFieldErrors } from '../../../../utils/apiError';
+
+// Backend field names (from UpdateProjectRequest) mapped onto this form's state keys.
+const FIELD_NAME_MAP: Record<string, 'name' | 'description'> = {
+  displayName: 'name',
+  description: 'description',
+};
 
 function EditProjectForm() {
   const { projectId } = useParams<{ projectId: string }>();
@@ -49,6 +56,7 @@ function EditProjectForm() {
   const [description, setDescription] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [initialized, setInitialized] = useState(false);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
 
   // Pre-fill from the already-loaded project list
   useEffect(() => {
@@ -76,6 +84,7 @@ function EditProjectForm() {
 
     try {
       setIsSubmitting(true);
+      setFieldErrors({});
       await updateProject(projectId, {
         id: project.id,
         organizationId: project.organizationId,
@@ -85,12 +94,24 @@ function EditProjectForm() {
       showSnackbar('Project updated successfully.', 'success');
       if (projectsListPath) navigate(projectsListPath);
     } catch (error) {
-      const message =
-        (error as any)?.response?.data?.description ||
-        (error as any)?.response?.data?.message ||
-        (error instanceof Error ? error.message : null) ||
-        'Failed to update project.';
-      showSnackbar(message, 'error');
+      const backendFieldErrors = getFieldErrors(error);
+      const mappedErrors: Record<string, string> = {};
+      let hasUnmapped = false;
+      backendFieldErrors?.forEach(({ field, message }) => {
+        const formField = FIELD_NAME_MAP[field];
+        if (formField) {
+          mappedErrors[formField] = message;
+        } else {
+          hasUnmapped = true;
+        }
+      });
+      if (Object.keys(mappedErrors).length > 0) {
+        setFieldErrors(mappedErrors);
+      }
+      if (hasUnmapped || Object.keys(mappedErrors).length === 0) {
+        const message = getErrorMessage(error, 'Failed to update project.');
+        showSnackbar(message, 'error');
+      }
     } finally {
       setIsSubmitting(false);
     }
@@ -122,8 +143,13 @@ function EditProjectForm() {
                 fullWidth
                 placeholder="My AI Project"
                 value={name}
-                onChange={(e) => setName(e.target.value)}
+                onChange={(e) => {
+                  setName(e.target.value);
+                  setFieldErrors((prev) => ({ ...prev, name: '' }));
+                }}
                 autoFocus
+                error={Boolean(fieldErrors.name)}
+                helperText={fieldErrors.name}
               />
             </FormControl>
           </Grid>
@@ -137,7 +163,12 @@ function EditProjectForm() {
                 minRows={3}
                 placeholder="Short description of the project."
                 value={description}
-                onChange={(e) => setDescription(e.target.value)}
+                onChange={(e) => {
+                  setDescription(e.target.value);
+                  setFieldErrors((prev) => ({ ...prev, description: '' }));
+                }}
+                error={Boolean(fieldErrors.description)}
+                helperText={fieldErrors.description}
               />
             </FormControl>
           </Grid>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/projects/ProjectListView.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/projects/ProjectListView.tsx
@@ -61,6 +61,7 @@ import {
 import { useAIWorkspaceSnackbar } from '../../../../hooks/aiWorkspaceSnackbar';
 import { FormattedMessage } from 'react-intl';
 import NoProjects from '../../../../assets/images/NoProjects.svg';
+import { getErrorMessage } from '../../../../utils/apiError';
 
 
 function ProjectListViewInner() {
@@ -129,11 +130,7 @@ function ProjectListViewInner() {
       await deleteProject(deleteTargetId);
       showSnackbar('Project deleted successfully.', 'success');
     } catch (err: unknown) {
-      const msg =
-        (err as any)?.response?.data?.description ||
-        (err as any)?.response?.data?.message ||
-        (err instanceof Error ? err.message : null) ||
-        'Failed to delete project.';
+      const msg = getErrorMessage(err, 'Failed to delete project.');
       showSnackbar(msg, 'error');
     } finally {
       setIsDeleting(false);

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxiesList.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxiesList.tsx
@@ -63,6 +63,7 @@ import { FormattedMessage } from 'react-intl';
 import NoProxies from '../../../../assets/images/NoProxies.svg';
 import ErrorAlert from '../../../../Components/common/ErrorAlert';
 import { useAIWorkspaceSnackbar } from '../../../../hooks/aiWorkspaceSnackbar';
+import { getErrorMessage } from '../../../../utils/apiError';
 
 function getHttpStatusCode(error?: Error | null): number | null {
   if (!error) return null;
@@ -77,12 +78,7 @@ function getHttpStatusCode(error?: Error | null): number | null {
 }
 
 function getErrorDescription(error: unknown, fallbackMessage: string): string {
-  return (
-    (error as any)?.response?.data?.description ||
-    (error as any)?.response?.data?.message ||
-    (error instanceof Error ? error.message : null) ||
-    fallbackMessage
-  );
+  return getErrorMessage(error, fallbackMessage);
 }
 
 type LLMProxyListLocationState = {

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyNew.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyNew.tsx
@@ -68,6 +68,7 @@ import { truncateProviderDisplayName } from '../../../../utils/providerTemplateD
 import type { CreateProxyRequest, LLMProvider } from '../../../../utils/types';
 import { useAIWorkspaceSnackbar } from '../../../../hooks/aiWorkspaceSnackbar';
 import { logger } from '../../../../utils/logger';
+import { getErrorMessage, getFieldErrors } from '../../../../utils/apiError';
 
 type FormState = {
   name: string;
@@ -75,6 +76,17 @@ type FormState = {
   providerId: string;
   version: string;
   description: string;
+};
+
+// Backend field names (from CreateProxyRequest) mapped onto this form's state keys.
+// "provider.auth.*" errors are not mapped here — best-effort only, they surface
+// via the general error banner instead of forcing an unclear match.
+const FIELD_NAME_MAP: Partial<Record<string, keyof FormState>> = {
+  displayName: 'name',
+  description: 'description',
+  version: 'version',
+  context: 'context',
+  'provider.id': 'providerId',
 };
 
 /** Derive a URL-safe proxy id from the display name (same logic as LLM provider). */
@@ -149,6 +161,7 @@ function LLMProxyNewContent({
   }));
 
   const [isCreating, setIsCreating] = useState(false);
+  const [fieldErrors, setFieldErrors] = useState<Partial<Record<keyof FormState, string>>>({});
   const [isApiKeyModalOpen, setIsApiKeyModalOpen] = useState(false);
   const [apiKeyDisplayName, setApiKeyDisplayName] = useState('');
   const [isGeneratingApiKey, setIsGeneratingApiKey] = useState(false);
@@ -332,6 +345,7 @@ function LLMProxyNewContent({
     let createdSecretHandle: string | null = null;
     try {
       setIsCreating(true);
+      setFieldErrors({});
 
       // Encrypt the provider API key as a secret before storing it in the proxy
       // config — even though it is a platform-issued key, it is still a credential
@@ -414,15 +428,30 @@ function LLMProxyNewContent({
           });
         });
       }
-      const description =
-        (error as any)?.response?.data?.description ||
-        (error as any)?.response?.data?.message ||
-        (error instanceof Error ? error.message : null) ||
-        intl.formatMessage({
-          id: 'aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxyNew.failed.to.create.proxy',
-          defaultMessage: 'Failed to create proxy',
-        });
-      showSnackbar(description, 'error');
+      const backendFieldErrors = getFieldErrors(error);
+      const mappedErrors: Partial<Record<keyof FormState, string>> = {};
+      let hasUnmapped = false;
+      backendFieldErrors?.forEach(({ field, message }) => {
+        const formField = FIELD_NAME_MAP[field];
+        if (formField) {
+          mappedErrors[formField] = message;
+        } else {
+          hasUnmapped = true;
+        }
+      });
+      if (Object.keys(mappedErrors).length > 0) {
+        setFieldErrors(mappedErrors);
+      }
+      if (hasUnmapped || Object.keys(mappedErrors).length === 0) {
+        const description = getErrorMessage(
+          error,
+          intl.formatMessage({
+            id: 'aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxyNew.failed.to.create.proxy',
+            defaultMessage: 'Failed to create proxy',
+          })
+        );
+        showSnackbar(description, 'error');
+      }
     } finally {
       setIsCreating(false);
     }
@@ -479,11 +508,7 @@ function LLMProxyNewContent({
       showSnackbar('API key generated successfully.', 'success');
     } catch (error) {
       logger.error('Failed to generate provider API key:', error);
-      const description =
-        (error as any)?.response?.data?.description ||
-        (error as any)?.response?.data?.message ||
-        (error instanceof Error ? error.message : null) ||
-        'Failed to generate API key. Please try again.';
+      const description = getErrorMessage(error, 'Failed to generate API key. Please try again.');
       setApiKeyError(description);
       showSnackbar(description, 'error');
     } finally {
@@ -550,12 +575,15 @@ function LLMProxyNewContent({
                   defaultMessage: 'WSO2 OpenAI Provider Proxy',
                 })}
                 value={formState.name}
-                onChange={(event) =>
+                onChange={(event) => {
                   setFormState((prev) => ({
                     ...prev,
                     name: event.target.value,
-                  }))
-                }
+                  }));
+                  setFieldErrors((prev) => ({ ...prev, name: undefined }));
+                }}
+                error={Boolean(fieldErrors.name)}
+                helperText={fieldErrors.name}
                 data-cyid="proxy-name-input"
               />
             </FormControl>
@@ -576,12 +604,15 @@ function LLMProxyNewContent({
                   defaultMessage: 'v1.0',
                 })}
                 value={formState.version}
-                onChange={(event) =>
+                onChange={(event) => {
                   setFormState((prev) => ({
                     ...prev,
                     version: event.target.value,
-                  }))
-                }
+                  }));
+                  setFieldErrors((prev) => ({ ...prev, version: undefined }));
+                }}
+                error={Boolean(fieldErrors.version)}
+                helperText={fieldErrors.version}
                 data-cyid="proxy-version-input"
               />
             </FormControl>
@@ -604,12 +635,15 @@ function LLMProxyNewContent({
                   defaultMessage: 'Primary OpenAI provider',
                 })}
                 value={formState.description}
-                onChange={(event) =>
+                onChange={(event) => {
                   setFormState((prev) => ({
                     ...prev,
                     description: event.target.value,
-                  }))
-                }
+                  }));
+                  setFieldErrors((prev) => ({ ...prev, description: undefined }));
+                }}
+                error={Boolean(fieldErrors.description)}
+                helperText={fieldErrors.description}
                 data-cyid="proxy-description-input"
               />
             </FormControl>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyOverview.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyOverview.tsx
@@ -69,6 +69,7 @@ import type {
   Proxy as LLMProxy,
   UpdateProxyRequest,
 } from '../../../../utils/types';
+import { getErrorMessage } from '../../../../utils/apiError';
 import {
   GatewayArtifactReadOnlyBanner,
 } from '../../../../utils/readOnlyArtifacts';
@@ -92,12 +93,7 @@ const UNSAVED_CHANGES_MESSAGE =
   'You have unsaved changes. Please save or cancel before leaving this page.';
 
 function getErrorDescription(error: unknown, fallbackMessage: string): string {
-  return (
-    (error as any)?.response?.data?.description ||
-    (error as any)?.response?.data?.message ||
-    (error instanceof Error ? error.message : null) ||
-    fallbackMessage
-  );
+  return getErrorMessage(error, fallbackMessage);
 }
 
 type LLMProxyOverviewLocationState = {

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/AddNewProvider/ProviderTemplateFormFields.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/AddNewProvider/ProviderTemplateFormFields.tsx
@@ -48,6 +48,8 @@ type ProviderTemplateFormFieldsProps = {
   template?: ProviderTemplate | null;
   isLoading: boolean;
   error: Error | null;
+  /** Backend field-level validation errors (from the create/update API call), keyed by FormState field name. */
+  fieldErrors?: Partial<Record<keyof FormState, string>>;
 };
 
 const VERSION_PATTERN = /^v\d+\.\d+$/;
@@ -73,6 +75,7 @@ export default function ProviderTemplateFormFields({
   template,
   isLoading,
   error,
+  fieldErrors = {},
 }: ProviderTemplateFormFieldsProps) {
   const [versionTouched, setVersionTouched] = React.useState(false);
   const [contextTouched, setContextTouched] = React.useState(false);
@@ -150,6 +153,8 @@ export default function ProviderTemplateFormFields({
             }}
             placeholder={`WSO2 ${template?.displayName || ''} Provider`}
             data-cyid="provider-name-input"
+            error={Boolean(fieldErrors.name)}
+            helperText={fieldErrors.name}
           />
         </FormControl>
       </Grid>
@@ -175,8 +180,8 @@ export default function ProviderTemplateFormFields({
             }}
             onBlur={() => setVersionTouched(true)}
             placeholder="v1.0"
-            error={Boolean(versionErrorMessage)}
-            helperText={versionErrorMessage || undefined}
+            error={Boolean(versionErrorMessage) || Boolean(fieldErrors.version)}
+            helperText={fieldErrors.version || versionErrorMessage || undefined}
             data-cyid="provider-version-input"
           />
         </FormControl>
@@ -201,6 +206,8 @@ export default function ProviderTemplateFormFields({
             }
             placeholder={`Primary ${template?.displayName || ''} provider`}
             data-cyid="provider-description-input"
+            error={Boolean(fieldErrors.description)}
+            helperText={fieldErrors.description}
           />
         </FormControl>
       </Grid>
@@ -223,8 +230,8 @@ export default function ProviderTemplateFormFields({
             }}
             onBlur={() => setContextTouched(true)}
             placeholder="/"
-            error={Boolean(contextErrorMessage)}
-            helperText={contextErrorMessage || undefined}
+            error={Boolean(contextErrorMessage) || Boolean(fieldErrors.context)}
+            helperText={fieldErrors.context || contextErrorMessage || undefined}
             data-cyid="provider-context-input"
           />
         </FormControl>
@@ -250,7 +257,8 @@ export default function ProviderTemplateFormFields({
                 }))
               }
               placeholder="https://api.openai.com/v1"
-              helperText="The base URL of the upstream LLM provider"
+              error={Boolean(fieldErrors.upstreamUrl)}
+              helperText={fieldErrors.upstreamUrl || 'The base URL of the upstream LLM provider'}
               data-cyid="provider-upstream-url-input"
             />
           </FormControl>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderNew.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderNew.tsx
@@ -56,9 +56,21 @@ import type {
 import type { ProviderTemplate } from '../../../../utils/types';
 import { familyHandle } from '../../../../utils/providerTemplateDisplay';
 import TemplateVersionDialog from './AddNewProvider/TemplateVersionDialog';
+import { getErrorMessage, getFieldErrors } from '../../../../utils/apiError';
 import { FormattedMessage } from 'react-intl';
 
 const VERSION_PATTERN = /^v\d+\.\d+$/;
+
+// Backend field names (from CreateLLMProviderRequest) mapped onto this form's state keys.
+// Auth sub-fields ("upstream.main.auth.*") are not mapped here — best-effort only,
+// they surface via the general error banner instead of forcing an unclear match.
+const FIELD_NAME_MAP: Partial<Record<string, keyof FormState>> = {
+  displayName: 'name',
+  description: 'description',
+  version: 'version',
+  context: 'context',
+  'upstream.main.url': 'upstreamUrl',
+};
 
 type TemplateBasedFormFieldsContainerProps = {
   formState: FormState;
@@ -66,6 +78,7 @@ type TemplateBasedFormFieldsContainerProps = {
   showCredential: boolean;
   setShowCredential: React.Dispatch<React.SetStateAction<boolean>>;
   setOpenapiSpec: React.Dispatch<React.SetStateAction<string>>;
+  fieldErrors: Partial<Record<keyof FormState, string>>;
 };
 
 function TemplateBasedFormFieldsContainer({
@@ -74,6 +87,7 @@ function TemplateBasedFormFieldsContainer({
   showCredential,
   setShowCredential,
   setOpenapiSpec,
+  fieldErrors,
 }: TemplateBasedFormFieldsContainerProps) {
   const { template, isLoading, error } = useProviderTemplate();
   const lastTemplateIdRef = useRef<string | null>(null);
@@ -132,6 +146,7 @@ function TemplateBasedFormFieldsContainer({
       template={template}
       isLoading={isLoading}
       error={error}
+      fieldErrors={fieldErrors}
     />
   );
 }
@@ -185,6 +200,7 @@ export default function ServiceProviderNew() {
     valuePrefix: '',
   });
   const isVersionValid = VERSION_PATTERN.test(formState.version.trim());
+  const [fieldErrors, setFieldErrors] = useState<Partial<Record<keyof FormState, string>>>({});
   const [showCredential, setShowCredential] = useState(false);
   const [guardrails, setGuardrails] = useState<GuardrailSelection[]>([]);
   const [guardrailDrawerOpen, setGuardrailDrawerOpen] = useState(false);
@@ -322,6 +338,7 @@ export default function ServiceProviderNew() {
     if (!isFormValid || !selectedTemplateId) return;
 
     try {
+      setFieldErrors({});
       const providerId = toProviderId(formState.name);
 
       const upstream = {
@@ -385,12 +402,24 @@ export default function ServiceProviderNew() {
       );
     } catch (error) {
       logger.error('Failed to create LLM provider:', error);
-      const description =
-        (error as any)?.response?.data?.description ||
-        (error as any)?.response?.data?.message ||
-        (error instanceof Error ? error.message : null) ||
-        'Failed to create LLM provider.';
-      showSnackbar(description, 'error');
+      const backendFieldErrors = getFieldErrors(error);
+      const mappedErrors: Partial<Record<keyof FormState, string>> = {};
+      let hasUnmapped = false;
+      backendFieldErrors?.forEach(({ field, message }) => {
+        const formField = FIELD_NAME_MAP[field];
+        if (formField) {
+          mappedErrors[formField] = message;
+        } else {
+          hasUnmapped = true;
+        }
+      });
+      if (Object.keys(mappedErrors).length > 0) {
+        setFieldErrors(mappedErrors);
+      }
+      if (hasUnmapped || Object.keys(mappedErrors).length === 0) {
+        const description = getErrorMessage(error, 'Failed to create LLM provider.');
+        showSnackbar(description, 'error');
+      }
     }
   };
 
@@ -525,6 +554,7 @@ export default function ServiceProviderNew() {
                 showCredential={showCredential}
                 setShowCredential={setShowCredential}
                 setOpenapiSpec={setOpenapiSpec}
+                fieldErrors={fieldErrors}
               />
             </ProviderTemplateProvider>
           )}

--- a/portals/ai-workspace/src/pages/register/OrgRegisterPage.tsx
+++ b/portals/ai-workspace/src/pages/register/OrgRegisterPage.tsx
@@ -45,6 +45,7 @@ import {
   registerOrganization,
   type RegisterOrganizationRequest,
 } from '../../apis/platformApis';
+import { getErrorMessage, getFieldErrors } from '../../utils/apiError';
 // ─── Constants ───────────────────────────────────────────────────────────────
 
 const REGIONS = [
@@ -224,8 +225,35 @@ export default function OrgRegisterPage() {
 
       setRegisteredOrgName(org.displayName);
       setRegisteredOrgHandle(org.id);
-    } catch (err: any) {
-      setApiError(err?.message ?? 'An unexpected error occurred.');
+    } catch (err: unknown) {
+      const backendFieldErrors = getFieldErrors(err);
+      if (backendFieldErrors?.length) {
+        // Backend field names ("id", "displayName") map onto this form's
+        // ("handle", "name") state keys; anything else falls through to the banner.
+        const fieldNameMap: Record<string, keyof FormErrors> = {
+          id: 'handle',
+          displayName: 'name',
+          region: 'region',
+        };
+        const mapped: FormErrors = {};
+        let hasUnmapped = false;
+        backendFieldErrors.forEach(({ field, message }) => {
+          const formField = fieldNameMap[field];
+          if (formField) {
+            mapped[formField] = message;
+          } else {
+            hasUnmapped = true;
+          }
+        });
+        if (Object.keys(mapped).length > 0) {
+          setErrors((prev) => ({ ...prev, ...mapped }));
+        }
+        if (hasUnmapped || Object.keys(mapped).length === 0) {
+          setApiError(getErrorMessage(err, 'An unexpected error occurred.'));
+        }
+      } else {
+        setApiError(getErrorMessage(err, 'An unexpected error occurred.'));
+      }
     } finally {
       setIsSubmitting(false);
     }

--- a/portals/ai-workspace/src/utils/apiError.ts
+++ b/portals/ai-workspace/src/utils/apiError.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// ============================================================================
+// Platform API Error Handling
+// ----------------------------------------------------------------------------
+// The Platform API returns a single standard error shape on every failed
+// request (see platform-api/resources/openapi.yaml "Error" schema):
+//
+//   { status: "error", code: "REST_API_NOT_FOUND", message: "...",
+//     errors?: FieldError[], details?: object, trackingId?: uuid }
+//
+// This module parses that shape into an `ApiError`, and provides helpers so
+// UI code never has to guess at field names or dump a raw backend message.
+// ============================================================================
+
+/** A single field-level validation failure. */
+export interface FieldError {
+  field: string;
+  message: string;
+}
+
+/** Raw error body shape returned by the Platform API on failed requests. */
+export interface PlatformErrorBody {
+  status: 'error';
+  code: string;
+  message: string;
+  errors?: FieldError[];
+  details?: Record<string, unknown>;
+  trackingId?: string;
+}
+
+/** Error thrown by API clients on non-2xx responses. */
+export interface ApiError extends Error {
+  status?: number;
+  /** Machine-readable code, e.g. "REST_API_NOT_FOUND". Prefer this over `status` for branching. */
+  code?: string;
+  /** Per-field validation failures, present on validation failures. */
+  errors?: FieldError[];
+  /** Structured metadata specific to this error condition; shape varies by `code`. */
+  details?: Record<string, unknown>;
+  /** Correlation ID for server-side (5xx) failures. */
+  trackingId?: string;
+  /** Raw parsed response body, kept for callers that need the full payload. */
+  data?: unknown;
+}
+
+/** UI messages are capped so a huge backend error string never floods a banner or toast. */
+const MAX_UI_MESSAGE_LENGTH = 160;
+
+/** Truncate a message to a UI-safe length, preferring a sentence boundary when there is one. */
+export function shortenMessage(message: string, maxLength = MAX_UI_MESSAGE_LENGTH): string {
+  const trimmed = (message ?? '').trim();
+  if (trimmed.length <= maxLength) return trimmed;
+
+  const truncated = trimmed.slice(0, maxLength);
+  const lastStop = Math.max(truncated.lastIndexOf('. '), truncated.lastIndexOf('.\n'));
+  const cut = lastStop > maxLength * 0.4 ? truncated.slice(0, lastStop + 1) : truncated;
+  return `${cut.replace(/[.,;:\s]+$/, '')}…`;
+}
+
+function asPlatformErrorBody(body: unknown): Partial<PlatformErrorBody> {
+  return body && typeof body === 'object' ? (body as Partial<PlatformErrorBody>) : {};
+}
+
+/**
+ * Build an `ApiError` from an HTTP status and the response's parsed JSON body
+ * (or `undefined` if the body wasn't valid JSON / wasn't the standard shape).
+ * The resulting `error.message` is already shortened and safe to render as-is.
+ */
+export function buildApiError(
+  status: number,
+  body: unknown,
+  fallbackMessage = `Request failed (HTTP ${status})`,
+): ApiError {
+  const parsed = asPlatformErrorBody(body);
+  const rawMessage = typeof parsed.message === 'string' && parsed.message.trim().length > 0
+    ? parsed.message
+    : fallbackMessage;
+
+  const err = new Error(shortenMessage(rawMessage)) as ApiError;
+  err.status = status;
+  err.code = typeof parsed.code === 'string' ? parsed.code : undefined;
+  err.errors = Array.isArray(parsed.errors) ? parsed.errors : undefined;
+  err.details = parsed.details && typeof parsed.details === 'object' ? parsed.details : undefined;
+  err.trackingId = typeof parsed.trackingId === 'string' ? parsed.trackingId : undefined;
+  err.data = body;
+  return err;
+}
+
+/** Short, UI-safe message for any error (Platform API error or otherwise). Never returns a huge string. */
+export function getErrorMessage(error: unknown, fallback = 'Something went wrong.'): string {
+  const message = (error as Error | null | undefined)?.message;
+  return message ? shortenMessage(message) : fallback;
+}
+
+/** Machine-readable error code (e.g. "REST_API_NOT_FOUND"). Prefer this over HTTP status for branching. */
+export function getErrorCode(error: unknown): string | undefined {
+  return (error as ApiError | null | undefined)?.code;
+}
+
+/** Per-field validation errors, if this was a validation failure. */
+export function getFieldErrors(error: unknown): FieldError[] | undefined {
+  return (error as ApiError | null | undefined)?.errors;
+}
+
+/** Correlation ID for 5xx failures, for the user to quote when reporting the error. */
+export function getTrackingId(error: unknown): string | undefined {
+  return (error as ApiError | null | undefined)?.trackingId;
+}
+
+/** HTTP status code, if this error originated from an HTTP response. */
+export function getHttpStatus(error: unknown): number | undefined {
+  return (error as ApiError | null | undefined)?.status;
+}
+
+/** Map field-level validation errors onto a `{ [fieldName]: message }` map for form state. */
+export function fieldErrorsToMap(errors?: FieldError[] | null): Record<string, string> {
+  if (!errors) return {};
+  return errors.reduce<Record<string, string>>((acc, e) => {
+    if (e?.field) acc[e.field] = e.message;
+    return acc;
+  }, {});
+}


### PR DESCRIPTION
This commit modifies the HeadOrganization method to first retrieve the organization by handle and then validate the organization ID against the token. The previous direct comparison was removed to streamline the logic and improve readability.
