### PR TITLE
[AI Workspace] Fix optional policy parameter serialization

### DIFF
--- a/portals/ai-workspace/src/pages/appShell/PolicyParameterEditor/PolicyParameterEditor.tsx
+++ b/portals/ai-workspace/src/pages/appShell/PolicyParameterEditor/PolicyParameterEditor.tsx
@@ -26,6 +26,7 @@ import {
   createDefaultArrayItem,
   deleteValueByPath,
   coerceValuesToSchemaTypes,
+  omitOptionalEmptyValues,
 } from './schemaUtils';
 import SchemaTree from './SchemaTree';
 import { useStyles } from './styles';
@@ -450,7 +451,11 @@ const PolicyParameterEditor: React.FC<PolicyParameterEditorProps> = ({
     // Coerce values to their schema-declared types so booleans, numbers,
     // and objects are not accidentally sent as strings
     const coercedValues = coerceValuesToSchemaTypes(parameters, values);
-    onSubmit(coercedValues);
+    const sanitizedValues = omitOptionalEmptyValues(
+      parameters,
+      coercedValues
+    );
+    onSubmit(sanitizedValues);
   }, [parameters, values, onSubmit]);
 
   return (

--- a/portals/ai-workspace/src/pages/appShell/PolicyParameterEditor/schemaUtils.ts
+++ b/portals/ai-workspace/src/pages/appShell/PolicyParameterEditor/schemaUtils.ts
@@ -368,6 +368,88 @@ export function coerceValuesToSchemaTypes(
 }
 
 /**
+ * Remove empty optional values before policy parameters are submitted.
+ *
+ * Optional schema properties must be omitted when they are not configured.
+ * Sending an empty value still makes the property present and causes schema
+ * constraints such as minLength or minItems to be evaluated by the gateway.
+ * Required empty values are retained so the form validation can report them.
+ */
+export function omitOptionalEmptyValues(
+  schema: ParameterSchema,
+  values: ParameterValues
+): ParameterValues {
+  if (schema.type !== 'object' || !schema.properties) return values;
+
+  const required = new Set(schema.required ?? []);
+  const result: ParameterValues = {};
+
+  Object.entries(values).forEach(([key, originalValue]) => {
+    const propSchema = schema.properties?.[key];
+
+    // Preserve values not described by the schema for parameter objects that
+    // allow arbitrary additional properties.
+    if (!propSchema) {
+      result[key] = originalValue;
+      return;
+    }
+
+    let value = originalValue;
+
+    if (
+      propSchema.type === 'object' &&
+      propSchema.properties &&
+      typeof value === 'object' &&
+      value !== null &&
+      !Array.isArray(value)
+    ) {
+      value = omitOptionalEmptyValues(
+        propSchema,
+        value as ParameterValues
+      );
+    } else if (
+      propSchema.type === 'array' &&
+      propSchema.items?.type === 'object' &&
+      propSchema.items.properties &&
+      Array.isArray(value)
+    ) {
+      value = value.map((item) => {
+        if (
+          typeof item !== 'object' ||
+          item === null ||
+          Array.isArray(item)
+        ) {
+          return item;
+        }
+
+        return omitOptionalEmptyValues(
+          propSchema.items!,
+          item as ParameterValues
+        );
+      });
+    }
+
+    const isEmptyObject =
+      typeof value === 'object' &&
+      value !== null &&
+      !Array.isArray(value) &&
+      Object.keys(value as ParameterValues).length === 0;
+    const isEmpty =
+      value === undefined ||
+      value === null ||
+      value === '' ||
+      (Array.isArray(value) && value.length === 0) ||
+      isEmptyObject;
+
+    if (isEmpty && !required.has(key)) return;
+
+    result[key] = value;
+  });
+
+  return result;
+}
+
+/**
  * Create a new array item with default values based on item schema
  */
 export function createDefaultArrayItem(itemSchema: ParameterSchema): unknown {


### PR DESCRIPTION

## Purpose

The AI Workspace policy parameter editor submitted optional policy parameters with empty values even when users left those fields blank.

For policies such as `aws-authentication`, optional parameters including `awsAccessKeyID`, `awsSecretAccessKey`, `awsSessionToken`, and `awsRoleExternalID` have `minLength: 1`. Sending them as empty strings makes them present in the payload, causing gateway schema validation to reject the provider deployment.

Bottom-up configurations worked because unconfigured optional parameters were omitted, while providers configured through the UI failed because those parameters were submitted as empty strings.

Resolves #2685

## Goals

- Omit optional policy parameters when they are not configured.
- Preserve optional and advanced parameters when users provide values.
- Preserve schema-defined defaults and required parameters.
- Preserve meaningful values such as `false` and `0`.
- Apply the fix consistently to all policies using the shared policy parameter editor.
- Keep gateway schema validation strict.

## Approach

Added schema-aware parameter sanitization to the shared `PolicyParameterEditor`.

Before submitting policy parameters, the editor now:

1. Coerces values to their schema-declared types.
2. Recursively removes empty optional strings, arrays, and objects.
3. Retains required fields so form validation can report missing required values.
4. Retains meaningful boolean and numeric values such as `false` and `0`.
5. Retains schema-defined defaults.
6. Retains populated advanced parameters.
7. Preserves additional parameters not explicitly described by the schema.

For an AWS STS AssumeRole configuration, the UI now submits a payload similar to:

```json
{
  "authenticationType": "sts-assume-role",
  "service": "bedrock",
  "region": "us-east-1",
  "awsRoleARN": "arn:aws:iam::123456789012:role/BedrockGatewayRole",
  "awsRoleSessionName": "aws-authentication-session"
}
```

The following unconfigured optional parameters are omitted instead of being submitted as empty strings:

```text
awsAccessKeyID
awsSecretAccessKey
awsSessionToken
awsRoleExternalID
```
## User stories

- As an AI Workspace user, I can configure AWS STS AssumeRole authentication without entering optional static AWS credentials.
- As an AI Workspace user, I can deploy an LLM provider without blank optional policy parameters causing gateway validation failures.
- As a policy user, I expect optional fields that I leave blank to be omitted from the submitted configuration.
- As a policy user, I expect advanced parameters that I configure to remain in the payload.
- As a gateway operator, I expect explicitly supplied invalid values to continue being rejected by schema validation.

## Documentation

N/A — this is a UI serialization bug fix. It does not introduce or change any user-facing configuration fields, APIs, or documented workflows.

## Automation tests

### Unit tests

No new automated unit tests were added because the AI Workspace frontend does not currently have a unit-test runner configured for this utility.

The sanitization behavior was verified using a focused payload assertion covering:

- Removal of optional empty strings.
- Removal of optional empty arrays.
- Removal of empty nested objects.
- Retention of populated AWS parameters.
- Retention of schema-defined defaults.
- Retention of `false` and `0`.

Code coverage was not collected.

### Integration tests

No new automated integration tests were added.

Manual local verification was performed using the AI Workspace, BFF, and Platform API:

- Added the `aws-authentication` policy to an LLM provider.
- Selected `sts-assume-role`.
- Left optional AWS credential fields blank.
- Inspected the provider update request in the browser Network tab.
- Confirmed that blank optional credential fields were absent from the payload.
- Confirmed that required values and schema defaults remained in the payload.
- Confirmed that populated advanced parameters remained in the payload.

The AI Workspace production build passed:

```bash
cd portals/ai-workspace
npm run build
```

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **Yes**
- Ran FindSecurityBugs plugin and verified report? **N/A — this change contains TypeScript/React frontend code; FindSecurityBugs is a Java-specific tool**
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **Yes**

Local runtime-generated encryption keys, certificates, configuration files, and test artifacts were not staged or committed.

## Samples

N/A — no samples are required because this is a shared UI serialization fix and does not introduce a new policy or configuration format.

## Related PRs

N/A

## Test environment

- Operating system: macOS
- Frontend: React with Vite
- Browser: Chromium-based browser; exact version not recorded
- Authentication: Local file-based authentication
- Platform API: Local Go process
- Database: Local Platform API default configuration
- JDK: N/A
- Verification URL: `https://localhost:5380`
