### PR TITLE
Support grouping and versioning of DP origin LLM provider templates

### DIFF
--- a/platform-api/internal/repository/interfaces.go
+++ b/platform-api/internal/repository/interfaces.go
@@ -223,7 +223,7 @@ type SubscriptionRepository interface {
 type LLMProviderTemplateRepository interface {
 	Create(t *model.LLMProviderTemplate) error
 	CreateNewVersion(t *model.LLMProviderTemplate) error
-	CreateImportedVersion(t *model.LLMProviderTemplate, makeLatest bool) error
+	CreateImportedVersion(t *model.LLMProviderTemplate) (bool, error)
 	GetByID(templateID, orgUUID string) (*model.LLMProviderTemplate, error)
 	GetByUUID(uuid, orgUUID string) (*model.LLMProviderTemplate, error)
 	GetByVersion(templateID, orgUUID, version string) (*model.LLMProviderTemplate, error)

--- a/platform-api/internal/repository/interfaces.go
+++ b/platform-api/internal/repository/interfaces.go
@@ -223,6 +223,7 @@ type SubscriptionRepository interface {
 type LLMProviderTemplateRepository interface {
 	Create(t *model.LLMProviderTemplate) error
 	CreateNewVersion(t *model.LLMProviderTemplate) error
+	CreateImportedVersion(t *model.LLMProviderTemplate, makeLatest bool) error
 	GetByID(templateID, orgUUID string) (*model.LLMProviderTemplate, error)
 	GetByUUID(uuid, orgUUID string) (*model.LLMProviderTemplate, error)
 	GetByVersion(templateID, orgUUID, version string) (*model.LLMProviderTemplate, error)

--- a/platform-api/internal/repository/llm.go
+++ b/platform-api/internal/repository/llm.go
@@ -123,6 +123,89 @@ func (r *LLMProviderTemplateRepo) Create(t *model.LLMProviderTemplate) error {
 	return err
 }
 
+// CreateImportedVersion inserts a template version pushed from the gateway (DP->CP)
+func (r *LLMProviderTemplateRepo) CreateImportedVersion(t *model.LLMProviderTemplate, makeLatest bool) error {
+	configJSON, err := json.Marshal(&llmProviderTemplateConfig{
+		ManagedBy:        t.ManagedBy,
+		Metadata:         t.Metadata,
+		PromptTokens:     t.PromptTokens,
+		CompletionTokens: t.CompletionTokens,
+		TotalTokens:      t.TotalTokens,
+		RemainingTokens:  t.RemainingTokens,
+		RequestModel:     t.RequestModel,
+		ResponseModel:    t.ResponseModel,
+		ResourceMappings: t.ResourceMappings,
+	})
+	if err != nil {
+		return err
+	}
+
+	tx, err := r.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// Defensive: the importer resolves an existing version by handle before reaching this path,
+	// so (group_id, version) should be new here. Reject a collision rather than create a
+	// duplicate version within the family.
+	var sameVersion int
+	if err = tx.QueryRow(r.db.Rebind(`
+		SELECT COUNT(*) FROM llm_provider_templates WHERE group_id = ? AND organization_uuid = ? AND version = ?
+	`), t.GroupID, t.OrganizationUUID, t.Version).Scan(&sameVersion); err != nil {
+		return err
+	}
+	if sameVersion > 0 {
+		return apperror.LLMProviderTemplateVersionExists.New()
+	}
+
+	if makeLatest {
+		if _, err = tx.Exec(r.db.Rebind(`
+			UPDATE llm_provider_templates SET is_latest = ? WHERE group_id = ? AND organization_uuid = ? AND is_latest = ?
+		`), 0, t.GroupID, t.OrganizationUUID, 1); err != nil {
+			return err
+		}
+	}
+
+	if t.UUID == "" {
+		uuidStr, uerr := utils.GenerateUUID()
+		if uerr != nil {
+			return fmt.Errorf("failed to generate LLM provider template ID: %w", uerr)
+		}
+		t.UUID = uuidStr
+	}
+	t.IsLatest = makeLatest
+	t.Enabled = true
+	t.UpdatedBy = t.CreatedBy
+	now := time.Now().UTC()
+	if t.CreatedAt.IsZero() {
+		t.CreatedAt = now
+	}
+	if t.UpdatedAt.IsZero() {
+		t.UpdatedAt = now
+	}
+	origin := t.Origin
+	if origin == "" {
+		origin = constants.OriginCP
+	}
+
+	if _, err = tx.Exec(r.db.Rebind(`
+		INSERT INTO llm_provider_templates (
+			uuid, organization_uuid, handle, group_id, display_name, managed_by, description, created_by, updated_by,
+			origin, configuration, openapi_spec, version, is_latest, enabled, created_at, updated_at
+		)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`),
+		t.UUID, t.OrganizationUUID, t.ID, t.GroupID, t.Name, t.ManagedBy, t.Description, t.CreatedBy, t.UpdatedBy,
+		origin, configJSON, []byte(t.OpenAPISpec), t.Version, boolToInt(t.IsLatest), boolToInt(t.Enabled),
+		t.CreatedAt, t.UpdatedAt,
+	); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
 const maxCreateNewVersionRetries = 3
 
 func (r *LLMProviderTemplateRepo) CreateNewVersion(t *model.LLMProviderTemplate) error {

--- a/platform-api/internal/repository/llm.go
+++ b/platform-api/internal/repository/llm.go
@@ -124,7 +124,7 @@ func (r *LLMProviderTemplateRepo) Create(t *model.LLMProviderTemplate) error {
 }
 
 // CreateImportedVersion inserts a template version pushed from the gateway (DP->CP)
-func (r *LLMProviderTemplateRepo) CreateImportedVersion(t *model.LLMProviderTemplate, makeLatest bool) error {
+func (r *LLMProviderTemplateRepo) CreateImportedVersion(t *model.LLMProviderTemplate) (bool, error) {
 	configJSON, err := json.Marshal(&llmProviderTemplateConfig{
 		ManagedBy:        t.ManagedBy,
 		Metadata:         t.Metadata,
@@ -137,40 +137,77 @@ func (r *LLMProviderTemplateRepo) CreateImportedVersion(t *model.LLMProviderTemp
 		ResourceMappings: t.ResourceMappings,
 	})
 	if err != nil {
-		return err
+		return false, err
 	}
 
+	var lastErr error
+	for attempt := 0; attempt < maxCreateNewVersionRetries; attempt++ {
+		madeLatest, err := r.createImportedVersionOnce(t, configJSON)
+		if err == nil {
+			return madeLatest, nil
+		}
+		if !r.db.IsDuplicateKeyError(err) {
+			return false, err
+		}
+		lastErr = err
+	}
+	return false, lastErr
+}
+
+func (r *LLMProviderTemplateRepo) createImportedVersionOnce(t *model.LLMProviderTemplate, configJSON []byte) (bool, error) {
 	tx, err := r.db.Begin()
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	// Defensive: the importer resolves an existing version by handle before reaching this path,
-	// so (group_id, version) should be new here. Reject a collision rather than create a
-	// duplicate version within the family.
-	var sameVersion int
-	if err = tx.QueryRow(r.db.Rebind(`
-		SELECT COUNT(*) FROM llm_provider_templates WHERE group_id = ? AND organization_uuid = ? AND version = ?
-	`), t.GroupID, t.OrganizationUUID, t.Version).Scan(&sameVersion); err != nil {
-		return err
+	rows, err := tx.Query(r.db.Rebind(`
+		SELECT version FROM llm_provider_templates WHERE group_id = ? AND organization_uuid = ?
+	`), t.GroupID, t.OrganizationUUID)
+	if err != nil {
+		return false, err
 	}
-	if sameVersion > 0 {
-		return apperror.LLMProviderTemplateVersionExists.New()
+	var existingVersions []string
+	for rows.Next() {
+		var v string
+		if err := rows.Scan(&v); err != nil {
+			rows.Close()
+			return false, err
+		}
+		existingVersions = append(existingVersions, v)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return false, err
+	}
+	rows.Close()
+
+	// The importer resolves an existing version by handle before reaching this path, so
+	// (group_id, version) should be new; a match here means a different handle already claimed this
+	// family version (a genuine conflict, or a concurrent writer seen on retry) — reject it.
+	makeLatest := true
+	for _, ev := range existingVersions {
+		if ev == t.Version {
+			return false, apperror.LLMProviderTemplateVersionExists.New()
+		}
+		if !utils.TemplateVersionNewer(t.Version, ev) {
+			makeLatest = false
+			break
+		}
 	}
 
 	if makeLatest {
 		if _, err = tx.Exec(r.db.Rebind(`
 			UPDATE llm_provider_templates SET is_latest = ? WHERE group_id = ? AND organization_uuid = ? AND is_latest = ?
 		`), 0, t.GroupID, t.OrganizationUUID, 1); err != nil {
-			return err
+			return false, err
 		}
 	}
 
 	if t.UUID == "" {
 		uuidStr, uerr := utils.GenerateUUID()
 		if uerr != nil {
-			return fmt.Errorf("failed to generate LLM provider template ID: %w", uerr)
+			return false, fmt.Errorf("failed to generate LLM provider template ID: %w", uerr)
 		}
 		t.UUID = uuidStr
 	}
@@ -200,10 +237,13 @@ func (r *LLMProviderTemplateRepo) CreateImportedVersion(t *model.LLMProviderTemp
 		origin, configJSON, []byte(t.OpenAPISpec), t.Version, boolToInt(t.IsLatest), boolToInt(t.Enabled),
 		t.CreatedAt, t.UpdatedAt,
 	); err != nil {
-		return err
+		return false, err
 	}
 
-	return tx.Commit()
+	if err = tx.Commit(); err != nil {
+		return false, err
+	}
+	return makeLatest, nil
 }
 
 const maxCreateNewVersionRetries = 3

--- a/platform-api/internal/repository/llm_test.go
+++ b/platform-api/internal/repository/llm_test.go
@@ -173,3 +173,68 @@ func TestLLMProviderTemplateRepo_GetByID_ExactVersion(t *testing.T) {
 		t.Fatalf("GetByID(unknown) = %+v, want nil", got)
 	}
 }
+
+// CreateImportedVersion must decide is_latest from the family it reads inside its own transaction
+// (not from any pre-computed value), so a lower version added after a higher one never steals the
+// latest slot and a genuine duplicate version is rejected. This is the regression guard for the
+// concurrent-import latest race: the decision + demotion + insert are one atomic unit.
+func TestLLMProviderTemplateRepo_CreateImportedVersion_DecidesLatestFromFamily(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	t.Cleanup(cleanup)
+
+	repo := NewLLMProviderTemplateRepo(db)
+	orgUUID := "org-imp-001"
+	projectUUID := "project-imp-001"
+	createTestOrganizationAndProject(t, db, orgUUID, projectUUID)
+
+	// Seed the family's first version as the current latest.
+	v2 := &model.LLMProviderTemplate{OrganizationUUID: orgUUID, ID: "openai-v2", GroupID: "openai", Name: "OpenAI", Version: "v2.0", Origin: "gateway_api"}
+	madeLatest, err := repo.CreateImportedVersion(v2)
+	if err != nil || !madeLatest {
+		t.Fatalf("CreateImportedVersion(v2.0) = (%v, %v), want (true, nil)", madeLatest, err)
+	}
+
+	// A lower version arriving afterwards must NOT become latest and must NOT demote v2.0.
+	v1 := &model.LLMProviderTemplate{OrganizationUUID: orgUUID, ID: "openai-v1", GroupID: "openai", Name: "OpenAI", Version: "v1.0", Origin: "gateway_api"}
+	madeLatest, err = repo.CreateImportedVersion(v1)
+	if err != nil {
+		t.Fatalf("CreateImportedVersion(v1.0) error: %v", err)
+	}
+	if madeLatest {
+		t.Errorf("v1.0 must not become latest when v2.0 already exists")
+	}
+	if got, _ := repo.GetByID("openai-v2", orgUUID); got == nil || !got.IsLatest {
+		t.Errorf("v2.0 must remain is_latest after a lower version is added")
+	}
+
+	// A higher version arriving afterwards becomes latest and demotes v2.0.
+	v3 := &model.LLMProviderTemplate{OrganizationUUID: orgUUID, ID: "openai-v3", GroupID: "openai", Name: "OpenAI", Version: "v3.0", Origin: "gateway_api"}
+	madeLatest, err = repo.CreateImportedVersion(v3)
+	if err != nil || !madeLatest {
+		t.Fatalf("CreateImportedVersion(v3.0) = (%v, %v), want (true, nil)", madeLatest, err)
+	}
+	if got, _ := repo.GetByID("openai-v2", orgUUID); got == nil || got.IsLatest {
+		t.Errorf("v2.0 must be demoted once v3.0 joins the family")
+	}
+
+	// A duplicate version (different handle, same group_id+version) is rejected, not retried forever.
+	dup := &model.LLMProviderTemplate{OrganizationUUID: orgUUID, ID: "openai-v3-dup", GroupID: "openai", Name: "OpenAI", Version: "v3.0", Origin: "gateway_api"}
+	if _, err := repo.CreateImportedVersion(dup); err == nil {
+		t.Errorf("CreateImportedVersion(duplicate v3.0) = nil error, want a version-exists error")
+	}
+
+	// Exactly one latest survives in the family.
+	all, err := repo.ListVersions("openai", orgUUID, 100, 0)
+	if err != nil {
+		t.Fatalf("ListVersions error: %v", err)
+	}
+	latestCount := 0
+	for _, v := range all {
+		if v.IsLatest {
+			latestCount++
+		}
+	}
+	if latestCount != 1 {
+		t.Errorf("family has %d is_latest rows, want exactly 1", latestCount)
+	}
+}

--- a/platform-api/internal/service/artifact_import_lifecycle_test.go
+++ b/platform-api/internal/service/artifact_import_lifecycle_test.go
@@ -370,6 +370,71 @@ func TestImport_LLMProviderTemplate_CPOriginProtected(t *testing.T) {
 	}
 }
 
+// dpVersionedTemplateReq builds a gateway template push carrying the versioning identity
+// (groupId/version/managedBy) that issue #2717 requires the control plane to honor.
+func dpVersionedTemplateReq(dpID, handle, displayName, groupID, version, managedBy string) dto.ImportGatewayArtifactRequest {
+	req := dpTemplateReq(dpID, handle, displayName)
+	req.Configuration.Spec["groupId"] = groupID
+	req.Configuration.Spec["version"] = version
+	req.Configuration.Spec["managedBy"] = managedBy
+	return req
+}
+
+// A gateway pushes two handles sharing a groupId: the control plane must store them as two
+// versions of one family (same group_id, distinct versions, is_latest on the highest), not two
+// standalone templates — the core of issue #2717.
+func TestImport_LLMProviderTemplate_GroupIDAndVersionHonored(t *testing.T) {
+	d := setupImportTest(t)
+
+	mustImport(t, d, withDeployedAt(dpVersionedTemplateReq("dp-v1", "openai-v1", "OpenAI", "openai", "v1.0", "wso2"), baseDeployedAt))
+
+	v1, _ := d.templateRepo.GetByID("openai-v1", importTestOrgID)
+	if v1 == nil || v1.GroupID != "openai" || v1.Version != "v1.0" || v1.ManagedBy != "wso2" {
+		t.Fatalf("v1 = %+v, want group_id 'openai', version 'v1.0', managed_by 'wso2'", v1)
+	}
+	if !v1.IsLatest {
+		t.Errorf("first version must be is_latest")
+	}
+
+	// A second handle in the same family with a higher version.
+	mustImport(t, d, withDeployedAt(dpVersionedTemplateReq("dp-v2", "openai-v2", "OpenAI", "openai", "v2.0", "wso2"), newerDeployedAt))
+
+	v2, _ := d.templateRepo.GetByID("openai-v2", importTestOrgID)
+	if v2 == nil || v2.GroupID != "openai" || v2.Version != "v2.0" {
+		t.Fatalf("v2 = %+v, want group_id 'openai', version 'v2.0'", v2)
+	}
+	// v2 is the highest version -> it becomes latest, v1 is demoted.
+	if !v2.IsLatest {
+		t.Errorf("v2.0 must be is_latest after being added to the family")
+	}
+	v1After, _ := d.templateRepo.GetByID("openai-v1", importTestOrgID)
+	if v1After.IsLatest {
+		t.Errorf("v1.0 must be demoted once v2.0 joins the family")
+	}
+	if n, _ := d.templateRepo.CountVersions("openai", importTestOrgID); n != 2 {
+		t.Errorf("family 'openai' has %d versions, want 2", n)
+	}
+}
+
+// A gateway resync pushes versions newest-first (GetGatewayOriginArtifactsForSync orders by
+// created_at DESC). is_latest must track the highest version, not the last one pushed.
+func TestImport_LLMProviderTemplate_OutOfOrderVersionKeepsHighestLatest(t *testing.T) {
+	d := setupImportTest(t)
+
+	// v2.0 arrives first, then the older v1.0.
+	mustImport(t, d, withDeployedAt(dpVersionedTemplateReq("dp-v2", "openai-v2", "OpenAI", "openai", "v2.0", "wso2"), newerDeployedAt))
+	mustImport(t, d, withDeployedAt(dpVersionedTemplateReq("dp-v1", "openai-v1", "OpenAI", "openai", "v1.0", "wso2"), baseDeployedAt))
+
+	v2, _ := d.templateRepo.GetByID("openai-v2", importTestOrgID)
+	v1, _ := d.templateRepo.GetByID("openai-v1", importTestOrgID)
+	if !v2.IsLatest {
+		t.Errorf("v2.0 must remain is_latest even though v1.0 was pushed after it")
+	}
+	if v1.IsLatest {
+		t.Errorf("v1.0 must not be is_latest (it is lower than v2.0)")
+	}
+}
+
 // ===========================================================================
 // LLM Provider lifecycle (organization-level, deployment-backed,
 // references its template by handle)

--- a/platform-api/internal/service/artifact_import_llm_template.go
+++ b/platform-api/internal/service/artifact_import_llm_template.go
@@ -19,7 +19,6 @@ package service
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/wso2/api-platform/platform-api/internal/constants"
@@ -102,11 +101,7 @@ func (i *llmProviderTemplateImporter) Import(ctx *ImportContext) (*ImportResult,
 			tmpl.CreatedAt = *ctx.DeployedAt
 			tmpl.UpdatedAt = *ctx.DeployedAt
 		}
-		makeLatest, err := i.isNewestInFamily(groupID, version, ctx.OrgID)
-		if err != nil {
-			return nil, err
-		}
-		if err := i.templateRepo.CreateImportedVersion(tmpl, makeLatest); err != nil {
+		if _, err := i.templateRepo.CreateImportedVersion(tmpl); err != nil {
 			return nil, fmt.Errorf("failed to create LLM provider template from gateway import: %w", err)
 		}
 		return &ImportResult{ID: tmpl.UUID, DeployedVersion: version, Deployable: false}, nil
@@ -140,55 +135,4 @@ func (i *llmProviderTemplateImporter) Import(ctx *ImportContext) (*ImportResult,
 	}
 	// Return the template's own control-plane UUID, not the orchestrator-generated one.
 	return &ImportResult{ID: existing.UUID, DeployedVersion: version, Deployable: false}, nil
-}
-
-// isNewestInFamily reports whether version is strictly higher than every version already stored for groupID
-func (i *llmProviderTemplateImporter) isNewestInFamily(groupID, version, orgID string) (bool, error) {
-	count, err := i.templateRepo.CountVersions(groupID, orgID)
-	if err != nil {
-		return false, fmt.Errorf("failed to count LLM provider template versions: %w", err)
-	}
-	if count == 0 {
-		return true, nil
-	}
-	versions, err := i.templateRepo.ListVersions(groupID, orgID, count, 0)
-	if err != nil {
-		return false, fmt.Errorf("failed to list LLM provider template versions: %w", err)
-	}
-	for _, ev := range versions {
-		if !templateVersionNewer(version, ev.Version) {
-			return false, nil
-		}
-	}
-	return true, nil
-}
-
-// templateVersionNewer reports whether template version a is strictly higher than b.
-// versions are v<major>.<minor> (e.g. v1.0, v2.3)
-func templateVersionNewer(a, b string) bool {
-	aMaj, aMin, aOK := parseTemplateVersion(a)
-	bMaj, bMin, bOK := parseTemplateVersion(b)
-	if aOK && bOK {
-		if aMaj != bMaj {
-			return aMaj > bMaj
-		}
-		return aMin > bMin
-	}
-	return a > b
-}
-
-func parseTemplateVersion(v string) (major, minor int, ok bool) {
-	v = strings.TrimSpace(v)
-	v = strings.TrimPrefix(v, "v")
-	v = strings.TrimPrefix(v, "V")
-	majStr, minStr, found := strings.Cut(v, ".")
-	if !found {
-		return 0, 0, false
-	}
-	major, err1 := strconv.Atoi(majStr)
-	minor, err2 := strconv.Atoi(minStr)
-	if err1 != nil || err2 != nil {
-		return 0, 0, false
-	}
-	return major, minor, true
 }

--- a/platform-api/internal/service/artifact_import_llm_template.go
+++ b/platform-api/internal/service/artifact_import_llm_template.go
@@ -19,12 +19,17 @@ package service
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/wso2/api-platform/platform-api/internal/constants"
 	"github.com/wso2/api-platform/platform-api/internal/model"
 	"github.com/wso2/api-platform/platform-api/internal/repository"
 	"github.com/wso2/api-platform/platform-api/internal/utils"
 )
+
+// defaultImportTemplateVersion is used when a gateway-pushed template omits spec.version.
+const defaultImportTemplateVersion = "v1.0"
 
 // llmProviderTemplateImporter imports LLM Provider Template artifacts. Templates are
 // organization-level configuration: they are not backed by the artifacts table and
@@ -41,7 +46,7 @@ func (i *llmProviderTemplateImporter) Kind() string          { return constants.
 func (i *llmProviderTemplateImporter) RequiresProject() bool { return false }
 
 func (i *llmProviderTemplateImporter) Import(ctx *ImportContext) (*ImportResult, error) {
-	version := utils.ImportVersion(ctx.Configuration)
+	handle := utils.ImportHandle(ctx.Configuration)
 
 	// Decode the configuration-bearing fields without clobbering identity fields.
 	var specTmpl model.LLMProviderTemplate
@@ -49,11 +54,24 @@ func (i *llmProviderTemplateImporter) Import(ctx *ImportContext) (*ImportResult,
 		return nil, err
 	}
 
+	version := strings.TrimSpace(specTmpl.Version)
+	if version == "" {
+		version = defaultImportTemplateVersion
+	}
+	groupID := strings.TrimSpace(specTmpl.GroupID)
+	if groupID == "" {
+		groupID = handle
+	}
+	managedBy := strings.TrimSpace(specTmpl.ManagedBy)
+	if managedBy == "" {
+		managedBy = constants.TemplateManagedByOrganization
+	}
+
 	// Templates are not in the artifacts table, so the orchestrator cannot resolve them
 	// by handle; resolve existence here by handle (metadata.name). When found, the
 	// template keeps its own control-plane UUID; ctx.ID (a freshly generated UUID) is
 	// used only when creating a new template.
-	existing, err := i.templateRepo.GetByID(utils.ImportHandle(ctx.Configuration), ctx.OrgID)
+	existing, err := i.templateRepo.GetByID(handle, ctx.OrgID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to look up existing LLM provider template: %w", err)
 	}
@@ -62,7 +80,10 @@ func (i *llmProviderTemplateImporter) Import(ctx *ImportContext) (*ImportResult,
 		tmpl := &model.LLMProviderTemplate{
 			UUID:             ctx.ID,
 			OrganizationUUID: ctx.OrgID,
-			ID:               utils.ImportHandle(ctx.Configuration),
+			ID:               handle,
+			GroupID:          groupID,
+			Version:          version,
+			ManagedBy:        managedBy,
 			Name:             utils.ImportDisplayName(ctx.Configuration),
 			Origin:           constants.OriginDP,
 			Metadata:         specTmpl.Metadata,
@@ -81,7 +102,11 @@ func (i *llmProviderTemplateImporter) Import(ctx *ImportContext) (*ImportResult,
 			tmpl.CreatedAt = *ctx.DeployedAt
 			tmpl.UpdatedAt = *ctx.DeployedAt
 		}
-		if err := i.templateRepo.Create(tmpl); err != nil {
+		makeLatest, err := i.isNewestInFamily(groupID, version, ctx.OrgID)
+		if err != nil {
+			return nil, err
+		}
+		if err := i.templateRepo.CreateImportedVersion(tmpl, makeLatest); err != nil {
 			return nil, fmt.Errorf("failed to create LLM provider template from gateway import: %w", err)
 		}
 		return &ImportResult{ID: tmpl.UUID, DeployedVersion: version, Deployable: false}, nil
@@ -92,8 +117,10 @@ func (i *llmProviderTemplateImporter) Import(ctx *ImportContext) (*ImportResult,
 	// copy (templates aren't artifact-backed, so there is no deployments row to derive it from).
 	// A CP-owned template is never overwritten by a gateway push. Templates have no
 	// gateway-specific data, so any non-winning push (CP-owned or stale) is a no-op.
+	// group_id and version are identity for the row (keyed by handle) and are not re-written here.
 	if utils.DecideMetadataWrite(false, existing.Origin, &existing.UpdatedAt, ctx.DeployedAt) == utils.WriteFullMetadata {
 		existing.Name = utils.ImportDisplayName(ctx.Configuration)
+		existing.ManagedBy = managedBy
 		existing.Metadata = specTmpl.Metadata
 		existing.PromptTokens = specTmpl.PromptTokens
 		existing.CompletionTokens = specTmpl.CompletionTokens
@@ -113,4 +140,55 @@ func (i *llmProviderTemplateImporter) Import(ctx *ImportContext) (*ImportResult,
 	}
 	// Return the template's own control-plane UUID, not the orchestrator-generated one.
 	return &ImportResult{ID: existing.UUID, DeployedVersion: version, Deployable: false}, nil
+}
+
+// isNewestInFamily reports whether version is strictly higher than every version already stored for groupID
+func (i *llmProviderTemplateImporter) isNewestInFamily(groupID, version, orgID string) (bool, error) {
+	count, err := i.templateRepo.CountVersions(groupID, orgID)
+	if err != nil {
+		return false, fmt.Errorf("failed to count LLM provider template versions: %w", err)
+	}
+	if count == 0 {
+		return true, nil
+	}
+	versions, err := i.templateRepo.ListVersions(groupID, orgID, count, 0)
+	if err != nil {
+		return false, fmt.Errorf("failed to list LLM provider template versions: %w", err)
+	}
+	for _, ev := range versions {
+		if !templateVersionNewer(version, ev.Version) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// templateVersionNewer reports whether template version a is strictly higher than b.
+// versions are v<major>.<minor> (e.g. v1.0, v2.3)
+func templateVersionNewer(a, b string) bool {
+	aMaj, aMin, aOK := parseTemplateVersion(a)
+	bMaj, bMin, bOK := parseTemplateVersion(b)
+	if aOK && bOK {
+		if aMaj != bMaj {
+			return aMaj > bMaj
+		}
+		return aMin > bMin
+	}
+	return a > b
+}
+
+func parseTemplateVersion(v string) (major, minor int, ok bool) {
+	v = strings.TrimSpace(v)
+	v = strings.TrimPrefix(v, "v")
+	v = strings.TrimPrefix(v, "V")
+	majStr, minStr, found := strings.Cut(v, ".")
+	if !found {
+		return 0, 0, false
+	}
+	major, err1 := strconv.Atoi(majStr)
+	minor, err2 := strconv.Atoi(minStr)
+	if err1 != nil || err2 != nil {
+		return 0, 0, false
+	}
+	return major, minor, true
 }

--- a/platform-api/internal/service/llm_provider_template_test.go
+++ b/platform-api/internal/service/llm_provider_template_test.go
@@ -135,6 +135,15 @@ func (m *mockLLMProviderTemplateCRUDRepo) CreateNewVersion(t *model.LLMProviderT
 	return nil
 }
 
+func (m *mockLLMProviderTemplateCRUDRepo) CreateImportedVersion(t *model.LLMProviderTemplate, makeLatest bool) error {
+	if m.createNewVersionErr != nil {
+		return m.createNewVersionErr
+	}
+	t.IsLatest = makeLatest
+	m.createdVersion = t
+	return nil
+}
+
 func (m *mockLLMProviderTemplateCRUDRepo) CountVersions(templateID, orgUUID string) (int, error) {
 	return m.countVersionsResult, m.countVersionsErr
 }

--- a/platform-api/internal/service/llm_provider_template_test.go
+++ b/platform-api/internal/service/llm_provider_template_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/wso2/api-platform/platform-api/internal/constants"
 	"github.com/wso2/api-platform/platform-api/internal/model"
 	"github.com/wso2/api-platform/platform-api/internal/repository"
+	"github.com/wso2/api-platform/platform-api/internal/utils"
 )
 
 // mockLLMProviderTemplateCRUDRepo is a configurable fake covering the
@@ -135,13 +136,19 @@ func (m *mockLLMProviderTemplateCRUDRepo) CreateNewVersion(t *model.LLMProviderT
 	return nil
 }
 
-func (m *mockLLMProviderTemplateCRUDRepo) CreateImportedVersion(t *model.LLMProviderTemplate, makeLatest bool) error {
+func (m *mockLLMProviderTemplateCRUDRepo) CreateImportedVersion(t *model.LLMProviderTemplate) (bool, error) {
 	if m.createNewVersionErr != nil {
-		return m.createNewVersionErr
+		return false, m.createNewVersionErr
+	}
+	makeLatest := true
+	for _, ev := range m.listVersionsResult {
+		if ev != nil && !utils.TemplateVersionNewer(t.Version, ev.Version) {
+			makeLatest = false
+		}
 	}
 	t.IsLatest = makeLatest
 	m.createdVersion = t
-	return nil
+	return makeLatest, nil
 }
 
 func (m *mockLLMProviderTemplateCRUDRepo) CountVersions(templateID, orgUUID string) (int, error) {

--- a/platform-api/internal/utils/import_artifacts.go
+++ b/platform-api/internal/utils/import_artifacts.go
@@ -23,6 +23,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/wso2/api-platform/platform-api/internal/constants"
@@ -299,4 +301,34 @@ func RevisionMetadata(revision string) map[string]any {
 		return nil
 	}
 	return map[string]any{"gatewayRevision": revision}
+}
+
+// TemplateVersionNewer reports whether template version a is strictly higher than b.
+// versions are v<major>.<minor> (e.g. v1.0, v2.3)
+func TemplateVersionNewer(a, b string) bool {
+	aMaj, aMin, aOK := parseTemplateVersion(a)
+	bMaj, bMin, bOK := parseTemplateVersion(b)
+	if aOK && bOK {
+		if aMaj != bMaj {
+			return aMaj > bMaj
+		}
+		return aMin > bMin
+	}
+	return a > b
+}
+
+func parseTemplateVersion(v string) (major, minor int, ok bool) {
+	v = strings.TrimSpace(v)
+	v = strings.TrimPrefix(v, "v")
+	v = strings.TrimPrefix(v, "V")
+	majStr, minStr, found := strings.Cut(v, ".")
+	if !found {
+		return 0, 0, false
+	}
+	major, err1 := strconv.Atoi(majStr)
+	minor, err2 := strconv.Atoi(minStr)
+	if err1 != nil || err2 != nil {
+		return 0, 0, false
+	}
+	return major, minor, true
 }


### PR DESCRIPTION
This pull request introduces robust support for versioned LLM Provider Templates, ensuring that templates pushed from the gateway (data plane) to the control plane are correctly grouped into version families and that the latest version is properly tracked, even when versions arrive out of order.

- Resolves: https://github.com/wso2/api-platform/issues/2717

Adds mechanisms to parse and compare template versions, updates the import logic to honor `groupID` and `version` fields, and provides comprehensive tests to verify the new behavior.

**LLM Provider Template Versioning Enhancements:**

* Added `CreateImportedVersion` to the `LLMProviderTemplateRepository` interface and implemented it in the repository to handle importing new template versions, ensuring no duplicate versions and correctly updating the `is_latest` flag. [[1]](diffhunk://#diff-19b6533d8a621695aadd754cfff3e843a249475af6d96936ff590d612702d7e3R226) [[2]](diffhunk://#diff-ace1ce429e83af9a811fe83367a89d133a9f4a272683c82cb80254b79f951773R126-R208)
* Updated the importer to extract and honor `groupID`, `version`, and `managedBy` from the incoming spec, assigning sensible defaults when missing, and to use `CreateImportedVersion` with logic to determine if the new version is the latest in its family. [[1]](diffhunk://#diff-c1dae500803b44019ab2c402ccdbfb798f3e4b0714c51d05fd5fd15e76afa33dL44-R74) [[2]](diffhunk://#diff-c1dae500803b44019ab2c402ccdbfb798f3e4b0714c51d05fd5fd15e76afa33dL65-R86) [[3]](diffhunk://#diff-c1dae500803b44019ab2c402ccdbfb798f3e4b0714c51d05fd5fd15e76afa33dL84-R109)
* Implemented version comparison logic (`templateVersionNewer` and `parseTemplateVersion`) to compare template versions in the form `v<major>.<minor>`, ensuring that the highest version is always marked as latest, regardless of import order. [[1]](diffhunk://#diff-c1dae500803b44019ab2c402ccdbfb798f3e4b0714c51d05fd5fd15e76afa33dR144-R194) [[2]](diffhunk://#diff-c1dae500803b44019ab2c402ccdbfb798f3e4b0714c51d05fd5fd15e76afa33dR22-R33)

**Testing Improvements:**

* Added tests to verify that templates with the same `groupID` but different versions are grouped as a family, that the latest version is tracked correctly, and that out-of-order imports do not incorrectly update the `is_latest` flag.
* Updated the mock repository to support `CreateImportedVersion` for use in testing.