### PR TITLE
fix(gateway-runtime): raise Envoy RE2 program size cap for deep parameterized routes

### DIFF
--- a/gateway/gateway-runtime/docker-entrypoint-debug.sh
+++ b/gateway/gateway-runtime/docker-entrypoint-debug.sh
@@ -85,9 +85,14 @@ export LOG_LEVEL="${LOG_LEVEL:-info}"
 # GOMAXPROCS limits Go's CPU usage - set to leave cores for Envoy (default: 2)
 # ROUTER_CONCURRENCY sets Envoy's worker thread count (default: auto-detect, 0 means use all cores)
 # APIP_GW_POLICY_ENGINE_METRICS_ENABLED controls metrics collection (default: true, set false for high-load)
+# APIP_GW_ROUTER_RE2_MAX_PROGRAM_SIZE sets Envoy's RE2 regex program-size error cap (default: 400).
+#   Envoy's built-in default is 100, which is too low for paths with many path parameters
+#   (each [^/]+ segment costs ~10 units; 7 params → program size 115 → RouteConfiguration rejected).
+#   400 covers paths with up to ~30 path parameters. Override if your API has deeper paths.
 export GOMAXPROCS="${GOMAXPROCS:-2}"
 export ROUTER_CONCURRENCY="${ROUTER_CONCURRENCY:-0}"
 export APIP_GW_POLICY_ENGINE_METRICS_ENABLED="${APIP_GW_POLICY_ENGINE_METRICS_ENABLED:-true}"
+export APIP_GW_ROUTER_RE2_MAX_PROGRAM_SIZE="${APIP_GW_ROUTER_RE2_MAX_PROGRAM_SIZE:-400}"
 
 # Graceful shutdown configuration (see docker-entrypoint.sh for details).
 # On SIGTERM the Router (Envoy) is drained before processes are terminated so in-flight
@@ -114,6 +119,7 @@ log "  Log Level: ${LOG_LEVEL}"
 log "  Policy Engine Socket: ${POLICY_ENGINE_SOCKET}"
 log "  GOMAXPROCS: ${GOMAXPROCS}"
 log "  Router Concurrency: ${ROUTER_CONCURRENCY}"
