### PR TITLE
[AI Workspace] Update quick start guides and configuration files to reference v1.2.0-alpha2

### DIFF
--- a/docs/ai-gateway/llm/quick-start-guide.md
+++ b/docs/ai-gateway/llm/quick-start-guide.md
@@ -22,14 +22,14 @@ docker compose version
 Replace ${version} with the actual release version of the API Platform Gateway.
 ```bash
 # Download distribution.
-wget https://github.com/wso2/api-platform/releases/download/ai-gateway/v1.2.0-M1/wso2apip-ai-gateway-1.2.0-M1.zip
+wget https://github.com/wso2/api-platform/releases/download/ai-gateway/v1.2.0-alpha2/wso2apip-ai-gateway-v1.2.0-alpha2.zip
 
 # Unzip the downloaded distribution.
-unzip wso2apip-ai-gateway-1.2.0-M1.zip
+unzip wso2apip-ai-gateway-v1.2.0-alpha2.zip
 
 
 # Start the complete stack
-cd wso2apip-ai-gateway-1.2.0-M1/
+cd wso2apip-ai-gateway-v1.2.0-alpha2/
 docker compose up -d
 
 # Verify gateway controller admin endpoint is running

--- a/docs/ai-gateway/llm/quick-start-guide.md
+++ b/docs/ai-gateway/llm/quick-start-guide.md
@@ -22,10 +22,10 @@ docker compose version
 Replace ${version} with the actual release version of the API Platform Gateway.
 ```bash
 # Download distribution.
-wget https://github.com/wso2/api-platform/releases/download/ai-gateway/v1.2.0-alpha2/wso2apip-ai-gateway-v1.2.0-alpha2.zip
+wget https://github.com/wso2/api-platform/releases/download/ai-gateway/v1.2.0-alpha2/wso2apip-ai-gateway-1.2.0-alpha2.zip
 
 # Unzip the downloaded distribution.
-unzip wso2apip-ai-gateway-v1.2.0-alpha2.zip
+unzip wso2apip-ai-gateway-1.2.0-alpha2.zip
 
 
 # Start the complete stack

--- a/docs/ai-gateway/mcp/quick-start-guide.md
+++ b/docs/ai-gateway/mcp/quick-start-guide.md
@@ -23,14 +23,14 @@ Replace `${version}` with the API Platform AI Gateway release version you want t
 
 ```bash
 # Download distribution.
-wget https://github.com/wso2/api-platform/releases/download/ai-gateway/v1.2.0-M1/wso2apip-ai-gateway-1.2.0-M1.zip
+wget https://github.com/wso2/api-platform/releases/download/ai-gateway/v1.2.0-alpha2/wso2apip-ai-gateway-v1.2.0-alpha2.zip
 
 # Unzip the downloaded distribution.
-unzip wso2apip-ai-gateway-1.2.0-M1.zip
+unzip wso2apip-ai-gateway-v1.2.0-alpha2.zip
 
 
 # Start the complete stack
-cd wso2apip-ai-gateway-1.2.0-M1/
+cd wso2apip-ai-gateway-v1.2.0-alpha2/
 docker compose -p ai-gateway up -d
 
 # Verify gateway controller admin endpoint is running

--- a/docs/ai-gateway/mcp/quick-start-guide.md
+++ b/docs/ai-gateway/mcp/quick-start-guide.md
@@ -23,10 +23,10 @@ Replace `${version}` with the API Platform AI Gateway release version you want t
 
 ```bash
 # Download distribution.
-wget https://github.com/wso2/api-platform/releases/download/ai-gateway/v1.2.0-alpha2/wso2apip-ai-gateway-v1.2.0-alpha2.zip
+wget https://github.com/wso2/api-platform/releases/download/ai-gateway/v1.2.0-alpha2/wso2apip-ai-gateway-1.2.0-alpha2.zip
 
 # Unzip the downloaded distribution.
-unzip wso2apip-ai-gateway-v1.2.0-alpha2.zip
+unzip wso2apip-ai-gateway-1.2.0-alpha2.zip
 
 
 # Start the complete stack

--- a/docs/gateway/quick-start-guide.md
+++ b/docs/gateway/quick-start-guide.md
@@ -22,10 +22,10 @@ Replace `${version}` with the API Platform Gateway release version you want to r
 
 ```bash
 # Download distribution.
-wget https://github.com/wso2/api-platform/releases/download/gateway/v1.2.0-alpha2/wso2apip-api-gateway-v1.2.0-alpha2.zip
+wget https://github.com/wso2/api-platform/releases/download/gateway/v1.2.0-alpha2/wso2apip-api-gateway-1.2.0-alpha2.zip
 
 # Unzip the downloaded distribution.
-unzip wso2apip-api-gateway-v1.2.0-alpha2.zip
+unzip wso2apip-api-gateway-1.2.0-alpha2.zip
 
 
 # Start the complete stack

--- a/docs/gateway/quick-start-guide.md
+++ b/docs/gateway/quick-start-guide.md
@@ -22,14 +22,14 @@ Replace `${version}` with the API Platform Gateway release version you want to r
 
 ```bash
 # Download distribution.
