### PR TITLE
ci(helm): accept non-v-prefixed appVersion in release workflow

### DIFF
--- a/.github/workflows/gateway-helm-release.yml
+++ b/.github/workflows/gateway-helm-release.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       appVersion:
-        description: 'App version (e.g., v1.0.0-m4)'
+        description: 'App version (e.g., 1.0.0-m4)'
         required: true
         type: string
 
@@ -39,8 +39,8 @@ jobs:
             echo "::error::Invalid version '${CHART_VERSION}'. Expected semver (e.g. 1.0.0 or 1.0.0-alpha.1)."
             exit 1
           fi
-          if ! echo "${APP_VERSION}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9._-]+)?$'; then
-            echo "::error::Invalid appVersion '${APP_VERSION}'. Expected v-prefixed semver (e.g. v1.0.0-m4)."
+          if ! echo "${APP_VERSION}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9._-]+)?$'; then
+            echo "::error::Invalid appVersion '${APP_VERSION}'. Expected semver (e.g. 1.0.0-m4)."
             exit 1
           fi
 


### PR DESCRIPTION
## Purpose

The gateway Helm release workflow fails at the `Validate input formats` step for every valid input, blocking releases.

PR #2646 added an input-format guard whose `appVersion` regex requires a leading `v` (`^v[0-9]...`), with a `v1.0.0-m4` example. However, the gateway release convention has never used a `v` prefix: the last successful release (`1.1.0`) used appVersion `1.1.0`, and all published image tags on ghcr.io are non-prefixed (`gateway-controller:1.2.0-alpha2` exists; `v1.2.0-alpha2` returns 404). The guard therefore rejects every appVersion that could actually match a published image, and it broke the workflow on its first run after merge.

## Approach

- Drop the `v` requirement from the `appVersion` regex (`^v[0-9]...` → `^[0-9]...`), restoring the behavior that released `1.1.0`.
- Correct the error message to reference non-prefixed semver.
- Correct the `appVersion` input hint from `v1.0.0-m4` to `1.0.0-m4`.

The shell-injection hardening from #2646 (env-var indirection, quoted tag refs, explicit tag step) is unaffected and retained.

## Related Issues

N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)