### PR TITLE
ci(helm): fix git tag pointing to wrong commit on draft release publish

### DIFF
--- a/.github/workflows/gateway-helm-release.yml
+++ b/.github/workflows/gateway-helm-release.yml
@@ -90,16 +90,22 @@ jobs:
         run: |
           helm push ${{ env.CHART_NAME }}-${{ inputs.version }}.tgz oci://${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/${{ env.REGISTRY_PATH }}
 
-      - name: Commit version changes
+      - name: Commit and push version changes
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add ${{ env.CHART_PATH }}/Chart.yaml
           if ! git diff --cached --quiet; then
             git commit -m "chore: bump helm-gateway chart version to ${{ inputs.version }}"
+            git push
           else
             echo "No changes to commit"
           fi
+
+      - name: Create and push git tag
+        run: |
+          git tag helm-gateway-${{ inputs.version }}
+          git push origin helm-gateway-${{ inputs.version }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/gateway-helm-release.yml
+++ b/.github/workflows/gateway-helm-release.yml
@@ -19,6 +19,8 @@ env:
   REGISTRY_USERNAME: api-platform-bot
   ORGANIZATION: wso2
   REGISTRY_PATH: api-platform/helm-charts
+  CHART_VERSION: ${{ inputs.version }}
+  APP_VERSION: ${{ inputs.appVersion }}
 
 jobs:
   release-helm-chart:
@@ -31,35 +33,45 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Validate input formats
+        run: |
+          if ! echo "${CHART_VERSION}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9._-]+)?$'; then
+            echo "::error::Invalid version '${CHART_VERSION}'. Expected semver (e.g. 1.0.0 or 1.0.0-alpha.1)."
+            exit 1
+          fi
+          if ! echo "${APP_VERSION}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9._-]+)?$'; then
+            echo "::error::Invalid appVersion '${APP_VERSION}'. Expected v-prefixed semver (e.g. v1.0.0-m4)."
+            exit 1
+          fi
+
       - name: Validate image tags match appVersion
         working-directory: ${{ env.CHART_PATH }}
         run: |
-          APP_VERSION="${{ inputs.appVersion }}"
           CONTROLLER_TAG=$(yq '.gateway.controller.image.tag' values.yaml)
           RUNTIME_TAG=$(yq '.gateway.gatewayRuntime.image.tag' values.yaml)
 
-          echo "App Version: $APP_VERSION"
+          echo "App Version: ${APP_VERSION}"
           echo "Controller image tag: $CONTROLLER_TAG"
           echo "Runtime image tag: $RUNTIME_TAG"
 
           FAILED=false
 
-          if [ "$CONTROLLER_TAG" != "$APP_VERSION" ]; then
-            echo "::error::gateway-controller image tag '$CONTROLLER_TAG' does not match appVersion '$APP_VERSION' in values.yaml"
+          if [ "$CONTROLLER_TAG" != "${APP_VERSION}" ]; then
+            echo "::error::gateway-controller image tag '$CONTROLLER_TAG' does not match appVersion '${APP_VERSION}' in values.yaml"
             FAILED=true
           fi
 
-          if [ "$RUNTIME_TAG" != "$APP_VERSION" ]; then
-            echo "::error::gateway-runtime image tag '$RUNTIME_TAG' does not match appVersion '$APP_VERSION' in values.yaml"
+          if [ "$RUNTIME_TAG" != "${APP_VERSION}" ]; then
+            echo "::error::gateway-runtime image tag '$RUNTIME_TAG' does not match appVersion '${APP_VERSION}' in values.yaml"
             FAILED=true
           fi
 
           if [ "$FAILED" = true ]; then
-            echo "::error::Please update the image tags in ${{ env.CHART_PATH }}/values.yaml to match the appVersion '$APP_VERSION' before releasing."
+            echo "::error::Please update the image tags in ${{ env.CHART_PATH }}/values.yaml to match the appVersion '${APP_VERSION}' before releasing."
             exit 1
           fi
 
-          echo "✅ All image tags match appVersion '$APP_VERSION'"
+          echo "✅ All image tags match appVersion '${APP_VERSION}'"
 
       - name: Install Helm
         uses: azure/setup-helm@v4
@@ -69,8 +81,8 @@ jobs:
       - name: Update Chart version
         working-directory: ${{ env.CHART_PATH }}
         run: |
-          sed -i "s/^version:.*/version: ${{ inputs.version }}/" Chart.yaml
-          sed -i "s/^appVersion:.*/appVersion: \"${{ inputs.appVersion }}\"/" Chart.yaml
+          sed -i "s/^version:.*/version: ${CHART_VERSION}/" Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: \"${APP_VERSION}\"/" Chart.yaml
           echo "Updated Chart.yaml:"
           cat Chart.yaml
 
@@ -88,7 +100,7 @@ jobs:
       - name: Push Helm chart
         working-directory: ${{ env.CHART_PATH }}
         run: |
-          helm push ${{ env.CHART_NAME }}-${{ inputs.version }}.tgz oci://${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/${{ env.REGISTRY_PATH }}
+          helm push "${CHART_NAME}-${CHART_VERSION}.tgz" "oci://${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/${{ env.REGISTRY_PATH }}"
 
       - name: Commit and push version changes
         run: |
@@ -96,7 +108,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add ${{ env.CHART_PATH }}/Chart.yaml
           if ! git diff --cached --quiet; then
-            git commit -m "chore: bump helm-gateway chart version to ${{ inputs.version }}"
+            git commit -m "chore: bump helm-gateway chart version to ${CHART_VERSION}"
             git push
           else
             echo "No changes to commit"
@@ -104,8 +116,9 @@ jobs:
 
       - name: Create and push git tag
         run: |
-          git tag helm-gateway-${{ inputs.version }}
-          git push origin helm-gateway-${{ inputs.version }}
+          TAG="helm-gateway-${CHART_VERSION}"
+          git tag "$TAG"
+          git push origin "refs/tags/$TAG"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -133,13 +146,13 @@ jobs:
         run: |
           echo "### Gateway Helm Chart Released :rocket:" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Chart Name:** \`${{ env.CHART_NAME }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Chart Version:** \`${{ inputs.version }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**App Version:** \`${{ inputs.appVersion }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Git Tag:** \`helm-gateway-${{ inputs.version }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Registry:** \`oci://${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/${{ env.REGISTRY_PATH }}/${{ env.CHART_NAME }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Chart Name:** \`${CHART_NAME}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Chart Version:** \`${CHART_VERSION}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**App Version:** \`${APP_VERSION}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Git Tag:** \`helm-gateway-${CHART_VERSION}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Registry:** \`oci://${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/${{ env.REGISTRY_PATH }}/${CHART_NAME}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "#### Install Command" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-          echo "helm install my-gateway oci://${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/${{ env.REGISTRY_PATH }}/${{ env.CHART_NAME }} --version ${{ inputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "helm install my-gateway oci://${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/${{ env.REGISTRY_PATH }}/${CHART_NAME} --version ${CHART_VERSION}" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Purpose

When the gateway Helm release workflow creates a draft release, GitHub defers tag creation to the moment the draft is published manually. This causes the tag to point to whatever the branch HEAD is at publish time rather than the code that was actually packaged and pushed to the OCI registry. Additionally, the Chart.yaml version bump commit was never pushed to the remote branch.

## Approach

- Push the Chart.yaml version bump commit to the remote branch immediately after committing (fixes the lost commit bug)
- Add an explicit "Create and push git tag" step to anchor the tag to the exact commit that was packaged, before the draft release is created
- When the draft is published, GitHub now uses the pre-existing tag instead of creating a new one at publish time

## Related Issues

N/A

## Documentation

N/A — workflow-only change with no user-facing impact.

## Automation tests

- Unit tests: N/A
- Integration tests: N/A

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

N/A

## Test environment

N/A