### PR TITLE
[AIW] Remove Coming soon tag in AWS LLM provider

### DIFF
--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/AddNewProvider/ProviderTemplateSelector.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/AddNewProvider/ProviderTemplateSelector.tsx
@@ -74,7 +74,7 @@ const getShortNameForTemplate = (templateName: string): string => {
   return templateName.substring(0, 2).toUpperCase();
 };
 
-const COMING_SOON_TEMPLATE_IDS = new Set(['awsbedrock', 'aws-bedrock']);
+const COMING_SOON_TEMPLATE_IDS = new Set<string>([]);
 
 type ProviderTemplateSelectorProps = {
   templatesLoading: boolean;


### PR DESCRIPTION
## Purpose
Remove Coming soon tag in AWS LLM provider 

## Approach
Cleared the coming soon list
Didn't remove the coming-soon tag functionality, as it might be used in future for other providers

## Samples
<img width="1512" height="810" alt="image" src="https://github.com/user-attachments/assets/105ff05d-e675-49c9-826c-19d452600e40" />
