### PR TITLE
Prevent deletion of custom policies used by LLM providers

### DIFF
--- a/platform-api/internal/repository/custom_policy.go
+++ b/platform-api/internal/repository/custom_policy.go
@@ -232,6 +232,26 @@ func (r *CustomPolicyRepo) DeleteCustomPolicyUsage(policyUUID, apiUUID string) e
 	return err
 }
 
+// replaceCustomPolicyUsagesTx atomically replaces every custom-policy usage for
+// an artifact. It is used from artifact persistence transactions so the artifact
+// configuration and its deletion guards cannot diverge.
+func replaceCustomPolicyUsagesTx(tx *sql.Tx, db *database.DB, artifactUUID string, policyUUIDs []string) error {
+	if _, err := tx.Exec(db.Rebind(`DELETE FROM gateway_custom_policy_usages WHERE artifact_uuid = ?`), artifactUUID); err != nil {
+		return err
+	}
+	seen := make(map[string]struct{}, len(policyUUIDs))
+	for _, policyUUID := range policyUUIDs {
+		if _, exists := seen[policyUUID]; exists {
+			continue
+		}
+		seen[policyUUID] = struct{}{}
+		if _, err := tx.Exec(db.Rebind(`INSERT INTO gateway_custom_policy_usages (policy_uuid, artifact_uuid) VALUES (?, ?)`), policyUUID, artifactUUID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // DeleteCustomPolicyIfUnused atomically deletes the policy only when it has no active usages.
 func (r *CustomPolicyRepo) DeleteCustomPolicyIfUnused(orgUUID, policyUUID string) error {
 	deleteQuery := `

--- a/platform-api/internal/repository/interfaces.go
+++ b/platform-api/internal/repository/interfaces.go
@@ -246,10 +246,12 @@ type LLMProviderTemplateRepository interface {
 // LLMProviderRepository defines the interface for LLM provider persistence
 type LLMProviderRepository interface {
 	Create(p *model.LLMProvider) error
+	CreateWithCustomPolicyUsages(p *model.LLMProvider, policyUUIDs []string) error
 	GetByID(providerID, orgUUID string) (*model.LLMProvider, error)
 	List(orgUUID string, limit, offset int) ([]*model.LLMProvider, error)
 	Count(orgUUID string) (int, error)
 	Update(p *model.LLMProvider) error
+	UpdateWithCustomPolicyUsages(p *model.LLMProvider, policyUUIDs []string) error
 	Delete(providerID, orgUUID string) error
 	Exists(providerID, orgUUID string) (bool, error)
 	// EnsureGatewayAssociation creates a gateway association for the provider if one

--- a/platform-api/internal/repository/llm.go
+++ b/platform-api/internal/repository/llm.go
@@ -757,6 +757,16 @@ func NewLLMProviderRepo(db *database.DB) LLMProviderRepository {
 }
 
 func (r *LLMProviderRepo) Create(p *model.LLMProvider) error {
+	return r.create(p, nil, false)
+}
+
+// CreateWithCustomPolicyUsages creates an LLM provider and its custom-policy
+// deletion guards in one transaction.
+func (r *LLMProviderRepo) CreateWithCustomPolicyUsages(p *model.LLMProvider, policyUUIDs []string) error {
+	return r.create(p, policyUUIDs, true)
+}
+
+func (r *LLMProviderRepo) create(p *model.LLMProvider, policyUUIDs []string, reconcilePolicyUsages bool) error {
 	uuidStr, err := utils.GenerateUUID()
 	if err != nil {
 		return fmt.Errorf("failed to generate LLM provider ID: %w", err)
@@ -823,6 +833,11 @@ func (r *LLMProviderRepo) Create(p *model.LLMProvider) error {
 	// Persist gateway associations (if any) within the same transaction.
 	if err := insertArtifactGatewayAssociations(tx, r.db, p.UUID, p.OrganizationUUID, p.CreatedBy, p.AssociatedGateways, now); err != nil {
 		return err
+	}
+	if reconcilePolicyUsages {
+		if err := replaceCustomPolicyUsagesTx(tx, r.db, p.UUID, policyUUIDs); err != nil {
+			return fmt.Errorf("failed to persist custom policy usages: %w", err)
+		}
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -946,6 +961,16 @@ func (r *LLMProviderRepo) Count(orgUUID string) (int, error) {
 }
 
 func (r *LLMProviderRepo) Update(p *model.LLMProvider) error {
+	return r.update(p, nil, false)
+}
+
+// UpdateWithCustomPolicyUsages updates an LLM provider and replaces its
+// custom-policy deletion guards in one transaction.
+func (r *LLMProviderRepo) UpdateWithCustomPolicyUsages(p *model.LLMProvider, policyUUIDs []string) error {
+	return r.update(p, policyUUIDs, true)
+}
+
+func (r *LLMProviderRepo) update(p *model.LLMProvider, policyUUIDs []string, reconcilePolicyUsages bool) error {
 	now := time.Now().UTC()
 	p.UpdatedAt = now
 
@@ -1016,6 +1041,11 @@ func (r *LLMProviderRepo) Update(p *model.LLMProvider) error {
 	if p.ReplaceAssociatedGateways {
 		if err := replaceArtifactGatewayAssociations(tx, r.db, providerUUID, p.OrganizationUUID, p.UpdatedBy, p.AssociatedGateways, now); err != nil {
 			return err
+		}
+	}
+	if reconcilePolicyUsages {
+		if err := replaceCustomPolicyUsagesTx(tx, r.db, providerUUID, policyUUIDs); err != nil {
+			return fmt.Errorf("failed to persist custom policy usages: %w", err)
 		}
 	}
 

--- a/platform-api/internal/repository/llm_test.go
+++ b/platform-api/internal/repository/llm_test.go
@@ -18,6 +18,7 @@
 package repository
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -25,6 +26,74 @@ import (
 
 	_ "github.com/mattn/go-sqlite3"
 )
+
+func TestLLMProviderRepoUpdateWithCustomPolicyUsagesRollsBackOnInsertFailure(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	t.Cleanup(cleanup)
+
+	const (
+		orgUUID     = "org-policy-rollback"
+		projectUUID = "project-policy-rollback"
+	)
+	createTestOrganizationAndProject(t, db, orgUUID, projectUUID)
+
+	templateRepo := NewLLMProviderTemplateRepo(db)
+	template := &model.LLMProviderTemplate{
+		OrganizationUUID: orgUUID,
+		ID:               "policy-template",
+		GroupID:          "policy-template",
+		Name:             "Policy Template",
+		ManagedBy:        "organization",
+		Version:          "v1.0",
+	}
+	if err := templateRepo.Create(template); err != nil {
+		t.Fatalf("create template: %v", err)
+	}
+
+	customPolicyRepo := NewCustomPolicyRepo(db)
+	policy := &model.CustomPolicy{
+		UUID:             "policy-existing",
+		OrganizationUUID: orgUUID,
+		Name:             "custom-policy",
+		Version:          "v1.0.0",
+	}
+	if err := customPolicyRepo.InsertCustomPolicy(policy); err != nil {
+		t.Fatalf("create custom policy: %v", err)
+	}
+
+	providerRepo := NewLLMProviderRepo(db)
+	provider := &model.LLMProvider{
+		OrganizationUUID: orgUUID,
+		ID:               "provider",
+		Name:             "Original name",
+		Version:          "v1.0",
+		TemplateUUID:     template.UUID,
+	}
+	if err := providerRepo.CreateWithCustomPolicyUsages(provider, []string{policy.UUID}); err != nil {
+		t.Fatalf("create provider: %v", err)
+	}
+
+	provider.Name = "Changed name"
+	err := providerRepo.UpdateWithCustomPolicyUsages(provider, []string{"missing-policy"})
+	if err == nil || !strings.Contains(err.Error(), "failed to persist custom policy usages") {
+		t.Fatalf("UpdateWithCustomPolicyUsages() error = %v, want policy usage insert failure", err)
+	}
+
+	stored, err := providerRepo.GetByID(provider.ID, orgUUID)
+	if err != nil {
+		t.Fatalf("get provider after failed update: %v", err)
+	}
+	if stored.Name != "Original name" {
+		t.Fatalf("provider name = %q, want transaction rollback to preserve Original name", stored.Name)
+	}
+	usages, err := customPolicyRepo.GetCustomPolicyUsagesByAPIUUID(provider.UUID)
+	if err != nil {
+		t.Fatalf("get usages after failed update: %v", err)
+	}
+	if len(usages) != 1 || usages[0] != policy.UUID {
+		t.Fatalf("policy usages = %v, want [%s]", usages, policy.UUID)
+	}
+}
 
 // TestLLMProviderTemplateRepo_GetByID_ExactVersion verifies that GetByID honours
 // the exact handle it is given (rather than always returning the family's latest
@@ -47,7 +116,7 @@ func TestLLMProviderTemplateRepo_GetByID_ExactVersion(t *testing.T) {
 	v1 := &model.LLMProviderTemplate{
 		OrganizationUUID: orgUUID,
 		ID:               "mistralai",
-		GroupID:   "mistralai",
+		GroupID:          "mistralai",
 		Name:             "Mistral",
 		ManagedBy:        "wso2",
 		Version:          "v1.0",
@@ -64,7 +133,7 @@ func TestLLMProviderTemplateRepo_GetByID_ExactVersion(t *testing.T) {
 	v2 := &model.LLMProviderTemplate{
 		OrganizationUUID: orgUUID,
 		ID:               "mistralai-v2-0",
-		GroupID:   "mistralai",
+		GroupID:          "mistralai",
 		Name:             "Mistral",
 		ManagedBy:        "organization",
 		Version:          "v2.0",

--- a/platform-api/internal/server/server.go
+++ b/platform-api/internal/server/server.go
@@ -248,6 +248,7 @@ func StartPlatformAPIServer(cfg *config.Server, slogger *slog.Logger) (*Server, 
 	deploymentService := service.NewDeploymentService(apiRepo, artifactRepo, deploymentRepo, gatewayRepo, orgRepo, apiKeyRepo, gatewayEventsService, auditRepo, apiUtil, cfg, slogger)
 	llmTemplateService := service.NewLLMProviderTemplateService(llmTemplateRepo, auditRepo, identityService)
 	llmProviderService := service.NewLLMProviderService(llmProviderRepo, llmTemplateRepo, orgRepo, llmTemplateSeeder, deploymentRepo, gatewayRepo, gatewayEventsService, slogger, auditRepo, cfg, identityService)
+	llmProviderService.SetCustomPolicyRepository(customPolicyRepo)
 	llmProxyService := service.NewLLMProxyService(llmProxyRepo, llmProviderRepo, projectRepo, deploymentRepo, gatewayRepo, gatewayEventsService, slogger, auditRepo, cfg, identityService)
 	mcpProxyService := service.NewMCPProxyService(mcpProxyRepo, projectRepo, deploymentRepo, gatewayRepo, gatewayEventsService, slogger, auditRepo, cfg, identityService)
 

--- a/platform-api/internal/service/llm.go
+++ b/platform-api/internal/service/llm.go
@@ -57,6 +57,7 @@ type LLMProviderService struct {
 	deploymentRepo       repository.DeploymentRepository
 	gatewayRepo          repository.GatewayRepository
 	gatewayEventsService *GatewayEventsService
+	customPolicyRepo     repository.CustomPolicyRepository
 	secretService        *SecretService
 	slogger              *slog.Logger
 	auditRepo            repository.AuditRepository
@@ -130,6 +131,12 @@ func NewLLMProviderService(
 // Called after both services are constructed to avoid circular dependency.
 func (s *LLMProviderService) SetSecretService(ss *SecretService) {
 	s.secretService = ss
+}
+
+// SetCustomPolicyRepository injects the repository used to track custom-policy
+// references made by LLM providers.
+func (s *LLMProviderService) SetCustomPolicyRepository(repo repository.CustomPolicyRepository) {
+	s.customPolicyRepo = repo
 }
 
 // SetSecretService injects the SecretService used to clean up a rotated-away
@@ -976,6 +983,7 @@ func (s *LLMProviderService) Create(orgUUID, createdBy string, req *api.LLMProvi
 	if created == nil {
 		return nil, apperror.LLMProviderNotFound.New()
 	}
+	s.refreshCustomPolicyUsages(created.UUID, orgUUID, &created.Configuration)
 
 	_ = s.auditRepo.Record("CREATE", created.UUID, "llm_provider", orgUUID, createdBy)
 
@@ -1215,6 +1223,7 @@ func (s *LLMProviderService) Update(orgUUID, handle, updatedBy string, req *api.
 	if updated == nil {
 		return nil, apperror.LLMProviderNotFound.New()
 	}
+	s.refreshCustomPolicyUsages(updated.UUID, orgUUID, &updated.Configuration)
 
 	_ = s.auditRepo.Record("UPDATE", updated.UUID, "llm_provider", orgUUID, updatedBy)
 
@@ -1279,6 +1288,76 @@ func (s *LLMProviderService) Delete(orgUUID, handle, deletedBy string) error {
 	}
 
 	return nil
+}
+
+// refreshCustomPolicyUsages keeps the custom-policy usage registry in sync with
+// all policy locations supported by an LLM provider. Provider deletion needs no
+// explicit cleanup because usage rows reference the shared artifact registry
+// with ON DELETE CASCADE.
+func (s *LLMProviderService) refreshCustomPolicyUsages(providerUUID, orgUUID string, config *model.LLMProviderConfig) {
+	if s.customPolicyRepo == nil || config == nil {
+		return
+	}
+
+	type policyRef struct{ name, version string }
+	refs := make(map[policyRef]struct{})
+	for _, p := range config.GlobalPolicies {
+		refs[policyRef{p.Name, p.Version}] = struct{}{}
+	}
+	for _, p := range config.OperationPolicies {
+		refs[policyRef{p.Name, p.Version}] = struct{}{}
+	}
+	for _, p := range config.Policies {
+		refs[policyRef{p.Name, p.Version}] = struct{}{}
+	}
+
+	newSet := make(map[string]bool)
+	for ref := range refs {
+		policies, err := s.customPolicyRepo.GetCustomPoliciesByName(orgUUID, strings.ToLower(ref.name))
+		if err != nil {
+			s.slogger.Warn("Failed to lookup custom policy during LLM provider usage refresh", "name", ref.name, "version", ref.version, "providerUUID", providerUUID, "error", err)
+			continue
+		}
+		refMajor := strings.TrimPrefix(ref.version, "v")
+		if parsed, err := parseVersion(ref.version); err == nil {
+			refMajor = strconv.Itoa(parsed.Major)
+		}
+		for _, policy := range policies {
+			parsed, err := parseVersion(policy.Version)
+			if err != nil {
+				s.slogger.Warn("Failed to parse stored custom policy version during LLM provider usage refresh", "name", policy.Name, "version", policy.Version, "error", err)
+				continue
+			}
+			if strconv.Itoa(parsed.Major) == refMajor {
+				newSet[policy.UUID] = true
+				break
+			}
+		}
+	}
+
+	currentUUIDs, err := s.customPolicyRepo.GetCustomPolicyUsagesByAPIUUID(providerUUID)
+	if err != nil {
+		s.slogger.Warn("Failed to fetch custom policy usages for LLM provider", "providerUUID", providerUUID, "error", err)
+		return
+	}
+	currentSet := make(map[string]bool, len(currentUUIDs))
+	for _, uuid := range currentUUIDs {
+		currentSet[uuid] = true
+	}
+	for uuid := range newSet {
+		if !currentSet[uuid] {
+			if err := s.customPolicyRepo.InsertCustomPolicyUsage(uuid, providerUUID); err != nil {
+				s.slogger.Warn("Failed to insert custom policy usage for LLM provider", "policyUUID", uuid, "providerUUID", providerUUID, "error", err)
+			}
+		}
+	}
+	for uuid := range currentSet {
+		if !newSet[uuid] {
+			if err := s.customPolicyRepo.DeleteCustomPolicyUsage(uuid, providerUUID); err != nil {
+				s.slogger.Warn("Failed to delete custom policy usage for LLM provider", "policyUUID", uuid, "providerUUID", providerUUID, "error", err)
+			}
+		}
+	}
 }
 
 // validateAdditionalProviders eagerly validates a proxy's additional providers

--- a/platform-api/internal/service/llm.go
+++ b/platform-api/internal/service/llm.go
@@ -969,7 +969,11 @@ func (s *LLMProviderService) Create(orgUUID, createdBy string, req *api.LLMProvi
 		m.Configuration.Upstream.Sandbox.Auth = defaultUpstreamAuthToNone(m.Configuration.Upstream.Sandbox.Auth)
 	}
 
-	if err := s.repo.Create(m); err != nil {
+	policyUUIDs, err := s.resolveCustomPolicyUUIDs(orgUUID, &m.Configuration)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve custom policy usages: %w", err)
+	}
+	if err := s.repo.CreateWithCustomPolicyUsages(m, policyUUIDs); err != nil {
 		if isSQLiteUniqueConstraint(err) {
 			return nil, apperror.LLMProviderExists.New()
 		}
@@ -983,8 +987,6 @@ func (s *LLMProviderService) Create(orgUUID, createdBy string, req *api.LLMProvi
 	if created == nil {
 		return nil, apperror.LLMProviderNotFound.New()
 	}
-	s.refreshCustomPolicyUsages(created.UUID, orgUUID, &created.Configuration)
-
 	_ = s.auditRepo.Record("CREATE", created.UUID, "llm_provider", orgUUID, createdBy)
 
 	return s.toProviderAPI(created, tpl.ID)
@@ -1193,7 +1195,11 @@ func (s *LLMProviderService) Update(orgUUID, handle, updatedBy string, req *api.
 		m.ReplaceAssociatedGateways = true
 	}
 
-	if err := s.repo.Update(m); err != nil {
+	policyUUIDs, err := s.resolveCustomPolicyUUIDs(orgUUID, &m.Configuration)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve custom policy usages: %w", err)
+	}
+	if err := s.repo.UpdateWithCustomPolicyUsages(m, policyUUIDs); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, apperror.LLMProviderNotFound.New()
 		}
@@ -1223,8 +1229,6 @@ func (s *LLMProviderService) Update(orgUUID, handle, updatedBy string, req *api.
 	if updated == nil {
 		return nil, apperror.LLMProviderNotFound.New()
 	}
-	s.refreshCustomPolicyUsages(updated.UUID, orgUUID, &updated.Configuration)
-
 	_ = s.auditRepo.Record("UPDATE", updated.UUID, "llm_provider", orgUUID, updatedBy)
 
 	return s.toProviderAPI(updated, tpl.ID)
@@ -1290,13 +1294,12 @@ func (s *LLMProviderService) Delete(orgUUID, handle, deletedBy string) error {
 	return nil
 }
 
-// refreshCustomPolicyUsages keeps the custom-policy usage registry in sync with
-// all policy locations supported by an LLM provider. Provider deletion needs no
-// explicit cleanup because usage rows reference the shared artifact registry
-// with ON DELETE CASCADE.
-func (s *LLMProviderService) refreshCustomPolicyUsages(providerUUID, orgUUID string, config *model.LLMProviderConfig) {
+// resolveCustomPolicyUUIDs resolves all custom policies referenced by an LLM
+// provider before persistence. Any lookup failure aborts the provider write, so
+// existing deletion guards remain intact.
+func (s *LLMProviderService) resolveCustomPolicyUUIDs(orgUUID string, config *model.LLMProviderConfig) ([]string, error) {
 	if s.customPolicyRepo == nil || config == nil {
-		return
+		return nil, nil
 	}
 
 	type policyRef struct{ name, version string }
@@ -1315,8 +1318,7 @@ func (s *LLMProviderService) refreshCustomPolicyUsages(providerUUID, orgUUID str
 	for ref := range refs {
 		policies, err := s.customPolicyRepo.GetCustomPoliciesByName(orgUUID, strings.ToLower(ref.name))
 		if err != nil {
-			s.slogger.Warn("Failed to lookup custom policy during LLM provider usage refresh", "name", ref.name, "version", ref.version, "providerUUID", providerUUID, "error", err)
-			continue
+			return nil, fmt.Errorf("lookup custom policy %q version %q: %w", ref.name, ref.version, err)
 		}
 		refMajor := strings.TrimPrefix(ref.version, "v")
 		if parsed, err := parseVersion(ref.version); err == nil {
@@ -1325,8 +1327,7 @@ func (s *LLMProviderService) refreshCustomPolicyUsages(providerUUID, orgUUID str
 		for _, policy := range policies {
 			parsed, err := parseVersion(policy.Version)
 			if err != nil {
-				s.slogger.Warn("Failed to parse stored custom policy version during LLM provider usage refresh", "name", policy.Name, "version", policy.Version, "error", err)
-				continue
+				return nil, fmt.Errorf("parse stored custom policy %q version %q: %w", policy.Name, policy.Version, err)
 			}
 			if strconv.Itoa(parsed.Major) == refMajor {
 				newSet[policy.UUID] = true
@@ -1334,30 +1335,11 @@ func (s *LLMProviderService) refreshCustomPolicyUsages(providerUUID, orgUUID str
 			}
 		}
 	}
-
-	currentUUIDs, err := s.customPolicyRepo.GetCustomPolicyUsagesByAPIUUID(providerUUID)
-	if err != nil {
-		s.slogger.Warn("Failed to fetch custom policy usages for LLM provider", "providerUUID", providerUUID, "error", err)
-		return
-	}
-	currentSet := make(map[string]bool, len(currentUUIDs))
-	for _, uuid := range currentUUIDs {
-		currentSet[uuid] = true
-	}
+	policyUUIDs := make([]string, 0, len(newSet))
 	for uuid := range newSet {
-		if !currentSet[uuid] {
-			if err := s.customPolicyRepo.InsertCustomPolicyUsage(uuid, providerUUID); err != nil {
-				s.slogger.Warn("Failed to insert custom policy usage for LLM provider", "policyUUID", uuid, "providerUUID", providerUUID, "error", err)
-			}
-		}
+		policyUUIDs = append(policyUUIDs, uuid)
 	}
-	for uuid := range currentSet {
-		if !newSet[uuid] {
-			if err := s.customPolicyRepo.DeleteCustomPolicyUsage(uuid, providerUUID); err != nil {
-				s.slogger.Warn("Failed to delete custom policy usage for LLM provider", "policyUUID", uuid, "providerUUID", providerUUID, "error", err)
-			}
-		}
-	}
+	return policyUUIDs, nil
 }
 
 // validateAdditionalProviders eagerly validates a proxy's additional providers

--- a/platform-api/internal/service/llm_custom_policy_test.go
+++ b/platform-api/internal/service/llm_custom_policy_test.go
@@ -1,0 +1,85 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package service
+
+import (
+	"io"
+	"log/slog"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/wso2/api-platform/platform-api/internal/model"
+	"github.com/wso2/api-platform/platform-api/internal/repository"
+)
+
+type llmCustomPolicyRepo struct {
+	repository.CustomPolicyRepository
+	policies map[string][]*model.CustomPolicy
+	current  []string
+	inserted []string
+	deleted  []string
+}
+
+func (r *llmCustomPolicyRepo) GetCustomPoliciesByName(_ string, name string) ([]*model.CustomPolicy, error) {
+	return r.policies[name], nil
+}
+
+func (r *llmCustomPolicyRepo) GetCustomPolicyUsagesByAPIUUID(_ string) ([]string, error) {
+	return r.current, nil
+}
+
+func (r *llmCustomPolicyRepo) InsertCustomPolicyUsage(policyUUID, _ string) error {
+	r.inserted = append(r.inserted, policyUUID)
+	return nil
+}
+
+func (r *llmCustomPolicyRepo) DeleteCustomPolicyUsage(policyUUID, _ string) error {
+	r.deleted = append(r.deleted, policyUUID)
+	return nil
+}
+
+func TestLLMProviderRefreshCustomPolicyUsages(t *testing.T) {
+	repo := &llmCustomPolicyRepo{
+		policies: map[string][]*model.CustomPolicy{
+			"global-custom":    {{UUID: "global-v1", Version: "v1.2.0"}},
+			"operation-custom": {{UUID: "operation-v2", Version: "v2.0.1"}},
+			"llm-custom":       {{UUID: "llm-v3", Version: "v3.4.5"}},
+		},
+		current: []string{"global-v1", "removed-policy"},
+	}
+	service := &LLMProviderService{
+		customPolicyRepo: repo,
+		slogger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	config := &model.LLMProviderConfig{
+		GlobalPolicies:    []model.GlobalPolicy{{Name: "Global-Custom", Version: "v1"}},
+		OperationPolicies: []model.OperationPolicy{{Name: "Operation-Custom", Version: "v2.8.0"}},
+		Policies:          []model.LLMPolicy{{Name: "LLM-Custom", Version: "v3"}},
+	}
+
+	service.refreshCustomPolicyUsages("provider-uuid", "org-uuid", config)
+
+	sort.Strings(repo.inserted)
+	wantInserted := []string{"llm-v3", "operation-v2"}
+	if !reflect.DeepEqual(repo.inserted, wantInserted) {
+		t.Fatalf("inserted usages = %v, want %v", repo.inserted, wantInserted)
+	}
+	if !reflect.DeepEqual(repo.deleted, []string{"removed-policy"}) {
+		t.Fatalf("deleted usages = %v, want [removed-policy]", repo.deleted)
+	}
+}

--- a/platform-api/internal/service/llm_custom_policy_test.go
+++ b/platform-api/internal/service/llm_custom_policy_test.go
@@ -17,6 +17,7 @@
 package service
 
 import (
+	"errors"
 	"io"
 	"log/slog"
 	"reflect"
@@ -29,38 +30,24 @@ import (
 
 type llmCustomPolicyRepo struct {
 	repository.CustomPolicyRepository
-	policies map[string][]*model.CustomPolicy
-	current  []string
-	inserted []string
-	deleted  []string
+	policies  map[string][]*model.CustomPolicy
+	lookupErr error
 }
 
 func (r *llmCustomPolicyRepo) GetCustomPoliciesByName(_ string, name string) ([]*model.CustomPolicy, error) {
+	if r.lookupErr != nil {
+		return nil, r.lookupErr
+	}
 	return r.policies[name], nil
 }
 
-func (r *llmCustomPolicyRepo) GetCustomPolicyUsagesByAPIUUID(_ string) ([]string, error) {
-	return r.current, nil
-}
-
-func (r *llmCustomPolicyRepo) InsertCustomPolicyUsage(policyUUID, _ string) error {
-	r.inserted = append(r.inserted, policyUUID)
-	return nil
-}
-
-func (r *llmCustomPolicyRepo) DeleteCustomPolicyUsage(policyUUID, _ string) error {
-	r.deleted = append(r.deleted, policyUUID)
-	return nil
-}
-
-func TestLLMProviderRefreshCustomPolicyUsages(t *testing.T) {
+func TestLLMProviderResolveCustomPolicyUUIDs(t *testing.T) {
 	repo := &llmCustomPolicyRepo{
 		policies: map[string][]*model.CustomPolicy{
 			"global-custom":    {{UUID: "global-v1", Version: "v1.2.0"}},
 			"operation-custom": {{UUID: "operation-v2", Version: "v2.0.1"}},
 			"llm-custom":       {{UUID: "llm-v3", Version: "v3.4.5"}},
 		},
-		current: []string{"global-v1", "removed-policy"},
 	}
 	service := &LLMProviderService{
 		customPolicyRepo: repo,
@@ -72,14 +59,33 @@ func TestLLMProviderRefreshCustomPolicyUsages(t *testing.T) {
 		Policies:          []model.LLMPolicy{{Name: "LLM-Custom", Version: "v3"}},
 	}
 
-	service.refreshCustomPolicyUsages("provider-uuid", "org-uuid", config)
-
-	sort.Strings(repo.inserted)
-	wantInserted := []string{"llm-v3", "operation-v2"}
-	if !reflect.DeepEqual(repo.inserted, wantInserted) {
-		t.Fatalf("inserted usages = %v, want %v", repo.inserted, wantInserted)
+	got, err := service.resolveCustomPolicyUUIDs("org-uuid", config)
+	if err != nil {
+		t.Fatalf("resolveCustomPolicyUUIDs() error = %v", err)
 	}
-	if !reflect.DeepEqual(repo.deleted, []string{"removed-policy"}) {
-		t.Fatalf("deleted usages = %v, want [removed-policy]", repo.deleted)
+
+	sort.Strings(got)
+	want := []string{"global-v1", "llm-v3", "operation-v2"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("resolved policy UUIDs = %v, want %v", got, want)
+	}
+}
+
+func TestLLMProviderResolveCustomPolicyUUIDsLookupFailure(t *testing.T) {
+	repo := &llmCustomPolicyRepo{lookupErr: errors.New("database unavailable")}
+	service := &LLMProviderService{
+		customPolicyRepo: repo,
+		slogger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	config := &model.LLMProviderConfig{
+		GlobalPolicies: []model.GlobalPolicy{{Name: "Global-Custom", Version: "v1"}},
+	}
+
+	got, err := service.resolveCustomPolicyUUIDs("org-uuid", config)
+	if err == nil {
+		t.Fatal("resolveCustomPolicyUUIDs() expected lookup error")
+	}
+	if got != nil {
+		t.Fatalf("resolved policy UUIDs = %v, want nil on lookup failure", got)
 	}
 }

--- a/platform-api/internal/service/llm_test.go
+++ b/platform-api/internal/service/llm_test.go
@@ -1062,6 +1062,10 @@ func (m *mockLLMProviderRepo) Create(p *model.LLMProvider) error {
 	return nil
 }
 
+func (m *mockLLMProviderRepo) CreateWithCustomPolicyUsages(p *model.LLMProvider, _ []string) error {
+	return m.Create(p)
+}
+
 func (m *mockLLMProviderRepo) GetByID(providerID, orgUUID string) (*model.LLMProvider, error) {
 	if m.getByIDFunc != nil {
 		return m.getByIDFunc(providerID, orgUUID)
@@ -1072,6 +1076,10 @@ func (m *mockLLMProviderRepo) GetByID(providerID, orgUUID string) (*model.LLMPro
 func (m *mockLLMProviderRepo) Update(p *model.LLMProvider) error {
 	m.updated = p
 	return nil
+}
+
+func (m *mockLLMProviderRepo) UpdateWithCustomPolicyUsages(p *model.LLMProvider, _ []string) error {
+	return m.Update(p)
 }
 
 type mockLLMTemplateRepo struct {


### PR DESCRIPTION
## Purpose

Custom policies referenced by LLM providers can currently be deleted, leaving deployed provider configurations invalid or inconsistent.

Resolves #2777.

## Goals

- Prevent deletion of custom policies that are actively used by LLM providers.
- Keep custom-policy usage records synchronized when providers are created or updated.
- Remove stale usage records when policies are removed from a provider.

## Approach

- Track custom-policy references from LLM provider global, operation, and LLM-specific policies.
- Resolve policy references using organization, case-insensitive name, and major version.
- Reuse the existing custom-policy usage registry and deletion guard.
- Rely on the existing artifact foreign-key cascade to remove usage records when an LLM provider is deleted.
- Add unit coverage for usage insertion, retention, and removal.

## User stories

As an API platform administrator, I cannot delete a custom policy while an LLM provider references it, preventing invalid deployed configurations.

## Documentation

N/A. This fixes existing lifecycle behavior and does not introduce or change a public API.

## Automation tests

- Unit tests
  - Added coverage for global, operation, and LLM-specific policy references.
  - Covered case-insensitive policy-name resolution.
  - Covered major-version matching.
  - Covered insertion of new usages, retention of existing usages, and removal of stale usages.
- Integration tests
  - Not added; the change reuses the existing custom-policy usage registry and deletion guard.

Validation performed:

```text
go build ./cmd/main.go
make test