### PR TITLE
Fix UI Inconsistencies in LLM Provider Management

### DIFF
--- a/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/EditExternalServer.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/EditExternalServer.tsx
@@ -45,7 +45,6 @@ import { useMemo } from 'react';
 
 const MAX_NAME_LENGTH = 255;
 const MAX_DESCRIPTION_LENGTH = 1023;
-const MAX_VERSION_LENGTH = 50;
 const MAX_CONTEXT_LENGTH = 255;
 
 function getErrorDescription(error: unknown, fallback: string): string {
@@ -53,10 +52,9 @@ function getErrorDescription(error: unknown, fallback: string): string {
 }
 
 // Backend field names (from MCPServer's update payload) mapped onto this form's state keys.
-const FIELD_NAME_MAP: Record<string, 'name' | 'description' | 'version' | 'context'> = {
+const FIELD_NAME_MAP: Record<string, 'name' | 'description' | 'context'> = {
   displayName: 'name',
   description: 'description',
-  version: 'version',
   context: 'context',
 };
 
@@ -93,7 +91,6 @@ export default function EditExternalServer() {
   const [isLoading, setIsLoading] = useState(true);
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
-  const [version, setVersion] = useState('');
   const [context, setContext] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
@@ -113,7 +110,6 @@ export default function EditExternalServer() {
           setServer(response);
           setName(response.displayName || '');
           setDescription(response.description || '');
-          setVersion(response.version || '');
           setContext(response.context || '');
         }
       } catch {
@@ -130,21 +126,19 @@ export default function EditExternalServer() {
     };
   }, [serverId, organizationId, apimBaseUrl]);
 
-  const isContextOrVersionChanged =
-    server !== null &&
-    (version !== (server.version || '') || context !== (server.context || ''));
+  const isContextChanged =
+    server !== null && context !== (server.context || '');
 
   const isFormValid = (): boolean => {
     if (!name || name.trim().length === 0) return false;
     if (name.length > MAX_NAME_LENGTH) return false;
     if (description.length > MAX_DESCRIPTION_LENGTH) return false;
-    if (version.length > MAX_VERSION_LENGTH) return false;
     if (context.length > MAX_CONTEXT_LENGTH) return false;
     return true;
   };
 
   const handleSubmit = async () => {
-    // Allowed even for gateway-created MCP proxies: name/version/context stay locked
+    // Allowed even for gateway-created MCP proxies: name/context stay locked
     // (part of the runtime artifact), so only the description can change, which the
     // control plane accepts without altering the gateway runtime artifact.
     if (!serverId || !server) return;
@@ -156,7 +150,6 @@ export default function EditExternalServer() {
         ...server,
         displayName: name,
         description: description || undefined,
-        version: version || undefined,
         context: context || undefined,
       };
       // Remove read-only fields before sending
@@ -264,16 +257,16 @@ export default function EditExternalServer() {
           <Stack spacing={3}>
             {isReadOnlyServer ? (
               <Alert severity="info">
-                This MCP proxy was created from a gateway. The name, version and
+                This MCP proxy was created from a gateway. The name and
                 context are part of the gateway runtime configuration and are
                 read-only here; only the description can be edited.
               </Alert>
             ) : null}
-            {isContextOrVersionChanged && (
+            {isContextChanged && (
               <Alert severity="warning">
-                You have modified the context or version of this MCP Proxy.
-                After updating, you will need to redeploy on the gateway for
-                the changes to take effect.
+                You have modified the context of this MCP Proxy. After
+                updating, you will need to redeploy on the gateway for the
+                changes to take effect.
               </Alert>
             )}
             <Box sx={{ display: 'flex', gap: 2 }}>
@@ -294,27 +287,6 @@ export default function EditExternalServer() {
                     fieldErrors.name ||
                     (name.length > MAX_NAME_LENGTH
                       ? `Name must not exceed ${MAX_NAME_LENGTH} characters (${name.length}/${MAX_NAME_LENGTH})`
-                      : '')
-                  }
-                />
-              </FormControl>
-
-              <FormControl sx={{ flex: 0.4 }}>
-                <FormLabel>Version</FormLabel>
-                <TextField
-                  fullWidth
-                  value={version}
-                  disabled={isReadOnlyServer}
-                  onChange={(e) => {
-                    setVersion(e.target.value);
-                    setFieldErrors((prev) => ({ ...prev, version: '' }));
-                  }}
-                  placeholder="e.g., 1.0"
-                  error={version.length > MAX_VERSION_LENGTH || Boolean(fieldErrors.version)}
-                  helperText={
-                    fieldErrors.version ||
-                    (version.length > MAX_VERSION_LENGTH
-                      ? `Version must not exceed ${MAX_VERSION_LENGTH} characters (${version.length}/${MAX_VERSION_LENGTH})`
                       : '')
                   }
                 />

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/EditLLMProxy.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/EditLLMProxy.tsx
@@ -41,7 +41,6 @@ import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
 
 const MAX_NAME_LENGTH = 255;
 const MAX_DESCRIPTION_LENGTH = 1023;
-const MAX_VERSION_LENGTH = 50;
 const MAX_CONTEXT_LENGTH = 255;
 
 function EditLLMProxyForm() {
@@ -59,19 +58,16 @@ function EditLLMProxyForm() {
 
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
-  const [version, setVersion] = useState('');
   const [context, setContext] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const isContextOrVersionChanged =
-    proxy !== null &&
-    (version !== (proxy.version || '') || context !== (proxy.context || ''));
+  const isContextChanged =
+    proxy !== null && context !== (proxy.context || '');
 
   useEffect(() => {
     if (proxy) {
       setName(proxy.displayName || '');
       setDescription(proxy.description || '');
-      setVersion(proxy.version || '');
       setContext(proxy.context || '');
     }
   }, [proxy]);
@@ -80,13 +76,12 @@ function EditLLMProxyForm() {
     if (!name || name.trim().length === 0) return false;
     if (name.length > MAX_NAME_LENGTH) return false;
     if (description.length > MAX_DESCRIPTION_LENGTH) return false;
-    if (version.length > MAX_VERSION_LENGTH) return false;
     if (context.length > MAX_CONTEXT_LENGTH) return false;
     return true;
   };
 
   const handleSubmit = async () => {
-    // Allowed even for gateway-created proxies: name/version/context stay locked
+    // Allowed even for gateway-created proxies: name/context stay locked
     // (part of the runtime artifact), so only the description can change, which the
     // control plane accepts without altering the gateway runtime artifact.
     if (!proxyId) return;
@@ -97,7 +92,6 @@ function EditLLMProxyForm() {
         ...proxy,
         displayName: name,
         description: description || undefined,
-        version: version || undefined,
         context: context || undefined,
       };
       // Remove read-only fields before sending
@@ -183,16 +177,16 @@ function EditLLMProxyForm() {
           <Stack spacing={3}>
             {isReadOnlyProxy ? (
               <Alert severity="info">
-                This proxy was created from a gateway. The name, version and
-                context are part of the gateway runtime configuration and are
+                This proxy was created from a gateway. The name and context
+                are part of the gateway runtime configuration and are
                 read-only here; only the description can be edited.
               </Alert>
             ) : null}
-            {isContextOrVersionChanged && (
+            {isContextChanged && (
               <Alert severity="warning">
-                You have modified the context or version of this proxy. After
-                updating, you will need to redeploy on the gateway for the
-                changes to take effect.
+                You have modified the context of this proxy. After updating,
+                you will need to redeploy on the gateway for the changes to
+                take effect.
               </Alert>
             )}
             <Box sx={{ display: 'flex', gap: 2 }}>
@@ -209,23 +203,6 @@ function EditLLMProxyForm() {
                   helperText={
                     name.length > MAX_NAME_LENGTH
                       ? `Name must not exceed ${MAX_NAME_LENGTH} characters (${name.length}/${MAX_NAME_LENGTH})`
-                      : ''
-                  }
-                />
-              </FormControl>
-
-              <FormControl sx={{ flex: 0.4 }}>
-                <FormLabel>Version</FormLabel>
-                <TextField
-                  fullWidth
-                  value={version}
-                  disabled={isReadOnlyProxy}
-                  onChange={(e) => setVersion(e.target.value)}
-                  placeholder="e.g., 1.0"
-                  error={version.length > MAX_VERSION_LENGTH}
-                  helperText={
-                    version.length > MAX_VERSION_LENGTH
-                      ? `Version must not exceed ${MAX_VERSION_LENGTH} characters (${version.length}/${MAX_VERSION_LENGTH})`
                       : ''
                   }
                 />

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyProviderTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyProviderTab.tsx
@@ -18,7 +18,6 @@
 
 import React, { useCallback, useEffect, useState } from 'react';
 import {
-  Button,
   FormControl,
   FormLabel,
   Grid,
@@ -37,7 +36,6 @@ import { logger } from '../../../../utils/logger';
 import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
 import type { LLMProvider, ProxyApiKeySecurity } from '../../../../utils/types';
 import { FormattedMessage } from 'react-intl';
-import { DisabledActionTooltip } from '../../../../utils/readOnlyArtifacts';
 
 /**
  * Provider tab – lets the user select / change the LLM Service Provider
@@ -108,18 +106,13 @@ export default function LLMProxyProviderTab() {
     };
   };
 
-  const handleSaveApiKey = () => {
-    if (isReadOnlyProxy) return;
-    if (!proxy || !apiKey.trim() || !providerDetail) {
-      showSnackbar('Please enter an API key.', 'error');
-      return;
-    }
+  const handleApiKeyChange = (value: string) => {
+    setApiKey(value);
+    if (isReadOnlyProxy || !proxy || !providerDetail) return;
     const providerId =
       typeof proxy.provider === 'string' ? proxy.provider : proxy.provider?.id;
-    if (!providerId) {
-      showSnackbar('Please select a provider first.', 'error');
-      return;
-    }
+    const trimmed = value.trim();
+    if (!providerId || !trimmed) return;
     const apiKeyHeader = providerDetail.security?.apiKey?.key || 'X-API-Key';
     setLocalProxy((prev) =>
       prev
@@ -130,13 +123,12 @@ export default function LLMProxyProviderTab() {
               auth: {
                 type: 'api-key',
                 header: apiKeyHeader,
-                value: apiKey.trim(),
+                value: trimmed,
               },
             },
           }
         : prev
     );
-    setApiKey('');
   };
 
   const handleProviderChange = async (event: { target: { value: string } }) => {
@@ -272,28 +264,12 @@ export default function LLMProxyProviderTab() {
                         placeholder="Enter API key"
                         value={apiKey}
                         disabled={isReadOnlyProxy}
-                        onChange={(e) => setApiKey(e.target.value)}
+                        onChange={(e) => handleApiKeyChange(e.target.value)}
                         fullWidth
                       />
                     </FormControl>
                   </Grid>
                 </Grid>
-
-                <DisabledActionTooltip disabled={isReadOnlyProxy}>
-                  <span>
-                    <Button
-                      variant="contained"
-                      onClick={handleSaveApiKey}
-                      disabled={isReadOnlyProxy || !apiKey.trim()}
-                      sx={{ alignSelf: 'flex-start' }}
-                    >
-                      <FormattedMessage
-                        id="aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxyProviderTab.save.api.key"
-                        defaultMessage={'Save API Key'}
-                      />
-                    </Button>
-                  </span>
-                </DisabledActionTooltip>
               </Stack>
             </Stack>
           )}

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/EditServiceProvider.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/EditServiceProvider.tsx
@@ -41,7 +41,6 @@ import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
 
 const MAX_NAME_LENGTH = 255;
 const MAX_DESCRIPTION_LENGTH = 1023;
-const MAX_VERSION_LENGTH = 50;
 const MAX_CONTEXT_LENGTH = 255;
 
 function EditServiceProviderForm() {
@@ -54,20 +53,16 @@ function EditServiceProviderForm() {
 
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
-  const [version, setVersion] = useState('');
   const [context, setContext] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const isContextOrVersionChanged =
-    provider !== null &&
-    (version !== (provider.version || '') ||
-      context !== (provider.context || ''));
+  const isContextChanged =
+    provider !== null && context !== (provider.context || '');
 
   useEffect(() => {
     if (provider) {
       setName(provider.displayName || '');
       setDescription(provider.description || '');
-      setVersion(provider.version || '');
       setContext(provider.context || '');
     }
   }, [provider]);
@@ -76,13 +71,12 @@ function EditServiceProviderForm() {
     if (!name || name.trim().length === 0) return false;
     if (name.length > MAX_NAME_LENGTH) return false;
     if (description.length > MAX_DESCRIPTION_LENGTH) return false;
-    if (version.length > MAX_VERSION_LENGTH) return false;
     if (context.length > MAX_CONTEXT_LENGTH) return false;
     return true;
   };
 
   const handleSubmit = async () => {
-    // Allowed even for gateway-created providers: name/version/context stay locked
+    // Allowed even for gateway-created providers: name/context stay locked
     // (they are part of the runtime artifact), so only the description can change,
     // which the control plane accepts without altering the gateway runtime artifact.
     if (!providerId) return;
@@ -93,7 +87,6 @@ function EditServiceProviderForm() {
         ...provider,
         displayName: name,
         description: description || undefined,
-        version: version || undefined,
         context: context || undefined,
       };
       // Remove read-only fields before sending
@@ -193,16 +186,16 @@ function EditServiceProviderForm() {
           <Stack spacing={3}>
             {isReadOnlyProvider ? (
               <Alert severity="info">
-                This provider was created from a gateway. The name, version and
+                This provider was created from a gateway. The name and
                 context are part of the gateway runtime configuration and are
                 read-only here; only the description can be edited.
               </Alert>
             ) : null}
-            {isContextOrVersionChanged && (
+            {isContextChanged && (
               <Alert severity="warning">
-                You have modified the context or version of this service
-                provider. After updating, you will need to redeploy on the
-                gateway for the changes to take effect.
+                You have modified the context of this service provider. After
+                updating, you will need to redeploy on the gateway for the
+                changes to take effect.
               </Alert>
             )}
             <Box sx={{ display: 'flex', gap: 2 }}>
@@ -219,23 +212,6 @@ function EditServiceProviderForm() {
                   helperText={
                     name.length > MAX_NAME_LENGTH
                       ? `Name must not exceed ${MAX_NAME_LENGTH} characters (${name.length}/${MAX_NAME_LENGTH})`
-                      : ''
-                  }
-                />
-              </FormControl>
-
-              <FormControl sx={{ flex: 0.4 }}>
-                <FormLabel>Version</FormLabel>
-                <TextField
-                  fullWidth
-                  value={version}
-                  disabled={isReadOnlyProvider}
-                  onChange={(e) => setVersion(e.target.value)}
-                  placeholder="e.g., 1.0"
-                  error={version.length > MAX_VERSION_LENGTH}
-                  helperText={
-                    version.length > MAX_VERSION_LENGTH
-                      ? `Version must not exceed ${MAX_VERSION_LENGTH} characters (${version.length}/${MAX_VERSION_LENGTH})`
                       : ''
                   }
                 />

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProvidersSummaryCard.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProvidersSummaryCard.tsx
@@ -340,6 +340,7 @@ export default function ServiceProvidersSummaryCard({
                       width: '100%',
                       p: 0,
                       alignItems: 'center',
+                      minHeight: '3.75rem',
                     },
                     '& .MuiCardHeader-content': {
                       minWidth: 0,
@@ -389,14 +390,16 @@ export default function ServiceProvidersSummaryCard({
                     }
                     subheader={
                       <Box sx={{ minWidth: 0, mt: 0.25 }}>
-                        <Typography
-                          variant="body2"
-                          color="text.secondary"
-                          fontSize="0.75rem"
-                          sx={{ mb: 0.25 }}
-                        >
-                          {truncateText(descriptionText, 70)}
-                        </Typography>
+                        {descriptionText && (
+                          <Typography
+                            variant="body2"
+                            color="text.secondary"
+                            fontSize="0.75rem"
+                            sx={{ mb: 0.25 }}
+                          >
+                            {truncateText(descriptionText, 70)}
+                          </Typography>
+                        )}
 
                         {templateDisplayName && (
                           <Stack

--- a/portals/ai-workspace/src/utils/tmpSPRequest.ts
+++ b/portals/ai-workspace/src/utils/tmpSPRequest.ts
@@ -118,6 +118,8 @@ export function buildFullProviderRequest(
     template: request.template,
     upstream: request.upstream,
     accessControl: request.accessControl,
+    globalPolicies: request.globalPolicies ?? [],
+    operationPolicies: request.operationPolicies ?? [],
     policies: request.policies ?? [],
 
     // Hardcoded default values for missing fields


### PR DESCRIPTION
This pull request removes the "version" field from the edit forms for external servers, LLM proxies, and service providers in the AI Workspace portal. The UI, state management, validation, and user messages have all been updated to reflect this change, simplifying the forms and eliminating all logic and references related to the "version" field. Additionally, the LLM Proxy Provider tab has been refactored to update the API key immediately as the user types, instead of requiring a separate "Save API Key" button.

Issue:

- https://github.com/wso2/api-platform/issues/2469
- https://github.com/wso2/api-platform/issues/2551
- https://github.com/wso2/api-platform/issues/2462

**Removal of "version" field from edit forms:**

* All code, state, validation, and UI related to the "version" field has been removed from `EditExternalServer.tsx`, `EditLLMProxy.tsx`, and `EditServiceProvider.tsx`. This includes state variables, form controls, validation logic, and payload construction. [[1]](diffhunk://#diff-f06e5a05ce44f8e07a93034d3ee819b4d550beaadf7d2dcd6ad3d79ccaf1276cL48-L59) [[2]](diffhunk://#diff-f06e5a05ce44f8e07a93034d3ee819b4d550beaadf7d2dcd6ad3d79ccaf1276cL96) [[3]](diffhunk://#diff-f06e5a05ce44f8e07a93034d3ee819b4d550beaadf7d2dcd6ad3d79ccaf1276cL116) [[4]](diffhunk://#diff-f06e5a05ce44f8e07a93034d3ee819b4d550beaadf7d2dcd6ad3d79ccaf1276cL133-R141) [[5]](diffhunk://#diff-f06e5a05ce44f8e07a93034d3ee819b4d550beaadf7d2dcd6ad3d79ccaf1276cL159) [[6]](diffhunk://#diff-f06e5a05ce44f8e07a93034d3ee819b4d550beaadf7d2dcd6ad3d79ccaf1276cL267-R269) [[7]](diffhunk://#diff-f06e5a05ce44f8e07a93034d3ee819b4d550beaadf7d2dcd6ad3d79ccaf1276cL301-L321) [[8]](diffhunk://#diff-6c5763cc12991795df6dc433196a1b03219d1be072214846436083d3154c50eeL44) [[9]](diffhunk://#diff-6c5763cc12991795df6dc433196a1b03219d1be072214846436083d3154c50eeL62-L74) [[10]](diffhunk://#diff-6c5763cc12991795df6dc433196a1b03219d1be072214846436083d3154c50eeL83-R84) [[11]](diffhunk://#diff-6c5763cc12991795df6dc433196a1b03219d1be072214846436083d3154c50eeL100) [[12]](diffhunk://#diff-6c5763cc12991795df6dc433196a1b03219d1be072214846436083d3154c50eeL186-R189) [[13]](diffhunk://#diff-6c5763cc12991795df6dc433196a1b03219d1be072214846436083d3154c50eeL216-L232) [[14]](diffhunk://#diff-21e3290405daa645b8c7cb9b953481eb74d43921832956e627dc81af8e08a4d3L44) [[15]](diffhunk://#diff-21e3290405daa645b8c7cb9b953481eb74d43921832956e627dc81af8e08a4d3L57-L70) [[16]](diffhunk://#diff-21e3290405daa645b8c7cb9b953481eb74d43921832956e627dc81af8e08a4d3L79-R79) [[17]](diffhunk://#diff-21e3290405daa645b8c7cb9b953481eb74d43921832956e627dc81af8e08a4d3L96) [[18]](diffhunk://#diff-21e3290405daa645b8c7cb9b953481eb74d43921832956e627dc81af8e08a4d3L196-R198) [[19]](diffhunk://#diff-21e3290405daa645b8c7cb9b953481eb74d43921832956e627dc81af8e08a4d3L226-L242)

* All user-facing messages and warnings have been updated to remove references to "version" and now only mention "name" and "context" as read-only fields. [[1]](diffhunk://#diff-f06e5a05ce44f8e07a93034d3ee819b4d550beaadf7d2dcd6ad3d79ccaf1276cL267-R269) [[2]](diffhunk://#diff-f06e5a05ce44f8e07a93034d3ee819b4d550beaadf7d2dcd6ad3d79ccaf1276cL133-R141) [[3]](diffhunk://#diff-6c5763cc12991795df6dc433196a1b03219d1be072214846436083d3154c50eeL186-R189) [[4]](diffhunk://#diff-21e3290405daa645b8c7cb9b953481eb74d43921832956e627dc81af8e08a4d3L196-R198)

**Refactor of LLM Proxy Provider tab:**

* The "Save API Key" button has been removed. The API key is now updated immediately as the user types, via the new `handleApiKeyChange` handler, streamlining the user experience. [[1]](diffhunk://#diff-dd154ecff617ce048ba6c9f9ce42c304ad3feae1616afd5821b9447e5f4f17f9L111-R115) [[2]](diffhunk://#diff-dd154ecff617ce048ba6c9f9ce42c304ad3feae1616afd5821b9447e5f4f17f9L133-L139) [[3]](diffhunk://#diff-dd154ecff617ce048ba6c9f9ce42c304ad3feae1616afd5821b9447e5f4f17f9L275-L296)

* Unused imports and components related to the removed button have also been cleaned up. [[1]](diffhunk://#diff-dd154ecff617ce048ba6c9f9ce42c304ad3feae1616afd5821b9447e5f4f17f9L21) [[2]](diffhunk://#diff-dd154ecff617ce048ba6c9f9ce42c304ad3feae1616afd5821b9447e5f4f17f9L40)

These changes simplify the forms, reduce user confusion, and streamline the UI for editing external servers, proxies, and service providers.## Purpose
> Explain **why** this feature or fix is required. Describe the underlying problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

## Goals
> Describe **what solutions** this feature or fix introduces to address the problems outlined above.

## Approach
> Describe **how** you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
