### PR TITLE
Refactor terminology from "LLM *" to "AI *" across AI Workspace

### DIFF
--- a/portals/ai-workspace/cypress/e2e/001-providers/001-provider-and-proxy.cy.js
+++ b/portals/ai-workspace/cypress/e2e/001-providers/001-provider-and-proxy.cy.js
@@ -160,7 +160,7 @@ describe('AI Workspace - OpenAI provider and proxy lifecycle', () => {
     );
     cy.contains(providerName, { timeout: 30000 }).should('be.visible');
 
-    cy.contains('button', 'Create App LLM Proxy', { timeout: 30000 })
+    cy.contains('button', 'Create App AI Proxy', { timeout: 30000 })
       .should('be.visible')
       .click();
 
@@ -173,7 +173,7 @@ describe('AI Workspace - OpenAI provider and proxy lifecycle', () => {
       .should('not.be.disabled')
       .click();
 
-    cy.contains('Create App LLM Proxy', { timeout: 30000 }).should(
+    cy.contains('Create App AI Proxy', { timeout: 30000 }).should(
       'be.visible'
     );
     cy.get('input[placeholder="WSO2 OpenAI Provider Proxy"]', {
@@ -196,7 +196,7 @@ describe('AI Workspace - OpenAI provider and proxy lifecycle', () => {
     cy.get('button[aria-label="Delete proxy"]', { timeout: 30000 })
       .should('be.visible')
       .click();
-    cy.contains('Delete App LLM Proxy', { timeout: 30000 }).should('be.visible');
+    cy.contains('Delete App AI Proxy', { timeout: 30000 }).should('be.visible');
     cy.get('[role="dialog"]').within(() => {
       cy.contains('button', 'Delete').click();
     });

--- a/portals/ai-workspace/cypress/e2e/001-providers/003-llm-proxy-secret-management.cy.js
+++ b/portals/ai-workspace/cypress/e2e/001-providers/003-llm-proxy-secret-management.cy.js
@@ -106,11 +106,11 @@ function createProviderViaUI(providerName) {
 }
 
 function navigateToCreateProxy(projectName) {
-  cy.contains('button', 'Create App LLM Proxy', { timeout: 30000 }).should('be.visible').click();
+  cy.contains('button', 'Create App AI Proxy', { timeout: 30000 }).should('be.visible').click();
   cy.contains('label', 'Projects', { timeout: 30000 }).parent().find('[role="combobox"]').click();
   cy.contains('[role="option"]', projectName, { timeout: 15000 }).click();
   cy.contains('button', 'Continue').should('not.be.disabled').click();
-  cy.contains('Create App LLM Proxy', { timeout: 30000 }).should('be.visible');
+  cy.contains('Create App AI Proxy', { timeout: 30000 }).should('be.visible');
 }
 
 // ---------------------------------------------------------------------------

--- a/portals/ai-workspace/cypress/e2e/005-provider-templates/005-custom-provider-template.cy.js
+++ b/portals/ai-workspace/cypress/e2e/005-provider-templates/005-custom-provider-template.cy.js
@@ -79,7 +79,7 @@ describe('AI Workspace - Custom LLM provider template lifecycle', () => {
   it('creates a custom template, versions it, uses it for a provider, and blocks deletion while in use', () => {
     // --- Create the custom template (v1.0) ---------------------------------
     cy.contains('Settings', { timeout: 30000 }).should('be.visible').click();
-    cy.contains('LLM Provider Templates', { timeout: 30000 }).should('be.visible');
+    cy.contains('AI Provider Templates', { timeout: 30000 }).should('be.visible');
 
     cy.get('[data-cyid="add-provider-template-button"]', { timeout: 30000 })
       .scrollIntoView()
@@ -96,7 +96,7 @@ describe('AI Workspace - Custom LLM provider template lifecycle', () => {
       .should('not.be.disabled')
       .click();
 
-    cy.contains('LLM Provider Templates', { timeout: 30000 }).should('be.visible');
+    cy.contains('AI Provider Templates', { timeout: 30000 }).should('be.visible');
     cy.get(`[data-cyid="provider-template-card-${templateV1Id}"]`, {
       timeout: 30000,
     })
@@ -219,7 +219,7 @@ describe('AI Workspace - Custom LLM provider template lifecycle', () => {
     });
 
     // That was the only remaining version, so the whole template is gone.
-    cy.contains('LLM Provider Templates', { timeout: 30000 }).should('be.visible');
+    cy.contains('AI Provider Templates', { timeout: 30000 }).should('be.visible');
     cy.contains(templateName).should('not.exist');
   });
 });

--- a/portals/ai-workspace/src/Components/GatewayDeploy/GatewayDeployConfigDrawer.tsx
+++ b/portals/ai-workspace/src/Components/GatewayDeploy/GatewayDeployConfigDrawer.tsx
@@ -99,7 +99,7 @@ export default function GatewayDeployConfigDrawer({
           value={host}
           onChange={(e) => setHost(e.target.value)}
           fullWidth
-          helperText="Gateway URL of the LLM Provider (optional)"
+          helperText="Gateway URL of the AI Provider (optional)"
         />
 
         <Box sx={{ mt: 'auto', display: 'flex', gap: 2, pt: 2 }}>

--- a/portals/ai-workspace/src/pages/appShell/AppSidebar.tsx
+++ b/portals/ai-workspace/src/pages/appShell/AppSidebar.tsx
@@ -222,7 +222,7 @@ export default function AppSidebar({
                       <Sidebar.ItemIcon>
                         <Handshake size={20} />
                       </Sidebar.ItemIcon>
-                      <Sidebar.ItemLabel>LLM Providers</Sidebar.ItemLabel>
+                      <Sidebar.ItemLabel>AI Providers</Sidebar.ItemLabel>
                     </Sidebar.Item>
                   </NavLink>
                 )}

--- a/portals/ai-workspace/src/pages/appShell/AppSidebar.tsx
+++ b/portals/ai-workspace/src/pages/appShell/AppSidebar.tsx
@@ -236,7 +236,7 @@ export default function AppSidebar({
                       <Sidebar.ItemIcon>
                         <Workflow size={20} />
                       </Sidebar.ItemIcon>
-                      <Sidebar.ItemLabel>App LLM Proxies</Sidebar.ItemLabel>
+                      <Sidebar.ItemLabel>App AI Proxies</Sidebar.ItemLabel>
                     </Sidebar.Item>
                   </NavLink>
                 )}

--- a/portals/ai-workspace/src/pages/appShell/QuickStartIntroPopup.tsx
+++ b/portals/ai-workspace/src/pages/appShell/QuickStartIntroPopup.tsx
@@ -203,7 +203,7 @@ export default function QuickStartIntroPopup({
               color: '#6a6a6c',
             }}
           >
-            Step-by-step guided flows for LLM Providers, MCP Proxies, and more —
+            Step-by-step guided flows for AI Providers, MCP Proxies, and more —
             set up your AI Gateway in minutes.
           </Typography>
 

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/applications/OverviewTabs/APIKeyTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/applications/OverviewTabs/APIKeyTab.tsx
@@ -91,7 +91,7 @@ function resolveMappedKeyId(key: MappedAPIKey): string {
 function formatAssociatedEntityKind(kind?: string): string {
   if (!kind) return '—';
   if (kind === 'LlmProvider') return 'AI Provider';
-  if (kind === 'LlmProxy') return 'App LLM Proxy';
+  if (kind === 'LlmProxy') return 'App AI Proxy';
   return kind;
 }
 

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/applications/OverviewTabs/APIKeyTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/applications/OverviewTabs/APIKeyTab.tsx
@@ -90,7 +90,7 @@ function resolveMappedKeyId(key: MappedAPIKey): string {
 
 function formatAssociatedEntityKind(kind?: string): string {
   if (!kind) return '—';
-  if (kind === 'LlmProvider') return 'LLM Provider';
+  if (kind === 'LlmProvider') return 'AI Provider';
   if (kind === 'LlmProxy') return 'App LLM Proxy';
   return kind;
 }

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/applications/OverviewTabs/AssociationsTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/applications/OverviewTabs/AssociationsTab.tsx
@@ -815,7 +815,7 @@ export default function AssociationsTab() {
     try {
       await loadOrganizationProviders();
     } catch {
-      setProviderDrawerLoadError('Failed to load LLM providers.');
+      setProviderDrawerLoadError('Failed to load AI providers.');
     } finally {
       setIsProviderDrawerLoading(false);
     }
@@ -919,13 +919,13 @@ export default function AssociationsTab() {
       const keyCount = linkedProviderKeyPayload.length;
       showSnackbar(
         providerCount > 0 && keyCount > 0
-          ? `${providerCount} LLM provider${
+          ? `${providerCount} AI provider${
               providerCount > 1 ? 's' : ''
             } associated and ${keyCount} API key${
               keyCount > 1 ? 's' : ''
             } added successfully.`
           : providerCount > 0
-          ? `${providerCount} LLM provider${
+          ? `${providerCount} AI provider${
               providerCount > 1 ? 's' : ''
             } associated successfully.`
           : `${keyCount} API key${keyCount > 1 ? 's' : ''} added successfully.`,
@@ -1120,7 +1120,7 @@ export default function AssociationsTab() {
       });
 
       const label =
-        deleteTarget.kind === 'LlmProvider' ? 'LLM provider' : 'LLM proxy';
+        deleteTarget.kind === 'LlmProvider' ? 'AI provider' : 'LLM proxy';
       setDeleteTarget(null);
       showSnackbar(`${label} association removed successfully.`, 'success');
     } catch (error) {
@@ -1417,7 +1417,7 @@ export default function AssociationsTab() {
 
       <AssociationSelectionDrawer
         open={providerDrawerOpen}
-        title="Add LLM Providers"
+        title="Add AI Providers"
         description="Select providers and their API keys to associate with this application."
         searchPlaceholder="Search providers..."
         searchValue={providerDrawerSearch}
@@ -1427,7 +1427,7 @@ export default function AssociationsTab() {
         isLoading={isProviderDrawerLoading}
         loadError={providerDrawerLoadError}
         items={filteredOrgProviders}
-        emptyStateText="No LLM providers found in this organization."
+        emptyStateText="No AI providers found in this organization."
         emptySearchText="No providers match your search."
         linkedIds={linkedProviderIds}
         selectedIds={selectedProviderIds}
@@ -1766,7 +1766,7 @@ export default function AssociationsTab() {
       >
         <DialogTitle>
           Remove{' '}
-          {deleteTarget?.kind === 'LlmProvider' ? 'LLM Provider' : 'LLM Proxy'}{' '}
+          {deleteTarget?.kind === 'LlmProvider' ? 'AI Provider' : 'LLM Proxy'}{' '}
           association
         </DialogTitle>
         <DialogContent>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/applications/OverviewTabs/AssociationsTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/applications/OverviewTabs/AssociationsTab.tsx
@@ -964,7 +964,7 @@ export default function AssociationsTab() {
     try {
       await loadOrganizationProxies();
     } catch {
-      setProxyDrawerLoadError('Failed to load LLM proxies.');
+      setProxyDrawerLoadError('Failed to load AI proxies.');
     } finally {
       setIsProxyDrawerLoading(false);
     }
@@ -1068,13 +1068,13 @@ export default function AssociationsTab() {
       const keyCount = linkedProxyKeyPayload.length;
       showSnackbar(
         proxyCount > 0 && keyCount > 0
-          ? `${proxyCount} LLM proxy${
+          ? `${proxyCount} AI proxy${
               proxyCount > 1 ? 's' : ''
             } associated and ${keyCount} API key${
               keyCount > 1 ? 's' : ''
             } added successfully.`
           : proxyCount > 0
-          ? `${proxyCount} LLM proxy${
+          ? `${proxyCount} AI proxy${
               proxyCount > 1 ? 's' : ''
             } associated successfully.`
           : `${keyCount} API key${keyCount > 1 ? 's' : ''} added successfully.`,
@@ -1120,7 +1120,7 @@ export default function AssociationsTab() {
       });
 
       const label =
-        deleteTarget.kind === 'LlmProvider' ? 'AI provider' : 'LLM proxy';
+        deleteTarget.kind === 'LlmProvider' ? 'AI provider' : 'AI proxy';
       setDeleteTarget(null);
       showSnackbar(`${label} association removed successfully.`, 'success');
     } catch (error) {
@@ -1311,7 +1311,7 @@ export default function AssociationsTab() {
     selectedCount: selectedProxyIds.size,
     pendingKeyCount: linkedProxyKeyPayload.length,
     entityLabel: 'Proxy',
-    defaultLabel: 'Add LLM Proxy',
+    defaultLabel: 'Add AI Proxy',
   });
 
   const managedIsProvider = manageKeysDrawerTarget?.kind === 'LlmProvider';
@@ -1486,7 +1486,7 @@ export default function AssociationsTab() {
 
       <AssociationSelectionDrawer
         open={proxyDrawerOpen}
-        title="Add LLM Proxies"
+        title="Add AI Proxies"
         description="Select proxies and their API keys to associate with this application."
         searchPlaceholder="Search proxies..."
         searchValue={proxyDrawerSearch}
@@ -1496,7 +1496,7 @@ export default function AssociationsTab() {
         isLoading={isProxyDrawerLoading}
         loadError={proxyDrawerLoadError}
         items={filteredOrgProxies}
-        emptyStateText="No LLM proxies found in this organization."
+        emptyStateText="No AI proxies found in this organization."
         emptySearchText="No proxies match your search."
         linkedIds={linkedProxyIds}
         selectedIds={selectedProxyIds}
@@ -1766,7 +1766,7 @@ export default function AssociationsTab() {
       >
         <DialogTitle>
           Remove{' '}
-          {deleteTarget?.kind === 'LlmProvider' ? 'AI Provider' : 'LLM Proxy'}{' '}
+          {deleteTarget?.kind === 'LlmProvider' ? 'AI Provider' : 'AI Proxy'}{' '}
           association
         </DialogTitle>
         <DialogContent>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/applications/OverviewTabs/AssociationsTable.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/applications/OverviewTabs/AssociationsTable.tsx
@@ -109,7 +109,7 @@ function renderPrimaryActions(
         startIcon={<Plus size={16} />}
         onClick={() => void onOpenProxyDrawer()}
       >
-        Add LLM Proxy
+        Add AI Proxy
       </Button>
     </Stack>
   );
@@ -274,7 +274,7 @@ export default function AssociationsTable({
                             label={
                               association.kind === 'LlmProvider'
                                 ? 'AI Provider'
-                                : 'LLM Proxy'
+                                : 'AI Proxy'
                             }
                             size="small"
                             variant="outlined"

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/applications/OverviewTabs/AssociationsTable.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/applications/OverviewTabs/AssociationsTable.tsx
@@ -101,7 +101,7 @@ function renderPrimaryActions(
         startIcon={<Plus size={16} />}
         onClick={() => void onOpenProviderDrawer()}
       >
-        Add LLM Provider
+        Add AI Provider
       </Button>
       <Button
         variant="contained"
@@ -273,7 +273,7 @@ export default function AssociationsTable({
                           <Chip
                             label={
                               association.kind === 'LlmProvider'
-                                ? 'LLM Provider'
+                                ? 'AI Provider'
                                 : 'LLM Proxy'
                             }
                             size="small"
@@ -466,7 +466,7 @@ export default function AssociationsTable({
           description={
             showNoSearchResults
               ? 'No associations match your search.'
-              : 'Associate LLM providers and proxies to enable AI capabilities for this application.'
+              : 'Associate AI providers and proxies to enable AI capabilities for this application.'
           }
           action={
             showNoSearchResults ? (

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/projects/ExploreMoreCard.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/projects/ExploreMoreCard.tsx
@@ -51,21 +51,21 @@ export default function ExploreMoreCard() {
       ],
     },
     {
-      title: 'LLM Provider Integration',
+      title: 'AI Provider Integration',
       subtitle:
         'Connect, configure, and maintain model providers for your workspace.',
       icon: Server,
       links: [
         {
-          label: 'LLM Providers Overview',
+          label: 'AI Providers Overview',
           href: 'https://wso2.com/bijira/docs/ai-workspace/llm-providers/overview/',
         },
         {
-          label: 'Configure a New LLM Provider',
+          label: 'Configure a New AI Provider',
           href: 'https://wso2.com/bijira/docs/ai-workspace/llm-providers/configure-provider/',
         },
         {
-          label: 'Manage Existing LLM Providers',
+          label: 'Manage Existing AI Providers',
           href: 'https://wso2.com/bijira/docs/ai-workspace/llm-providers/manage-provider/',
         },
       ],

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/projects/ExploreMoreCard.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/projects/ExploreMoreCard.tsx
@@ -71,20 +71,20 @@ export default function ExploreMoreCard() {
       ],
     },
     {
-      title: 'App LLM Proxy Management',
-      subtitle: 'Create and operate App LLM Proxies for secure and governed access.',
+      title: 'App AI Proxy Management',
+      subtitle: 'Create and operate App AI Proxies for secure and governed access.',
       icon: Network,
       links: [
         {
-          label: 'App LLM Proxies Overview',
+          label: 'App AI Proxies Overview',
           href: 'https://wso2.com/bijira/docs/ai-workspace/llm-proxies/overview/',
         },
         {
-          label: 'Create a New App LLM Proxy',
+          label: 'Create a New App AI Proxy',
           href: 'https://wso2.com/api-platform/docs/ai-workspace/llm-proxies/configure-proxy/',
         },
         {
-          label: 'Manage Existing App LLM Proxies',
+          label: 'Manage Existing App AI Proxies',
           href: 'https://wso2.com/bijira/docs/ai-workspace/llm-proxies/manage-proxy/',
         },
       ],

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/projects/ProxyQuickStartBanner.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/projects/ProxyQuickStartBanner.tsx
@@ -467,7 +467,7 @@ export default function ProxyQuickStartBanner() {
                   severity="warning"
                   sx={{ fontSize: 14, maxWidth: 'fit-content' }}
                 >
-                  You need one or more Gateways and LLM Providers please contact
+                  You need one or more Gateways and AI Providers please contact
                   Organization admin.
                 </Alert>
               ) : (

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/projects/ProxyQuickStartBanner.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/projects/ProxyQuickStartBanner.tsx
@@ -326,21 +326,21 @@ export default function ProxyQuickStartBanner() {
     () => [
       {
         id: 'create-proxy',
-        title: 'Create\nApp LLM Proxy',
+        title: 'Create\nApp AI Proxy',
         icon: Plus,
         path: createProxyPath,
         completed: completion.hasProxies,
       },
       {
         id: 'deploy-proxy',
-        title: 'Deploy\nApp LLM Proxy',
+        title: 'Deploy\nApp AI Proxy',
         icon: Rocket,
         path: deployProxyPath,
         completed: completion.hasProxyDeployments,
       },
       {
         id: 'consume-proxy',
-        title: 'Consume\nApp LLM Proxy',
+        title: 'Consume\nApp AI Proxy',
         icon: Package,
         path: consumeProxyPath,
         completed: completion.hasProxyConsumptions,
@@ -458,7 +458,7 @@ export default function ProxyQuickStartBanner() {
                     fontSize: 24,
                   }}
                 >
-                  Expose your 1st App LLM Proxy
+                  Expose your 1st App AI Proxy
                 </Typography>
               </Box>
 

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/CreateProviderTemplate.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/CreateProviderTemplate.tsx
@@ -270,7 +270,7 @@ export default function CreateProviderTemplate() {
           <PageTitle.Header>
             <FormattedMessage
               id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.CreateProviderTemplate.title"
-              defaultMessage={'Add LLM Provider Template'}
+              defaultMessage={'Add AI Provider Template'}
             />
           </PageTitle.Header>
         </PageTitle>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/EditProviderTemplate.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/EditProviderTemplate.tsx
@@ -114,7 +114,7 @@ function EditProviderTemplateForm({ template }: { template: ProviderTemplate }) 
           <PageTitle.Header>
             <FormattedMessage
               id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.EditProviderTemplate.title"
-              defaultMessage={'Edit LLM Provider Template'}
+              defaultMessage={'Edit AI Provider Template'}
             />
           </PageTitle.Header>
         </PageTitle>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/ProviderTemplatesList.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/ProviderTemplatesList.tsx
@@ -276,14 +276,14 @@ export default function ProviderTemplatesList({
           <PageTitle.Header>
             <FormattedMessage
               id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.ProviderTemplatesList.title"
-              defaultMessage={'LLM Provider Templates'}
+              defaultMessage={'AI Provider Templates'}
             />
           </PageTitle.Header>
           <PageTitle.SubHeader>
             <FormattedMessage
               id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.ProviderTemplatesList.subtitle"
               defaultMessage={
-                'Define reusable templates for connecting LLM providers.'
+                'Define reusable templates for connecting AI providers.'
               }
             />
           </PageTitle.SubHeader>
@@ -342,7 +342,7 @@ export default function ProviderTemplatesList({
               <Typography variant="h6" sx={{ fontWeight: 700 }}>
                 <FormattedMessage
                   id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.ProviderTemplatesList.empty.title"
-                  defaultMessage={'Create your first LLM Provider Template'}
+                  defaultMessage={'Create your first AI Provider Template'}
                 />
               </Typography>
               <Typography
@@ -353,7 +353,7 @@ export default function ProviderTemplatesList({
                 <FormattedMessage
                   id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.ProviderTemplatesList.empty.subtitle"
                   defaultMessage={
-                    'A template holds the endpoint and auth details for connecting a custom LLM provider.'
+                    'A template holds the endpoint and auth details for connecting a custom AI provider.'
                   }
                 />
               </Typography>
@@ -404,10 +404,10 @@ export default function ProviderTemplatesList({
               variant="h6"
               sx={{ fontWeight: 700, mb: 0.5, mt: 0 }}
             >
-              Custom LLM Providers
+              Custom AI Providers
             </Typography>
             <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-              Templates you create to connect your own LLM providers.
+              Templates you create to connect your own AI providers.
             </Typography>
 
             {filteredTemplates.length > 0 ? (
@@ -488,7 +488,7 @@ export default function ProviderTemplatesList({
                     <FormattedMessage
                       id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.ProviderTemplatesList.empty.title"
                       defaultMessage={
-                        'Create your first LLM Provider Template'
+                        'Create your first AI Provider Template'
                       }
                     />
                   </Typography>
@@ -500,7 +500,7 @@ export default function ProviderTemplatesList({
                     <FormattedMessage
                       id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.ProviderTemplatesList.empty.subtitle"
                       defaultMessage={
-                        'A template holds the endpoint and auth details for connecting a custom LLM provider.'
+                        'A template holds the endpoint and auth details for connecting a custom AI provider.'
                       }
                     />
                   </Typography>
@@ -530,7 +530,7 @@ export default function ProviderTemplatesList({
                   Built-in Templates
                 </Typography>
                 <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-                  Built-in LLM providers, included by default.
+                  Built-in AI providers, included by default.
                 </Typography>
                 {filteredBuiltIn.length > 0 ? (
                   <Box sx={cardGridSx}>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxiesList.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxiesList.tsx
@@ -98,7 +98,7 @@ export default function LLMProxiesList() {
   } = useProxies();
   const { providersResponse } = useLLMProviders();
   const proxies = proxiesResponse.list;
-  const emptyMessage = 'No Available App LLM Proxies';
+  const emptyMessage = 'No Available App AI Proxies';
   const {
     currentProject,
     currentOrganization,
@@ -124,7 +124,7 @@ export default function LLMProxiesList() {
   useEffect(() => {
     const state = location.state as LLMProxyListLocationState;
     if (state?.proxyDeleted) {
-      showSnackbar('Successfully deleted App LLM Proxy.', 'success');
+      showSnackbar('Successfully deleted App AI Proxy.', 'success');
       navigate(location.pathname, { replace: true, state: null });
     }
   }, [location.pathname, location.state, navigate, showSnackbar]);
@@ -190,11 +190,11 @@ export default function LLMProxiesList() {
     if (!deleteTarget) return;
     try {
       await deleteProxy(deleteTarget.id);
-      showSnackbar('Successfully deleted App LLM Proxy.', 'success');
+      showSnackbar('Successfully deleted App AI Proxy.', 'success');
       setDeleteTarget(null);
     } catch (error) {
       showSnackbar(
-        getErrorDescription(error, 'Failed to delete App LLM Proxy.'),
+        getErrorDescription(error, 'Failed to delete App AI Proxy.'),
         'error'
       );
       setDeleteTarget(null);
@@ -211,7 +211,7 @@ export default function LLMProxiesList() {
 
   const isProxyQuotaReached = false;
   const proxyQuotaTooltip =
-    'You cannot create more App LLM Proxies because your organization has reached the maximum limit of 5 proxies.';
+    'You cannot create more App AI Proxies because your organization has reached the maximum limit of 5 proxies.';
   const createProxyButtonSx = {
     opacity: isProxyQuotaReached ? 0.55 : 1,
     '&.Mui-disabled': {
@@ -236,9 +236,9 @@ export default function LLMProxiesList() {
               }}
             >
               <PageTitle sx={{ minWidth: 0, flex: 1 }}>
-                <PageTitle.Header>App LLM Proxies</PageTitle.Header>
+                <PageTitle.Header>App AI Proxies</PageTitle.Header>
                 <PageTitle.SubHeader>
-                  Manage and monitor your App LLM Proxy deployments.
+                  Manage and monitor your App AI Proxy deployments.
                 </PageTitle.SubHeader>
               </PageTitle>
 
@@ -258,7 +258,7 @@ export default function LLMProxiesList() {
                         disabled={isProxyQuotaReached}
                         sx={createProxyButtonSx}
                       >
-                        Create App LLM Proxy
+                        Create App AI Proxy
                       </Button>
                     </Box>
                   </Tooltip>
@@ -277,7 +277,7 @@ export default function LLMProxiesList() {
                     <FormattedMessage
                       id="aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxiesList.llm.proxies.are.created.and.managed.at.the.project.level"
                       defaultMessage={
-                        'App LLM Proxies are created and managed at the project level.'
+                        'App AI Proxies are created and managed at the project level.'
                       }
                     />
                   </Typography>
@@ -378,7 +378,7 @@ export default function LLMProxiesList() {
                 <Typography variant="h6" sx={{ fontWeight: 700 }}>
                   <FormattedMessage
                     id="aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxiesList.create.your.first.llm.proxy"
-                    defaultMessage={'Create your first App LLM Proxy'}
+                    defaultMessage={'Create your first App AI Proxy'}
                   />
                 </Typography>
                 <Typography
@@ -389,7 +389,7 @@ export default function LLMProxiesList() {
                   <FormattedMessage
                     id="aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxiesList.setup.an.llm.proxy.description"
                     defaultMessage={
-                      'Set up an App LLM Proxy to route model traffic and manage AI access across your applications.'
+                      'Set up an App AI Proxy to route model traffic and manage AI access across your applications.'
                     }
                   />
                 </Typography>
@@ -403,7 +403,7 @@ export default function LLMProxiesList() {
                       disabled={isProxyQuotaReached}
                       sx={createProxyButtonSx}
                     >
-                      Create App LLM Proxy
+                      Create App AI Proxy
                     </Button>
                   </Box>
                 </Tooltip>
@@ -415,7 +415,7 @@ export default function LLMProxiesList() {
             <Grid size={{ xs: 12 }}>
               <TextField
                 fullWidth
-                placeholder="Search App LLM Proxies..."
+                placeholder="Search App AI Proxies..."
                 value={searchQuery}
                 onChange={(event) => setSearchQuery(event.target.value)}
                 slotProps={{
@@ -451,7 +451,7 @@ export default function LLMProxiesList() {
                             <Typography variant="body2" color="text.secondary">
                               <FormattedMessage
                                 id="aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxiesList.no.llm.proxies.found"
-                                defaultMessage={'No App LLM Proxies found.'}
+                                defaultMessage={'No App AI Proxies found.'}
                               />
                             </Typography>
                           </TableCell>
@@ -547,7 +547,7 @@ export default function LLMProxiesList() {
         open={Boolean(deleteTarget)}
         onClose={() => setDeleteTarget(null)}
       >
-        <DialogTitle>Delete App LLM Proxy</DialogTitle>
+        <DialogTitle>Delete App AI Proxy</DialogTitle>
         <DialogContent>
           <DialogContentText>
             Are you sure you want to delete {deleteTarget?.name}?

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxiesSummaryCardSection.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxiesSummaryCardSection.tsx
@@ -96,7 +96,7 @@ export default function LLMProxiesSummaryCardSection({
 
       {!isEmptyState ? (
         <CardHeader
-          title="App LLM Proxies"
+          title="App AI Proxies"
           subheader={
             isLoading
               ? 'Loading…'
@@ -189,7 +189,7 @@ export default function LLMProxiesSummaryCardSection({
             <Typography variant="h6" sx={{ fontWeight: 700 }}>
               <FormattedMessage
                 id="aiWorkspace.pages.appShell.appShellPages.overview.Overview.create.your.first.llm.proxy"
-                defaultMessage={'Create your first App LLM Proxy'}
+                defaultMessage={'Create your first App AI Proxy'}
               />
             </Typography>
             <Typography
@@ -200,7 +200,7 @@ export default function LLMProxiesSummaryCardSection({
               <FormattedMessage
                 id="aiWorkspace.pages.appShell.appShellPages.overview.Overview.create.your.first.llm.proxy.description"
                 defaultMessage={
-                  'Set up an App LLM Proxy to route model traffic and manage AI access across your applications.'
+                  'Set up an App AI Proxy to route model traffic and manage AI access across your applications.'
                 }
               />
             </Typography>
@@ -212,7 +212,7 @@ export default function LLMProxiesSummaryCardSection({
             >
               <FormattedMessage
                 id="aiWorkspace.pages.appShell.appShellPages.overview.Overview.create.llm.proxy"
-                defaultMessage={'Create App LLM Proxy'}
+                defaultMessage={'Create App AI Proxy'}
               />
             </Button>
           </Stack>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyDeploy.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyDeploy.tsx
@@ -50,7 +50,7 @@ function LLMProxyDeployContent() {
         startIcon={<ChevronLeft size={24} />}
         onClick={() => navigate(-1)}
       >
-        Back to App LLM Proxy
+        Back to App AI Proxy
       </Button>
 
       <GatewayDeployProvider
@@ -68,7 +68,7 @@ function LLMProxyDeployContent() {
           <Typography variant="subtitle2">
             <FormattedMessage
               id="aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxyDeploy.deploy.llm.proxy.to.your.gateways"
-              defaultMessage={'Deploy App LLM Proxy to your Gateways'}
+              defaultMessage={'Deploy App AI Proxy to your Gateways'}
             />
           </Typography>
           {proxy?.readOnly && (

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyDeploymentsCard.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyDeploymentsCard.tsx
@@ -259,7 +259,7 @@ export default function LLMProxyDeploymentsCard() {
               <FormattedMessage
                 id="aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxyDeploymentsCard.start.using.this.llm.proxy"
                 defaultMessage={
-                  'Start using this App LLM Proxy'
+                  'Start using this App AI Proxy'
                 }
               />
             </Typography>
@@ -347,7 +347,7 @@ export default function LLMProxyDeploymentsCard() {
             <Typography variant="h6" sx={{ mb: 1.5, fontWeight: 600 }}>
               <FormattedMessage
                 id="aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxyDeploymentsCard.api.keys"
-                defaultMessage={'App LLM Proxy Keys'}
+                defaultMessage={'App AI Proxy Keys'}
               />
             </Typography>
             <Stack spacing={2}>
@@ -368,7 +368,7 @@ export default function LLMProxyDeploymentsCard() {
                     <FormattedMessage
                       id="aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxyDeploymentsCard.generate.an.api.key"
                       defaultMessage={
-                        'Generate an App LLM Proxy key to authenticate requests to deployed gateways'
+                        'Generate an App AI Proxy key to authenticate requests to deployed gateways'
                       }
                     />
                   </Typography>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyNew.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyNew.tsx
@@ -559,7 +559,7 @@ function LLMProxyNewContent({
           <PageTitle.Header>
             <FormattedMessage
               id="aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxyNew.create.llm.proxy"
-              defaultMessage="Create App LLM Proxy"
+              defaultMessage="Create App AI Proxy"
             />
           </PageTitle.Header>
         </PageTitle>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyNew.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyNew.tsx
@@ -670,7 +670,7 @@ function LLMProxyNewContent({
                   <FormLabel sx={{ mb: 0.5 }}>
                     <FormattedMessage
                       id="aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxyNew.llm.service.provider"
-                      defaultMessage="LLM Provider"
+                      defaultMessage="AI Provider"
                     />
                   </FormLabel>
                   <Select
@@ -802,7 +802,7 @@ function LLMProxyNewContent({
                             <Typography variant="body2" color="text.secondary">
                               <FormattedMessage
                                 id="aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxyNew.generate.provider.api.key.description"
-                                defaultMessage="Generate an API key for the selected LLM provider."
+                                defaultMessage="Generate an API key for the selected AI provider."
                               />
                             </Typography>
                           )}

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyOverview.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyOverview.tsx
@@ -184,7 +184,7 @@ function ProxyOverviewContent() {
   useEffect(() => {
     const state = location.state as LLMProxyOverviewLocationState;
     if (state?.proxyAdded) {
-      showSnackbar('Successfully created App LLM Proxy.', 'success');
+      showSnackbar('Successfully created App AI Proxy.', 'success');
       navigate(location.pathname, { replace: true, state: null });
     }
   }, [location.pathname, location.state, navigate, showSnackbar]);
@@ -260,7 +260,7 @@ function ProxyOverviewContent() {
       });
     } catch (err) {
       showSnackbar(
-        getErrorDescription(err, 'Failed to delete App LLM Proxy.'),
+        getErrorDescription(err, 'Failed to delete App AI Proxy.'),
         'error'
       );
     } finally {
@@ -555,7 +555,7 @@ function ProxyOverviewContent() {
         open={deleteDialogOpen}
         onClose={() => setDeleteDialogOpen(false)}
       >
-        <DialogTitle>Delete App LLM Proxy</DialogTitle>
+        <DialogTitle>Delete App AI Proxy</DialogTitle>
         <DialogContent>
           <DialogContentText>
             Are you sure you want to delete <strong>{proxy.displayName}</strong>? This

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyOverviewTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyOverviewTab.tsx
@@ -651,7 +651,7 @@ export default function LLMProxyOverviewTab() {
                   <Typography variant="h6" sx={{ mb: 1.5, fontWeight: 600 }}>
                     <FormattedMessage
                       id="aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxyOverviewTab.api.keys"
-                      defaultMessage={'App LLM Proxy Keys'}
+                      defaultMessage={'App AI Proxy Keys'}
                     />
                   </Typography>
                   <Stack spacing={2}>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyProviderTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyProviderTab.tsx
@@ -185,7 +185,7 @@ export default function LLMProxyProviderTab() {
           <Typography variant="h6" sx={{ mb: 1.5, fontWeight: 600 }}>
             <FormattedMessage
               id="aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxyProviderTab.llm.service.provider"
-              defaultMessage={'LLM Provider'}
+              defaultMessage={'AI Provider'}
             />
           </Typography>
 

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/quickStart/AIGatewayStepBanner/AIGatewayStepBanner.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/quickStart/AIGatewayStepBanner/AIGatewayStepBanner.tsx
@@ -187,7 +187,7 @@ export default function AIGatewayStepBanner({
                 <Box component="span" sx={{ fontWeight: 600 }}>
                   Next:{' '}
                 </Box>
-                Create LLM Provider and deploy on your new gateway.
+                Create AI Provider and deploy on your new gateway.
               </Typography>
             </>
           ) : (

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/quickStart/Main.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/quickStart/Main.tsx
@@ -243,7 +243,7 @@ export default function QuickStart(): JSX.Element {
     gatewayCounts.ai + gatewayCounts.api >= MAX_GATEWAYS_PER_ORG;
   const nextButtonTooltip =
     selectedOptionId === 'provider-proxy' && isProviderQuotaReached
-      ? 'You cannot continue because your organization has reached the maximum limit of 5 LLM providers.'
+      ? 'You cannot continue because your organization has reached the maximum limit of 5 AI providers.'
       : selectedOptionId === 'manage-gateways' && isGatewayQuotaReached
       ? getGatewayQuotaTooltip(gatewayCounts)
       : '';

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/quickStart/lllmStepBanner/LLLMStepBanner.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/quickStart/lllmStepBanner/LLLMStepBanner.tsx
@@ -89,7 +89,7 @@ export default function LLLMStepBanner({
     (selectedProvider?.policies?.filter(
       (p) => !(p.name === 'llm-cost' && p.version === 'v1')
     ).length ?? 0) > 0;
-  const resolvedProviderName = providerName?.trim() || 'LLM Provider';
+  const resolvedProviderName = providerName?.trim() || 'AI Provider';
 
   useEffect(() => {
     if (!selectedProviderId || !organizationId) {
@@ -159,7 +159,7 @@ export default function LLLMStepBanner({
       },
       {
         id: 'consume',
-        title: 'Consume LLM Provider',
+        title: 'Consume AI Provider',
         icon: Package,
         completed: stepCompletion.hasConsumptions,
       },
@@ -306,7 +306,7 @@ export default function LLLMStepBanner({
               const isTooltipStep = tooltipStepId === step.id;
               const hoverTooltip =
                 step.id === 'consume' && !stepCompletion.hasDeployments
-                  ? 'Deploy to a gateway first before consuming the LLM provider'
+                  ? 'Deploy to a gateway first before consuming the AI provider'
                   : '';
               const tooltipTitle = isTooltipStep && tooltipMessage ? tooltipMessage : hoverTooltip;
               const tooltipOpen = isTooltipStep && !!tooltipMessage ? true : undefined;

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/quickStart/manageGatewaysOption.ts
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/quickStart/manageGatewaysOption.ts
@@ -43,7 +43,7 @@ export function getManageGatewaysOption(getNextPath: () => string): QuickStartOp
       {
         title: 'Prepare for deployments',
         description:
-          'Make the gateway available for App LLM Proxies, providers, and MCP proxy deployments.',
+          'Make the gateway available for App AI Proxies, providers, and MCP proxy deployments.',
       },
     ],
     accentColor: '#C96B00',

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/quickStart/providerProxyOption.ts
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/quickStart/providerProxyOption.ts
@@ -23,14 +23,14 @@ import type { QuickStartOption } from './types';
 export function getProviderProxyOption(getNextPath: () => string): QuickStartOption {
   return {
     id: 'provider-proxy',
-    label: 'Expose My LLM Providers Securely',
-    description: 'Register an LLM provider your applications can use.',
-    title: 'Set up an LLM provider and expose it with a proxy',
+    label: 'Expose My AI Providers Securely',
+    description: 'Register an AI provider your applications can use.',
+    title: 'Set up an AI provider and expose it with a proxy',
     subtitle:
       'Connect your model provider, define a reusable proxy, and prepare it for deployment through your AI workspace.',
     steps: [
       {
-        title: 'Add LLM provider',
+        title: 'Add AI provider',
         description:
           'Register the provider, credentials, and models you want to make available.',
       },

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/AddNewProvider/ProviderTemplateFormFields.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/AddNewProvider/ProviderTemplateFormFields.tsx
@@ -258,7 +258,7 @@ export default function ProviderTemplateFormFields({
               }
               placeholder="https://api.openai.com/v1"
               error={Boolean(fieldErrors.upstreamUrl)}
-              helperText={fieldErrors.upstreamUrl || 'The base URL of the upstream LLM provider'}
+              helperText={fieldErrors.upstreamUrl || 'The base URL of the upstream AI provider'}
               data-cyid="provider-upstream-url-input"
             />
           </FormControl>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ProvidersList.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ProvidersList.tsx
@@ -190,7 +190,7 @@ export default function ServiceProviders() {
   ) => {
     if (!currentOrganization?.uuid) {
       showSnackbar(
-        'Unable to verify App LLM Proxy usage because organization details are unavailable.',
+        'Unable to verify App AI Proxy usage because organization details are unavailable.',
         'error'
       );
       return;
@@ -218,7 +218,7 @@ export default function ServiceProviders() {
       setDeleteConfirmationInput('');
     } catch {
       showSnackbar(
-        'Failed to verify App LLM Proxy usage for this provider. Deletion has been blocked. Please try again.',
+        'Failed to verify App AI Proxy usage for this provider. Deletion has been blocked. Please try again.',
         'error'
       );
     } finally {

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ProvidersList.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ProvidersList.tsx
@@ -151,10 +151,10 @@ export default function ServiceProviders() {
 
   // Access the list from the API response
   const providers = providersResponse.list;
-  const emptyMessage = 'No Available LLM Providers';
+  const emptyMessage = 'No Available AI Providers';
   const isProviderQuotaReached = false;
   const providerQuotaTooltip =
-    'You cannot create more providers because your organization has reached the maximum limit of 5 LLM providers.';
+    'You cannot create more providers because your organization has reached the maximum limit of 5 AI providers.';
 
   const filteredProviders = useMemo(() => {
     const query = searchQuery.trim().toLowerCase();
@@ -287,7 +287,7 @@ export default function ServiceProviders() {
                 <FormattedMessage
                   id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ProvidersList.project.level.disabled.subtitle"
                   defaultMessage={
-                    'Switch to organization level to view and manage LLM providers.'
+                    'Switch to organization level to view and manage AI providers.'
                   }
                 />
               </Typography>
@@ -325,14 +325,14 @@ export default function ServiceProviders() {
           <PageTitle.Header>
             <FormattedMessage
               id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ProvidersList.llm.service.providers"
-              defaultMessage={'LLM Providers'}
+              defaultMessage={'AI Providers'}
             />
           </PageTitle.Header>
           <PageTitle.SubHeader>
             <FormattedMessage
               id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ProvidersList.manage.and.monitor.your.connected.llm.service.providers"
               defaultMessage={
-                'Manage and monitor your connected LLM Providers.'
+                'Manage and monitor your connected AI Providers.'
               }
             />
           </PageTitle.SubHeader>
@@ -435,7 +435,7 @@ export default function ServiceProviders() {
             <Typography variant="h6" sx={{ fontWeight: 700 }}>
               <FormattedMessage
                 id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProvidersSummaryCard.create.your.first.llm.provider"
-                defaultMessage={'Create your first LLM Provider'}
+                defaultMessage={'Create your first AI Provider'}
               />
             </Typography>
 
@@ -447,7 +447,7 @@ export default function ServiceProviders() {
               <FormattedMessage
                 id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProvidersSummaryCard.connect.and.manage.providers.description"
                 defaultMessage={
-                  'Set up an LLM provider to start connecting models and powering AI applications in your workspace.'
+                  'Set up an AI provider to start connecting models and powering AI applications in your workspace.'
                 }
               />
             </Typography>
@@ -780,7 +780,7 @@ export default function ServiceProviders() {
         }}
       >
         <DialogTitle>
-          Are you sure you want to remove the LLM Provider{' '}
+          Are you sure you want to remove the AI Provider{' '}
           <strong>'{deleteTarget?.name ?? ''}'</strong>?
         </DialogTitle>
         <DialogContent>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderDeploymentsCard.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderDeploymentsCard.tsx
@@ -337,7 +337,7 @@ export default function ServiceProviderDeploymentsCard({
             <Typography variant="body2" color="text.secondary">
               <FormattedMessage
                 id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderDeploymentsCard.start.using.this.llm.provider"
-                defaultMessage={'Start using this LLM provider'}
+                defaultMessage={'Start using this AI provider'}
               />
             </Typography>
           </Box> */}

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderNew.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderNew.tsx
@@ -427,7 +427,7 @@ export default function ServiceProviderNew() {
         setFieldErrors(mappedErrors);
       }
       if (hasUnmapped || Object.keys(mappedErrors).length === 0) {
-        const description = getErrorMessage(error, 'Failed to create LLM provider.');
+        const description = getErrorMessage(error, 'Failed to create AI provider.');
         showSnackbar(description, 'error');
       }
     }
@@ -515,7 +515,7 @@ export default function ServiceProviderNew() {
           <PageTitle.Header>
             <FormattedMessage
               id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderNew.add.llm.service.provider"
-              defaultMessage={'Add LLM Provider'}
+              defaultMessage={'Add AI Provider'}
             />
           </PageTitle.Header>
         </PageTitle>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverview.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverview.tsx
@@ -490,7 +490,7 @@ function ServiceProviderOverviewContent() {
 
   const isProxyQuotaReached = false;
   const proxyQuotaTooltip =
-    'You cannot create more App LLM Proxies because your organization has reached the maximum limit of 5 proxies.';
+    'You cannot create more App AI Proxies because your organization has reached the maximum limit of 5 proxies.';
   const isReadOnlyProvider = Boolean(provider?.readOnly);
   const createProxyTooltip = isProxyQuotaReached ? proxyQuotaTooltip : '';
 
@@ -567,7 +567,7 @@ function ServiceProviderOverviewContent() {
   ) => {
     if (!currentOrganization?.uuid) {
       showSnackbar(
-        'Unable to verify App LLM Proxy usage because organization details are unavailable.',
+        'Unable to verify App AI Proxy usage because organization details are unavailable.',
         'error'
       );
       return;
@@ -595,7 +595,7 @@ function ServiceProviderOverviewContent() {
       setDeleteConfirmationInput('');
     } catch {
       showSnackbar(
-        'Failed to verify App LLM Proxy usage for this provider. Deletion has been blocked. Please try again.',
+        'Failed to verify App AI Proxy usage for this provider. Deletion has been blocked. Please try again.',
         'error'
       );
     } finally {
@@ -945,12 +945,12 @@ function ServiceProviderOverviewContent() {
       <DialogTitle>
         <FormattedMessage
           id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderOverview.projectPicker.title"
-          defaultMessage="Create App LLM Proxy"
+          defaultMessage="Create App AI Proxy"
         />
         <Typography variant="body2" color="text.secondary">
           <FormattedMessage
             id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderOverview.projectPicker.description"
-            defaultMessage="Select a project to continue creating the App LLM Proxy."
+            defaultMessage="Select a project to continue creating the App AI Proxy."
           />
         </Typography>
       </DialogTitle>
@@ -1229,7 +1229,7 @@ function ServiceProviderOverviewContent() {
                     >
                       <FormattedMessage
                         id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderOverview.create.llm.proxy"
-                        defaultMessage="Create App LLM Proxy"
+                        defaultMessage="Create App AI Proxy"
                       />
                     </Button>
                   </Box>
@@ -1534,7 +1534,7 @@ function ServiceProviderOverviewContent() {
                   >
                     <FormattedMessage
                       id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderOverview.create.llm.proxy"
-                      defaultMessage="Create App LLM Proxy"
+                      defaultMessage="Create App AI Proxy"
                     />
                   </Button>
                 </DisabledActionTooltip>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverview.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverview.tsx
@@ -1032,7 +1032,7 @@ function ServiceProviderOverviewContent() {
       }}
     >
       <DialogTitle>
-        Are you sure you want to remove the LLM Provider{' '}
+        Are you sure you want to remove the AI Provider{' '}
         <strong>'{deleteTarget?.name ?? ''}'</strong>?
       </DialogTitle>
       <DialogContent>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProvidersSummaryCard.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProvidersSummaryCard.tsx
@@ -92,11 +92,11 @@ export default function ServiceProvidersSummaryCard({
   onCreateProvider,
   onProviderClick,
   maxItems = 5,
-  title = 'LLM Providers',
+  title = 'AI Providers',
   isLoading = false,
   error,
   onRetry,
-  emptyMessage = 'No Available LLM Providers',
+  emptyMessage = 'No Available AI Providers',
   showSeeMore = true,
 }: ServiceProvidersSummaryCardProps) {
   const { hasPermission } = useAppAuth();
@@ -255,7 +255,7 @@ export default function ServiceProvidersSummaryCard({
             <Typography variant="h6" sx={{ fontWeight: 700 }}>
               <FormattedMessage
                 id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProvidersSummaryCard.create.your.first.llm.provider"
-                defaultMessage={'Create your first LLM Provider'}
+                defaultMessage={'Create your first AI Provider'}
               />
             </Typography>
 
@@ -267,7 +267,7 @@ export default function ServiceProvidersSummaryCard({
               <FormattedMessage
                 id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProvidersSummaryCard.connect.and.manage.providers.description"
                 defaultMessage={
-                  'Set up an LLM provider to start connecting models and powering AI applications in your workspace.'
+                  'Set up an AI provider to start connecting models and powering AI applications in your workspace.'
                 }
               />
             </Typography>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/settings/Main.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/settings/Main.tsx
@@ -54,7 +54,7 @@ interface NavItem {
 const NAV_ITEMS: NavItem[] = [
   {
     key: 'templates',
-    label: 'LLM Provider Templates',
+    label: 'AI Provider Templates',
     icon: <LayoutTemplate size={18} />,
     path: '/settings/llm-provider-templates',
   },

--- a/portals/ai-workspace/src/pages/login/BasicAuthLoginPage.tsx
+++ b/portals/ai-workspace/src/pages/login/BasicAuthLoginPage.tsx
@@ -48,7 +48,7 @@ interface Props {
 }
 
 const sloganItems = [
-  { icon: <Cloud size={20} />, title: 'Connect multiple LLM providers and models' },
+  { icon: <Cloud size={20} />, title: 'Connect multiple AI providers and models' },
   { icon: <AppWindow size={20} />, title: 'Build, run, and iterate AI workflows' },
   { icon: <Cog size={20} />, title: 'Configure prompts, tools, and runtime settings' },
   { icon: <FlaskConical size={20} />, title: 'Test, evaluate, and compare model responses' },

--- a/portals/ai-workspace/src/pages/register/OrgRegisterPage.tsx
+++ b/portals/ai-workspace/src/pages/register/OrgRegisterPage.tsx
@@ -322,7 +322,7 @@ export default function OrgRegisterPage() {
 
           <Stack spacing={2} sx={{ position: 'relative' }}>
             {[
-              'Connect and manage multiple LLM providers',
+              'Connect and manage multiple AI providers',
               'Deploy AI gateways with policy controls',
               'Build, test, and iterate AI proxies',
               'Monitor usage with built-in analytics',


### PR DESCRIPTION
# UI Terminology Rename: "LLM Provider" → "AI Provider", "LLM Proxy" → "AI Proxy"

**Date:** 2026-07-13
**Scope:** `portals/ai-workspace` — user-visible UI strings only

## Why
- - https://github.com/wso2/api-platform/issues/2579

`chat/completions` is not the only resource the platform supports — providers can also
serve embeddings, image models, and other AI resources, so "LLM Provider" sounds
limiting. "AI Provider" matches how the product is described to buyers in practice. "AI Proxy" follows
for consistency — a proxy fronting an AI Provider that serves embeddings is not an
"LLM" proxy.

## What changed

Display-level rename only, case-preserving:

| Before | After |
|---|---|
| LLM Provider(s) | AI Provider(s) |
| LLM Provider Templates | AI Provider Templates |
| (App) LLM Proxy / Proxies | (App) AI Proxy / Proxies |

Covered surfaces: sidebar navigation, page titles and descriptions, buttons, form
labels and helper texts, drawers, delete-confirmation dialogs, error/success
snackbars, empty states, org-limit warnings, quick-start banners, Explore More cards,
and the login/register feature bullets. Cypress assertions on the renamed labels were
updated to match ("LLM Provider Templates", "Create/Delete App AI Proxy").

## What deliberately did NOT change

- **Code identifiers**: file/component names (`LLMProxyNew.tsx`, `llmProviderApis.ts`),
  context names, entity kind values (`LlmProvider`, `LlmProxy`), routes, and API paths.
- **API contracts**: no request/response shapes or backend field names.
- **Logs**: `logger.*` messages keep the old wording (not user-visible).
- **Stored data**: auto-generated secret descriptions (`Auto-generated secret for LLM
  provider/proxy ...`) are backend payloads, not UI labels.
- **MCP Proxy**: left as-is; it remains a sibling concept to AI Proxy.

## Stats

- 130 string replacements across 40 files (65 provider + 65 proxy).
- Verified with `tsc --noEmit`: no new errors introduced (pre-existing errors on the
  branch are unrelated to string literals).

