### PR TITLE
 Fix the issue of LLM proxy returning 401 when the provider uses an API key prefix 

### DIFF
--- a/gateway/gateway-controller/pkg/constants/constants.go
+++ b/gateway/gateway-controller/pkg/constants/constants.go
@@ -137,7 +137,7 @@ const (
 	WEBSUB_HUB_DYNAMIC_HTTP_PORT   = 8082
 	WEBSUB_HUB_DYNAMIC_HTTPS_PORT  = 8445
 
-	// LLM Transformer constants
+	API_KEY_AUTH_POLICY_NAME           = "api-key-auth"
 	UPSTREAM_AUTH_APIKEY_POLICY_NAME   = "set-headers"
 	UPSTREAM_AUTH_APIKEY_POLICY_PARAMS = "request:\n" +
 		"  headers:\n" +

--- a/gateway/gateway-controller/pkg/utils/llm_transformer.go
+++ b/gateway/gateway-controller/pkg/utils/llm_transformer.go
@@ -149,6 +149,11 @@ func (t *LLMProviderTransformer) transformProxy(proxy *api.LLMProxyConfiguration
 		Url: &upstream,
 	}
 
+	// valuePrefix of each additional provider's downstream api-key-auth, keyed by
+	// provider id, captured while resolving them below and reused when attaching the
+	// per-provider loopback upstream auth (Step 3.5).
+	additionalValuePrefixByID := map[string]string{}
+
 	// Step 3.1: Resolve additional providers (multi-provider proxies). Each is
 	// exposed as a named UpstreamDefinition so policies can route to it via
 	// the loopback context. The primary provider above remains the default.
@@ -178,6 +183,9 @@ func (t *LLMProviderTransformer) transformProxy(proxy *api.LLMProxyConfiguration
 			addCtx, err := addCfg.GetContext()
 			if err != nil {
 				return nil, fmt.Errorf("failed to get context for additional provider '%s': %w", ap.Id, err)
+			}
+			if addProviderConfig, ok := addCfg.SourceConfiguration.(api.LLMProviderConfiguration); ok {
+				additionalValuePrefixByID[ap.Id] = apiKeyAuthValuePrefix(addProviderConfig.Spec.GlobalPolicies)
 			}
 			addURL := fmt.Sprintf("%s://%s:%d%s",
 				constants.SchemeHTTP, constants.LocalhostIP, t.routerConfig.ListenerPort, addCtx)
@@ -231,7 +239,7 @@ func (t *LLMProviderTransformer) transformProxy(proxy *api.LLMProxyConfiguration
 	var upstreamAuthPolicies []api.Policy
 	var transformerPolicies []api.Policy
 	if proxy.Spec.Provider.Auth != nil {
-		pol, err := t.proxyUpstreamAuthPolicy(proxy.Spec.Provider.Auth, "provider.auth")
+		pol, err := t.proxyUpstreamAuthPolicy(proxy.Spec.Provider.Auth, apiKeyAuthValuePrefix(providerConfig.Spec.GlobalPolicies), "provider.auth")
 		if err != nil {
 			return nil, err
 		}
@@ -250,7 +258,7 @@ func (t *LLMProviderTransformer) transformProxy(proxy *api.LLMProxyConfiguration
 			}
 
 			if ap.Auth != nil {
-				pol, err := t.proxyUpstreamAuthPolicy(ap.Auth, fmt.Sprintf("additionalProviders[%s].auth", name))
+				pol, err := t.proxyUpstreamAuthPolicy(ap.Auth, additionalValuePrefixByID[ap.Id], fmt.Sprintf("additionalProviders[%s].auth", name))
 				if err != nil {
 					return nil, err
 				}
@@ -768,7 +776,26 @@ func GetUpstreamAuthApikeyPolicyParams(header, value string) (map[string]interfa
 	return m, nil
 }
 
-func (t *LLMProviderTransformer) proxyUpstreamAuthPolicy(auth *api.LLMUpstreamAuth, field string) (*api.Policy, error) {
+// apiKeyAuthValuePrefix returns the valuePrefix configured on a provider's downstream
+// api-key-auth global policy (empty when absent). A proxy loops back into the provider's
+// own context, so the credential it injects on that hop must carry the same prefix the
+// provider's api-key-auth expects, otherwise the loopback request is rejected with 401.
+func apiKeyAuthValuePrefix(globalPolicies *[]api.Policy) string {
+	if globalPolicies == nil {
+		return ""
+	}
+	for _, p := range *globalPolicies {
+		if p.Name != constants.API_KEY_AUTH_POLICY_NAME || p.Params == nil {
+			continue
+		}
+		if v, ok := (*p.Params)["valuePrefix"].(string); ok {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}
+
+func (t *LLMProviderTransformer) proxyUpstreamAuthPolicy(auth *api.LLMUpstreamAuth, valuePrefix, field string) (*api.Policy, error) {
 	if auth == nil {
 		return nil, nil
 	}
@@ -780,7 +807,14 @@ func (t *LLMProviderTransformer) proxyUpstreamAuthPolicy(auth *api.LLMUpstreamAu
 		if auth.Value == nil || *auth.Value == "" {
 			return nil, fmt.Errorf("%s.value is required", field)
 		}
-		params, err := GetUpstreamAuthApikeyPolicyParams(*auth.Header, *auth.Value)
+		// The loopback hop re-enters the provider's own api-key-auth. When that policy
+		// declares a valuePrefix (e.g. "Bearer"), the injected credential must be prefixed
+		// the same way — a single space separator matches how the provider strips it.
+		value := *auth.Value
+		if valuePrefix != "" {
+			value = valuePrefix + " " + value
+		}
+		params, err := GetUpstreamAuthApikeyPolicyParams(*auth.Header, value)
 		if err != nil {
 			return nil, fmt.Errorf("failed to build upstream auth params: %w", err)
 		}

--- a/gateway/gateway-controller/pkg/utils/llm_transformer.go
+++ b/gateway/gateway-controller/pkg/utils/llm_transformer.go
@@ -766,14 +766,19 @@ func applyResilienceToTrafficRoutes(ops []api.Operation, resilience *api.Resilie
 	}
 }
 
-// GetUpstreamAuthApikeyPolicyParams renders the policy params with given header and value
+// GetUpstreamAuthApikeyPolicyParams builds the set-headers policy params for the given
+// header and value.
 func GetUpstreamAuthApikeyPolicyParams(header, value string) (map[string]interface{}, error) {
-	rendered := fmt.Sprintf(constants.UPSTREAM_AUTH_APIKEY_POLICY_PARAMS, header, value)
-	var m map[string]interface{}
-	if err := yaml.Unmarshal([]byte(rendered), &m); err != nil {
-		return nil, err
-	}
-	return m, nil
+	return map[string]interface{}{
+		"request": map[string]interface{}{
+			"headers": []interface{}{
+				map[string]interface{}{
+					"name":  header,
+					"value": value,
+				},
+			},
+		},
+	}, nil
 }
 
 // apiKeyAuthValuePrefix returns the valuePrefix configured on a provider's downstream
@@ -876,15 +881,13 @@ func selectedProviderExecutionCondition(providerName string, includeDefault bool
 	return fmt.Sprintf("'selected_provider' in request.Metadata && %s", selectedExpr)
 }
 
-// GetHostAdditionPolicyParams renders the policy params with given host value (host-rewrite)
+// GetHostAdditionPolicyParams builds the host-rewrite policy params. Constructed
+// structurally (not via YAML interpolation) so a host value containing a quote or newline
+// cannot break or inject the params.
 func GetHostAdditionPolicyParams(value string) (map[string]interface{}, error) {
-	rendered := fmt.Sprintf(constants.PROXY_HOST__HEADER_POLICY_PARAMS, value)
-	var m map[string]interface{}
-	// For host-rewrite, params are simple mapping, so unmarshal into map
-	if err := yaml.Unmarshal([]byte(rendered), &m); err != nil {
-		return nil, err
-	}
-	return m, nil
+	return map[string]interface{}{
+		"host": value,
+	}, nil
 }
 
 // buildTemplateParams extracts template parameters from the LLM provider template for the given resource path

--- a/gateway/gateway-controller/pkg/utils/llm_transformer_multiprovider_test.go
+++ b/gateway/gateway-controller/pkg/utils/llm_transformer_multiprovider_test.go
@@ -242,6 +242,99 @@ func TestLLMProviderTransformer_TransformProxy_AdditionalProviderTransformerIsCo
 	assert.Equal(t, "claude-sonnet-4-5-20250929", (*transformerPolicy.Params)["model"])
 }
 
+// Test that a proxy that loops back into a provider with a downstream api-key-auth policy
+func TestLLMProviderTransformer_TransformProxy_LoopbackAuthCarriesProviderValuePrefix(t *testing.T) {
+	store := storage.NewConfigStore()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	db := newTestSQLiteStorage(t, logger)
+
+	template := &models.StoredLLMProviderTemplate{
+		UUID: "0000-db-template-id-0000-000000000003",
+		Configuration: api.LLMProviderTemplate{
+			ApiVersion: api.LLMProviderTemplateApiVersionGatewayApiPlatformWso2Comv1,
+			Kind:       api.LLMProviderTemplateKindLlmProviderTemplate,
+			Metadata:   api.Metadata{Name: "mistralai"},
+			Spec:       api.LLMProviderTemplateData{DisplayName: "mistralai"},
+		},
+	}
+	require.NoError(t, db.SaveLLMProviderTemplate(template))
+
+	// Provider whose downstream api-key-auth requires a "Bearer" prefix, carried as a
+	// global policy exactly as platform-api deploys it.
+	providerSourceConfig := api.LLMProviderConfiguration{
+		ApiVersion: api.LLMProviderConfigurationApiVersionGatewayApiPlatformWso2Comv1,
+		Kind:       api.LLMProviderConfigurationKindLlmProvider,
+		Metadata:   api.Metadata{Name: "mistral-provider"},
+		Spec: api.LLMProviderConfigData{
+			DisplayName:   "mistral-provider",
+			Version:       "v1.0",
+			Context:       stringPtr("/mistral-provider"),
+			Template:      "mistralai",
+			Upstream:      api.LLMProviderConfigData_Upstream{Url: stringPtr("https://example.com")},
+			AccessControl: api.LLMAccessControl{Mode: api.AllowAll},
+			GlobalPolicies: &[]api.Policy{{
+				Name: constants.API_KEY_AUTH_POLICY_NAME,
+				Params: &map[string]interface{}{
+					"in":          "header",
+					"key":         "X-API-Key",
+					"valuePrefix": "Bearer",
+				},
+			}},
+		},
+	}
+	require.NoError(t, db.SaveConfig(&models.StoredConfig{
+		UUID:                "mistral-provider-uuid",
+		Kind:                string(api.LLMProviderConfigurationKindLlmProvider),
+		Handle:              "mistral-provider",
+		DisplayName:         "mistral-provider",
+		Version:             "v1.0",
+		SourceConfiguration: providerSourceConfig,
+		DesiredState:        models.StateDeployed,
+	}))
+
+	transformer := NewLLMProviderTransformer(store, db, &config.RouterConfig{ListenerPort: 8080}, newTestPolicyVersionResolver())
+
+	proxy := &api.LLMProxyConfiguration{
+		ApiVersion: api.LLMProxyConfigurationApiVersionGatewayApiPlatformWso2Comv1,
+		Kind:       api.LLMProxyConfigurationKindLlmProxy,
+		Metadata:   api.Metadata{Name: "proxy-from-mistral"},
+		Spec: api.LLMProxyConfigData{
+			DisplayName: "proxy-from-mistral",
+			Version:     "v1.0",
+			Provider: api.LLMProxyProvider{
+				Id: "mistral-provider",
+				Auth: &api.LLMUpstreamAuth{
+					Type:   api.LLMUpstreamAuthTypeApiKey,
+					Header: stringPtr("X-API-Key"),
+					Value:  stringPtr(`{{ secret "sec-1" }}`),
+				},
+			},
+		},
+	}
+
+	result, err := transformer.Transform(proxy, &api.RestAPI{})
+	require.NoError(t, err)
+
+	var authPolicy *api.Policy
+	for i := range result.Spec.Operations {
+		if result.Spec.Operations[i].Policies == nil {
+			continue
+		}
+		for _, pol := range *result.Spec.Operations[i].Policies {
+			if pol.Name == constants.UPSTREAM_AUTH_APIKEY_POLICY_NAME {
+				p := pol
+				authPolicy = &p
+				break
+			}
+		}
+		if authPolicy != nil {
+			break
+		}
+	}
+	require.NotNil(t, authPolicy, "expected an upstream auth (set-headers) policy on the proxy")
+	assert.Equal(t, `Bearer {{ secret "sec-1" }}`, firstRequestHeaderValue(t, authPolicy.Params))
+}
+
 func firstRequestHeaderValue(t *testing.T, params *map[string]interface{}) string {
 	t.Helper()
 	require.NotNil(t, params)

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyNew.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyNew.tsx
@@ -411,6 +411,7 @@ function LLMProxyNewContent({
             enabled: Boolean(providerDetail?.security?.apiKey?.enabled),
             key: providerDetail?.security?.apiKey?.key ?? '',
             in: providerDetail?.security?.apiKey?.in ?? 'header',
+            valuePrefix: providerDetail?.security?.apiKey?.valuePrefix,
           },
         },
       };

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyProviderTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyProviderTab.tsx
@@ -98,6 +98,7 @@ export default function LLMProxyProviderTab() {
           enabled: Boolean(providerApiKey.enabled),
           key: providerApiKey.key ?? '',
           in: providerApiKey.in ?? 'header',
+          valuePrefix: providerApiKey.valuePrefix,
         }
       : undefined;
     return {


### PR DESCRIPTION
## Purpose
A proxy forwards each request to its provider on the same gateway, and the provider's API key check expects the key as Bearer <key>. The proxy builds that forwarded key itself, but it was sending the bare key with no Bearer in front, so the provider rejected it  with `401 "Valid API key required"`.

This change makes the gateway-controller add the provider's configured value prefix to the key it forwards, so it now sends Bearer <key> as the provider expects. Providers with no value prefix are unchanged.

Resolves: https://github.com/wso2/api-platform/issues/2667