### PR TITLE
Move LLM provider template logo and OpenAPI spec URLs to wso2/api-platform

### DIFF
--- a/platform-api/resources/default-llm-provider-templates/anthropic-template.yaml
+++ b/platform-api/resources/default-llm-provider-templates/anthropic-template.yaml
@@ -28,8 +28,8 @@ spec:
     auth:
       type: apiKey
       header: x-api-key
-    logoUrl: https://raw.githubusercontent.com/nomadxd/openapi-connectors/main/openapi/anthropic.claude/icon.png
-    openapiSpecUrl: https://raw.githubusercontent.com/nomadxd/openapi-connectors/main/openapi/anthropic.claude/openapi.yaml
+    logoUrl: https://raw.githubusercontent.com/wso2/api-platform/main/llm-provider-specs/anthropic/icon.png
+    openapiSpecUrl: https://raw.githubusercontent.com/wso2/api-platform/main/llm-provider-specs/anthropic/openapi.yaml
   promptTokens:
     location: payload
     identifier: $.usage.input_tokens

--- a/platform-api/resources/default-llm-provider-templates/awsbedrock-template.yaml
+++ b/platform-api/resources/default-llm-provider-templates/awsbedrock-template.yaml
@@ -24,8 +24,8 @@ spec:
   managedBy: wso2
   version: v1.0
   metadata:
-    logoUrl: https://raw.githubusercontent.com/nomadxd/openapi-connectors/main/openapi/aws.bedrock/icon.png
-    openapiSpecUrl: https://raw.githubusercontent.com/nomadxd/openapi-connectors/main/openapi/aws.bedrock/openapi.yaml
+    logoUrl: https://raw.githubusercontent.com/wso2/api-platform/main/llm-provider-specs/awsbedrock/icon.png
+    openapiSpecUrl: https://raw.githubusercontent.com/wso2/api-platform/main/llm-provider-specs/awsbedrock/openapi.yaml
   promptTokens:
     location: payload
     identifier: $.usage.inputTokens

--- a/platform-api/resources/default-llm-provider-templates/azureaifoundry-template.yaml
+++ b/platform-api/resources/default-llm-provider-templates/azureaifoundry-template.yaml
@@ -27,7 +27,8 @@ spec:
     auth:
       type: apiKey
       header: api-key
-    logoUrl: https://raw.githubusercontent.com/nomadxd/openapi-connectors/main/openapi/azure.openai/icon.png
+    logoUrl: https://raw.githubusercontent.com/wso2/api-platform/main/llm-provider-specs/azureai-foundry/icon.png
+    openapiSpecUrl: https://raw.githubusercontent.com/wso2/api-platform/main/llm-provider-specs/azureai-foundry/openapi.yaml
   promptTokens:
     location: payload
     identifier: $.usage.prompt_tokens

--- a/platform-api/resources/default-llm-provider-templates/azureopenai-template.yaml
+++ b/platform-api/resources/default-llm-provider-templates/azureopenai-template.yaml
@@ -27,8 +27,8 @@ spec:
     auth:
       type: apiKey
       header: api-key
-    logoUrl: https://raw.githubusercontent.com/nomadxd/openapi-connectors/refs/heads/main/openapi/azure.openai.v2/icon.png
-    openapiSpecUrl: https://raw.githubusercontent.com/nomadxd/openapi-connectors/refs/heads/main/openapi/azure.openai.v2/openapi.yaml
+    logoUrl: https://raw.githubusercontent.com/wso2/api-platform/main/llm-provider-specs/azure-openai/icon.png
+    openapiSpecUrl: https://raw.githubusercontent.com/wso2/api-platform/main/llm-provider-specs/azure-openai/openapi.yaml
   promptTokens:
     location: payload
     identifier: $.usage.prompt_tokens

--- a/platform-api/resources/default-llm-provider-templates/gemini-template.yaml
+++ b/platform-api/resources/default-llm-provider-templates/gemini-template.yaml
@@ -28,6 +28,8 @@ spec:
     auth:
       type: apiKey
       header: x-goog-api-key
+    logoUrl: https://raw.githubusercontent.com/wso2/api-platform/main/llm-provider-specs/gemini/icon.png
+    openapiSpecUrl: https://raw.githubusercontent.com/wso2/api-platform/main/llm-provider-specs/gemini/openapi.yaml
   promptTokens:
     location: payload
     identifier: $.usageMetadata.promptTokenCount

--- a/platform-api/resources/default-llm-provider-templates/mistral-template.yaml
+++ b/platform-api/resources/default-llm-provider-templates/mistral-template.yaml
@@ -29,8 +29,8 @@ spec:
       type: apiKey
       header: Authorization
       valuePrefix: "Bearer "
-    logoUrl: https://raw.githubusercontent.com/nomadxd/openapi-connectors/main/openapi/mistral/icon.png
-    openapiSpecUrl: https://raw.githubusercontent.com/nomadxd/openapi-connectors/main/openapi/mistral/openapi.yaml
+    logoUrl: https://raw.githubusercontent.com/wso2/api-platform/main/llm-provider-specs/mistral/icon.png
+    openapiSpecUrl: https://raw.githubusercontent.com/wso2/api-platform/main/llm-provider-specs/mistral/openapi.yaml
   promptTokens:
     location: payload
     identifier: $.usage.prompt_tokens

--- a/platform-api/resources/default-llm-provider-templates/openai-template.yaml
+++ b/platform-api/resources/default-llm-provider-templates/openai-template.yaml
@@ -29,8 +29,8 @@ spec:
       type: apiKey
       header: Authorization
       valuePrefix: "Bearer "
-    logoUrl: https://raw.githubusercontent.com/nomadxd/openapi-connectors/main/openapi/openai/icon.png
-    openapiSpecUrl: https://raw.githubusercontent.com/nomadxd/openapi-connectors/main/openapi/openai/openapi.yaml
+    logoUrl: https://raw.githubusercontent.com/wso2/api-platform/main/llm-provider-specs/openai/icon.png
+    openapiSpecUrl: https://raw.githubusercontent.com/wso2/api-platform/main/llm-provider-specs/openai/openapi.yaml
   promptTokens:
     location: payload
     identifier: $.usage.prompt_tokens

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/AddNewProvider/ProviderTemplateSelector.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/AddNewProvider/ProviderTemplateSelector.tsx
@@ -203,7 +203,7 @@ export default function ProviderTemplateSelector({
                       display: 'flex',
                       alignItems: 'center',
                       justifyContent: 'center',
-                      backgroundColor: 'background.default',
+                      backgroundColor: 'common.white',
                       overflow: 'hidden',
                     }}
                   >


### PR DESCRIPTION
## Purpose

The built-in LLM provider templates referenced their logo and OpenAPI spec from a personal fork (`github.com/nomadxd/openapi-connectors`). This PR repoints all of them to the official `wso2/api-platform` repository under a consistent `llm-provider-specs/<provider>/` layout, so the built-in templates no longer depend on an individual's repo.
