### PR TITLE
fix(gateway-builder): add git to runtime template Python dep install

### DIFF
--- a/gateway/gateway-builder/templates/Dockerfile.gateway-runtime.tmpl
+++ b/gateway/gateway-builder/templates/Dockerfile.gateway-runtime.tmpl
@@ -29,10 +29,10 @@ RUN rm -rf /app/python-executor
 COPY python-executor/ /app/python-executor/
 
 # Install python dependencies for custom policies
-RUN apt-get update && apt-get install -y --no-install-recommends python3-pip && \
+RUN apt-get update && apt-get install -y --no-install-recommends git python3-pip && \
     pip3 install --no-cache-dir --upgrade pip setuptools wheel && \
     pip3 install --no-cache-dir --target /app/python-libs -r /app/python-executor/requirements.txt && \
-    apt-get purge -y python3-pip && \
+    apt-get purge -y git python3-pip && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 USER wso2


### PR DESCRIPTION
## Purpose

When gateway-builder generates the custom gateway-runtime image (via `Dockerfile.gateway-runtime.tmpl`), it installs Python dependencies from the policy `requirements.txt`. If that file contains a `git+https://` URL (e.g. the `prompt-compressor` policy), `pip` fails with `Cannot find command 'git'` because `git` was not installed in that build step.

Fixes https://github.com/wso2/api-platform/issues/2663

## Goals

Ensure the generated gateway-runtime Dockerfile can install Python dependencies that reference `git+https://` URLs without build failures.

## Approach

- Add `git` to the `apt-get install` step in `Dockerfile.gateway-runtime.tmpl` alongside `python3-pip`.
- Purge `git` in the same `RUN` layer (alongside `python3-pip`) so neither tool persists in the final image, keeping the layer size minimal.
- The main `gateway-runtime/Dockerfile` already installs `git` in its `python-deps` stage — this fix brings the builder template into parity.

## User stories

As a gateway developer using a Python policy with a `git+https://` dependency, the `ap gateway image build` command succeeds without `git`-not-found errors.

## Documentation

N/A — internal build fix, no user-facing documentation change.

## Automation tests

- Unit tests: N/A
- Integration tests: Existing gateway build integration tests cover the generated Dockerfile execution path.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (Dockerfile change only)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

N/A

## Test environment

- macOS (darwin 25.5.0), Docker BuildKit