### PR TITLE
docs(gateway): fix doc link in distribution README

### DIFF
--- a/gateway/distribution/README.md
+++ b/gateway/distribution/README.md
@@ -176,11 +176,11 @@ This produces two images:
 
 Update the image references in `docker-compose.yaml` to use your custom builds.
 
-See the [API Platform CLI documentation](https://apim.docs.wso2.com/en/latest/api-platform/gateway/) for full build options.
+See the [WSO2 API Platform documentation](https://wso2.com/api-platform/docs/) (Tools section) for CLI usage and full build options.
 
 ## License
 
-Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com)
+Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com)
 
 Licensed under the Apache License, Version 2.0. You may obtain a copy of the License at
 http://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
## Purpose

The distribution README added in #2639 contained a stale deep link (`apim.docs.wso2.com/en/latest/api-platform/gateway/`) that is likely to break as the documentation site is reorganised over time.

## Goals

Replace the specific deep link with a stable top-level docs URL so it remains valid regardless of page-level reorganisation.

## Approach

- Replace `https://apim.docs.wso2.com/en/latest/api-platform/gateway/` with `https://wso2.com/api-platform/docs/` and add a "(Tools section)" pointer to guide users to the right area.

## User stories

As a user reading the distribution README, I want doc links that don't go stale so I can always reach the relevant documentation.

## Documentation

N/A — this change is itself a documentation fix.

## Automation tests

- Unit tests: N/A
- Integration tests: N/A

## Security checks

- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin: N/A (no code changes)
- Confirmed no keys, passwords, tokens, or secrets committed: yes

## Samples

N/A

## Related PRs

Follows #2639 (adds the distribution README this PR fixes).

## Test environment

N/A