### PR TITLE
[AI GATEWAY] Rename openai-header-router policy to llm-header-router in multi provider routing

### DIFF
--- a/gateway/examples/openai-multi-provider-proxy.yaml
+++ b/gateway/examples/openai-multi-provider-proxy.yaml
@@ -18,7 +18,7 @@
 #     router in front of it. With no "selected_provider" in the request
 #     metadata the translator runs unconditionally.
 #
-#   * Multi-provider mode    — put openai-header-router first. It writes
+#   * Multi-provider mode    — put llm-header-router first. It writes
 #     the chosen provider into metadata["selected_provider"]. Each
 #     translator then runs only when that selection equals its own "id".
 #     The "id" doubles as the upstream cluster name, so it must match an
@@ -98,7 +98,7 @@ spec:
           params:
             key: X-API-Key
             in: header
-    - name: openai-header-router
+    - name: llm-header-router
       version: v1
       paths:
         - path: /chat/completions

--- a/gateway/gateway-controller/pkg/utils/llm_transformer_multiprovider_test.go
+++ b/gateway/gateway-controller/pkg/utils/llm_transformer_multiprovider_test.go
@@ -101,7 +101,7 @@ func TestLLMProviderTransformer_TransformProxy_AdditionalProviderAuthIsCondition
 				},
 			}},
 			Policies: &[]api.LLMPolicy{{
-				Name:    "openai-header-router",
+				Name:    "llm-header-router",
 				Version: "v1",
 				Paths: []api.LLMPolicyPath{{
 					Path:    "/chat/completions",


### PR DESCRIPTION
## Purpose

The header-based provider-selection policy added for LLM multi-provider routing in #2586 was named `openai-header-router`. That name is misleading: the policy is **not** OpenAI-specific — it selects among *any* configured LLM provider (Anthropic, Azure OpenAI, Mistral, Gemini, AWS Bedrock, …) based on a request header, writing the choice into `metadata["selected_provider"]`. The `openai-` prefix implies an OpenAI-only scope and confuses users wiring up non-OpenAI backends.

This PR renames the policy references to the provider-agnostic `llm-header-router`, as a follow-up cleanup to the multi-provider routing introduced in #2586.

Relates to #2586.

## Goals

- Rename the api-platform references `openai-header-router` → `llm-header-router` so they match the renamed policy.
- Keep the change surgical and reference-only — no behavioural change.

## Approach

Pure string rename across the only two files in this repo that reference the policy by name (confirmed with a full-clone grep):

| File | Change |
|---|---|
| `gateway/examples/openai-multi-provider-proxy.yaml` | doc comment + `policies[].name` → `llm-header-router` |
| `gateway/gateway-controller/pkg/utils/llm_transformer_multiprovider_test.go` | test fixture `Name` → `llm-header-router` |

No transformer/controller logic is touched. The router policy name is a free-form string in the proxy config, and `LLMProviderTransformer.Transform` passes user policy names through as-is (it does not validate them against a catalog), so this is a safe reference update. The actual policy rename — directory, Go package, `PolicyName` constant, `policy-definition.yaml`, and `go.mod` module path — lands in the `wso2/gateway-controllers` policy repository (companion change). **Both must merge together**, otherwise the example/test reference a policy name the gateway build does not yet contain.

## User stories

- As an operator configuring an LLM proxy that fans out to multiple providers, the routing policy name (`llm-header-router`) reflects that it routes among **any** provider — not just OpenAI — removing confusion when setting up Anthropic / Gemini / Bedrock / Mistral / Azure OpenAI backends.

## Documentation

N/A — no committed product documentation references the policy name; the multi-provider proxy **example** (`gateway/examples/openai-multi-provider-proxy.yaml`) doubles as the sample and is updated in this PR.

## Automation tests

- **Unit tests**
  - `TestLLMProviderTransformer_TransformProxy_AdditionalProviderAuthIsConditional` uses the policy name in its fixture; updated to `llm-header-router` and passing. Sibling `...TransformerIsConditional` also green.
  - No coverage delta — the change is reference-only, not new logic. `gofmt` clean.
- **Integration tests**
  - N/A — no integration/BDD test references this policy name; runtime behaviour is unchanged.

## Security checks

- Followed secure coding standards (WSO2 secure engineering guidelines)? **yes** — reference-only rename; no logic or security surface changed.
- Ran FindSecurityBugs plugin and verified report? **N/A** — no Java / security-relevant code changed (Go + YAML string rename only).
- Confirmed this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes** — verified; the diff is a 3-line string rename across 2 files.

## Samples

`gateway/examples/openai-multi-provider-proxy.yaml` — the multi-provider proxy sample now attaches the router as `llm-header-router`. Applied via `ap gateway apply -f gateway/examples/openai-multi-provider-proxy.yaml` (or `POST /llm-proxies` on the gateway-controller) once the renamed policy is present in the gateway build.

## Related PRs

- **#2586** — [AI Gateway] Add multi-provider routing for LLM proxies (introduced the `openai-header-router` policy this renames).
- **#2590** — [FIX] Address further review comments on multi-provider routing (prior review-comment thread on the same branch).
- Companion policy rename in **`wso2/gateway-controllers`** (the actual `llm-header-router` policy source) — _add link_ — **must merge in lockstep** with this PR.

## Test environment

- Go 1.26.x
- macOS (darwin) / Linux
- JDK / Database / Browser: N/A (no Java, DB, or UI changes)
- Verified: `go test ./pkg/utils/ -run TestLLMProviderTransformer_TransformProxy_AdditionalProvider` → PASS
