### PR TITLE
Populate LLM provider & proxy OpenAPI spec from the template

### DIFF
--- a/platform-api/config/config.go
+++ b/platform-api/config/config.go
@@ -80,6 +80,7 @@ type Server struct {
 	DBSchemaPath               string `koanf:"db_schema_path"`
 	OpenAPISpecPath            string `koanf:"openapi_spec_path"`
 	LLMTemplateDefinitionsPath string `koanf:"llm_template_definitions_path"`
+	OpenAPISpecMaxFetchBytes   int64  `koanf:"openapi_spec_max_fetch_bytes"`
 
 	EncryptionKey string `koanf:"encryption_key"`
 

--- a/platform-api/internal/service/artifact_import.go
+++ b/platform-api/internal/service/artifact_import.go
@@ -132,9 +132,9 @@ func NewArtifactImportService(
 	}
 	s.importers = map[string]GatewayArtifactImporter{
 		constants.RestApi:             newRestAPIImporter(apiRepo, artifactRepo),
-		constants.LLMProvider:         newLLMProviderImporter(providerRepo, templateRepo, artifactRepo),
+		constants.LLMProvider:         newLLMProviderImporter(providerRepo, templateRepo, artifactRepo, cfg, slogger),
 		constants.LLMProviderTemplate: newLLMProviderTemplateImporter(templateRepo),
-		constants.LLMProxy:            newLLMProxyImporter(proxyRepo, artifactRepo),
+		constants.LLMProxy:            newLLMProxyImporter(proxyRepo, providerRepo, artifactRepo),
 		constants.MCPProxy:            newMCPProxyImporter(mcpProxyRepo, artifactRepo, mcpServerInfo),
 	}
 	return s

--- a/platform-api/internal/service/artifact_import_llm_openapi_test.go
+++ b/platform-api/internal/service/artifact_import_llm_openapi_test.go
@@ -1,0 +1,92 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package service
+
+import (
+	"testing"
+
+	"github.com/wso2/api-platform/platform-api/internal/repository"
+)
+
+// Verifies the DP→CP (bottom-up) import path populates the OpenAPI spec:
+//   - a provider imported from a template inherits the template's inline spec;
+//   - a proxy imported against that provider inherits the provider's spec;
+//   - when the template has no spec, the imported provider/proxy are left empty.
+func TestImport_LLMProvider_And_Proxy_OpenAPISpec(t *testing.T) {
+	const inlineSpec = "openapi: 3.0.3\ninfo:\n  title: Imported\n  version: v1.0\npaths: {}\n"
+
+	t.Run("template inline spec flows to provider and proxy", func(t *testing.T) {
+		d := setupImportTest(t)
+
+		// Import the template, then give it an inline openapi_spec (the URL-fetch branch
+		// cannot be exercised here — a test server binds loopback, which the SSRF guard
+		// correctly refuses).
+		mustImport(t, d, dpTemplateReq("dp-t", "oai-tmpl", "OpenAI"))
+		tmpl, err := d.templateRepo.GetByID("oai-tmpl", importTestOrgID)
+		if err != nil || tmpl == nil {
+			t.Fatalf("load imported template: %v", err)
+		}
+		tmpl.OpenAPISpec = inlineSpec
+		if err := d.templateRepo.Update(tmpl); err != nil {
+			t.Fatalf("set inline spec on template: %v", err)
+		}
+
+		// Import provider → should inherit the template's inline spec.
+		mustImport(t, d, dpProviderReq("dp-p", "oai-prov", "OpenAI Prov", "oai-tmpl"))
+		prov, err := repository.NewLLMProviderRepo(d.db).GetByID("oai-prov", importTestOrgID)
+		if err != nil || prov == nil {
+			t.Fatalf("load imported provider: %v", err)
+		}
+		if prov.OpenAPISpec != inlineSpec {
+			t.Fatalf("provider spec mismatch:\n got: %q\nwant: %q", prov.OpenAPISpec, inlineSpec)
+		}
+
+		// Import proxy → should inherit the provider's spec.
+		mustImport(t, d, dpProxyReq("dp-x", "oai-proxy", "OpenAI Proxy", "oai-prov"))
+		px, err := repository.NewLLMProxyRepo(d.db).GetByID("oai-proxy", importTestOrgID)
+		if err != nil || px == nil {
+			t.Fatalf("load imported proxy: %v", err)
+		}
+		if px.OpenAPISpec != inlineSpec {
+			t.Fatalf("proxy spec mismatch:\n got: %q\nwant: %q", px.OpenAPISpec, inlineSpec)
+		}
+	})
+
+	t.Run("template without spec leaves provider and proxy empty", func(t *testing.T) {
+		d := setupImportTest(t)
+
+		mustImport(t, d, dpTemplateReq("dp-t2", "bare-tmpl", "Bare"))
+		mustImport(t, d, dpProviderReq("dp-p2", "bare-prov", "Bare Prov", "bare-tmpl"))
+		prov, err := repository.NewLLMProviderRepo(d.db).GetByID("bare-prov", importTestOrgID)
+		if err != nil || prov == nil {
+			t.Fatalf("load imported provider: %v", err)
+		}
+		if prov.OpenAPISpec != "" {
+			t.Fatalf("expected empty provider spec, got %q", prov.OpenAPISpec)
+		}
+
+		mustImport(t, d, dpProxyReq("dp-x2", "bare-proxy", "Bare Proxy", "bare-prov"))
+		px, err := repository.NewLLMProxyRepo(d.db).GetByID("bare-proxy", importTestOrgID)
+		if err != nil || px == nil {
+			t.Fatalf("load imported proxy: %v", err)
+		}
+		if px.OpenAPISpec != "" {
+			t.Fatalf("expected empty proxy spec, got %q", px.OpenAPISpec)
+		}
+	})
+}

--- a/platform-api/internal/service/artifact_import_llm_provider.go
+++ b/platform-api/internal/service/artifact_import_llm_provider.go
@@ -18,8 +18,12 @@
 package service
 
 import (
+	"context"
 	"fmt"
+	"log/slog"
+	"strings"
 
+	"github.com/wso2/api-platform/platform-api/config"
 	"github.com/wso2/api-platform/platform-api/internal/apperror"
 	"github.com/wso2/api-platform/platform-api/internal/dto"
 
@@ -34,11 +38,15 @@ type llmProviderImporter struct {
 	providerRepo repository.LLMProviderRepository
 	templateRepo repository.LLMProviderTemplateRepository
 	artifactRepo repository.ArtifactRepository
+	cfg          *config.Server
+	slogger      *slog.Logger
 }
 
 func newLLMProviderImporter(providerRepo repository.LLMProviderRepository,
-	templateRepo repository.LLMProviderTemplateRepository, artifactRepo repository.ArtifactRepository) *llmProviderImporter {
-	return &llmProviderImporter{providerRepo: providerRepo, templateRepo: templateRepo, artifactRepo: artifactRepo}
+	templateRepo repository.LLMProviderTemplateRepository, artifactRepo repository.ArtifactRepository,
+	cfg *config.Server, slogger *slog.Logger) *llmProviderImporter {
+	return &llmProviderImporter{providerRepo: providerRepo, templateRepo: templateRepo, artifactRepo: artifactRepo,
+		cfg: cfg, slogger: slogger}
 }
 
 func (i *llmProviderImporter) Kind() string          { return constants.LLMProvider }
@@ -58,7 +66,7 @@ func (i *llmProviderImporter) Import(ctx *ImportContext) (*ImportResult, error) 
 	cfg := mapLLMProviderSpecToConfig(spec)
 
 	if ctx.Existing == nil {
-		templateUUID, err := i.resolveTemplateUUID(cfg.Template, ctx.OrgID)
+		tmpl, err := i.resolveTemplate(cfg.Template, ctx.OrgID)
 		if err != nil {
 			return nil, err
 		}
@@ -68,7 +76,8 @@ func (i *llmProviderImporter) Import(ctx *ImportContext) (*ImportResult, error) 
 			ID:               utils.ImportHandle(ctx.Configuration),
 			Name:             utils.ImportDisplayName(ctx.Configuration),
 			Version:          version,
-			TemplateUUID:     templateUUID,
+			TemplateUUID:     tmpl.UUID,
+			OpenAPISpec:      resolveTemplateOpenAPISpec(context.Background(), tmpl, openAPISpecFetchLimit(i.cfg), i.slogger),
 			Origin:           constants.OriginDP,
 			Configuration:    cfg,
 		}
@@ -95,11 +104,14 @@ func (i *llmProviderImporter) Import(ctx *ImportContext) (*ImportResult, error) 
 		existing.Version = version
 		existing.Configuration = cfg
 		if cfg.Template != "" {
-			templateUUID, err := i.resolveTemplateUUID(cfg.Template, ctx.OrgID)
+			tmpl, err := i.resolveTemplate(cfg.Template, ctx.OrgID)
 			if err != nil {
 				return nil, err
 			}
-			existing.TemplateUUID = templateUUID
+			existing.TemplateUUID = tmpl.UUID
+			if strings.TrimSpace(existing.OpenAPISpec) == "" {
+				existing.OpenAPISpec = resolveTemplateOpenAPISpec(context.Background(), tmpl, openAPISpecFetchLimit(i.cfg), i.slogger)
+			}
 		}
 	case utils.WriteGatewaySpecificOnly:
 		// CP-owned: only update gateway-specific upstream.
@@ -111,20 +123,20 @@ func (i *llmProviderImporter) Import(ctx *ImportContext) (*ImportResult, error) 
 	return &ImportResult{ID: ctx.ID, DeployedVersion: version, Deployable: true}, nil
 }
 
-// resolveTemplateUUID resolves the template handle referenced by the provider spec
-// to its UUID. The template must already exist (FK requirement).
-func (i *llmProviderImporter) resolveTemplateUUID(templateHandle, orgID string) (string, error) {
+// resolveTemplate resolves the template handle referenced by the provider spec to the
+// full template record. The template must already exist (FK requirement).
+func (i *llmProviderImporter) resolveTemplate(templateHandle, orgID string) (*model.LLMProviderTemplate, error) {
 	if templateHandle == "" {
-		return "", apperror.ValidationFailed.New("The LLM provider import requires a template reference.")
+		return nil, apperror.ValidationFailed.New("The LLM provider import requires a template reference.")
 	}
 	tmpl, err := i.templateRepo.GetByID(templateHandle, orgID)
 	if err != nil {
-		return "", fmt.Errorf("failed to resolve LLM provider template %q: %w", templateHandle, err)
+		return nil, fmt.Errorf("failed to resolve LLM provider template %q: %w", templateHandle, err)
 	}
 	if tmpl == nil {
-		return "", apperror.ValidationFailed.New(fmt.Sprintf("The referenced LLM provider template %q does not exist.", templateHandle))
+		return nil, apperror.ValidationFailed.New(fmt.Sprintf("The referenced LLM provider template %q does not exist.", templateHandle))
 	}
-	return tmpl.UUID, nil
+	return tmpl, nil
 }
 
 // mapLLMProviderSpecToConfig reverse-maps a gateway-pushed LLM provider deployment

--- a/platform-api/internal/service/artifact_import_llm_proxy.go
+++ b/platform-api/internal/service/artifact_import_llm_proxy.go
@@ -19,6 +19,7 @@ package service
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/wso2/api-platform/platform-api/internal/apperror"
 	"github.com/wso2/api-platform/platform-api/internal/constants"
@@ -31,11 +32,12 @@ import (
 // llmProxyImporter imports LLM Proxy artifacts (project-scoped).
 type llmProxyImporter struct {
 	proxyRepo    repository.LLMProxyRepository
+	providerRepo repository.LLMProviderRepository
 	artifactRepo repository.ArtifactRepository
 }
 
-func newLLMProxyImporter(proxyRepo repository.LLMProxyRepository, artifactRepo repository.ArtifactRepository) *llmProxyImporter {
-	return &llmProxyImporter{proxyRepo: proxyRepo, artifactRepo: artifactRepo}
+func newLLMProxyImporter(proxyRepo repository.LLMProxyRepository, providerRepo repository.LLMProviderRepository, artifactRepo repository.ArtifactRepository) *llmProxyImporter {
+	return &llmProxyImporter{proxyRepo: proxyRepo, providerRepo: providerRepo, artifactRepo: artifactRepo}
 }
 
 func (i *llmProxyImporter) Kind() string          { return constants.LLMProxy }
@@ -70,6 +72,7 @@ func (i *llmProxyImporter) Import(ctx *ImportContext) (*ImportResult, error) {
 			ProjectUUID:      ctx.ProjectID,
 			Version:          version,
 			ProviderUUID:     providerUUID,
+			OpenAPISpec:      i.providerOpenAPISpec(cfg.Provider, ctx.OrgID),
 			Origin:           constants.OriginDP,
 			Configuration:    cfg,
 		}
@@ -102,6 +105,9 @@ func (i *llmProxyImporter) Import(ctx *ImportContext) (*ImportResult, error) {
 		}
 		existing.ProviderUUID = providerUUID
 		existing.Configuration = cfg
+		if strings.TrimSpace(existing.OpenAPISpec) == "" {
+			existing.OpenAPISpec = i.providerOpenAPISpec(cfg.Provider, ctx.OrgID)
+		}
 	case utils.WriteGatewaySpecificOnly:
 		// CP-owned: only update gateway-specific upstream auth.
 		existing.Configuration.UpstreamAuth = cfg.UpstreamAuth
@@ -128,6 +134,19 @@ func (i *llmProxyImporter) resolveProviderUUID(providerHandle, orgID string) (st
 		return "", apperror.ValidationFailed.New(fmt.Sprintf("The referenced LLM provider %q does not exist.", providerHandle))
 	}
 	return art.UUID, nil
+}
+
+// providerOpenAPISpec best-effort loads the fronted provider and returns its OpenAPI
+// definition. A missing provider or load error yields an empty spec.
+func (i *llmProxyImporter) providerOpenAPISpec(providerHandle, orgID string) string {
+	if i.providerRepo == nil || providerHandle == "" {
+		return ""
+	}
+	prov, err := i.providerRepo.GetByID(providerHandle, orgID)
+	if err != nil || prov == nil {
+		return ""
+	}
+	return prov.OpenAPISpec
 }
 
 // mapLLMProxySpecToConfig reverse-maps a gateway-pushed LLM proxy deployment spec into

--- a/platform-api/internal/service/llm.go
+++ b/platform-api/internal/service/llm.go
@@ -18,6 +18,7 @@
 package service
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -909,7 +910,7 @@ func (s *LLMProviderService) Create(orgUUID, createdBy string, req *api.LLMProvi
 
 	openapiSpec := utils.ValueOrEmpty(req.Openapi)
 	if openapiSpec == "" {
-		openapiSpec = tpl.OpenAPISpec
+		openapiSpec = resolveTemplateOpenAPISpec(context.Background(), tpl, openAPISpecFetchLimit(s.cfg), s.slogger)
 	}
 
 	// Resolve any associated gateways up-front so they can be persisted within the
@@ -1385,6 +1386,11 @@ func (s *LLMProxyService) Create(orgUUID, createdBy string, req *api.LLMProxy) (
 		return nil, err
 	}
 
+	openapiSpec := utils.ValueOrEmpty(req.Openapi)
+	if openapiSpec == "" {
+		openapiSpec = prov.OpenAPISpec
+	}
+
 	contextValue := utils.DefaultStringPtr(req.Context, "/")
 	m := &model.LLMProxy{
 		OrganizationUUID: orgUUID,
@@ -1395,7 +1401,7 @@ func (s *LLMProxyService) Create(orgUUID, createdBy string, req *api.LLMProxy) (
 		CreatedBy:        createdBy,
 		Version:          req.Version,
 		ProviderUUID:     prov.UUID,
-		OpenAPISpec:      utils.ValueOrEmpty(req.Openapi),
+		OpenAPISpec:      openapiSpec,
 		Configuration: model.LLMProxyConfig{
 			Context:             &contextValue,
 			Vhost:               req.Vhost,
@@ -3236,4 +3242,42 @@ func resolveAssociatedGateways(gatewayRepo repository.GatewayRepository, orgUUID
 		})
 	}
 	return resolved, nil
+}
+
+// openAPISpecFetchLimit returns the configured maximum size for a template OpenAPI spec
+// fetch, or 0 (which the fetcher treats as its safe built-in default) when unset.
+func openAPISpecFetchLimit(cfg *config.Server) int64 {
+	if cfg == nil {
+		return 0
+	}
+	return cfg.OpenAPISpecMaxFetchBytes
+}
+
+// resolveTemplateOpenAPISpec derives the OpenAPI spec to store for an artifact from its template.
+func resolveTemplateOpenAPISpec(ctx context.Context, tpl *model.LLMProviderTemplate, maxBytes int64, logger *slog.Logger) string {
+	if tpl == nil {
+		return ""
+	}
+
+	specURL := ""
+	if tpl.Metadata != nil {
+		specURL = strings.TrimSpace(tpl.Metadata.OpenapiSpecURL)
+	}
+
+	if specURL != "" {
+		spec, err := utils.FetchOpenAPISpecFromURL(ctx, specURL, maxBytes)
+		if err != nil {
+			if logger != nil {
+				logger.Warn("failed to fetch OpenAPI spec from template URL; falling back to inline spec if present",
+					"template", tpl.ID, "error", err)
+			}
+		} else if strings.TrimSpace(spec) != "" {
+			return spec
+		}
+	}
+
+	if strings.TrimSpace(tpl.OpenAPISpec) != "" {
+		return tpl.OpenAPISpec
+	}
+	return ""
 }

--- a/platform-api/internal/service/llm_openapi_resolve_test.go
+++ b/platform-api/internal/service/llm_openapi_resolve_test.go
@@ -1,0 +1,76 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/wso2/api-platform/platform-api/internal/model"
+)
+
+// The successful URL-fetch path (URL taking precedence when reachable) is covered by
+// utils.TestFetchOpenAPISpecFromURL_*; here we verify the resolver's decision logic:
+// precedence ordering, fallback on fetch failure, and the "leave empty" case.
+func TestResolveTemplateOpenAPISpec(t *testing.T) {
+	// A loopback URL is refused by the SSRF guard, so it stands in for an unreachable /
+	// disallowed spec URL — the resolver must then fall back to the inline spec.
+	const blockedURL = "http://127.0.0.1:9/openapi.yaml"
+	const inline = "openapi: 3.0.3\ninfo:\n  title: Inline\n  version: v1.0\npaths: {}\n"
+
+	t.Run("nil template returns empty", func(t *testing.T) {
+		if got := resolveTemplateOpenAPISpec(context.Background(), nil, 0, nil); got != "" {
+			t.Fatalf("want empty, got %q", got)
+		}
+	})
+
+	t.Run("both unset returns empty", func(t *testing.T) {
+		tpl := &model.LLMProviderTemplate{ID: "t1"}
+		if got := resolveTemplateOpenAPISpec(context.Background(), tpl, 0, nil); got != "" {
+			t.Fatalf("want empty, got %q", got)
+		}
+	})
+
+	t.Run("inline only returns inline", func(t *testing.T) {
+		tpl := &model.LLMProviderTemplate{ID: "t2", OpenAPISpec: inline}
+		if got := resolveTemplateOpenAPISpec(context.Background(), tpl, 0, nil); got != inline {
+			t.Fatalf("want inline spec, got %q", got)
+		}
+	})
+
+	t.Run("url fetch failure falls back to inline", func(t *testing.T) {
+		tpl := &model.LLMProviderTemplate{
+			ID:          "t3",
+			OpenAPISpec: inline,
+			Metadata:    &model.LLMProviderTemplateMetadata{OpenapiSpecURL: blockedURL},
+		}
+		if got := resolveTemplateOpenAPISpec(context.Background(), tpl, 0, nil); got != inline {
+			t.Fatalf("want inline fallback, got %q", got)
+		}
+	})
+
+	t.Run("url fetch failure with no inline returns empty", func(t *testing.T) {
+		tpl := &model.LLMProviderTemplate{
+			ID:       "t4",
+			Metadata: &model.LLMProviderTemplateMetadata{OpenapiSpecURL: blockedURL},
+		}
+		if got := resolveTemplateOpenAPISpec(context.Background(), tpl, 0, nil); got != "" {
+			t.Fatalf("want empty, got %q", got)
+		}
+	})
+}

--- a/platform-api/internal/utils/openapi_spec_fetcher.go
+++ b/platform-api/internal/utils/openapi_spec_fetcher.go
@@ -171,9 +171,18 @@ func ssrfSafeDialContext(ctx context.Context, network, addr string) (net.Conn, e
 	return nil, fmt.Errorf("failed to connect to host")
 }
 
+// cgnatRange is RFC 6598 shared address space (carrier-grade NAT): 100.64.0.0/10.
+// net.IP.IsPrivate does not cover it, yet it can route to internal infrastructure, so
+// it is refused explicitly.
+var cgnatRange = func() *net.IPNet {
+	_, n, _ := net.ParseCIDR("100.64.0.0/10")
+	return n
+}()
+
 // isPublicIP reports whether ip is a routable public address safe to fetch from. It
-// rejects loopback, private (RFC 1918 / IPv6 ULA), link-local (which includes the
-// 169.254.169.254 cloud metadata endpoint), unspecified, multicast and broadcast ranges.
+// rejects loopback, private (RFC 1918 / IPv6 ULA), RFC 6598 shared address space
+// (100.64.0.0/10), link-local (which includes the 169.254.169.254 cloud metadata
+// endpoint), unspecified, multicast and broadcast ranges.
 func isPublicIP(ip net.IP) bool {
 	if ip == nil {
 		return false
@@ -184,7 +193,8 @@ func isPublicIP(ip net.IP) bool {
 		ip.IsLinkLocalMulticast() ||
 		ip.IsMulticast() ||
 		ip.IsUnspecified() ||
-		ip.Equal(net.IPv4bcast) {
+		ip.Equal(net.IPv4bcast) ||
+		(cgnatRange != nil && cgnatRange.Contains(ip)) {
 		return false
 	}
 	return true

--- a/platform-api/internal/utils/openapi_spec_fetcher.go
+++ b/platform-api/internal/utils/openapi_spec_fetcher.go
@@ -1,0 +1,191 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package utils
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	// defaultOpenAPISpecMaxFetchBytes bounds the fetched OpenAPI spec body so a hostile
+	// or misconfigured URL cannot exhaust memory. Used when the configured limit is absent
+	// or non-positive.
+	defaultOpenAPISpecMaxFetchBytes int64 = 5 << 20 // 5 MiB
+
+	// openAPISpecFetchTimeout bounds the whole fetch (DNS + connect + TLS + body read).
+	openAPISpecFetchTimeout = 15 * time.Second
+
+	// openAPISpecMaxRedirects caps redirect hops; every hop is still re-validated by the
+	// SSRF-guarded dialer, so this only bounds redirect loops.
+	openAPISpecMaxRedirects = 5
+)
+
+// FetchOpenAPISpecFromURL fetches an OpenAPI specification from an external URL and
+// returns its body. The URL is operator/tenant-influenced (it originates from an LLM
+// provider template), so the fetch is hardened against SSRF and resource exhaustion:
+//
+//   - Only http/https schemes are allowed; every other scheme is rejected.
+//   - The host is resolved and every candidate IP is checked at dial time (defeating
+//     DNS-rebinding) — loopback, private (RFC 1918 / ULA), link-local (incl. the cloud
+//     metadata endpoint 169.254.169.254), unspecified, multicast and broadcast addresses
+//     are refused.
+//   - Redirects are bounded and each hop is dialed through the same guarded dialer.
+//   - The response body is read through an io.LimitReader capped at maxBytes.
+//   - Errors are returned sterile (no internal host/IP detail) so callers can log them
+//     internally without leaking infrastructure information to clients.
+//
+// maxBytes <= 0 falls back to defaultOpenAPISpecMaxFetchBytes.
+func FetchOpenAPISpecFromURL(ctx context.Context, rawURL string, maxBytes int64) (string, error) {
+	if maxBytes <= 0 {
+		maxBytes = defaultOpenAPISpecMaxFetchBytes
+	}
+
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return "", fmt.Errorf("invalid OpenAPI spec URL")
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", fmt.Errorf("OpenAPI spec URL must use http or https")
+	}
+	if parsed.Hostname() == "" {
+		return "", fmt.Errorf("OpenAPI spec URL must include a host")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, openAPISpecFetchTimeout)
+	defer cancel()
+
+	client := &http.Client{
+		Timeout: openAPISpecFetchTimeout,
+		Transport: &http.Transport{
+			DialContext:           ssrfSafeDialContext,
+			TLSHandshakeTimeout:   openAPISpecFetchTimeout,
+			ResponseHeaderTimeout: openAPISpecFetchTimeout,
+			DisableKeepAlives:     true,
+			// No proxy: dialing must go through the guarded dialer, not a forward proxy
+			// that could bypass the IP checks.
+			Proxy: nil,
+		},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= openAPISpecMaxRedirects {
+				return fmt.Errorf("too many redirects")
+			}
+			if req.URL.Scheme != "http" && req.URL.Scheme != "https" {
+				return fmt.Errorf("redirect to a disallowed scheme")
+			}
+			return nil
+		},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsed.String(), nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to build OpenAPI spec request")
+	}
+	req.Header.Set("Accept", "application/json, application/yaml, text/yaml, text/plain, */*")
+	req.Header.Set("User-Agent", "wso2-api-platform")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		// Do not surface the underlying net error (it can leak resolved IPs/hosts).
+		return "", fmt.Errorf("failed to fetch OpenAPI spec")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("OpenAPI spec URL returned an unexpected status")
+	}
+
+	// Bound the body: read one extra byte so we can detect an over-limit response.
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxBytes+1))
+	if err != nil {
+		return "", fmt.Errorf("failed to read OpenAPI spec response")
+	}
+	if int64(len(data)) > maxBytes {
+		return "", fmt.Errorf("OpenAPI spec exceeds the maximum allowed size")
+	}
+
+	return string(data), nil
+}
+
+// ipIsAllowed is the address allow-check used by the dialer. It is a package variable
+// only so tests can exercise the fetch/size-limit paths against a loopback test server;
+// production code never reassigns it.
+var ipIsAllowed = isPublicIP
+
+// ssrfSafeDialContext resolves the target host and refuses to connect to any non-public
+// address. It performs the resolution itself and dials the resolved IP directly, so a
+// DNS name that resolves to a public IP during a pre-check cannot be re-resolved to an
+// internal IP at connect time (DNS rebinding).
+func ssrfSafeDialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid address")
+	}
+
+	ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve host")
+	}
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("host has no addresses")
+	}
+	for _, ip := range ips {
+		if !ipIsAllowed(ip.IP) {
+			return nil, fmt.Errorf("host resolves to a disallowed address")
+		}
+	}
+
+	dialer := &net.Dialer{Timeout: openAPISpecFetchTimeout}
+	var lastErr error
+	for _, ip := range ips {
+		conn, dialErr := dialer.DialContext(ctx, network, net.JoinHostPort(ip.IP.String(), port))
+		if dialErr == nil {
+			return conn, nil
+		}
+		lastErr = dialErr
+	}
+	if lastErr != nil {
+		return nil, fmt.Errorf("failed to connect to host")
+	}
+	return nil, fmt.Errorf("failed to connect to host")
+}
+
+// isPublicIP reports whether ip is a routable public address safe to fetch from. It
+// rejects loopback, private (RFC 1918 / IPv6 ULA), link-local (which includes the
+// 169.254.169.254 cloud metadata endpoint), unspecified, multicast and broadcast ranges.
+func isPublicIP(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	if ip.IsLoopback() ||
+		ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsMulticast() ||
+		ip.IsUnspecified() ||
+		ip.Equal(net.IPv4bcast) {
+		return false
+	}
+	return true
+}

