### PR TITLE
feat(gateway): add opt-in pprof endpoints on admin servers

### DIFF
--- a/gateway/configs/config-template.toml
+++ b/gateway/configs/config-template.toml
@@ -19,6 +19,15 @@ enabled = true
 port = 9092
 allowed_ips = ["*"]
 
+[controller.admin_server.pprof]
+# Go runtime profiling (net/http/pprof) served on the admin server, off by default.
+# When profiling, also restrict admin_server.allowed_ips or reach it via port-forward.
+enabled = false
+# runtime.SetBlockProfileRate arg (0 = block profiling off; e.g. 10000 samples ~1/10µs blocking)
+block_profile_rate = 0
+# runtime.SetMutexProfileFraction arg (0 = mutex profiling off; e.g. 5 samples 1/5 contentions)
+mutex_profile_fraction = 0
+
 [controller.policy_server]
 # Policy xDS gRPC port for policy distribution
 port = 18001
@@ -249,6 +258,15 @@ extproc_port = 9001
 enabled = true
 port = 9002
 allowed_ips = ["*", "127.0.0.1"]
+
+[policy_engine.admin.pprof]
+# Go runtime profiling (net/http/pprof) served on the admin server, off by default.
+# When profiling, also restrict admin.allowed_ips or reach it via port-forward.
+enabled = false
+# runtime.SetBlockProfileRate arg (0 = block profiling off; e.g. 10000 samples ~1/10µs blocking)
+block_profile_rate = 0
+# runtime.SetMutexProfileFraction arg (0 = mutex profiling off; e.g. 5 samples 1/5 contentions)
+mutex_profile_fraction = 0
 
 [policy_engine.config_mode]
 mode = "xds"

--- a/gateway/gateway-controller/cmd/controller/main.go
+++ b/gateway/gateway-controller/cmd/controller/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -681,6 +682,14 @@ func main() {
 		outerMiddlewares = append(outerMiddlewares, middleware.MetricsMiddleware())
 	}
 	handler := gohttpkit.Chain(outerMiddlewares...)(mux)
+
+	// Enable block/mutex profiling sampling when pprof is enabled. These are the
+	// only profiles that need explicit rate setup; 0 leaves them disabled. Gated so
+	// the sampling overhead is never paid unless pprof is deliberately turned on.
+	if cfg.Controller.AdminServer.Pprof.Enabled {
+		runtime.SetBlockProfileRate(cfg.Controller.AdminServer.Pprof.BlockProfileRate)
+		runtime.SetMutexProfileFraction(cfg.Controller.AdminServer.Pprof.MutexProfileFraction)
+	}
 
 	// Start controller admin server for debug endpoints if enabled.
 	var controllerAdminServer *adminserver.Server

--- a/gateway/gateway-controller/pkg/adminserver/server.go
+++ b/gateway/gateway-controller/pkg/adminserver/server.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/http/pprof"
 	"time"
 
 	adminapi "github.com/wso2/api-platform/gateway/gateway-controller/pkg/api/admin"
@@ -63,6 +64,19 @@ func NewServer(cfg *config.AdminServerConfig, apiServer apiServer, logger *slog.
 			deprecatedAdminPathMiddleware(AdminAPIBasePath),
 		},
 	})
