### PR TITLE
Change provider Overview UI

### DIFF
--- a/portals/ai-workspace/src/Components/SwaggerSpecViewer/SwaggerSpecViewer.css
+++ b/portals/ai-workspace/src/Components/SwaggerSpecViewer/SwaggerSpecViewer.css
@@ -96,6 +96,154 @@
   display: none;
 }
 
+.swagger-spec-viewer .swagger-ui .access-control-not-allowed {
+  position: relative;
+}
+
+.swagger-spec-viewer
+  .swagger-ui
+  .opblock:has(> .access-control-not-allowed),
+.swagger-spec-viewer
+  .swagger-ui
+  .opblock-tag-section:has(
+    > .opblock-tag[data-tag='__wso2_not_allowed_resources__']
+  )
+  .opblock {
+  background: #f5f5f5 !important;
+  border-color: #bdbdbd !important;
+  box-shadow: none !important;
+  opacity: 0.72;
+}
+
+.swagger-spec-viewer
+  .swagger-ui
+  .access-control-not-allowed
+  .opblock-summary,
+.swagger-spec-viewer
+  .swagger-ui
+  .opblock-tag-section:has(
+    > .opblock-tag[data-tag='__wso2_not_allowed_resources__']
+  )
+  .opblock-summary {
+  position: relative;
+  background: #f5f5f5 !important;
+  cursor: pointer;
+}
+
+.swagger-spec-viewer
+  .swagger-ui
+  .access-control-not-allowed
+  .opblock-summary-method,
+.swagger-spec-viewer
+  .swagger-ui
+  .opblock-tag-section:has(
+    > .opblock-tag[data-tag='__wso2_not_allowed_resources__']
+  )
+  .opblock-summary-method {
+  background: #757575 !important;
+  color: #fff !important;
+  text-shadow: none;
+}
+
+.swagger-spec-viewer
+  .swagger-ui
+  .access-control-not-allowed
+  :is(.opblock-summary-path, .opblock-summary-description),
+.swagger-spec-viewer
+  .swagger-ui
+  .opblock-tag-section:has(
+    > .opblock-tag[data-tag='__wso2_not_allowed_resources__']
+  )
+  :is(.opblock-summary-path, .opblock-summary-description) {
+  color: #757575 !important;
+  text-decoration: none;
+}
+
+.swagger-spec-viewer
+  .swagger-ui
+  .opblock-tag-section:has(
+    > .opblock-tag[data-tag='__wso2_not_allowed_resources__']
+  )
+  .opblock-summary::after {
+  content: 'Not allowed';
+  position: absolute;
+  top: 50%;
+  right: 48px;
+  transform: translateY(-50%);
+  padding: 3px 9px;
+  color: #616161;
+  background: #e0e0e0;
+  border: 1px solid #bdbdbd;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  pointer-events: none;
+}
+
+:is(
+    html[data-mui-color-scheme='dark'],
+    body[data-mui-color-scheme='dark'],
+    html[data-color-scheme='dark'],
+    body[data-color-scheme='dark'],
+    html[data-theme='dark'],
+    body[data-theme='dark'],
+    html.dark,
+    body.dark
+  )
+  .swagger-spec-viewer
+  .swagger-ui
+  .opblock:has(> .access-control-not-allowed),
+:is(
+    html[data-mui-color-scheme='dark'],
+    body[data-mui-color-scheme='dark'],
+    html[data-color-scheme='dark'],
+    body[data-color-scheme='dark'],
+    html[data-theme='dark'],
+    body[data-theme='dark'],
+    html.dark,
+    body.dark
+  )
+  .swagger-spec-viewer
+  .swagger-ui
+  .access-control-not-allowed
+  .opblock-summary,
+:is(
+    html[data-mui-color-scheme='dark'],
+    body[data-mui-color-scheme='dark'],
+    html[data-color-scheme='dark'],
+    body[data-color-scheme='dark'],
+    html[data-theme='dark'],
+    body[data-theme='dark'],
+    html.dark,
+    body.dark
+  )
+  .swagger-spec-viewer
+  .swagger-ui
+  .opblock-tag-section:has(
+    > .opblock-tag[data-tag='__wso2_not_allowed_resources__']
+  )
+  .opblock,
+:is(
+    html[data-mui-color-scheme='dark'],
+    body[data-mui-color-scheme='dark'],
+    html[data-color-scheme='dark'],
+    body[data-color-scheme='dark'],
+    html[data-theme='dark'],
+    body[data-theme='dark'],
+    html.dark,
+    body.dark
+  )
+  .swagger-spec-viewer
+  .swagger-ui
+  .opblock-tag-section:has(
+    > .opblock-tag[data-tag='__wso2_not_allowed_resources__']
+  )
+  .opblock-summary {
+  background: #2f2f2f !important;
+  border-color: #616161 !important;
+}
+
 :is(
     html[data-mui-color-scheme='dark'],
     body[data-mui-color-scheme='dark'],

--- a/portals/ai-workspace/src/Components/SwaggerSpecViewer/SwaggerSpecViewer.tsx
+++ b/portals/ai-workspace/src/Components/SwaggerSpecViewer/SwaggerSpecViewer.tsx
@@ -28,6 +28,11 @@ import { Search } from '@wso2/oxygen-ui-icons-react';
 import SwaggerUI from 'swagger-ui-react';
 import 'swagger-ui-react/swagger-ui.css';
 import './SwaggerSpecViewer.css';
+import type { AccessControl } from '../../utils/types';
+import {
+  buildExceptionSet,
+  normalizeAccessControlMode,
+} from '../../utils/openApiAccessControl';
 
 const SwaggerUIComponent =
   SwaggerUI as unknown as React.ComponentType<Record<string, unknown>>;
@@ -49,6 +54,7 @@ type SwaggerSpecViewerProps = {
   disableTryOutBtn?: boolean;
   disableResponseSection?: boolean;
   enableResourceSearch?: boolean;
+  accessControl?: AccessControl;
 };
 
 type SwaggerSpec = Record<string, unknown>;
@@ -269,6 +275,79 @@ function hasResourceOperations(spec: SwaggerSpec): boolean {
   );
 }
 
