### PR TITLE
Switch Backend LLM Rate-Limit Policy from advanced-ratelimit to basic-ratelimit

### DIFF
--- a/docs/ai-workspace/features/global-policies-llm-providers-proxies.md
+++ b/docs/ai-workspace/features/global-policies-llm-providers-proxies.md
@@ -1,6 +1,6 @@
 # Global Policies for LLM Providers and LLM Proxies
 
-Global policies apply a single policy across **every operation** of an LLM Provider or LLM Proxy, rather than to one path and method at a time. They are the natural way to express a provider-wide control — a token budget for the whole provider, a single request ceiling shared across all endpoints, or a guardrail that must run on every route.
+Global policies apply a single policy across **every operation** of an LLM Provider or LLM Proxy, rather than to one path and method at a time. They are the natural way to express a provider-wide control — a single request ceiling shared across all endpoints, or a guardrail that must run on every route.
 
 Policies attached to an LLM Provider or Proxy now fall into two lists:
 
@@ -24,7 +24,7 @@ The same distinction holds for guardrails: a global guardrail runs on every oper
 
 ### Which to choose
 
-- Use a **global policy** when the control describes the provider or proxy as a whole: "this provider may consume at most X tokens per hour," "mask PII on every request regardless of endpoint."
+- Use a **global policy** when the control describes the provider or proxy as a whole: "this provider may accept at most X requests per hour," "mask PII on every request regardless of endpoint."
 - Use an **operation policy** when different endpoints need different treatment: a stricter limit on an expensive completion route, a guardrail only on a route that accepts free-text input.
 
 ## Configuring Policies
@@ -62,8 +62,6 @@ Global rate limits are a **hard ceiling on total traffic** and are counted **per
 
 Rejected requests receive HTTP `429` with the body `Rate limit exceeded`.
 
-> **Advanced rate limit and shared counters.** The advanced rate-limit policy keys its counter per route by default, which would silo the limit per operation. When you attach it as a *global* policy, the platform automatically configures it to key on the provider or proxy instead, so a single bucket is shared across all routes — matching the behaviour of a global basic rate limit. Any key-extraction setting you configure explicitly is preserved.
-
 ## Legacy Policies
 
 The original flat **policies** list is **deprecated** but continues to work, so existing configurations behave exactly as before.
@@ -83,18 +81,16 @@ Global and operation policies require a gateway running a version that understan
 
 ## Example
 
