### PR TITLE
Add Custom policy feature in AI Workspcae

### DIFF
--- a/platform-api/api/generated.go
+++ b/platform-api/api/generated.go
@@ -2783,8 +2783,8 @@ type ListGatewayCustomPoliciesParams struct {
 
 // SyncCustomPolicyParams defines parameters for SyncCustomPolicy.
 type SyncCustomPolicyParams struct {
-	// GatewayId UUID of the gateway whose manifest contains the policy
-	GatewayId openapi_types.UUID `form:"gatewayId" json:"gatewayId" yaml:"gatewayId"`
+	// GatewayId Handle (URL-friendly slug) of the gateway whose manifest contains the policy
+	GatewayId string `form:"gatewayId" json:"gatewayId" yaml:"gatewayId"`
 
 	// PolicyName Name of the custom policy (case-insensitive)
 	PolicyName string `form:"policyName" json:"policyName" yaml:"policyName"`

--- a/platform-api/internal/handler/gateway.go
+++ b/platform-api/internal/handler/gateway.go
@@ -378,16 +378,13 @@ func (h *GatewayHandler) GetGatewayManifest(w http.ResponseWriter, r *http.Reque
 		return apperror.Unauthorized.New().WithLogMessage("organization claim not found in token")
 	}
 
-	gatewayId := r.PathValue("gatewayId")
-	if gatewayId == "" {
+	gatewayHandle := r.PathValue("gatewayId")
+	if gatewayHandle == "" {
 		return apperror.ValidationFailed.New("Gateway ID is required")
 	}
 
-	dataFromDb, err := h.gatewayService.GetStoredManifest(gatewayId, orgId)
+	dataFromDb, err := h.gatewayService.GetStoredManifest(gatewayHandle, orgId)
 	if err != nil {
-		if strings.Contains(err.Error(), "invalid UUID") {
-			return apperror.ValidationFailed.Wrap(err, "Invalid gateway ID format")
-		}
 		return serviceError(err, "failed to retrieve gateway manifest")
 	}
 
@@ -405,15 +402,15 @@ func (h *GatewayHandler) SyncCustomPolicy(w http.ResponseWriter, r *http.Request
 		return apperror.Unauthorized.New().WithLogMessage("organization claim not found in token")
 	}
 
-	gatewayId := r.URL.Query().Get("gatewayId")
+	gatewayHandle := r.URL.Query().Get("gatewayId")
 	policyName := r.URL.Query().Get("policyName")
 	version := r.URL.Query().Get("policyVersion")
 
-	if gatewayId == "" || policyName == "" || version == "" {
+	if gatewayHandle == "" || policyName == "" || version == "" {
 		return apperror.ValidationFailed.New("gatewayId, policyName and policyVersion are required")
 	}
 
-	policy, err := h.gatewayService.SyncCustomPolicy(gatewayId, orgId, policyName, version)
+	policy, err := h.gatewayService.SyncCustomPolicy(gatewayHandle, orgId, policyName, version)
 	if err != nil {
 		var appErr *apperror.Error
 		if errors.As(err, &appErr) {

--- a/platform-api/internal/service/custom_policy_test.go
+++ b/platform-api/internal/service/custom_policy_test.go
@@ -42,16 +42,31 @@ type mockGatewayRepoForPolicy struct {
 	manifestErr error
 
 	// call tracking
-	getByUUIDCalled      bool
-	getManifestCalled    bool
-	lastGatewayID        string
-	storedManifest       []byte
-	updatedVersion       string
+	getByHandleCalled bool
+	getManifestCalled bool
+	lastGatewayHandle string
+	storedManifest    []byte
+	updatedVersion    string
 }
 
+// GetByHandleAndOrgID mimics the repository's org-scoped lookup: a gateway is only
+// returned when its OrganizationID matches the requested orgID, exactly like the
+// real `WHERE g.handle = ? AND g.organization_uuid = ?` query.
+func (m *mockGatewayRepoForPolicy) GetByHandleAndOrgID(handle, orgID string) (*model.Gateway, error) {
+	m.getByHandleCalled = true
+	m.lastGatewayHandle = handle
+	if m.gatewayErr != nil {
+		return nil, m.gatewayErr
+	}
+	if m.gateway != nil && m.gateway.OrganizationID != orgID {
+		return nil, nil
+	}
+	return m.gateway, nil
+}
+
+// GetByUUID backs ReceiveGatewayManifest, which is called by the gateway controller
+// with its own UUID and is unrelated to the handle-based SyncCustomPolicy lookup above.
 func (m *mockGatewayRepoForPolicy) GetByUUID(gatewayID string) (*model.Gateway, error) {
-	m.getByUUIDCalled = true
-	m.lastGatewayID = gatewayID
 	return m.gateway, m.gatewayErr
 }
 

--- a/platform-api/internal/service/gateway.go
+++ b/platform-api/internal/service/gateway.go
@@ -102,21 +102,18 @@ func NewGatewayService(gatewayRepo repository.GatewayRepository, orgRepo reposit
 	}
 }
 
-// GetStoredManifest returns the latest gateway manifest. Called by APIM to retrieve
-// the manifest that was pushed by the gateway controller on connect.
-func (s *GatewayService) GetStoredManifest(gatewayID, orgID string) (*Manifest, error) {
-	gateway, err := s.gatewayRepo.GetByUUID(gatewayID)
+// GetStoredManifest returns the latest gateway manifest. Public gateway routes
+// identify a gateway by its handle, while the manifest is stored by gateway UUID.
+func (s *GatewayService) GetStoredManifest(gatewayHandle, orgID string) (*Manifest, error) {
+	gateway, err := s.gatewayRepo.GetByHandleAndOrgID(gatewayHandle, orgID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get gateway: %w", err)
 	}
 	if gateway == nil {
 		return nil, apperror.GatewayNotFound.New()
 	}
-	if gateway.OrganizationID != orgID {
-		return nil, apperror.GatewayNotFound.New()
-	}
 
-	raw, err := s.gatewayRepo.GetGatewayManifest(gatewayID)
+	raw, err := s.gatewayRepo.GetGatewayManifest(gateway.ID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get gateway manifest: %w", err)
 	}
@@ -328,29 +325,27 @@ func parseVersion(v string) (parsedVersion, error) {
 }
 
 // SyncCustomPolicy upserts a custom policy from the gateway manifest into the gateway_custom_policies table.
-// The gateway must belong to the caller's organization. The policy must exist in the manifest and it should be a custom policy.
-func (s *GatewayService) SyncCustomPolicy(gatewayID, orgID, policyName, version string) (*model.CustomPolicy, error) {
+// The gateway is identified by its handle and must belong to the caller's organization. The policy must
+// exist in the manifest and it should be a custom policy.
+func (s *GatewayService) SyncCustomPolicy(gatewayHandle, orgID, policyName, version string) (*model.CustomPolicy, error) {
 	policyName = strings.ToLower(policyName)
 
-	gateway, err := s.gatewayRepo.GetByUUID(gatewayID)
+	gateway, err := s.gatewayRepo.GetByHandleAndOrgID(gatewayHandle, orgID)
 	if err != nil {
-		s.slogger.Error("failed to get gateway", slog.String("gateway_id", gatewayID), slog.String("org_id", orgID), slog.String("error", err.Error()))
+		s.slogger.Error("failed to get gateway", slog.String("gateway_handle", gatewayHandle), slog.String("org_id", orgID), slog.String("error", err.Error()))
 		return nil, apperror.GatewayNotFound.New()
 	}
 	if gateway == nil {
 		return nil, apperror.GatewayNotFound.New()
 	}
-	if gateway.OrganizationID != orgID {
-		return nil, apperror.GatewayNotFound.New().WithLogMessage("gateway belongs to a different organization")
-	}
 
-	raw, err := s.gatewayRepo.GetGatewayManifest(gatewayID)
+	raw, err := s.gatewayRepo.GetGatewayManifest(gateway.ID)
 	if err != nil {
-		s.slogger.Error("failed to read gateway manifest", slog.String("gateway_id", gatewayID), slog.String("org_id", orgID))
+		s.slogger.Error("failed to read gateway manifest", slog.String("gateway_id", gateway.ID), slog.String("org_id", orgID))
 		return nil, fmt.Errorf("failed to read gateway manifest: %w", err)
 	}
 	if len(raw) == 0 {
-		s.slogger.Error("gateway manifest is not available", slog.String("gateway_id", gatewayID), slog.String("org_id", orgID))
+		s.slogger.Error("gateway manifest is not available", slog.String("gateway_id", gateway.ID), slog.String("org_id", orgID))
 		return nil, apperror.PolicyInvalidState.New().WithLogMessage("gateway manifest is not available")
 	}
 
@@ -367,12 +362,12 @@ func (s *GatewayService) SyncCustomPolicy(gatewayID, orgID, policyName, version 
 		}
 	}
 	if found == nil {
-		s.slogger.Error("policy not found in gateway manifest", slog.String("gateway_id", gatewayID), slog.String("org_id", orgID), slog.String("policy_name", policyName), slog.String("version", version))
+		s.slogger.Error("policy not found in gateway manifest", slog.String("gateway_id", gateway.ID), slog.String("org_id", orgID), slog.String("policy_name", policyName), slog.String("version", version))
 		return nil, apperror.CustomPolicyVersionNotFnd.New().
 			WithLogMessage(fmt.Sprintf("policy '%s' version '%s' not found in gateway manifest", policyName, version))
 	}
 	if found.ManagedBy != constants.PolicyManagedByOrganization {
-		s.slogger.Error("policy is not a custom policy", slog.String("gateway_id", gatewayID), slog.String("org_id", orgID), slog.String("policy_name", policyName), slog.String("version", version))
+		s.slogger.Error("policy is not a custom policy", slog.String("gateway_id", gateway.ID), slog.String("org_id", orgID), slog.String("policy_name", policyName), slog.String("version", version))
 		return nil, apperror.PolicyInvalidState.New().
 			WithLogMessage(fmt.Sprintf("policy '%s' version '%s' is not a custom policy", policyName, version))
 	}
@@ -418,8 +413,8 @@ func (s *GatewayService) SyncCustomPolicy(gatewayID, orgID, policyName, version 
 		Version:          version,
 		Description:      found.Description,
 		PolicyDefinition: policyDefJSON,
-		CreatedBy:        gatewayID,
-		UpdatedBy:        gatewayID,
+		CreatedBy:        gateway.ID,
+		UpdatedBy:        gateway.ID,
 	}
 
 	if sameMajorVersionedPolicy != nil {
@@ -450,7 +445,7 @@ func (s *GatewayService) SyncCustomPolicy(gatewayID, orgID, policyName, version 
 			return nil, fmt.Errorf("failed to update custom policy: %w", err)
 		}
 		s.slogger.Info("Custom policy updated (minor version bump)",
-			slog.String("gateway_id", gatewayID),
+			slog.String("gateway_id", gateway.ID),
 			slog.String("org_id", orgID),
 			slog.String("policy_name", policyName),
 			slog.String("old_version", sameMajorVersionedPolicy.Version),
@@ -467,7 +462,7 @@ func (s *GatewayService) SyncCustomPolicy(gatewayID, orgID, policyName, version 
 			return nil, fmt.Errorf("failed to insert custom policy: %w", err)
 		}
 		s.slogger.Info("Custom policy created",
-			slog.String("gateway_id", gatewayID),
+			slog.String("gateway_id", gateway.ID),
 			slog.String("org_id", orgID),
 			slog.String("policy_name", policyName),
 			slog.String("version", version),

--- a/platform-api/internal/service/gateway_manifest_test.go
+++ b/platform-api/internal/service/gateway_manifest_test.go
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+import (
+	"testing"
+
+	"github.com/wso2/api-platform/platform-api/internal/model"
+	"github.com/wso2/api-platform/platform-api/internal/repository"
+)
+
+type gatewayManifestRepository struct {
+	repository.GatewayRepository
+	gateway            *model.Gateway
+	manifest           []byte
+	lookupHandle       string
+	lookupOrganization string
+	manifestGatewayID  string
+}
+
+func (r *gatewayManifestRepository) GetByHandleAndOrgID(handle, orgID string) (*model.Gateway, error) {
+	r.lookupHandle = handle
+	r.lookupOrganization = orgID
+	return r.gateway, nil
+}
+
+func (r *gatewayManifestRepository) GetGatewayManifest(gatewayID string) ([]byte, error) {
+	r.manifestGatewayID = gatewayID
+	return r.manifest, nil
+}
+
+func TestGetStoredManifestResolvesGatewayHandleToUUID(t *testing.T) {
+	const (
+		gatewayHandle = "test"
+		gatewayUUID   = "019f6a6f-8db4-797d-a894-15d8577c4b44"
+		orgID         = "019f6a6e-774d-717d-875c-bb11413aa38e"
+	)
+	wantManifest := []byte(`[{"name":"rate-limit"}]`)
+	repo := &gatewayManifestRepository{
+		gateway: &model.Gateway{
+			ID:             gatewayUUID,
+			Handle:         gatewayHandle,
+			OrganizationID: orgID,
+		},
+		manifest: wantManifest,
+	}
+	service := &GatewayService{gatewayRepo: repo}
+
+	manifest, err := service.GetStoredManifest(gatewayHandle, orgID)
+	if err != nil {
+		t.Fatalf("GetStoredManifest() error = %v", err)
+	}
+	if repo.lookupHandle != gatewayHandle || repo.lookupOrganization != orgID {
+		t.Errorf("gateway lookup = (%q, %q), want (%q, %q)",
+			repo.lookupHandle, repo.lookupOrganization, gatewayHandle, orgID)
+	}
+	if repo.manifestGatewayID != gatewayUUID {
+		t.Errorf("manifest lookup ID = %q, want gateway UUID %q", repo.manifestGatewayID, gatewayUUID)
+	}
+	if string(manifest.Policies) != string(wantManifest) {
+		t.Errorf("manifest policies = %s, want %s", manifest.Policies, wantManifest)
+	}
+}
+
+func TestGetStoredManifestReturnsNotFoundForUnknownHandle(t *testing.T) {
+	service := &GatewayService{gatewayRepo: &gatewayManifestRepository{}}
+
+	_, err := service.GetStoredManifest("unknown", "org-id")
+	if err == nil {
+		t.Fatal("GetStoredManifest() expected gateway-not-found error, got nil")
+	}
+}

--- a/platform-api/resources/openapi.yaml
+++ b/platform-api/resources/openapi.yaml
@@ -3453,9 +3453,9 @@ paths:
           required: true
           schema:
             type: string
-            pattern: '^[a-z0-9-]+$'
             minLength: 3
-            maxLength: 63
+            maxLength: 40
+            readOnly: true
           description: Handle (URL-friendly slug) of the gateway whose manifest contains the policy
           example: "prod-gateway-01"
         - name: policyName

--- a/platform-api/resources/openapi.yaml
+++ b/platform-api/resources/openapi.yaml
@@ -3453,9 +3453,11 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
-          description: UUID of the gateway whose manifest contains the policy
-          example: "019d18ee-fed1-7e86-bef6-f64211c3c5bc"
+            pattern: '^[a-z0-9-]+$'
+            minLength: 3
+            maxLength: 63
+          description: Handle (URL-friendly slug) of the gateway whose manifest contains the policy
+          example: "prod-gateway-01"
         - name: policyName
           in: query
           required: true

--- a/portals/ai-workspace/src/App.tsx
+++ b/portals/ai-workspace/src/App.tsx
@@ -67,10 +67,11 @@ import ServiceProviderDeploy from './pages/appShell/appShellPages/serviceProvide
 import EditServiceProvider from './pages/appShell/appShellPages/serviceProvider/EditServiceProvider';
 
 import GatewaysLayout from './pages/appShell/appShellPages/gateways/GatewaysLayout.tsx';
+import CustomPoliciesList from './pages/appShell/appShellPages/gateways/CustomPoliciesList';
 import OrgRegisterPage from './pages/register/OrgRegisterPage';
 import Insights from './pages/appShell/appShellPages/insights/Main';
 import QuickStart from './pages/appShell/appShellPages/quickStart/Main';
-import Settings from './pages/appShell/appShellPages/settings/Main';
+import Settings, { SettingsIndexRedirect } from './pages/appShell/appShellPages/settings/Main';
 import ProviderTemplatesList from './pages/appShell/appShellPages/providerTemplate/ProviderTemplatesList';
 import ExternalServersList from './pages/appShell/appShellPages/externalServers/ExternalServersList';
 import ExternalServersNew from './pages/appShell/appShellPages/externalServers/ExternalServersNew';
@@ -540,10 +541,7 @@ export default function App() {
             />
             <Route path="settings" element={<ServiceProviderLayout />}>
               <Route element={<Settings />}>
-                <Route
-                  index
-                  element={<Navigate to="llm-provider-templates" replace />}
-                />
+                <Route index element={<SettingsIndexRedirect />} />
                 <Route
                   path="llm-provider-templates"
                   element={
@@ -581,6 +579,14 @@ export default function App() {
                   element={
                     <WithPageBoundary>
                       <CreateProviderTemplateVersion />
+                    </WithPageBoundary>
+                  }
+                />
+                <Route
+                  path="custom-policies"
+                  element={
+                    <WithPageBoundary>
+                      <CustomPoliciesList />
                     </WithPageBoundary>
                   }
                 />

--- a/portals/ai-workspace/src/apis/gatewayPolicyApis.ts
+++ b/portals/ai-workspace/src/apis/gatewayPolicyApis.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ * Licensed under the Apache License, Version 2.0.
+ */
+
+import {
+  del,
+  get,
+  post,
+} from '../clients/choreoApiClient';
+
+const GATEWAY_API_PATH = '/gateways';
+const CUSTOM_POLICY_API_PATH = '/gateway-custom-policies';
+
+export interface GatewayManifestPolicy {
+  name: string;
+  version: string;
+  displayName?: string;
+  description?: string;
+  managedBy?: string;
+  /** @deprecated Older Platform API versions returned this boolean. */
+  isCustomPolicy?: boolean;
+  policyDefinition?: Record<string, unknown>;
+}
+
+export interface GatewayPolicyManifest {
+  policies?: GatewayManifestPolicy[];
+}
+
+export interface GatewayCustomPolicy {
+  uuid: string;
+  organizationUuid: string;
+  name: string;
+  displayName?: string;
+  version: string;
+  description?: string;
+  provider?: string;
+  policyDefinition: Record<string, unknown>;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface GatewayCustomPolicyListResponse {
+  count: number;
+  list: GatewayCustomPolicy[];
+  pagination: {
+    limit: number;
+    offset: number;
+    total: number;
+  };
+}
+
+/** Get the policy manifest installed on a gateway. */
+export const getGatewayPolicyManifest = (
+  gatewayId: string,
+): Promise<GatewayPolicyManifest> =>
+  get<GatewayPolicyManifest>(
+    `${GATEWAY_API_PATH}/${encodeURIComponent(gatewayId)}/manifest`,
+  );
+
+/** List custom policies synced to the organization in the current session. */
+export const getGatewayCustomPolicies = (): Promise<GatewayCustomPolicyListResponse> =>
+  get<GatewayCustomPolicyListResponse>(CUSTOM_POLICY_API_PATH);
+
+/** Sync a custom policy from a gateway manifest into the organization. */
+export const syncGatewayCustomPolicy = (
+  gatewayId: string,
+  policyName: string,
+  policyVersion: string,
+): Promise<GatewayCustomPolicy> => {
+  const params = new URLSearchParams({
+    gatewayId,
+    policyName,
+    policyVersion,
+  });
+
+  return post<GatewayCustomPolicy>(
+    `${CUSTOM_POLICY_API_PATH}/sync?${params.toString()}`,
+  );
+};
+
+/** Get one custom-policy version from the current organization. */
+export const getGatewayCustomPolicy = (
+  gatewayCustomPolicyId: string,
+  version: string,
+): Promise<GatewayCustomPolicy> =>
+  get<GatewayCustomPolicy>(
+    `${CUSTOM_POLICY_API_PATH}/${encodeURIComponent(gatewayCustomPolicyId)}/versions/${encodeURIComponent(version)}`,
+  );
+
+/** Delete one custom-policy version from the current organization. */
+export const deleteGatewayCustomPolicy = (
+  gatewayCustomPolicyId: string,
+  version: string,
+): Promise<void> =>
+  del<void>(
+    `${CUSTOM_POLICY_API_PATH}/${encodeURIComponent(gatewayCustomPolicyId)}/versions/${encodeURIComponent(version)}`,
+  );
+
+const gatewayPolicyApis = {
+  getGatewayPolicyManifest,
+  getGatewayCustomPolicies,
+  syncGatewayCustomPolicy,
+  getGatewayCustomPolicy,
+  deleteGatewayCustomPolicy,
+};
+
+export default gatewayPolicyApis;

--- a/portals/ai-workspace/src/apis/policyHubApis.ts
+++ b/portals/ai-workspace/src/apis/policyHubApis.ts
@@ -22,17 +22,33 @@ import { GuardrailsResponse } from '../utils/types';
 
 /**
  * Fetch guardrail policies from Policy Hub API
- * 
+ *
  * @param categories - Comma-separated list of categories (default: 'Guardrails,AI')
+ * @param limit - Max number of policies to return per page (default: 40)
+ * @param offset - Number of policies to skip, for pagination (default: 0)
  * @returns Promise with the policies response
  */
 export const getGuardrails = async (
-  categories: string
+  categories: string,
+  limit = 60,
+  offset = 0
 ): Promise<GuardrailsResponse> => {
   return get<GuardrailsResponse>(
     '/policies',
-    { categories, limit: 40 },
+    { categories, limit, offset },
     API_BASE_URLS.policyHubApi
+  );
+};
+
+/** Fetch all policies for the gateway policy catalogue. */
+export const getPolicies = async (
+  offset = 0,
+  limit = 100,
+): Promise<GuardrailsResponse> => {
+  return get<GuardrailsResponse>(
+    '/policies',
+    { offset, limit },
+    API_BASE_URLS.policyHubApi,
   );
 };
 
@@ -56,6 +72,7 @@ export const getPolicyDefinition = async (
 // Export all policy hub API functions
 const policyHubApis = {
   getGuardrails,
+  getPolicies,
   getPolicyDefinition,
 };
 

--- a/portals/ai-workspace/src/contexts/GatewayPoliciesContext.tsx
+++ b/portals/ai-workspace/src/contexts/GatewayPoliciesContext.tsx
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ * Licensed under the Apache License, Version 2.0.
+ */
+
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import {
+  getGatewayCustomPolicy,
+  getGatewayCustomPolicies,
+  getGatewayPolicyManifest,
+  syncGatewayCustomPolicy,
+} from '../apis/gatewayPolicyApis';
+import type {
+  GatewayCustomPolicy,
+  GatewayManifestPolicy,
+} from '../apis/gatewayPolicyApis';
+import { getPolicies } from '../apis/policyHubApis';
+import type { PolicyHubPolicy } from '../utils/types';
+
+export type GatewayPolicyRow = {
+  key: string;
+  policyName: string;
+  name: string;
+  version: string;
+  displayVersion: string;
+  description: string;
+  policyType: "Policy Hub" | "Custom";
+  syncStatus: "N/A" | "Synced" | "Not synced";
+  customPolicyId?: string;
+};
+
+type GatewayPoliciesContextValue = {
+  policies: GatewayPolicyRow[];
+  isLoading: boolean;
+  error: Error | null;
+  refresh: () => Promise<void>;
+  syncPolicy: (policyName: string, version: string) => Promise<GatewayCustomPolicy>;
+  syncingPolicyKey: string | null;
+};
+
+const GatewayPoliciesContext = createContext<GatewayPoliciesContextValue | null>(null);
+
+const normalizedVersion = (version: string) => version.replace(/^v/i, "");
+const displayVersion = (version: string) => normalizedVersion(version).split(".")[0];
+const policyKey = (name: string, version: string) =>
+  `${name.trim().toLowerCase()}@${normalizedVersion(version)}`;
+const isCustomManifestPolicy = (policy: GatewayManifestPolicy) => {
+  if (typeof policy.isCustomPolicy === "boolean") return policy.isCustomPolicy;
+  const managedBy = policy.managedBy?.trim().toLowerCase();
+  return managedBy === "organization" || managedBy === "customer";
+};
+
+function mergePolicies(
+  manifestPolicies: GatewayManifestPolicy[],
+  customPolicies: GatewayCustomPolicy[],
+  hubPolicies: PolicyHubPolicy[],
+): GatewayPolicyRow[] {
+  const rows = new Map<string, GatewayPolicyRow>();
+  const hubPolicyByKey = new Map(
+    hubPolicies.map((policy) => [policyKey(policy.name, policy.version), policy]),
+  );
+
+  const synced = new Map(
+    customPolicies.map((policy) => [policyKey(policy.name, policy.version), policy]),
+  );
+  manifestPolicies.forEach((policy) => {
+    const key = policyKey(policy.name, policy.version);
+    const hubPolicy = hubPolicyByKey.get(key);
+    const syncedPolicy = synced.get(key);
+    const isCustomPolicy = isCustomManifestPolicy(policy);
+    rows.set(key, {
+      key,
+      policyName: policy.name,
+      name: policy.displayName || hubPolicy?.displayName || policy.name,
+      // Keep the controller-reported value (for example, "v1.0.0") for API
+      // calls because SyncCustomPolicy matches the stored manifest version.
+      version: policy.version,
+      displayVersion: displayVersion(policy.version),
+      description: policy.description || hubPolicy?.description || "—",
+      policyType: isCustomPolicy ? "Custom" : "Policy Hub",
+      syncStatus: isCustomPolicy ? (syncedPolicy ? "Synced" : "Not synced") : "N/A",
+      customPolicyId: syncedPolicy?.uuid,
+    });
+  });
+
+  return [...rows.values()].sort((left, right) => left.name.localeCompare(right.name));
+}
+
+export function GatewayPoliciesProvider({ gatewayId, children }: { gatewayId: string; children: React.ReactNode }) {
+  const [policies, setPolicies] = useState<GatewayPolicyRow[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const [syncingPolicyKey, setSyncingPolicyKey] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!gatewayId) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      const [manifest, customResponse, hubResponse] = await Promise.all([
+        getGatewayPolicyManifest(gatewayId),
+        getGatewayCustomPolicies(),
+        getPolicies(),
+      ]);
+      setPolicies(
+        mergePolicies(
+          manifest.policies || [],
+          customResponse.list || [],
+          hubResponse.data || [],
+        ),
+      );
+    } catch (cause) {
+      setError(cause instanceof Error ? cause : new Error("Failed to load gateway policies"));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [gatewayId]);
+
+  useEffect(() => { void refresh(); }, [refresh]);
+
+  const syncPolicy = useCallback(async (policyName: string, version: string) => {
+    const key = policyKey(policyName, version);
+    setSyncingPolicyKey(key);
+    try {
+      const syncedPolicy = await syncGatewayCustomPolicy(gatewayId, policyName, version);
+
+      // Read the persisted version back through the detail resource before the UI
+      // reports success. This also ensures the returned UUID/version can be used by
+      // subsequent custom-policy operations.
+      const persistedPolicy = await getGatewayCustomPolicy(
+        syncedPolicy.uuid,
+        syncedPolicy.version,
+      );
+      await refresh();
+      return persistedPolicy;
+    } finally {
+      setSyncingPolicyKey(null);
+    }
+  }, [gatewayId, refresh]);
+
+  const value = useMemo(
+    () => ({ policies, isLoading, error, refresh, syncPolicy, syncingPolicyKey }),
+    [policies, isLoading, error, refresh, syncPolicy, syncingPolicyKey],
+  );
+  return <GatewayPoliciesContext.Provider value={value}>{children}</GatewayPoliciesContext.Provider>;
+}
+
+export function useGatewayPolicies() {
+  const context = useContext(GatewayPoliciesContext);
+  if (!context) throw new Error("useGatewayPolicies must be used within GatewayPoliciesProvider");
+  return context;
+}

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/PolicyMapper.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/PolicyMapper.tsx
@@ -39,9 +39,12 @@ import {
   getGuardrails,
   getPolicyDefinition as fetchPolicyDefinitionYaml,
 } from '../../../../apis/policyHubApis';
+import { getGatewayCustomPolicies } from '../../../../apis/gatewayPolicyApis';
+import type { GatewayCustomPolicy } from '../../../../apis/gatewayPolicyApis';
 import type { PolicyHubPolicy } from '../../../../utils/types';
 import PolicyParameterEditor from '../../PolicyParameterEditor/PolicyParameterEditor';
 import type {
+  ParameterSchema,
   PolicyDefinition as PolicyDefinitionSchema,
   ParameterValues,
 } from '../../PolicyParameterEditor/types';
@@ -77,7 +80,79 @@ type Props = {
   readOnly?: boolean;
 };
 
-function DragHandle(): JSX.Element {
+/** A drawer list entry — either a Policy Hub guardrail or a synced gateway
+ * custom policy, rendered and clicked through the same UI. */
+type DrawerGuardrailItem = PolicyHubPolicy & {
+  isCustomPolicy?: boolean;
+  customPolicyUuid?: string;
+  customPolicyDefinition?: Record<string, unknown>;
+};
+
+/** Custom policy versions come back as full semver with a "v" prefix (e.g.
+ * "v1.0.0"), unlike Policy Hub guardrails which are already display-formatted
+ * (e.g. "1.0"). Reformat to major.minor so both render the same way. */
+const formatPolicyVersion = (version?: string): string => {
+  if (!version) return '0';
+  const [major = '0', minor = '0'] = version.replace(/^v/i, '').split('.');
+  return `${major}.${minor}`;
+};
+
+const toDrawerItem = (policy: GatewayCustomPolicy): DrawerGuardrailItem => ({
+  name: policy.name,
+  version: formatPolicyVersion(policy.version),
+  displayName: policy.displayName || policy.name,
+  description: policy.description,
+  provider: policy.provider,
+  isCustomPolicy: true,
+  customPolicyUuid: policy.uuid,
+  customPolicyDefinition: policy.policyDefinition,
+});
+
+/** Custom policies already carry their full definition inline (no policy-hub
+ * YAML fetch needed) — just reshape it into a PolicyDefinitionSchema. */
+const buildPolicyDefinitionFromCustomPolicy = (item: {
+  name: string;
+  version: string;
+  description?: string;
+  policyDefinition?: Record<string, unknown>;
+}): PolicyDefinitionSchema => {
+  const def = (item.policyDefinition ?? {}) as {
+    description?: string;
+    parameters?: ParameterSchema;
+    systemParameters?: ParameterSchema;
+  };
+  return {
+    name: item.name,
+    version: item.version,
+    description: item.description || def.description || '',
+    parameters: def.parameters ?? { type: 'object', properties: {} },
+    systemParameters: def.systemParameters,
+  };
+};
+
+/** Fetches MCP Policy Hub guardrails and synced gateway custom policies in
+ * parallel, merging and sorting them alphabetically. Either source failing
+ * independently still yields the other's results. */
+const fetchAllPolicies = async (): Promise<DrawerGuardrailItem[]> => {
+  const [hubResult, customResult] = await Promise.allSettled([
+    getGuardrails('MCP'),
+    getGatewayCustomPolicies(),
+  ]);
+  const hubItems: DrawerGuardrailItem[] =
+    hubResult.status === 'fulfilled' ? hubResult.value.data ?? [] : [];
+  if (customResult.status === 'rejected') {
+    logger.error('Failed to load custom policies:', customResult.reason);
+  }
+  const customItems: DrawerGuardrailItem[] =
+    customResult.status === 'fulfilled'
+      ? (customResult.value.list ?? []).map(toDrawerItem)
+      : [];
+  return [...hubItems, ...customItems].sort((a, b) =>
+    (a.displayName || a.name).localeCompare(b.displayName || b.name)
+  );
+};
+
+function DragHandle(): React.JSX.Element {
   return (
     <Box
       sx={{
@@ -113,7 +188,7 @@ export default function PolicyMapper({
   onReorderPolicies,
   validationResult,
   readOnly = false,
-}: Props): JSX.Element {
+}: Props): React.JSX.Element {
   const intl = useIntl();
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [draggedInstanceId, setDraggedInstanceId] = useState<string | null>(
@@ -124,7 +199,7 @@ export default function PolicyMapper({
   );
 
   // Drawer state
-  const [fetchedPolicies, setFetchedPolicies] = useState<PolicyHubPolicy[]>([]);
+  const [fetchedPolicies, setFetchedPolicies] = useState<DrawerGuardrailItem[]>([]);
   const [isFetchingPolicies, setIsFetchingPolicies] = useState(false);
   const [fetchPoliciesError, setFetchPoliciesError] = useState<string | null>(
     null
@@ -162,8 +237,7 @@ export default function PolicyMapper({
     setIsFetchingPolicies(true);
     setFetchPoliciesError(null);
     try {
-      const response = await getGuardrails('MCP');
-      setFetchedPolicies(response.data ?? []);
+      setFetchedPolicies(await fetchAllPolicies());
     } catch {
       setFetchPoliciesError('Failed to fetch policies.');
     } finally {
@@ -178,8 +252,7 @@ export default function PolicyMapper({
     setFetchPoliciesError(null);
 
     try {
-      const response = await getGuardrails('MCP');
-      const policies = response.data ?? [];
+      const policies = await fetchAllPolicies();
       setFetchedPolicies(policies);
 
       const matchedPolicy = policies.find((p) => p.name === item.policyName);
@@ -193,6 +266,23 @@ export default function PolicyMapper({
       setIsDetailView(true);
       setPolicyDefinition(null);
       setDefinitionError(null);
+
+      if (matchedPolicy.isCustomPolicy) {
+        setIsFetchingPolicies(false);
+        if (!matchedPolicy.customPolicyDefinition) {
+          setDefinitionError('No definition available for this custom policy.');
+          return;
+        }
+        setPolicyDefinition(
+          buildPolicyDefinitionFromCustomPolicy({
+            name: matchedPolicy.name,
+            version: matchedPolicy.version,
+            description: matchedPolicy.description,
+            policyDefinition: matchedPolicy.customPolicyDefinition,
+          })
+        );
+        return;
+      }
 
       if (!matchedPolicy.version) {
         setDefinitionError('No version available for this policy.');
@@ -216,13 +306,29 @@ export default function PolicyMapper({
     }
   };
 
-  const handlePolicyClick = async (policy: PolicyHubPolicy) => {
+  const handlePolicyClick = async (policy: DrawerGuardrailItem) => {
     if (readOnly) return;
     setSelectedDrawerPolicy(policy.name);
     setIsDetailView(true);
     setPolicyDefinition(null);
     setPolicySettings({});
     setDefinitionError(null);
+
+    if (policy.isCustomPolicy) {
+      if (!policy.customPolicyDefinition) {
+        setDefinitionError('No definition available for this custom policy.');
+        return;
+      }
+      setPolicyDefinition(
+        buildPolicyDefinitionFromCustomPolicy({
+          name: policy.name,
+          version: policy.version,
+          description: policy.description,
+          policyDefinition: policy.customPolicyDefinition,
+        })
+      );
+      return;
+    }
 
     if (!policy.version) {
       setDefinitionError('No version available for this policy.');
@@ -263,7 +369,9 @@ export default function PolicyMapper({
         policyId: policy.name,
         policyName: policy.name,
         displayName: policy.displayName || policy.name,
-        version: policy.version ? `v${policy.version.split('.')[0]}` : 'v0',
+        version: policy.version
+          ? `v${policy.version.replace(/^v/i, '').split('.')[0]}`
+          : 'v0',
         params,
       });
     }
@@ -632,12 +740,22 @@ export default function PolicyMapper({
                                     >
                                       {policy.displayName || policy.name}
                                     </Typography>
-                                    <Chip
-                                      label={policy.version || 'v0'}
-                                      size="small"
-                                      variant="outlined"
-                                      color="default"
-                                    />
+                                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                                      {policy.provider && (
+                                        <Chip
+                                          label={policy.provider}
+                                          size="small"
+                                          variant="outlined"
+                                          color="default"
+                                        />
+                                      )}
+                                      <Chip
+                                        label={policy.version || 'v0'}
+                                        size="small"
+                                        variant="outlined"
+                                        color="default"
+                                      />
+                                    </Box>
                                   </Box>
                                 </ListItemButton>
                               </Box>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/gateways/CustomPoliciesList.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/gateways/CustomPoliciesList.tsx
@@ -1,0 +1,549 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { ElementType } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Box,
+  Card,
+  IconButton,
+  InputAdornment,
+  PageContent,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TablePagination,
+  TableRow,
+  TableSortLabel,
+  TextField,
+  Tooltip,
+  Typography,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Button,
+} from '@wso2/oxygen-ui';
+import { Search, ShieldCheck, Trash2 } from '@wso2/oxygen-ui-icons-react';
+import { FormattedMessage, useIntl } from 'react-intl';
+import ErrorAlert from '../../../../Components/common/ErrorAlert';
+import {
+  deleteGatewayCustomPolicy,
+  getGatewayCustomPolicies,
+} from '../../../../apis/gatewayPolicyApis';
+import type { GatewayCustomPolicy } from '../../../../apis/gatewayPolicyApis';
+import { useAIWorkspaceSnackbar } from '../../../../hooks/aiWorkspaceSnackbar';
+import { getErrorMessage } from '../../../../utils/apiError';
+import { useAppAuth } from '../../../../contexts/AppAuthContext';
+import { SCOPES } from '../../../../auth/permissions';
+
+const ROWS_PER_PAGE_OPTIONS = [10, 25, 50];
+
+type SortableField = 'name' | 'version' | 'createdAt' | 'updatedAt';
+
+const tableHeaders: {
+  key: string;
+  label: React.ReactNode;
+  sortable?: boolean;
+}[] = [
+  {
+    key: 'name',
+    sortable: true,
+    label: (
+      <FormattedMessage
+        id="aiWorkspace.pages.appShell.appShellPages.gateways.CustomPoliciesList.header.name"
+        defaultMessage="Name"
+      />
+    ),
+  },
+  {
+    key: 'version',
+    sortable: true,
+    label: (
+      <FormattedMessage
+        id="aiWorkspace.pages.appShell.appShellPages.gateways.CustomPoliciesList.header.version"
+        defaultMessage="Version"
+      />
+    ),
+  },
+  {
+    key: 'description',
+    label: (
+      <FormattedMessage
+        id="aiWorkspace.pages.appShell.appShellPages.gateways.CustomPoliciesList.header.description"
+        defaultMessage="Description"
+      />
+    ),
+  },
+  {
+    key: 'createdAt',
+    sortable: true,
+    label: (
+      <FormattedMessage
+        id="aiWorkspace.pages.appShell.appShellPages.gateways.CustomPoliciesList.header.createdAt"
+        defaultMessage="Created At"
+      />
+    ),
+  },
+  {
+    key: 'updatedAt',
+    sortable: true,
+    label: (
+      <FormattedMessage
+        id="aiWorkspace.pages.appShell.appShellPages.gateways.CustomPoliciesList.header.updatedAt"
+        defaultMessage="Updated At"
+      />
+    ),
+  },
+];
+
+function compareValues(a: string, b: string, order: 'asc' | 'desc'): number {
+  const result = a.localeCompare(b);
+  return order === 'asc' ? result : -result;
+}
+
+function getSortValue(
+  policy: GatewayCustomPolicy,
+  field: SortableField
+): string {
+  return (policy[field] ?? '').toString();
+}
+
+function formatVersion(version: string): string {
+  return `v${version.replace(/^v/i, '')}`;
+}
+
+interface CustomPoliciesListProps {
+  // When true, renders bare (no PageContent padding) for embedding inside a
+  // page that already provides its own PageContent — e.g. GatewaysList.
+  embedded?: boolean;
+}
+
+export default function CustomPoliciesList({
+  embedded = false,
+}: CustomPoliciesListProps) {
+  const intl = useIntl();
+  const showSnackbar = useAIWorkspaceSnackbar();
+  const { hasPermission } = useAppAuth();
+  const canDelete = hasPermission(SCOPES.GATEWAY_CUSTOM_POLICY_DELETE);
+
+  const [policies, setPolicies] = useState<GatewayCustomPolicy[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const [searchQuery, setSearchQuery] = useState('');
+  const [sortedColumn, setSortedColumn] = useState<SortableField>('name');
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(ROWS_PER_PAGE_OPTIONS[0]);
+
+  const [deleteTarget, setDeleteTarget] = useState<{
+    uuid: string;
+    version: string;
+    name: string;
+  } | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const fetchPolicies = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await getGatewayCustomPolicies();
+      setPolicies(response.list || []);
+    } catch (cause) {
+      setError(
+        cause instanceof Error
+          ? cause
+          : new Error('Failed to load custom policies')
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchPolicies();
+  }, [fetchPolicies]);
+
+  useEffect(() => {
+    setPage(0);
+  }, [rowsPerPage, searchQuery, sortedColumn, sortOrder]);
+
+  const handleSortBy = (field: SortableField) => {
+    if (sortedColumn === field) {
+      setSortOrder((prev) => (prev === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortedColumn(field);
+      setSortOrder('asc');
+    }
+  };
+
+  const filteredAndSorted = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
+    const filtered = query
+      ? policies.filter((policy) =>
+          [policy.name, policy.version, policy.description]
+            .filter(Boolean)
+            .join(' ')
+            .toLowerCase()
+            .includes(query)
+        )
+      : policies;
+
+    return [...filtered].sort((a, b) =>
+      compareValues(
+        getSortValue(a, sortedColumn),
+        getSortValue(b, sortedColumn),
+        sortOrder
+      )
+    );
+  }, [policies, searchQuery, sortedColumn, sortOrder]);
+
+  const pageItems = useMemo(
+    () =>
+      filteredAndSorted.slice(
+        page * rowsPerPage,
+        page * rowsPerPage + rowsPerPage
+      ),
+    [filteredAndSorted, page, rowsPerPage]
+  );
+
+  const handleDeleteConfirm = async () => {
+    if (!deleteTarget) return;
+    setIsDeleting(true);
+    try {
+      await deleteGatewayCustomPolicy(deleteTarget.uuid, deleteTarget.version);
+      setDeleteTarget(null);
+      showSnackbar('Custom policy deleted successfully', 'success');
+      await fetchPolicies();
+    } catch (cause) {
+      showSnackbar(
+        getErrorMessage(cause, 'Failed to delete the custom policy.'),
+        'error'
+      );
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const Wrapper: ElementType = embedded ? Box : PageContent;
+
+  return (
+    <Wrapper {...(embedded ? {} : { fullWidth: true })}>
+      <Box sx={{ mb: 2 }}>
+        <Typography variant="h4">
+          <FormattedMessage
+            id="aiWorkspace.pages.appShell.appShellPages.gateways.CustomPoliciesList.title"
+            defaultMessage="Custom Policies"
+          />
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          <FormattedMessage
+            id="aiWorkspace.pages.appShell.appShellPages.gateways.CustomPoliciesList.subtitle"
+            defaultMessage="Policies synced from your gateways into this organization."
+          />
+        </Typography>
+      </Box>
+
+      {pageItems.length !== 0 && (
+        <Box sx={{ mb: 2 }}>
+          <TextField
+            fullWidth
+            placeholder={intl.formatMessage({
+              id: 'aiWorkspace.pages.appShell.appShellPages.gateways.CustomPoliciesList.search.placeholder',
+              defaultMessage: 'Search policies...',
+            })}
+            value={searchQuery}
+            disabled={isLoading}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            slotProps={{
+              input: {
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <Search size={20} />
+                  </InputAdornment>
+                ),
+              },
+            }}
+          />
+        </Box>
+      )}
+
+      {error ? (
+        <ErrorAlert error={error} onRetry={fetchPolicies} />
+      ) : !isLoading && pageItems.length === 0 ? (
+        <Box
+          sx={{
+            border: '1px dashed',
+            borderColor: 'divider',
+            borderRadius: 2,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            px: 3,
+            py: 8,
+          }}
+        >
+          <Stack spacing={1.5} alignItems="center" sx={{ textAlign: 'center' }}>
+            <Box
+              sx={{
+                width: 64,
+                height: 64,
+                borderRadius: 2,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                color: 'primary.main',
+                bgcolor: (theme) =>
+                  `color-mix(in srgb, ${theme.palette.primary.main} 12%, transparent)`,
+                border: '1px solid',
+                borderColor: (theme) =>
+                  `color-mix(in srgb, ${theme.palette.primary.main} 30%, transparent)`,
+              }}
+            >
+              <ShieldCheck size={28} />
+            </Box>
+            <Typography variant="body1" sx={{ fontWeight: 700 }}>
+              <FormattedMessage
+                id="aiWorkspace.pages.appShell.appShellPages.gateways.CustomPoliciesList.noData.title"
+                defaultMessage="No custom policies found"
+              />
+            </Typography>
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ maxWidth: 380 }}
+            >
+              {searchQuery ? (
+                <FormattedMessage
+                  id="aiWorkspace.pages.appShell.appShellPages.gateways.CustomPoliciesList.noData.noResults"
+                  defaultMessage="No custom policies match your search."
+                />
+              ) : (
+                <FormattedMessage
+                  id="aiWorkspace.pages.appShell.appShellPages.gateways.CustomPoliciesList.noData.description"
+                  defaultMessage="Custom policies synced from your gateways will appear here."
+                />
+              )}
+            </Typography>
+          </Stack>
+        </Box>
+      ) : (
+        <Card>
+          <TableContainer>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  {tableHeaders.map((header) => (
+                    <TableCell key={header.key}>
+                      {header.sortable ? (
+                        <TableSortLabel
+                          active={sortedColumn === header.key}
+                          direction={sortOrder}
+                          onClick={() =>
+                            handleSortBy(header.key as SortableField)
+                          }
+                        >
+                          {header.label}
+                        </TableSortLabel>
+                      ) : (
+                        header.label
+                      )}
+                    </TableCell>
+                  ))}
+                  {canDelete ? (
+                    <TableCell align="right">
+                      <FormattedMessage
+                        id="aiWorkspace.pages.appShell.appShellPages.gateways.CustomPoliciesList.header.actions"
+                        defaultMessage="Actions"
+                      />
+                    </TableCell>
+                  ) : null}
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {isLoading ? (
+                  <TableRow>
+                    <TableCell colSpan={canDelete ? 6 : 5}>
+                      <Typography variant="body2" color="text.secondary">
+                        <FormattedMessage
+                          id="aiWorkspace.pages.appShell.appShellPages.gateways.CustomPoliciesList.loading"
+                          defaultMessage="Loading custom policies..."
+                        />
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  pageItems.map((policy) => (
+                    <TableRow key={`${policy.uuid}-${policy.version}`} hover>
+                      <TableCell>
+                        <Typography
+                          variant="body2"
+                          sx={{ fontWeight: 600 }}
+                          title={policy.name}
+                        >
+                          {policy.name}
+                        </Typography>
+                      </TableCell>
+                      <TableCell>
+                        <Typography variant="body2">
+                          {formatVersion(policy.version)}
+                        </Typography>
+                      </TableCell>
+                      <TableCell>
+                        <Typography
+                          variant="body2"
+                          color="text.secondary"
+                          sx={{
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                            maxWidth: 320,
+                          }}
+                          title={policy.description || '-'}
+                        >
+                          {policy.description || '-'}
+                        </Typography>
+                      </TableCell>
+                      <TableCell>
+                        <Tooltip
+                          title={
+                            policy.createdAt
+                              ? new Date(policy.createdAt).toLocaleTimeString()
+                              : ''
+                          }
+                          placement="top"
+                        >
+                          <Typography variant="body2" color="text.secondary">
+                            {policy.createdAt
+                              ? new Date(policy.createdAt).toLocaleDateString()
+                              : '-'}
+                          </Typography>
+                        </Tooltip>
+                      </TableCell>
+                      <TableCell>
+                        <Tooltip
+                          title={
+                            policy.updatedAt
+                              ? new Date(policy.updatedAt).toLocaleTimeString()
+                              : ''
+                          }
+                          placement="top"
+                        >
+                          <Typography variant="body2" color="text.secondary">
+                            {policy.updatedAt
+                              ? new Date(policy.updatedAt).toLocaleDateString()
+                              : '-'}
+                          </Typography>
+                        </Tooltip>
+                      </TableCell>
+                      {canDelete ? (
+                        <TableCell align="right">
+                          <IconButton
+                            size="small"
+                            color="error"
+                            onClick={() =>
+                              setDeleteTarget({
+                                uuid: policy.uuid,
+                                version: policy.version,
+                                name: policy.name,
+                              })
+                            }
+                            aria-label={intl.formatMessage(
+                              {
+                                id: 'aiWorkspace.pages.appShell.appShellPages.gateways.CustomPoliciesList.delete.policy',
+                                defaultMessage: 'Delete {name}',
+                              },
+                              { name: policy.name }
+                            )}
+                          >
+                            <Trash2 size={16} />
+                          </IconButton>
+                        </TableCell>
+                      ) : null}
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </TableContainer>
+
+          {filteredAndSorted.length > 0 && (
+            <TablePagination
+              component="div"
+              count={filteredAndSorted.length}
+              page={page}
+              onPageChange={(_event, nextPage) => setPage(nextPage)}
+              rowsPerPage={rowsPerPage}
+              onRowsPerPageChange={(event) =>
+                setRowsPerPage(parseInt(event.target.value, 10))
+              }
+              rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
+            />
+          )}
+        </Card>
+      )}
+
+      <Dialog open={Boolean(deleteTarget)} onClose={() => setDeleteTarget(null)}>
+        <DialogTitle>
+          <FormattedMessage
+            id="aiWorkspace.pages.appShell.appShellPages.gateways.CustomPoliciesList.deleteDialog.title"
+            defaultMessage="Delete Custom Policy"
+          />
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            <FormattedMessage
+              id="aiWorkspace.pages.appShell.appShellPages.gateways.CustomPoliciesList.deleteDialog.message"
+              defaultMessage="Are you sure you want to delete {name}? This action cannot be undone."
+              values={{ name: <strong>{deleteTarget?.name}</strong> }}
+            />
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={() => setDeleteTarget(null)}
+            variant="outlined"
+            color="secondary"
+            disabled={isDeleting}
+          >
+            <FormattedMessage
+              id="aiWorkspace.pages.appShell.appShellPages.gateways.CustomPoliciesList.deleteDialog.cancel"
+              defaultMessage="Cancel"
+            />
+          </Button>
+          <Button
+            color="error"
+            variant="contained"
+            onClick={() => void handleDeleteConfirm()}
+            disabled={isDeleting}
+          >
+            <FormattedMessage
+              id="aiWorkspace.pages.appShell.appShellPages.gateways.CustomPoliciesList.deleteDialog.confirm"
+              defaultMessage="Delete"
+            />
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Wrapper>
+  );
+}

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/gateways/CustomPoliciesList.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/gateways/CustomPoliciesList.tsx
@@ -264,7 +264,7 @@ export default function CustomPoliciesList({
         </Typography>
       </Box>
 
-      {pageItems.length !== 0 && (
+      {policies.length !== 0 && (
         <Box sx={{ mb: 2 }}>
           <TextField
             fullWidth

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/gateways/GatewayPolicies.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/gateways/GatewayPolicies.tsx
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ * Licensed under the Apache License, Version 2.0.
+ */
+
+import {
+  Alert,
+  Button,
+  Chip,
+  CircularProgress,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Tooltip,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { useGatewayPolicies } from "../../../../contexts/GatewayPoliciesContext";
+import useAIWorkspaceSnackbar from "../../../../hooks/aiWorkspaceSnackbar";
+
+export default function GatewayPolicies() {
+  const { policies, isLoading, error, refresh, syncPolicy, syncingPolicyKey } =
+    useGatewayPolicies();
+  const showSnackbar = useAIWorkspaceSnackbar();
+
+  const handleSync = async (policyName: string, version: string) => {
+    try {
+      await syncPolicy(policyName, version);
+      showSnackbar(
+        `Policy ${policyName} version ${version} synced successfully.`,
+        "success",
+      );
+    } catch (cause) {
+      const message =
+        cause instanceof Error
+          ? cause.message
+          : "Failed to sync the custom policy.";
+      showSnackbar(message, "error");
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <TableContainer sx={{ border: 1, borderColor: "divider", px: 3, py: 2 }}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell sx={{ width: 220 }}>Name</TableCell>
+              <TableCell sx={{ width: 112 }}>Version</TableCell>
+              <TableCell>Description</TableCell>
+              <TableCell sx={{ width: 190 }}>Policy Type</TableCell>
+              <TableCell sx={{ width: 120 }}>Sync Status</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {[0, 1, 2, 3].map((key) => (
+              <TableRow key={key}>
+                <TableCell>
+                  <Skeleton variant="text" width="70%" height={20} />
+                </TableCell>
+                <TableCell>
+                  <Skeleton variant="rounded" width={64} height={24} />
+                </TableCell>
+                <TableCell>
+                  <Skeleton variant="text" width="90%" height={20} />
+                </TableCell>
+                <TableCell>
+                  <Skeleton variant="rounded" width={140} height={24} />
+                </TableCell>
+                <TableCell>
+                  <Skeleton variant="rounded" width={100} height={24} />
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    );
+  }
+  if (error) {
+    return (
+      <Alert
+        severity="error"
+        action={
+          <Button color="inherit" size="small" onClick={() => void refresh()}>
+            Retry
+          </Button>
+        }
+      >
+        {error.message}
+      </Alert>
+    );
+  }
+  if (!policies.length)
+    return <Alert severity="info">No gateway manifest received yet.</Alert>;
+
+  return (
+    <TableContainer sx={{ border: 1, borderColor: "divider", px: 3, py: 2 }}>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell sx={{ width: 220 }}>Name</TableCell>
+            <TableCell sx={{ width: 112 }}>Version</TableCell>
+            <TableCell>Description</TableCell>
+            <TableCell sx={{ width: 190 }}>Policy Type</TableCell>
+            <TableCell sx={{ width: 120 }}>Sync Status</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {policies.map((policy) => (
+            <TableRow key={policy.key} hover>
+              <TableCell>
+                <Typography variant="body2">{policy.name}</Typography>
+              </TableCell>
+              <TableCell>
+                <Chip
+                  label={`v${policy.displayVersion}`}
+                  size="small"
+                  variant="outlined"
+                  sx={{ minWidth: 72 }}
+                />
+              </TableCell>
+              <TableCell>
+                <Typography variant="body2" color="text.secondary">
+                  {policy.description}
+                </Typography>
+              </TableCell>
+              <TableCell>
+                <Chip
+                  label={policy.policyType}
+                  size="small"
+                  variant="outlined"
+                  sx={{ minWidth: 160 }}
+                />
+              </TableCell>
+              <TableCell>
+                {policy.syncStatus === "N/A" ? (
+                  <Typography variant="body2" color="text.secondary">
+                    N/A
+                  </Typography>
+                ) : policy.syncStatus === "Synced" ? (
+                  <Chip
+                    label="Latest Version Available"
+                    size="small"
+                    color="success"
+                    variant="outlined"
+                  />
+                ) : (
+                  <Tooltip title="Click to sync the policy">
+                    <span>
+                      <Button
+                        size="small"
+                        variant="contained"
+                        disabled={syncingPolicyKey !== null}
+                        onClick={() =>
+                          void handleSync(policy.policyName, policy.version)
+                        }
+                        startIcon={
+                          syncingPolicyKey === policy.key ? (
+                            <CircularProgress size={14} color="inherit" />
+                          ) : undefined
+                        }
+                      >
+                        Sync
+                      </Button>
+                    </span>
+                  </Tooltip>
+                )}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/gateways/ViewGateway.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/gateways/ViewGateway.tsx
@@ -90,6 +90,8 @@ import {
 import type { ColorScheme } from "../../../../utils/colorScheme";
 import AIGatewayStepBanner from "../quickStart/AIGatewayStepBanner";
 import ErrorAlert from "../../../../Components/common/ErrorAlert";
+import { GatewayPoliciesProvider } from "../../../../contexts/GatewayPoliciesContext";
+import GatewayPolicies from "./GatewayPolicies";
 
 const resolveGatewayVersion = (gatewayVersion?: string): string => {
   const entry = gatewayVersion
@@ -210,6 +212,7 @@ export default function ViewGateway() {
   const [showDrawerRegistrationToken, setShowDrawerRegistrationToken] =
     useState(false);
   const [tabIndex, setTabIndex] = useState(0);
+  const [viewTabIndex, setViewTabIndex] = useState(0);
   const [isRegenerateDialogOpen, setIsRegenerateDialogOpen] = useState(false);
   const [isRegeneratingToken, setIsRegeneratingToken] = useState(false);
   const [hasJustRegeneratedToken, setHasJustRegeneratedToken] = useState(false);
@@ -738,8 +741,20 @@ GATEWAY_REGISTRATION_TOKEN=${registrationToken || ""}`;
         </Box>
       </Card>
 
-      {/* Get Started Card */}
       <Card>
+        <Tabs
+          value={viewTabIndex}
+          onChange={(_, value) => setViewTabIndex(value)}
+          variant="scrollable"
+          allowScrollButtonsMobile
+        >
+          <Tab label="Configurations" />
+          <Tab label="Policies" />
+        </Tabs>
+        <Divider />
+
+        {/* Get Started */}
+        <Box sx={{ display: viewTabIndex === 0 ? "block" : "none" }}>
         <CardContent sx={{ p: 3 }}>
           <Box sx={{ mb: 3 }}>
             <Typography variant="h5">Get Started</Typography>
@@ -1720,6 +1735,15 @@ GATEWAY_REGISTRATION_TOKEN=${registrationToken || ""}`;
             </Stack>
           </TabPanel>
         </CardContent>
+        </Box>
+
+        {viewTabIndex === 1 && (
+          <GatewayPoliciesProvider
+            gatewayId={gateway.id}
+          >
+            <GatewayPolicies />
+          </GatewayPoliciesProvider>
+        )}
       </Card>
 
       <Drawer

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyGuardrailsTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyGuardrailsTab.tsx
@@ -47,6 +47,8 @@ import {
 } from '@wso2/oxygen-ui-icons-react';
 import YAML from 'yaml';
 import { getGuardrails } from '../../../../apis/policyHubApis';
+import { getGatewayCustomPolicies } from '../../../../apis/gatewayPolicyApis';
+import type { GatewayCustomPolicy } from '../../../../apis/gatewayPolicyApis';
 import { useProxy } from '../../../../contexts/proxy';
 import { useGuardrails } from '../../../../contexts/GuardrailsContext';
 import { logger } from '../../../../utils/logger';
@@ -55,9 +57,11 @@ import { GuardrailPill, PolicyCategorySelector } from '../../../../Components/Gu
 import { ResourceRow } from '../../../../Components/ResourceView';
 import PolicyParameterEditor from '../../PolicyParameterEditor/PolicyParameterEditor';
 import type {
+  ParameterSchema,
   PolicyDefinition,
   ParameterValues,
 } from '../../PolicyParameterEditor/types';
+import type { PolicyHubPolicy } from '../../../../utils/types';
 import { parsePolicyYaml } from '../../PolicyParameterEditor/yamlParser';
 import { FormattedMessage } from 'react-intl';
 import ErrorAlert from '../../../../Components/common/ErrorAlert';
@@ -136,6 +140,56 @@ const parseOpenApiText = (text: string): ResourceItem[] => {
   }
 };
 
+/** A drawer list entry — either a Policy Hub guardrail or a synced gateway
+ * custom policy, rendered and clicked through the same UI. */
+type DrawerGuardrailItem = PolicyHubPolicy & {
+  isCustomPolicy?: boolean;
+  customPolicyUuid?: string;
+  customPolicyDefinition?: Record<string, unknown>;
+};
+
+/** Custom policy versions come back as full semver with a "v" prefix (e.g.
+ * "v1.0.0"), unlike Policy Hub guardrails which are already display-formatted
+ * (e.g. "1.0"). Reformat to major.minor so both render the same way. */
+const formatPolicyVersion = (version?: string): string => {
+  if (!version) return '0';
+  const [major = '0', minor = '0'] = version.replace(/^v/i, '').split('.');
+  return `${major}.${minor}`;
+};
+
+const toDrawerItem = (policy: GatewayCustomPolicy): DrawerGuardrailItem => ({
+  name: policy.name,
+  version: formatPolicyVersion(policy.version),
+  displayName: policy.displayName || policy.name,
+  description: policy.description,
+  provider: policy.provider,
+  isCustomPolicy: true,
+  customPolicyUuid: policy.uuid,
+  customPolicyDefinition: policy.policyDefinition,
+});
+
+/** Custom policies already carry their full definition inline (no policy-hub
+ * YAML fetch needed) — just reshape it into a PolicyDefinition. */
+const buildPolicyDefinitionFromCustomPolicy = (item: {
+  name: string;
+  version: string;
+  description?: string;
+  policyDefinition?: Record<string, unknown>;
+}): PolicyDefinition => {
+  const def = (item.policyDefinition ?? {}) as {
+    description?: string;
+    parameters?: ParameterSchema;
+    systemParameters?: ParameterSchema;
+  };
+  return {
+    name: item.name,
+    version: item.version,
+    description: item.description || def.description || '',
+    parameters: def.parameters ?? { type: 'object', properties: {} },
+    systemParameters: def.systemParameters,
+  };
+};
+
 // ─── Component ───────────────────────────────────────────────────────────────
 
 /**
@@ -180,6 +234,8 @@ export default function LLMProxyGuardrailsTab() {
   const [selectedCategories, setSelectedCategories] = useState<string[]>(['AI']);
   const [drawerGuardrails, setDrawerGuardrails] = useState<typeof availableGuardrails>([]);
   const [drawerGuardrailsLoading, setDrawerGuardrailsLoading] = useState(false);
+  const [customPolicies, setCustomPolicies] = useState<GatewayCustomPolicy[]>([]);
+  const [customPoliciesLoading, setCustomPoliciesLoading] = useState(false);
 
   const fetchDrawerGuardrails = useCallback(async (categories: string[]) => {
     if (categories.length === 0) {
@@ -197,9 +253,46 @@ export default function LLMProxyGuardrailsTab() {
     }
   }, []);
 
+  const fetchCustomPolicies = useCallback(async () => {
+    setCustomPoliciesLoading(true);
+    try {
+      const response = await getGatewayCustomPolicies();
+      setCustomPolicies(response.list || []);
+    } catch (e) {
+      logger.error('Failed to load custom policies:', e);
+      setCustomPolicies([]);
+    } finally {
+      setCustomPoliciesLoading(false);
+    }
+  }, []);
+
   useEffect(() => {
     void fetchDrawerGuardrails(selectedCategories);
   }, [selectedCategories, fetchDrawerGuardrails]);
+
+  useEffect(() => {
+    void fetchCustomPolicies();
+  }, [fetchCustomPolicies]);
+
+  // Drawer list = Policy Hub guardrails for the selected categories, plus all
+  // synced gateway custom policies (always shown, independent of category
+  // filtering) — merged and sorted alphabetically by display name.
+  const drawerItems: DrawerGuardrailItem[] = useMemo(() => {
+    const customItems = customPolicies.map(toDrawerItem);
+    return [...drawerGuardrails, ...customItems].sort((a, b) =>
+      (a.displayName || a.name).localeCompare(b.displayName || b.name)
+    );
+  }, [drawerGuardrails, customPolicies]);
+
+  const drawerItemsLoading = drawerGuardrailsLoading || customPoliciesLoading;
+
+  // Custom policies applied to the proxy are indistinguishable from hub
+  // policies once saved, so pill-edit needs its own name-keyed lookup.
+  const customPolicyByName = useMemo(() => {
+    const map = new Map<string, GatewayCustomPolicy>();
+    customPolicies.forEach((p) => map.set(p.name, p));
+    return map;
+  }, [customPolicies]);
 
   // Reset drawer state on close
   useEffect(() => {
@@ -325,10 +418,10 @@ export default function LLMProxyGuardrailsTab() {
   }, [proxy?.openapi, proxy?.operationPolicies, policies]);
 
   const selectedGuardrailPolicy =
-    drawerGuardrails.find((p) => p.name === selectedGuardrail) ??
+    drawerItems.find((p) => p.name === selectedGuardrail) ??
     availableGuardrails.find((p) => p.name === selectedGuardrail);
   const selectedGuardrailVersion = selectedGuardrailPolicy?.version
-    ? `v${selectedGuardrailPolicy.version.split('.')[0]}`
+    ? `v${selectedGuardrailPolicy.version.replace(/^v/i, '').split('.')[0]}`
     : 'v0';
 
   // ── Drawer openers ──────────────────────────────────────────────────────
@@ -392,6 +485,13 @@ export default function LLMProxyGuardrailsTab() {
     setDefinitionError(null);
     setDrawerOpen(true);
 
+    // Custom policies carry their definition inline — no policy-hub lookup.
+    const customPolicy = customPolicyByName.get(policyName);
+    if (customPolicy) {
+      setPolicyDefinition(buildPolicyDefinitionFromCustomPolicy(customPolicy));
+      return;
+    }
+
     // Prefer the policy-hub version, but fall back to the applied policy's own
     // version so non-guardrail policies shown as pills (e.g. rate-limit policies,
     // which the guardrails hub list doesn't include) can still load their
@@ -423,16 +523,29 @@ export default function LLMProxyGuardrailsTab() {
 
   // ── Guardrail selection & definition loading ────────────────────────────
 
-  const handleGuardrailClick = async (guardrail: {
-    name: string;
-    version?: string;
-  }) => {
+  const handleGuardrailClick = async (guardrail: DrawerGuardrailItem) => {
     if (isReadOnlyProxy) return;
     setSelectedGuardrail(guardrail.name);
     setIsDetailView(true);
     setPolicyDefinition(null);
     setGuardrailSettings({});
     setDefinitionError(null);
+
+    if (guardrail.isCustomPolicy) {
+      if (!guardrail.customPolicyDefinition) {
+        setDefinitionError('No definition available for this custom policy.');
+        return;
+      }
+      setPolicyDefinition(
+        buildPolicyDefinitionFromCustomPolicy({
+          name: guardrail.name,
+          version: guardrail.version,
+          description: guardrail.description,
+          policyDefinition: guardrail.customPolicyDefinition,
+        })
+      );
+      return;
+    }
 
     if (!guardrail.version) {
       setDefinitionError('No version available for this guardrail.');
@@ -457,10 +570,7 @@ export default function LLMProxyGuardrailsTab() {
   const handleRetryDefinition = () => {
     if (!selectedGuardrailPolicy) return;
 
-    void handleGuardrailClick({
-      name: selectedGuardrailPolicy.name,
-      version: selectedGuardrailPolicy.version,
-    });
+    void handleGuardrailClick(selectedGuardrailPolicy);
   };
 
   // ── Build path & submit ─────────────────────────────────────────────────
@@ -1158,12 +1268,12 @@ export default function LLMProxyGuardrailsTab() {
                         }}
                       />
                       <Stack spacing={1.25} sx={{ mt: 1 }}>
-                        {drawerGuardrailsLoading ? (
+                        {drawerItemsLoading ? (
                           <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, py: 2 }}>
                             <CircularProgress size={16} />
                             <Typography variant="body2" color="text.secondary">Loading...</Typography>
                           </Box>
-                        ) : drawerGuardrails
+                        ) : drawerItems
                           .filter((g) => {
                             if (!guardrailSearchQuery.trim()) return true;
                             const query = guardrailSearchQuery.toLowerCase();
@@ -1190,12 +1300,7 @@ export default function LLMProxyGuardrailsTab() {
                                 <Box sx={{ p: 1 }}>
                                   <ListItemButton
                                     selected={isSelected}
-                                    onClick={() =>
-                                      handleGuardrailClick({
-                                        name: guardrail.name,
-                                        version: guardrail.version,
-                                      })
-                                    }
+                                    onClick={() => handleGuardrailClick(guardrail)}
                                     sx={{
                                       p: 0.75,
                                       borderRadius: 1,
@@ -1219,12 +1324,22 @@ export default function LLMProxyGuardrailsTab() {
                                         {guardrail.displayName ||
                                           guardrail.name}
                                       </Typography>
-                                      <Chip
-                                        label={guardrail.version || 'v0'}
-                                        size="small"
-                                        variant="outlined"
-                                        color="default"
-                                      />
+                                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                                        {guardrail.provider && (
+                                          <Chip
+                                            label={guardrail.provider}
+                                            size="small"
+                                            variant="outlined"
+                                            color="default"
+                                          />
+                                        )}
+                                        <Chip
+                                          label={guardrail.version || 'v0'}
+                                          size="small"
+                                          variant="outlined"
+                                          color="default"
+                                        />
+                                      </Box>
                                     </Box>
                                   </ListItemButton>
                                 </Box>
@@ -1237,10 +1352,15 @@ export default function LLMProxyGuardrailsTab() {
                   ) : (
                     <Stack spacing={1.5} sx={{ mt: 1 }}>
                       <Box>
-                        <Typography variant="subtitle2">
-                          {selectedGuardrailPolicy?.displayName ||
-                            selectedGuardrailPolicy?.name}
-                        </Typography>
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+                          <Typography variant="subtitle2">
+                            {selectedGuardrailPolicy?.displayName ||
+                              selectedGuardrailPolicy?.name}
+                          </Typography>
+                          {Boolean(selectedGuardrailPolicy?.isCustomPolicy) && (
+                            <Chip label="Custom" size="small" variant="outlined" color="primary" />
+                          )}
+                        </Box>
                         <Typography variant="caption" color="text.secondary">
                           {selectedGuardrailPolicy?.version}
                         </Typography>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/AddNewProvider/GuardrailsSection.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/AddNewProvider/GuardrailsSection.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Box,
   Button,
@@ -36,9 +36,13 @@ import {
 } from '@wso2/oxygen-ui';
 import { Plus, Search, X } from '@wso2/oxygen-ui-icons-react';
 import { useGuardrails } from '../../../../../contexts/GuardrailsContext';
-import { GuardrailPill } from '../../../../../Components/GuardrailPill';
+import { getGuardrails } from '../../../../../apis/policyHubApis';
+import { getGatewayCustomPolicies } from '../../../../../apis/gatewayPolicyApis';
+import type { GatewayCustomPolicy } from '../../../../../apis/gatewayPolicyApis';
+import { GuardrailPill, PolicyCategorySelector } from '../../../../../Components/GuardrailPill';
 import PolicyParameterEditor from '../../../PolicyParameterEditor/PolicyParameterEditor';
 import type {
+  ParameterSchema,
   PolicyDefinition,
   ParameterValues,
 } from '../../../PolicyParameterEditor/types';
@@ -47,6 +51,60 @@ import type { GuardrailSelection } from './serviceProviderTypes';
 import { FormattedMessage } from 'react-intl';
 import ErrorAlert from '../../../../../Components/common/ErrorAlert';
 import { familyHandle } from '../../../../../utils/providerTemplateDisplay';
+import type { PolicyHubPolicy } from '../../../../../utils/types';
+import { logger } from '../../../../../utils/logger';
+
+const GUARDRAILS_PAGE_SIZE = 40;
+
+/** A drawer list entry — either a Policy Hub guardrail or a synced gateway
+ * custom policy, rendered and clicked through the same UI. */
+type DrawerGuardrailItem = PolicyHubPolicy & {
+  isCustomPolicy?: boolean;
+  customPolicyUuid?: string;
+  customPolicyDefinition?: Record<string, unknown>;
+};
+
+/** Custom policy versions come back as full semver with a "v" prefix (e.g.
+ * "v1.0.0"), unlike Policy Hub guardrails which are already display-formatted
+ * (e.g. "1.0"). Reformat to major.minor so both render the same way. */
+const formatPolicyVersion = (version?: string): string => {
+  if (!version) return '0';
+  const [major = '0', minor = '0'] = version.replace(/^v/i, '').split('.');
+  return `${major}.${minor}`;
+};
+
+const toDrawerItem = (policy: GatewayCustomPolicy): DrawerGuardrailItem => ({
+  name: policy.name,
+  version: formatPolicyVersion(policy.version),
+  displayName: policy.displayName || policy.name,
+  description: policy.description,
+  provider: policy.provider,
+  isCustomPolicy: true,
+  customPolicyUuid: policy.uuid,
+  customPolicyDefinition: policy.policyDefinition,
+});
+
+/** Custom policies already carry their full definition inline (no policy-hub
+ * YAML fetch needed) — just reshape it into a PolicyDefinition. */
+const buildPolicyDefinitionFromCustomPolicy = (item: {
+  name: string;
+  version: string;
+  description?: string;
+  policyDefinition?: Record<string, unknown>;
+}): PolicyDefinition => {
+  const def = (item.policyDefinition ?? {}) as {
+    description?: string;
+    parameters?: ParameterSchema;
+    systemParameters?: ParameterSchema;
+  };
+  return {
+    name: item.name,
+    version: item.version,
+    description: item.description || def.description || '',
+    parameters: def.parameters ?? { type: 'object', properties: {} },
+    systemParameters: def.systemParameters,
+  };
+};
 
 type GuardrailsSectionProps = {
   guardrails: GuardrailSelection[];
@@ -57,7 +115,10 @@ type GuardrailsSectionProps = {
   onOpenDrawer: () => void;
   onCloseDrawer: () => void;
   onSelectGuardrail: (guardrail: string) => void;
-  onAddGuardrail: (values: ParameterValues) => void;
+  onAddGuardrail: (
+    guardrail: { name: string; version: string },
+    values: ParameterValues
+  ) => void;
   onRemoveGuardrail: (guardrailName: string) => void;
 };
 
@@ -78,9 +139,6 @@ export default function GuardrailsSection({
     familyHandle(selectedTemplateId) !== 'azureai-foundry';
   const {
     guardrails: availableGuardrails = [],
-    isLoading: isLoadingGuardrails,
-    error: guardrailsError,
-    refreshGuardrails,
     getGuardrailDefinition,
   } = useGuardrails();
 
@@ -91,9 +149,122 @@ export default function GuardrailsSection({
   const [definitionError, setDefinitionError] = useState<string | null>(null);
   const [guardrailSearchQuery, setGuardrailSearchQuery] = useState('');
 
-  const selectedGuardrailPolicy = availableGuardrails.find(
-    (policy) => policy.name === selectedGuardrail
+  // Drawer-local guardrail list — fetched by selected category with its own
+  // pagination, independent of the GuardrailsContext (which only loads the
+  // default 'Guardrails,AI' category, capped at one page).
+  const [selectedCategories, setSelectedCategories] = useState<string[]>(['AI']);
+  const [drawerGuardrails, setDrawerGuardrails] = useState<PolicyHubPolicy[]>([]);
+  const [drawerGuardrailsLoading, setDrawerGuardrailsLoading] = useState(false);
+  const [drawerGuardrailsError, setDrawerGuardrailsError] =
+    useState<Error | null>(null);
+  const [guardrailsOffset, setGuardrailsOffset] = useState(0);
+  const [hasMoreGuardrails, setHasMoreGuardrails] = useState(false);
+  const [isLoadingMoreGuardrails, setIsLoadingMoreGuardrails] = useState(false);
+  const [customPolicies, setCustomPolicies] = useState<GatewayCustomPolicy[]>([]);
+  const [customPoliciesLoading, setCustomPoliciesLoading] = useState(false);
+
+  // Drawer list = Policy Hub guardrails for the selected categories, plus all
+  // synced gateway custom policies (always shown, independent of category
+  // filtering) — merged and sorted alphabetically by display name.
+  const drawerItems: DrawerGuardrailItem[] = useMemo(() => {
+    const customItems = customPolicies.map(toDrawerItem);
+    return [...drawerGuardrails, ...customItems].sort((a, b) =>
+      (a.displayName || a.name).localeCompare(b.displayName || b.name)
+    );
+  }, [drawerGuardrails, customPolicies]);
+
+  const drawerItemsLoading = drawerGuardrailsLoading || customPoliciesLoading;
+
+  const selectedGuardrailPolicy =
+    drawerItems.find((policy) => policy.name === selectedGuardrail) ??
+    availableGuardrails.find((policy) => policy.name === selectedGuardrail);
+
+  const fetchDrawerGuardrails = useCallback(
+    async (categories: string[], offset: number, append: boolean) => {
+      if (categories.length === 0) {
+        setDrawerGuardrails([]);
+        setHasMoreGuardrails(false);
+        return;
+      }
+      if (append) {
+        setIsLoadingMoreGuardrails(true);
+      } else {
+        setDrawerGuardrailsLoading(true);
+      }
+      setDrawerGuardrailsError(null);
+      try {
+        const response = await getGuardrails(
+          categories.join(','),
+          GUARDRAILS_PAGE_SIZE,
+          offset
+        );
+        setDrawerGuardrails((prev) =>
+          append ? [...prev, ...response.data] : response.data
+        );
+        const total =
+          response.pagination?.total ?? response.count ?? response.data.length;
+        setHasMoreGuardrails(offset + response.data.length < total);
+      } catch (err) {
+        if (!append) setDrawerGuardrails([]);
+        setDrawerGuardrailsError(
+          err instanceof Error ? err : new Error('Failed to load guardrails')
+        );
+      } finally {
+        setDrawerGuardrailsLoading(false);
+        setIsLoadingMoreGuardrails(false);
+      }
+    },
+    []
   );
+
+  useEffect(() => {
+    if (!guardrailDrawerOpen) return;
+    setGuardrailsOffset(0);
+    void fetchDrawerGuardrails(selectedCategories, 0, false);
+  }, [guardrailDrawerOpen, selectedCategories, fetchDrawerGuardrails]);
+
+  const fetchCustomPolicies = useCallback(async () => {
+    setCustomPoliciesLoading(true);
+    try {
+      const response = await getGatewayCustomPolicies();
+      setCustomPolicies(response.list || []);
+    } catch (e) {
+      logger.error('Failed to load custom policies:', e);
+      setCustomPolicies([]);
+    } finally {
+      setCustomPoliciesLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!guardrailDrawerOpen) return;
+    void fetchCustomPolicies();
+  }, [guardrailDrawerOpen, fetchCustomPolicies]);
+
+  const handleLoadMoreGuardrails = useCallback(() => {
+    if (isLoadingMoreGuardrails || drawerGuardrailsLoading || !hasMoreGuardrails) {
+      return;
+    }
+    const nextOffset = guardrailsOffset + GUARDRAILS_PAGE_SIZE;
+    setGuardrailsOffset(nextOffset);
+    void fetchDrawerGuardrails(selectedCategories, nextOffset, true);
+  }, [
+    isLoadingMoreGuardrails,
+    drawerGuardrailsLoading,
+    hasMoreGuardrails,
+    guardrailsOffset,
+    selectedCategories,
+    fetchDrawerGuardrails,
+  ]);
+
+  const handleGuardrailListScroll = (
+    event: React.UIEvent<HTMLDivElement>
+  ) => {
+    const { scrollTop, scrollHeight, clientHeight } = event.currentTarget;
+    if (scrollHeight - scrollTop - clientHeight < 80) {
+      handleLoadMoreGuardrails();
+    }
+  };
 
   useEffect(() => {
     if (!guardrailDrawerOpen) {
@@ -104,14 +275,27 @@ export default function GuardrailsSection({
     }
   }, [guardrailDrawerOpen]);
 
-  const handleGuardrailClick = async (guardrail: {
-    name: string;
-    version?: string;
-  }) => {
+  const handleGuardrailClick = async (guardrail: DrawerGuardrailItem) => {
     onSelectGuardrail(guardrail.name);
     setIsDetailView(true);
     setPolicyDefinition(null);
     setDefinitionError(null);
+
+    if (guardrail.isCustomPolicy) {
+      if (!guardrail.customPolicyDefinition) {
+        setDefinitionError('No definition available for this custom policy.');
+        return;
+      }
+      setPolicyDefinition(
+        buildPolicyDefinitionFromCustomPolicy({
+          name: guardrail.name,
+          version: guardrail.version,
+          description: guardrail.description,
+          policyDefinition: guardrail.customPolicyDefinition,
+        })
+      );
+      return;
+    }
 
     if (!guardrail.version) {
       setDefinitionError('No version available for this guardrail.');
@@ -134,17 +318,21 @@ export default function GuardrailsSection({
   };
 
   const handlePolicySubmit = (values: ParameterValues) => {
-    onAddGuardrail(values);
+    if (!selectedGuardrailPolicy) return;
+    onAddGuardrail(
+      {
+        name: selectedGuardrailPolicy.name,
+        version: selectedGuardrailPolicy.version || '1.0.0',
+      },
+      values
+    );
     setIsDetailView(false);
   };
 
   const handleRetryDefinition = () => {
     if (!selectedGuardrailPolicy) return;
 
-    void handleGuardrailClick({
-      name: selectedGuardrailPolicy.name,
-      version: selectedGuardrailPolicy.version,
-    });
+    void handleGuardrailClick(selectedGuardrailPolicy);
   };
 
   return (
@@ -256,53 +444,65 @@ export default function GuardrailsSection({
 
           <Stack spacing={3}>
             <Box>
-              {isLoadingGuardrails ? (
-                <Box
-                  sx={{ display: 'flex', alignItems: 'center', gap: 2, py: 2 }}
-                >
-                  <CircularProgress size={20} />
-                  <Typography variant="body2" color="text.secondary">
-                    <FormattedMessage
-                      id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.AddNewProvider.GuardrailsSection.loading.guardrails"
-                      defaultMessage={'Loading guardrails...'}
+              {!isDetailView ? (
+                <>
+                  <Box sx={{ my: 1 }}>
+                    <PolicyCategorySelector
+                      value={selectedCategories}
+                      onChange={setSelectedCategories}
                     />
-                  </Typography>
-                </Box>
-              ) : guardrailsError ? (
-                <Box sx={{ mt: 1 }}>
-                  <ErrorAlert
-                    error={guardrailsError}
-                    onRetry={() => {
-                      void refreshGuardrails();
+                  </Box>
+
+                  <TextField
+                    size="small"
+                    fullWidth
+                    placeholder="Search guardrails"
+                    value={guardrailSearchQuery}
+                    onChange={(e) => setGuardrailSearchQuery(e.target.value)}
+                    sx={{ mt: 1 }}
+                    slotProps={{
+                      input: {
+                        startAdornment: (
+                          <InputAdornment position="start">
+                            <Search size={16} />
+                          </InputAdornment>
+                        ),
+                      },
                     }}
                   />
-                </Box>
-              ) : (
-                <>
-                  {!isDetailView ? (
-                    <>
-                      <TextField
-                        size="small"
-                        fullWidth
-                        placeholder="Search guardrails"
-                        value={guardrailSearchQuery}
-                        onChange={(e) =>
-                          setGuardrailSearchQuery(e.target.value)
-                        }
-                        sx={{ mt: 1 }}
-                        slotProps={{
-                          input: {
-                            startAdornment: (
-                              <InputAdornment position="start">
-                                <Search size={16} />
-                              </InputAdornment>
-                            ),
-                          },
+
+                  {drawerItemsLoading ? (
+                    <Box
+                      sx={{ display: 'flex', alignItems: 'center', gap: 2, py: 2 }}
+                    >
+                      <CircularProgress size={20} />
+                      <Typography variant="body2" color="text.secondary">
+                        <FormattedMessage
+                          id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.AddNewProvider.GuardrailsSection.loading.guardrails"
+                          defaultMessage={'Loading guardrails...'}
+                        />
+                      </Typography>
+                    </Box>
+                  ) : drawerGuardrailsError ? (
+                    <Box sx={{ mt: 1 }}>
+                      <ErrorAlert
+                        error={drawerGuardrailsError}
+                        onRetry={() => {
+                          void fetchDrawerGuardrails(selectedCategories, 0, false);
                         }}
                       />
-                      <Stack spacing={1.25} sx={{ mt: 1 }}>
-                        {availableGuardrails
-                          .filter((g) => !g.categories?.includes('MCP'))
+                    </Box>
+                  ) : (
+                    <Box
+                      onScroll={handleGuardrailListScroll}
+                      sx={{
+                        mt: 1,
+                        overflowY: 'auto',
+                        pr: 0.5,
+                      }}
+                    >
+                      <Stack spacing={1.25}>
+                        {drawerItems
                           .filter((g) => {
                             if (!guardrailSearchQuery.trim()) return true;
                             const query = guardrailSearchQuery.toLowerCase();
@@ -329,12 +529,7 @@ export default function GuardrailsSection({
                                 <Box sx={{ p: 1 }}>
                                   <ListItemButton
                                     selected={isSelected}
-                                    onClick={() =>
-                                      handleGuardrailClick({
-                                        name: guardrail.name,
-                                        version: guardrail.version,
-                                      })
-                                    }
+                                    onClick={() => handleGuardrailClick(guardrail)}
                                     sx={{
                                       p: 0.75,
                                       borderRadius: 1,
@@ -358,20 +553,47 @@ export default function GuardrailsSection({
                                         {guardrail.displayName ||
                                           guardrail.name}
                                       </Typography>
-                                      <Chip
-                                        label={guardrail.version || 'v0'}
-                                        size="small"
-                                        variant="outlined"
-                                      />
+                                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                                        {guardrail.provider && (
+                                          <Chip
+                                            label={guardrail.provider}
+                                            size="small"
+                                            variant="outlined"
+                                          />
+                                        )}
+                                        <Chip
+                                          label={guardrail.version || 'v0'}
+                                          size="small"
+                                          variant="outlined"
+                                        />
+                                      </Box>
                                     </Box>
                                   </ListItemButton>
                                 </Box>
                               </Card>
                             );
                           })}
+                        {isLoadingMoreGuardrails && (
+                          <Box
+                            sx={{
+                              display: 'flex',
+                              alignItems: 'center',
+                              justifyContent: 'center',
+                              gap: 1,
+                              py: 1.5,
+                            }}
+                          >
+                            <CircularProgress size={16} />
+                            <Typography variant="body2" color="text.secondary">
+                              Loading more...
+                            </Typography>
+                          </Box>
+                        )}
                       </Stack>
-                    </>
-                  ) : (
+                    </Box>
+                  )}
+                </>
+              ) : (
                     <Stack spacing={1.5} sx={{ mt: 1 }}>
                       {/* <Box>
                         <Typography variant="subtitle2">
@@ -429,8 +651,6 @@ export default function GuardrailsSection({
                         </CardContent>
                       </Card>
                     </Stack>
-                  )}
-                </>
               )}
             </Box>
 

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderGuardrailsTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderGuardrailsTab.tsx
@@ -48,6 +48,8 @@ import {
 } from '@wso2/oxygen-ui-icons-react';
 import YAML from 'yaml';
 import { getGuardrails } from '../../../../apis/policyHubApis';
+import { getGatewayCustomPolicies } from '../../../../apis/gatewayPolicyApis';
+import type { GatewayCustomPolicy } from '../../../../apis/gatewayPolicyApis';
 import { useLLMProvider } from '../../../../contexts/llmProvider';
 import { useGuardrails } from '../../../../contexts/GuardrailsContext';
 import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
@@ -57,10 +59,11 @@ import { GuardrailPill, PolicyCategorySelector } from '../../../../Components/Gu
 import { ResourceRow } from '../../../../Components/ResourceView';
 import PolicyParameterEditor from '../../PolicyParameterEditor/PolicyParameterEditor';
 import type {
+  ParameterSchema,
   PolicyDefinition,
   ParameterValues,
 } from '../../PolicyParameterEditor/types';
-import type { AccessControl } from '../../../../utils/types';
+import type { AccessControl, PolicyHubPolicy } from '../../../../utils/types';
 import { parsePolicyYaml } from '../../PolicyParameterEditor/yamlParser';
 import { FormattedMessage } from 'react-intl';
 import ErrorAlert from '../../../../Components/common/ErrorAlert';
@@ -157,6 +160,56 @@ const parseOpenApiText = (
   }
 };
 
+/** A drawer list entry — either a Policy Hub guardrail or a synced gateway
+ * custom policy, rendered and clicked through the same UI. */
+type DrawerGuardrailItem = PolicyHubPolicy & {
+  isCustomPolicy?: boolean;
+  customPolicyUuid?: string;
+  customPolicyDefinition?: Record<string, unknown>;
+};
+
+/** Custom policy versions come back as full semver with a "v" prefix (e.g.
+ * "v1.0.0"), unlike Policy Hub guardrails which are already display-formatted
+ * (e.g. "1.0"). Reformat to major.minor so both render the same way. */
+const formatPolicyVersion = (version?: string): string => {
+  if (!version) return '0';
+  const [major = '0', minor = '0'] = version.replace(/^v/i, '').split('.');
+  return `${major}.${minor}`;
+};
+
+const toDrawerItem = (policy: GatewayCustomPolicy): DrawerGuardrailItem => ({
+  name: policy.name,
+  version: formatPolicyVersion(policy.version),
+  displayName: policy.displayName || policy.name,
+  description: policy.description,
+  provider: policy.provider,
+  isCustomPolicy: true,
+  customPolicyUuid: policy.uuid,
+  customPolicyDefinition: policy.policyDefinition,
+});
+
+/** Custom policies already carry their full definition inline (no policy-hub
+ * YAML fetch needed) — just reshape it into a PolicyDefinition. */
+const buildPolicyDefinitionFromCustomPolicy = (item: {
+  name: string;
+  version: string;
+  description?: string;
+  policyDefinition?: Record<string, unknown>;
+}): PolicyDefinition => {
+  const def = (item.policyDefinition ?? {}) as {
+    description?: string;
+    parameters?: ParameterSchema;
+    systemParameters?: ParameterSchema;
+  };
+  return {
+    name: item.name,
+    version: item.version,
+    description: item.description || def.description || '',
+    parameters: def.parameters ?? { type: 'object', properties: {} },
+    systemParameters: def.systemParameters,
+  };
+};
+
 export default function ServiceProviderGuardrailsTab() {
   const { provider, isLoading, error, updateProvider, isDraftMode } =
     useLLMProvider();
@@ -196,6 +249,8 @@ export default function ServiceProviderGuardrailsTab() {
   const [selectedCategories, setSelectedCategories] = useState<string[]>(['AI']);
   const [drawerGuardrails, setDrawerGuardrails] = useState<typeof availableGuardrails>([]);
   const [drawerGuardrailsLoading, setDrawerGuardrailsLoading] = useState(false);
+  const [customPolicies, setCustomPolicies] = useState<GatewayCustomPolicy[]>([]);
+  const [customPoliciesLoading, setCustomPoliciesLoading] = useState(false);
   const showSnackbar = useAIWorkspaceSnackbar();
 
   const fetchDrawerGuardrails = useCallback(async (categories: string[]) => {
@@ -214,9 +269,46 @@ export default function ServiceProviderGuardrailsTab() {
     }
   }, []);
 
+  const fetchCustomPolicies = useCallback(async () => {
+    setCustomPoliciesLoading(true);
+    try {
+      const response = await getGatewayCustomPolicies();
+      setCustomPolicies(response.list || []);
+    } catch (e) {
+      logger.error('Failed to load custom policies:', e);
+      setCustomPolicies([]);
+    } finally {
+      setCustomPoliciesLoading(false);
+    }
+  }, []);
+
   useEffect(() => {
     void fetchDrawerGuardrails(selectedCategories);
   }, [selectedCategories, fetchDrawerGuardrails]);
+
+  useEffect(() => {
+    void fetchCustomPolicies();
+  }, [fetchCustomPolicies]);
+
+  // Drawer list = Policy Hub guardrails for the selected categories, plus all
+  // synced gateway custom policies (always shown, independent of category
+  // filtering) — merged and sorted alphabetically by display name.
+  const drawerItems: DrawerGuardrailItem[] = useMemo(() => {
+    const customItems = customPolicies.map(toDrawerItem);
+    return [...drawerGuardrails, ...customItems].sort((a, b) =>
+      (a.displayName || a.name).localeCompare(b.displayName || b.name)
+    );
+  }, [drawerGuardrails, customPolicies]);
+
+  const drawerItemsLoading = drawerGuardrailsLoading || customPoliciesLoading;
+
+  // Custom policies applied to the provider are indistinguishable from hub
+  // policies once saved, so pill-edit needs its own name-keyed lookup.
+  const customPolicyByName = useMemo(() => {
+    const map = new Map<string, GatewayCustomPolicy>();
+    customPolicies.forEach((p) => map.set(p.name, p));
+    return map;
+  }, [customPolicies]);
 
   useEffect(() => {
     if (!drawerOpen) {
@@ -349,10 +441,10 @@ export default function ServiceProviderGuardrailsTab() {
   ]);
 
   const selectedGuardrailPolicy =
-    drawerGuardrails.find((policy) => policy.name === selectedGuardrail) ??
+    drawerItems.find((policy) => policy.name === selectedGuardrail) ??
     availableGuardrails.find((policy) => policy.name === selectedGuardrail);
   const selectedGuardrailVersion = selectedGuardrailPolicy?.version
-    ? `v${selectedGuardrailPolicy.version.split('.')[0]}`
+    ? `v${selectedGuardrailPolicy.version.replace(/^v/i, '').split('.')[0]}`
     : 'v0';
 
   const openAddDrawerForGlobal = () => {
@@ -412,6 +504,13 @@ export default function ServiceProviderGuardrailsTab() {
     setDefinitionError(null);
     setDrawerOpen(true);
 
+    // Custom policies carry their definition inline — no policy-hub lookup.
+    const customPolicy = customPolicyByName.get(policyName);
+    if (customPolicy) {
+      setPolicyDefinition(buildPolicyDefinitionFromCustomPolicy(customPolicy));
+      return;
+    }
+
     // Prefer the policy-hub version, but fall back to the applied policy's own
     // version so non-guardrail policies shown as pills (e.g. the llm-cost tracker,
     // which the guardrails hub list doesn't include) can still load their
@@ -441,15 +540,28 @@ export default function ServiceProviderGuardrailsTab() {
       });
   };
 
-  const handleGuardrailClick = async (guardrail: {
-    name: string;
-    version?: string;
-  }) => {
+  const handleGuardrailClick = async (guardrail: DrawerGuardrailItem) => {
     setSelectedGuardrail(guardrail.name);
     setIsDetailView(true);
     setPolicyDefinition(null);
     setGuardrailSettings({});
     setDefinitionError(null);
+
+    if (guardrail.isCustomPolicy) {
+      if (!guardrail.customPolicyDefinition) {
+        setDefinitionError('No definition available for this custom policy.');
+        return;
+      }
+      setPolicyDefinition(
+        buildPolicyDefinitionFromCustomPolicy({
+          name: guardrail.name,
+          version: guardrail.version,
+          description: guardrail.description,
+          policyDefinition: guardrail.customPolicyDefinition,
+        })
+      );
+      return;
+    }
 
     if (!guardrail.version) {
       setDefinitionError('No version available for this guardrail.');
@@ -475,10 +587,7 @@ export default function ServiceProviderGuardrailsTab() {
   const handleRetryDefinition = () => {
     if (!selectedGuardrailPolicy) return;
 
-    void handleGuardrailClick({
-      name: selectedGuardrailPolicy.name,
-      version: selectedGuardrailPolicy.version,
-    });
+    void handleGuardrailClick(selectedGuardrailPolicy);
   };
 
   const buildPolicyPath = (params: ParameterValues) => {
@@ -1173,12 +1282,12 @@ export default function ServiceProviderGuardrailsTab() {
                         }}
                       />
                     <Stack spacing={1.25} sx={{ mt: 1 }}>
-                      {drawerGuardrailsLoading ? (
+                      {drawerItemsLoading ? (
                         <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, py: 2 }}>
                           <CircularProgress size={16} />
                           <Typography variant="body2" color="text.secondary">Loading...</Typography>
                         </Box>
-                      ) : drawerGuardrails
+                      ) : drawerItems
                         .filter((g) => {
                           if (!guardrailSearchQuery.trim()) return true;
                           const query = guardrailSearchQuery.toLowerCase();
@@ -1205,12 +1314,7 @@ export default function ServiceProviderGuardrailsTab() {
                               <Box sx={{ p: 1 }}>
                                 <ListItemButton
                                   selected={isSelected}
-                                  onClick={() =>
-                                    handleGuardrailClick({
-                                      name: guardrail.name,
-                                      version: guardrail.version,
-                                    })
-                                  }
+                                  onClick={() => handleGuardrailClick(guardrail)}
                                   sx={{
                                     p: 0.75,
                                     borderRadius: 1,
@@ -1233,12 +1337,22 @@ export default function ServiceProviderGuardrailsTab() {
                                     >
                                       {guardrail.displayName || guardrail.name}
                                     </Typography>
-                                    <Chip
-                                      label={guardrail.version || 'v0'}
-                                      size="small"
-                                      variant="outlined"
-                                      color="default"
-                                    />
+                                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                                      {guardrail.provider && (
+                                        <Chip
+                                          label={guardrail.provider}
+                                          size="small"
+                                          variant="outlined"
+                                          color="default"
+                                        />
+                                      )}
+                                      <Chip
+                                        label={guardrail.version || 'v0'}
+                                        size="small"
+                                        variant="outlined"
+                                        color="default"
+                                      />
+                                    </Box>
                                   </Box>
                                 </ListItemButton>
                               </Box>
@@ -1250,10 +1364,15 @@ export default function ServiceProviderGuardrailsTab() {
                   ) : (
                     <Stack spacing={1.5} sx={{ mt: 1 }}>
                       <Box>
-                        <Typography variant="subtitle2">
-                          {selectedGuardrailPolicy?.displayName ||
-                            selectedGuardrailPolicy?.name}
-                        </Typography>
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+                          <Typography variant="subtitle2">
+                            {selectedGuardrailPolicy?.displayName ||
+                              selectedGuardrailPolicy?.name}
+                          </Typography>
+                          {Boolean(selectedGuardrailPolicy?.isCustomPolicy) && (
+                            <Chip label="Custom" size="small" variant="outlined" color="primary" />
+                          )}
+                        </Box>
                         <Typography variant="caption" color="text.secondary">
                           {selectedGuardrailPolicy?.version}
                         </Typography>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderNew.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderNew.tsx
@@ -33,7 +33,6 @@ import {
   ProviderTemplateProvider,
   useProviderTemplate,
 } from '../../../../contexts/llmProvider';
-import { useGuardrails } from '../../../../contexts/GuardrailsContext';
 import { ChevronLeft } from '@wso2/oxygen-ui-icons-react';
 import { useAppAuth } from '../../../../contexts/AppAuthContext';
 import { SCOPES } from '../../../../auth/permissions';
@@ -211,8 +210,6 @@ export default function ServiceProviderNew() {
     Record<string, unknown>
   >({});
 
-  const { guardrails: availableGuardrails = [] } = useGuardrails();
-
   useEffect(() => {
     if (isProjectLevel && hasPermission(SCOPES.LLM_PROVIDER_MANAGE)) {
       setCurrentProject(null);
@@ -248,10 +245,6 @@ export default function ServiceProviderNew() {
     );
   }
 
-  const selectedGuardrailPolicy = availableGuardrails.find(
-    (policy) => policy.name === selectedGuardrail
-  );
-
   const handleOpenGuardrailDrawer = () => {
     setSelectedGuardrail(null);
     setGuardrailSettings({});
@@ -264,12 +257,14 @@ export default function ServiceProviderNew() {
     setGuardrailSettings(existing?.settings ?? {});
   };
 
-  const handleAddGuardrail = (settings: Record<string, unknown>) => {
-    if (!selectedGuardrail || !selectedGuardrailPolicy) return;
+  const handleAddGuardrail = (
+    guardrail: { name: string; version: string },
+    settings: Record<string, unknown>
+  ) => {
     setGuardrailSettings(settings);
     setGuardrails((prev) => {
       const existingIndex = prev.findIndex(
-        (item) => item.name === selectedGuardrail
+        (item) => item.name === guardrail.name
       );
       const configurationSummary = Object.entries(settings)
         .filter(([, value]) => Boolean(value))
@@ -291,8 +286,8 @@ export default function ServiceProviderNew() {
         return [
           ...prev,
           {
-            name: selectedGuardrail,
-            version: selectedGuardrailPolicy.version || '1.0.0',
+            name: guardrail.name,
+            version: guardrail.version || '1.0.0',
             configuration: configurationSummary,
             settings,
           },
@@ -300,8 +295,8 @@ export default function ServiceProviderNew() {
       }
       const next = [...prev];
       next[existingIndex] = {
-        name: selectedGuardrail,
-        version: selectedGuardrailPolicy.version || '1.0.0',
+        name: guardrail.name,
+        version: guardrail.version || '1.0.0',
         configuration: configurationSummary,
         settings,
       };

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/settings/Main.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/settings/Main.tsx
@@ -24,7 +24,7 @@
 // ---------------------------------------------------------------------------
 
 import { type ReactNode } from 'react';
-import { Navigate, Outlet, useNavigate } from 'react-router-dom';
+import { Navigate, Outlet, useLocation, useNavigate } from 'react-router-dom';
 import {
   Box,
   Divider,
@@ -35,7 +35,7 @@ import {
   PageTitle,
   Stack,
 } from '@wso2/oxygen-ui';
-import { LayoutTemplate } from '@wso2/oxygen-ui-icons-react';
+import { LayoutTemplate, ShieldCheck } from '@wso2/oxygen-ui-icons-react';
 import { FormattedMessage } from 'react-intl';
 import { useAppShell } from '../../../../contexts/AppShellContext';
 import { useAppAuth } from '../../../../contexts/AppAuthContext';
@@ -48,6 +48,8 @@ interface NavItem {
   icon: ReactNode;
   // Settings-relative path the item navigates to.
   path: string;
+  // Permission required to see/use this item.
+  scope: string;
 }
 
 // Settings navigation. LLM Provider Templates is first/default.
@@ -57,18 +59,30 @@ const NAV_ITEMS: NavItem[] = [
     label: 'LLM Provider Templates',
     icon: <LayoutTemplate size={18} />,
     path: '/settings/llm-provider-templates',
+    scope: SCOPES.LLM_TEMPLATE_MANAGE,
+  },
+  {
+    key: 'customPolicies',
+    label: 'Custom Policies',
+    icon: <ShieldCheck size={18} />,
+    path: '/settings/custom-policies',
+    scope: SCOPES.GATEWAY_CUSTOM_POLICY_READ,
   },
 ];
 
 export default function Settings() {
   const navigate = useNavigate();
+  const location = useLocation();
   const { currentOrganization } = useAppShell();
   const { hasPermission } = useAppAuth();
-  // Only one area today; it stays selected across all its sub-pages.
-  const selectedKey = 'templates';
 
-  // Settings requires template-manage permission; send others to org home.
-  if (!hasPermission(SCOPES.LLM_TEMPLATE_MANAGE)) {
+  const visibleNavItems = NAV_ITEMS.filter((item) => hasPermission(item.scope));
+  const selectedKey = visibleNavItems.find((item) =>
+    location.pathname.includes(item.path)
+  )?.key;
+
+  // Settings requires at least one visible section; send others to org home.
+  if (visibleNavItems.length === 0) {
     return (
       <Navigate
         to={buildOrgPath(currentOrganization, '/home')}
@@ -91,7 +105,7 @@ export default function Settings() {
             </PageTitle.Header>
           </PageTitle>
           <List dense disablePadding>
-            {NAV_ITEMS.map((item) => (
+            {visibleNavItems.map((item) => (
               <ListItemButton
                 key={item.key}
                 selected={item.key === selectedKey}
@@ -122,4 +136,13 @@ export default function Settings() {
       </Box>
     </Box>
   );
+}
+
+export function SettingsIndexRedirect() {
+  const { currentOrganization } = useAppShell();
+  const { hasPermission } = useAppAuth();
+  const firstVisibleItem = NAV_ITEMS.find((item) => hasPermission(item.scope));
+  const target = firstVisibleItem ? firstVisibleItem.path : '/home';
+
+  return <Navigate to={buildOrgPath(currentOrganization, target)} replace />;
 }


### PR DESCRIPTION
This pull request introduces several backend and frontend changes to support identifying gateways by their handle (URL-friendly slug) instead of UUID, especially for custom policy management. It also adds new API integrations and UI routes for managing gateway custom policies in the frontend. The most important changes are summarized below:

Issue: https://github.com/wso2/api-platform/issues/2676

<img width="1325" height="456" alt="Screenshot 2026-07-21 at 16 05 26" src="https://github.com/user-attachments/assets/964caa15-afbf-4142-bab2-9473470223ec" />
<img width="1888" height="818" alt="Screenshot 2026-07-21 at 16 06 01" src="https://github.com/user-attachments/assets/3f9da4f0-1d52-4941-b221-096db1f109b7" />
<img width="1646" height="676" alt="Screenshot 2026-07-21 at 16 06 18" src="https://github.com/user-attachments/assets/ceb53a67-df98-4120-9169-fe141ecad71c" />


**Backend: Gateway Handle Support and Service Logic Updates**
* Changed all relevant API parameters, service methods, and repository calls to use the gateway handle (slug) instead of UUID for identifying gateways in custom policy management and manifest retrieval. This includes updating OpenAPI specs, handler logic, and service methods. [[1]](diffhunk://#diff-9a8387679fa87f5b5ea1b73bc4cbe40da2b8f018caa862b94a7ed01b539164e6L2786-R2787) [[2]](diffhunk://#diff-caba75640cb8fb07ecdc2baa8b7ff2ab75026e090db4fd41584570a19734e815L381-L390) [[3]](diffhunk://#diff-caba75640cb8fb07ecdc2baa8b7ff2ab75026e090db4fd41584570a19734e815L408-R413) [[4]](diffhunk://#diff-1888188f2fb29a696ac97d37efa83f4d54b31236baa5d08097176859bf978cbeL105-R116) [[5]](diffhunk://#diff-1888188f2fb29a696ac97d37efa83f4d54b31236baa5d08097176859bf978cbeL331-R348) [[6]](diffhunk://#diff-7a55d32e82d7d62afb11d5c8cb79f0837910757469aabc9d3141b0ce1c434309L3456-R3460)
* Refactored repository and service layer lookups to use `GetByHandleAndOrgID` instead of `GetByUUID`, ensuring organization scoping and correct manifest retrieval. Updated mocks and added a new test to validate handle-to-UUID resolution. [[1]](diffhunk://#diff-27bdccbcd19567081f9178220acbb681431eb75ed385060a3a58bc915bf80120L45-L54) [[2]](diffhunk://#diff-949fca69e4178beaea3d856d61de34e13e5b4205ea7d850b439313b328435f85R1-R86)

**Frontend: Gateway Custom Policy Management Integration**
* Added a new API module (`gatewayPolicyApis.ts`) for managing gateway custom policies, including listing, syncing, retrieving, and deleting custom policies via the platform API.
* Added a new UI route and page (`CustomPoliciesList`) under the settings section for viewing and managing custom policies in the frontend application. [[1]](diffhunk://#diff-4da7d52c0f032f6c555c67000c9107432507d795d0dd6a5d757e04a75c2d11d3R70-R74) [[2]](diffhunk://#diff-4da7d52c0f032f6c555c67000c9107432507d795d0dd6a5d757e04a75c2d11d3R585-R592)

**Frontend: Policy Hub API Improvements**
* Enhanced the Policy Hub API integration to support pagination and a new method for fetching all policies for the gateway policy catalogue. [[1]](diffhunk://#diff-5189fc955fa03b1ef00d687de2ac9b962d36c162513638c8d6aa5db7c87ae048R27-R54) [[2]](diffhunk://#diff-5189fc955fa03b1ef00d687de2ac9b962d36c162513638c8d6aa5db7c87ae048R75)

These changes collectively improve the developer experience by allowing gateway operations to use more user-friendly identifiers, and they lay the groundwork for enhanced custom policy management in the UI.