### PR TITLE
Apply upstreamDefinition Connect Timeout on the RuntimeDeployConfig Path

### DIFF
--- a/gateway/gateway-controller/pkg/models/runtime_deploy_config.go
+++ b/gateway/gateway-controller/pkg/models/runtime_deploy_config.go
@@ -117,10 +117,11 @@ type Policy struct {
 
 // UpstreamCluster represents an Envoy cluster with its endpoints.
 type UpstreamCluster struct {
-	Name      string // upstream definition name; "" for the main/sandbox slot clusters
-	BasePath  string
-	Endpoints []Endpoint
-	TLS       *UpstreamTLS
+	Name           string // upstream definition name; "" for the main/sandbox slot clusters
+	BasePath       string
+	Endpoints      []Endpoint
+	TLS            *UpstreamTLS
+	ConnectTimeout *time.Duration // ConnectTimeout is the per-upstream TCP connect timeout
 }
 
 // Endpoint is a single upstream host:port target.

--- a/gateway/gateway-controller/pkg/transform/restapi.go
+++ b/gateway/gateway-controller/pkg/transform/restapi.go
@@ -247,6 +247,10 @@ func (t *RestAPITransformer) Transform(cfg *models.StoredConfig) (*models.Runtim
 			if def.BasePath != nil && *def.BasePath != "" {
 				basePath = *def.BasePath
 			}
+			defConnectTimeout, err := definitionConnectTimeout(&def)
+			if err != nil {
+				return nil, fmt.Errorf("upstream definition '%s': %w", def.Name, err)
+			}
 			endpoints := make([]models.Endpoint, 0, len(def.Upstreams))
 			tlsExists := false
 			plaintextExists := false
@@ -278,10 +282,11 @@ func (t *RestAPITransformer) Transform(cfg *models.StoredConfig) (*models.Runtim
 					"all endpoints in a definition must use the same scheme", def.Name)
 			}
 			rdc.UpstreamClusters[defClusterKey] = &models.UpstreamCluster{
-				Name:      def.Name,
-				BasePath:  basePath,
-				Endpoints: endpoints,
-				TLS:       &models.UpstreamTLS{Enabled: tlsExists},
+				Name:           def.Name,
+				BasePath:       basePath,
+				Endpoints:      endpoints,
+				TLS:            &models.UpstreamTLS{Enabled: tlsExists},
+				ConnectTimeout: defConnectTimeout,
 			}
 		}
 	}
@@ -496,6 +501,18 @@ func (t *RestAPITransformer) addUpstreamCluster(
 		basePath = "/"
 	}
 
+	// The connect timeout can only come from a referenced upstreamDefinition
+	// (direct-URL upstreams have no timeout field). Resolve it here so the RDC->Envoy
+	// translation applies it to this cluster instead of falling back to the global default.
+	var connectTimeout *time.Duration
+	if up != nil && up.Ref != nil && strings.TrimSpace(*up.Ref) != "" {
+		ct, terr := definitionConnectTimeout(lookupUpstreamDefinition(*up.Ref, upstreamDefinitions))
+		if terr != nil {
+			return nil, fmt.Errorf("%s upstream: %w", upstreamName, terr)
+		}
+		connectTimeout = ct
+	}
+
 	clusterKey := fmt.Sprintf("upstream_%s_%s_%d", upstreamName, parsedURL.Hostname(), port)
 
 	rdc.UpstreamClusters[clusterKey] = &models.UpstreamCluster{
@@ -504,7 +521,8 @@ func (t *RestAPITransformer) addUpstreamCluster(
 			Host: parsedURL.Hostname(),
 			Port: port,
 		}},
