### PR TITLE
[APIP] Change DB initialization

### DIFF
--- a/.github/workflows/event-gateway-integration-test-postgres.yml
+++ b/.github/workflows/event-gateway-integration-test-postgres.yml
@@ -92,9 +92,13 @@ jobs:
             exit 1
           }
 
+          # Assert the full provisioned schema: core (artifacts) plus the
+          # event-gateway-specific tables the controller no longer creates for
+          # external DBs (websub_apis, webbroker_apis, webhook_secrets) — so a
+          # silently-failed pre-provisioning init hook is caught here.
           table_count="$(docker compose -p "$PROJECT" -f docker-compose.test.postgres.yaml exec -T postgres \
-            psql -U gateway -d gateway_test -tAc "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'artifacts';")"
-          [ "$table_count" = "1" ]
+            psql -U gateway -d gateway_test -tAc "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_name IN ('artifacts', 'websub_apis', 'webbroker_apis', 'webhook_secrets');")"
+          [ "$table_count" = "4" ]
 
           conn_count="$(docker compose -p "$PROJECT" -f docker-compose.test.postgres.yaml exec -T postgres \
             psql -U gateway -d gateway_test -tAc "SELECT COUNT(*) FROM pg_stat_activity WHERE application_name = 'gateway-controller';")"

--- a/.github/workflows/event-gateway-integration-test-postgres.yml
+++ b/.github/workflows/event-gateway-integration-test-postgres.yml
@@ -78,12 +78,16 @@ jobs:
 
           docker compose -p "$PROJECT" -f docker-compose.test.postgres.yaml up -d postgres gateway-controller
 
+          # The controller no longer applies schema DDL (the core schema is
+          # pre-provisioned via Postgres's init hook); wait instead for it to
+          # report a successful DB connection, which gates the connection check
+          # below. Schema presence is asserted separately via the table check.
           timeout 90 bash -c '
-            until docker logs egw-it-gateway-controller 2>&1 | grep -qE "Initializing PostgreSQL schema|PostgreSQL schema initialized"; do
+            until docker logs egw-it-gateway-controller 2>&1 | grep -qE "PostgreSQL storage initialized"; do
               sleep 2
             done
           ' || {
-            echo "=== Schema init timed out — gateway-controller logs ==="
+            echo "=== Controller startup timed out — gateway-controller logs ==="
             docker logs egw-it-gateway-controller 2>&1 || true
             exit 1
           }

--- a/.github/workflows/event-gateway-integration-test-postgres.yml
+++ b/.github/workflows/event-gateway-integration-test-postgres.yml
@@ -78,10 +78,6 @@ jobs:
 
           docker compose -p "$PROJECT" -f docker-compose.test.postgres.yaml up -d postgres gateway-controller
 
-          # The controller no longer applies schema DDL (the core schema is
-          # pre-provisioned via Postgres's init hook); wait instead for it to
-          # report a successful DB connection, which gates the connection check
-          # below. Schema presence is asserted separately via the table check.
           timeout 90 bash -c '
             until docker logs egw-it-gateway-controller 2>&1 | grep -qE "PostgreSQL storage initialized"; do
               sleep 2

--- a/.github/workflows/event-gateway-integration-test-sqlserver.yml
+++ b/.github/workflows/event-gateway-integration-test-sqlserver.yml
@@ -103,11 +103,15 @@ jobs:
           }
           trap 'dump_logs; cleanup' EXIT
 
+          # Assert the full provisioned schema: core (artifacts) plus the
+          # event-gateway-specific tables the controller no longer creates for
+          # external DBs (websub_apis, webbroker_apis, webhook_secrets) — so a
+          # silently-failed pre-provisioning init step is caught here.
           table_count="$(docker compose -p "$PROJECT" -f docker-compose.test.sqlserver.yaml exec -T sqlserver \
             /opt/mssql-tools18/bin/sqlcmd -C -S localhost -U sa -P "$MSSQL_SA_PASSWORD" -d gateway_test -h -1 -W \
-            -Q "SET NOCOUNT ON; SELECT COUNT(*) FROM information_schema.tables WHERE table_name = 'artifacts'" | tr -d '[:space:]')"
-          echo "artifacts table_count=$table_count"
-          [ "$table_count" = "1" ]
+            -Q "SET NOCOUNT ON; SELECT COUNT(*) FROM information_schema.tables WHERE table_name IN ('artifacts', 'websub_apis', 'webbroker_apis', 'webhook_secrets')" | tr -d '[:space:]')"
+          echo "provisioned table_count=$table_count"
+          [ "$table_count" = "4" ]
 
           # The controller's DSN sets 'app name=gateway-controller', so its sessions are
           # tagged accordingly in sys.dm_exec_sessions (SQL Server's analog of pg_stat_activity).

--- a/.github/workflows/event-gateway-integration-test-sqlserver.yml
+++ b/.github/workflows/event-gateway-integration-test-sqlserver.yml
@@ -81,12 +81,16 @@ jobs:
 
           docker compose -p "$PROJECT" -f docker-compose.test.sqlserver.yaml up -d sqlserver mssql-init gateway-controller
 
+          # The controller no longer applies schema DDL (the core schema is
+          # pre-provisioned via the mssql-init one-shot); wait instead for it to
+          # report a successful DB connection, which gates the connection check
+          # below. Schema presence is asserted separately via the table check.
           timeout 120 bash -c '
-            until docker logs egw-it-gateway-controller 2>&1 | grep -qE "Initializing SQLServer schema|SQLServer schema initialized"; do
+            until docker logs egw-it-gateway-controller 2>&1 | grep -qE "SQLServer storage initialized"; do
               sleep 2
             done
           ' || {
-            echo "=== Schema init timed out — gateway-controller logs ==="
+            echo "=== Controller startup timed out — gateway-controller logs ==="
             docker logs egw-it-gateway-controller 2>&1 || true
             exit 1
           }

