### PR TITLE
[AI GATEWAY] Add AWS Bedrock multi-provider support

### DIFF
--- a/gateway/examples/bedrock-openai-proxy.yaml
+++ b/gateway/examples/bedrock-openai-proxy.yaml
@@ -1,0 +1,54 @@
+# --------------------------------------------------------------------
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+# --------------------------------------------------------------------
+
+# --------------------------------------------------------------------
+# OpenAI -> AWS Bedrock LLM Proxy (single-provider)
+#
+# Exposes an OpenAI-shaped /chat/completions endpoint that the
+# `openai-to-bedrock-transformer` policy translates into Bedrock's Converse API format
+# (path /model/{modelId}/converse[-stream], body rewrite) and forwards to the
+# existing `bedrock-provider` upstream. For streaming requests the policy
+# decodes Bedrock's binary Amazon event-stream and re-emits OpenAI SSE, so
+# OpenAI clients get `data: {...}` chunks terminated by `data: [DONE]`.
+#
+# Single-provider mode: there is no router in front of the policy, so nothing
+# sets metadata["selected_provider"] and the translator runs on every request.
+#
+# The provider must already be deployed (see bedrock-provider.yaml) with its
+# Bearer key on upstream.auth (the policy does NOT inject the Bedrock key).
+# The provider example's api-key-auth policy expects the proxy to send the
+# issued provider loopback key in X-API-Key.
+# --------------------------------------------------------------------
+
+apiVersion: gateway.api-platform.wso2.com/v1
+kind: LlmProxy
+metadata:
+  name: openai-to-bedrock
+spec:
+  displayName: OpenAI to Bedrock Proxy
+  version: v1.0
+  context: /openai-bedrock
+  provider:
+    id: bedrock-provider
+    auth:
+      type: api-key
+      header: X-API-Key
+      value: REPLACE_WITH_BEDROCK_PROVIDER_LOOPBACK_KEY
+  policies:
+    - name: openai-to-bedrock-transformer
+      version: v1
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            # Bedrock puts the model id in the URL path; the translator builds
+            # /model/<model>/converse[-stream] from this param. Use an inference
+            # profile id your key can invoke (e.g. us.* / eu.*).
+            model: us.amazon.nova-lite-v1:0

--- a/gateway/examples/bedrock-provider.yaml
+++ b/gateway/examples/bedrock-provider.yaml
@@ -1,0 +1,73 @@
+# --------------------------------------------------------------------
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+# --------------------------------------------------------------------
+
+# --------------------------------------------------------------------
+# AWS Bedrock LLM Provider Configuration (native Converse API)
+#
+# Uses the built-in `awsbedrock` template and points to the region-specific
+# Bedrock runtime endpoint. AWS Bedrock now supports Bearer-token auth
+# (Amazon Bedrock API keys) in addition to the legacy SigV4 flow -- this
+# provider uses the Bearer key. Replace the placeholder with a real key and
+# set the URL to the region your key and model access live in.
+#
+# The model id is carried in the URL path (/model/{modelId}/converse), so the
+# awsbedrock template extracts request/response model via location: pathParam
+# (a RE2 capture group), for both /converse and /converse-stream.
+#
+# Auth: upstream.auth is the gateway -> Bedrock vendor auth. The header is
+# Authorization and the value is sent verbatim, so the "Bearer " prefix MUST
+# be included here (the portal auto-prepends it; raw YAML does not). Proxies in
+# front of this provider inherit this vendor auth automatically.
+# --------------------------------------------------------------------
+
+apiVersion: gateway.api-platform.wso2.com/v1
+kind: LlmProvider
+metadata:
+  name: bedrock-provider
+spec:
+  displayName: AWS Bedrock Provider
+  version: v1.0
+  template: awsbedrock
+  context: /bedrock
+  upstream:
+    # Match the region your key/model access is in. For the no-AWS mock
+    # (bedrock-mock.py), use: http://host.docker.internal:9010
+    url: https://bedrock-runtime.us-east-1.amazonaws.com
+    auth:
+      type: api-key
+      header: Authorization
+      # Bedrock expects:  Authorization: Bearer <key>  -- sent verbatim, so the
+      # "Bearer " prefix MUST be included here. The mock ignores the value.
+      value: Bearer REPLACE_WITH_BEDROCK_API_KEY
+  policies:
+    - name: api-key-auth
+      version: v1
+      paths:
+        - path: /model/{modelId}/converse
+          methods: [POST]
+          params:
+            key: X-API-Key
+            in: header
+        - path: /model/{modelId}/converse-stream
+          methods: [POST]
+          params:
+            key: X-API-Key
+            in: header
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /model/{modelId}/converse
+        methods: [POST]
+      - path: /model/{modelId}/converse-stream
+        methods: [POST]
+
+# The proxy in front of this provider authenticates over the internal loopback
+# route with an API key issued for this LlmProvider (see bedrock-testing.md,
+# "Issue a consumer key"). Set the issued value as the proxy's provider.auth.value.

