### PR TITLE
Enhance LLM Provider management and improve UI error handling

### DIFF
--- a/platform-api/internal/apperror/catalog.go
+++ b/platform-api/internal/apperror/catalog.go
@@ -99,6 +99,7 @@ var (
 	LLMProviderTemplateVersionExists     = def(CodeLLMProviderTemplateVersionExists, http.StatusConflict, "This template version already exists.")
 	LLMProviderTemplateManagedByReserved = def(CodeLLMProviderTemplateManagedByReserved, http.StatusBadRequest, "'wso2' is reserved and cannot be used as managedBy on custom templates.")
 	LLMProviderTemplateInUse             = def(CodeLLMProviderTemplateInUse, http.StatusConflict, "This template version is in use by one or more providers.")
+	LLMProviderTemplateDisabled          = def(CodeLLMProviderTemplateDisabled, http.StatusBadRequest, "The referenced LLM provider template is disabled.")
 	LLMProviderTemplateReadOnly          = def(CodeLLMProviderTemplateReadOnly, http.StatusForbidden, "Built-in templates are read-only and cannot be modified.")
 	LLMProviderTemplateNotToggleable     = def(CodeLLMProviderTemplateNotToggleable, http.StatusForbidden, "Only built-in templates can be enabled or disabled.")
 )

--- a/platform-api/internal/apperror/codes.go
+++ b/platform-api/internal/apperror/codes.go
@@ -65,6 +65,7 @@ const (
 	CodeLLMProviderTemplateVersionExists     = "LLM_PROVIDER_TEMPLATE_VERSION_EXISTS"
 	CodeLLMProviderTemplateManagedByReserved = "LLM_PROVIDER_TEMPLATE_MANAGED_BY_RESERVED"
 	CodeLLMProviderTemplateInUse             = "LLM_PROVIDER_TEMPLATE_IN_USE"
+	CodeLLMProviderTemplateDisabled          = "LLM_PROVIDER_TEMPLATE_DISABLED"
 	CodeLLMProviderTemplateReadOnly          = "LLM_PROVIDER_TEMPLATE_READ_ONLY"
 	CodeLLMProviderTemplateNotToggleable     = "LLM_PROVIDER_TEMPLATE_NOT_TOGGLEABLE"
 )

--- a/platform-api/internal/service/llm.go
+++ b/platform-api/internal/service/llm.go
@@ -857,6 +857,10 @@ func (s *LLMProviderService) Create(orgUUID, createdBy string, req *api.LLMProvi
 	if tpl == nil {
 		return nil, apperror.LLMProviderTemplateRefNotFound.New()
 	}
+	if !tpl.Enabled {
+		return nil, apperror.LLMProviderTemplateDisabled.New().
+			WithLogMessage("llm provider template is disabled")
+	}
 
 	// Determine handle: use provided id or auto-generate from displayName
 	var handle string
@@ -901,9 +905,6 @@ func (s *LLMProviderService) Create(orgUUID, createdBy string, req *api.LLMProvi
 	}
 	if err := validateLLMResourceLimit(providerCount, s.cfg.ArtifactLimits.MaxLLMProvidersPerOrg, apperror.LLMProviderLimitReached.New()); err != nil {
 		return nil, err
-	}
-	if !tpl.Enabled {
-		return nil, apperror.ValidationFailed.New("The referenced LLM provider template version is disabled.")
 	}
 
 	openapiSpec := utils.ValueOrEmpty(req.Openapi)
@@ -1085,6 +1086,10 @@ func (s *LLMProviderService) Update(orgUUID, handle, updatedBy string, req *api.
 	}
 	if tpl == nil {
 		return nil, apperror.LLMProviderTemplateRefNotFound.New()
+	}
+	if !tpl.Enabled {
+		return nil, apperror.LLMProviderTemplateDisabled.New().
+			WithLogMessage("llm provider template is disabled")
 	}
 
 	// Validate {{ secret "..." }} placeholders anywhere in the request — see

--- a/platform-api/internal/service/llm_test.go
+++ b/platform-api/internal/service/llm_test.go
@@ -1271,7 +1271,7 @@ func TestLLMProviderServiceCreateReturnsConflictForDuplicateHandle(t *testing.T)
 	providerRepo := &mockLLMProviderRepo{existsResult: true}
 	templateRepo := &mockLLMTemplateRepo{
 		getByIDFunc: func(templateID, orgUUID string) (*model.LLMProviderTemplate, error) {
-			return &model.LLMProviderTemplate{UUID: "tpl-openai", ID: "openai"}, nil
+			return &model.LLMProviderTemplate{UUID: "tpl-openai", ID: "openai", Enabled: true}, nil
 		},
 	}
 	service := NewLLMProviderService(providerRepo, templateRepo, nil, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{}, newTestIdentityService())
@@ -1313,7 +1313,7 @@ func TestLLMProviderServiceUpdatePreservesUpstreamAuthValue(t *testing.T) {
 	}
 	templateRepo := &mockLLMTemplateRepo{
 		getByIDFunc: func(templateID, orgUUID string) (*model.LLMProviderTemplate, error) {
-			return &model.LLMProviderTemplate{UUID: "tpl-openai", ID: "openai"}, nil
+			return &model.LLMProviderTemplate{UUID: "tpl-openai", ID: "openai", Enabled: true}, nil
 		},
 	}
 	service := NewLLMProviderService(providerRepo, templateRepo, nil, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{}, newTestIdentityService())
@@ -1495,6 +1495,50 @@ func TestLLMProxyServiceUpdatePreservesProviderAuthValue(t *testing.T) {
 	}
 }
 
