### PR TITLE
Fix MCP proxy upstream URL manipulation

### DIFF
--- a/platform-api/internal/service/mcp.go
+++ b/platform-api/internal/service/mcp.go
@@ -24,8 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"net/url"
-	"strings"
 	"time"
 
 	"github.com/wso2/api-platform/platform-api/api"
@@ -536,16 +534,13 @@ func (s *MCPProxyService) FetchServerInfo(orgUUID string, req *api.MCPServerInfo
 			return nil, apperror.MCPProxyNotFound.New()
 		}
 
-		// Use stored URL from proxy configuration
+		// Use the stored URL from the proxy configuration verbatim. The stored value is the
+		// full MCP endpoint URL that was validated at creation time; the gateway forwards to
+		// exactly this upstream path, so we must not append "/mcp" (or otherwise manipulate it)
+		// here — doing so would diverge from what is stored and deployed to the gateway.
 		if proxy.Configuration.Upstream.Main != nil && proxy.Configuration.Upstream.Main.URL != "" {
 			url = proxy.Configuration.Upstream.Main.URL
 		}
-
-		normalizedURL, err := ensureMCPEndpointURL(url)
-		if err != nil {
-			return nil, apperror.ValidationFailed.Wrap(err, "The configured MCP server URL is invalid.")
-		}
-		url = normalizedURL
 
 		// Use stored auth from proxy configuration
 		if proxy.Configuration.Upstream.Main != nil && proxy.Configuration.Upstream.Main.Auth != nil {
@@ -577,27 +572,6 @@ func (s *MCPProxyService) FetchServerInfo(orgUUID string, req *api.MCPServerInfo
 	}
 
 	return utils.FetchMCPServerInfo(url, headerName, headerValue)
-}
-
-func ensureMCPEndpointURL(rawURL string) (string, error) {
-	parsedURL, err := url.Parse(rawURL)
-	if err != nil {
-		return "", err
-	}
-
-	path := strings.TrimRight(parsedURL.Path, "/")
-	if path == "" {
-		parsedURL.Path = "/mcp"
-		return parsedURL.String(), nil
-	}
-
-	if strings.HasSuffix(path, "/mcp") {
-		parsedURL.Path = path
-		return parsedURL.String(), nil
-	}
-
-	parsedURL.Path = path + "/mcp"
-	return parsedURL.String(), nil
 }
 
 // Helper functions

--- a/platform-api/internal/service/mcp_test.go
+++ b/platform-api/internal/service/mcp_test.go
@@ -19,8 +19,13 @@ package service
 
 import (
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/wso2/api-platform/platform-api/api"
 	"github.com/wso2/api-platform/platform-api/config"
 	"github.com/wso2/api-platform/platform-api/internal/apperror"
@@ -72,5 +77,66 @@ func TestMCPProxyServiceUpdateRejectsInvalidPolicyVersion(t *testing.T) {
 	_, err := service.Update("org-1", "mcp-proxy-1", "alice", request)
 	if !apperror.ValidationFailed.Is(err) {
 		t.Fatalf("expected ErrInvalidPolicyVersion, got: %v", err)
+	}
+}
+
+// TestFetchServerInfoRefetchUsesStoredURLVerbatim verifies that the refetch flow (proxyId
+// provided) contacts the MCP backend at EXACTLY the stored upstream URL path — it must not
+// append "/mcp" (or otherwise manipulate the path). This is the regression guard for the
+// removed ensureMCPEndpointURL normalization: the stored URL is the full MCP endpoint that
+// was validated at creation time, and the gateway forwards to exactly this path.
+func TestFetchServerInfoRefetchUsesStoredURLVerbatim(t *testing.T) {
+	tests := []struct {
+		name       string
+		storedPath string // path suffix appended to the test server base URL and stored on the proxy
+		wantPath   string // path the backend must actually receive
+	}{
+		// Upstream already points at the backend's "/mcp" endpoint: contact it as-is, no "/mcp/mcp".
+		{"mcp endpoint stored verbatim", "/mcp", "/mcp"},
+		// Upstream has no path: contact the root, never rewritten to "/mcp".
+		{"root upstream not rewritten to /mcp", "", "/"},
+		// Custom-path upstream: contact exactly that path.
+		{"custom path stored verbatim", "/api/v1/mcp-server", "/api/v1/mcp-server"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var mu sync.Mutex
+			var paths []string
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				paths = append(paths, r.URL.Path)
+				mu.Unlock()
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("mcp-session-id", "test-session")
+				// Minimal valid MCP initialize/JSON-RPC result so the handshake proceeds.
+				_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","serverInfo":{"name":"test","version":"1.0"}}}`))
+			}))
+			defer srv.Close()
+
+			proxy := &model.MCPProxy{
+				Handle: "mcp-proxy-1",
+				Configuration: model.MCPProxyConfiguration{
+					Upstream: model.UpstreamConfig{
+						Main: &model.UpstreamEndpoint{URL: srv.URL + tt.storedPath},
+					},
+				},
+			}
+			repo := &mockMCPProxyRepository{getByHandleResult: proxy}
+			service := NewMCPProxyService(repo, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{}, newTestIdentityService())
+
+			proxyID := "mcp-proxy-1"
+			_, err := service.FetchServerInfo("org-1", &api.MCPServerInfoFetchRequest{ProxyId: &proxyID})
+			require.NoError(t, err)
+
+			mu.Lock()
+			defer mu.Unlock()
+			require.NotEmpty(t, paths, "backend should have received at least one request")
+			for _, p := range paths {
+				assert.Equal(t, tt.wantPath, p, "backend received an unexpected path")
+				assert.NotContains(t, p, "/mcp/mcp", "the /mcp resource path must not be doubled on the backend")
+			}
+		})
 	}
 }

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/ExternalServersNew.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/ExternalServersNew.tsx
@@ -256,7 +256,10 @@ export default function ExternalServersNew(): JSX.Element {
       // vhost: 'mcp.gw.com', --- TODO Remove Tentatively ---
       upstream: {
         main: {
-          url: serverTarget.trim().replace(/\/mcp$/, ''),
+          // Preserve the validated endpoint URL verbatim. This is the exact URL that
+          // fetch-server-info just validated, and the gateway forwards requests to exactly
+          // this upstream path, so we must not strip or otherwise manipulate it.
+          url: serverTarget.trim(),
           ...(authHeaderName.trim() && resolvedAuthValue
             ? {
                 auth: {


### PR DESCRIPTION
## Purpose

- Resolves: https://github.com/wso2/api-platform/issues/2673
 
* **Follow-up to #2565**: Aligns with the change that modified the gateway default to forward MCP `/mcp` routes to exactly the configured upstream path instead of auto-appending `/mcp`. The stored upstream is now expected to be the full MCP endpoint URL.
* **The Problem**: Both `ai-workspace` and `platform-api` still manipulated the URL against the old contract. As a result, the stored/deployed upstream no longer matched the real MCP endpoint, causing a `404` error on connect (including via the create wizard's *"Try with Sample URL"*).
* **The Fix**: Preserve the provided backend URL end-to-end and never manipulate it with a `/mcp` substring.
    * **`ai-workspace`**: Stop stripping a trailing `/mcp` from the validated endpoint URL before storing it as the upstream — send the exact URL `fetch-server-info` already validated.
    * **`platform-api`**: Stop re-appending `/mcp` to the stored upstream URL on refetch (`FetchServerInfo`). Use it verbatim, consistent with Create/Update and the gateway deployment YAML builder, which already use it as-is. Removed the now-dead `ensureMCPEndpointURL` helper.

> **Note**: Migration of existing proxies whose stored URLs were already stripped of `/mcp` is out of scope for this PR and will be handled separately.