--- a/gateway/examples/openai-multi-provider-proxy.yaml
+++ b/gateway/examples/openai-multi-provider-proxy.yaml
@@ -89,6 +89,16 @@ spec:
         params:
           model: gemini-2.5-flash
           apiVersion: v1beta
+    - id: bedrock-provider
+      auth:
+        type: api-key
+        header: X-API-Key
+        value: REPLACE_WITH_BEDROCK_PROVIDER_LOOPBACK_KEY
+      transformer:
+        type: openai-to-bedrock-transformer
+        version: v1
+        params:
+          model: us.amazon.nova-lite-v1:0
   policies:
     - name: api-key-auth
       version: v1
@@ -117,6 +127,8 @@ spec:
                 provider: mistral-provider
               - headerValue: gemini
                 provider: gemini-provider
+              - headerValue: bedrock
+                provider: bedrock-provider
 
     # - name: token-based-ratelimit
     #   version: v1

--- a/gateway/gateway-controller/default-llm-provider-templates/awsbedrock-template.yaml
+++ b/gateway/gateway-controller/default-llm-provider-templates/awsbedrock-template.yaml
@@ -36,7 +36,7 @@ spec:
     identifier: $.usage.totalTokens
   requestModel:
     location: pathParam
-    identifier: (?<=model/)[a-zA-Z0-9.:-]+(?=/)
+    identifier: model/([A-Za-z0-9.:-]+)/
   responseModel:
     location: pathParam
-    identifier: (?<=model/)[a-zA-Z0-9.:-]+(?=/)
+    identifier: model/([A-Za-z0-9.:-]+)/

--- a/gateway/gateway-controller/pkg/utils/llm_transformer.go
+++ b/gateway/gateway-controller/pkg/utils/llm_transformer.go
@@ -179,15 +179,22 @@ func (t *LLMProviderTransformer) transformProxy(proxy *api.LLMProxyConfiguration
 			if err != nil {
 				return nil, fmt.Errorf("failed to get context for additional provider '%s': %w", ap.Id, err)
 			}
-			addURL := fmt.Sprintf("%s://%s:%d%s",
-				constants.SchemeHTTP, constants.LocalhostIP, t.routerConfig.ListenerPort, addCtx)
-			defs = append(defs, api.UpstreamDefinition{
+			// Named upstream definition URLs are host-only. Keep the provider context
+			// in basePath so dynamic provider routing does not drop it and send the
+			// loopback request to the proxy listener root.
+			addURL := fmt.Sprintf("%s://%s:%d",
+				constants.SchemeHTTP, constants.LocalhostIP, t.routerConfig.ListenerPort)
+			def := api.UpstreamDefinition{
 				Name: name,
 				Upstreams: []struct {
 					Url    string `json:"url" yaml:"url"`
 					Weight *int   `json:"weight,omitempty" yaml:"weight,omitempty"`
 				}{{Url: addURL}},
-			})
+			}
+			if addCtx != "" && addCtx != constants.BASE_PATH {
+				def.BasePath = &addCtx
+			}
+			defs = append(defs, def)
 		}
 		spec.UpstreamDefinitions = &defs
 	}

