### PR TITLE
     Pull requests list [AI Gateway] Rename injected transformer provider parameter to providerId 

### DIFF
--- a/gateway/examples/openai-multi-provider-proxy.yaml
+++ b/gateway/examples/openai-multi-provider-proxy.yaml
@@ -21,7 +21,7 @@
 #   * Multi-provider mode    — put openai-header-router first. It writes
 #     the chosen provider into metadata["selected_provider"]. Each
 #     translator then runs only when that selection equals its own
-#     "provider-id". The "provider-id" doubles as the upstream cluster
+#     "providerId". The "providerId" doubles as the upstream cluster
 #     name, so it must match an entry in additionalProviders (id or as).
 #
 # --------------------------------------------------------------------

--- a/gateway/gateway-controller/pkg/utils/llm_transformer.go
+++ b/gateway/gateway-controller/pkg/utils/llm_transformer.go
@@ -799,7 +799,7 @@ func (t *LLMProviderTransformer) proxyUpstreamAuthPolicy(auth *api.LLMUpstreamAu
 
 // proxyTransformerPolicy builds a translator policy for an additional provider's
 // inline transformer. The provider's upstream name is passed to the translator
-// as its "provider-id" param so it targets the correct upstream, and gates
+// as its "providerId" param so it targets the correct upstream, and gates
 // execution so the translator runs only when this provider is selected.
 func (t *LLMProviderTransformer) proxyTransformerPolicy(transformer *api.LLMProxyTransformer, name, field string) (*api.Policy, error) {
 	if transformer == nil {
@@ -818,7 +818,7 @@ func (t *LLMProviderTransformer) proxyTransformerPolicy(transformer *api.LLMProx
 			params[k] = v
 		}
 	}
-	params["provider-id"] = name
+	params["providerId"] = name
 
 	condition := selectedProviderExecutionCondition(name, false)
 	return &api.Policy{

--- a/gateway/gateway-controller/pkg/utils/llm_transformer_multiprovider_test.go
+++ b/gateway/gateway-controller/pkg/utils/llm_transformer_multiprovider_test.go
@@ -238,7 +238,7 @@ func TestLLMProviderTransformer_TransformProxy_AdditionalProviderTransformerIsCo
 	require.NotNil(t, transformerPolicy.ExecutionCondition)
 	assert.Contains(t, *transformerPolicy.ExecutionCondition, "anthropic-provider")
 	require.NotNil(t, transformerPolicy.Params)
-	assert.Equal(t, "anthropic-provider", (*transformerPolicy.Params)["provider-id"])
+	assert.Equal(t, "anthropic-provider", (*transformerPolicy.Params)["providerId"])
 	assert.Equal(t, "claude-sonnet-4-5-20250929", (*transformerPolicy.Params)["model"])
 }
 


### PR DESCRIPTION
## Purpose

PR #2684 renamed the injected multi-provider transformer parameter from `id` to `provider-id`. However, transformer policy parameters follow camelCase naming conventions, and the expected parameter name is `providerId`.

This follow-up corrects the parameter contract so transformer policies can reliably identify and route requests to the selected upstream provider.

Follow-up to https://github.com/wso2/api-platform/pull/2684.

## Goals

- Rename the injected transformer parameter from `provider-id` to `providerId`.
- Align the Gateway Controller and transformer policies on the camelCase parameter contract.
- Preserve the existing provider selection and upstream routing behavior.
- Update the relevant unit test and sample comments.

## Approach

The Gateway Controller now injects the resolved provider upstream name using:

```go
params["providerId"] = name
```

The existing provider-name resolution behavior remains unchanged:

- Use `additionalProviders[].as` when configured.
- Otherwise, use `additionalProviders[].id`.
- Execute the transformer only when its provider is selected.

The corresponding unit-test assertion and multi-provider proxy sample comments were also updated to use `providerId`.

This change does not affect the UI.

## User stories

- As an API developer, I want transformer policies to receive the provider identifier using the expected parameter name so requests are routed correctly.
- As a platform developer, I want the Gateway Controller and transformer policies to use a consistent camelCase parameter contract.
- As an operator, I want existing multi-provider configurations to continue working without configuration changes.

## Documentation

N/A — `providerId` is injected internally by the Gateway Controller and is not a user-configured API field.

The comments in the `openai-multi-provider-proxy.yaml` sample were updated to describe the corrected internal contract.

## Automation tests

- Unit tests
  - Updated `TestLLMProviderTransformer_TransformProxy_AdditionalProviderTransformerIsConditional` to verify that the resolved provider name is injected through `params["providerId"]`.
  - The focused Gateway Controller unit test passes.
  - Code coverage was not measured separately for this focused change.

- Integration tests
  - No new integration tests were added.
  - The change is limited to correcting the name of an internally injected transformer parameter.
  - Provider selection, execution conditions, and upstream-name resolution remain unchanged.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **Yes**
- Ran FindSecurityBugs plugin and verified report? **N/A — this is a Go change, and FindSecurityBugs applies to Java projects**
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **Yes**

## Samples

Updated the OpenAI multi-provider proxy sample comments to document that each transformer receives its resolved upstream provider name through `providerId`.

No sample configuration fields were renamed:

- `additionalProviders[].id` remains unchanged.
- `additionalProviders[].as` remains unchanged.
- Router mappings and `selected_provider` metadata remain unchanged.

## Related PRs

- https://github.com/wso2/api-platform/pull/2684
- https://github.com/wso2/gateway-controllers/pull/222
- https://github.com/wso2/gateway-controllers/pull/228
- https://github.com/wso2/api-platform/pull/2586

## Test environment

- Go: 1.26.x
- Operating system: macOS, ARM64
- JDK: N/A
- Database: N/A
- Browser: N/A