### PR TITLE
Change LLM Provider policy UI

### DIFF
--- a/portals/ai-workspace/src/Components/SwaggerSpecViewer/SwaggerSpecViewer.tsx
+++ b/portals/ai-workspace/src/Components/SwaggerSpecViewer/SwaggerSpecViewer.tsx
@@ -16,7 +16,15 @@
  * under the License.
  */
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
+import {
+  InputAdornment,
+  MenuItem,
+  Stack,
+  TextField,
+  Typography,
+} from '@wso2/oxygen-ui';
+import { Search } from '@wso2/oxygen-ui-icons-react';
 import SwaggerUI from 'swagger-ui-react';
 import 'swagger-ui-react/swagger-ui.css';
 import './SwaggerSpecViewer.css';
@@ -40,6 +48,7 @@ type SwaggerSpecViewerProps = {
   hideOperationHeader?: boolean;
   disableTryOutBtn?: boolean;
   disableResponseSection?: boolean;
+  enableResourceSearch?: boolean;
 };
 
 type SwaggerSpec = Record<string, unknown>;
@@ -196,6 +205,70 @@ function mergePlainHeaders(
   return nextHeaders;
 }
 
+type ResourceMethod = 'all' | (typeof HTTP_METHODS)[number];
+
+function filterSpecResources(
+  spec: SwaggerSpec,
+  searchValue: string,
+  selectedMethod: ResourceMethod
+): SwaggerSpec {
+  const query = searchValue.trim().toLowerCase();
+  if (
+    (!query && selectedMethod === 'all') ||
+    !spec.paths ||
+    typeof spec.paths !== 'object'
+  ) {
+    return spec;
+  }
+
+  const filteredPaths: Record<string, unknown> = {};
+  Object.entries(spec.paths as Record<string, unknown>).forEach(
+    ([path, pathValue]) => {
+      if (!pathValue || typeof pathValue !== 'object') return;
+
+      const pathItem = pathValue as Record<string, unknown>;
+      const pathMatches = path.toLowerCase().includes(query);
+      const matchingOperations = HTTP_METHODS.filter((method) => {
+        const operation = pathItem[method];
+        if (!operation || typeof operation !== 'object') return false;
+        if (selectedMethod !== 'all' && method !== selectedMethod) return false;
+        if (pathMatches) return true;
+
+        const { summary, description } = operation as Record<string, unknown>;
+        return [summary, description].some(
+          (value) =>
+            typeof value === 'string' && value.toLowerCase().includes(query)
+        );
+      });
+
+      if (matchingOperations.length === 0) return;
+
+      filteredPaths[path] = Object.fromEntries(
+        Object.entries(pathItem).filter(
+          ([key]) =>
+            !HTTP_METHODS.includes(key as (typeof HTTP_METHODS)[number]) ||
+            matchingOperations.includes(key as (typeof HTTP_METHODS)[number])
+        )
+      );
+    }
+  );
+
+  return { ...spec, paths: filteredPaths };
+}
+
+function hasResourceOperations(spec: SwaggerSpec): boolean {
+  if (!spec.paths || typeof spec.paths !== 'object') return false;
+
+  return Object.values(spec.paths as Record<string, unknown>).some(
+    (pathValue) =>
+      Boolean(pathValue) &&
+      typeof pathValue === 'object' &&
+      HTTP_METHODS.some((method) =>
+        Boolean((pathValue as Record<string, unknown>)[method])
+      )
+  );
+}
+
 export default function SwaggerSpecViewer({
   spec,
   className,
@@ -212,7 +285,11 @@ export default function SwaggerSpecViewer({
   hideOperationHeader = false,
   disableTryOutBtn = false,
   disableResponseSection = false,
+  enableResourceSearch = false,
 }: SwaggerSpecViewerProps) {
+  const [resourceSearchValue, setResourceSearchValue] = useState('');
+  const [selectedResourceMethod, setSelectedResourceMethod] =
+    useState<ResourceMethod>('all');
   const normalizedRequestBaseUrl = requestBaseUrl?.trim().replace(/\/+$/, '');
   const normalizedDefaultHeaders = useMemo(
     () =>
@@ -232,6 +309,20 @@ export default function SwaggerSpecViewer({
     }
     return applyRequestBaseUrlToSpec(spec, normalizedRequestBaseUrl);
   }, [normalizedRequestBaseUrl, spec]);
+
+  const displayedSpec = useMemo(
+    () =>
+      filterSpecResources(
+        specWithRequestBaseUrl,
+        resourceSearchValue,
+        selectedResourceMethod
+      ),
+    [resourceSearchValue, selectedResourceMethod, specWithRequestBaseUrl]
+  );
+  const hasDisplayedResources = useMemo(
+    () => hasResourceOperations(displayedSpec),
+    [displayedSpec]
+  );
 
   const plugin = useMemo(() => {
     const wrapSelectors: Record<string, unknown> = {};
@@ -456,17 +547,59 @@ export default function SwaggerSpecViewer({
     .join(' ');
 
   return (
-    <div className={containerClassName}>
-      <SwaggerUIComponent
-        key={swaggerInstanceKey}
-        spec={specWithRequestBaseUrl}
-        docExpansion={docExpansion}
-        defaultModelsExpandDepth={defaultModelsExpandDepth}
-        displayRequestDuration={displayRequestDuration}
-        showMutatedRequest={!disableNetworkExecution}
-        plugins={plugins}
-        requestInterceptor={requestInterceptor}
-      />
-    </div>
+    <Stack className={containerClassName} spacing={2}>
+      {enableResourceSearch ? (
+        <Stack direction="row" spacing={2} sx={{ px: 1 }}>
+          <TextField
+            fullWidth
+            size="small"
+            value={resourceSearchValue}
+            onChange={(event) => setResourceSearchValue(event.target.value)}
+            placeholder="Search resources by path or description"
+            slotProps={{
+              input: {
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <Search size={18} />
+                  </InputAdornment>
+                ),
+              },
+            }}
+          />
+          <TextField
+            select
+            size="small"
+            value={selectedResourceMethod}
+            onChange={(event) =>
+              setSelectedResourceMethod(event.target.value as ResourceMethod)
+            }
+            sx={{ width: 180, flexShrink: 0 }}
+          >
+            <MenuItem value="all">All methods</MenuItem>
+            {HTTP_METHODS.map((method) => (
+              <MenuItem key={method} value={method}>
+                {method.toUpperCase()}
+              </MenuItem>
+            ))}
+          </TextField>
+        </Stack>
+      ) : null}
+      {enableResourceSearch && !hasDisplayedResources ? (
+        <Typography variant='body2' color="text.secondary" sx={{ px: 1, py: 2 }}>
+          No resources match your search.
+        </Typography>
+      ) : (
+        <SwaggerUIComponent
+          key={swaggerInstanceKey}
+          spec={displayedSpec}
+          docExpansion={docExpansion}
+          defaultModelsExpandDepth={defaultModelsExpandDepth}
+          displayRequestDuration={displayRequestDuration}
+          showMutatedRequest={!disableNetworkExecution}
+          plugins={plugins}
+          requestInterceptor={requestInterceptor}
+        />
+      )}
+    </Stack>
   );
 }

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyOverviewTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyOverviewTab.tsx
@@ -567,6 +567,7 @@ export default function LLMProxyOverviewTab() {
                 docExpansion="list"
                 defaultModelsExpandDepth={-1}
                 displayRequestDuration
+                enableResourceSearch
               />
             )}
           </Box>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderNew.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderNew.tsx
@@ -333,6 +333,11 @@ export default function ServiceProviderNew() {
       .replace(/[^a-z0-9]+/g, '-')
       .replace(/^-+|-+$/g, '');
 
+  const toMajorPolicyVersion = (version: string): string => {
+    const majorVersion = version.trim().match(/^v?(\d+)/i)?.[1];
+    return majorVersion ? `v${majorVersion}` : version;
+  };
+
   const handleCreateProvider = async () => {
     if (!isFormValid || !selectedTemplateId) return;
 
@@ -382,7 +387,7 @@ export default function ServiceProviderNew() {
             : []),
           ...guardrails.map((guardrail) => ({
             name: guardrail.name,
-            version: guardrail.version,
+            version: toMajorPolicyVersion(guardrail.version),
             params: guardrail.settings ?? {},
           })),
         ],

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverview.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverview.tsx
@@ -932,6 +932,7 @@ function ServiceProviderOverviewContent() {
         docExpansion="list"
         defaultModelsExpandDepth={-1}
         displayRequestDuration
+        enableResourceSearch
       />
     );
   };

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverviewTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverviewTab.tsx
@@ -707,6 +707,7 @@ export default function ServiceProviderOverviewTab({
                 docExpansion="list"
                 defaultModelsExpandDepth={-1}
                 displayRequestDuration
+                enableResourceSearch
               />
             )}
           </Box>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderSecurityTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderSecurityTab.tsx
@@ -232,12 +232,12 @@ export default function ServiceProviderSecurityTab() {
                     defaultMessage={'header'}
                   />
                 </MenuItem>
-                <MenuItem value="query">
+                {/* <MenuItem value="query">
                   <FormattedMessage
                     id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderSecurityTab.query"
                     defaultMessage={'query'}
                   />
-                </MenuItem>
+                </MenuItem> */}
               </Select>
             </FormControl>
           </Stack>


### PR DESCRIPTION
This pull request introduces a resource search feature to the `SwaggerSpecViewer` component, allowing users to filter API resources by path, description, or HTTP method. The search UI is conditionally rendered and enabled in several pages that use the Swagger viewer. Additionally, a minor update ensures that only the major version is used for guardrail policy versions when creating a new service provider. There is also a small change that comments out the "query" option in the security tab's select menu.

Issue:

- https://github.com/wso2/api-platform/issues/2665
- https://github.com/wso2/api-platform/issues/2661

**Enhancements to SwaggerSpecViewer:**

* Added a resource search bar and HTTP method filter to the `SwaggerSpecViewer` component, enabling users to filter displayed API resources by path, description, or method. The search is controlled by the new `enableResourceSearch` prop. [[1]](diffhunk://#diff-0ace31787b19ed5c3d73d7ab3f8e77f5ade7568c829c9568d6739765c6913390L19-R27) [[2]](diffhunk://#diff-0ace31787b19ed5c3d73d7ab3f8e77f5ade7568c829c9568d6739765c6913390R51) [[3]](diffhunk://#diff-0ace31787b19ed5c3d73d7ab3f8e77f5ade7568c829c9568d6739765c6913390R208-R271) [[4]](diffhunk://#diff-0ace31787b19ed5c3d73d7ab3f8e77f5ade7568c829c9568d6739765c6913390R288-R292) [[5]](diffhunk://#diff-0ace31787b19ed5c3d73d7ab3f8e77f5ade7568c829c9568d6739765c6913390R313-R326) [[6]](diffhunk://#diff-0ace31787b19ed5c3d73d7ab3f8e77f5ade7568c829c9568d6739765c6913390L459-R603)
* Enabled the resource search feature (`enableResourceSearch`) in the LLM Proxy Overview, Service Provider Overview, and Service Provider Overview Tab pages, making the search UI available to users on those pages. [[1]](diffhunk://#diff-714644b39bb5327a77a80f1e61ec062608d8a21868584c8bff8d47243f4dd137R570) [[2]](diffhunk://#diff-efd312aa5753c561eb31097151c2aeae08fb9be9e263231e841214bbfb366e2aR935) [[3]](diffhunk://#diff-dfa3730c5433bcf6bc014ddec3c15813182c9f41e4b0c65fb3b47947829185a9R710)

**Service Provider creation improvement:**

* Updated the service provider creation logic to use only the major version (e.g., `v1`) for guardrail policy versions, standardizing how versions are stored. [[1]](diffhunk://#diff-5f3cfa9035307148cacb9a695d1cde1ebe05c3b5c50435d0f5ec42d6bfa6280dR336-R340) [[2]](diffhunk://#diff-5f3cfa9035307148cacb9a695d1cde1ebe05c3b5c50435d0f5ec42d6bfa6280dL385-R390)

**UI adjustment:**

* Commented out the "query" option in the security tab's select menu, likely to temporarily hide it from the UI.