+// TestLLMProviderServiceCreate_DisabledTemplate_Rejected proves a provider
+// cannot be created against a disabled template.
+func TestLLMProviderServiceCreate_DisabledTemplate_Rejected(t *testing.T) {
+	providerRepo := &mockLLMProviderRepo{}
+	templateRepo := &mockLLMTemplateRepo{
+		getByIDFunc: func(templateID, orgUUID string) (*model.LLMProviderTemplate, error) {
+			return &model.LLMProviderTemplate{UUID: "tpl-openai", ID: "openai", Enabled: false}, nil
+		},
+	}
+	service := NewLLMProviderService(providerRepo, templateRepo, nil, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{}, newTestIdentityService())
+
+	_, err := service.Create("org-1", "alice", validProviderRequest("openai"))
+	if !apperror.LLMProviderTemplateDisabled.Is(err) {
+		t.Fatalf("expected LLMProviderTemplateDisabled, got: %v", err)
+	}
+	if providerRepo.created != nil {
+		t.Error("expected provider creation to be aborted, but repo.Create was called")
+	}
+}
+
+// TestLLMProviderServiceUpdate_DisabledTemplate_Rejected proves a provider
+// cannot be updated to reference a disabled template.
+func TestLLMProviderServiceUpdate_DisabledTemplate_Rejected(t *testing.T) {
+	providerRepo := &mockLLMProviderRepo{
+		getByIDFunc: func(providerID, orgUUID string) (*model.LLMProvider, error) {
+			return &model.LLMProvider{UUID: "prov-uuid", ID: providerID, TemplateUUID: "tpl-openai"}, nil
+		},
+	}
+	templateRepo := &mockLLMTemplateRepo{
+		getByIDFunc: func(templateID, orgUUID string) (*model.LLMProviderTemplate, error) {
+			return &model.LLMProviderTemplate{UUID: "tpl-openai", ID: "openai", Enabled: false}, nil
+		},
+	}
+	service := NewLLMProviderService(providerRepo, templateRepo, nil, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{}, newTestIdentityService())
+
+	_, err := service.Update("org-1", "provider-1", "alice", validProviderRequest("openai"))
+	if !apperror.LLMProviderTemplateDisabled.Is(err) {
+		t.Fatalf("expected LLMProviderTemplateDisabled, got: %v", err)
+	}
+	if providerRepo.updated != nil {
+		t.Error("expected provider update to be aborted, but repo.Update was called")
+	}
+}
+
 // TestLLMProviderServiceCreate_PolicySecretRef_Rejected proves secret-ref
 // validation now covers the whole request, not just upstream.auth — a
 // placeholder embedded in a policy param (not upstream) must also be rejected.