+const ACCESS_CONTROL_ALLOWED_EXTENSION = 'x-wso2-access-control-allowed';
+const ACCESS_CONTROL_ALLOWED_TAG = '__wso2_allowed_resources__';
+const ACCESS_CONTROL_NOT_ALLOWED_TAG = '__wso2_not_allowed_resources__';
+
+function annotateSpecAccessControl(
+  spec: SwaggerSpec,
+  accessControl?: AccessControl
+): SwaggerSpec {
+  const mode = normalizeAccessControlMode(accessControl?.mode);
+  const paths = spec.paths;
+  if (!mode || !paths || typeof paths !== 'object') return spec;
+
+  const exceptions = buildExceptionSet(accessControl);
+  const annotatedPaths: Record<string, unknown> = {};
+
+  Object.entries(paths as Record<string, unknown>).forEach(([path, value]) => {
+    if (!value || typeof value !== 'object') {
+      annotatedPaths[path] = value;
+      return;
+    }
+
+    const pathItem = value as Record<string, unknown>;
+    const annotatedPathItem: Record<string, unknown> = { ...pathItem };
+    HTTP_METHODS.forEach((method) => {
+      const operation = pathItem[method];
+      if (!operation || typeof operation !== 'object') return;
+
+      const isException = exceptions.has(`${method.toUpperCase()}::${path}`);
+      const allowed = mode === 'allow_all' ? !isException : isException;
+      annotatedPathItem[method] = {
+        ...(operation as Record<string, unknown>),
+        tags: [
+          allowed
+            ? ACCESS_CONTROL_ALLOWED_TAG
+            : ACCESS_CONTROL_NOT_ALLOWED_TAG,
+        ],
+        [ACCESS_CONTROL_ALLOWED_EXTENSION]: allowed,
+      };
+    });
+    annotatedPaths[path] = annotatedPathItem;
+  });
+
+  return {
+    ...spec,
+    // Swagger builds tag groups in this declared order before applying its
+    // optional sorter. Keep the allowed group first even when the first path in
+    // a deny-all specification is denied.
+    tags: [
+      { name: ACCESS_CONTROL_ALLOWED_TAG },
+      { name: ACCESS_CONTROL_NOT_ALLOWED_TAG },
+    ],
+    paths: annotatedPaths,
+  };
+}
+
+function isSwaggerOperationAllowed(operation: unknown): boolean {
+  try {
+    const immutableOperation = operation as {
+      get?: (key: string) => unknown;
+    };
+    const nestedOperation = (immutableOperation?.get?.('operation') ??
+      immutableOperation?.get?.('op')) as {
+      get?: (key: string) => unknown;
+    } | undefined;
+    const allowed =
+      immutableOperation?.get?.(ACCESS_CONTROL_ALLOWED_EXTENSION) ??
+      nestedOperation?.get?.(ACCESS_CONTROL_ALLOWED_EXTENSION);
+    return allowed !== false;
+  } catch {
+    return true;
+  }
+}
+
 export default function SwaggerSpecViewer({
   spec,
   className,
@@ -286,6 +365,7 @@ export default function SwaggerSpecViewer({
   disableTryOutBtn = false,
   disableResponseSection = false,
   enableResourceSearch = false,
+  accessControl,
 }: SwaggerSpecViewerProps) {
   const [resourceSearchValue, setResourceSearchValue] = useState('');
   const [selectedResourceMethod, setSelectedResourceMethod] =
@@ -312,12 +392,20 @@ export default function SwaggerSpecViewer({
 
   const displayedSpec = useMemo(
     () =>
-      filterSpecResources(
-        specWithRequestBaseUrl,
-        resourceSearchValue,
-        selectedResourceMethod
+      annotateSpecAccessControl(
+        filterSpecResources(
+          specWithRequestBaseUrl,
+          resourceSearchValue,
+          selectedResourceMethod
+        ),
+        accessControl
       ),
-    [resourceSearchValue, selectedResourceMethod, specWithRequestBaseUrl]
+    [
+      accessControl,
+      resourceSearchValue,
+      selectedResourceMethod,
+      specWithRequestBaseUrl,
+    ]
   );
   const hasDisplayedResources = useMemo(
     () => hasResourceOperations(displayedSpec),
@@ -328,6 +416,23 @@ export default function SwaggerSpecViewer({
     const wrapSelectors: Record<string, unknown> = {};
     const wrapComponents: Record<string, unknown> = {};
     const wrapActions: Record<string, unknown> = {};
+
+    if (accessControl) {
+      wrapComponents.OperationSummary =
+        (Original: React.ComponentType<Record<string, unknown>>) =>
+        (props: Record<string, unknown>) => {
+          const allowed = isSwaggerOperationAllowed(props.operationProps);
+          return (
+            <div
+              className={allowed ? undefined : 'access-control-not-allowed'}
+              aria-disabled={!allowed}
+              title={allowed ? undefined : 'This resource is not allowed'}
+            >
+              <Original {...props} />
+            </div>
+          );
+        };
+    }
 
     if (hideAuthorizeButton) {
       wrapComponents.authorizeBtn = () => () => null;
@@ -473,11 +578,34 @@ export default function SwaggerSpecViewer({
   }, [
     defaultHeadersObject,
     disableNetworkExecution,
+    accessControl,
     hideAuthorizeButton,
     hideInfoSection,
   ]);
 
   const plugins = plugin ? [plugin] : undefined;
+
+  const operationsSorter = useMemo(
+    () =>
+      accessControl
+        ? (first: unknown, second: unknown) =>
+            Number(isSwaggerOperationAllowed(second)) -
+            Number(isSwaggerOperationAllowed(first))
+        : undefined,
+    [accessControl]
+  );
+
+  const tagsSorter = useMemo(
+    () =>
+      accessControl
+        ? (first: string, second: string) => {
+            if (first === ACCESS_CONTROL_ALLOWED_TAG) return -1;
+            if (second === ACCESS_CONTROL_ALLOWED_TAG) return 1;
+            return first.localeCompare(second);
+          }
+        : undefined,
+    [accessControl]
+  );
 
   const requestInterceptor = useMemo(() => {
     if (!normalizedRequestBaseUrl && normalizedDefaultHeaders.length === 0) {
@@ -598,6 +726,8 @@ export default function SwaggerSpecViewer({
           showMutatedRequest={!disableNetworkExecution}
           plugins={plugins}
           requestInterceptor={requestInterceptor}
+          operationsSorter={operationsSorter}
+          tagsSorter={tagsSorter}
         />
       )}
     </Stack>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverview.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverview.tsx
@@ -91,7 +91,6 @@ import {
   getProviderTemplateDisplayName,
   truncateProviderDisplayName,
 } from '../../../../utils/providerTemplateDisplay';
-import { filterOpenApiSpecByAccessControl } from '../../../../utils/openApiAccessControl';
 import { useAppAuth } from '../../../../contexts/AppAuthContext';
 import { SCOPES } from '../../../../auth/permissions';
 import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
@@ -342,11 +341,6 @@ function ServiceProviderOverviewContent() {
     [openApiSpecText]
   );
   const activeAccessControl = (draftProvider ?? provider)?.accessControl;
-  const filteredOpenApiSpec = useMemo(
-    () =>
-      filterOpenApiSpecByAccessControl(parsedOpenApiSpec, activeAccessControl),
-    [parsedOpenApiSpec, activeAccessControl]
-  );
   const hasOpenApiSpecText = openApiSpecText.trim().length > 0;
   const apiKeyHeaderName = provider?.security?.apiKey?.key?.trim()
     ? provider.security.apiKey.key.trim()
@@ -921,7 +915,8 @@ function ServiceProviderOverviewContent() {
 
     return (
       <SwaggerSpecViewer
-        spec={filteredOpenApiSpec ?? parsedOpenApiSpec ?? {}}
+        spec={parsedOpenApiSpec ?? {}}
+        accessControl={activeAccessControl}
         requestBaseUrl={generatedInvokeUrl}
         defaultHeaders={swaggerDefaultHeaders}
         disableTryOutBtn={gateways.length === 0}

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverviewTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverviewTab.tsx
@@ -65,7 +65,6 @@ import NoData from '../../../../assets/images/NoData.svg';
 import { FormattedMessage } from 'react-intl';
 import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
 import SwaggerSpecViewer from '../../../../Components/SwaggerSpecViewer';
-import { filterOpenApiSpecByAccessControl } from '../../../../utils/openApiAccessControl';
 import { buildProjectPath } from '../../../../utils/projectRouting';
 import {
   DisabledActionTooltip,
@@ -166,14 +165,6 @@ export default function ServiceProviderOverviewTab({
     () => parseOpenApiSpec(provider?.openapi || ''),
     [provider?.openapi]
   );
-  const filteredOpenApiSpec = useMemo(
-    () =>
-      filterOpenApiSpecByAccessControl(
-        parsedOpenApiSpec,
-        provider?.accessControl
-      ),
-    [parsedOpenApiSpec, provider?.accessControl]
-  );
   const selectedGateway = useMemo(
     () => gateways.find((gateway) => gateway.id === selectedGatewayId) ?? null,
     [gateways, selectedGatewayId]
@@ -194,7 +185,7 @@ export default function ServiceProviderOverviewTab({
     return `${normalizedBase}${normalizedContext}`;
   }, [provider?.context, selectedGateway?.endpoints, selectedGateway?.vhost]);
   const swaggerSpecWithGatewayServer = useMemo<OpenApiSpec>(() => {
-    const baseSpec = filteredOpenApiSpec ?? parsedOpenApiSpec;
+    const baseSpec = parsedOpenApiSpec;
     if (!baseSpec) return {};
     if (!generatedGatewayUrl) return baseSpec;
 
@@ -212,7 +203,7 @@ export default function ServiceProviderOverviewTab({
       ...baseSpec,
       servers: [{ url: generatedGatewayUrl }, ...nonDuplicateServers],
     };
-  }, [filteredOpenApiSpec, generatedGatewayUrl, parsedOpenApiSpec]);
+  }, [generatedGatewayUrl, parsedOpenApiSpec]);
   const swaggerDefaultHeaders = useMemo<
     Record<string, string> | undefined
   >(() => {
@@ -708,6 +699,7 @@ export default function ServiceProviderOverviewTab({
                 defaultModelsExpandDepth={-1}
                 displayRequestDuration
                 enableResourceSearch
+                accessControl={provider?.accessControl}
               />
             )}
           </Box>


### PR DESCRIPTION
This pull request introduces access control visualization for OpenAPI resources in the `SwaggerSpecViewer` component. The main changes involve annotating the OpenAPI spec with access control information, updating the UI to visually indicate "not allowed" resources, and refactoring how access control filtering is handled in pages that use the viewer.

<img width="1911" height="949" alt="Screenshot 2026-07-15 at 15 20 40" src="https://github.com/user-attachments/assets/69f0b9fa-21bf-4414-9651-f46cebb50345" />


**Access Control Visualization and Integration:**

* The `SwaggerSpecViewer` component now accepts an `accessControl` prop and dynamically annotates the OpenAPI spec to mark allowed and not allowed resources. These are visually distinguished in the UI with custom styles and badges. [[1]](diffhunk://#diff-0ace31787b19ed5c3d73d7ab3f8e77f5ade7568c829c9568d6739765c6913390R57) [[2]](diffhunk://#diff-0ace31787b19ed5c3d73d7ab3f8e77f5ade7568c829c9568d6739765c6913390R278-R350) [[3]](diffhunk://#diff-0ace31787b19ed5c3d73d7ab3f8e77f5ade7568c829c9568d6739765c6913390R368) [[4]](diffhunk://#diff-2ec5b09be39bad0e0ef14d163b04149f64fed275afd72eab814fadb63c5609c5R99-R246)
* Operations and tags are sorted to prioritize allowed resources, and not allowed operations are visually dimmed and labeled. [[1]](diffhunk://#diff-0ace31787b19ed5c3d73d7ab3f8e77f5ade7568c829c9568d6739765c6913390R581-R609) [[2]](diffhunk://#diff-0ace31787b19ed5c3d73d7ab3f8e77f5ade7568c829c9568d6739765c6913390R729-R730) [[3]](diffhunk://#diff-2ec5b09be39bad0e0ef14d163b04149f64fed275afd72eab814fadb63c5609c5R99-R246)
* The UI disables interaction and adds tooltips for not allowed resources, improving clarity for users. [[1]](diffhunk://#diff-0ace31787b19ed5c3d73d7ab3f8e77f5ade7568c829c9568d6739765c6913390R420-R436) [[2]](diffhunk://#diff-2ec5b09be39bad0e0ef14d163b04149f64fed275afd72eab814fadb63c5609c5R99-R246)

**Codebase Refactoring:**

* The previous approach of pre-filtering OpenAPI specs by access control in `ServiceProviderOverview` and `ServiceProviderOverviewTab` has been removed. Instead, access control is now handled entirely within `SwaggerSpecViewer`, simplifying the data flow and reducing duplicated logic. [[1]](diffhunk://#diff-efd312aa5753c561eb31097151c2aeae08fb9be9e263231e841214bbfb366e2aL94) [[2]](diffhunk://#diff-efd312aa5753c561eb31097151c2aeae08fb9be9e263231e841214bbfb366e2aL345-L349) [[3]](diffhunk://#diff-efd312aa5753c561eb31097151c2aeae08fb9be9e263231e841214bbfb366e2aL924-R919) [[4]](diffhunk://#diff-dfa3730c5433bcf6bc014ddec3c15813182c9f41e4b0c65fb3b47947829185a9L68) [[5]](diffhunk://#diff-dfa3730c5433bcf6bc014ddec3c15813182c9f41e4b0c65fb3b47947829185a9L169-L176) [[6]](diffhunk://#diff-dfa3730c5433bcf6bc014ddec3c15813182c9f41e4b0c65fb3b47947829185a9L197-R188) [[7]](diffhunk://#diff-dfa3730c5433bcf6bc014ddec3c15813182c9f41e4b0c65fb3b47947829185a9L215-R206) [[8]](diffhunk://#diff-dfa3730c5433bcf6bc014ddec3c15813182c9f41e4b0c65fb3b47947829185a9R702)

**Styling Enhancements:**

* New CSS rules visually distinguish not allowed operations and tags, including support for dark mode. Not allowed resources are shown with reduced opacity, a "Not allowed" badge, and disabled interaction cues.

These changes collectively improve the clarity and maintainability of access control handling in the OpenAPI viewer, providing a better user experience and simplifying the codebase.