### PR TITLE
refactor(ai-workspace): harden SPA static path containment check

### DIFF
--- a/portals/ai-workspace/bff/internal/server/static.go
+++ b/portals/ai-workspace/bff/internal/server/static.go
@@ -36,8 +36,12 @@ func spaHandler(staticDir string) http.Handler {
 		clean := filepath.Clean(r.URL.Path)
 		full := filepath.Join(staticDir, clean)
 
-		// Prevent path traversal outside staticDir.
-		if !strings.HasPrefix(full, filepath.Clean(staticDir)) {
+		// Prevent path traversal outside staticDir. Assert containment against
+		// the root with a trailing separator so a sibling dir whose name merely
+		// shares the prefix (e.g. root "/var/www" vs "/var/www-secret") cannot
+		// pass a bare HasPrefix check.
+		root := filepath.Clean(staticDir)
+		if full != root && !strings.HasPrefix(full, root+string(filepath.Separator)) {
 			http.NotFound(w, r)
 			return
 		}

--- a/portals/ai-workspace/bff/internal/server/static_test.go
+++ b/portals/ai-workspace/bff/internal/server/static_test.go
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the
+ * License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	indexBody  = "<!doctype html><title>spa</title>"
+	assetBody  = "console.log('app');"
+	secretBody = "TOP-SECRET-OUTSIDE-STATIC-DIR"
+)
+
+// newStaticTestDir lays out a temp tree where the secret file lives OUTSIDE the
+// served static dir, so any response echoing secretBody proves a traversal escape:
+//
+//	<tmp>/secret.txt        <- must never be served
+//	<tmp>/static/index.html <- SPA entrypoint
+//	<tmp>/static/assets/app.js
+func newStaticTestDir(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "secret.txt"), []byte(secretBody), 0o600); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+	staticDir := filepath.Join(tmp, "static")
+	if err := os.MkdirAll(filepath.Join(staticDir, "assets"), 0o755); err != nil {
+		t.Fatalf("mkdir static: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(staticDir, "index.html"), []byte(indexBody), 0o600); err != nil {
+		t.Fatalf("write index: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(staticDir, "assets", "app.js"), []byte(assetBody), 0o600); err != nil {
+		t.Fatalf("write asset: %v", err)
+	}
+	return staticDir
+}
+
+func TestSPAHandlerServesHashedAssetCacheable(t *testing.T) {
+	h := spaHandler(newStaticTestDir(t))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/assets/app.js", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Body.String(); got != assetBody {
+		t.Errorf("body = %q, want %q", got, assetBody)
+	}
+	// Hashed assets must not be marked no-store so they stay cacheable.
+	if cc := rec.Header().Get("Cache-Control"); cc == "no-store" {
+		t.Errorf("Cache-Control = %q, want asset to be cacheable", cc)
+	}
+}
+
+func TestSPAHandlerServesIndexNoStore(t *testing.T) {
+	h := spaHandler(newStaticTestDir(t))
+
+	// The SPA root and any client-side route with no matching file both resolve
+	// to index.html served no-store (replaces nginx try_files $uri /index.html).
+	for _, path := range []string{"/", "/dashboard/settings"} {
+		t.Run(path, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200", rec.Code)
+			}
+			if got := rec.Body.String(); got != indexBody {
+				t.Errorf("body = %q, want index fallback %q", got, indexBody)
+			}
+			if rec.Header().Get("Cache-Control") != "no-store" {
+				t.Errorf("Cache-Control = %q, want no-store", rec.Header().Get("Cache-Control"))
+			}
+		})
+	}
+}
+
+// TestSPAHandlerPathTraversalContained is the regression test for the reported
+// (false-positive) traversal sink: adversarial paths must never resolve the
+// secret file outside staticDir. filepath.Clean on the root-absolute URL path
+// collapses every escaping "..", so each payload resolves inside staticDir,
+// misses, and falls back to index.html.
+func TestSPAHandlerPathTraversalContained(t *testing.T) {
+	h := spaHandler(newStaticTestDir(t))
+
+	payloads := []string{
+		"/../secret.txt",
+		"/../../secret.txt",
+		"/../../../../../../secret.txt",
+		"/assets/../../secret.txt",
+		"/%2e%2e%2fsecret.txt",             // encoded ../
+		"/..%2f..%2fsecret.txt",            // encoded ../../
+		"/%2e%2e%2f%2e%2e%2fsecret.txt",    // encoded ../../
+		"/assets/%2e%2e%2f%2e%2e%2fsecret.txt",
+	}
+
+	for _, p := range payloads {
+		t.Run(p, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, p, nil))
+
+			// Hard invariant: the file outside staticDir must never be served.
+			if body := rec.Body.String(); strings.Contains(body, secretBody) {
+				t.Fatalf("path traversal escaped staticDir: response leaked secret file (status %d)", rec.Code)
+			}
+			// A contained request is never a 200 serving arbitrary content: the
+			// stdlib file server rejects the ".." path (400), and even if a
+			// refactor let it through, filepath.Clean keeps it inside staticDir
+			// where it misses and falls back to index.html.
+			if rec.Code == http.StatusOK && rec.Body.String() != indexBody {
+				t.Errorf("status 200 served unexpected body %q", rec.Body.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Purpose

A static-analysis scan flagged the `os.Stat` call in `portals/ai-workspace/bff/internal/server/static.go` as a High severity path/directory traversal sink. Investigation confirmed this is a false positive — `filepath.Clean` on the root-absolute `r.URL.Path` collapses all escaping `..` before the join, so `os.Stat` can never resolve outside `staticDir`. However, the existing containment guard relied on a bare `strings.HasPrefix` check, which is a weak pattern flagged by the project's `file-access.md` rule and left the safety of the handler as an emergent property rather than an explicit assertion. The `spaHandler` also had no unit test coverage at all.

## Goals

Make the SPA static handler's traversal containment explicit and correct, satisfy the `file-access.md` separator-suffixed prefix rule, silence the scanner finding as a documented false positive with hardened code, and lock in the behaviour with the handler's first unit tests.

## Approach

- Replace the bare `strings.HasPrefix(full, filepath.Clean(staticDir))` guard with a separator-suffixed containment assertion so a sibling directory sharing the root's name prefix (e.g. `/var/www` vs `/var/www-secret`) cannot pass.
- Explicitly allow the exact-root case (`full == root`) so a request for `/` still falls through to serving `index.html`.
- Add a comment documenting the security intent so containment is no longer an implicit side effect of `Clean` on a rooted path.
- Add `static_test.go` — the first unit test for `spaHandler` — covering asset serving, index no-store fallback, and traversal containment.

## User stories

N/A

## Documentation

N/A — internal hardening of an existing request handler with no behavioural or API change.

## Automation tests

 - Unit tests
   > New `static_test.go` (137 lines), the first coverage for `spaHandler`: `TestSPAHandlerServesHashedAssetCacheable` (asset served 200, cacheable), `TestSPAHandlerServesIndexNoStore` (`/` and SPA client routes fall back to `index.html` with `no-store`), and `TestSPAHandlerPathTraversalContained` (8 raw and URL-encoded `..` payloads assert a file outside `staticDir` is never served — the regression test for this finding). All passing.
 - Integration tests
   > N/A

## Security checks

 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no (Go component; the flagged finding was reviewed manually, confirmed a false positive, then hardened and covered by a regression test)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

N/A

## Test environment

Go 1.26 (ai-workspace BFF component); `go test ./internal/server/` passes and LSP diagnostics report no type or compile errors.

## Remarks

The original code was **not** an exploitable traversal — this is defense-in-depth hardening that makes the containment guarantee explicit, plus regression tests. The scanner finding on the `os.Stat` line should be marked a false positive.