--- a/.github/workflows/event-gateway-integration-test-sqlserver.yml
+++ b/.github/workflows/event-gateway-integration-test-sqlserver.yml
@@ -81,10 +81,6 @@ jobs:
 
           docker compose -p "$PROJECT" -f docker-compose.test.sqlserver.yaml up -d sqlserver mssql-init gateway-controller
 
-          # The controller no longer applies schema DDL (the core schema is
-          # pre-provisioned via the mssql-init one-shot); wait instead for it to
-          # report a successful DB connection, which gates the connection check
-          # below. Schema presence is asserted separately via the table check.
           timeout 120 bash -c '
             until docker logs egw-it-gateway-controller 2>&1 | grep -qE "SQLServer storage initialized"; do
               sleep 2

--- a/.github/workflows/gateway-integration-test-postgres.yml
+++ b/.github/workflows/gateway-integration-test-postgres.yml
@@ -61,10 +61,6 @@ jobs:
             exit 1
           }
 
-          # The gateway-controller no longer applies schema DDL to external
-          # databases — the schema is pre-provisioned (here, via Postgres's
-          # first-boot init hook). Assert the schema is present by checking for
-          # the expected table rather than a controller schema-init log line.
           table_count="$(docker compose -p "$PROJECT" -f docker-compose.test.postgres.yaml exec -T postgres \
             psql -U gateway -d gateway_test -tAc "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'artifacts';")"
           [ "$table_count" = "1" ]

--- a/.github/workflows/gateway-integration-test-postgres.yml
+++ b/.github/workflows/gateway-integration-test-postgres.yml
@@ -61,9 +61,10 @@ jobs:
             exit 1
           }
 
-          docker logs it-gateway-controller > /tmp/gateway-controller.log 2>&1 || true
-          grep -Eq "Initializing PostgreSQL schema|PostgreSQL schema initialized" /tmp/gateway-controller.log
-
+          # The gateway-controller no longer applies schema DDL to external
+          # databases — the schema is pre-provisioned (here, via Postgres's
+          # first-boot init hook). Assert the schema is present by checking for
+          # the expected table rather than a controller schema-init log line.
           table_count="$(docker compose -p "$PROJECT" -f docker-compose.test.postgres.yaml exec -T postgres \
             psql -U gateway -d gateway_test -tAc "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'artifacts';")"
           [ "$table_count" = "1" ]

--- a/.github/workflows/gateway-integration-test-sqlserver.yml
+++ b/.github/workflows/gateway-integration-test-sqlserver.yml
@@ -76,9 +76,10 @@ jobs:
           }
           trap 'dump_logs; cleanup' EXIT
 
-          docker logs it-gateway-controller > /tmp/gateway-controller.log 2>&1 || true
-          grep -Eq "Initializing SQLServer schema|SQLServer schema initialized" /tmp/gateway-controller.log
-
+          # The gateway-controller no longer applies schema DDL to external
+          # databases — the schema is pre-provisioned (here, via the mssql-init
+          # one-shot). Assert the schema is present by checking for the expected
+          # table rather than a controller schema-init log line.
           table_count="$(docker compose -p "$PROJECT" -f docker-compose.test.sqlserver.yaml exec -T sqlserver \
             /opt/mssql-tools18/bin/sqlcmd -C -S localhost -U sa -P "$MSSQL_SA_PASSWORD" -d gateway_test -h -1 -W \
             -Q "SET NOCOUNT ON; SELECT COUNT(*) FROM information_schema.tables WHERE table_name = 'artifacts'" | tr -d '[:space:]')"

--- a/.github/workflows/gateway-integration-test-sqlserver.yml
+++ b/.github/workflows/gateway-integration-test-sqlserver.yml
@@ -76,10 +76,6 @@ jobs:
           }
           trap 'dump_logs; cleanup' EXIT
 
-          # The gateway-controller no longer applies schema DDL to external
-          # databases — the schema is pre-provisioned (here, via the mssql-init
-          # one-shot). Assert the schema is present by checking for the expected
-          # table rather than a controller schema-init log line.
           table_count="$(docker compose -p "$PROJECT" -f docker-compose.test.sqlserver.yaml exec -T sqlserver \
             /opt/mssql-tools18/bin/sqlcmd -C -S localhost -U sa -P "$MSSQL_SA_PASSWORD" -d gateway_test -h -1 -W \
             -Q "SET NOCOUNT ON; SELECT COUNT(*) FROM information_schema.tables WHERE table_name = 'artifacts'" | tr -d '[:space:]')"

--- a/event-gateway/docker-compose.test.postgres.yaml
+++ b/event-gateway/docker-compose.test.postgres.yaml
@@ -32,6 +32,17 @@ services:
       - POSTGRES_DB=gateway_test
       - POSTGRES_USER=gateway
       - POSTGRES_PASSWORD=gateway
+    volumes:
+      # event-gateway-controller reuses gateway-controller's storage package,
+      # which no longer auto-applies schema DDL to external databases — and the
+      # event-gateway controller likewise no longer auto-applies its own DDL for
+      # external backends. Both the core schema and the event-gateway-specific
+      # tables (websub_apis, webbroker_apis, webhook_secrets) must therefore be
+      # pre-provisioned by the operator. Apply both here via Postgres's first-boot
+      # init hooks (01 core, then 02 event-gateway), so the IT suite exercises the
+      # same pre-provisioned-DB path operators use.
+      - ../gateway/gateway-controller/pkg/storage/gateway-controller-db.postgres.sql:/docker-entrypoint-initdb.d/01-gateway-controller-schema.sql:ro
+      - ./gateway-controller/pkg/dbschema/eventgateway-db.postgres.sql:/docker-entrypoint-initdb.d/02-eventgateway-schema.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U gateway -d gateway_test"]
       interval: 5s