+
+	// Go runtime profiling endpoints, registered only when explicitly enabled.
+	// They are wrapped in the same IP whitelist as the other admin routes — the
+	// selective middleware here (not on the mux itself) is what protects them, so
+	// registering directly on the mux without it would leave pprof unauthenticated.
+	if cfg.Pprof.Enabled {
+		ipmw := createSelectiveIPWhitelistMiddleware(cfg.AllowedIPs)
+		mux.Handle("/debug/pprof/", ipmw(http.HandlerFunc(pprof.Index)))
+		mux.Handle("/debug/pprof/cmdline", ipmw(http.HandlerFunc(pprof.Cmdline)))
+		mux.Handle("/debug/pprof/profile", ipmw(http.HandlerFunc(pprof.Profile)))
+		mux.Handle("/debug/pprof/symbol", ipmw(http.HandlerFunc(pprof.Symbol)))
+		mux.Handle("/debug/pprof/trace", ipmw(http.HandlerFunc(pprof.Trace)))
+	}
 
 	s.httpSrv = &http.Server{
 		Addr:              fmt.Sprintf(":%d", cfg.Port),

--- a/gateway/gateway-controller/pkg/config/config.go
+++ b/gateway/gateway-controller/pkg/config/config.go
@@ -304,9 +304,22 @@ type ServerConfig struct {
 
 // AdminServerConfig holds controller admin HTTP server configuration.
 type AdminServerConfig struct {
-	Enabled    bool     `koanf:"enabled"`
-	Port       int      `koanf:"port"`
-	AllowedIPs []string `koanf:"allowed_ips"`
+	Enabled    bool        `koanf:"enabled"`
+	Port       int         `koanf:"port"`
+	AllowedIPs []string    `koanf:"allowed_ips"`
+	Pprof      PprofConfig `koanf:"pprof"`
+}
+
+// PprofConfig gates the Go runtime profiling endpoints (net/http/pprof) served on
+// the admin HTTP server. Disabled by default; when disabled the /debug/pprof/*
+// routes are not registered at all (they return 404, not 403).
+type PprofConfig struct {
+	// Enabled registers the /debug/pprof/* handlers on the admin server.
+	Enabled bool `koanf:"enabled"`
+	// BlockProfileRate is passed to runtime.SetBlockProfileRate (0 = block profiling off).
+	BlockProfileRate int `koanf:"block_profile_rate"`
+	// MutexProfileFraction is passed to runtime.SetMutexProfileFraction (0 = mutex profiling off).
+	MutexProfileFraction int `koanf:"mutex_profile_fraction"`
 }
 
 // PolicyServerConfig holds policy xDS server-related configuration
@@ -845,6 +858,11 @@ func defaultConfig() *Config {
 				Enabled:    true,
 				Port:       9092,
 				AllowedIPs: []string{"*"},
+				Pprof: PprofConfig{
+					Enabled:              false,
+					BlockProfileRate:     0,
+					MutexProfileFraction: 0,
+				},
 			},
 			PolicyServer: PolicyServerConfig{
 				Port: 18001,

--- a/gateway/gateway-runtime/policy-engine/cmd/policy-engine/main.go
+++ b/gateway/gateway-runtime/policy-engine/cmd/policy-engine/main.go
@@ -26,6 +26,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"runtime"
 	"syscall"
 	"time"
 
@@ -238,6 +239,14 @@ func main() {
 
 	grpcServer := grpc.NewServer()
 	extprocv3.RegisterExternalProcessorServer(grpcServer, extprocServer)
+
+	// Enable block/mutex profiling sampling when pprof is enabled. These are the
+	// only profiles that need explicit rate setup; 0 leaves them disabled. Gated so
+	// the sampling overhead is never paid unless pprof is deliberately turned on.
+	if cfg.PolicyEngine.Admin.Pprof.Enabled {
+		runtime.SetBlockProfileRate(cfg.PolicyEngine.Admin.Pprof.BlockProfileRate)
+		runtime.SetMutexProfileFraction(cfg.PolicyEngine.Admin.Pprof.MutexProfileFraction)
+	}
 
 	// Start admin HTTP server if enabled
 	var adminServer *admin.Server

--- a/gateway/gateway-runtime/policy-engine/internal/admin/server.go
+++ b/gateway/gateway-runtime/policy-engine/internal/admin/server.go
@@ -24,6 +24,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/http/pprof"
 	"strings"
 	"time"
 
@@ -50,6 +51,16 @@ func NewServer(cfg *config.AdminConfig, k *kernel.Kernel, reg *registry.PolicyRe
 	mux.Handle("/xds_sync_status", ipWhitelistMiddleware(cfg.AllowedIPs, xdsSyncHandler))
 	// Health endpoint is registered without IP whitelist so Docker/k8s health probes can reach it
 	mux.Handle("/health", healthHandler)
+
+	// Go runtime profiling endpoints, registered only when explicitly enabled and
+	// wrapped in the same IP whitelist as the other admin routes.
+	if cfg.Pprof.Enabled {
+		mux.Handle("/debug/pprof/", ipWhitelistMiddleware(cfg.AllowedIPs, http.HandlerFunc(pprof.Index)))
+		mux.Handle("/debug/pprof/cmdline", ipWhitelistMiddleware(cfg.AllowedIPs, http.HandlerFunc(pprof.Cmdline)))
+		mux.Handle("/debug/pprof/profile", ipWhitelistMiddleware(cfg.AllowedIPs, http.HandlerFunc(pprof.Profile)))
+		mux.Handle("/debug/pprof/symbol", ipWhitelistMiddleware(cfg.AllowedIPs, http.HandlerFunc(pprof.Symbol)))
+		mux.Handle("/debug/pprof/trace", ipWhitelistMiddleware(cfg.AllowedIPs, http.HandlerFunc(pprof.Trace)))
+	}
 
 	httpServer := &http.Server{
 		Addr:              fmt.Sprintf(":%d", cfg.Port),

--- a/gateway/gateway-runtime/policy-engine/internal/config/config.go
+++ b/gateway/gateway-runtime/policy-engine/internal/config/config.go
@@ -252,6 +252,23 @@ type AdminConfig struct {
 	// AllowedIPs is a list of IP addresses allowed to access the admin API
 	// Defaults to localhost only (127.0.0.1 and ::1)
 	AllowedIPs []string `koanf:"allowed_ips"`
+
+	// Pprof gates the Go runtime profiling endpoints served on this admin server.
+	Pprof PprofConfig `koanf:"pprof"`
+}
+
+// PprofConfig gates the Go runtime profiling endpoints (net/http/pprof) served on
+// the admin HTTP server. Disabled by default; when disabled the /debug/pprof/*
+// routes are not registered at all (they return 404, not 403).
+type PprofConfig struct {
+	// Enabled registers the /debug/pprof/* handlers on the admin server.
+	Enabled bool `koanf:"enabled"`
+
+	// BlockProfileRate is passed to runtime.SetBlockProfileRate (0 = block profiling off).
+	BlockProfileRate int `koanf:"block_profile_rate"`
+
+	// MutexProfileFraction is passed to runtime.SetMutexProfileFraction (0 = mutex profiling off).
+	MutexProfileFraction int `koanf:"mutex_profile_fraction"`
 }
 
 // ConfigModeConfig specifies how policy chains are configured
@@ -452,6 +469,11 @@ func defaultConfig() *Config {
 				Enabled:    true,
 				Port:       9002,
 				AllowedIPs: []string{"*"},
+				Pprof: PprofConfig{
+					Enabled:              false,
+					BlockProfileRate:     0,
+					MutexProfileFraction: 0,
+				},
 			},
 			Metrics: MetricsConfig{
 				Enabled: false,


### PR DESCRIPTION
## Purpose

While running gateway performance tests we lacked a way to inspect where time is spent inside the two Go processes (gateway-controller and policy-engine), making it hard to tell whether a bottleneck is CPU, IO, or lock contention.
This PR exposes Go's `net/http/pprof` profiling endpoints on each service so CPU, heap, goroutine, block, mutex, and execution-trace profiles can be captured during load.

Resolves #857

## Goals

Provide on-demand runtime profiling for the gateway-controller and policy-engine, disabled by default and reachable only through the existing admin server and its IP whitelist.

## Approach

- Add a `PprofConfig` (`enabled`, `block_profile_rate`, `mutex_profile_fraction`) under each service's admin config, disabled by default in `defaultConfig()`.
- Register `/debug/pprof/*` on the existing admin HTTP server (controller `9092`, policy-engine `9002`) only when `pprof.enabled`, so the routes are absent (return 404) when disabled.
- Wrap the pprof handlers in the same IP whitelist as the other admin routes; on the controller this is mandatory because its whitelist wraps route handlers rather than the mux, so unwrapped routes would be unauthenticated.
- Gate `runtime.SetBlockProfileRate` and `runtime.SetMutexProfileFraction` behind the same flag so the sampling overhead is never paid unless profiling is deliberately turned on.
- Document the defaults in `config-template.toml`; no new dependencies (`net/http/pprof` and `runtime` are stdlib), and no Dockerfile, compose, or Helm changes are required.

## User stories

As a gateway operator or developer running performance tests, I want to attach `go tool pprof` to a running gateway-controller or policy-engine so that I can identify CPU, IO, or lock-contention bottlenecks without shipping a debug build.

## Documentation

N/A — internal debug/profiling capability with no user-facing API or product-documentation impact.

## Automation tests

- Unit tests
  > No unit tests added; the change is configuration plumbing plus conditional handler registration on the existing admin server.
- Integration tests
  > No integration tests added. Verified that both modules compile with `go build ./...` for gateway-controller and policy-engine. The feature is off by default, so existing admin/health behaviour is unchanged.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — FindSecurityBugs is Java-specific; these are Go modules.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

N/A

## Test environment

Go 1.26.5, macOS (darwin/arm64). Verified via `go build ./...` on both gateway-controller and policy-engine modules.

## Remarks

pprof is off by default. To enable it in a deployment, set the admin pprof config (e.g. via the container env var `APIP_GW_CONTROLLER_ADMIN__SERVER_PPROF_ENABLED=true` / `APIP_GW_POLICY__ENGINE_ADMIN_PPROF_ENABLED=true`, plus the optional block/mutex rates) and reach the admin port over `kubectl port-forward` or `docker exec` rather than publishing it. When enabling, tighten `allowed_ips` since the default is `*`.