-wget https://github.com/wso2/api-platform/releases/download/gateway/v1.2.0-M1/wso2apip-api-gateway-1.2.0-M1.zip
+wget https://github.com/wso2/api-platform/releases/download/gateway/v1.2.0-alpha2/wso2apip-api-gateway-v1.2.0-alpha2.zip
 
 # Unzip the downloaded distribution.
-unzip wso2apip-api-gateway-1.2.0-M1.zip
+unzip wso2apip-api-gateway-v1.2.0-alpha2.zip
 
 
 # Start the complete stack
-cd wso2apip-api-gateway-1.2.0-M1/
+cd wso2apip-api-gateway-v1.2.0-alpha2/
 docker compose up -d
 
 # Verify gateway controller admin endpoint is running

--- a/portals/ai-workspace/configs/config-template.toml
+++ b/portals/ai-workspace/configs/config-template.toml
@@ -90,7 +90,7 @@ default_org_region = '{{ env "APIP_AIW_DEFAULT_ORG_REGION" "us" }}'
 # Each entry: version (helm chart minor), latestVersion (image/chart tag shown to the
 # user and used in the helm --version flag), channel ("STS" | "LTS"). The first entry
 # is the default selection.
-platform_gateway_versions = '{{ env "APIP_AIW_PLATFORM_GATEWAY_VERSIONS" "[{\"version\":\"1.2\",\"latestVersion\":\"v1.2.0-M1\",\"channel\":\"STS\"}]" }}'
+platform_gateway_versions = '{{ env "APIP_AIW_PLATFORM_GATEWAY_VERSIONS" "[{\"version\":\"1.2\",\"latestVersion\":\"v1.2.0-alpha2\",\"channel\":\"STS\"}]" }}'
 
 # Verbose logging in the browser console.
 debug = '{{ env "APIP_AIW_DEBUG" "false" }}'

--- a/portals/ai-workspace/configs/config.toml
+++ b/portals/ai-workspace/configs/config.toml
@@ -13,7 +13,7 @@ auth_mode = '{{ env "APIP_AIW_AUTH_MODE" "basic" }}'
 domain = '{{ env "APIP_AIW_DOMAIN" "localhost:5380" }}'
 controlplane_host = '{{ env "APIP_AIW_CONTROLPLANE_HOST" "host.docker.internal:9243" }}'
 default_org_region = '{{ env "APIP_AIW_DEFAULT_ORG_REGION" "us" }}'
-platform_gateway_versions = '{{ env "APIP_AIW_PLATFORM_GATEWAY_VERSIONS" "[{\"version\":\"1.2\",\"latestVersion\":\"v1.2.0-M1\",\"channel\":\"STS\"}]" }}'
+platform_gateway_versions = '{{ env "APIP_AIW_PLATFORM_GATEWAY_VERSIONS" "[{\"version\":\"1.2\",\"latestVersion\":\"v1.2.0-alpha2\",\"channel\":\"STS\"}]" }}'
 
 listen_addr = '{{ env "APIP_AIW_LISTEN_ADDR" ":5380" }}'
 static_dir  = '{{ env "APIP_AIW_STATIC_DIR" "/app" }}'

--- a/portals/ai-workspace/production/README.md
+++ b/portals/ai-workspace/production/README.md
@@ -152,7 +152,7 @@ default_org_region = "us"
 
 # Available gateway versions shown in the create-gateway version selector (JSON array string).
 # Each entry: version (helm chart minor), latestVersion (image/chart tag), channel ("STS" | "LTS").
-platform_gateway_versions = '[{"version":"1.2","latestVersion":"v1.2.0-M1","channel":"STS"}]'
+platform_gateway_versions = '[{"version":"1.2","latestVersion":"v1.2.0-alpha2","channel":"STS"}]'
 
 [platform_api]
 # The upstream the BFF proxies to, server-to-server. An origin, not a base path — the

--- a/portals/ai-workspace/src/config.env.ts
+++ b/portals/ai-workspace/src/config.env.ts
@@ -141,7 +141,7 @@ export interface GatewayVersionEntry {
 export const PLATFORM_GATEWAY_VERSIONS = getEnvOrDefault<GatewayVersionEntry[]>(
   'APIP_AIW_PLATFORM_GATEWAY_VERSIONS',
   [
-    { version: '1.2', latestVersion: 'v1.2.0-M1', channel: 'STS' }
+    { version: '1.2', latestVersion: 'v1.2.0-alpha2', channel: 'STS' }
   ]
 );
 


### PR DESCRIPTION
- Updated download links and directory names in quick start guides for AI Gateway, MCP, and API Gateway to use the new alpha version.
- Modified configuration files to reflect the latest version of the platform gateway, changing references from v1.2.0-M1 to v1.2.0-alpha2.
- Ensured consistency across documentation and configuration settings for the new release.