--- a/event-gateway/docker-compose.test.sqlserver.yaml
+++ b/event-gateway/docker-compose.test.sqlserver.yaml
@@ -71,13 +71,13 @@ services:
     entrypoint: ["/bin/bash", "-c"]
     command:
       - >
-        /opt/mssql-tools18/bin/sqlcmd -C -S sqlserver -U sa -P "$$MSSQL_SA_PASSWORD"
+        /opt/mssql-tools18/bin/sqlcmd -b -C -S sqlserver -U sa -P "$$MSSQL_SA_PASSWORD"
         -Q "IF DB_ID('$$MSSQL_DB') IS NULL CREATE DATABASE [$$MSSQL_DB]"
         &&
-        /opt/mssql-tools18/bin/sqlcmd -C -S sqlserver -U sa -P "$$MSSQL_SA_PASSWORD"
+        /opt/mssql-tools18/bin/sqlcmd -b -C -S sqlserver -U sa -P "$$MSSQL_SA_PASSWORD"
         -d "$$MSSQL_DB" -i /schema/gateway-controller-schema.sql
         &&
-        /opt/mssql-tools18/bin/sqlcmd -C -S sqlserver -U sa -P "$$MSSQL_SA_PASSWORD"
+        /opt/mssql-tools18/bin/sqlcmd -b -C -S sqlserver -U sa -P "$$MSSQL_SA_PASSWORD"
         -d "$$MSSQL_DB" -i /schema/eventgateway-schema.sql
     restart: "no"
     networks:

--- a/event-gateway/docker-compose.test.sqlserver.yaml
+++ b/event-gateway/docker-compose.test.sqlserver.yaml
@@ -57,11 +57,28 @@ services:
     environment:
       - MSSQL_SA_PASSWORD=${MSSQL_SA_PASSWORD:-EGW_Strong!Pass123}
       - MSSQL_DB=gateway_test
+    volumes:
+      # event-gateway-controller reuses gateway-controller's storage package,
+      # which no longer auto-applies schema DDL to external databases — and the
+      # event-gateway controller likewise no longer auto-applies its own DDL for
+      # external backends. Both the core schema and the event-gateway-specific
+      # tables (websub_apis, webbroker_apis, webhook_secrets) must therefore be
+      # pre-provisioned by the operator. Apply both shipped scripts here after
+      # creating the database, so the IT suite exercises the same
+      # pre-provisioned-DB path operators use.
+      - ../gateway/gateway-controller/pkg/storage/gateway-controller-db.sqlserver.sql:/schema/gateway-controller-schema.sql:ro
+      - ./gateway-controller/pkg/dbschema/eventgateway-db.sqlserver.sql:/schema/eventgateway-schema.sql:ro
     entrypoint: ["/bin/bash", "-c"]
     command:
       - >
         /opt/mssql-tools18/bin/sqlcmd -C -S sqlserver -U sa -P "$$MSSQL_SA_PASSWORD"
         -Q "IF DB_ID('$$MSSQL_DB') IS NULL CREATE DATABASE [$$MSSQL_DB]"
+        &&
+        /opt/mssql-tools18/bin/sqlcmd -C -S sqlserver -U sa -P "$$MSSQL_SA_PASSWORD"
+        -d "$$MSSQL_DB" -i /schema/gateway-controller-schema.sql
+        &&
+        /opt/mssql-tools18/bin/sqlcmd -C -S sqlserver -U sa -P "$$MSSQL_SA_PASSWORD"
+        -d "$$MSSQL_DB" -i /schema/eventgateway-schema.sql
     restart: "no"
     networks:
       - egw-network

