### PR TITLE
[Devportal] Remove type field from key manager configurations

### DIFF
--- a/docs/rest-apis/devportal/key-managers.md
+++ b/docs/rest-apis/devportal/key-managers.md
@@ -62,7 +62,6 @@ This operation requires <strong>Basic Auth</strong> authentication.
   "id": "asgardeo-prod",
   "displayName": "Asgardeo",
   "orgId": "org-12345",
-  "type": "GENERIC_OIDC",
   "enabled": true,
   "tokenEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/token",
   "createdBy": "alice@example.com",
@@ -192,7 +191,6 @@ This operation requires <strong>Basic Auth</strong> authentication.
       "id": "asgardeo-prod",
       "displayName": "Asgardeo",
       "orgId": "org-12345",
-      "type": "GENERIC_OIDC",
       "enabled": true,
       "tokenEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/token",
       "createdBy": "alice@example.com",
@@ -241,7 +239,6 @@ Status Code **200**
 |»»» id|string|false|none|The key manager's handle (unique per org). Not the internal database uuid.|
 |»»» displayName|string|false|none|none|
 |»»» orgId|string|false|none|none|
-|»»» type|string|false|read-only|Fixed at `GENERIC_OIDC` for every key manager. Not client-configurable.|
 |»»» enabled|boolean|false|none|none|
 |»»» tokenEndpoint|string(uri)|false|none|none|
 |»»» createdBy|string|false|none|Identity of the user who created this key manager, or `deleted_user` if that user's IDP reference no longer exists. Present on single-resource GET responses and list items.|