-		TLS: &models.UpstreamTLS{Enabled: parsedURL.Scheme == "https"},
+		TLS:            &models.UpstreamTLS{Enabled: parsedURL.Scheme == "https"},
+		ConnectTimeout: connectTimeout,
 	}
 
 	return &upstreamClusterResult{
@@ -521,6 +539,43 @@ func sanitizeEnvoyClusterName(host, scheme string) string {
 	name := strings.ReplaceAll(host, ".", "_")
 	name = strings.ReplaceAll(name, ":", "_")
 	return "cluster_" + scheme + "_" + name
+}
+
+// lookupUpstreamDefinition returns the upstream definition named ref (after trimming
+// whitespace), or nil if defs is nil or no definition matches.
+func lookupUpstreamDefinition(ref string, defs *[]api.UpstreamDefinition) *api.UpstreamDefinition {
+	if defs == nil {
+		return nil
+	}
+	name := strings.TrimSpace(ref)
+	for i := range *defs {
+		if strings.TrimSpace((*defs)[i].Name) == name {
+			return &(*defs)[i]
+		}
+	}
+	return nil
+}
+
+// definitionConnectTimeout parses an upstream definition's timeout.connect into a
+// *time.Duration. A nil definition, absent timeout, or empty string yields (nil, nil)
+// meaning "use the router's global default". A malformed or non-positive value is an
+// error so a bad config fails fast instead of silently falling back to the default.
+func definitionConnectTimeout(def *api.UpstreamDefinition) (*time.Duration, error) {
+	if def == nil || def.Timeout == nil || def.Timeout.Connect == nil {
+		return nil, nil
+	}
+	s := strings.TrimSpace(*def.Timeout.Connect)
+	if s == "" {
+		return nil, nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return nil, fmt.Errorf("invalid connect timeout %q: %w", s, err)
+	}
+	if d <= 0 {
+		return nil, fmt.Errorf("connect timeout must be positive, got %v", d)
+	}
+	return &d, nil
 }
 
 // resolveUpstreamURL resolves the URL from an upstream (direct URL or ref). For a ref it

--- a/gateway/gateway-controller/pkg/transform/restapi_test.go
+++ b/gateway/gateway-controller/pkg/transform/restapi_test.go
@@ -761,7 +761,7 @@ func TestRestAPITransformer_SimpleAndMatchSamePathCoexist(t *testing.T) {
 		Version:     "1.0.0",
 		Operations: []api.Operation{
 			{Method: api.Ptr(api.OperationMethod("GET")), Path: api.Ptr("/via-match")}, // simple, header-less
-			{Match: mkMatch("GET", "/via-match", hdrMatch("x-variant", "alpha"))},        // match, header-conditioned
+			{Match: mkMatch("GET", "/via-match", hdrMatch("x-variant", "alpha"))},      // match, header-conditioned
 		},
 		Upstream: struct {
 			Main    api.Upstream  `json:"main" yaml:"main"`
@@ -851,5 +851,63 @@ func TestRestAPITransformer_OperationFormCombinations(t *testing.T) {
 		base := "GET|/test/c|main.local"
 		require.Contains(t, rdc.Routes, base)
 		require.Empty(t, rdc.Routes[base].MatchHeaders)
+	})
+}
+
+// TestRestAPITransformer_ConnectTimeoutFromDefinition is the transformer half of the
+// connect-timeout regression guard: an upstreamDefinition's timeout.connect must be carried
+// onto the RuntimeDeployConfig clusters (both the definition cluster and an API-level cluster
+// that references it) so the RDC->Envoy translation can apply it instead of dropping it.
+// A definition without a timeout leaves ConnectTimeout nil (the global default applies later).
+func TestRestAPITransformer_ConnectTimeoutFromDefinition(t *testing.T) {
+	transformer := NewRestAPITransformer(testRouterCfg(), &config.Config{}, map[string]models.PolicyDefinition{})
+
+	build := func(connect *string) (*models.RuntimeDeployConfig, error) {
+		def := api.UpstreamDefinition{
+			Name: "timed-svc",
+			Upstreams: []struct {
+				Url    string `json:"url" yaml:"url"`
+				Weight *int   `json:"weight,omitempty" yaml:"weight,omitempty"`
+			}{{Url: "http://backend:8080"}},
+		}
+		if connect != nil {
+			def.Timeout = &api.UpstreamTimeout{Connect: connect}
+		}
+		apiData := api.APIConfigData{
+			DisplayName:         "Timeout API",
+			Context:             "/test",
+			Version:             "1.0.0",
+			UpstreamDefinitions: &[]api.UpstreamDefinition{def},
+			Upstream: struct {
+				Main    api.Upstream  `json:"main" yaml:"main"`
+				Sandbox *api.Upstream `json:"sandbox,omitempty" yaml:"sandbox,omitempty"`
+			}{Main: api.Upstream{Ref: ptrStr("timed-svc")}},
+			Operations: []api.Operation{{Method: api.Ptr(api.OperationMethod("GET")), Path: ptrStr("/hello")}},
+		}
+		return transformer.Transform(&models.StoredConfig{
+			UUID: "timeout-api", Kind: string(api.RestAPIKindRestApi),
+			Configuration: api.RestAPI{Kind: api.RestAPIKindRestApi, Metadata: api.Metadata{Name: "timeout-api"}, Spec: apiData},
+		})
+	}
+
+	t.Run("definition timeout maps onto every referencing cluster", func(t *testing.T) {
+		rdc, err := build(ptrStr("8s"))
+		require.NoError(t, err)
+		// Both the API-level ref cluster and the definition cluster reference timed-svc.
+		require.GreaterOrEqual(t, len(rdc.UpstreamClusters), 2,
+			"expected the API-level ref cluster and the definition cluster")
+		for name, uc := range rdc.UpstreamClusters {
+			require.NotNil(t, uc.ConnectTimeout, "cluster %q must carry the definition connect timeout", name)
+			assert.Equal(t, 8*time.Second, *uc.ConnectTimeout, "cluster %q connect timeout", name)
+		}
+	})
+
+	t.Run("no definition timeout leaves ConnectTimeout nil", func(t *testing.T) {
+		rdc, err := build(nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, rdc.UpstreamClusters)
+		for name, uc := range rdc.UpstreamClusters {
+			assert.Nil(t, uc.ConnectTimeout, "cluster %q must have no connect timeout so the global default applies", name)
+		}
 	})
 }

--- a/gateway/gateway-controller/pkg/xds/translator.go
+++ b/gateway/gateway-controller/pkg/xds/translator.go
@@ -101,8 +101,8 @@ type Translator struct {
 // Route and Idle come from the resilience block.
 type resolvedTimeout struct {
 	Connect *time.Duration
-	Route *time.Duration
-	Idle  *time.Duration
+	Route   *time.Duration
+	Idle    *time.Duration
 }
 
 // NewTranslator creates a new translator
@@ -240,7 +240,10 @@ func (t *Translator) translateRuntimeConfig(rdc *models.RuntimeDeployConfig) ([]
 		if len(uc.Endpoints) == 0 {
 			continue
 		}
-		var connectTimeout *time.Duration
+		// Per-upstream connect timeout resolved by the transformer from
+		// upstreamDefinitions.timeout.connect; nil falls back to the router default
+		// inside createCluster/createWeightedCluster.
+		connectTimeout := uc.ConnectTimeout
 		if len(uc.Endpoints) == 1 {
 			ep := uc.Endpoints[0]
 			parsedURL := &url.URL{

--- a/gateway/gateway-controller/pkg/xds/translator_test.go
+++ b/gateway/gateway-controller/pkg/xds/translator_test.go
@@ -2499,3 +2499,41 @@ func TestBuildMatchHeaders_HeaderMatchersRendered(t *testing.T) {
 	require.True(t, ok, "RegularExpression header match must stay a safe_regex, got %T", flavor.GetHeaderMatchSpecifier())
 	assert.Equal(t, "red|blue", rx.SafeRegexMatch.GetRegex())
 }
+
+// TestTranslator_TranslateRuntimeConfig_AppliesConnectTimeout is the translator half of the
+// connect-timeout regression guard: translateRuntimeConfig must apply an UpstreamCluster's
+// ConnectTimeout to the emitted Envoy cluster, and fall back to the router's global default
+// (5s here) when it is nil — rather than dropping the per-upstream value.
+func TestTranslator_TranslateRuntimeConfig_AppliesConnectTimeout(t *testing.T) {
+	translator := createTestTranslator()
+	d := 8 * time.Second
+	rdc := &models.RuntimeDeployConfig{
+		Metadata: models.Metadata{UUID: "u", Kind: "RestApi"},
+		Routes:   map[string]*models.Route{},
+		UpstreamClusters: map[string]*models.UpstreamCluster{
+			"with_timeout": {
+				BasePath:       "/",
+				Endpoints:      []models.Endpoint{{Host: "backend", Port: 8080}},
+				TLS:            &models.UpstreamTLS{},
+				ConnectTimeout: &d,
+			},
+			"without_timeout": {
+				BasePath:  "/",
+				Endpoints: []models.Endpoint{{Host: "backend2", Port: 8080}},
+				TLS:       &models.UpstreamTLS{},
+			},
+		},
+	}
+
+	_, clusters, err := translator.translateRuntimeConfig(rdc)
+	require.NoError(t, err)
+
+	got := map[string]time.Duration{}
+	for _, c := range clusters {
+		got[c.GetName()] = c.GetConnectTimeout().AsDuration()
+	}
+	assert.Equal(t, 8*time.Second, got["with_timeout"],
+		"an explicit per-upstream connect timeout must be applied to the Envoy cluster")
+	assert.Equal(t, 5*time.Second, got["without_timeout"],
+		"a nil connect timeout must fall back to the router global default (5s), not be dropped to zero")
+}

--- a/gateway/it/features/upstream-connect-timeout.feature
+++ b/gateway/it/features/upstream-connect-timeout.feature
@@ -30,6 +30,10 @@ Feature: Timeouts
 
   # Tests cluster connect_timeout: upstream does not accept TCP connection in time.
   # Uses unreachable IP (192.0.2.1 per RFC 5737) so connect attempt hangs until connect_timeout.
+  # The definition timeout (8s) is chosen deliberately above the global default (5s) plus the
+  # 1s assertion tolerance: the "at least 8 seconds" check (effective >=7s) can only pass if the
+  # per-upstream 8s timeout actually reaches Envoy. If the connect timeout were dropped and the
+  # cluster fell back to the 5s default, the request would 503 at ~5s and this assertion would fail.
   Scenario: RestApi backend timeout using upstreamDefinitions
     Given I authenticate using basic auth as "admin"
     When I deploy this API configuration:
@@ -45,7 +49,7 @@ Feature: Timeouts
         upstreamDefinitions:
           - name: my-timeout-upstream
             timeout:
-              connect: 6000ms
+              connect: 8000ms
             upstreams:
               - url: http://192.0.2.1:8080
         upstream:
@@ -62,7 +66,7 @@ Feature: Timeouts
     And I record the current time as "request_start"
     When I send a GET request to "http://localhost:8080/timeout-api/v1.0/"
     Then the response status code should be 503
-    And the request should have taken at least "6" seconds since "request_start"
+    And the request should have taken at least "8" seconds since "request_start"
     Given I authenticate using basic auth as "admin"
     When I delete the API "timeout-api-v1.0"
     Then the response should be successful
@@ -142,8 +146,9 @@ Feature: Timeouts
 
   # LLM Provider connect_timeout via upstreamDefinitions ref: the provider's upstream references a
   # definition whose only target is unreachable (192.0.2.1). The connect attempt hangs until the
-  # per-upstream connect timeout (6s), then the gateway returns 503. Proves the ref -> upstreamDefinition
-  # connect timeout works for LLM providers exactly as it does for RestApi.
+  # per-upstream connect timeout (8s), then the gateway returns 503. Proves the ref -> upstreamDefinition
+  # connect timeout works for LLM providers exactly as it does for RestApi. The 8s value (above the 5s
+  # global default + 1s tolerance) makes "at least 8 seconds" pass only when the timeout truly applies.
   Scenario: LLM provider backend connect timeout using upstreamDefinitions ref
     Given I authenticate using basic auth as "admin"
     When I create this LLM provider:
@@ -160,7 +165,7 @@ Feature: Timeouts
         upstreamDefinitions:
           - name: llm-unreachable-upstream
             timeout:
-              connect: 6000ms
+              connect: 8000ms
             upstreams:
               - url: http://192.0.2.1:8080
         upstream:
@@ -173,13 +178,15 @@ Feature: Timeouts
     And I record the current time as "request_start"
     When I send a GET request to "http://localhost:8080/llm-connect-timeout/get"
     Then the response status code should be 503
-    And the request should have taken at least "6" seconds since "request_start"
+    And the request should have taken at least "8" seconds since "request_start"
     Given I authenticate using basic auth as "admin"
     When I delete the LLM provider "llm-connect-timeout-provider"
     Then the response should be successful
 
   # MCP connect_timeout via upstreamDefinitions ref: the MCP backend reference is unreachable, so the
-  # synthesized /mcp route's connect attempt hangs until the per-upstream connect timeout (6s) -> 503.
+  # synthesized /mcp route's connect attempt hangs until the per-upstream connect timeout (8s) -> 503.
+  # The 8s value (above the 5s global default + 1s tolerance) makes "at least 8 seconds" pass only
+  # when the per-upstream timeout truly reaches Envoy, not when it silently falls back to the default.
   Scenario: MCP backend connect timeout using upstreamDefinitions ref
     Given I authenticate using basic auth as "admin"
     When I deploy this MCP configuration:
@@ -196,7 +203,7 @@ Feature: Timeouts
         upstreamDefinitions:
           - name: mcp-unreachable-upstream
             timeout:
-              connect: 6000ms
+              connect: 8000ms
             upstreams:
               - url: http://192.0.2.1:3001
         upstream:
@@ -210,7 +217,7 @@ Feature: Timeouts
     And I record the current time as "request_start"
     When I send a GET request to "http://localhost:8080/mcp-connect-timeout/mcp"
     Then the response status code should be 503
-    And the request should have taken at least "6" seconds since "request_start"
+    And the request should have taken at least "8" seconds since "request_start"
     Given I authenticate using basic auth as "admin"
     When I delete the MCP proxy "mcp-connect-timeout"
     Then the response should be successful


### PR DESCRIPTION
## Purpose
> Connect timeout settings defined in upstreamDefinitions[].timeout.connect were being ignored for REST, MCP, and LLM APIs, causing all upstreams to use Envoy's default 5-second timeout. This change fixes the issue by carrying the configured connect timeout through the deployment model and into the generated Envoy clusters. It also updates integration tests to verify an 8-second timeout is applied and adds unit tests to prevent regressions.

- Related issue: https://github.com/wso2/api-platform/issues/1000