-A provider with a global token budget shared across all operations, plus a stricter per-route request limit on the completions endpoint:
+A provider with a global request ceiling shared across all operations, plus a stricter per-route request limit on the completions endpoint:
 
 ```yaml
 globalPolicies:
-  - name: advanced-ratelimit
+  - name: basic-ratelimit
     version: v1
     params:
-      quotas:
-        - name: request-limit
-          limits:
-            - limit: 10000
-              duration: "1h"
+      limits:
+        - requests: 10000
+          duration: "1h"
 operationPolicies:
   - name: basic-ratelimit
     version: v1

--- a/docs/ai-workspace/features/global-policies-llm-providers-proxies.md
+++ b/docs/ai-workspace/features/global-policies-llm-providers-proxies.md
@@ -68,12 +68,14 @@ Rejected requests receive HTTP `429` with the body `Rate limit exceeded`.
 
 The original flat **policies** list is **deprecated** but continues to work, so existing configurations behave exactly as before.
 
-When a configuration is created or edited through the AI Workspace UI, each legacy entry is migrated into the new lists automatically, according to its scope:
+When a configuration is created or edited through the AI Workspace UI (via the Platform API), each legacy entry is migrated into the new lists automatically, according to its scope:
 
 - A **route-specific** legacy entry — one scoped to a specific path, or to specific methods — becomes an **operation policy**.
 - A **provider-wide** legacy entry — one that applied to all paths and all methods — becomes a **global policy**.
 
-You should pick **one style per resource**: either the deprecated flat `policies` list, or the new global/operation lists. A configuration that mixes a non-empty legacy `policies` list with the new lists is rejected. (Global and operation policies together are always fine — they are complementary.)
+This migration happens **on the fly**. If a configuration submitted to the Platform API happens to carry both a legacy `policies` list and the new lists at the same time, it is **not rejected** — the Platform API merges every legacy entry into the appropriate new list and clears the legacy field, so no policy is dropped. You should still pick **one style per resource** for clarity, but a mix is reconciled rather than refused. (Global and operation policies together are always fine — they are complementary.)
+
+> **Note.** The mix restriction is enforced only at the **gateway**. Because the Platform API always canonicalises to the two-list form before sending an artifact, the gateway never receives a mixed configuration in normal operation; the gateway-side check rejects a mixed `policies` + `globalPolicies`/`operationPolicies` artifact only if one is submitted to it directly.
 
 ## Gateway Version Requirements
 

--- a/gateway/gateway-controller/pkg/utils/llm_transformer.go
+++ b/gateway/gateway-controller/pkg/utils/llm_transformer.go
@@ -363,12 +363,7 @@ func (t *LLMProviderTransformer) transformProxy(proxy *api.LLMProxyConfiguration
 	// Append because the proxy may already hold an api-level host-header policy (see Step 3).
 	if proxy.Spec.GlobalPolicies != nil && len(*proxy.Spec.GlobalPolicies) > 0 {
 		gp := make([]api.Policy, len(*proxy.Spec.GlobalPolicies))
-		for i, p := range *proxy.Spec.GlobalPolicies {
-			if p.Name == "advanced-ratelimit" {
-				p = withGlobalAdvancedRatelimitKeyExtraction(p)
-			}
-			gp[i] = p
-		}
+		copy(gp, *proxy.Spec.GlobalPolicies)
 		if spec.Policies == nil {
 			spec.Policies = &gp
 		} else {
@@ -718,12 +713,7 @@ func (t *LLMProviderTransformer) transformProvider(provider *api.LLMProviderConf
 	// applied across ALL operations as one shared scope, evaluated before operation-level policies.
 	if provider.Spec.GlobalPolicies != nil && len(*provider.Spec.GlobalPolicies) > 0 {
 		gp := make([]api.Policy, len(*provider.Spec.GlobalPolicies))
-		for i, p := range *provider.Spec.GlobalPolicies {
-			if p.Name == "advanced-ratelimit" {
-				p = withGlobalAdvancedRatelimitKeyExtraction(p)
-			}
-			gp[i] = p
-		}
+		copy(gp, *provider.Spec.GlobalPolicies)
 		if spec.Policies == nil {
 			spec.Policies = &gp
 		} else {
@@ -982,29 +972,6 @@ func legacyToOperationPolicy(p api.LLMPolicy) api.OperationPolicy {
 		op.Paths = append(op.Paths, api.OperationPolicyPath{Path: pe.Path, Methods: methods, Params: pe.Params})
 	}
 	return op
-}
-
-// withGlobalAdvancedRatelimitKeyExtraction returns a copy of p with
-// keyExtraction set to [{type:"apiname"}] in params if not already present,
-// so that advanced-ratelimit in globalPolicies uses one shared API-level
-// counter rather than the default per-route (routename) bucket.
-func withGlobalAdvancedRatelimitKeyExtraction(p api.Policy) api.Policy {
-	// Treat nil params as an empty map so the apiname key-extraction default is
-	// injected even when the policy carried no params.
-	var existing map[string]interface{}
-	if p.Params != nil {
-		if _, ok := (*p.Params)["keyExtraction"]; ok {
-			return p
-		}
-		existing = *p.Params
-	}
-	newParams := make(map[string]interface{}, len(existing)+1)
-	for k, v := range existing {
-		newParams[k] = v
-	}
-	newParams["keyExtraction"] = []map[string]interface{}{{"type": "apiname"}}
-	p.Params = &newParams
-	return p
 }
 
 // collectOperationLevelLLMPolicies merges the operation-level policies with the deprecated

--- a/platform-api/internal/service/artifact_import_llm_policies.go
+++ b/platform-api/internal/service/artifact_import_llm_policies.go
@@ -32,6 +32,7 @@ const (
 	importPolicyAPIKeyAuth        = "api-key-auth"
 	importPolicyTokenRateLimit    = "token-based-ratelimit"
 	importPolicyAdvancedRateLimit = "advanced-ratelimit"
+	importPolicyBasicRateLimit    = "basic-ratelimit"
 	importPolicyCostRateLimit     = "llm-cost-based-ratelimit"
 	importPolicyLLMCost           = "llm-cost"
 )
@@ -59,6 +60,7 @@ func liftLLMPolicies(policies []model.LLMPolicy, liftRateLimits bool) (*model.Se
 		if !liftRateLimits &&
 			(p.Name == importPolicyTokenRateLimit ||
 				p.Name == importPolicyAdvancedRateLimit ||
+				p.Name == importPolicyBasicRateLimit ||
 				p.Name == importPolicyCostRateLimit) {
 			remaining = append(remaining, p)
 			continue
@@ -75,6 +77,10 @@ func liftLLMPolicies(policies []model.LLMPolicy, liftRateLimits bool) (*model.Se
 		case importPolicyAdvancedRateLimit:
 			for _, path := range p.Paths {
 				rl.addRequest(path)
+			}
+		case importPolicyBasicRateLimit:
+			for _, path := range p.Paths {
+				rl.addBasicRequest(path)
 			}
 		case importPolicyCostRateLimit:
 			for _, path := range p.Paths {
@@ -192,6 +198,24 @@ func (b *rateLimitBuilder) addRequest(path model.LLMPolicyPath) {
 	cfg.Request = &model.RequestRateLimit{
 		Enabled: true,
 		Count:   asInt(first["limit"]),
+		Reset:   parseImportResetWindow(asString(first["duration"])),
+	}
+}
+
+// addBasicRequest lifts a basic-ratelimit policy (params: limits[].requests) back into
+// a provider-level request limit. basic-ratelimit carries no keyExtraction and no quota
+// wrapper; the "/*" path maps to the provider Global/Default and any other path to a
+// resource-wise limit.
+func (b *rateLimitBuilder) addBasicRequest(path model.LLMPolicyPath) {
+	limits := asSlice(path.Params["limits"])
+	if len(limits) == 0 {
+		return
+	}
+	first := asMap(limits[0])
+	cfg := b.target(false, path.Path)
+	cfg.Request = &model.RequestRateLimit{
+		Enabled: true,
+		Count:   asInt(first["requests"]),
 		Reset:   parseImportResetWindow(asString(first["duration"])),
 	}
 }

--- a/platform-api/internal/service/artifact_import_llm_policies_test.go
+++ b/platform-api/internal/service/artifact_import_llm_policies_test.go
@@ -154,7 +154,7 @@ func TestLiftLLMPolicies_RoundTrip(t *testing.T) {
 	for _, p := range remaining {
 		switch p.Name {
 		case importPolicyAPIKeyAuth, importPolicyTokenRateLimit, importPolicyAdvancedRateLimit,
-			importPolicyCostRateLimit:
+			importPolicyBasicRateLimit, importPolicyCostRateLimit:
 			t.Errorf("security/rate-limit policy %q leaked into remaining policies", p.Name)
 		}
 	}

--- a/platform-api/internal/service/llm_deployment.go
+++ b/platform-api/internal/service/llm_deployment.go
@@ -43,6 +43,7 @@ import (
 const (
 	tokenBasedRateLimitPolicyName   = "token-based-ratelimit"
 	advancedRateLimitPolicyName     = "advanced-ratelimit"
+	basicRateLimitPolicyName        = "basic-ratelimit"
 	apiKeyAuthPolicyName            = "api-key-auth"
 	llmCostPolicyName               = "llm-cost"
 	llmCostBasedRateLimitPolicyName = "llm-cost-based-ratelimit"
@@ -712,19 +713,11 @@ func generateLLMProviderDeploymentYAML(provider *model.LLMProvider, templateHand
 						return dto.LLMProviderDeploymentYAML{}, fmt.Errorf("invalid request reset window: %w", err)
 					}
 					params := map[string]interface{}{
-						"quotas": []map[string]interface{}{
-							{
-								"name": "request-limit",
-								"limits": []map[string]interface{}{
-									{"limit": requestLimit.Count, "duration": duration},
-								},
-							},
-						},
-						"keyExtraction": []map[string]interface{}{
-							{"type": "apiname"},
+						"limits": []map[string]interface{}{
+							{"requests": requestLimit.Count, "duration": duration},
 						},
 					}
-					globalPolicies = append(globalPolicies, api.Policy{Name: advancedRateLimitPolicyName, Version: "", Params: &params})
+					globalPolicies = append(globalPolicies, api.Policy{Name: basicRateLimitPolicyName, Version: "", Params: &params})
 				}
 				if providerLevel.Global.Cost != nil && providerLevel.Global.Cost.Enabled {
 					costLimit := providerLevel.Global.Cost
@@ -770,17 +763,12 @@ func generateLLMProviderDeploymentYAML(provider *model.LLMProvider, templateHand
 					if err != nil {
 						return dto.LLMProviderDeploymentYAML{}, fmt.Errorf("invalid request reset window: %w", err)
 					}
-					addOrAppendOperationPolicyPath(&operationPolicies, advancedRateLimitPolicyName, "", api.OperationPolicyPath{
+					addOrAppendOperationPolicyPath(&operationPolicies, basicRateLimitPolicyName, "", api.OperationPolicyPath{
 						Path:    "/*",
 						Methods: []api.OperationPolicyPathMethods{api.OperationPolicyPathMethodsAsterisk},
 						Params: map[string]interface{}{
-							"quotas": []map[string]interface{}{
-								{
-									"name": "request-limit",
-									"limits": []map[string]interface{}{
-										{"limit": requestLimit.Count, "duration": duration},
-									},
-								},
+							"limits": []map[string]interface{}{
+								{"requests": requestLimit.Count, "duration": duration},
 							},
 						},
 					})
@@ -832,17 +820,12 @@ func generateLLMProviderDeploymentYAML(provider *model.LLMProvider, templateHand
 						if err != nil {
 							return dto.LLMProviderDeploymentYAML{}, fmt.Errorf("invalid request reset window for resource %s: %w", r.Resource, err)
 						}
-						addOrAppendOperationPolicyPath(&operationPolicies, advancedRateLimitPolicyName, "", api.OperationPolicyPath{
+						addOrAppendOperationPolicyPath(&operationPolicies, basicRateLimitPolicyName, "", api.OperationPolicyPath{
 							Path:    r.Resource,
 							Methods: []api.OperationPolicyPathMethods{api.OperationPolicyPathMethodsAsterisk},
 							Params: map[string]interface{}{
-								"quotas": []map[string]interface{}{
-									{
-										"name": "request-limit",
-										"limits": []map[string]interface{}{
-											{"limit": requestLimit.Count, "duration": duration},
-										},
-									},
+								"limits": []map[string]interface{}{
+									{"requests": requestLimit.Count, "duration": duration},
 								},
 							},
 						})
@@ -909,33 +892,21 @@ func generateLLMProviderDeploymentYAML(provider *model.LLMProvider, templateHand
 					if err != nil {
 						return dto.LLMProviderDeploymentYAML{}, fmt.Errorf("invalid consumer request reset window: %w", err)
 					}
-					policies = append(policies, api.LLMPolicy{
-						Name:    advancedRateLimitPolicyName,
-						Version: "",
-						Paths: []api.LLMPolicyPath{
+					params := map[string]interface{}{
+						"quotas": []map[string]interface{}{
 							{
-								Path:    "/*",
-								Methods: []api.LLMPolicyPathMethods{"*"},
-								Params: map[string]interface{}{
-									"quotas": []map[string]interface{}{
-										{
-											"name": "consumer-request-limit",
-											"limits": []map[string]interface{}{
-												{
-													"limit":    requestLimit.Count,
-													"duration": duration,
-												},
-											},
-											"keyExtraction": []map[string]interface{}{
-												{"type": "routename"},
-												{"type": "metadata", "key": "x-wso2-application-id"},
-											},
-										},
-									},
+								"name": "consumer-request-limit",
+								"limits": []map[string]interface{}{
+									{"limit": requestLimit.Count, "duration": duration},
+								},
+								"keyExtraction": []map[string]interface{}{
+									{"type": "apiname"},
+									{"type": "metadata", "key": "x-wso2-application-id"},
 								},
 							},
 						},
-					})
+					}
+					globalPolicies = append(globalPolicies, api.Policy{Name: advancedRateLimitPolicyName, Version: "", Params: &params})
 				}
 				if consumerLevel.Global.Cost != nil && consumerLevel.Global.Cost.Enabled {
 					costLimit := consumerLevel.Global.Cost
@@ -1064,9 +1035,6 @@ func generateLLMProviderDeploymentYAML(provider *model.LLMProvider, templateHand
 			continue
 		}
 		params := p.Params
-		if p.Name == advancedRateLimitPolicyName && params != nil {
-			params = withGlobalAdvancedRatelimitKeyExtraction(params)
-		}
 		entry := api.Policy{Name: p.Name, Version: normalizePolicyVersionToMajor(p.Version)}
 		if p.ExecutionCondition != "" {
 			entry.ExecutionCondition = &p.ExecutionCondition
@@ -1815,9 +1783,6 @@ func generateLLMProxyDeploymentYAML(proxy *model.LLMProxy) (dto.LLMProxyDeployme
 			continue
 		}
 		params := p.Params
-		if p.Name == advancedRateLimitPolicyName && params != nil {
-			params = withGlobalAdvancedRatelimitKeyExtraction(params)
-		}
 		entry := api.Policy{Name: p.Name, Version: normalizePolicyVersionToMajor(p.Version)}
 		if p.ExecutionCondition != "" {
 			entry.ExecutionCondition = &p.ExecutionCondition
@@ -1968,27 +1933,6 @@ func orderLLMPolicies(policies []api.LLMPolicy) []api.LLMPolicy {
 		policies[costIdx], policies[rateLimitIdx] = policies[rateLimitIdx], policies[costIdx]
 	}
 	return policies
-}
-
-// withGlobalAdvancedRatelimitKeyExtraction returns a copy of params with
-// keyExtraction defaulted to [{type:"apiname"}] when the caller did not set one.
-// advanced-ratelimit defaults to a per-route (routename) key; in globalPolicies
-// that would create one bucket per operation, so an apiname key is injected to
-// give a single shared API-level counter.
-//
-// An explicit keyExtraction is intentionally preserved untouched: a user who sets
-// it (e.g. a per-consumer header key, or routename on purpose) has made a
-// deliberate choice that this default must not override.
-func withGlobalAdvancedRatelimitKeyExtraction(params map[string]interface{}) map[string]interface{} {
-	if _, ok := params["keyExtraction"]; ok {
-		return params
-	}
-	out := make(map[string]interface{}, len(params)+1)
-	for k, v := range params {
-		out[k] = v
-	}
-	out["keyExtraction"] = []map[string]interface{}{{"type": "apiname"}}
-	return out
 }
 
 // orderLLMGlobalPolicies ensures llm-cost-based-ratelimit precedes llm-cost in the global policy list.

--- a/platform-api/internal/service/llm_deployment_test.go
+++ b/platform-api/internal/service/llm_deployment_test.go
@@ -47,11 +47,9 @@ func providerWithConsumerLimits(rl *model.LLMRateLimitingConfig) *model.LLMProvi
 	}
 }
 
-// TestGenerateYAML_ConsumerRequestLimit verifies that a consumer-only request limit
-// generates a single advanced-ratelimit policy where the key extraction includes
-// x-wso2-application-id (making it consumer-scoped). Unlike token/cost limits,
-// the request limit does NOT use a consumerBased flag — it uses the application ID
-// directly in the key extraction.
+// TestGenerateYAML_ConsumerRequestLimit verifies that a consumer provider-wide request limit
+// is emitted as a GLOBAL advanced-ratelimit policy keyed on apiname + x-wso2-application-id
+// — one shared bucket per consumer across all routes.
 func TestGenerateYAML_ConsumerRequestLimit(t *testing.T) {
 	count := 100
 	rl := &model.LLMRateLimitingConfig{
@@ -80,12 +78,26 @@ func TestGenerateYAML_ConsumerRequestLimit(t *testing.T) {
 	if !strings.Contains(yamlStr, "x-wso2-application-id") {
 		t.Error("expected x-wso2-application-id in key extraction for consumer request limit")
 	}
+	// Provider-wide (global) per-consumer bucket must key on apiname, not routename,
+	// so it is shared across all routes for a given consumer.
+	if !strings.Contains(yamlStr, "apiname") {
+		t.Errorf("expected apiname key extraction for consumer GLOBAL request limit:\n%s", yamlStr)
+	}
+	if strings.Contains(yamlStr, "routename") {
+		t.Errorf("expected no routename key for consumer GLOBAL request limit (would silo per route):\n%s", yamlStr)
+	}
+	// A provider-wide per-consumer limit is a GLOBAL policy: emitted into globalPolicies,
+	// never operationPolicies.
+	if findGlobalPolicy(yamlArtifact.Spec.GlobalPolicies, "advanced-ratelimit") == nil {
+		t.Errorf("expected consumer global request in globalPolicies:\n%s", yamlStr)
+	}
+	if findOperationPolicy(yamlArtifact.Spec.OperationPolicies, "advanced-ratelimit") != nil {
+		t.Errorf("expected consumer global request NOT in operationPolicies:\n%s", yamlStr)
+	}
 	// Should NOT have a backend (non-consumer) advanced-ratelimit entry
 	if strings.Count(yamlStr, "advanced-ratelimit") > 1 {
 		t.Error("expected only one advanced-ratelimit policy (consumer), got more than one")
 	}
-
-	t.Logf("Generated YAML:\n%s", yamlStr)
 }
 
 // TestGenerateYAML_ConsumerTokenLimit verifies that a consumer token limit
@@ -228,9 +240,10 @@ func TestGenerateYAML_BackendOnlyTokenLimit(t *testing.T) {
 	t.Logf("Generated YAML:\n%s", yamlStr)
 }
 
-// TestGenerateYAML_BackendOnlyRequestLimit verifies that a backend-only request limit
-// generates an advanced-ratelimit policy with quota name "request-limit" (not "consumer-request-limit")
-// and without x-wso2-application-id in the key extraction.
+// TestGenerateYAML_BackendOnlyRequestLimit verifies that a backend (provider-level) global
+// request limit produces a basic-ratelimit global policy with a plain {requests, duration}
+// limit — basic-ratelimit shares one bucket across all routes by keying on the API by
+// default, so no keyExtraction or per-consumer key is part of its shape.
 func TestGenerateYAML_BackendOnlyRequestLimit(t *testing.T) {
 	count := 500
 	rl := &model.LLMRateLimitingConfig{
@@ -244,21 +257,30 @@ func TestGenerateYAML_BackendOnlyRequestLimit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	yamlBytes, _ := yaml.Marshal(yamlArtifact)
-	yamlStr := string(yamlBytes)
-	if !strings.Contains(yamlStr, "advanced-ratelimit") {
-		t.Error("expected advanced-ratelimit in generated YAML")
+
+	if len(yamlArtifact.Spec.GlobalPolicies) != 1 {
+		t.Fatalf("expected exactly one global policy, got: %d", len(yamlArtifact.Spec.GlobalPolicies))
 	}
-	if strings.Contains(yamlStr, "x-wso2-application-id") {
-		t.Error("expected no x-wso2-application-id for backend-only request limit")
+	requestPolicy := findGlobalPolicy(yamlArtifact.Spec.GlobalPolicies, "basic-ratelimit")
+	if requestPolicy == nil {
+		t.Fatalf("expected basic-ratelimit global policy, got: %+v", yamlArtifact.Spec.GlobalPolicies)
 	}
-	if !strings.Contains(yamlStr, "request-limit") {
-		t.Error("expected quota name 'request-limit' in generated YAML")
+	if requestPolicy.Params == nil {
+		t.Fatalf("expected basic-ratelimit policy to have params")
 	}
-	if strings.Contains(yamlStr, "consumer-request-limit") {
-		t.Error("expected no 'consumer-request-limit' for backend-only request limit")
+	if len(*requestPolicy.Params) != 1 {
+		t.Fatalf("expected params to contain only 'limits', got: %#v", *requestPolicy.Params)
 	}
-	t.Logf("Generated YAML:\n%s", yamlStr)
+	limits, ok := (*requestPolicy.Params)["limits"].([]map[string]interface{})
+	if !ok || len(limits) != 1 {
+		t.Fatalf("expected limits with one entry, got: %#v", (*requestPolicy.Params)["limits"])
+	}
+	if limits[0]["requests"] != count {
+		t.Errorf("expected requests %d, got: %#v", count, limits[0]["requests"])
+	}
+	if limits[0]["duration"] != "1h" {
+		t.Errorf("expected duration 1h, got: %#v", limits[0]["duration"])
+	}
 }
 
 // TestGenerateYAML_BackendOnlyCostLimit verifies that a backend-only cost limit
@@ -358,9 +380,10 @@ func TestGenerateYAML_BackendPerResourceCostLimit(t *testing.T) {
 // Backend + consumer for individual limit types
 // ---------------------------------------------------------------------------
 
-// TestGenerateYAML_BothBackendAndConsumerRequestLimits verifies that backend and consumer
-// request limits produce two advanced-ratelimit policies with distinct quota names:
-// "request-limit" (backend, no app-id key) and "consumer-request-limit" (consumer, with app-id key).
+// TestGenerateYAML_BothBackendAndConsumerRequestLimits verifies that a backend request
+// limit and a consumer request limit produce distinct policies: the backend limit is a
+// basic-ratelimit (apiname-shared, no keyExtraction) while the consumer limit remains an
+// advanced-ratelimit with quota name "consumer-request-limit" keyed on x-wso2-application-id.
 func TestGenerateYAML_BothBackendAndConsumerRequestLimits(t *testing.T) {
 	count := 100
 	rl := &model.LLMRateLimitingConfig{
@@ -381,8 +404,11 @@ func TestGenerateYAML_BothBackendAndConsumerRequestLimits(t *testing.T) {
 	}
 	yamlBytes, _ := yaml.Marshal(yamlArtifact)
 	yamlStr := string(yamlBytes)
-	if strings.Count(yamlStr, "advanced-ratelimit") < 2 {
-		t.Error("expected two advanced-ratelimit policies (one backend, one consumer)")
+	if strings.Count(yamlStr, "advanced-ratelimit") != 1 {
+		t.Error("expected exactly one advanced-ratelimit policy (consumer only)")
+	}
+	if !strings.Contains(yamlStr, "basic-ratelimit") {
+		t.Error("expected a basic-ratelimit policy for the backend request limit")
 	}
 	if !strings.Contains(yamlStr, "consumer-request-limit") {
 		t.Error("expected 'consumer-request-limit' quota name for consumer policy")
@@ -508,6 +534,72 @@ func TestGenerateYAML_AllThreeConsumerLimits(t *testing.T) {
 	}
 
 	t.Logf("Generated YAML:\n%s", yamlStr)
+}
+
+// TestRoundTrip_ConsumerGlobalRequestLimit verifies the consumer global request limit
+// survives the CP->DP forward conversion (now via globalPolicies) and the DP->CP import,
+// landing back in ConsumerLevel.Global.Request.
+func TestRoundTrip_ConsumerGlobalRequestLimit(t *testing.T) {
+	rl := &model.LLMRateLimitingConfig{
+		ConsumerLevel: &model.RateLimitingScopeConfig{
+			Global: &model.RateLimitingLimitConfig{
+				Request: &model.RequestRateLimit{Enabled: true, Count: 100, Reset: model.RateLimitResetWindow{Duration: 1, Unit: "hour"}},
+			},
+		},
+	}
+	out, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cfg := mapLLMProviderSpecToConfig(out.Spec)
+	if cfg.RateLimiting == nil || cfg.RateLimiting.ConsumerLevel == nil || cfg.RateLimiting.ConsumerLevel.Global == nil ||
+		cfg.RateLimiting.ConsumerLevel.Global.Request == nil {
+		t.Fatalf("consumer global request not reconstructed: %+v", cfg.RateLimiting)
+	}
+	req := cfg.RateLimiting.ConsumerLevel.Global.Request
+	if !req.Enabled || req.Count != 100 || req.Reset.Unit != "hour" || req.Reset.Duration != 1 {
+		t.Errorf("consumer global request = %+v, want enabled count=100 reset=1h", req)
+	}
+	// It must NOT be misclassified as a provider-level (backend) limit.
+	if cfg.RateLimiting.ProviderLevel != nil {
+		t.Errorf("expected no provider-level limit, got: %+v", cfg.RateLimiting.ProviderLevel)
+	}
+}
+
+// TestGenerateYAML_ConsumerResourceWiseRequestLimitKeepsRoutename verifies that a
+// consumer RESOURCE-WISE request limit stays keyed on routename + application id (an
+// independent per-route, per-consumer bucket) — the counterpart to the apiname-keyed
+// consumer global limit.
+func TestGenerateYAML_ConsumerResourceWiseRequestLimitKeepsRoutename(t *testing.T) {
+	rl := &model.LLMRateLimitingConfig{
+		ConsumerLevel: &model.RateLimitingScopeConfig{
+			ResourceWise: &model.ResourceWiseRateLimitingConfig{
+				Resources: []model.RateLimitingResourceLimit{
+					{
+						Resource: "/v1/chat",
+						Limit: model.RateLimitingLimitConfig{
+							Request: &model.RequestRateLimit{Enabled: true, Count: 50, Reset: model.RateLimitResetWindow{Duration: 1, Unit: "hour"}},
+						},
+					},
+				},
+			},
+		},
+	}
+	yamlArtifact, err := generateLLMProviderDeploymentYAML(providerWithConsumerLimits(rl), "anthropic")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	yamlBytes, _ := yaml.Marshal(yamlArtifact)
+	yamlStr := string(yamlBytes)
+	if !strings.Contains(yamlStr, "routename") {
+		t.Errorf("expected routename key for consumer resource-wise request limit:\n%s", yamlStr)
+	}
+	if strings.Contains(yamlStr, "apiname") {
+		t.Errorf("expected no apiname key for consumer resource-wise request limit:\n%s", yamlStr)
+	}
+	if !strings.Contains(yamlStr, "x-wso2-application-id") {
+		t.Errorf("expected x-wso2-application-id key for consumer resource-wise request limit:\n%s", yamlStr)
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/platform-api/internal/service/llm_test.go
+++ b/platform-api/internal/service/llm_test.go
@@ -638,34 +638,26 @@ func TestGenerateLLMProviderDeploymentYAML_WithProviderGlobalRateLimit(t *testin
 		t.Fatalf("expected token duration 1h, got: %#v", firstTokenLimit["duration"])
 	}
 
-	requestPolicy := findGlobalPolicy(out.Spec.GlobalPolicies, "advanced-ratelimit")
+	requestPolicy := findGlobalPolicy(out.Spec.GlobalPolicies, "basic-ratelimit")
 	if requestPolicy == nil {
-		t.Fatalf("expected advanced-ratelimit global policy to exist")
+		t.Fatalf("expected basic-ratelimit global policy to exist")
 	}
 	if requestPolicy.Params == nil {
 		t.Fatalf("expected request policy to have params")
 	}
-	quotas, ok := (*requestPolicy.Params)["quotas"].([]interface{})
-	if !ok || len(quotas) != 1 {
-		t.Fatalf("expected quotas with one entry, got: %#v", (*requestPolicy.Params)["quotas"])
+	if _, ok := (*requestPolicy.Params)["keyExtraction"]; ok {
+		t.Fatalf("expected no keyExtraction on global basic-ratelimit, got: %#v", (*requestPolicy.Params)["keyExtraction"])
 	}
-	firstQuota, ok := quotas[0].(map[string]interface{})
-	if !ok {
-		t.Fatalf("expected first quota as object, got: %#v", quotas[0])
-	}
-	if firstQuota["name"] != "request-limit" {
-		t.Fatalf("expected quota name request-limit, got: %#v", firstQuota["name"])
-	}
-	limits, ok := firstQuota["limits"].([]interface{})
+	limits, ok := (*requestPolicy.Params)["limits"].([]interface{})
 	if !ok || len(limits) != 1 {
-		t.Fatalf("expected quota limits with one entry, got: %#v", firstQuota["limits"])
+		t.Fatalf("expected limits with one entry, got: %#v", (*requestPolicy.Params)["limits"])
 	}
 	firstRequestLimit, ok := limits[0].(map[string]interface{})
 	if !ok {
 		t.Fatalf("expected first request limit as object, got: %#v", limits[0])
 	}
-	if firstRequestLimit["limit"] != 1 {
-		t.Fatalf("expected request limit 1, got: %#v", firstRequestLimit["limit"])
+	if firstRequestLimit["requests"] != 1 {
+		t.Fatalf("expected request count 1, got: %#v", firstRequestLimit["requests"])
 	}
 	if firstRequestLimit["duration"] != "1h" {
 		t.Fatalf("expected request duration 1h, got: %#v", firstRequestLimit["duration"])
@@ -751,9 +743,9 @@ func TestGenerateLLMProviderDeploymentYAML_WithProviderResourceWiseRateLimit(t *
 		t.Fatalf("expected token policy path /audio/speech")
 	}
 
-	requestPolicy := findOperationPolicy(out.Spec.OperationPolicies, "advanced-ratelimit")
+	requestPolicy := findOperationPolicy(out.Spec.OperationPolicies, "basic-ratelimit")
 	if requestPolicy == nil {
-		t.Fatalf("expected advanced-ratelimit operation policy to exist")
+		t.Fatalf("expected basic-ratelimit operation policy to exist")
 	}
 	if len(requestPolicy.Paths) != 2 {
 		t.Fatalf("expected 2 request policy paths, got: %d", len(requestPolicy.Paths))
@@ -786,24 +778,16 @@ func TestGenerateLLMProviderDeploymentYAML_WithProviderResourceWiseRateLimit(t *
 	}
 
 	for _, p := range []*api.OperationPolicyPath{assistantsRequestPath, audioRequestPath} {
-		quotas, ok := p.Params["quotas"].([]interface{})
-		if !ok || len(quotas) != 1 {
-			t.Fatalf("expected quotas with one entry, got: %#v", p.Params["quotas"])
-		}
-		firstQuota, ok := quotas[0].(map[string]interface{})
-		if !ok {
-			t.Fatalf("expected first quota object, got: %#v", quotas[0])
-		}
-		limits, ok := firstQuota["limits"].([]interface{})
+		limits, ok := p.Params["limits"].([]interface{})
 		if !ok || len(limits) != 1 {
-			t.Fatalf("expected limits with one entry, got: %#v", firstQuota["limits"])
+			t.Fatalf("expected limits with one entry, got: %#v", p.Params["limits"])
 		}
 		firstRequestLimit, ok := limits[0].(map[string]interface{})
 		if !ok {
 			t.Fatalf("expected request limit object, got: %#v", limits[0])
 		}
-		if firstRequestLimit["limit"] != 1 {
-			t.Fatalf("expected request limit 1, got: %#v", firstRequestLimit["limit"])
+		if firstRequestLimit["requests"] != 1 {
+			t.Fatalf("expected request count 1, got: %#v", firstRequestLimit["requests"])
 		}
 		if firstRequestLimit["duration"] != "1h" {
 			t.Fatalf("expected request duration 1h, got: %#v", firstRequestLimit["duration"])
@@ -884,9 +868,9 @@ func TestGenerateLLMProviderDeploymentYAML_WithProviderResourceWiseRateLimitAndD
 		t.Fatalf("expected 3 token policy paths (default + 2 unique resources), got: %d", len(tokenPolicy.Paths))
 	}
 
-	requestPolicy := findOperationPolicy(out.Spec.OperationPolicies, "advanced-ratelimit")
+	requestPolicy := findOperationPolicy(out.Spec.OperationPolicies, "basic-ratelimit")
 	if requestPolicy == nil {
-		t.Fatalf("expected advanced-ratelimit operation policy to exist")
+		t.Fatalf("expected basic-ratelimit operation policy to exist")
 	}
 	if len(requestPolicy.Paths) != 3 {
 		t.Fatalf("expected 3 request policy paths (default + 2 unique resources), got: %d", len(requestPolicy.Paths))
@@ -916,24 +900,16 @@ func TestGenerateLLMProviderDeploymentYAML_WithProviderResourceWiseRateLimitAndD
 	}
 
 	for _, p := range requestPolicy.Paths {
-		quotas, ok := p.Params["quotas"].([]interface{})
-		if !ok || len(quotas) != 1 {
-			t.Fatalf("expected quotas with one entry, got: %#v", p.Params["quotas"])
-		}
-		firstQuota, ok := quotas[0].(map[string]interface{})
-		if !ok {
-			t.Fatalf("expected first quota object, got: %#v", quotas[0])
-		}
-		limits, ok := firstQuota["limits"].([]interface{})
+		limits, ok := p.Params["limits"].([]interface{})
 		if !ok || len(limits) != 1 {
-			t.Fatalf("expected limits with one entry, got: %#v", firstQuota["limits"])
+			t.Fatalf("expected limits with one entry, got: %#v", p.Params["limits"])
 		}
 		firstRequestLimit, ok := limits[0].(map[string]interface{})
 		if !ok {
 			t.Fatalf("expected request limit object, got: %#v", limits[0])
 		}
-		if firstRequestLimit["limit"] != 1 || firstRequestLimit["duration"] != "1h" {
-			t.Fatalf("expected request limit {limit:1,duration:1h}, got: %#v", firstRequestLimit)
+		if firstRequestLimit["requests"] != 1 || firstRequestLimit["duration"] != "1h" {
+			t.Fatalf("expected request limit {requests:1,duration:1h}, got: %#v", firstRequestLimit)
 		}
 	}
 }


### PR DESCRIPTION
## Purpose

Resolves the following issues:
- https://github.com/wso2/api-platform/issues/2338
- https://github.com/wso2/api-platform/issues/2504
- https://github.com/wso2/api-platform/issues/2467 

This pull request updates the handling of global rate limits for LLM providers and proxies, simplifying the implementation and documentation by introducing a new `basic-ratelimit` policy for provider-wide request ceilings. The changes remove the need for custom key extraction logic for global rate limits, update YAML generation and import/export code to use the new policy, and clarify the documentation to match the new behavior.

**Global Rate Limit Policy Refactor**

* Replaces the use of `advanced-ratelimit` for provider-wide request ceilings with a new, simpler `basic-ratelimit` policy, which does not require key extraction or quota wrappers. All code paths generating or importing provider-level request limits now use `basic-ratelimit` with a `limits[].requests` parameter. [[1]](diffhunk://#diff-87b7518eac020ce0efa180b7a77fb4c03674647efe40a2d0724a358c27f00e00R46) [[2]](diffhunk://#diff-87b7518eac020ce0efa180b7a77fb4c03674647efe40a2d0724a358c27f00e00L715-R720) [[3]](diffhunk://#diff-87b7518eac020ce0efa180b7a77fb4c03674647efe40a2d0724a358c27f00e00L773-R771) [[4]](diffhunk://#diff-87b7518eac020ce0efa180b7a77fb4c03674647efe40a2d0724a358c27f00e00L835-R828) [[5]](diffhunk://#diff-43d88cea399d4de887a9724986c42c0f1d275ad7066fce58fbb2e30abaf53e38R35) [[6]](diffhunk://#diff-43d88cea399d4de887a9724986c42c0f1d275ad7066fce58fbb2e30abaf53e38R81-R84) [[7]](diffhunk://#diff-43d88cea399d4de887a9724986c42c0f1d275ad7066fce58fbb2e30abaf53e38R205-R222)

* Removes all code that previously injected a default key extraction for `advanced-ratelimit` in global policies, as this is no longer needed with `basic-ratelimit`. [[1]](diffhunk://#diff-ba984a3fd89ae41e327d1277609301e2d508575f277cb992bd5eec764c26a3e6L366-R366) [[2]](diffhunk://#diff-ba984a3fd89ae41e327d1277609301e2d508575f277cb992bd5eec764c26a3e6L721-R716) [[3]](diffhunk://#diff-ba984a3fd89ae41e327d1277609301e2d508575f277cb992bd5eec764c26a3e6L987-L1009) [[4]](diffhunk://#diff-87b7518eac020ce0efa180b7a77fb4c03674647efe40a2d0724a358c27f00e00L1067-L1069) [[5]](diffhunk://#diff-87b7518eac020ce0efa180b7a77fb4c03674647efe40a2d0724a358c27f00e00L1818-L1820) [[6]](diffhunk://#diff-87b7518eac020ce0efa180b7a77fb4c03674647efe40a2d0724a358c27f00e00L1973-L1993)

**Documentation Updates**

* Updates documentation to describe the new `basic-ratelimit` approach, removing references to global token budgets and clarifying that provider-wide request ceilings are implemented using `basic-ratelimit`. Also clarifies migration and compatibility behavior for legacy and new policy lists. [[1]](diffhunk://#diff-5b5c7ef0464f9225b8e314c4f2dcf6a9fe31994beaf77059d241ceffa85d8a3dL3-R3) [[2]](diffhunk://#diff-5b5c7ef0464f9225b8e314c4f2dcf6a9fe31994beaf77059d241ceffa85d8a3dL27-R27) [[3]](diffhunk://#diff-5b5c7ef0464f9225b8e314c4f2dcf6a9fe31994beaf77059d241ceffa85d8a3dL65-R92)

**Import/Export and Testing Adjustments**

* Updates the import/export logic to recognize and correctly handle `basic-ratelimit` policies, ensuring they are lifted and round-tripped correctly. Test cases are updated to reflect the new policy. [[1]](diffhunk://#diff-43d88cea399d4de887a9724986c42c0f1d275ad7066fce58fbb2e30abaf53e38R63) [[2]](diffhunk://#diff-f508eb1f69876a287d4457a54c4849e6fd8c441608ca3ad18c608eda7a31da47L157-R157) [[3]](diffhunk://#diff-7e8061e2b27337679fe09df71bb6dc484b8475192593e3bf78f455138b3df81aL50-R52)

These changes simplify global rate limit configuration and ensure consistent, predictable behavior for provider-wide request ceilings.