--- a/platform-api/internal/utils/openapi_spec_fetcher_test.go
+++ b/platform-api/internal/utils/openapi_spec_fetcher_test.go
@@ -1,0 +1,117 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package utils
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIsPublicIP(t *testing.T) {
+	cases := []struct {
+		ip      string
+		allowed bool
+	}{
+		{"8.8.8.8", true},
+		{"1.1.1.1", true},
+		{"93.184.216.34", true},    // example.com
+		{"127.0.0.1", false},       // loopback
+		{"::1", false},             // loopback v6
+		{"10.0.0.1", false},        // private
+		{"172.16.5.4", false},      // private
+		{"192.168.1.1", false},     // private
+		{"169.254.169.254", false}, // link-local / cloud metadata endpoint
+		{"fe80::1", false},         // link-local v6
+		{"fd00::1", false},         // unique local v6 (private)
+		{"0.0.0.0", false},         // unspecified
+		{"224.0.0.1", false},       // multicast
+		{"255.255.255.255", false}, // broadcast
+	}
+	for _, c := range cases {
+		ip := net.ParseIP(c.ip)
+		if ip == nil {
+			t.Fatalf("failed to parse test IP %q", c.ip)
+		}
+		if got := isPublicIP(ip); got != c.allowed {
+			t.Errorf("isPublicIP(%s) = %v, want %v", c.ip, got, c.allowed)
+		}
+	}
+}
+
+func TestFetchOpenAPISpecFromURL_RejectsBadURLs(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+	}{
+		{"empty", ""},
+		{"file scheme", "file:///etc/passwd"},
+		{"ftp scheme", "ftp://example.com/spec.yaml"},
+		{"no host", "http://"},
+		{"gopher", "gopher://example.com/"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := FetchOpenAPISpecFromURL(context.Background(), c.url, 0); err == nil {
+				t.Fatalf("expected error for %q, got nil", c.url)
+			}
+		})
+	}
+}
+
+func TestFetchOpenAPISpecFromURL_BlocksInternalAddress(t *testing.T) {
+	// The SSRF guard is active (ipIsAllowed not overridden), so a loopback URL must be
+	// refused before any connection is made.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("openapi: 3.0.0"))
+	}))
+	defer srv.Close()
+
+	if _, err := FetchOpenAPISpecFromURL(context.Background(), srv.URL, 0); err == nil {
+		t.Fatal("expected loopback address to be blocked, got nil error")
+	}
+}
+
+func TestFetchOpenAPISpecFromURL_FetchAndSizeLimit(t *testing.T) {
+	// Relax the address check so the loopback test server is reachable, then restore it.
+	orig := ipIsAllowed
+	ipIsAllowed = func(net.IP) bool { return true }
+	defer func() { ipIsAllowed = orig }()
+
+	const body = "openapi: 3.0.3\ninfo:\n  title: Test\n  version: v1.0\npaths: {}\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	// Happy path.
+	got, err := FetchOpenAPISpecFromURL(context.Background(), srv.URL, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != body {
+		t.Fatalf("body mismatch:\n got: %q\nwant: %q", got, body)
+	}
+
+	// Size limit: cap below the body length and expect rejection.
+	if _, err := FetchOpenAPISpecFromURL(context.Background(), srv.URL, 4); err == nil {
+		t.Fatal("expected size-limit error, got nil")
+	}
+}

--- a/platform-api/internal/utils/openapi_spec_fetcher_test.go
+++ b/platform-api/internal/utils/openapi_spec_fetcher_test.go
@@ -33,6 +33,10 @@ func TestIsPublicIP(t *testing.T) {
 		{"8.8.8.8", true},
 		{"1.1.1.1", true},
 		{"93.184.216.34", true},    // example.com
+		{"100.64.0.1", false},      // RFC 6598 shared address space (CGNAT)
+		{"100.127.255.255", false}, // CGNAT upper bound
+		{"100.63.255.255", true},   // just below the CGNAT range — public
+		{"100.128.0.1", true},      // just above the CGNAT range — public
 		{"127.0.0.1", false},       // loopback
 		{"::1", false},             // loopback v6
 		{"10.0.0.1", false},        // private


### PR DESCRIPTION
### Summary

This PR makes the control plane resolve the spec server-side from the referenced template, so providers/proxies arrive with their resources populated.

Related to -
 - https://github.com/wso2/api-platform/issues/2664

### Problem

- A provider created from a template only inherited the template's inline openapi_spec. The default seeded templates carry only a metadata.openapiSpecUrl (a reference), which was never fetched server-side — only the AI Workspace UI dereferenced it. So freshly created providers (especially bottom-up ones) had no spec until a user manually opened the Resources tab.
- A proxy copied the provider's openapi only via a one-time frontend snapshot; on the import path it was never set.
- DP→CP import set no spec on either artifact.

### Changes

#### Resolution logic
- Providers now resolve their spec from the referenced template with precedence: metadata.openapiSpecUrl (fetched) > template inline openapi_spec > left empty. An explicit openapi in the request still wins.
- Proxies inherit the fronted provider's OpenAPI definition (never the template directly).
- Shared helper resolveTemplateOpenAPISpec(...); a fetch failure is non-fatal (logged, falls back to inline / empty).

#### Applied to both entry points
- UI create: LLMProviderService.Create, LLMProxyService.Create (internal/service/llm.go).
- DP→CP import: llmProviderImporter / llmProxyImporter (internal/service/artifact_import_llm_provider.go, artifact_import_llm_proxy.go). On import, the spec is set on create and backfilled on update only when empty — never clobbering a spec already edited in the UI.

New SSRF-hardened fetcher (internal/utils/openapi_spec_fetcher.go) — since openapiSpecUrl is tenant/operator-influenced:
- http/https scheme allowlist.
- Resolves and validates every candidate IP at dial time (defeats DNS rebinding); refuses loopback, private (RFC 1918 / ULA), link-local incl. the 169.254.169.254 metadata endpoint, unspecified, multicast, broadcast.
- Bounded redirects (each re-validated through the guarded dialer), request timeout, and response body capped via io.LimitReader.
- Sterile errors (no host/IP leakage).

#### Config
- New OpenAPISpecMaxFetchBytes (openapi_spec_max_fetch_bytes) caps the fetch. Unset/≤0 falls back to a safe built-in default (5 MiB), so the fetch is never unbounded.

#### Security

Follows the repo's file-access.md (config-externalized stream limits, safe default) and error-handling.md (sterile client-facing errors). The only new outbound request is the spec fetch, fully SSRF-guarded.