### PR TITLE
fix(gateway-builder,cli): stage python-executor inside builder container

### DIFF
--- a/cli/src/internal/gateway/docker_build.go
+++ b/cli/src/internal/gateway/docker_build.go
@@ -19,7 +19,6 @@
 package gateway
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -70,14 +69,6 @@ func BuildGatewayImages(config DockerBuildConfig) error {
 		}
 	}
 
-	if err := ensureBuildLockInControllerContext(config.TempDir); err != nil {
-		return err
-	}
-
-	if err := ensurePythonExecutorInRuntimeContext(config.TempDir); err != nil {
-		return err
-	}
-
 	fmt.Println("  ✓ Gateway-builder completed")
 
 	// Step 2: Build the two images
@@ -100,50 +91,6 @@ func BuildGatewayImages(config DockerBuildConfig) error {
 				return err
 			}
 		}
-	}
-
-	return nil
-}
-
-func ensureBuildLockInControllerContext(tempDir string) error {
-	buildManifestSrc := filepath.Join(tempDir, "build-manifest.yaml")
-	if _, err := os.Stat(buildManifestSrc); err != nil {
-		return fmt.Errorf("build-manifest.yaml not found in gateway-builder output: %w", err)
-	}
-
-	buildManifestDst := filepath.Join(tempDir, "output", "gateway-controller", "build-manifest.yaml")
-	if _, err := os.Stat(buildManifestDst); err == nil {
-		return nil
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("failed to access gateway-controller build-manifest.yaml: %w", err)
-	}
-
-	if err := utils.CopyFile(buildManifestSrc, buildManifestDst); err != nil {
-		return fmt.Errorf("failed to copy build-manifest.yaml into gateway-controller build context: %w", err)
-	}
-
-	return nil
-}
-
-// ensurePythonExecutorInRuntimeContext stages the python-executor directory
-// produced by gateway-builder into the gateway-runtime Docker build context
-// so the Dockerfile's `COPY python-executor/ ...` can resolve it.
-func ensurePythonExecutorInRuntimeContext(tempDir string) error {
-	pythonExecutorSrc := filepath.Join(tempDir, "output", "python-executor")
-	if _, err := os.Stat(pythonExecutorSrc); err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil
-		}
-		return fmt.Errorf("failed to access python-executor output: %w", err)
-	}
-
-	pythonExecutorDst := filepath.Join(tempDir, "output", "gateway-runtime", "python-executor")
-	if err := os.RemoveAll(pythonExecutorDst); err != nil {
-		return fmt.Errorf("failed to clear existing python-executor in gateway-runtime build context: %w", err)
-	}
-
-	if err := utils.CopyDir(pythonExecutorSrc, pythonExecutorDst); err != nil {
-		return fmt.Errorf("failed to copy python-executor into gateway-runtime build context: %w", err)
 	}
 
 	return nil

--- a/gateway/gateway-builder/cmd/builder/main.go
+++ b/gateway/gateway-builder/cmd/builder/main.go
@@ -255,6 +255,20 @@ func main() {
 		errors.FatalError(errors.NewDockerError("Dockerfile generation failed", err))
 	}
 
+	// Stage python-executor into the gateway-runtime build context so that the
+	// Dockerfile's `COPY python-executor/ ...` directive resolves correctly when the
+	// CLI later runs `docker build` on the output directory.  Doing this here (inside
+	// the container) avoids a host-side file operation on root-owned output files,
+	// which fails with permission denied when using a rootful Docker daemon on Linux.
+	pythonExecutorSrc := filepath.Join(*outputDir, "python-executor")
+	if _, statErr := os.Stat(pythonExecutorSrc); statErr == nil {
+		pythonExecutorDst := filepath.Join(*outputDir, "gateway-runtime", "python-executor")
+		if err := fsutil.CopyDir(pythonExecutorSrc, pythonExecutorDst); err != nil {
+			errors.FatalError(errors.NewGenerationError("failed to stage python-executor into gateway-runtime build context", err))
+		}
+		slog.Info("Staged python-executor into gateway-runtime build context", "dst", pythonExecutorDst)
+	}
+
 	// Phase 6: Build Info Generation
 	slog.Info("Starting Phase 6: Build Info Generation", "phase", "build-info")
 

--- a/gateway/gateway-builder/pkg/fsutil/path_validation.go
+++ b/gateway/gateway-builder/pkg/fsutil/path_validation.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 )
 
 // ValidatePathExists checks if a file or directory exists and is accessible.
@@ -50,6 +51,27 @@ func ValidatePathExists(path string, pathType string) error {
 	}
 
 	return fmt.Errorf("failed to access %s: %s: %w", pathType, path, err)
+}
+
+// CopyDir recursively copies src into dst, preserving file modes.
+func CopyDir(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, info.Mode())
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		return CopyFile(path, target)
+	})
 }
 
 // CopyFile copies a file from src to dst


### PR DESCRIPTION
## Purpose

Gateway image build fails with `permission denied` on Linux machines using a rootful Docker daemon. The gateway-builder container runs as root and writes output files owned by `root:root` into the bind-mounted temp workspace. The CLI then tries to copy `python-executor/` into `output/gateway-runtime/` on the host — a root-owned directory — and fails.

Resolves #2675

Backport of #2727 to `ap/0.8.x`.

## Goals

Move all post-build file staging into the gateway-builder container itself, so the CLI never needs to touch root-owned output files after the container exits.

## Approach

- Add `fsutil.CopyDir` to the shared `gateway-builder/pkg/fsutil` package (also eliminates the duplicate private `copyDir` in `policyengine/generator.go`)
- In `gateway-builder/cmd/builder/main.go`, stage `output/python-executor/` → `output/gateway-runtime/python-executor/` inside the container after Dockerfile generation — same pattern already used for `build-manifest.yaml` into the controller context
- Remove `ensurePythonExecutorInRuntimeContext` and `ensureBuildLockInControllerContext` from the CLI entirely; the CLI no longer touches the output directory after the builder exits
- Works on all platforms and Docker modes with no OS-level detection

## User stories

As a developer using a rootful Docker daemon on Linux, `ap gateway image build` should complete successfully without permission errors.

## Documentation

N/A

## Automation tests

- Unit tests: existing gateway-builder unit tests continue to pass; `fsutil.CopyDir` follows the same pattern as the existing private `copyDir`
- Integration tests: N/A (requires a rootful Docker Linux environment to reproduce)

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? yes
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

- #2727 (main branch)

## Test environment

- Linux (Ubuntu) with rootful Docker daemon