### PR TITLE
Add `other` backend authentication type to LLM Provider

### DIFF
--- a/platform-api/api/generated.go
+++ b/platform-api/api/generated.go
@@ -318,6 +318,7 @@ const (
 	ApiKey UpstreamAuthType = "api-key"
 	Basic  UpstreamAuthType = "basic"
 	Bearer UpstreamAuthType = "bearer"
+	Other  UpstreamAuthType = "other"
 )
 
 // Defines values for UserAPIKeyItemArtifactType.

--- a/platform-api/internal/service/llm.go
+++ b/platform-api/internal/service/llm.go
@@ -2215,6 +2215,8 @@ func normalizeUpstreamAuthType(authType string) string {
 		return string(api.Basic)
 	case "bearer":
 		return string(api.Bearer)
+	case "other":
+		return string(api.Other)
 	default:
 		return normalized
 	}

--- a/platform-api/internal/service/llm_deployment.go
+++ b/platform-api/internal/service/llm_deployment.go
@@ -1101,7 +1101,10 @@ func generateLLMProviderDeploymentYAML(provider *model.LLMProvider, templateHand
 	policies = orderLLMPolicies(policies)
 
 	upstream := dto.LLMUpstreamYAML{URL: main.URL, Ref: main.Ref}
-	if main.Auth != nil {
+	// "other" means auth to the upstream is handled entirely by user-attached
+	// policies (e.g. aws-authentication) - omit the auth block from the deployment
+	// artifact so the gateway does not attach a header-setting policy of its own.
+	if main.Auth != nil && normalizeUpstreamAuthType(main.Auth.Type) != "other" {
 		upstream.Auth = mapModelAuthToAPI(main.Auth)
 	}
 
@@ -1869,7 +1872,10 @@ func generateLLMProxyDeploymentYAML(proxy *model.LLMProxy) (dto.LLMProxyDeployme
 		},
 	}
 
-	if proxy.Configuration.UpstreamAuth != nil {
+	// "other" means auth to the upstream is handled entirely by user-attached
+	// policies - omit the auth block from the deployment artifact so the gateway
+	// does not attach a header-setting policy of its own.
+	if proxy.Configuration.UpstreamAuth != nil && normalizeUpstreamAuthType(proxy.Configuration.UpstreamAuth.Type) != "other" {
 		proxyDeployment.Spec.Provider.Auth = mapModelUpstreamAuthToAPI(proxy.Configuration.UpstreamAuth)
 	}
 

--- a/platform-api/internal/service/llm_deployment_test.go
+++ b/platform-api/internal/service/llm_deployment_test.go
@@ -22,6 +22,74 @@ func TestMapModelAuthToAPI_NormalizesApiKeyType(t *testing.T) {
 
 func float32Ptr(f float32) *float32 { return &f }
 
+// TestGenerateLLMProviderDeploymentYAML_OtherAuthOmitsUpstreamAuth verifies that when the
+// upstream auth type is "other", the deployment artifact sent to the gateway omits the auth
+// block entirely - the gateway must never see a credential-less "other" auth type; it must
+// see no auth block at all, exactly as if auth were never configured.
+func TestGenerateLLMProviderDeploymentYAML_OtherAuthOmitsUpstreamAuth(t *testing.T) {
+	provider := &model.LLMProvider{
+		ID:      "test-provider",
+		Name:    "Test Provider",
+		Version: "v1.0",
+		Configuration: model.LLMProviderConfig{
+			Context: strPtr("/test"),
+			Upstream: &model.UpstreamConfig{
+				Main: &model.UpstreamEndpoint{
+					URL:  "https://api.anthropic.com",
+					Auth: &model.UpstreamAuth{Type: "other"},
+				},
+			},
+			AccessControl: &model.LLMAccessControl{Mode: "allow_all"},
+		},
+	}
+
+	yamlArtifact, err := generateLLMProviderDeploymentYAML(provider, "anthropic")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if yamlArtifact.Spec.Upstream.Auth != nil {
+		t.Fatalf("expected upstream auth to be omitted for auth type 'other', got %+v", yamlArtifact.Spec.Upstream.Auth)
+	}
+
+	out, err := yaml.Marshal(yamlArtifact)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+	if strings.Contains(string(out), "auth:") {
+		t.Fatalf("expected marshaled YAML to omit the auth block entirely, got:\n%s", out)
+	}
+}
+
+// TestGenerateLLMProxyDeploymentYAML_OtherAuthOmitsProviderAuth is the LLM Proxy counterpart
+// of TestGenerateLLMProviderDeploymentYAML_OtherAuthOmitsUpstreamAuth.
+func TestGenerateLLMProxyDeploymentYAML_OtherAuthOmitsProviderAuth(t *testing.T) {
+	proxy := &model.LLMProxy{
+		ID:      "test-proxy",
+		Name:    "Test Proxy",
+		Version: "v1.0",
+		Configuration: model.LLMProxyConfig{
+			Provider:     "test-provider",
+			UpstreamAuth: &model.UpstreamAuth{Type: "other"},
+		},
+	}
+
+	yamlArtifact, err := generateLLMProxyDeploymentYAML(proxy)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if yamlArtifact.Spec.Provider.Auth != nil {
+		t.Fatalf("expected provider auth to be omitted for auth type 'other', got %+v", yamlArtifact.Spec.Provider.Auth)
+	}
+
+	out, err := yaml.Marshal(yamlArtifact)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+	if strings.Contains(string(out), "auth:") {
+		t.Fatalf("expected marshaled YAML to omit the auth block entirely, got:\n%s", out)
+	}
+}
+
 // providerWithConsumerLimits builds a minimal LLMProvider model with the given
 // consumer-level rate limiting config and no backend (provider-level) limits.
 func providerWithConsumerLimits(rl *model.LLMRateLimitingConfig) *model.LLMProvider {

--- a/platform-api/internal/service/llm_test.go
+++ b/platform-api/internal/service/llm_test.go
@@ -75,6 +75,7 @@ func TestNormalizeUpstreamAuthType(t *testing.T) {
 		{name: "api key upper with underscore", input: "API_KEY", expected: "api-key"},
 		{name: "basic", input: "basic", expected: "basic"},
 		{name: "bearer", input: "bearer", expected: "bearer"},
+		{name: "other", input: "other", expected: "other"},
 		{name: "unknown preserved", input: "custom", expected: "custom"},
 		{name: "empty", input: "", expected: ""},
 	}

--- a/platform-api/resources/openapi.yaml
+++ b/platform-api/resources/openapi.yaml
@@ -6714,7 +6714,7 @@ components:
         type:
           type: string
           description: Authentication type
-          enum: [ basic, bearer, api-key ]
+          enum: [ basic, bearer, api-key, other ]
           example: api-key
         header:
           type: string

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/AddNewProvider/ProviderTemplateFormFields.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/AddNewProvider/ProviderTemplateFormFields.tsx
@@ -23,6 +23,7 @@ import {
   Chip,
   Divider,
   FormControl,
+  FormHelperText,
   FormLabel,
   Grid,
   IconButton,
@@ -114,6 +115,7 @@ export default function ProviderTemplateFormFields({
   const hasTemplateUrl = Boolean(template?.metadata?.endpointUrl);
   const hasTemplateAuthType = Boolean(template?.metadata?.auth?.type);
   const hasTemplateAuthHeader = Boolean(template?.metadata?.auth?.header);
+  const isOtherAuthType = formState.upstreamAuthType === 'other';
   const trimmedVersion = formState.version.trim();
   const versionErrorMessage = !versionTouched
     ? ''
@@ -277,25 +279,40 @@ export default function ProviderTemplateFormFields({
             </FormLabel>
             <Select
               value={formState.upstreamAuthType}
-              onChange={(e) =>
+              onChange={(e) => {
+                const nextAuthType = e.target.value;
                 setFormState((prev) => ({
                   ...prev,
-                  upstreamAuthType: e.target.value,
-                }))
-              }
+                  upstreamAuthType: nextAuthType,
+                  upstreamAuthHeader:
+                    nextAuthType === 'other' ? '' : prev.upstreamAuthHeader,
+                  upstreamAuthValue:
+                    nextAuthType === 'other' ? '' : prev.upstreamAuthValue,
+                }));
+              }}
             >
-              {['api-key'].map((type) => (
+              {['api-key', 'other'].map((type) => (
                 <MenuItem key={type} value={type}>
                   {type}
                 </MenuItem>
               ))}
             </Select>
+            {isOtherAuthType && (
+              <FormHelperText>
+                <FormattedMessage
+                  id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.AddNewProvider.ProviderTemplateFormFields.authentication.type.other.note"
+                  defaultMessage={
+                    'No credentials are stored for this provider. Use a policy to configure authentication.'
+                  }
+                />
+              </FormHelperText>
+            )}
           </FormControl>
         </Grid>
       )}
 
-      {/* Auth Header - only show if not provided by template */}
-      {!hasTemplateAuthHeader && (
+      {/* Auth Header - only show if not provided by template and auth type is not "other" */}
+      {!hasTemplateAuthHeader && !isOtherAuthType && (
         <Grid size={{ xs: 12, md: 6 }}>
           <FormControl fullWidth>
             <FormLabel>
@@ -319,56 +336,58 @@ export default function ProviderTemplateFormFields({
         </Grid>
       )}
 
-      {/* Auth Value - always show; optional, provider can be created without it */}
-      <Grid size={{ xs: 12 }}>
-        <FormControl fullWidth>
-          <FormLabel>
-            <FormattedMessage
-              id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.AddNewProvider.ProviderTemplateFormFields.api.key"
-              defaultMessage={'API Key'}
+      {/* Auth Value - shown unless auth type is "other"; optional, provider can be created without it */}
+      {!isOtherAuthType && (
+        <Grid size={{ xs: 12 }}>
+          <FormControl fullWidth>
+            <FormLabel>
+              <FormattedMessage
+                id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.AddNewProvider.ProviderTemplateFormFields.api.key"
+                defaultMessage={'API Key'}
+              />
+            </FormLabel>
+            <TextField
+              fullWidth
+              value={formState.upstreamAuthValue}
+              onChange={(e) =>
+                setFormState((prev) => ({
+                  ...prev,
+                  upstreamAuthValue: e.target.value,
+                }))
+              }
+              type={showCredential ? 'text' : 'password'}
+              data-cyid="provider-api-key-input"
+              slotProps={{
+                input: {
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      <IconButton
+                        size="small"
+                        onClick={() => setShowCredential((prev) => !prev)}
+                        aria-label={
+                          showCredential ? 'Hide credentials' : 'Show credentials'
+                        }
+                      >
+                        {showCredential ? (
+                          <EyeOff size={18} />
+                        ) : (
+                          <Eye size={18} />
+                        )}
+                      </IconButton>
+                    </InputAdornment>
+                  ),
+                },
+              }}
+              placeholder="Enter your API key or token (optional)"
+              // helperText={
+              //   template?.metadata?.auth?.valuePrefix
+              //     ? `Will be prefixed with: ${template.metadata.auth.valuePrefix}`
+              //     : 'Your authentication credential for the upstream provider'
+              // }
             />
-          </FormLabel>
-          <TextField
-            fullWidth
-            value={formState.upstreamAuthValue}
-            onChange={(e) =>
-              setFormState((prev) => ({
-                ...prev,
-                upstreamAuthValue: e.target.value,
-              }))
-            }
-            type={showCredential ? 'text' : 'password'}
-            data-cyid="provider-api-key-input"
-            slotProps={{
-              input: {
-                endAdornment: (
-                  <InputAdornment position="end">
-                    <IconButton
-                      size="small"
-                      onClick={() => setShowCredential((prev) => !prev)}
-                      aria-label={
-                        showCredential ? 'Hide credentials' : 'Show credentials'
-                      }
-                    >
-                      {showCredential ? (
-                        <EyeOff size={18} />
-                      ) : (
-                        <Eye size={18} />
-                      )}
-                    </IconButton>
-                  </InputAdornment>
-                ),
-              },
-            }}
-            placeholder="Enter your API key or token (optional)"
-            // helperText={
-            //   template?.metadata?.auth?.valuePrefix
-            //     ? `Will be prefixed with: ${template.metadata.auth.valuePrefix}`
-            //     : 'Your authentication credential for the upstream provider'
-            // }
-          />
-        </FormControl>
-      </Grid>
+          </FormControl>
+        </Grid>
+      )}
 
       {/* Show what values are being used from template */}
       {/* {(hasTemplateUrl || hasTemplateAuthType || hasTemplateAuthHeader) && (

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderConnectionTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderConnectionTab.tsx
@@ -19,6 +19,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   FormControl,
+  FormHelperText,
   FormLabel,
   IconButton,
   InputAdornment,
@@ -55,6 +56,7 @@ export default function ServiceProviderConnectionTab() {
   const showSnackbar = useAIWorkspaceSnackbar();
   const isReadOnlyProvider = Boolean(provider?.readOnly);
   const isFormDisabled = isLoading || Boolean(error) || isReadOnlyProvider;
+  const isOtherAuthType = (authenticationType || 'api-key') === 'other';
 
   const valuePrefix = useMemo(() => {
     return providerTemplate?.metadata?.auth?.valuePrefix || '';
@@ -150,6 +152,7 @@ export default function ServiceProviderConnectionTab() {
     const nextType = value.trim();
     if (!nextType || nextType === (provider.upstream?.main?.auth?.type || ''))
       return;
+    const isOther = nextType === 'other';
     try {
       const {
         status,
@@ -166,8 +169,8 @@ export default function ServiceProviderConnectionTab() {
             url: provider.upstream?.main?.url || '',
             auth: {
               type: nextType,
-              header: provider.upstream?.main?.auth?.header || '',
-              value: provider.upstream?.main?.auth?.value || '',
+              header: isOther ? '' : provider.upstream?.main?.auth?.header || '',
+              value: isOther ? '' : provider.upstream?.main?.auth?.value || '',
             },
           },
         },
@@ -302,6 +305,10 @@ export default function ServiceProviderConnectionTab() {
             onChange={(e) => {
               const nextValue = String(e.target.value);
               setAuthenticationType(nextValue);
+              if (nextValue === 'other') {
+                setAuthenticationHeader('');
+                setCredentialValue('');
+              }
               if (isDraftMode) {
                 void handleUpdateAuthentication(nextValue);
               }
@@ -313,81 +320,98 @@ export default function ServiceProviderConnectionTab() {
             }}
           >
             <MenuItem value="api-key">api-key</MenuItem>
+            <MenuItem value="other">other</MenuItem>
           </Select>
+          {isOtherAuthType && (
+            <FormHelperText>
+              No credentials are stored for this provider. Use a policy to
+              configure authentication.
+            </FormHelperText>
+          )}
         </FormControl>
 
-        <FormControl fullWidth>
-          <FormLabel>Authentication Header</FormLabel>
-          <TextField
-            size="small"
-            value={authenticationHeader}
-            disabled={isFormDisabled}
-            onChange={(e) => {
-              const nextValue = e.target.value;
-              setAuthenticationHeader(nextValue);
-              if (isDraftMode) {
-                void handleUpdateAuthenticationHeader(nextValue);
-              }
-            }}
-            onBlur={() => {
-              if (!isDraftMode) {
-                void handleUpdateAuthenticationHeader();
-              }
-            }}
-          />
-        </FormControl>
+        {!isOtherAuthType && (
+          <>
+            <FormControl fullWidth>
+              <FormLabel>Authentication Header</FormLabel>
+              <TextField
+                size="small"
+                value={authenticationHeader}
+                disabled={isFormDisabled}
+                onChange={(e) => {
+                  const nextValue = e.target.value;
+                  setAuthenticationHeader(nextValue);
+                  if (isDraftMode) {
+                    void handleUpdateAuthenticationHeader(nextValue);
+                  }
+                }}
+                onBlur={() => {
+                  if (!isDraftMode) {
+                    void handleUpdateAuthenticationHeader();
+                  }
+                }}
+              />
+            </FormControl>
 
-        <FormControl fullWidth>
-          <FormLabel>Credentials</FormLabel>
-          <TextField
-            size="small"
-            type={showCredential ? 'text' : 'password'}
-            value={credentialValue}
-            disabled={isFormDisabled}
-            onFocus={() => {
-              if (isCredentialMasked) {
-                setCredentialValue('');
-                setIsCredentialMasked(false);
-                setHasCredentialChanged(false);
-              }
-            }}
-            onChange={(e) => {
-              const nextValue = e.target.value;
-              setCredentialValue(nextValue);
-              setHasCredentialChanged(true);
-              if (isDraftMode && !isCredentialMasked) {
-                void handleUpdateCredential(nextValue);
-              }
-            }}
-            onBlur={() => {
-              if (!isDraftMode && !isCredentialMasked && hasCredentialChanged) {
-                void handleUpdateCredential();
-              }
-            }}
-            slotProps={{
-              input: {
-                endAdornment: (
-                  <InputAdornment position="end">
-                    <IconButton
-                      size="small"
-                      disabled={isFormDisabled}
-                      onClick={() => setShowCredential((prev) => !prev)}
-                      aria-label={
-                        showCredential ? 'Hide credentials' : 'Show credentials'
-                      }
-                    >
-                      {showCredential ? (
-                        <EyeOff size={18} />
-                      ) : (
-                        <Eye size={18} />
-                      )}
-                    </IconButton>
-                  </InputAdornment>
-                ),
-              },
-            }}
-          />
-        </FormControl>
+            <FormControl fullWidth>
+              <FormLabel>Credentials</FormLabel>
+              <TextField
+                size="small"
+                type={showCredential ? 'text' : 'password'}
+                value={credentialValue}
+                disabled={isFormDisabled}
+                onFocus={() => {
+                  if (isCredentialMasked) {
+                    setCredentialValue('');
+                    setIsCredentialMasked(false);
+                    setHasCredentialChanged(false);
+                  }
+                }}
+                onChange={(e) => {
+                  const nextValue = e.target.value;
+                  setCredentialValue(nextValue);
+                  setHasCredentialChanged(true);
+                  if (isDraftMode && !isCredentialMasked) {
+                    void handleUpdateCredential(nextValue);
+                  }
+                }}
+                onBlur={() => {
+                  if (
+                    !isDraftMode &&
+                    !isCredentialMasked &&
+                    hasCredentialChanged
+                  ) {
+                    void handleUpdateCredential();
+                  }
+                }}
+                slotProps={{
+                  input: {
+                    endAdornment: (
+                      <InputAdornment position="end">
+                        <IconButton
+                          size="small"
+                          disabled={isFormDisabled}
+                          onClick={() => setShowCredential((prev) => !prev)}
+                          aria-label={
+                            showCredential
+                              ? 'Hide credentials'
+                              : 'Show credentials'
+                          }
+                        >
+                          {showCredential ? (
+                            <EyeOff size={18} />
+                          ) : (
+                            <Eye size={18} />
+                          )}
+                        </IconButton>
+                      </InputAdornment>
+                    ),
+                  },
+                }}
+              />
+            </FormControl>
+          </>
+        )}
       </Stack>
     </>
   );

--- a/portals/ai-workspace/src/utils/types.ts
+++ b/portals/ai-workspace/src/utils/types.ts
@@ -192,7 +192,7 @@ export interface ModelProvider {
  * Authentication configuration for upstream
  */
 export interface UpstreamAuth {
-  type: 'api-key' | 'oauth2' | 'basic' | string;
+  type: 'api-key' | 'oauth2' | 'basic' | 'other' | string;
   header?: string;
   value?: string;
 }


### PR DESCRIPTION
### Purpose

- Resolves: https://github.com/wso2/api-platform/issues/2686

This pull request adds support for a new upstream authentication type, `"other"`, which allows authentication to be handled entirely by user-attached policies rather than by storing credentials in the platform. The changes ensure that when `"other"` is selected, credential fields are hidden in the UI, no credentials are stored, and the deployment artifact omits the auth block. Comprehensive backend and frontend updates, as well as tests, are included to support this new authentication flow.

**Backend changes:**

* Added `"other"` as a valid `UpstreamAuthType` throughout the API, OpenAPI spec, and normalization logic. [[1]](diffhunk://#diff-9a8387679fa87f5b5ea1b73bc4cbe40da2b8f018caa862b94a7ed01b539164e6R321) [[2]](diffhunk://#diff-7a55d32e82d7d62afb11d5c8cb79f0837910757469aabc9d3141b0ce1c434309L6717-R6717) [[3]](diffhunk://#diff-f02b87a8b23ad9d19e48c4d47075f4a21f4ff7935214eea5e5015a7f155dbffdR2218-R2219) [[4]](diffhunk://#diff-20b2c80f22a7ad784fe6d1da48a5fb1ccf8323d37e4a758b4267665132922986R78)
* Updated deployment artifact generation to omit the `auth` block if the type is `"other"`, preventing the gateway from attaching header-setting policies. [[1]](diffhunk://#diff-87b7518eac020ce0efa180b7a77fb4c03674647efe40a2d0724a358c27f00e00L1104-R1107) [[2]](diffhunk://#diff-87b7518eac020ce0efa180b7a77fb4c03674647efe40a2d0724a358c27f00e00L1872-R1878)
* Added backend tests to verify that the `auth` block is omitted for `"other"` in both provider and proxy deployment YAML.

**Frontend/UI changes:**

* Updated provider creation and connection forms to include `"other"` as an authentication type, hide credential fields, and display a helper message when selected. [[1]](diffhunk://#diff-c61b2c3da4e6d27c7596b1637afe4a2274f78c44095dec55cd0a3894a152ed7dR26) [[2]](diffhunk://#diff-c61b2c3da4e6d27c7596b1637afe4a2274f78c44095dec55cd0a3894a152ed7dR118) [[3]](diffhunk://#diff-c61b2c3da4e6d27c7596b1637afe4a2274f78c44095dec55cd0a3894a152ed7dL280-R315) [[4]](diffhunk://#diff-c61b2c3da4e6d27c7596b1637afe4a2274f78c44095dec55cd0a3894a152ed7dL322-R340) [[5]](diffhunk://#diff-c61b2c3da4e6d27c7596b1637afe4a2274f78c44095dec55cd0a3894a152ed7dR390) [[6]](diffhunk://#diff-001ea464189d9c7880ec96f181795e7a992ca7ded7463ac0ff92068f597f140aR22) [[7]](diffhunk://#diff-001ea464189d9c7880ec96f181795e7a992ca7ded7463ac0ff92068f597f140aR59) [[8]](diffhunk://#diff-001ea464189d9c7880ec96f181795e7a992ca7ded7463ac0ff92068f597f140aR155) [[9]](diffhunk://#diff-001ea464189d9c7880ec96f181795e7a992ca7ded7463ac0ff92068f597f140aL169-R173) [[10]](diffhunk://#diff-001ea464189d9c7880ec96f181795e7a992ca7ded7463ac0ff92068f597f140aR308-R311) [[11]](diffhunk://#diff-001ea464189d9c7880ec96f181795e7a992ca7ded7463ac0ff92068f597f140aR323-R334) [[12]](diffhunk://#diff-001ea464189d9c7880ec96f181795e7a992ca7ded7463ac0ff92068f597f140aL363-R383) [[13]](diffhunk://#diff-001ea464189d9c7880ec96f181795e7a992ca7ded7463ac0ff92068f597f140aL376-R398) [[14]](diffhunk://#diff-001ea464189d9c7880ec96f181795e7a992ca7ded7463ac0ff92068f597f140aR413-R414)
* Ensured that switching to `"other"` clears any previously entered credential values in the form state. [[1]](diffhunk://#diff-c61b2c3da4e6d27c7596b1637afe4a2274f78c44095dec55cd0a3894a152ed7dL280-R315) [[2]](diffhunk://#diff-001ea464189d9c7880ec96f181795e7a992ca7ded7463ac0ff92068f597f140aR308-R311)

**Type definition updates:**

* Extended the `UpstreamAuth` TypeScript interface to include `"other"` as a valid type.

<img width="1335" height="765" alt="image" src="https://github.com/user-attachments/assets/cda931ac-1ead-4501-aebe-5cf11e72904e" />

<img width="1335" height="765" alt="image" src="https://github.com/user-attachments/assets/acbeed2f-e78a-4c4b-80fb-9a94fbabd16b" />