@@ -256,7 +253,6 @@ Status Code **200**
 |»» *anonymous*|[KeyManagerPublicResponseSchema](schemas.md#schemakeymanagerpublicresponseschema)|false|none|Minimal developer-facing key manager view.|
 |»»» id|string|false|none|The key manager's handle (unique per org). Not the internal database uuid.|
 |»»» displayName|string|false|none|none|
-|»»» type|string|false|read-only|Fixed at `GENERIC_OIDC` for every key manager.|
 |»»» tokenEndpoint|string(uri)|false|none|none|
 
 *continued*
@@ -267,13 +263,6 @@ Status Code **200**
 |»» total|integer|true|none|Total number of records matching the query.|
 |»» limit|integer|true|none|Maximum number of records returned in this response.|
 |»» offset|integer|true|none|Number of records skipped before this page.|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|type|GENERIC_OIDC|
-|type|GENERIC_OIDC|
 
 ## Get a key manager
 
@@ -316,7 +305,6 @@ This operation requires <strong>Basic Auth</strong> authentication.
   "id": "asgardeo-prod",
   "displayName": "Asgardeo",
   "orgId": "org-12345",
-  "type": "GENERIC_OIDC",
   "enabled": true,
   "tokenEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/token",
   "createdBy": "alice@example.com",
@@ -417,7 +405,6 @@ This operation requires <strong>Basic Auth</strong> authentication.
   "id": "asgardeo-prod",
   "displayName": "Asgardeo",
   "orgId": "org-12345",
-  "type": "GENERIC_OIDC",
   "enabled": true,
   "tokenEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/token",
   "createdBy": "alice@example.com",

--- a/docs/rest-apis/devportal/schemas.md
+++ b/docs/rest-apis/devportal/schemas.md
@@ -1449,7 +1449,6 @@ Partial update payload for a key manager. All fields are optional; only supplied
   "id": "asgardeo-prod",
   "displayName": "Asgardeo",
   "orgId": "org-12345",
-  "type": "GENERIC_OIDC",
   "enabled": true,
   "tokenEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/token",
   "createdBy": "alice@example.com",
@@ -1469,19 +1468,12 @@ Key manager configuration.
 |id|string|false|none|The key manager's handle (unique per org). Not the internal database uuid.|
 |displayName|string|false|none|none|
 |orgId|string|false|none|none|
-|type|string|false|read-only|Fixed at `GENERIC_OIDC` for every key manager. Not client-configurable.|
 |enabled|boolean|false|none|none|
 |tokenEndpoint|string(uri)|false|none|none|
 |createdBy|string|false|none|Identity of the user who created this key manager, or `deleted_user` if that user's IDP reference no longer exists. Present on single-resource GET responses and list items.|
 |updatedBy|string|false|none|Identity of the user who last updated this key manager, or `deleted_user` if that user's IDP reference no longer exists. Present on single-resource GET responses only, omitted on list items.|
 |createdAt|string(date-time)|false|none|none|
 |updatedAt|string(date-time)|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|type|GENERIC_OIDC|
 
 <h2 id="tocS_KeyManagerPublicResponseSchema">KeyManagerPublicResponseSchema</h2>
 
@@ -1494,7 +1486,6 @@ Key manager configuration.
 {
   "id": "asgardeo-prod",
   "displayName": "Asgardeo",
-  "type": "GENERIC_OIDC",
   "tokenEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/token"
 }
 
@@ -1508,14 +1499,7 @@ Minimal developer-facing key manager view.
 |---|---|---|---|---|
 |id|string|false|none|The key manager's handle (unique per org). Not the internal database uuid.|
 |displayName|string|false|none|none|
-|type|string|false|read-only|Fixed at `GENERIC_OIDC` for every key manager.|
 |tokenEndpoint|string(uri)|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|type|GENERIC_OIDC|
 
 <h2 id="tocS_WebhookSubscriberRequest">WebhookSubscriberRequest</h2>
 

--- a/portals/developer-portal/database/schema.postgres.sql
+++ b/portals/developer-portal/database/schema.postgres.sql
@@ -105,7 +105,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS "uq_api_subscription_plan_mappings_plan_api" O
 CREATE INDEX IF NOT EXISTS "idx_api_subscription_plan_mappings_api_uuid" ON "dp_api_subscription_plan_mappings" ("api_uuid");
 
 -- dp_key_managers
-CREATE TABLE IF NOT EXISTS "dp_key_managers" ("uuid" VARCHAR(40) , "org_uuid" VARCHAR(40) NOT NULL REFERENCES "dp_organizations" ("uuid") ON DELETE NO ACTION ON UPDATE CASCADE, "handle" VARCHAR(255) NOT NULL, "display_name" VARCHAR(255) NOT NULL, "type" VARCHAR(64) NOT NULL, "enabled" SMALLINT NOT NULL DEFAULT 1, "token_endpoint" VARCHAR(255) NOT NULL, "created_by" VARCHAR(255) NOT NULL, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL, "updated_by" VARCHAR(255) NOT NULL, "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL, PRIMARY KEY ("uuid"));
+CREATE TABLE IF NOT EXISTS "dp_key_managers" ("uuid" VARCHAR(40) , "org_uuid" VARCHAR(40) NOT NULL REFERENCES "dp_organizations" ("uuid") ON DELETE NO ACTION ON UPDATE CASCADE, "handle" VARCHAR(255) NOT NULL, "display_name" VARCHAR(255) NOT NULL, "enabled" SMALLINT NOT NULL DEFAULT 1, "token_endpoint" VARCHAR(255) NOT NULL, "created_by" VARCHAR(255) NOT NULL, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL, "updated_by" VARCHAR(255) NOT NULL, "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL, PRIMARY KEY ("uuid"));
 
 CREATE UNIQUE INDEX IF NOT EXISTS "uq_key_manager_org_handle" ON "dp_key_managers" ("org_uuid", "handle");
 

--- a/portals/developer-portal/docs/administer/key-manager-integration.md
+++ b/portals/developer-portal/docs/administer/key-manager-integration.md
@@ -43,7 +43,7 @@ curl -k -X POST https://localhost:3000/api/v0.9/key-managers \
 | `spec.tokenEndpoint` | Yes | OAuth2 token endpoint. The portal proxies `client_credentials` token requests here using the client ID/secret the developer supplies |
 | `spec.enabled` | No | Whether the key manager is active. Defaults to `true` |
 
-Every key manager is treated as a generic OAuth2 `client_credentials` provider — there is no `type` to configure.
+Every key manager is treated as a generic OAuth2 `client_credentials` provider.
 
 ## List Key Managers
 

--- a/portals/developer-portal/docs/devportal-openapi-spec-v0.9.yaml
+++ b/portals/developer-portal/docs/devportal-openapi-spec-v0.9.yaml
@@ -3945,7 +3945,6 @@ components:
               - id: asgardeo-prod
                 displayName: Asgardeo
                 orgId: org-12345
-                type: GENERIC_OIDC
                 enabled: true
                 tokenEndpoint: https://api.asgardeo.io/t/myorg/oauth2/token
                 createdBy: alice@example.com
@@ -5161,13 +5160,6 @@ components:
         orgId:
           type: string
           example: org-12345
-        type:
-          type: string
-          description: Fixed at `GENERIC_OIDC` for every key manager. Not client-configurable.
-          enum:
-            - GENERIC_OIDC
-          readOnly: true
-          example: GENERIC_OIDC
         enabled:
           type: boolean
           example: true
@@ -5205,13 +5197,6 @@ components:
         displayName:
           type: string
           example: Asgardeo
-        type:
-          type: string
-          description: Fixed at `GENERIC_OIDC` for every key manager.
-          enum:
-            - GENERIC_OIDC
-          readOnly: true
-          example: GENERIC_OIDC
         tokenEndpoint:
           type: string
           format: uri

--- a/portals/developer-portal/it/rest-api/key-managers/key-managers.spec.js
+++ b/portals/developer-portal/it/rest-api/key-managers/key-managers.spec.js
@@ -16,9 +16,8 @@
 // under the License.
 // --------------------------------------------------------------------
 
-// POST/GET/PUT/DELETE /key-managers. Every key manager is a generic OAuth2
-// client_credentials OIDC provider (type is fixed server-side at GENERIC_OIDC
-// and is not client-configurable).
+// POST/GET/PUT/DELETE /key-managers. Every key manager is an OAuth2
+// client_credentials provider.
 // Body accepts YAML or JSON per the handler; keep the fixture JSON-only.
 // `admin` manages org-level integration config.
 
@@ -39,7 +38,6 @@ describe('key managers', () => {
         });
         expect(res.status).toBe(201);
         expect(res.body.id).toBe(id);
-        expect(res.body.type).toBe('GENERIC_OIDC');
     });
 
     it('retrieves a key manager', async () => {
@@ -86,15 +84,5 @@ describe('key managers', () => {
         const res = await client.as('admin').get('/key-managers');
         expect(res.status).toBe(200);
         expect(res.body.list.some((km) => km.id === id)).toBe(true);
-    });
-
-    it('every created key manager is GENERIC_OIDC by default', async () => {
-        const res = await client.as('admin').post('/key-managers', {
-            id: uniqueHandle('km'),
-            displayName: 'Default Type KM',
-            tokenEndpoint: 'https://asgardeo.example.invalid/oauth2/token',
-        });
-        expect(res.status).toBe(201);
-        expect(res.body.type).toBe('GENERIC_OIDC');
     });
 });

--- a/portals/developer-portal/it/rest-api/key-managers/token-generation.spec.js
+++ b/portals/developer-portal/it/rest-api/key-managers/token-generation.spec.js
@@ -97,7 +97,7 @@ describe('OAuth token generation', () => {
     async function setupAppWithKeyMapping() {
         const kmId = uniqueHandle('km');
         await client.as('admin').post('/key-managers', {
-            id: kmId, displayName: 'Mock KM', type: 'GENERIC_OIDC', tokenEndpoint: tokenUrl.href,
+            id: kmId, displayName: 'Mock KM', tokenEndpoint: tokenUrl.href,
         });
 
         const appId = uniqueHandle('app');

--- a/portals/developer-portal/src/dao/keyManagerDao.js
+++ b/portals/developer-portal/src/dao/keyManagerDao.js
@@ -28,7 +28,6 @@ const create = async (orgId, kmData, createdBy) => {
             org_uuid: orgId,
             handle: kmData.handle,
             display_name: kmData.displayName,
-            type: kmData.type,
             ...(kmData.enabled !== undefined && { enabled: kmData.enabled ? 1 : 0 }),
             token_endpoint: kmData.tokenEndpoint,
             created_by: createdBy,
@@ -52,7 +51,6 @@ const update = async (kmId, kmData, updatedBy) => {
         const updatePayload = {
             ...(kmData.handle && { handle: kmData.handle }),
             ...(kmData.displayName && { display_name: kmData.displayName }),
-            ...(kmData.type && { type: kmData.type }),
             ...(kmData.enabled !== undefined && { enabled: kmData.enabled ? 1 : 0 }),
             ...(kmData.tokenEndpoint && { token_endpoint: kmData.tokenEndpoint }),
             updated_by: updatedBy,

--- a/portals/developer-portal/src/dto/keyManagerDto.js
+++ b/portals/developer-portal/src/dto/keyManagerDto.js
@@ -26,7 +26,6 @@ class KeyManagerDTO {
         this.id = km.handle;
         this.displayName = km.display_name;
         this.orgId = km.org_uuid;
-        this.type = km.type;
         this.enabled = !!km.enabled;
         this.tokenEndpoint = km.token_endpoint;
         applyAudit(this, audit);
@@ -41,7 +40,6 @@ class KeyManagerPublicDTO {
     constructor(km) {
         this.id = km.handle;
         this.displayName = km.display_name;
-        this.type = km.type;
         this.tokenEndpoint = km.token_endpoint;
     }
 }

--- a/portals/developer-portal/src/models/keyManager.js
+++ b/portals/developer-portal/src/models/keyManager.js
@@ -37,10 +37,6 @@ const KeyManager = sequelize.define('dp_key_manager', {
         type: DataTypes.STRING,
         allowNull: false
     },
-    type: {
-        type: DataTypes.STRING(64),
-        allowNull: false
-    },
     enabled: {
         type: DataTypes.SMALLINT,
         allowNull: false,

--- a/portals/developer-portal/src/services/keyManagerService.js
+++ b/portals/developer-portal/src/services/keyManagerService.js
@@ -25,13 +25,6 @@ const util = require('../utils/util');
 const logger = require('../config/logger');
 const { logUserAction } = require('../middlewares/auditLogger');
 
-/**
- * Every key manager is a standard OAuth2 client_credentials-based generic
- * OIDC provider. The `type` column is retained on the model for backward
- * compatibility but is no longer client-configurable.
- */
-const DEFAULT_KM_TYPE = 'GENERIC_OIDC';
-
 // ---------------------------------------------------------------------------
 // YAML ingestion helpers (mirrors parseIdentityProviderFromYamlFile pattern)
 // ---------------------------------------------------------------------------
@@ -44,7 +37,6 @@ function mapYamlToKeyManager(yamlDoc) {
     return {
         handle: yamlDoc.metadata?.name || spec.name,
         displayName: spec.displayName || spec.name,
-        type: DEFAULT_KM_TYPE,
         enabled: spec.enabled !== undefined ? spec.enabled : true,
         tokenEndpoint: spec.tokenEndpoint,
     };
@@ -148,7 +140,7 @@ const createKeyManager = async (req, res) => {
         }
 
         const userId = util.resolveActor(req);
-        const record = await kmDao.create(orgId, { ...payload, handle: resolvedHandle, type: DEFAULT_KM_TYPE }, userId);
+        const record = await kmDao.create(orgId, { ...payload, handle: resolvedHandle }, userId);
         logUserAction('KEY_MANAGER_CREATED', req, { orgId, kmId: record.uuid, resourceUuid: record.uuid, resourceType: 'key_manager' });
         let audit;
         try {
@@ -181,8 +173,6 @@ const updateKeyManager = async (req, res) => {
         const orgId = req.orgId;
         const { kmId: kmHandle } = req.params;
         const payload = _resolvePayload(req);
-        // The key manager type is fixed at GENERIC_OIDC and is not client-configurable.
-        delete payload.type;
 
         const kmId = await kmDao.getIdByHandle(orgId, kmHandle);
         if (!kmId) {


### PR DESCRIPTION
## Purpose
Remove type field from key manager configurations

## Approach
Removed the column and its references as we are not using the type currently

## Related PRs
N/A