--- a/event-gateway/gateway-controller/cmd/controller/main.go
+++ b/event-gateway/gateway-controller/cmd/controller/main.go
@@ -204,11 +204,21 @@ func main() {
 	defer db.Close()
 
 	// websub_apis, webbroker_apis, and webhook_secrets are event-gateway-specific
-	// tables that core's own schema scripts do not define. Apply them against the
-	// same database connection core just opened.
-	if err := dbschema.Apply(context.Background(), db.GetDB(), cfg.Controller.Storage.Type); err != nil {
-		log.Error("Failed to initialize event-gateway database schema", slog.Any("error", err))
-		os.Exit(1)
+	// tables that core's own schema scripts do not define. Core storage auto-creates
+	// its schema only for the embedded sqlite backend; for operator-owned external
+	// databases (postgres, sqlserver) the schema — including these event-gateway
+	// tables — must be pre-provisioned by the operator, matching gateway-controller's
+	// policy of never running DDL against an external database at startup. So only
+	// auto-apply for sqlite; for external backends the tables are expected to already
+	// exist (see the shipped eventgateway-db.*.sql scripts).
+	if strings.EqualFold(cfg.Controller.Storage.Type, "sqlite") {
+		if err := dbschema.Apply(context.Background(), db.GetDB(), cfg.Controller.Storage.Type); err != nil {
+			log.Error("Failed to initialize event-gateway database schema", slog.Any("error", err))
+			os.Exit(1)
+		}
+	} else {
+		log.Info("Skipping event-gateway schema auto-apply for external database; schema must be pre-provisioned",
+			slog.String("storage_type", cfg.Controller.Storage.Type))
 	}
 
 	var eventHubInstance eventhub.EventHub

--- a/gateway/Makefile
+++ b/gateway/Makefile
@@ -232,7 +232,8 @@ AI_DIST_ZIP  := target/$(AI_DIST_NAME).zip
 dist: clean-dist ## Build standalone gateway distribution zip
 	@echo "Building distribution $(DIST_NAME)..."
 	@mkdir -p $(DIST_DIR)/configs $(DIST_DIR)/resources/certificates \
-	          $(DIST_DIR)/resources/listener-certs $(DIST_DIR)/resources/secure-backend
+	          $(DIST_DIR)/resources/listener-certs $(DIST_DIR)/resources/secure-backend \
+	          $(DIST_DIR)/resources/gateway-controller/db-scripts
 	@cp build.yaml build-manifest.yaml $(DIST_DIR)/
 	@cp -R configs/. $(DIST_DIR)/configs/
 	@cp -R observability $(DIST_DIR)/
@@ -240,6 +241,8 @@ dist: clean-dist ## Build standalone gateway distribution zip
 	@cp gateway-controller/listener-certs/default-listener.crt $(DIST_DIR)/resources/listener-certs/
 	@cp gateway-controller/listener-certs/default-listener.key $(DIST_DIR)/resources/listener-certs/
 	@cp -R resources/secure-backend/. $(DIST_DIR)/resources/secure-backend/
+	@cp gateway-controller/pkg/storage/gateway-controller-db.postgres.sql  $(DIST_DIR)/resources/gateway-controller/db-scripts/
+	@cp gateway-controller/pkg/storage/gateway-controller-db.sqlserver.sql $(DIST_DIR)/resources/gateway-controller/db-scripts/
 	@cp distribution/docker-compose.yaml $(DIST_DIR)/docker-compose.yaml
 	@mkdir -p $(DIST_DIR)/scripts
 	@cp scripts/setup.sh $(DIST_DIR)/scripts/setup.sh

--- a/gateway/distribution/README.md
+++ b/gateway/distribution/README.md
@@ -22,7 +22,9 @@ wso2apip-api-gateway-<version>/
 └── resources/
     ├── certificates/            # CA certificate for upstream TLS verification
     ├── listener-certs/          # Self-signed TLS certificate/key for the HTTPS listener
-    └── secure-backend/          # Test certificates for mTLS backend testing
+    ├── secure-backend/          # Test certificates for mTLS backend testing
+    └── gateway-controller/
+        └── db-scripts/          # Schema DDL for external Postgres/SQL Server (see Database)
 ```
 
 ## Prerequisites
@@ -79,6 +81,47 @@ Edit `configs/config.toml` before starting the gateway. The most commonly change
 | `tracing.enabled` | Enable OpenTelemetry tracing | `false` |
 
 See `configs/config-template.toml` for a fully-commented reference of every available setting.
+
+## Database
+
+The gateway controller supports three storage backends, selected via `[controller.storage].type` in `configs/config.toml`:
+
+| `type` | Description | Schema provisioning |
+|--------|--------------|----------------------|
+| `sqlite` (default) | Local file-based database (`./data/gateway.db`) | Applied automatically on startup |
+| `postgres` | External PostgreSQL | Must be pre-provisioned by the operator |
+| `sqlserver` | External Microsoft SQL Server | Must be pre-provisioned by the operator |
+
+For `sqlite`, no manual step is required — the controller creates and migrates the local database file itself on first start.
+
+For `postgres` and `sqlserver`, the controller connects to the database you provide but does **not** run any schema DDL against it — auto-applying DDL against an operator-owned external database at startup is treated as a security risk. Before starting the controller, create the target database and apply the matching script from `resources/gateway-controller/db-scripts/`:
+
+```bash
+# PostgreSQL
+psql "host=<host> port=<port> dbname=<database> user=<user>" \
+  -f resources/gateway-controller/db-scripts/gateway-controller-db.postgres.sql
+
+# SQL Server
+sqlcmd -S <host>,<port> -d <database> -U <user> \
+  -i resources/gateway-controller/db-scripts/gateway-controller-db.sqlserver.sql
+```
+
+Then point the controller at the database in `configs/config.toml`:
+
+```toml
+[controller.storage]
+type = "postgres"   # or "sqlserver"
+
+[controller.storage.postgres]
+host = "your-postgres-host"
+port = 5432
+database = "gateway"
+user = "gateway"
+password = ""       # prefer supplying via api-platform.env
+sslmode = "require"
+```
+
+See `configs/config-template.toml` for the full `[controller.storage.*]` reference, including the SQL Server equivalent under `[controller.storage.database]`.
 
 ## Connecting to WSO2 API Platform
 

--- a/gateway/gateway-controller/pkg/storage/gateway-controller-db.sqlserver.sql
+++ b/gateway/gateway-controller/pkg/storage/gateway-controller-db.sqlserver.sql
@@ -11,6 +11,15 @@
 --   BOOLEAN           -> BIT
 --   INTEGER           -> INT
 -- Every object is guarded by IF NOT EXISTS so the batch is idempotent.
+--
+-- The filtered indexes below (CREATE INDEX ... WHERE ...) require QUOTED_IDENTIFIER
+-- and ANSI_NULLS to be ON. The Go database/sql driver connects with these ON, so
+-- the old in-controller ExecContext path applied this script cleanly; sqlcmd/ODBC
+-- connects with QUOTED_IDENTIFIER OFF, so applying via sqlcmd fails with
+-- "Msg 1934 ... CREATE INDEX failed ... 'QUOTED_IDENTIFIER'" and aborts the batch.
+-- Set them explicitly here so the script applies identically under both.
+SET QUOTED_IDENTIFIER ON;
+SET ANSI_NULLS ON;
 
 -- Base table for all artifact types
 IF OBJECT_ID(N'dbo.artifacts', N'U') IS NULL

--- a/gateway/gateway-controller/pkg/storage/gateway-controller-db.sqlserver.sql
+++ b/gateway/gateway-controller/pkg/storage/gateway-controller-db.sqlserver.sql
@@ -12,14 +12,21 @@
 --   INTEGER           -> INT
 -- Every object is guarded by IF NOT EXISTS so the batch is idempotent.
 --
--- The filtered indexes below (CREATE INDEX ... WHERE ...) require QUOTED_IDENTIFIER
--- and ANSI_NULLS to be ON. The Go database/sql driver connects with these ON, so
--- the old in-controller ExecContext path applied this script cleanly; sqlcmd/ODBC
--- connects with QUOTED_IDENTIFIER OFF, so applying via sqlcmd fails with
+-- The filtered indexes below (CREATE INDEX ... WHERE ...) require the seven
+-- SET options SQL Server mandates for filtered indexes to be correct. The Go
+-- database/sql driver connects with them correct, so the old in-controller
+-- ExecContext path applied this script cleanly; sqlcmd/ODBC connects with
+-- QUOTED_IDENTIFIER OFF, so applying via sqlcmd fails with
 -- "Msg 1934 ... CREATE INDEX failed ... 'QUOTED_IDENTIFIER'" and aborts the batch.
--- Set them explicitly here so the script applies identically under both.
+-- Set all seven explicitly so the script applies identically regardless of the
+-- client's session defaults (see MS docs: SET options required for filtered indexes).
 SET QUOTED_IDENTIFIER ON;
 SET ANSI_NULLS ON;
+SET ANSI_PADDING ON;
+SET ANSI_WARNINGS ON;
+SET ARITHABORT ON;
+SET CONCAT_NULL_YIELDS_NULL ON;
+SET NUMERIC_ROUNDABORT OFF;
 
 -- Base table for all artifact types
 IF OBJECT_ID(N'dbo.artifacts', N'U') IS NULL

--- a/gateway/gateway-controller/pkg/storage/postgres.go
+++ b/gateway/gateway-controller/pkg/storage/postgres.go
@@ -21,7 +21,6 @@ package storage
 import (
 	"context"
 	"database/sql"
-	_ "embed"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -35,11 +34,7 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-//go:embed gateway-controller-db.postgres.sql
-var postgresSchemaSQL string
-
 const (
-	postgresSchemaLockID  = int64(749251473)
 	pgUniqueViolationCode = "23505"
 )
 
@@ -100,11 +95,6 @@ func newPostgresStorage(cfg PostgresConnectionConfig, logger *slog.Logger) (*Pos
 		return nil, fmt.Errorf("failed to ping postgres database: %w", err)
 	}
 
-	if err := storage.initSchema(); err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("failed to initialize schema: %w", err)
-	}
-
 	logger.Info("PostgreSQL storage initialized",
 		slog.String("host", cfg.Host),
 		slog.Int("port", cfg.Port),
@@ -117,53 +107,6 @@ func newPostgresStorage(cfg PostgresConnectionConfig, logger *slog.Logger) (*Pos
 		slog.String("dsn", sanitizePostgresDSN(dsn)))
 
 	return storage, nil
-}
-
-// initSchema creates the database schema if it doesn't exist.
-func (s *PostgresStorage) initSchema() (retErr error) {
-	ctx := context.Background()
-
-	conn, err := s.db.Conn(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to acquire postgres connection for schema init: %w", err)
-	}
-	defer func() {
-		if closeErr := conn.Close(); closeErr != nil {
-			if retErr != nil {
-				retErr = fmt.Errorf("%w; failed to close schema init connection: %v", retErr, closeErr)
-			} else {
-				retErr = fmt.Errorf("failed to close schema init connection: %w", closeErr)
-			}
-		}
-	}()
-
-	if _, err := conn.ExecContext(ctx, s.rebind(`SELECT pg_advisory_lock(?)`), postgresSchemaLockID); err != nil {
-		return fmt.Errorf("failed to acquire schema init lock: %w", err)
-	}
-	defer func() {
-		if _, unlockErr := conn.ExecContext(ctx, s.rebind(`SELECT pg_advisory_unlock(?)`), postgresSchemaLockID); unlockErr != nil {
-			if retErr != nil {
-				retErr = fmt.Errorf("%w; failed to release schema init lock: %v", retErr, unlockErr)
-			} else {
-				retErr = fmt.Errorf("failed to release schema init lock: %w", unlockErr)
-			}
-		}
-	}()
-
-	s.logger.Info("Initializing PostgreSQL schema")
-	if err := s.execSchemaStatements(ctx, conn, postgresSchemaSQL); err != nil {
-		return fmt.Errorf("failed to execute postgres schema: %w", err)
-	}
-
-	s.logger.Info("PostgreSQL schema initialized")
-	return nil
-}
-
-func (s *PostgresStorage) execSchemaStatements(ctx context.Context, conn *sql.Conn, schema string) error {
-	if _, err := conn.ExecContext(ctx, schema); err != nil {
-		return err
-	}
-	return nil
 }
 
 func withDefaultPostgresConfig(cfg PostgresConnectionConfig) PostgresConnectionConfig {

--- a/gateway/gateway-controller/pkg/storage/sqlserver.go
+++ b/gateway/gateway-controller/pkg/storage/sqlserver.go
@@ -21,7 +21,6 @@ package storage
 import (
 	"context"
 	"database/sql"
-	_ "embed"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -34,13 +33,7 @@ import (
 	mssql "github.com/microsoft/go-mssqldb"
 )
 
-//go:embed gateway-controller-db.sqlserver.sql
-var sqlserverSchemaSQL string
-
 const (
-	// sqlserverSchemaLockResource names the application lock used to serialize
-	// concurrent schema initialization across controller replicas.
-	sqlserverSchemaLockResource = "gateway-controller-schema-init"
 	// SQL Server error numbers for unique-constraint / duplicate-key violations.
 	sqlserverUniqueConstraintErr = 2627 // PRIMARY KEY / UNIQUE constraint violation
 	sqlserverDuplicateKeyErr     = 2601 // unique index violation
@@ -49,10 +42,6 @@ const (
 	// in tests). The config layer normalizes/validates the value before this for
 	// config-driven startup; this keeps the storage layer self-sufficient.
 	defaultSQLServerEncrypt = "true"
-	// schemaInitTimeout bounds the schema-initialization path (connection,
-	// application lock and DDL) so a stalled server cannot hang startup forever.
-	// It must exceed the 30s app-lock wait used in initSchema.
-	schemaInitTimeout = 2 * time.Minute
 )
 
 // SQLServerConnectionConfig holds SQL Server-specific connection settings.
@@ -113,11 +102,6 @@ func newSQLServerStorage(cfg SQLServerConnectionConfig, logger *slog.Logger) (*S
 		return nil, fmt.Errorf("failed to ping sqlserver database: %w", err)
 	}
 
-	if err := storage.initSchema(); err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("failed to initialize schema: %w", err)
-	}
-
 	logger.Info("SQLServer storage initialized",
 		slog.String("host", cfg.Host),
 		slog.Int("port", cfg.Port),
@@ -131,64 +115,6 @@ func newSQLServerStorage(cfg SQLServerConnectionConfig, logger *slog.Logger) (*S
 		slog.String("dsn", sanitizeSQLServerDSN(dsn)))
 
 	return storage, nil
-}
-
-// initSchema creates the database schema if it doesn't exist. The embedded
-// schema is idempotent (every object is guarded by IF NOT EXISTS); an
-// application lock serializes concurrent initialization across replicas.
-func (s *SQLServerStorage) initSchema() (retErr error) {
-	// Bound the whole init path (connection acquisition, app-lock wait and DDL)
-	// so startup cannot hang indefinitely if SQL Server stalls after the ping.
-	ctx, cancel := context.WithTimeout(context.Background(), schemaInitTimeout)
-	defer cancel()
-
-	conn, err := s.db.Conn(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to acquire sqlserver connection for schema init: %w", err)
-	}
-	defer func() {
-		if closeErr := conn.Close(); closeErr != nil {
-			if retErr != nil {
-				retErr = fmt.Errorf("%w; failed to close schema init connection: %v", retErr, closeErr)
-			} else {
-				retErr = fmt.Errorf("failed to close schema init connection: %w", closeErr)
-			}
-		}
-	}()
-
-	// Serialize schema init across replicas with a session-scoped application lock.
-	// sp_getapplock reports failure (e.g. a lock-wait timeout) only through its
-	// integer return code, not via a driver error, so capture and inspect it.
-	// Non-negative means granted (0 = granted, 1 = granted after waiting);
-	// negative codes (-1 timeout, -2 cancelled, -3 deadlock, -999 other) are failures.
-	var lockStatus mssql.ReturnStatus
-	if _, err := conn.ExecContext(ctx,
-		"EXEC sp_getapplock @Resource = @p1, @LockMode = 'Exclusive', @LockOwner = 'Session', @LockTimeout = 30000",
-		sqlserverSchemaLockResource, &lockStatus); err != nil {
-		return fmt.Errorf("failed to acquire schema init lock: %w", err)
-	}
-	if lockStatus < 0 {
-		return fmt.Errorf("failed to acquire schema init lock: sp_getapplock returned %d", int(lockStatus))
-	}
-	defer func() {
-		if _, unlockErr := conn.ExecContext(ctx,
-			"EXEC sp_releaseapplock @Resource = @p1, @LockOwner = 'Session'",
-			sqlserverSchemaLockResource); unlockErr != nil {
-			if retErr != nil {
-				retErr = fmt.Errorf("%w; failed to release schema init lock: %v", retErr, unlockErr)
-			} else {
-				retErr = fmt.Errorf("failed to release schema init lock: %w", unlockErr)
-			}
-		}
-	}()
-
-	s.logger.Info("Initializing SQLServer schema")
-	if _, err := conn.ExecContext(ctx, sqlserverSchemaSQL); err != nil {
-		return fmt.Errorf("failed to execute sqlserver schema: %w", err)
-	}
-
-	s.logger.Info("SQLServer schema initialized")
-	return nil
 }
 
 func withDefaultSQLServerConfig(cfg SQLServerConnectionConfig) SQLServerConnectionConfig {

--- a/gateway/it/docker-compose.test.postgres.yaml
+++ b/gateway/it/docker-compose.test.postgres.yaml
@@ -60,6 +60,12 @@ services:
       - POSTGRES_DB=gateway_test
       - POSTGRES_USER=gateway
       - POSTGRES_PASSWORD=gateway
+    volumes:
+      # gateway-controller no longer auto-applies schema DDL against external
+      # databases on startup (schema must be pre-provisioned by the operator) —
+      # apply it here via Postgres's first-boot init hook instead, so the IT
+      # suite exercises the same pre-provisioned-DB path operators use.
+      - ../gateway-controller/pkg/storage/gateway-controller-db.postgres.sql:/docker-entrypoint-initdb.d/01-gateway-controller-schema.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U gateway -d gateway_test"]
       interval: 5s

--- a/gateway/it/docker-compose.test.sqlserver.yaml
+++ b/gateway/it/docker-compose.test.sqlserver.yaml
@@ -97,10 +97,10 @@ services:
     entrypoint: ["/bin/bash", "-c"]
     command:
       - >
-        /opt/mssql-tools18/bin/sqlcmd -C -S sqlserver -U sa -P "$$MSSQL_SA_PASSWORD"
+        /opt/mssql-tools18/bin/sqlcmd -b -C -S sqlserver -U sa -P "$$MSSQL_SA_PASSWORD"
         -Q "IF DB_ID('$$MSSQL_DB') IS NULL CREATE DATABASE [$$MSSQL_DB]"
         &&
-        /opt/mssql-tools18/bin/sqlcmd -C -S sqlserver -U sa -P "$$MSSQL_SA_PASSWORD"
+        /opt/mssql-tools18/bin/sqlcmd -b -C -S sqlserver -U sa -P "$$MSSQL_SA_PASSWORD"
         -d "$$MSSQL_DB" -i /schema/gateway-controller-schema.sql
     restart: "no"
     networks:

--- a/gateway/it/docker-compose.test.sqlserver.yaml
+++ b/gateway/it/docker-compose.test.sqlserver.yaml
@@ -79,7 +79,10 @@ services:
       - it-gateway-runtime-network
 
   # One-shot: SQL Server does not auto-create an application database, so create
-  # gateway_test once the server is healthy. The controller auto-creates its schema.
+  # gateway_test once the server is healthy. gateway-controller no longer auto-applies
+  # schema DDL against external databases on startup (schema must be pre-provisioned
+  # by the operator) — apply the shipped schema script here instead, so the IT suite
+  # exercises the same pre-provisioned-DB path operators use.
   mssql-init:
     container_name: it-mssql-init
     image: mcr.microsoft.com/mssql/server:2022-latest
@@ -89,11 +92,16 @@ services:
     environment:
       - MSSQL_SA_PASSWORD=${MSSQL_SA_PASSWORD:-Gateway_Strong!Pass123}
       - MSSQL_DB=gateway_test
+    volumes:
+      - ../gateway-controller/pkg/storage/gateway-controller-db.sqlserver.sql:/schema/gateway-controller-schema.sql:ro
     entrypoint: ["/bin/bash", "-c"]
     command:
       - >
         /opt/mssql-tools18/bin/sqlcmd -C -S sqlserver -U sa -P "$$MSSQL_SA_PASSWORD"
         -Q "IF DB_ID('$$MSSQL_DB') IS NULL CREATE DATABASE [$$MSSQL_DB]"
+        &&
+        /opt/mssql-tools18/bin/sqlcmd -C -S sqlserver -U sa -P "$$MSSQL_SA_PASSWORD"
+        -d "$$MSSQL_DB" -i /schema/gateway-controller-schema.sql
     restart: "no"
     networks:
       - it-gateway-runtime-network

--- a/tests/integration-e2e/docker-compose.sqlserver.yaml
+++ b/tests/integration-e2e/docker-compose.sqlserver.yaml
@@ -17,9 +17,10 @@ services:
     networks: [e2e]
 
   # Creates both databases via sqlcmd (the server images do not auto-create them)
-  # and pre-provisions the platform_api schema: platform-api only auto-runs DDL
-  # for SQLite, so against SQL Server the operator must provision it. The
-  # gateway-controller still auto-migrates its own gateway_test schema.
+  # and pre-provisions both schemas: neither platform-api nor the gateway-controller
+  # auto-runs DDL against an external SQL Server, so the operator must provision
+  # them. platform_api gets the platform-api schema; gateway_test gets the
+  # gateway-controller schema.
   mssql-init:
     image: mcr.microsoft.com/mssql-tools:latest
     depends_on:
@@ -34,11 +35,13 @@ services:
         done;
         /opt/mssql-tools/bin/sqlcmd -S sqlserver -U sa -P "$${MSSQL_SA_PASSWORD}" -b -Q
         "IF DB_ID('platform_api') IS NULL CREATE DATABASE [platform_api]; IF DB_ID('gateway_test') IS NULL CREATE DATABASE [gateway_test];" &&
-        /opt/mssql-tools/bin/sqlcmd -S sqlserver -U sa -P "$${MSSQL_SA_PASSWORD}" -b -I -d platform_api -i /schema/schema.sqlserver.sql
+        /opt/mssql-tools/bin/sqlcmd -S sqlserver -U sa -P "$${MSSQL_SA_PASSWORD}" -b -I -d platform_api -i /schema/schema.sqlserver.sql &&
+        /opt/mssql-tools/bin/sqlcmd -S sqlserver -U sa -P "$${MSSQL_SA_PASSWORD}" -b -I -d gateway_test -i /gw-schema/schema.sqlserver.sql
     environment:
       - MSSQL_SA_PASSWORD=${MSSQL_PASSWORD:-Strong!Passw0rd}
     volumes:
       - ../../platform-api/internal/database/schema.sqlserver.sql:/schema/schema.sqlserver.sql:ro
+      - ../../gateway/gateway-controller/pkg/storage/gateway-controller-db.sqlserver.sql:/gw-schema/schema.sqlserver.sql:ro
     networks: [e2e]
 
   # One-shot init container: generates the TLS pair the platform-api HTTPS

--- a/tests/integration-e2e/docker-compose.yaml
+++ b/tests/integration-e2e/docker-compose.yaml
@@ -28,6 +28,9 @@ services:
       # The developer portal likewise pre-loads its schema on postgres (it does
       # not sequelize.sync() on external DBs); init-db.sql applies it too.
       - ../../portals/developer-portal/database/schema.postgres.sql:/devportal-schema/schema.postgres.sql:ro
+      # The gateway-controller no longer auto-migrates its schema on external
+      # databases either; init-db.sql applies it to gateway_test / gateway_test2.
+      - ../../gateway/gateway-controller/pkg/storage/gateway-controller-db.postgres.sql:/gw-schema/schema.postgres.sql:ro
     ports:
       - "55433:5432"
     healthcheck:

--- a/tests/integration-e2e/init-db.sql
+++ b/tests/integration-e2e/init-db.sql
@@ -14,8 +14,7 @@ CREATE DATABASE devportal;
 -- platform-api only auto-runs schema DDL for SQLite; against an external
 -- database it expects the schema to be pre-provisioned by the operator. Apply
 -- the platform-api schema to its database here so the file-based org seeding at
--- startup finds its tables. (gateway-controller still auto-migrates its own
--- gateway_test / gateway_test2 schema.)
+-- startup finds its tables.
 \connect platform_api
 \i /schema/schema.postgres.sql
 
@@ -23,3 +22,12 @@ CREATE DATABASE devportal;
 -- an external postgres — its own postgres compose loads this dump at init too).
 \connect devportal
 \i /devportal-schema/schema.postgres.sql
+
+-- The gateway-controller likewise no longer auto-migrates its schema on external
+-- databases, so pre-provision it into both gateway-controller stores here
+-- (gateway_test, plus gateway_test2 for the multi-gateway scenario).
+\connect gateway_test
+\i /gw-schema/schema.postgres.sql
+
+\connect gateway_test2
+\i /gw-schema/schema.postgres.sql


### PR DESCRIPTION
Related to https://github.com/wso2/api-platform/issues/2803

This pull request updates the event-gateway and gateway-controller to stop auto-applying schema DDL to external databases (Postgres and SQL Server) at startup. Instead, operators must pre-provision the required schema using the shipped SQL scripts. The integration test setups and documentation are updated accordingly to reflect and enforce this new policy.

**Database schema provisioning changes:**

* The gateway-controller now only auto-applies schema DDL for the embedded `sqlite` backend; for external databases (`postgres`, `sqlserver`), the schema must be pre-provisioned by the operator. The code that auto-applied DDL for Postgres and SQL Server has been removed from `postgres.go` and `sqlserver.go`; the controller logs a message instead if using an external DB. (`gateway/gateway-controller/cmd/controller/main.go`, `gateway/gateway-controller/pkg/storage/postgres.go`, `gateway/gateway-controller/pkg/storage/sqlserver.go`) [[1]](diffhunk://#diff-19dc17be1cbfe1d2bf10917895b40be689bc3ac7e61deb6f3745b29f1aac1b90L207-R222) [[2]](diffhunk://#diff-88e24a210cb1eb2024c6e9ab86c4980ceab15b18e089f57dbb98289f19395a8eL24) [[3]](diffhunk://#diff-88e24a210cb1eb2024c6e9ab86c4980ceab15b18e089f57dbb98289f19395a8eL38-L42) [[4]](diffhunk://#diff-88e24a210cb1eb2024c6e9ab86c4980ceab15b18e089f57dbb98289f19395a8eL103-L107) [[5]](diffhunk://#diff-88e24a210cb1eb2024c6e9ab86c4980ceab15b18e089f57dbb98289f19395a8eL122-L168) [[6]](diffhunk://#diff-f109a8810c53867a0879dca9269b52f5a4fa31c167124e20bb5489e06eb54693L24) [[7]](diffhunk://#diff-f109a8810c53867a0879dca9269b52f5a4fa31c167124e20bb5489e06eb54693L37-L43) [[8]](diffhunk://#diff-f109a8810c53867a0879dca9269b52f5a4fa31c167124e20bb5489e06eb54693L52-L55)

* The shipped SQL schema scripts for Postgres and SQL Server are now included in the distribution under `resources/gateway-controller/db-scripts/`, and the SQL Server script is updated to explicitly set `QUOTED_IDENTIFIER` and `ANSI_NULLS` for compatibility with `sqlcmd`. (`gateway/Makefile`, `gateway/gateway-controller/pkg/storage/gateway-controller-db.sqlserver.sql`, `gateway/distribution/README.md`) [[1]](diffhunk://#diff-cfbe9fcfb59cb9fbcfedef29acbc45c1986861c57557d5300bd987c85233e092L235-R245) [[2]](diffhunk://#diff-6f94ca53bfeb5d85bd55e180647232d7048ad4c83e674c53bd99e70cb605be54R14-R22) [[3]](diffhunk://#diff-01bcfb7bb7632b059ed95568a1fc0d83bd41260ababf5d16929d6910d1a578e3L25-R27) [[4]](diffhunk://#diff-01bcfb7bb7632b059ed95568a1fc0d83bd41260ababf5d16929d6910d1a578e3R85-R125)

**Integration test and Docker Compose changes:**

* The integration test Docker Compose files for Postgres and SQL Server now pre-provision both the core and event-gateway-specific tables by mounting the SQL scripts and running them at container startup, matching the new operator workflow. (`event-gateway/docker-compose.test.postgres.yaml`, `event-gateway/docker-compose.test.sqlserver.yaml`) [[1]](diffhunk://#diff-59ccc61e0ba6115f19d1b89f092a6084567d978e5679dda37bb11cc890cd2da9R35-R45) [[2]](diffhunk://#diff-6953898e828d87ca7411647be5d38f6833ebfc7e52714165eab3affa83d10c24R60-R81)

* Integration test workflows (`.github/workflows/`) are updated to:
  - Wait for the controller to report a successful DB connection (not schema init).
  - Assert the presence of all required tables (including event-gateway-specific tables) to catch any schema provisioning failures.
  - Remove log checks for schema initialization messages. (`.github/workflows/event-gateway-integration-test-postgres.yml`, `.github/workflows/event-gateway-integration-test-sqlserver.yml`, `.github/workflows/gateway-integration-test-postgres.yml`, `.github/workflows/gateway-integration-test-sqlserver.yml`) [[1]](diffhunk://#diff-e8707550b15e232fa1914f8eda7cc49049c9b3fb51668574ee6fc4711337a820R81-R101) [[2]](diffhunk://#diff-83a0414c5f4a3c440cfafe578c89fbad9958b7443bf8e90ae9adf7cc9ec34a31R84-R93) [[3]](diffhunk://#diff-83a0414c5f4a3c440cfafe578c89fbad9958b7443bf8e90ae9adf7cc9ec34a31R106-R114) [[4]](diffhunk://#diff-09e72524ed6e5ed1804e22a00ad320a63505da0ccbb2196df114c3bd5c4a8368L64-R67) [[5]](diffhunk://#diff-eeaa136612cee54b195ec2e133c2cbbccb8eaa5efd34ff7d8e3636495b8319e6L79-R82)

**Documentation:**

* The distribution README is updated with clear instructions for operators on how to pre-provision the database schema for external Postgres and SQL Server backends, including example commands and configuration guidance. (`gateway/distribution/README.md`) [[1]](diffhunk://#diff-01bcfb7bb7632b059ed95568a1fc0d83bd41260ababf5d16929d6910d1a578e3L25-R27) [[2]](diffhunk://#diff-01bcfb7bb7632b059ed95568a1fc0d83bd41260ababf5d16929d6910d1a578e3R85-R125)