### PR TITLE
ci(cli): add pull-requests write permission to release workflow

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Purpose

The CLI release workflow fails at the "Create PR for version bump" step with `Resource not accessible by integration`. The `peter-evans/create-pull-request` action requires `pull-requests: write` permission to open a PR, but the job only declared `contents: write`.

Fixes the failing run: https://github.com/wso2/api-platform/actions/runs/29498503006/job/87621184031

## Approach

- Add `pull-requests: write` to the `release` job permissions in `.github/workflows/cli-release.yml`

## Related Issues

N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes