### PR TITLE
Bump API key policy version to 1.2.0

### DIFF
--- a/gateway/build-manifest.yaml
+++ b/gateway/build-manifest.yaml
@@ -7,7 +7,7 @@ policies:
       version: v1.0.1
       gomodule: github.com/wso2/gateway-controllers/policies/analytics-header-filter@v1
     - name: api-key-auth
-      version: v1.1.0
+      version: v1.2.0
       gomodule: github.com/wso2/gateway-controllers/policies/api-key-auth@v1
     - name: aws-bedrock-guardrail
       version: v1.0.2


### PR DESCRIPTION
Upgrade the version of the `api-key-auth` policy in the `gateway/build-manifest.yaml` file. The version is incremented from `v1.1.0` to `v1.2.0`.