+log "  Router RE2 Max Program Size: ${APIP_GW_ROUTER_RE2_MAX_PROGRAM_SIZE}"
 log "  Policy Engine Metrics: ${APIP_GW_POLICY_ENGINE_METRICS_ENABLED}"
 [[ ${#ROUTER_ARGS[@]} -gt 0 ]] && log "  Router extra args: ${ROUTER_ARGS[*]}"
 [[ ${#PE_ARGS[@]} -gt 0 ]] && log "  Policy Engine extra args: ${PE_ARGS[*]}"

--- a/gateway/gateway-runtime/docker-entrypoint.sh
+++ b/gateway/gateway-runtime/docker-entrypoint.sh
@@ -106,9 +106,14 @@ export LOG_LEVEL="${LOG_LEVEL:-info}"
 # GOMAXPROCS limits Go's CPU usage - set to leave cores for Envoy (default: 2)
 # ROUTER_CONCURRENCY sets Envoy's worker thread count (default: auto-detect, 0 means use all cores)
 # APIP_GW_POLICY_ENGINE_METRICS_ENABLED controls metrics collection (default: true, set false for high-load)
+# APIP_GW_ROUTER_RE2_MAX_PROGRAM_SIZE sets Envoy's RE2 regex program-size error cap (default: 400).
+#   Envoy's built-in default is 100, which is too low for paths with many path parameters
+#   (each [^/]+ segment costs ~10 units; 7 params → program size 115 → RouteConfiguration rejected).
+#   400 covers paths with up to ~30 path parameters. Override if your API has deeper paths.
 export GOMAXPROCS="${GOMAXPROCS:-2}"
 export ROUTER_CONCURRENCY="${ROUTER_CONCURRENCY:-0}"
 export APIP_GW_POLICY_ENGINE_METRICS_ENABLED="${APIP_GW_POLICY_ENGINE_METRICS_ENABLED:-true}"
+export APIP_GW_ROUTER_RE2_MAX_PROGRAM_SIZE="${APIP_GW_ROUTER_RE2_MAX_PROGRAM_SIZE:-400}"
 
 # Python Executor configuration
 export PYTHON_POLICY_WORKERS="${PYTHON_POLICY_WORKERS:-4}"
@@ -146,6 +151,7 @@ log "  Log Level: ${LOG_LEVEL}"
 log "  Policy Engine Socket: ${POLICY_ENGINE_SOCKET}"
 log "  GOMAXPROCS: ${GOMAXPROCS}"
 log "  Router Concurrency: ${ROUTER_CONCURRENCY}"
+log "  Router RE2 Max Program Size: ${APIP_GW_ROUTER_RE2_MAX_PROGRAM_SIZE}"
 log "  Policy Engine Metrics: ${APIP_GW_POLICY_ENGINE_METRICS_ENABLED}"
 log "  Python Workers: ${PYTHON_POLICY_WORKERS}"
 log "  Python Max Concurrent: ${PYTHON_POLICY_MAX_CONCURRENT}"

--- a/gateway/gateway-runtime/router/config/config-override.yaml
+++ b/gateway/gateway-runtime/router/config/config-override.yaml
@@ -16,6 +16,19 @@
 # under the License.
 # --------------------------------------------------------------------
 
+layered_runtime:
+  layers:
+    - name: static_layer
+      static_layer:
+        re2:
+          max_program_size:
+            # Raise the RE2 program size cap above Envoy's default of 100.
+            # Deep parameterized paths (e.g. 7 path params) generate regexes whose RE2
+            # program size exceeds 100, causing Envoy to reject the entire RouteConfiguration.
+            # Each [^/]+ segment costs ~10 program-size units; 400 covers paths with up to
+            # ~30 path parameters. Override at runtime via APIP_GW_ROUTER_RE2_MAX_PROGRAM_SIZE.
+            error_level: ${APIP_GW_ROUTER_RE2_MAX_PROGRAM_SIZE}
+
 static_resources:
   clusters:
     - name: xds_cluster


### PR DESCRIPTION
## Purpose

Envoy's default `re2.max_program_size.error_level` of 100 is too low for APIs with deeply nested parameterized paths. Each `[^/]+` path parameter segment costs ~10 RE2 program-size units, so a path with 7 parameters reaches a program size of ~115, exceeding the cap. When any single route regex exceeds the limit, Envoy rejects the entire RouteConfiguration — taking down all routes on the gateway, not just the offending one.

Resolves #2626

## Approach

- Add a `layered_runtime` static layer to `config-override.yaml` that sets `re2.max_program_size.error_level` from env var `APIP_GW_ROUTER_RE2_MAX_PROGRAM_SIZE`
- Default the env var to `400` in both `docker-entrypoint.sh` and `docker-entrypoint-debug.sh` (covers ~30 path parameters, well beyond any realistic API design)
- Log the configured value at startup alongside other performance tuning vars
- The `RegexMatcher.GoogleRE2.max_program_size` xDS proto field is not used — it was deprecated in Envoy v1.15 and is ignored in v1.38; `layered_runtime` is the only supported mechanism
- No per-request performance impact: RE2 matching is O(input length) regardless of program size; the only cost is NFA compilation at xDS push time

## Related Issues

Resolves #2626

## Validation

Validated on a live k3s cluster (colima, Envoy v1.38) with an API carrying shallow routes and deep parameterized routes alongside each other.

**API deployed:**
```yaml
operations:
  # Shallow routes
  - { method: GET,  path: /simple }
  - { method: GET,  path: /users/{userId} }
  - { method: POST, path: /orgs/{orgId}/repos }
  # Deep routes — each [^/]+ segment costs ~10 RE2 program-size units
  - { method: GET,  path: /a/{p1}/b/{p2}/c/{p3}/d/{p4}/e/{p5}/f/{p6}/g/{p7} }       # ~115 program size
  - { method: POST, path: /a/{p1}/b/{p2}/c/{p3}/d/{p4}/e/{p5}/f/{p6}/g/{p7} }       # ~115 program size
  - { method: PUT,  path: /a/{p1}/b/{p2}/c/{p3}/d/{p4}/e/{p5}/f/{p6}/g/{p7}/h/{p8} } # ~125 program size
```

**Envoy runtime after fix:**
```
re2.max_program_size.error_level: 400
```

**Route responses (all HTTP 200):**
```
GET  /deep/simple                              → 200
GET  /deep/users/123                           → 200
POST /deep/orgs/myorg/repos                    → 200
GET  /deep/a/1/b/2/c/3/d/4/e/5/f/6/g/7       → 200  ← was rejected before fix
POST /deep/a/1/b/2/c/3/d/4/e/5/f/6/g/7       → 200  ← was rejected before fix
PUT  /deep/a/1/b/2/c/3/d/4/e/5/f/6/g/7/h/8   → 200  ← was rejected before fix
```

Before the fix, deploying any route with ≥7 path parameters would cause Envoy to reject the entire RouteConfiguration, returning 404 for every route on the gateway.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes