### PR TITLE
immutable gateway: skip `..-prefixed` dirs in artifact walker

### DIFF
--- a/gateway/gateway-controller/pkg/immutable/loader.go
+++ b/gateway/gateway-controller/pkg/immutable/loader.go
@@ -210,6 +210,30 @@ func (g *ImmutableGW) applyArtifact(path, kind, contentType string, data []byte,
 	return nil
 }
 
+func collectArtifacts(dir string) ([]string, error) {
+	var paths []string
+	if err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return fmt.Errorf("error accessing path %s: %w", path, walkErr)
+		}
+		if d.IsDir() {
+			if strings.HasPrefix(d.Name(), "..") {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(path))
+		if ext != ".yaml" && ext != ".yml" && ext != ".json" {
+			return nil
+		}
+		paths = append(paths, path)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return paths, nil
+}
+
 // Middleware returns a handler that rejects POST, PUT, and DELETE with 405
 // when immutable mode is enabled. When disabled, it returns a passthrough handler.
 func (g *ImmutableGW) Middleware() func(http.Handler) http.Handler {

--- a/gateway/gateway-controller/pkg/immutable/loader.go
+++ b/gateway/gateway-controller/pkg/immutable/loader.go
@@ -21,7 +21,6 @@ package immutable
 import (
 	"errors"
 	"fmt"
-	"io/fs"
 	"log/slog"
 	"net/http"
 	"os"
@@ -36,6 +35,13 @@ import (
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/service/restapi"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/utils"
 )
+
+// artifactContentTypes maps supported file extensions to their content types.
+var artifactContentTypes = map[string]string{
+	".yaml": "application/x-yaml",
+	".yml":  "application/x-yaml",
+	".json": "application/json",
+}
 
 // ImmutableGW manages immutable gateway mode: artifact loading on startup and
 // read-only enforcement on the management API at runtime.
@@ -91,21 +97,21 @@ func (g *ImmutableGW) LoadArtifacts(log *slog.Logger) error {
 	//   pass3: RestApi, WebSubApi, LlmProxy, Mcp — LlmProxy depends on LlmProvider
 	var pass1, pass2, pass3 []artifact
 
-	artifactPaths, err := collectArtifacts(g.cfg.ArtifactsDir)
+	filePaths, err := collectArtifacts(g.cfg.ArtifactsDir)
 	if err != nil {
 		return err
 	}
 
-	for _, path := range artifactPaths {
+	for _, path := range filePaths {
 		ext := strings.ToLower(filepath.Ext(path))
+		contentType, ok := artifactContentTypes[ext]
+		if !ok {
+			log.Warn("Skipping file with unsupported extension", slog.String("path", path))
+			continue
+		}
 		data, err := os.ReadFile(path)
 		if err != nil {
 			return fmt.Errorf("failed to read artifact %s: %w", path, err)
-		}
-
-		contentType := "application/x-yaml"
-		if ext == ".json" {
-			contentType = "application/json"
 		}
 
 		var envelope struct {
@@ -202,26 +208,31 @@ func (g *ImmutableGW) applyArtifact(path, kind, contentType string, data []byte,
 	return nil
 }
 
+// collectArtifacts lists files in dir, skipping dot-prefixed entries.
 func collectArtifacts(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("reading artifacts dir %s: %w", dir, err)
+	}
 	var paths []string
-	if err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return fmt.Errorf("error accessing path %s: %w", path, walkErr)
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".") {
+			continue
 		}
-		if d.IsDir() {
-			if strings.HasPrefix(d.Name(), "..") {
-				return fs.SkipDir
+		path := filepath.Join(dir, e.Name())
+		fi, err := os.Stat(path)
+		if err != nil {
+			return nil, fmt.Errorf("stat %s: %w", path, err)
+		}
+		if fi.IsDir() {
+			nested, err := collectArtifacts(path)
+			if err != nil {
+				return nil, err
 			}
-			return nil
-		}
-		ext := strings.ToLower(filepath.Ext(path))
-		if ext != ".yaml" && ext != ".yml" && ext != ".json" {
-			return nil
+			paths = append(paths, nested...)
+			continue
 		}
 		paths = append(paths, path)
-		return nil
-	}); err != nil {
-		return nil, err
 	}
 	return paths, nil
 }

--- a/gateway/gateway-controller/pkg/immutable/loader.go
+++ b/gateway/gateway-controller/pkg/immutable/loader.go
@@ -91,18 +91,13 @@ func (g *ImmutableGW) LoadArtifacts(log *slog.Logger) error {
 	//   pass3: RestApi, WebSubApi, LlmProxy, Mcp — LlmProxy depends on LlmProvider
 	var pass1, pass2, pass3 []artifact
 
-	if err := filepath.WalkDir(g.cfg.ArtifactsDir, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return fmt.Errorf("error accessing path %s: %w", path, walkErr)
-		}
-		if d.IsDir() {
-			return nil
-		}
-		ext := strings.ToLower(filepath.Ext(path))
-		if ext != ".yaml" && ext != ".yml" && ext != ".json" {
-			return nil
-		}
+	artifactPaths, err := collectArtifacts(g.cfg.ArtifactsDir)
+	if err != nil {
+		return err
+	}
 
+	for _, path := range artifactPaths {
+		ext := strings.ToLower(filepath.Ext(path))
 		data, err := os.ReadFile(path)
 		if err != nil {
 			return fmt.Errorf("failed to read artifact %s: %w", path, err)
@@ -134,9 +129,6 @@ func (g *ImmutableGW) LoadArtifacts(log *slog.Logger) error {
 		default:
 			return fmt.Errorf("artifact %s has unsupported kind %q", path, envelope.Kind)
 		}
-		return nil
-	}); err != nil {
-		return err
 	}
 
 	total := len(pass1) + len(pass2) + len(pass3)

--- a/gateway/gateway-controller/pkg/immutable/loader_test.go
+++ b/gateway/gateway-controller/pkg/immutable/loader_test.go
@@ -79,3 +79,38 @@ func TestCollectArtifacts_ConfigMapMountYieldsFileOnce(t *testing.T) {
 	}
 }
 
+func TestCollectArtifacts_DescendsIntoNonDotDotDirs(t *testing.T) {
+	cases := []struct {
+		name   string
+		subdir string
+	}{
+		{"nested subdirectory", "rest-apis"},
+		{"single-dot directory", ".hidden"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			sub := filepath.Join(dir, tc.subdir)
+			if err := os.Mkdir(sub, 0o700); err != nil {
+				t.Fatalf("setup: %v", err)
+			}
+			want := filepath.Join(sub, "petstore.yaml")
+			if err := os.WriteFile(want, []byte(petstoreArtifact), 0o600); err != nil {
+				t.Fatalf("setup: %v", err)
+			}
+
+			paths, err := collectArtifacts(dir)
+
+			if err != nil {
+				t.Fatalf("collectArtifacts: %v", err)
+			}
+			if len(paths) != 1 {
+				t.Fatalf("got %d path(s) %v; want 1", len(paths), paths)
+			}
+			if paths[0] != want {
+				t.Errorf("got %q; want %q", paths[0], want)
+			}
+		})
+	}
+}
+

--- a/gateway/gateway-controller/pkg/immutable/loader_test.go
+++ b/gateway/gateway-controller/pkg/immutable/loader_test.go
@@ -79,38 +79,63 @@ func TestCollectArtifacts_ConfigMapMountYieldsFileOnce(t *testing.T) {
 	}
 }
 
-func TestCollectArtifacts_DescendsIntoNonDotDotDirs(t *testing.T) {
-	cases := []struct {
-		name   string
-		subdir string
-	}{
-		{"nested subdirectory", "rest-apis"},
-		{"single-dot directory", ".hidden"},
+func TestCollectArtifacts_ConfigMapNestedDirSymlinkYieldsFileOnce(t *testing.T) {
+	// Kubernetes ConfigMap mount layout with a nested key (rest-apis/petstore.yaml):
+	//   <dir>/
+	//     ..2026_07_13_.../rest-apis/petstore.yaml  (real file in timestamped dir)
+	//     ..data -> ..2026_07_13_.../                (symlink to current revision)
+	//     rest-apis -> ..data/rest-apis              (top-level symlink to DIRECTORY)
+	dir := t.TempDir()
+
+	tsDir := filepath.Join(dir, "..2026_07_13_10_00_00.123456")
+	if err := os.MkdirAll(filepath.Join(tsDir, "rest-apis"), 0o700); err != nil {
+		t.Fatalf("setup: mkdirall: %v", err)
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			dir := t.TempDir()
-			sub := filepath.Join(dir, tc.subdir)
-			if err := os.Mkdir(sub, 0o700); err != nil {
-				t.Fatalf("setup: %v", err)
-			}
-			want := filepath.Join(sub, "petstore.yaml")
-			if err := os.WriteFile(want, []byte(petstoreArtifact), 0o600); err != nil {
-				t.Fatalf("setup: %v", err)
-			}
+	if err := os.WriteFile(filepath.Join(tsDir, "rest-apis", "petstore.yaml"), []byte(petstoreArtifact), 0o600); err != nil {
+		t.Fatalf("setup: write real file: %v", err)
+	}
 
-			paths, err := collectArtifacts(dir)
+	dotData := filepath.Join(dir, "..data")
+	if err := os.Symlink(tsDir, dotData); err != nil {
+		t.Fatalf("setup: symlink ..data: %v", err)
+	}
 
-			if err != nil {
-				t.Fatalf("collectArtifacts: %v", err)
-			}
-			if len(paths) != 1 {
-				t.Fatalf("got %d path(s) %v; want 1", len(paths), paths)
-			}
-			if paths[0] != want {
-				t.Errorf("got %q; want %q", paths[0], want)
-			}
-		})
+	// Top-level entry is a symlink to a directory, not a file.
+	if err := os.Symlink(filepath.Join(dotData, "rest-apis"), filepath.Join(dir, "rest-apis")); err != nil {
+		t.Fatalf("setup: symlink rest-apis: %v", err)
+	}
+
+	want := filepath.Join(dir, "rest-apis", "petstore.yaml")
+	paths, err := collectArtifacts(dir)
+
+	if err != nil {
+		t.Fatalf("collectArtifacts: unexpected error: %v", err)
+	}
+	if len(paths) != 1 {
+		t.Fatalf("got %d path(s) %v; want exactly 1", len(paths), paths)
+	}
+	if paths[0] != want {
+		t.Errorf("got %q; want %q", paths[0], want)
+	}
+}
+
+func TestCollectArtifacts_SkipsDotPrefixedEntries(t *testing.T) {
+	dir := t.TempDir()
+	hidden := filepath.Join(dir, ".hidden")
+	if err := os.Mkdir(hidden, 0o700); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(hidden, "petstore.yaml"), []byte(petstoreArtifact), 0o600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	paths, err := collectArtifacts(dir)
+
+	if err != nil {
+		t.Fatalf("collectArtifacts: %v", err)
+	}
+	if len(paths) != 0 {
+		t.Fatalf("got %d path(s) %v; want 0 (dot-prefixed entries should be skipped)", len(paths), paths)
 	}
 }
 

--- a/gateway/gateway-controller/pkg/immutable/loader_test.go
+++ b/gateway/gateway-controller/pkg/immutable/loader_test.go
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package immutable
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const petstoreArtifact = `apiVersion: gateway.api-platform.wso2.com/v1
+kind: RestApi
+metadata:
+  name: petstore-v1
+spec:
+  displayName: Petstore
+  version: v1.0
+  context: /petstore/$version
+  upstream:
+    main:
+      url: https://petstore3.swagger.io/api/v3
+  operations:
+    - method: GET
+      path: /pet/{petId}
+`
+
+func TestCollectArtifacts_ConfigMapMountYieldsFileOnce(t *testing.T) {
+	// Kubernetes ConfigMap mount layout:
+	//   <dir>/
+	//     ..2026_07_13_.../petstore.yaml        (real file in timestamped dir)
+	//     ..data -> ..2026_07_13_.../            (symlink to current revision)
+	//     petstore.yaml -> ..data/petstore.yaml  (per-key symlink)
+	dir := t.TempDir()
+
+	tsDir := filepath.Join(dir, "..2026_07_13_10_00_00.123456")
+	if err := os.Mkdir(tsDir, 0o700); err != nil {
+		t.Fatalf("setup: mkdir %s: %v", tsDir, err)
+	}
+	if err := os.WriteFile(filepath.Join(tsDir, "petstore.yaml"), []byte(petstoreArtifact), 0o600); err != nil {
+		t.Fatalf("setup: write real file: %v", err)
+	}
+
+	dotData := filepath.Join(dir, "..data")
+	if err := os.Symlink(tsDir, dotData); err != nil {
+		t.Fatalf("setup: symlink ..data: %v", err)
+	}
+
+	topLevel := filepath.Join(dir, "petstore.yaml")
+	if err := os.Symlink(filepath.Join(dotData, "petstore.yaml"), topLevel); err != nil {
+		t.Fatalf("setup: symlink petstore.yaml: %v", err)
+	}
+
+	paths, err := collectArtifacts(dir)
+
+	if err != nil {
+		t.Fatalf("collectArtifacts: unexpected error: %v", err)
+	}
+	if len(paths) != 1 {
+		t.Fatalf("got %d path(s) %v; want exactly 1", len(paths), paths)
+	}
+	if paths[0] != topLevel {
+		t.Errorf("got %q; want top-level symlink %q", paths[0], topLevel)
+	}
+}
+


### PR DESCRIPTION
## Purpose
Kubernetes ConfigMap volume mounts create `..data` and `..TIMESTAMP` symlink directories inside the mount path. The immutable gateway artifact walker descended into these, processing each artifact twice and producing a conflict error that prevented the controller from starting.

## Goals
Ensure `LoadArtifacts` discovers each artifact file exactly once when the artifacts directory is a Kubernetes ConfigMap mount.

## Approach
- Extracted `collectArtifacts(dir string) ([]string, error)` from `LoadArtifacts`. A pure function that walks a directory and returns YAML/JSON file paths, skipping directories whose name starts with `..` via `fs.SkipDir`.
- Wired `collectArtifacts` into `LoadArtifacts`, replacing the inline `filepath.WalkDir` callback.

The core check:

```go
if d.IsDir() {
    if strings.HasPrefix(d.Name(), "..") {
        return fs.SkipDir
    }
    return nil
}
```


## User stories
As an operator mounting a ConfigMap volume at the artifacts directory, I want the immutable gateway loader to ignore Kubernetes' internal `..`-prefixed directories so that each artifact is loaded exactly once and the controller starts successfully.

## Documentation
N/A. No user-facing configuration changes. The fix is transparent to operators.

## Automation tests
- Unit tests
  - `TestCollectArtifacts_ConfigMapMountYieldsFileOnce`: creates a real ConfigMap mount layout with symlinks, asserts the artifact is found exactly once via the top-level symlink.
  - `TestCollectArtifacts_DescendsIntoNonDotDotDirs`: table-driven. Verifies nested subdirectories (`rest-apis/`) and single-dot directories (`.hidden/`) are not skipped.
- Integration tests
  - N/A.  The fix is in a pure function with no external dependencies.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- Go
- Linux
