### PR TITLE
Revert Go version to 1.26.2 in SDK core and AI module

### DIFF
--- a/sdk/ai/go.mod
+++ b/sdk/ai/go.mod
@@ -1,6 +1,6 @@
 module github.com/wso2/api-platform/sdk/ai
 
-go 1.26.5
+go 1.26.2
 
 require (
 	github.com/goccy/go-json v0.10.5

--- a/sdk/core/go.mod
+++ b/sdk/core/go.mod
@@ -1,3 +1,3 @@
 module github.com/wso2/api-platform/sdk/core
 
-go 1.26.5
+go 1.26.2


### PR DESCRIPTION
### Purpose

- $subject
- Related Issues: https://github.com/wso2/api-platform/issues/2796