### PR TITLE
Add configuration for downstream buffer limit

### DIFF
--- a/gateway/configs/config-template.toml
+++ b/gateway/configs/config-template.toml
@@ -220,6 +220,8 @@ connect_timeout_ms = 5000
 [router.http_listener]
 server_header_transformation = "OVERWRITE"
 server_header_value = "WSO2 API Platform"
+# Downstream per-connection buffer limit in bytes (default: 1048576 / 1 MiB)
+per_connection_buffer_limit_bytes = 1048576
 
 # HTTP Connection Manager (downstream) timeouts
 # A value of zero disables any of these timeout settings.

--- a/gateway/gateway-controller/pkg/config/config.go
+++ b/gateway/gateway-controller/pkg/config/config.go
@@ -597,9 +597,10 @@ type VHostEntry struct {
 
 // HTTPListenerConfig holds HTTP listener related configuration of an API
 type HTTPListenerConfig struct {
-	ServerHeaderTransformation string      `koanf:"server_header_transformation"` // Options: "APPEND_IF_ABSENT", "OVERWRITE", "PASS_THROUGH"
-	ServerHeaderValue          string      `koanf:"server_header_value"`          // Custom value for the Server header
-	Timeouts                   HCMTimeouts `koanf:"timeouts"`                     // HTTP Connection Manager (downstream) timeouts
+	ServerHeaderTransformation 		string      `koanf:"server_header_transformation"` 		// Options: "APPEND_IF_ABSENT", "OVERWRITE", "PASS_THROUGH"
+	ServerHeaderValue          		string      `koanf:"server_header_value"`          		// Custom value for the Server header
+	Timeouts                   		HCMTimeouts `koanf:"timeouts"`                     		// HTTP Connection Manager (downstream) timeouts
+	PerConnectionBufferLimitBytes 	uint32 		`koanf:"per_connection_buffer_limit_bytes"` // Downstream per-connection buffer limit in bytes
 }
 
 // HCMTimeouts holds HTTP Connection Manager (downstream/connection) timeouts.
@@ -1037,6 +1038,7 @@ func defaultConfig() *Config {
 					StreamIdleTimeout:     5 * time.Minute, // Envoy default
 					IdleTimeout:           1 * time.Hour,   // Envoy default (connection-level)
 				},
+				PerConnectionBufferLimitBytes: 1048576, // 1 MiB, matches Envoy's built-in default
 			},
 		},
 		Analytics: AnalyticsConfig{
@@ -2047,6 +2049,16 @@ func (c *Config) validateHTTPListenerConfig() error {
 			commonconstants.OVERWRITE,
 			commonconstants.PASS_THROUGH,
 			httpListener.ServerHeaderTransformation)
+	}
+
+	// Set default value if not provided
+	if httpListener.PerConnectionBufferLimitBytes == 0 {
+		httpListener.PerConnectionBufferLimitBytes = 1048576 // 1 MiB, matches Envoy's built-in default
+	}
+
+	if httpListener.PerConnectionBufferLimitBytes > constants.MaxReasonableBufferLimitBytes {
+		return fmt.Errorf("http_listener.per_connection_buffer_limit_bytes must not exceed %d, got: %d",
+			constants.MaxReasonableBufferLimitBytes, httpListener.PerConnectionBufferLimitBytes)
 	}
 
 	return nil

--- a/gateway/gateway-controller/pkg/config/config_test.go
+++ b/gateway/gateway-controller/pkg/config/config_test.go
@@ -1574,6 +1574,35 @@ func TestConfig_ValidateHTTPListenerConfig(t *testing.T) {
 	}
 }
 
+func TestConfig_ValidateHTTPListenerConfig_BufferLimit(t *testing.T) {
+	tests := []struct {
+		name               string
+		bufferLimitBytes   uint32
+		wantErr            bool
+		errContains        string
+		expectedAfterValid uint32
+	}{
+		{name: "Unset defaults to 1 MiB", bufferLimitBytes: 0, wantErr: false, expectedAfterValid: 1048576},
+		{name: "Valid custom value", bufferLimitBytes: 2097152, wantErr: false, expectedAfterValid: 2097152},
+		{name: "Exceeds max reasonable value", bufferLimitBytes: constants.MaxReasonableBufferLimitBytes + 1, wantErr: true, errContains: "per_connection_buffer_limit_bytes must not exceed"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfig()
+			cfg.Router.HTTPListener.PerConnectionBufferLimitBytes = tt.bufferLimitBytes
+			err := cfg.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedAfterValid, cfg.Router.HTTPListener.PerConnectionBufferLimitBytes)
+			}
+		})
+	}
+}
+
 func TestConfig_HelperMethods(t *testing.T) {
 	t.Run("IsAccessLogsEnabled", func(t *testing.T) {
 		cfg := validConfig()

--- a/gateway/gateway-controller/pkg/constants/constants.go
+++ b/gateway/gateway-controller/pkg/constants/constants.go
@@ -72,6 +72,10 @@ const (
 	MaxReasonableTimeoutMs       = uint32(3600000) // 1 hour in milliseconds
 	MaxReasonablePolicyTimeoutMs = uint32(60000)   // 60 seconds in milliseconds
 	
+	// MaxReasonableBufferLimitBytes caps the downstream per-connection buffer limit in bytes, 
+	// preventing unreasonably large values that could lead to resource exhaustion or performance degradation.
+	MaxReasonableBufferLimitBytes = uint32(104857600) // 100 MiB
+
 	// MaxReasonableConnectionTimeoutMs caps connection-level timeouts (request, request-headers,etc.), 
 	// allowing higher values than MaxReasonableTimeoutMs to support long-lived idle connections.
 	MaxReasonableConnectionTimeoutMs = uint32(86400000) // 24 hours in milliseconds

--- a/gateway/gateway-controller/pkg/xds/translator.go
+++ b/gateway/gateway-controller/pkg/xds/translator.go
@@ -1328,6 +1328,7 @@ func (t *Translator) createListener(virtualHosts []*route.VirtualHost, isHTTPS b
 			},
 		},
 		FilterChains: []*listener.FilterChain{filterChain},
+		PerConnectionBufferLimitBytes: wrapperspb.UInt32(t.routerConfig.HTTPListener.PerConnectionBufferLimitBytes),
 	}, routeConfig, nil
 }
 

--- a/gateway/gateway-controller/pkg/xds/translator_test.go
+++ b/gateway/gateway-controller/pkg/xds/translator_test.go
@@ -372,6 +372,7 @@ func testRouterConfig() *config.RouterConfig {
 		},
 		HTTPListener: config.HTTPListenerConfig{
 			ServerHeaderTransformation: commonconstants.OVERWRITE,
+			PerConnectionBufferLimitBytes: 1048576,
 		},
 		LuaScriptPath: "../../lua/request_transformation.lua",
 	}
