### PR TITLE
Fix Security key issue

### DIFF
--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/AddNewProvider/serviceProviderTypes.ts
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/AddNewProvider/serviceProviderTypes.ts
@@ -27,8 +27,6 @@ export type FormState = {
   upstreamAuthHeader: string;
   upstreamAuthValue: string;
   valuePrefix: string;
-  securityKeyName: string;
-  securityKeyPrefix: string;
 };
 
 export type GuardrailSelection = {

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderNew.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderNew.tsx
@@ -111,14 +111,6 @@ function TemplateBasedFormFieldsContainer({
         : prev.upstreamAuthHeader,
       upstreamAuthValue: templateChanged ? '' : prev.upstreamAuthValue,
       valuePrefix: template?.metadata?.auth?.valuePrefix || '',
-      // Consumer-facing security config (how callers authenticate to our
-      // gateway) mirrors the template's upstream auth metadata, when present.
-      securityKeyName: templateChanged
-        ? template?.metadata?.auth?.header || 'X-API-Key'
-        : prev.securityKeyName,
-      securityKeyPrefix: templateChanged
-        ? template?.metadata?.auth?.valuePrefix || ''
-        : prev.securityKeyPrefix,
     }));
 
     // Resolve OpenAPI spec. Prefer the inline spec stored on the template
@@ -206,8 +198,6 @@ export default function ServiceProviderNew() {
     upstreamAuthHeader: 'Authorization',
     upstreamAuthValue: '',
     valuePrefix: '',
-    securityKeyName: 'X-API-Key',
-    securityKeyPrefix: '',
   });
   const isVersionValid = VERSION_PATTERN.test(formState.version.trim());
   const [fieldErrors, setFieldErrors] = useState<Partial<Record<keyof FormState, string>>>({});
@@ -370,11 +360,8 @@ export default function ServiceProviderNew() {
         enabled: true,
         apiKey: {
           enabled: true,
-          key: formState.securityKeyName || 'X-API-Key',
+          key: 'X-API-Key',
           in: 'header' as const,
-          ...(formState.securityKeyPrefix
-            ? { keyPrefix: formState.securityKeyPrefix }
-            : {}),
         },
       };
 

--- a/portals/ai-workspace/src/utils/tmpSPRequest.ts
+++ b/portals/ai-workspace/src/utils/tmpSPRequest.ts
@@ -127,7 +127,7 @@ export function buildFullProviderRequest(
     modelProviders:
       request.modelProviders ?? buildModelProvidersFromTemplate(request.template),
     rateLimiting: {},
-    security: request.security ?? {
+    security: {
       enabled: true,
       apiKey: {
         enabled: true,


### PR DESCRIPTION
This pull request simplifies the handling of security key configuration for service providers by removing user-configurable fields and standardizing the security key to use a default value. The changes ensure consistency in how API keys are handled across the service provider setup flow.

issue: https://github.com/wso2/api-platform/issues/2628

**Security Key Configuration Simplification:**

* Removed `securityKeyName` and `securityKeyPrefix` from the `FormState` type and all related logic, eliminating user-facing customization of these fields. [[1]](diffhunk://#diff-5b4fb78875a38dc2a55c4375a826cd4afdca403437fb3cee7e0ddc5d28671f2eL30-L31) [[2]](diffhunk://#diff-5f3cfa9035307148cacb9a695d1cde1ebe05c3b5c50435d0f5ec42d6bfa6280dL114-L121) [[3]](diffhunk://#diff-5f3cfa9035307148cacb9a695d1cde1ebe05c3b5c50435d0f5ec42d6bfa6280dL209-L210)
* Updated the service provider creation logic to always use `'X-API-Key'` as the security key name, removing conditional logic for key prefix.
* Standardized the security configuration in `buildFullProviderRequest` to always set the security section explicitly, regardless of the request input.