### PR TITLE
fix(gateway-builder): force GOTOOLCHAIN=auto for go subprocesses

### DIFF
--- a/gateway/gateway-builder/internal/compilation/compiler.go
+++ b/gateway/gateway-builder/internal/compilation/compiler.go
@@ -73,7 +73,7 @@ func runGoModDownload(srcDir string) error {
 
 	cmd := exec.Command("go", "mod", "download")
 	cmd.Dir = srcDir
-	cmd.Env = goenv.Env()
+	cmd.Env = goenv.WithToolchain(cmd.Environ())
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
@@ -94,7 +94,7 @@ func runGoModTidy(srcDir string) error {
 
 	cmd := exec.Command("go", "mod", "tidy")
 	cmd.Dir = srcDir
-	cmd.Env = goenv.Env()
+	cmd.Env = goenv.WithToolchain(cmd.Environ())
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
@@ -168,7 +168,7 @@ func runGoBuild(srcDir string, options *types.CompilationOptions) error {
 	cmd.Dir = srcDir
 
 	// Set environment for static binary
-	cmd.Env = goenv.Env()
+	cmd.Env = goenv.WithToolchain(cmd.Environ())
 	if options.CGOEnabled {
 		cmd.Env = append(cmd.Env, "CGO_ENABLED=1")
 	} else {

--- a/gateway/gateway-builder/internal/compilation/compiler.go
+++ b/gateway/gateway-builder/internal/compilation/compiler.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 
 	"github.com/wso2/api-platform/gateway/gateway-builder/pkg/errors"
+	"github.com/wso2/api-platform/gateway/gateway-builder/pkg/goenv"
 	"github.com/wso2/api-platform/gateway/gateway-builder/pkg/types"
 )
 
@@ -72,6 +73,7 @@ func runGoModDownload(srcDir string) error {
 
 	cmd := exec.Command("go", "mod", "download")
 	cmd.Dir = srcDir
+	cmd.Env = goenv.Env()
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
@@ -92,6 +94,7 @@ func runGoModTidy(srcDir string) error {
 
 	cmd := exec.Command("go", "mod", "tidy")
 	cmd.Dir = srcDir
+	cmd.Env = goenv.Env()
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
@@ -165,7 +168,7 @@ func runGoBuild(srcDir string, options *types.CompilationOptions) error {
 	cmd.Dir = srcDir
 
 	// Set environment for static binary
-	cmd.Env = os.Environ()
+	cmd.Env = goenv.Env()
 	if options.CGOEnabled {
 		cmd.Env = append(cmd.Env, "CGO_ENABLED=1")
 	} else {

--- a/gateway/gateway-builder/internal/discovery/manifest.go
+++ b/gateway/gateway-builder/internal/discovery/manifest.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/wso2/api-platform/gateway/gateway-builder/pkg/errors"
 	"github.com/wso2/api-platform/gateway/gateway-builder/pkg/fsutil"
+	"github.com/wso2/api-platform/gateway/gateway-builder/pkg/goenv"
 	"github.com/wso2/api-platform/gateway/gateway-builder/pkg/types"
 	"golang.org/x/mod/modfile"
 	"gopkg.in/yaml.v3"
@@ -618,6 +619,7 @@ func resolveModuleInfo(gomodule string) (*moduleInfo, error) {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "go", "mod", "download", "-json", gomodule)
+	cmd.Env = goenv.Env()
 
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr

--- a/gateway/gateway-builder/internal/discovery/manifest.go
+++ b/gateway/gateway-builder/internal/discovery/manifest.go
@@ -619,7 +619,7 @@ func resolveModuleInfo(gomodule string) (*moduleInfo, error) {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "go", "mod", "download", "-json", gomodule)
-	cmd.Env = goenv.Env()
+	cmd.Env = goenv.WithToolchain(cmd.Environ())
 
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr

--- a/gateway/gateway-builder/internal/policyengine/gomod.go
+++ b/gateway/gateway-builder/internal/policyengine/gomod.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/wso2/api-platform/gateway/gateway-builder/pkg/goenv"
 	"github.com/wso2/api-platform/gateway/gateway-builder/pkg/types"
 	"golang.org/x/mod/modfile"
 )
@@ -49,6 +50,7 @@ var (
 var runGoGet = func(ctx context.Context, dir, target string) (stderr []byte, err error) {
 	cmd := exec.CommandContext(ctx, "go", "get", target)
 	cmd.Dir = dir
+	cmd.Env = goenv.Env()
 	var buf bytes.Buffer
 	cmd.Stderr = &buf
 	err = cmd.Run()

--- a/gateway/gateway-builder/internal/policyengine/gomod.go
+++ b/gateway/gateway-builder/internal/policyengine/gomod.go
@@ -50,7 +50,7 @@ var (
 var runGoGet = func(ctx context.Context, dir, target string) (stderr []byte, err error) {
 	cmd := exec.CommandContext(ctx, "go", "get", target)
 	cmd.Dir = dir
-	cmd.Env = goenv.Env()
+	cmd.Env = goenv.WithToolchain(cmd.Environ())
 	var buf bytes.Buffer
 	cmd.Stderr = &buf
 	err = cmd.Run()

--- a/gateway/gateway-builder/pkg/goenv/goenv.go
+++ b/gateway/gateway-builder/pkg/goenv/goenv.go
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Package goenv builds the environment used when the builder shells out to the
+// `go` toolchain.
+package goenv
+
+import (
+	"os"
+	"strings"
+)
+
+// gotoolchainKey is the environment variable Go consults to decide whether it
+// may switch to a different toolchain than the one it was invoked as.
+const gotoolchainKey = "GOTOOLCHAIN"
+
+// Env returns a copy of the current process environment with GOTOOLCHAIN set to
+// "auto" so the `go` command may download and switch to the toolchain a module
+// requires.
+//
+// The official golang base images pin GOTOOLCHAIN=local. With that setting, a
+// `go` command refuses to build or download a module whose go.mod declares a
+// newer `go` directive than the toolchain baked into the image — it fails with
+// "requires go >= X (running go Y; GOTOOLCHAIN=local)" instead of fetching the
+// newer toolchain. Policies are published independently of the builder and may
+// declare a newer `go` directive than the builder image ships, so we default to
+// "auto" to let `go` transparently download and switch to the required version.
+//
+// An explicit operator override (any GOTOOLCHAIN value other than the empty
+// string or "local", e.g. a pinned "go1.26.6") is respected and left untouched.
+func Env() []string {
+	env := os.Environ()
+	for i, e := range env {
+		v, ok := strings.CutPrefix(e, gotoolchainKey+"=")
+		if !ok {
+			continue
+		}
+		if v != "" && v != "local" {
+			// Explicit, non-local override — respect it.
+			return env
+		}
+		// Replace the local/empty value in place. Appending a second entry is
+		// not enough: os.Getenv in the child reads the first occurrence, so a
+		// leading "local" would still win.
+		env[i] = gotoolchainKey + "=auto"
+		return env
+	}
+	// Not set at all — add it.
+	return append(env, gotoolchainKey+"=auto")
+}

--- a/gateway/gateway-builder/pkg/goenv/goenv.go
+++ b/gateway/gateway-builder/pkg/goenv/goenv.go
@@ -20,18 +20,14 @@
 // `go` toolchain.
 package goenv
 
-import (
-	"os"
-	"strings"
-)
+import "strings"
 
 // gotoolchainKey is the environment variable Go consults to decide whether it
 // may switch to a different toolchain than the one it was invoked as.
 const gotoolchainKey = "GOTOOLCHAIN"
 
-// Env returns a copy of the current process environment with GOTOOLCHAIN set to
-// "auto" so the `go` command may download and switch to the toolchain a module
-// requires.
+// WithToolchain returns env with GOTOOLCHAIN set to "auto" so the `go` command
+// may download and switch to the toolchain a module requires.
 //
 // The official golang base images pin GOTOOLCHAIN=local. With that setting, a
 // `go` command refuses to build or download a module whose go.mod declares a
@@ -43,8 +39,11 @@ const gotoolchainKey = "GOTOOLCHAIN"
 //
 // An explicit operator override (any GOTOOLCHAIN value other than the empty
 // string or "local", e.g. a pinned "go1.26.6") is respected and left untouched.
-func Env() []string {
-	env := os.Environ()
+//
+// Callers should pass exec.Cmd.Environ() (after setting Cmd.Dir) rather than
+// os.Environ(), so the PWD entry os/exec derives from Cmd.Dir is preserved —
+// setting Cmd.Env at all suppresses that automatic PWD update.
+func WithToolchain(env []string) []string {
 	for i, e := range env {
 		v, ok := strings.CutPrefix(e, gotoolchainKey+"=")
 		if !ok {

--- a/gateway/gateway-builder/pkg/goenv/goenv_test.go
+++ b/gateway/gateway-builder/pkg/goenv/goenv_test.go
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package goenv
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// gotoolchainValues returns every GOTOOLCHAIN= value present in env, in order.
+func gotoolchainValues(env []string) []string {
+	var vals []string
+	for _, e := range env {
+		if v, ok := strings.CutPrefix(e, gotoolchainKey+"="); ok {
+			vals = append(vals, v)
+		}
+	}
+	return vals
+}
+
+func TestEnv(t *testing.T) {
+	tests := []struct {
+		name  string
+		set   bool
+		value string
+		want  string
+	}{
+		{name: "unset defaults to auto", set: false, want: "auto"},
+		{name: "local is overridden to auto", set: true, value: "local", want: "auto"},
+		{name: "empty is overridden to auto", set: true, value: "", want: "auto"},
+		{name: "explicit auto is kept", set: true, value: "auto", want: "auto"},
+		{name: "pinned version is respected", set: true, value: "go1.26.6", want: "go1.26.6"},
+		{name: "path+auto is respected", set: true, value: "go1.26.6+auto", want: "go1.26.6+auto"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// t.Setenv registers cleanup that restores the original value, so
+			// mutating the var (including unsetting it) below is safe.
+			t.Setenv(gotoolchainKey, tt.value)
+			if !tt.set {
+				os.Unsetenv(gotoolchainKey)
+			}
+
+			got := gotoolchainValues(Env())
+			if len(got) != 1 {
+				t.Fatalf("expected exactly one GOTOOLCHAIN entry, got %v", got)
+			}
+			if got[0] != tt.want {
+				t.Errorf("GOTOOLCHAIN = %q, want %q", got[0], tt.want)
+			}
+		})
+	}
+}

--- a/gateway/gateway-builder/pkg/goenv/goenv_test.go
+++ b/gateway/gateway-builder/pkg/goenv/goenv_test.go
@@ -19,7 +19,6 @@
 package goenv
 
 import (
-	"os"
 	"strings"
 	"testing"
 )
@@ -35,30 +34,22 @@ func gotoolchainValues(env []string) []string {
 	return vals
 }
 
-func TestEnv(t *testing.T) {
+func TestWithToolchain(t *testing.T) {
 	tests := []struct {
-		name  string
-		set   bool
-		value string
-		want  string
+		name string
+		in   []string
+		want string
 	}{
-		{name: "unset defaults to auto", set: false, want: "auto"},
-		{name: "local is overridden to auto", set: true, value: "local", want: "auto"},
-		{name: "empty is overridden to auto", set: true, value: "", want: "auto"},
-		{name: "explicit auto is kept", set: true, value: "auto", want: "auto"},
-		{name: "pinned version is respected", set: true, value: "go1.26.6", want: "go1.26.6"},
-		{name: "path+auto is respected", set: true, value: "go1.26.6+auto", want: "go1.26.6+auto"},
+		{name: "unset defaults to auto", in: []string{"HOME=/root"}, want: "auto"},
+		{name: "local is overridden to auto", in: []string{"GOTOOLCHAIN=local"}, want: "auto"},
+		{name: "empty is overridden to auto", in: []string{"GOTOOLCHAIN="}, want: "auto"},
+		{name: "explicit auto is kept", in: []string{"GOTOOLCHAIN=auto"}, want: "auto"},
+		{name: "pinned version is respected", in: []string{"GOTOOLCHAIN=go1.26.6"}, want: "go1.26.6"},
+		{name: "path+auto is respected", in: []string{"GOTOOLCHAIN=go1.26.6+auto"}, want: "go1.26.6+auto"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// t.Setenv registers cleanup that restores the original value, so
-			// mutating the var (including unsetting it) below is safe.
-			t.Setenv(gotoolchainKey, tt.value)
-			if !tt.set {
-				os.Unsetenv(gotoolchainKey)
-			}
-
-			got := gotoolchainValues(Env())
+			got := gotoolchainValues(WithToolchain(tt.in))
 			if len(got) != 1 {
 				t.Fatalf("expected exactly one GOTOOLCHAIN entry, got %v", got)
 			}
@@ -66,5 +57,23 @@ func TestEnv(t *testing.T) {
 				t.Errorf("GOTOOLCHAIN = %q, want %q", got[0], tt.want)
 			}
 		})
+	}
+}
+
+// TestWithToolchainPreservesOtherVars ensures the helper only touches
+// GOTOOLCHAIN and leaves the rest of the environment (e.g. the PWD entry
+// os/exec derives from Cmd.Dir) intact.
+func TestWithToolchainPreservesOtherVars(t *testing.T) {
+	in := []string{"PWD=/some/dir", "GOTOOLCHAIN=local", "HOME=/root"}
+	got := WithToolchain(in)
+
+	found := map[string]bool{}
+	for _, e := range got {
+		found[e] = true
+	}
+	for _, want := range []string{"PWD=/some/dir", "HOME=/root"} {
+		if !found[want] {
+			t.Errorf("expected %q to be preserved, got %v", want, got)
+		}
 	}
 }


### PR DESCRIPTION
## Purpose

When the gateway-builder runs on an older base image (e.g. Go 1.26.2) and a policy's `go.mod` declares a newer `go` directive than the image ships, the build fails with `requires go >= X (running go Y; GOTOOLCHAIN=local)`.

The root cause is that the official `golang` base images pin `GOTOOLCHAIN=local`, which forbids `go` from downloading and switching to the required toolchain. Since policies are published independently of the builder, their `go` directive can outpace the builder image's baked-in Go, breaking the build.

This PR makes the builder resilient to that version drift by letting `go` fetch the toolchain a policy requires.

## Approach

- Add `pkg/goenv.Env()`, which returns the process environment with `GOTOOLCHAIN=auto` so `go` can transparently download and switch toolchains. It replaces a `local`/empty value in place (avoiding duplicate-key ambiguity where the child would read the leading `local`) and respects an explicit operator pin such as `go1.26.6`.
- Apply `goenv.Env()` to all five `go` subprocesses the builder spawns: `go mod download -json` (discovery), `go get` (policyengine), and `go mod download` / `go mod tidy` / `go build` (compilation).
- Add unit tests for `goenv.Env()` covering unset, `local`, empty, explicit `auto`, pinned version, and path+auto, asserting exactly one `GOTOOLCHAIN` entry results.

Verified against the real `jwt-auth@v1` policy in a `golang:1.26.2` image: `GOTOOLCHAIN=local` reproduces the failure (exit 1), while `GOTOOLCHAIN=auto` switches to `go1.26.5` and succeeds (exit 0).

## Related Issues

Fixes #2796

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