--- a/gateway/gateway-controller/pkg/utils/llm_transformer_multiprovider_test.go
+++ b/gateway/gateway-controller/pkg/utils/llm_transformer_multiprovider_test.go
@@ -119,6 +119,10 @@ func TestLLMProviderTransformer_TransformProxy_AdditionalProviderAuthIsCondition
 	require.NotNil(t, result.Spec.UpstreamDefinitions)
 	require.Len(t, *result.Spec.UpstreamDefinitions, 1)
 	assert.Equal(t, "anthropic-provider", (*result.Spec.UpstreamDefinitions)[0].Name)
+	require.NotNil(t, (*result.Spec.UpstreamDefinitions)[0].BasePath)
+	assert.Equal(t, "/anthropic-provider", *(*result.Spec.UpstreamDefinitions)[0].BasePath)
+	require.Len(t, (*result.Spec.UpstreamDefinitions)[0].Upstreams, 1)
+	assert.Equal(t, "http://127.0.0.1:8080", (*result.Spec.UpstreamDefinitions)[0].Upstreams[0].Url)
 
 	var chatOp *api.Operation
 	for i := range result.Spec.Operations {

--- a/gateway/system-policies/analytics/analytics.go
+++ b/gateway/system-policies/analytics/analytics.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"log/slog"
 	"reflect"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 
 	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 	"github.com/wso2/api-platform/sdk/core/utils"
@@ -568,7 +570,7 @@ func (a *AnalyticsPolicy) OnResponseBodyChunk(_ context.Context, ctx *policy.Res
 				// Streaming responses are SSE; the last data event carries usage fields.
 				tokenInfo, err := extractLLMProviderAnalyticsInfoFromBytes(
 					template, ctx.RequestHeaders, ctx.ResponseHeaders,
-					requestBodyBytes, accumulated,
+					requestBodyBytes, accumulated, ctx.RequestPath,
 				)
 				if err != nil {
 					slog.Warn("Failed to extract LLM token info from streaming response", "error", err)
@@ -662,7 +664,7 @@ func extractLLMProviderAnalyticsInfo(template map[string]interface{}, ctx *polic
 
 	return extractLLMProviderAnalyticsInfoFromBytes(
 		template, ctx.RequestHeaders, ctx.ResponseHeaders,
-		requestBodyBytes, responseBodyBytes,
+		requestBodyBytes, responseBodyBytes, ctx.RequestPath,
 	)
 }
 
@@ -676,6 +678,7 @@ func extractLLMProviderAnalyticsInfoFromBytes(
 	template map[string]interface{},
 	requestHeaders, responseHeaders *policy.Headers,
 	requestBodyBytes, responseBodyBytes []byte,
+	requestPath string,
 ) (*LLMProviderAnalyticsInfo, error) {
 	var responseJSON map[string]interface{}
 	if len(responseBodyBytes) > 0 {
@@ -693,7 +696,7 @@ func extractLLMProviderAnalyticsInfoFromBytes(
 		_ = json.Unmarshal(requestBodyBytes, &requestJSON)
 	}
 
-	return extractLLMAnalyticsFromJSON(template, requestHeaders, responseHeaders, requestJSON, responseJSON)
+	return extractLLMAnalyticsFromJSON(template, requestHeaders, responseHeaders, requestJSON, responseJSON, requestPath)
 }
 
 // extractLLMAnalyticsFromJSON is the core extraction logic operating on pre-parsed JSON maps.
@@ -701,6 +704,7 @@ func extractLLMAnalyticsFromJSON(
 	template map[string]interface{},
 	requestHeaders, responseHeaders *policy.Headers,
 	requestJSON, responseJSON map[string]interface{},
+	requestPath string,
 ) (*LLMProviderAnalyticsInfo, error) {
 	if template == nil {
 		return nil, fmt.Errorf("template is nil")
@@ -754,6 +758,14 @@ func extractLLMAnalyticsFromJSON(
 				}
 			}
 			return nil, fmt.Errorf("header %s not found", identifier)
+		case "pathparam":
+			// Model ids for providers like AWS Bedrock and Gemini live in the
+			// request URL path (e.g. /model/{modelId}/converse), not the body or
+			// a header. The identifier is a regex whose first capture group (when
+			// present) is the value; otherwise the whole match is used. The path
+			// is available for both buffered and streaming responses, so this
+			// meters the model in either case.
+			return extractPathParam(requestPath, identifier)
 		default:
 			return nil, fmt.Errorf("unsupported location %s", location)
 		}
@@ -804,6 +816,48 @@ func extractLLMAnalyticsFromJSON(
 	}
 
 	return info, nil
+}
+
+// pathParamRegexCache memoises compiled pathParam identifiers so the response
+// data path does not recompile a provider template's regex on every request.
+var pathParamRegexCache sync.Map // map[string]*regexp.Regexp
+
+// extractPathParam applies a pathParam identifier (a regex) to the request URL
+// path and returns the first capture group when the pattern defines one,
+// otherwise the whole match. AWS Bedrock and Gemini carry the model id in the
+// path (e.g. /model/{modelId}/converse), which is why request/response model is
+// declared with `location: pathParam`. The path is present for both buffered
+// and streaming responses, so the model meters in either case. Go's regexp is
+// RE2 — identifiers must use a capture group, not lookaround.
+func extractPathParam(requestPath, pattern string) (string, error) {
+	if requestPath == "" {
+		return "", fmt.Errorf("request path not available")
+	}
+	re, err := compilePathParamRegex(pattern)
+	if err != nil {
+		return "", err
+	}
+	match := re.FindStringSubmatch(requestPath)
+	if match == nil {
+		return "", fmt.Errorf("pathParam identifier did not match request path")
+	}
+	if len(match) > 1 {
+		return match[1], nil
+	}
+	return match[0], nil
+}
+
+// compilePathParamRegex compiles (and caches) a pathParam identifier regex.
+func compilePathParamRegex(pattern string) (*regexp.Regexp, error) {
+	if cached, ok := pathParamRegexCache.Load(pattern); ok {
+		return cached.(*regexp.Regexp), nil
+	}
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("invalid pathParam identifier %q: %w", pattern, err)
+	}
+	pathParamRegexCache.Store(pattern, re)
+	return re, nil
 }
 
 // populateTokenAnalyticsMetadata copies LLM token fields into an analytics metadata map.

--- a/gateway/system-policies/analytics/analytics_bedrock_test.go
+++ b/gateway/system-policies/analytics/analytics_bedrock_test.go
@@ -1,0 +1,134 @@
+package analytics
+
+import "testing"
+
+// TestExtractPathParam covers the pathParam extraction used to meter the model
+// id for providers that carry it in the URL path (AWS Bedrock, Gemini) rather
+// than the body or a header.
+func TestExtractPathParam(t *testing.T) {
+	cases := []struct {
+		name    string
+		path    string
+		pattern string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "bedrock converse model id",
+			path:    "/bedrock/model/us.amazon.nova-lite-v1:0/converse",
+			pattern: "model/([A-Za-z0-9.:-]+)/",
+			want:    "us.amazon.nova-lite-v1:0",
+		},
+		{
+			name:    "bedrock streaming model id",
+			path:    "/bedrock/model/us.anthropic.claude-3-5-sonnet-20240620-v1:0/converse-stream",
+			pattern: "model/([A-Za-z0-9.:-]+)/",
+			want:    "us.anthropic.claude-3-5-sonnet-20240620-v1:0",
+		},
+		{
+			name:    "no capture group returns whole match",
+			path:    "/v1beta/models/gemini-1.5-flash:generateContent",
+			pattern: "models/[A-Za-z0-9.-]+",
+			want:    "models/gemini-1.5-flash",
+		},
+		{
+			name:    "empty path errors",
+			path:    "",
+			pattern: "model/([A-Za-z0-9.:-]+)/",
+			wantErr: true,
+		},
+		{
+			name:    "no match errors",
+			path:    "/bedrock/health",
+			pattern: "model/([A-Za-z0-9.:-]+)/",
+			wantErr: true,
+		},
+		{
+			// Go's regexp is RE2 — lookbehind is unsupported. This is exactly the
+			// class of pattern that must never reach the extractor, which is why
+			// the awsbedrock template uses a capture group instead.
+			name:    "lookbehind pattern rejected by RE2",
+			path:    "/bedrock/model/x/converse",
+			pattern: "(?<=model/)[A-Za-z0-9.:-]+(?=/)",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := extractPathParam(tc.path, tc.pattern)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got value %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExtractLLMAnalyticsBedrockPathParam verifies the AWS Bedrock template
+// shape end-to-end: token counts come from the response payload ($.usage.*)
+// while the model id is taken from the request URL path (location: pathParam),
+// which is the only place native Bedrock exposes it. The path is present on both
+// the buffered and streaming response contexts, so this resolves in either case.
+func TestExtractLLMAnalyticsBedrockPathParam(t *testing.T) {
+	template := map[string]interface{}{
+		"metadata": map[string]interface{}{"name": "awsbedrock"},
+		"spec": map[string]interface{}{
+			"displayName":      "AWS Bedrock",
+			"promptTokens":     map[string]interface{}{"location": "payload", "identifier": "$.usage.inputTokens"},
+			"completionTokens": map[string]interface{}{"location": "payload", "identifier": "$.usage.outputTokens"},
+			"totalTokens":      map[string]interface{}{"location": "payload", "identifier": "$.usage.totalTokens"},
+			"requestModel":     map[string]interface{}{"location": "pathParam", "identifier": "model/([A-Za-z0-9.:-]+)/"},
+			"responseModel":    map[string]interface{}{"location": "pathParam", "identifier": "model/([A-Za-z0-9.:-]+)/"},
+		},
+	}
+
+	// Bedrock Converse numbers arrive as JSON numbers → float64 once unmarshalled.
+	responseJSON := map[string]interface{}{
+		"usage": map[string]interface{}{
+			"inputTokens":  float64(11),
+			"outputTokens": float64(7),
+			"totalTokens":  float64(18),
+		},
+	}
+
+	const requestPath = "/bedrock/model/us.amazon.nova-lite-v1:0/converse"
+
+	info, err := extractLLMAnalyticsFromJSON(template, nil, nil, nil, responseJSON, requestPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.PromptTokens == nil || *info.PromptTokens != 11 {
+		t.Errorf("PromptTokens = %v, want 11", info.PromptTokens)
+	}
+	if info.CompletionTokens == nil || *info.CompletionTokens != 7 {
+		t.Errorf("CompletionTokens = %v, want 7", info.CompletionTokens)
+	}
+	if info.TotalTokens == nil || *info.TotalTokens != 18 {
+		t.Errorf("TotalTokens = %v, want 18", info.TotalTokens)
+	}
+	if info.RequestModel == nil || *info.RequestModel != "us.amazon.nova-lite-v1:0" {
+		t.Errorf("RequestModel = %v, want us.amazon.nova-lite-v1:0", info.RequestModel)
+	}
+	if info.ResponseModel == nil || *info.ResponseModel != "us.amazon.nova-lite-v1:0" {
+		t.Errorf("ResponseModel = %v, want us.amazon.nova-lite-v1:0", info.ResponseModel)
+	}
+
+	// The metadata that actually reaches analytics must carry the resolved model.
+	meta := map[string]any{}
+	populateTokenAnalyticsMetadata(meta, info)
+	if meta[ModelIDMetadataKey] != "us.amazon.nova-lite-v1:0" {
+		t.Errorf("%s = %v, want us.amazon.nova-lite-v1:0", ModelIDMetadataKey, meta[ModelIDMetadataKey])
+	}
+	if meta[PromptTokenCountMetadataKey] != "11" {
+		t.Errorf("%s = %v, want \"11\"", PromptTokenCountMetadataKey, meta[PromptTokenCountMetadataKey])
+	}
+}

--- a/platform-api/resources/default-llm-provider-templates/awsbedrock-template.yaml
+++ b/platform-api/resources/default-llm-provider-templates/awsbedrock-template.yaml
@@ -24,6 +24,17 @@ spec:
   managedBy: wso2
   version: v1.0
   metadata:
+    # AWS Bedrock now supports Bearer-token auth (Amazon Bedrock API keys) in
+    # addition to the legacy SigV4 flow. The gateway injects this as
+    # `Authorization: Bearer <key>`; the portal prepends the `Bearer ` prefix so
+    # the operator only pastes the raw key. endpointUrl is deliberately omitted
+    # because the Bedrock runtime host is region-specific
+    # (https://bedrock-runtime.<region>.amazonaws.com) and must be supplied per
+    # provider.
+    auth:
+      type: apiKey
+      header: Authorization
+      valuePrefix: "Bearer "
     logoUrl: https://raw.githubusercontent.com/nomadxd/openapi-connectors/main/openapi/aws.bedrock/icon.png
     openapiSpecUrl: https://raw.githubusercontent.com/nomadxd/openapi-connectors/main/openapi/aws.bedrock/openapi.yaml
   promptTokens:


### PR DESCRIPTION

## Purpose

AWS Bedrock support is required so AI Gateway users can invoke Bedrock models using Amazon Bedrock API keys and expose them through OpenAI-compatible LLM proxies.

This change addresses the following issues:

- The Bedrock provider metadata did not describe Bearer-token authentication.
- Bedrock model identifiers are carried in the request path, but analytics did not support extracting models from `pathParam`.
- The existing Bedrock model regex used lookbehind, which is unsupported by Go's RE2 regular-expression engine.
- Additional-provider loopback contexts such as `/bedrock` were embedded in named upstream URLs. Named upstream URLs are host-only, so the context was dropped and multi-provider requests returned HTTP 404.
- Sample configurations were needed for deploying a native Bedrock provider and an OpenAI-to-Bedrock proxy.

Related issue: N/A — no issue link was provided.

<!-- Replace the preceding line with `Resolves #<issue-number>` when applicable. -->

## Goals

- Support AWS Bedrock API-key authentication using `Authorization: Bearer <key>`.
- Enable Bedrock model extraction from request paths for analytics.
- Preserve additional-provider contexts during multi-provider routing.
- Support real Bedrock requests through native, single-provider, and multi-provider proxy paths.
- Support OpenAI-compatible non-streaming and streaming Bedrock responses.
- Provide reusable Bedrock provider and proxy samples.
- Add regression coverage for Bedrock analytics and multi-provider base-path handling.

## Approach

- Added Bedrock authentication metadata to the platform provider template.
- Replaced the unsupported lookbehind regex with the following RE2-compatible capture-group expression:

  ```text
  model/([A-Za-z0-9.:-]+)/
  ```

- Added `pathParam` analytics extraction using a cached compiled regular expression.
- Passed the request path through buffered and streaming analytics extraction.
- Updated LLM proxy transformation so named additional-provider upstreams:

  - Use a host-only loopback URL.
  - Preserve the provider context in `upstreamDefinitions[].basePath`.

- Added unit tests covering Bedrock model/token analytics and additional-provider base-path preservation.
- Added sample YAML configurations for:

  - A native AWS Bedrock provider.
  - An OpenAI-to-Bedrock proxy.

No UI changes are included, so no screenshot or animated GIF is required.

## User stories

- As a gateway administrator, I can configure an AWS Bedrock provider using a Bedrock API key and a regional runtime endpoint.
- As an API consumer, I can invoke Bedrock through an OpenAI-compatible chat-completions endpoint.
- As an API consumer, I can select Bedrock through the multi-provider `x-provider` routing header.
- As an API consumer, I can use both non-streaming and streaming Bedrock responses.
- As an operator, I can observe the Bedrock model and token usage in analytics.
- As an operator, I can configure additional providers with non-root contexts without internal loopback routing returning HTTP 404.

## Documentation

N/A — no published product-documentation pages are changed.

The PR includes the following configuration samples:

- `gateway/examples/bedrock-provider.yaml`
- `gateway/examples/bedrock-openai-proxy.yaml`

## Automation tests

### Unit tests

The following tests were executed successfully:

```bash
cd gateway/gateway-controller

go test ./pkg/utils \
  -run 'TestLLMProviderTransformer_TransformProxy_AdditionalProvider' \
  -count=1
```

```bash
cd gateway/system-policies/analytics

go test ./...
```

Coverage was added for:

- Bedrock request-model extraction from path parameters.
- Bedrock response-model extraction.
- Bedrock prompt, completion, and total-token extraction.
- Invalid and non-matching path-parameter expressions.
- Additional-provider loopback URL and base-path preservation.

A numerical coverage percentage was not collected.

### Integration tests

No new automated integration-test feature was added in this PR.

Manual E2E testing was completed against real provider accounts:

- Direct AWS Bedrock Runtime invocation.
- Native Bedrock provider invocation through the gateway.
- OpenAI-to-Bedrock non-streaming proxy request.
- OpenAI-to-Bedrock streaming proxy request.
- Multi-provider routing using `x-provider: bedrock`.
- Multi-provider switching between real Anthropic and AWS Bedrock providers.
- Missing consumer API key returned HTTP 401.
- Bedrock streaming produced OpenAI-compatible SSE chunks.
- Bedrock streaming terminated with `data: [DONE]`.
- Streaming responses included model and token-usage information.

Models tested:

- AWS Bedrock: `us.amazon.nova-lite-v1:0`
- Anthropic routing verification: `claude-sonnet-4-5-20250929`

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **Yes**
- Ran FindSecurityBugs plugin and verified report? **No — not applicable because this PR contains no Java changes**
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **Yes**

The committed sample files contain placeholders only. Real AWS, Anthropic, gateway loopback, and consumer API keys were not committed.

## Samples

### Native Bedrock provider

File:

```text
gateway/examples/bedrock-provider.yaml
```

Demonstrates:

- A region-specific Bedrock Runtime endpoint.
- Bearer-token upstream authentication.
- Native `/model/{model}/converse` and streaming access.
- Gateway consumer API-key authentication.

### OpenAI-to-Bedrock proxy

File:

```text
gateway/examples/bedrock-openai-proxy.yaml
```

Demonstrates:

- An OpenAI-compatible `/chat/completions` endpoint.
- Proxy-to-provider loopback authentication.
- OpenAI request conversion to Bedrock Converse format.
- Bedrock responses converted into OpenAI-compatible responses.

## Related PRs

- Multi-provider routing base branch: `wso2/api-platform:multi-provider-routing`
- Bedrock transformer policy module: Add the related policy-repository PR link here.
- No other related PRs are currently available.

## Test environment

- Operating system: macOS 15.7.7, amd64
- Container runtime: Rancher Desktop
- Docker client: 29.1.4-rd
- Docker context: `rancher-desktop`
- Gateway version: `1.2.0-M2-SNAPSHOT`
- Go version: `go1.26.5 darwin/amd64`
- Database: Gateway controller default embedded SQLite storage
- JDK: N/A — no Java changes; no JDK installed
- Browser: N/A — API and gateway runtime changes only
- AWS environment: Real AWS account with Amazon Bedrock Runtime access
- AWS model: `us.amazon.nova-lite-v1:0`
- Additional provider: Real Anthropic API account
- Anthropic model: `claude-sonnet-4-5-20250929`
- Client tools: `curl`, `jq`, and Docker Compose
