### PR TITLE
[PlatformAPI] Clean up deployment records when a gateway is deleted

### DIFF
--- a/platform-api/internal/integration/cascade_test.go
+++ b/platform-api/internal/integration/cascade_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+
+	"github.com/wso2/api-platform/platform-api/internal/repository"
 )
 
 // graph holds the identifiers seeded into a single organization.
@@ -33,6 +35,7 @@ type graph struct {
 	plan, sub, gateway, deploy string
 	apiKey                     string
 	planLimit                  string
+	secretHandle               string
 }
 
 // seedOrgGraph inserts a representative object graph for one organization that
@@ -45,8 +48,9 @@ func seedOrgGraph(t *testing.T, it *itDB) graph {
 		org: id(), project: id(), app: id(),
 		apiArtifact: id(), depArtifact: id(),
 		plan: id(), sub: id(), gateway: id(), deploy: id(),
-		apiKey:    id(),
-		planLimit: id(),
+		apiKey:       id(),
+		planLimit:    id(),
+		secretHandle: id(),
 	}
 
 	it.exec(t, `INSERT INTO organizations (uuid, handle, display_name, region, idp_organization_ref_uuid) VALUES (?, ?, ?, ?, ?)`,
@@ -79,6 +83,13 @@ func seedOrgGraph(t *testing.T, it *itDB) graph {
 		g.deploy, "d", g.depArtifact, g.org, g.gateway, []byte("x"))
 	it.exec(t, `INSERT INTO deployment_status (artifact_uuid, organization_uuid, gateway_uuid, deployment_uuid) VALUES (?, ?, ?, ?)`,
 		g.depArtifact, g.org, g.gateway, g.deploy)
+
+	// One gateway-scoped secret ref (written at deploy time) and one artifact-level secret
+	// ref (gateway_id = ''), so gateway deletion tests can assert only the former is removed.
+	it.exec(t, `INSERT INTO artifact_secret_refs (organization_uuid, artifact_uuid, secret_handle, gateway_id) VALUES (?, ?, ?, ?)`,
+		g.org, g.depArtifact, g.secretHandle, g.gateway)
+	it.exec(t, `INSERT INTO artifact_secret_refs (organization_uuid, artifact_uuid, secret_handle, gateway_id) VALUES (?, ?, ?, ?)`,
+		g.org, g.depArtifact, g.secretHandle, "")
 
 	// An API key on the deployment artifact + its application mapping.
 	it.exec(t, `INSERT INTO api_keys (uuid, artifact_uuid, handle, display_name, masked_api_key, api_key_hashes) VALUES (?, ?, ?, ?, ?, ?)`,
@@ -128,6 +139,73 @@ func TestCascade_DeleteGatewayRemovesDeployments(t *testing.T) {
 	}
 	if got := it.count(t, "deployment_status", "deployment_uuid", g.deploy); got != 0 {
 		t.Fatalf("[%s] deployment_status not removed after gateway delete: %d remain", it.driver, got)
+	}
+}
+
+// TestCascade_GatewayRepoDeleteRemovesDeploymentInfo verifies that
+// GatewayRepo.Delete (issue #2658) explicitly removes deployments,
+// deployment_status and gateway-scoped artifact_secret_refs for the deleted
+// gateway, rather than relying solely on FK cascade — which on SQL Server does
+// not cover a deployment_status row without a matching deployments snapshot,
+// and never covers artifact_secret_refs (no FK to gateways on any engine).
+// It also confirms HasActiveDeployment no longer reports the artifact as
+// deployed, which is what previously blocked artifact deletion with a 409
+// ARTIFACT_DEPLOYED after the gateway had already been removed.
+func TestCascade_GatewayRepoDeleteRemovesDeploymentInfo(t *testing.T) {
+	it := openITDB(t)
+	defer it.db.Close()
+	g := seedOrgGraph(t, it)
+
+	if got := it.count(t, "deployment_status", "deployment_uuid", g.deploy); got != 1 {
+		t.Fatalf("precondition: want 1 deployment_status, got %d", got)
+	}
+	if got := it.count(t, "artifact_secret_refs", "secret_handle", g.secretHandle); got != 2 {
+		t.Fatalf("precondition: want 2 artifact_secret_refs, got %d", got)
+	}
+
+	deploymentRepo := repository.NewDeploymentRepo(it.db, repository.NewArtifactTableRegistry())
+	if active, err := deploymentRepo.HasActiveDeployment(g.depArtifact, g.org); err != nil {
+		t.Fatalf("HasActiveDeployment precondition check failed: %v", err)
+	} else if !active {
+		t.Fatalf("precondition: want artifact to have an active deployment")
+	}
+
+	gatewayRepo := repository.NewGatewayRepo(it.db)
+	if err := gatewayRepo.Delete(g.gateway, g.org); err != nil {
+		t.Fatalf("[%s] GatewayRepo.Delete failed: %v", it.driver, err)
+	}
+
+	if got := it.count(t, "deployments", "uuid", g.deploy); got != 0 {
+		t.Fatalf("[%s] deployment not removed after GatewayRepo.Delete: %d remain", it.driver, got)
+	}
+	if got := it.count(t, "deployment_status", "deployment_uuid", g.deploy); got != 0 {
+		t.Fatalf("[%s] deployment_status not removed after GatewayRepo.Delete: %d remain", it.driver, got)
+	}
+
+	var gatewayScopedRefs int
+	q := it.db.Rebind(`SELECT COUNT(*) FROM artifact_secret_refs WHERE secret_handle = ? AND gateway_id = ?`)
+	if err := it.db.QueryRow(q, g.secretHandle, g.gateway).Scan(&gatewayScopedRefs); err != nil {
+		t.Fatalf("count gateway-scoped artifact_secret_refs failed: %v", err)
+	}
+	if gatewayScopedRefs != 0 {
+		t.Fatalf("[%s] gateway-scoped artifact_secret_refs not removed after GatewayRepo.Delete: %d remain", it.driver, gatewayScopedRefs)
+	}
+
+	var artifactLevelRefs int
+	q = it.db.Rebind(`SELECT COUNT(*) FROM artifact_secret_refs WHERE secret_handle = ? AND gateway_id = ?`)
+	if err := it.db.QueryRow(q, g.secretHandle, "").Scan(&artifactLevelRefs); err != nil {
+		t.Fatalf("count artifact-level artifact_secret_refs failed: %v", err)
+	}
+	if artifactLevelRefs != 1 {
+		t.Fatalf("[%s] artifact-level artifact_secret_refs unexpectedly removed: want 1, got %d", it.driver, artifactLevelRefs)
+	}
+
+	active, err := deploymentRepo.HasActiveDeployment(g.depArtifact, g.org)
+	if err != nil {
+		t.Fatalf("HasActiveDeployment failed: %v", err)
+	}
+	if active {
+		t.Fatalf("[%s] HasActiveDeployment still reports an active deployment after gateway delete; artifact delete would be blocked with 409 ARTIFACT_DEPLOYED", it.driver)
 	}
 }
 

--- a/platform-api/internal/repository/gateway.go
+++ b/platform-api/internal/repository/gateway.go
@@ -323,7 +323,32 @@ func (r *GatewayRepo) Delete(gatewayID, organizationID string) error {
 		return err
 	}
 
-	// Delete gateway with organization isolation (gateway_tokens and deployments will be cascade deleted via FK)
+	// Deployment cleanup is explicit rather than left to FK cascade: on SQL Server the
+	// deployment_status.gateway_uuid edge is ON DELETE NO ACTION (to avoid the multiple
+	// cascade-paths restriction), so a status row with no matching deployments snapshot for
+	// this gateway would otherwise survive and make HasActiveDeployment report the artifact
+	// as still deployed. artifact_secret_refs has no FK to gateways at all on any engine.
+	// Status rows are deleted before deployments so this is correct regardless of the
+	// deployment_uuid -> deployments cascade edge.
+	deleteStatusQuery := `DELETE FROM deployment_status WHERE gateway_uuid = ? AND organization_uuid = ?`
+	if _, err = tx.Exec(r.db.Rebind(deleteStatusQuery), gatewayID, organizationID); err != nil {
+		return err
+	}
+
+	deleteDeploymentsQuery := `DELETE FROM deployments WHERE gateway_uuid = ? AND organization_uuid = ?`
+	if _, err = tx.Exec(r.db.Rebind(deleteDeploymentsQuery), gatewayID, organizationID); err != nil {
+		return err
+	}
+
+	// Gateway-scoped secret refs (gateway_id = gateway UUID). Artifact-level refs
+	// (gateway_id = '') are intentionally left untouched.
+	deleteSecretRefsQuery := `DELETE FROM artifact_secret_refs WHERE gateway_id = ? AND organization_uuid = ?`
+	if _, err = tx.Exec(r.db.Rebind(deleteSecretRefsQuery), gatewayID, organizationID); err != nil {
+		return err
+	}
+
+	// Delete gateway with organization isolation (gateway_tokens and gateway_endpoints will
+	// still be cascade deleted via FK; deployment-related tables were removed explicitly above)
 	deleteGatewayQuery := `DELETE FROM gateways WHERE uuid = ? AND organization_uuid = ?`
 	result, err := tx.Exec(r.db.Rebind(deleteGatewayQuery), gatewayID, organizationID)
 	if err != nil {

--- a/platform-api/internal/service/gateway.go
+++ b/platform-api/internal/service/gateway.go
@@ -754,7 +754,9 @@ func (s *GatewayService) UpdateGateway(gatewayId, orgId, updatedBy string, req *
 	return s.gatewayModelToAPI(gateway)
 }
 
-// DeleteGateway deletes a gateway and all associated tokens (CASCADE)
+// DeleteGateway deletes a gateway along with all its deployment information (deployments,
+// deployment statuses, gateway-scoped secret refs, artifact-gateway mappings) and tokens,
+// so no artifact is left appearing deployed on the removed gateway.
 func (s *GatewayService) DeleteGateway(gatewayID, orgID, deletedBy string) error {
 	// Verify gateway exists and belongs to organization (gatewayID is now the handle)
 	gateway, err := s.gatewayRepo.GetByHandleAndOrgID(gatewayID, orgID)
@@ -765,7 +767,8 @@ func (s *GatewayService) DeleteGateway(gatewayID, orgID, deletedBy string) error
 		return apperror.GatewayNotFound.New()
 	}
 
-	// Delete gateway by UUID (FK CASCADE will automatically remove tokens and deployments; association_mappings cleanup is handled by the repository)
+	// Delete gateway by UUID; the repository explicitly removes deployment-related rows and
+	// association mappings, and FK CASCADE removes gateway_tokens/gateway_endpoints.
 	err = s.gatewayRepo.Delete(gateway.ID, orgID)
 	if err != nil {
 		return err


### PR DESCRIPTION
### Purpose

- Resolves: https://github.com/wso2/api-platform/issues/2658

This pull request enhances the deletion logic for gateways to ensure all deployment-related records are properly removed, preventing artifacts from incorrectly appearing as deployed after a gateway is deleted. It introduces explicit cleanup of deployment statuses and gateway-scoped secret references, adds comprehensive integration tests to verify this behavior, and updates documentation for clarity.

**Repository logic improvements:**
- [`platform-api/internal/repository/gateway.go`](diffhunk://#diff-1505772e7ff38cda5d5ef82cb58ebd88011941691af5e3149e53e28bf215c9f7L326-R351): The `GatewayRepo.Delete` method now explicitly deletes related `deployment_status`, `deployments`, and gateway-scoped `artifact_secret_refs` before removing the gateway itself. This avoids issues with foreign key cascades, especially on SQL Server, and ensures no orphaned records remain that could block artifact deletion.

**Integration test enhancements:**
- [`platform-api/internal/integration/cascade_test.go`](diffhunk://#diff-926224641525d0ef437806c448293c3213d449b0a81be550cc6d87cbe358e7f0R145-R211): Added a new test, `TestCascade_GatewayRepoDeleteRemovesDeploymentInfo`, which verifies that deleting a gateway removes all associated deployments, deployment statuses, and gateway-scoped secret references, and confirms that artifacts are no longer reported as deployed.
- [`platform-api/internal/integration/cascade_test.go`](diffhunk://#diff-926224641525d0ef437806c448293c3213d449b0a81be550cc6d87cbe358e7f0R38): Updated the test data setup to include gateway-scoped and artifact-level secret references, allowing for precise assertions about what should and should not be deleted. [[1]](diffhunk://#diff-926224641525d0ef437806c448293c3213d449b0a81be550cc6d87cbe358e7f0R38) [[2]](diffhunk://#diff-926224641525d0ef437806c448293c3213d449b0a81be550cc6d87cbe358e7f0R53) [[3]](diffhunk://#diff-926224641525d0ef437806c448293c3213d449b0a81be550cc6d87cbe358e7f0R87-R93)

**Service and documentation updates:**
- [`platform-api/internal/service/gateway.go`](diffhunk://#diff-1888188f2fb29a696ac97d37efa83f4d54b31236baa5d08097176859bf978cbeL757-R759): Updated comments and logic in `DeleteGateway` to clarify that the repository now handles explicit deletion of all deployment-related data, not just relying on foreign key cascades. [[1]](diffhunk://#diff-1888188f2fb29a696ac97d37efa83f4d54b31236baa5d08097176859bf978cbeL757-R759) [[2]](diffhunk://#diff-1888188f2fb29a696ac97d37efa83f4d54b31236baa5d08097176859bf978cbeL768-R771)