@@ -1635,7 +1679,7 @@ func TestLLMProviderServiceUpdate_CleansUpRotatedSecret(t *testing.T) {
 	}
 	templateRepo := &mockLLMTemplateRepo{
 		getByIDFunc: func(templateID, orgUUID string) (*model.LLMProviderTemplate, error) {
-			return &model.LLMProviderTemplate{UUID: "tpl-openai", ID: "openai"}, nil
+			return &model.LLMProviderTemplate{UUID: "tpl-openai", ID: "openai", Enabled: true}, nil
 		},
 	}
 	secretRepo := newMockRepo()

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/ProviderTemplateOverview.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/ProviderTemplateOverview.tsx
@@ -102,6 +102,9 @@ function TabPanel({ value, index, children }: TabPanelProps) {
 
 const tabs = ['Overview', 'Connection', 'Token Mapping'];
 
+const UNSAVED_CHANGES_MESSAGE =
+  'You have unsaved changes. Please save or cancel before leaving this page.';
+
 function parseOpenApiSpec(text: string): Record<string, unknown> | null {
   if (!text.trim()) return null;
   try {
@@ -179,6 +182,14 @@ export default function ProviderTemplateOverview() {
   const [isDeleting, setIsDeleting] = useState(false);
 
   const listPath = buildOrgPath(currentOrganization, '/settings/llm-provider-templates');
+
+  const handleTabChange = (_: React.SyntheticEvent, value: number) => {
+    if (value !== tabIndex && isDirty) {
+      showSnackbar(UNSAVED_CHANGES_MESSAGE, 'error');
+      return;
+    }
+    setTabIndex(value);
+  };
 
   useEffect(() => {
     const organizationId = currentOrganization?.uuid;
@@ -867,7 +878,7 @@ export default function ProviderTemplateOverview() {
         <Card>
           <Tabs
             value={tabIndex}
-            onChange={(_, value) => setTabIndex(value)}
+            onChange={handleTabChange}
             variant="scrollable"
             allowScrollButtonsMobile
           >

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/ProviderTemplateOverview.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/ProviderTemplateOverview.tsx
@@ -726,7 +726,7 @@ export default function ProviderTemplateOverview() {
                     endIcon={<ChevronDown size={16} />}
                     sx={{ borderRadius: 5, px: 1.5 }}
                   >
-                    {selectedVersion || template.version || 'v1'}
+                    {selectedVersion || template.version || 'v1.0'}
                   </Button>
                   <Menu
                     anchorEl={versionMenuAnchor}
@@ -755,9 +755,9 @@ export default function ProviderTemplateOverview() {
                             {sectionLabel}
                           </Typography>
                           {visibleVersions.map((v) => {
-                            const ver = v.version || 'v1';
+                            const ver = v.version || 'v1.0';
                             const isSelected =
-                              ver === (selectedVersion || template.version || 'v1');
+                              ver === (selectedVersion || template.version || 'v1.0');
                             return (
                               <MenuItem
                                 key={ver}

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/AddNewProvider/ProviderTemplateSelector.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/AddNewProvider/ProviderTemplateSelector.tsx
@@ -49,9 +49,11 @@ import {
   truncateProviderDisplayName,
 } from '../../../../../utils/providerTemplateDisplay';
 
-// Logo mapping for provider templates by name (case-insensitive partial match)
-const getLogoForTemplate = (templateName: string): string | null => {
-  const lowerName = templateName.toLowerCase();
+const getLogoForTemplate = (template: ProviderTemplate): string | null => {
+  const logoUrl =
+    template.metadata?.logoUrl?.trim() || template.logoUrl?.trim();
+  if (logoUrl) return logoUrl;
+  const lowerName = template.displayName.toLowerCase();
   if (lowerName.includes('bedrock') || lowerName.includes('aws'))
     return awsBedrockLogo;
   if (lowerName.includes('openai') && !lowerName.includes('azure'))
@@ -160,7 +162,7 @@ export default function ProviderTemplateSelector({
                 familyHandle(templateId)
               );
               const isSelected = !isComingSoon && selectedTemplateId === template.id;
-              const logo = getLogoForTemplate(template.displayName);
+              const logo = getLogoForTemplate(template);
               const shortName = getShortNameForTemplate(template.displayName);
               return (
                 <Form.CardButton

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderModelsTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderModelsTab.tsx
@@ -427,7 +427,7 @@ export default function ServiceProviderModelsTab() {
                         onClick={() => setSelectedProviderId(p.id)}
                         removeDisabled={isSaving || isReadOnlyProvider}
                         onRemove={
-                          p.id === 'azureai-foundry' && !isReadOnlyProvider
+                          !isReadOnlyProvider
                             ? () => {
                                 void removeProvider(p.id);
                               }

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderModelsTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderModelsTab.tsx
@@ -39,6 +39,7 @@ import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
 import { FormattedMessage } from 'react-intl';
 import NoModelsImage from '../../../../assets/images/NoModels.svg';
 import { DisabledActionTooltip } from '../../../../utils/readOnlyArtifacts';
+import { isBuiltInProviderTemplate } from '../../../../utils/providerTemplateDisplay';
 
 type ProviderOption = {
   id: string;
@@ -191,11 +192,16 @@ export default function ServiceProviderModelsTab() {
     []
   );
 
+  const isCustomTemplate = !isBuiltInProviderTemplate(provider?.template);
+
   const [providers, setProviders] = useState(provider?.modelProviders ?? []);
   const [selectedProviderId, setSelectedProviderId] = useState<string>('');
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [selectedOptionId, setSelectedOptionId] = useState<string | null>(null);
   const [newModelName, setNewModelName] = useState('');
+  const [newProviderName, setNewProviderName] = useState('');
+  const [isProviderNameInputVisible, setIsProviderNameInputVisible] =
+    useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const showSnackbar = useAIWorkspaceSnackbar();
 
@@ -299,6 +305,45 @@ export default function ServiceProviderModelsTab() {
     if (isProviderAdded) {
       setDrawerOpen(false);
       setSelectedOptionId(null);
+    }
+  };
+
+  const addCustomProvider = async () => {
+    if (!provider || isLoading || error || isSaving) return;
+
+    const trimmedName = newProviderName.trim();
+    if (!trimmedName) return;
+
+    if ((provider.modelProviders ?? []).length >= 1) {
+      return;
+    }
+
+    const slug = trimmedName
+      .toLowerCase()
+      .replace(/\s+/g, '-')
+      .replace(/[^a-z0-9._-]/g, '');
+    if (!slug) {
+      showSnackbar('Enter a valid provider name.', 'warning');
+      return;
+    }
+
+    const nextProviders = [
+      {
+        id: slug,
+        displayName: trimmedName,
+        models: [],
+      },
+    ];
+
+    const isProviderAdded = await updateModelProviders(
+      nextProviders,
+      'Model provider added successfully.',
+      'Failed to add model provider.',
+      slug
+    );
+    if (isProviderAdded) {
+      setNewProviderName('');
+      setIsProviderNameInputVisible(false);
     }
   };
 
@@ -497,20 +542,56 @@ export default function ServiceProviderModelsTab() {
                         defaultMessage={'No providers added yet.'}
                       />
                     </Typography>
-                    <DisabledActionTooltip disabled={isReadOnlyProvider}>
-                      <Button
+                    {isCustomTemplate && isProviderNameInputVisible ? (
+                      <TextField
                         size="small"
-                        variant="outlined"
-                        startIcon={<Plus size={16} />}
+                        fullWidth
+                        autoFocus
+                        value={newProviderName}
                         disabled={isSaving || isReadOnlyProvider}
-                        onClick={() => setDrawerOpen(true)}
-                      >
-                        <FormattedMessage
-                          id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderModelsTab.add.model.provider.2"
-                          defaultMessage={'Add Model Provider'}
-                        />
-                      </Button>
-                    </DisabledActionTooltip>
+                        onChange={(event) =>
+                          setNewProviderName(event.target.value)
+                        }
+                        onKeyDown={(event) => {
+                          if (event.key === 'Enter') {
+                            event.preventDefault();
+                            void addCustomProvider();
+                          }
+                        }}
+                        onBlur={() => {
+                          if (!newProviderName.trim()) {
+                            // Nothing typed — collapse back to the button.
+                            setNewProviderName('');
+                            setIsProviderNameInputVisible(false);
+                            return;
+                          }
+                          void addCustomProvider();
+                        }}
+                        placeholder="Enter provider name"
+                        inputProps={{ 'aria-label': 'Model provider name' }}
+                      />
+                    ) : (
+                      <DisabledActionTooltip disabled={isReadOnlyProvider}>
+                        <Button
+                          size="small"
+                          variant="outlined"
+                          startIcon={<Plus size={16} />}
+                          disabled={isSaving || isReadOnlyProvider}
+                          onClick={() => {
+                            if (isCustomTemplate) {
+                              setIsProviderNameInputVisible(true);
+                            } else {
+                              setDrawerOpen(true);
+                            }
+                          }}
+                        >
+                          <FormattedMessage
+                            id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderModelsTab.add.model.provider.2"
+                            defaultMessage={'Add Model Provider'}
+                          />
+                        </Button>
+                      </DisabledActionTooltip>
+                    )}
                   </Stack>
                 </Box>
               )}

--- a/portals/ai-workspace/src/utils/apiError.ts
+++ b/portals/ai-workspace/src/utils/apiError.ts
@@ -40,6 +40,7 @@ export interface PlatformErrorBody {
   status: 'error';
   code: string;
   message: string;
+  description?: string;
   errors?: FieldError[];
   details?: Record<string, unknown>;
   trackingId?: string;
@@ -89,9 +90,12 @@ export function buildApiError(
   fallbackMessage = `Request failed (HTTP ${status})`,
 ): ApiError {
   const parsed = asPlatformErrorBody(body);
-  const rawMessage = typeof parsed.message === 'string' && parsed.message.trim().length > 0
-    ? parsed.message
-    : fallbackMessage;
+  const rawMessage =
+    typeof parsed.description === 'string' && parsed.description.trim().length > 0
+      ? parsed.description
+      : typeof parsed.message === 'string' && parsed.message.trim().length > 0
+        ? parsed.message
+        : fallbackMessage;
 
   const err = new Error(shortenMessage(rawMessage)) as ApiError;
   err.status = status;


### PR DESCRIPTION
## Purpose
Fixes several issues in LLM provider management across the AI Workspace UI and Platform API.

## Changes
- Fix custom logos not loading in "Add LLM Provider" cards
- Block tab switching when there are unsaved changes in the provider models tab
- Block creating a provider from a disabled template.
Resolves : https://github.com/wso2/api-platform/issues/2473
- Allow removing a provider from a multi-model provider
Resolves : https://github.com/wso2/api-platform/issues/2468
- Add input field when creating custom model providers
- Improve error messages shown in the UI

## UI changes

For Custom LLM Templates: 
<img width="1397" height="346" alt="image" src="https://github.com/user-attachments/assets/257afd30-084f-4eff-8b4f-68f79a7a1b84" />

For templates with Multi model provider support:
<img width="1437" height="410" alt="image" src="https://github.com/user-attachments/assets/338e9a98-1173-4946-8598-37fa607b03d4" />

