### PR TITLE
[AI Gateway] Rename injected transformer provider parameter to provider-id

### DIFF
--- a/gateway/examples/openai-multi-provider-proxy.yaml
+++ b/gateway/examples/openai-multi-provider-proxy.yaml
@@ -20,9 +20,9 @@
 #
 #   * Multi-provider mode    — put openai-header-router first. It writes
 #     the chosen provider into metadata["selected_provider"]. Each
-#     translator then runs only when that selection equals its own "id".
-#     The "id" doubles as the upstream cluster name, so it must match an
-#     entry in additionalProviders (id or as).
+#     translator then runs only when that selection equals its own
+#     "provider-id". The "provider-id" doubles as the upstream cluster
+#     name, so it must match an entry in additionalProviders (id or as).
 #
 # --------------------------------------------------------------------
 

--- a/gateway/gateway-controller/pkg/utils/llm_transformer.go
+++ b/gateway/gateway-controller/pkg/utils/llm_transformer.go
@@ -798,9 +798,9 @@ func (t *LLMProviderTransformer) proxyUpstreamAuthPolicy(auth *api.LLMUpstreamAu
 }
 
 // proxyTransformerPolicy builds a translator policy for an additional provider's
-// inline transformer. The provider's upstream name is passed to the translator as
-// its "id" param so it targets the correct upstream, and gates execution so the
-// translator runs only when this provider is the selected upstream.
+// inline transformer. The provider's upstream name is passed to the translator
+// as its "provider-id" param so it targets the correct upstream, and gates
+// execution so the translator runs only when this provider is selected.
 func (t *LLMProviderTransformer) proxyTransformerPolicy(transformer *api.LLMProxyTransformer, name, field string) (*api.Policy, error) {
 	if transformer == nil {
 		return nil, nil
@@ -818,7 +818,7 @@ func (t *LLMProviderTransformer) proxyTransformerPolicy(transformer *api.LLMProx
 			params[k] = v
 		}
 	}
-	params["id"] = name
+	params["provider-id"] = name
 
 	condition := selectedProviderExecutionCondition(name, false)
 	return &api.Policy{

--- a/gateway/gateway-controller/pkg/utils/llm_transformer_multiprovider_test.go
+++ b/gateway/gateway-controller/pkg/utils/llm_transformer_multiprovider_test.go
@@ -238,7 +238,7 @@ func TestLLMProviderTransformer_TransformProxy_AdditionalProviderTransformerIsCo
 	require.NotNil(t, transformerPolicy.ExecutionCondition)
 	assert.Contains(t, *transformerPolicy.ExecutionCondition, "anthropic-provider")
 	require.NotNil(t, transformerPolicy.Params)
-	assert.Equal(t, "anthropic-provider", (*transformerPolicy.Params)["id"])
+	assert.Equal(t, "anthropic-provider", (*transformerPolicy.Params)["provider-id"])
 	assert.Equal(t, "claude-sonnet-4-5-20250929", (*transformerPolicy.Params)["model"])
 }
 


### PR DESCRIPTION

## Purpose

The OpenAI multi-provider transformer policies now use `provider-id` as the injected parameter identifying their target upstream provider. The Gateway Controller previously injected this value using `params["id"]`, creating a contract mismatch that could prevent transformer policies from selecting and routing to the correct upstream.

This change aligns the Gateway Controller with the transformer policy contract.

Related changes:

- https://github.com/wso2/gateway-controllers/pull/222
- https://github.com/wso2/gateway-controllers/pull/228

## Goals

- Inject the provider upstream name using the `provider-id` parameter.
- Keep provider selection and upstream routing consistent across all transformer policies.
- Preserve the existing resolution behavior where `additionalProviders[].as` is used when configured, otherwise falling back to `additionalProviders[].id`.
- Update tests and samples to reflect the renamed parameter.

## Approach

The Gateway Controller’s multi-provider transformer construction has been updated to inject:

```go
params["provider-id"] = name
```

The existing provider-name resolution remains unchanged:

- Use `additionalProviders[].as` when configured.
- Otherwise, use `additionalProviders[].id`.

The corresponding unit-test assertion and multi-provider proxy sample documentation were updated to use `provider-id`.

This change does not affect the UI.

## User stories

- As an API developer, I want multi-provider transformer policies to receive the expected provider identifier so requests are routed to the correct upstream provider.
- As a platform developer, I want the Gateway Controller and transformer policies to use a consistent parameter contract.
- As an operator, I want existing `additionalProviders[].id` and `additionalProviders[].as` configurations to continue working without changes.

## Documentation

No product documentation impact. The parameter is injected internally by the Gateway Controller and is not manually configured when a transformer is attached to an additional provider.

The `openai-multi-provider-proxy.yaml` sample comments were updated to document the internal `provider-id` contract.

## Automation tests

- Unit tests
  - Updated `TestLLMProviderTransformer_TransformProxy_AdditionalProviderTransformerIsConditional` to verify that the resolved provider upstream name is injected through `params["provider-id"]`.
  - The focused Gateway Controller unit test passes.
  - Code coverage was not measured separately for this focused change.

- Integration tests
  - No new integration tests were added.
  - The change is limited to renaming an internally injected transformer parameter.
  - Existing provider selection, execution conditions, and upstream-name resolution remain unchanged.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **Yes**
- Ran FindSecurityBugs plugin and verified report? **N/A — this is a Go change; FindSecurityBugs is a Java/SpotBugs plugin**
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **Yes**

## Samples

Updated the OpenAI multi-provider proxy sample comments to explain that each transformer receives its resolved upstream provider name through `provider-id`.

No sample configuration fields were renamed:

- `additionalProviders[].id` remains unchanged.
- `additionalProviders[].as` remains unchanged.
- Router mappings and `selected_provider` metadata remain unchanged.

## Related PRs

- https://github.com/wso2/gateway-controllers/pull/222
- https://github.com/wso2/gateway-controllers/pull/228
- https://github.com/wso2/api-platform/pull/2586

## Test environment

- Go: 1.26.x
- Operating system: macOS, ARM64
- JDK: N/A
- Database: N/A
- Browser: N/A