@@ -2101,6 +2102,21 @@ func TestTranslator_CreateListener_HTTP(t *testing.T) {
 	assert.NotNil(t, listener)
 	assert.NotNil(t, routeConfig)
 	assert.Contains(t, listener.Name, "8080")
+	assert.Equal(t, uint32(1048576), listener.GetPerConnectionBufferLimitBytes().GetValue())
+}
+
+func TestTranslator_CreateListener_PerConnectionBufferLimitBytes(t *testing.T) {
+	logger := createTestLogger()
+	routerCfg := testRouterConfig()
+	routerCfg.HTTPListener.PerConnectionBufferLimitBytes = 2097152
+	cfg := testConfig()
+	cfg.Router = *routerCfg
+	translator := NewTranslator(logger, routerCfg, nil, cfg)
+
+	listener, _, err := translator.createListener(nil, false)
+	assert.NoError(t, err)
+	assert.NotNil(t, listener)
+	assert.Equal(t, uint32(2097152), listener.GetPerConnectionBufferLimitBytes().GetValue())
 }
 
 func TestTranslator_CreateDownstreamTLSContext_NoCert(t *testing.T) {


### PR DESCRIPTION
## Purpose

- $Subject
- Related Issues: https://github.com/wso2/api-platform/issues/2620

## Description

This pull request introduces support for configuring the downstream per-connection buffer limit in the HTTP listener, aligning with Envoy's capabilities. It adds a new configuration field, enforces reasonable limits to prevent resource exhaustion, and ensures the value is properly validated and propagated throughout the system. Comprehensive tests have been added to verify correct behavior and error handling.

**Configuration and Validation Enhancements:**

* Added a new `per_connection_buffer_limit_bytes` field to the HTTP listener configuration (`config-template.toml`, `HTTPListenerConfig` in `config.go`), with a default value of 1 MiB (1048576 bytes). [[1]](diffhunk://#diff-6487092be72481ac57d644144897abc3bd33aa5420b37a1b4ea41fbd9e014261R223-R224) [[2]](diffhunk://#diff-759820d8e87eb79fe8787e5b88acd63aa78b6de67954358630c3ce11084b971cR603) [[3]](diffhunk://#diff-759820d8e87eb79fe8787e5b88acd63aa78b6de67954358630c3ce11084b971cR1041)
* Implemented validation to ensure the buffer limit is set, defaults to 1 MiB if unset, and does not exceed a maximum reasonable value of 100 MiB (`MaxReasonableBufferLimitBytes`). [[1]](diffhunk://#diff-759820d8e87eb79fe8787e5b88acd63aa78b6de67954358630c3ce11084b971cR2054-R2063) [[2]](diffhunk://#diff-103a6da5eab55523ccdedaedc5719592dae46bc8746a0af51729a5aed6b47cffR75-R78)

**Propagation and Usage:**

* Updated the listener creation logic to propagate the configured buffer limit to Envoy via the xDS translator (`createListener` in `translator.go`).

**Testing Improvements:**

* Added unit tests to verify defaulting, custom values, and validation errors for the buffer limit in both configuration validation and xDS translation (`config_test.go`, `translator_test.go`). [[1]](diffhunk://#diff-7433877545cdd4af7768222b53412ee62cd4a4b795622fa8aba07864f085c503R1577-R1605) [[2]](diffhunk://#diff-6ec1d16cfb57033bc7cdbfa343739d32c7a78fb64a6d305601f4679adf2824c5R375) [[3]](diffhunk://#diff-6ec1d16cfb57033bc7cdbfa343739d32c7a78fb64a6d305601f4679adf2824c5R2105-R2119)