### PR TITLE
Enable path Normalization by default

### DIFF
--- a/common/constants/constants.go
+++ b/common/constants/constants.go
@@ -32,3 +32,11 @@ const (
 	// ServerName for HCM listener in Gateway
 	ServerName = "WSO2 API Platform"
 )
+
+const (
+	// PathWithEscapedSlashesAction options for the HCM listener.
+	KEEP_UNCHANGED        = "KEEP_UNCHANGED"
+	REJECT_REQUEST        = "REJECT_REQUEST"
+	UNESCAPE_AND_REDIRECT = "UNESCAPE_AND_REDIRECT"
+	UNESCAPE_AND_FORWARD  = "UNESCAPE_AND_FORWARD"
+)

--- a/gateway/configs/config-template.toml
+++ b/gateway/configs/config-template.toml
@@ -260,6 +260,12 @@ server_header_transformation = "OVERWRITE"
 server_header_value = "WSO2 API Platform"
 # Downstream per-connection buffer limit in bytes (default: 1048576 / 1 MiB)
 per_connection_buffer_limit_bytes = 1048576
+# Disable dot-segment resolution and duplicate-slash merging on the request path. Defaults to
+# false (normalization enabled) so route matching cannot be fooled by ".." or "//" in the path.
+disable_path_normalization = false
+# How to handle escaped slashes ("%2F"/"%5C") in the request path. Options: "KEEP_UNCHANGED"
+# (default), "REJECT_REQUEST", "UNESCAPE_AND_REDIRECT", "UNESCAPE_AND_FORWARD".
+path_with_escaped_slashes_action = "KEEP_UNCHANGED"
 
 # HTTP Connection Manager (downstream) timeouts
 # A value of zero disables any of these timeout settings.

--- a/gateway/gateway-controller/pkg/config/config.go
+++ b/gateway/gateway-controller/pkg/config/config.go
@@ -606,6 +606,8 @@ type HTTPListenerConfig struct {
 	ServerHeaderValue             string      `koanf:"server_header_value"`               // Custom value for the Server header
 	Timeouts                      HCMTimeouts `koanf:"timeouts"`                          // HTTP Connection Manager (downstream) timeouts
 	PerConnectionBufferLimitBytes uint32      `koanf:"per_connection_buffer_limit_bytes"` // Downstream per-connection buffer limit in bytes
+	DisablePathNormalization      bool        `koanf:"disable_path_normalization"`
+	PathWithEscapedSlashesAction  string      `koanf:"path_with_escaped_slashes_action"` // Options: "KEEP_UNCHANGED", "REJECT_REQUEST", "UNESCAPE_AND_REDIRECT", "UNESCAPE_AND_FORWARD"
 }
 
 // HCMTimeouts holds HTTP Connection Manager (downstream/connection) timeouts.
@@ -1021,7 +1023,9 @@ func defaultConfig() *Config {
 					StreamIdleTimeout:     5 * time.Minute, // Envoy default
 					IdleTimeout:           1 * time.Hour,   // Envoy default (connection-level)
 				},
-				PerConnectionBufferLimitBytes: 1048576, // 1 MiB, matches Envoy's built-in default
+				PerConnectionBufferLimitBytes: 1048576,                        // 1 MiB, matches Envoy's built-in default
+				DisablePathNormalization:      false,                          // Path normalization enabled by default
+				PathWithEscapedSlashesAction:  commonconstants.KEEP_UNCHANGED, // Leave escaped-slash paths unchanged by default
 			},
 		},
 		Analytics: AnalyticsConfig{
@@ -2053,6 +2057,35 @@ func (c *Config) validateHTTPListenerConfig() error {
 	if httpListener.PerConnectionBufferLimitBytes > constants.MaxReasonableBufferLimitBytes {
 		return fmt.Errorf("http_listener.per_connection_buffer_limit_bytes must not exceed %d, got: %d",
 			constants.MaxReasonableBufferLimitBytes, httpListener.PerConnectionBufferLimitBytes)
+	}
+
+	// Leave escaped-slash paths unchanged when unset.
+	if httpListener.PathWithEscapedSlashesAction == "" {
+		httpListener.PathWithEscapedSlashesAction = commonconstants.KEEP_UNCHANGED
+	}
+
+	validEscapedSlashesActions := []string{
+		commonconstants.KEEP_UNCHANGED,
+		commonconstants.REJECT_REQUEST,
+		commonconstants.UNESCAPE_AND_REDIRECT,
+		commonconstants.UNESCAPE_AND_FORWARD,
+	}
+
+	isValidAction := false
+	for _, valid := range validEscapedSlashesActions {
+		if httpListener.PathWithEscapedSlashesAction == valid {
+			isValidAction = true
+			break
+		}
+	}
+
+	if !isValidAction {
+		return fmt.Errorf("http_listener.path_with_escaped_slashes_action must be one of: %s, %s, %s, %s. Got: %s",
+			commonconstants.KEEP_UNCHANGED,
+			commonconstants.REJECT_REQUEST,
+			commonconstants.UNESCAPE_AND_REDIRECT,
+			commonconstants.UNESCAPE_AND_FORWARD,
+			httpListener.PathWithEscapedSlashesAction)
 	}
 
 	return nil

--- a/gateway/gateway-controller/pkg/config/config_test.go
+++ b/gateway/gateway-controller/pkg/config/config_test.go
@@ -1813,6 +1813,99 @@ resource_attributes = {"deployment.environment" = "prod", "service.namespace" = 
 	})
 }
 
+func TestDefaultConfig_PathNormalizationEnabledByDefault(t *testing.T) {
+	cfg := defaultConfig()
+	assert.False(t, cfg.Router.HTTPListener.DisablePathNormalization, "path normalization must be enabled by default")
+}
+
+func TestLoadConfig_PathNormalization(t *testing.T) {
+	t.Run("omitted section defaults to enabled", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.toml")
+		require.NoError(t, os.WriteFile(configPath, []byte(""), 0o644))
+
+		cfg, err := LoadConfig(configPath)
+		require.NoError(t, err)
+		assert.False(t, cfg.Router.HTTPListener.DisablePathNormalization)
+	})
+
+	t.Run("explicit opt-out parses from toml", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.toml")
+		toml := `
+[router.http_listener]
+disable_path_normalization = true
+`
+		require.NoError(t, os.WriteFile(configPath, []byte(toml), 0o644))
+
+		cfg, err := LoadConfig(configPath)
+		require.NoError(t, err)
+		assert.True(t, cfg.Router.HTTPListener.DisablePathNormalization)
+	})
+}
+
+func TestDefaultConfig_PathWithEscapedSlashesActionKeepUnchangedByDefault(t *testing.T) {
+	cfg := defaultConfig()
+	assert.Equal(t, commonconstants.KEEP_UNCHANGED, cfg.Router.HTTPListener.PathWithEscapedSlashesAction,
+		"escaped-slash paths must be left unchanged by default")
+}
+
+func TestLoadConfig_PathWithEscapedSlashesAction(t *testing.T) {
+	t.Run("omitted section defaults to keep unchanged", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.toml")
+		require.NoError(t, os.WriteFile(configPath, []byte(""), 0o644))
+
+		cfg, err := LoadConfig(configPath)
+		require.NoError(t, err)
+		assert.Equal(t, commonconstants.KEEP_UNCHANGED, cfg.Router.HTTPListener.PathWithEscapedSlashesAction)
+	})
+
+	t.Run("explicit override parses from toml", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.toml")
+		toml := `
+[router.http_listener]
+path_with_escaped_slashes_action = "UNESCAPE_AND_FORWARD"
+`
+		require.NoError(t, os.WriteFile(configPath, []byte(toml), 0o644))
+
+		cfg, err := LoadConfig(configPath)
+		require.NoError(t, err)
+		assert.Equal(t, commonconstants.UNESCAPE_AND_FORWARD, cfg.Router.HTTPListener.PathWithEscapedSlashesAction)
+	})
+}
+
+func TestConfig_ValidateHTTPListenerConfig_PathWithEscapedSlashesAction(t *testing.T) {
+	tests := []struct {
+		name        string
+		action      string
+		wantErr     bool
+		errContains string
+	}{
+		{name: "Valid REJECT_REQUEST", action: commonconstants.REJECT_REQUEST, wantErr: false},
+		{name: "Valid KEEP_UNCHANGED", action: commonconstants.KEEP_UNCHANGED, wantErr: false},
+		{name: "Valid UNESCAPE_AND_REDIRECT", action: commonconstants.UNESCAPE_AND_REDIRECT, wantErr: false},
+		{name: "Valid UNESCAPE_AND_FORWARD", action: commonconstants.UNESCAPE_AND_FORWARD, wantErr: false},
+		{name: "Empty defaults to KEEP_UNCHANGED", action: "", wantErr: false},
+		{name: "Invalid action", action: "INVALID", wantErr: true, errContains: "path_with_escaped_slashes_action must be one of"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfig()
+			cfg.Router.HTTPListener.PathWithEscapedSlashesAction = tt.action
+			err := cfg.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestConfig_CaseInsensitiveAlgorithm(t *testing.T) {
 	cfg := validConfig()
 	cfg.APIKey.Algorithm = strings.ToUpper(constants.HashingAlgorithmSHA256)

--- a/gateway/gateway-controller/pkg/xds/translator.go
+++ b/gateway/gateway-controller/pkg/xds/translator.go
@@ -1191,6 +1191,21 @@ func (t *Translator) resolveUpstreamCluster(upstreamName string, up *api.Upstrea
 // SharedRouteConfigName is the name of the shared route configuration used by both HTTP and HTTPS listeners
 const SharedRouteConfigName = "shared_route_config"
 
+// convertPathWithEscapedSlashesAction maps the configured string to the Envoy HCM enum.
+// Unknown values fall back to KEEP_UNCHANGED.
+func convertPathWithEscapedSlashesAction(action string) hcm.HttpConnectionManager_PathWithEscapedSlashesAction {
+	switch action {
+	case commonconstants.REJECT_REQUEST:
+		return hcm.HttpConnectionManager_REJECT_REQUEST
+	case commonconstants.UNESCAPE_AND_REDIRECT:
+		return hcm.HttpConnectionManager_UNESCAPE_AND_REDIRECT
+	case commonconstants.UNESCAPE_AND_FORWARD:
+		return hcm.HttpConnectionManager_UNESCAPE_AND_FORWARD
+	default:
+		return hcm.HttpConnectionManager_KEEP_UNCHANGED
+	}
+}
+
 // createListener creates an Envoy listener with access logging
 // If isHTTPS is true, creates an HTTPS listener with TLS configuration
 // Uses RDS (Route Discovery Service) to share route configuration between listeners
@@ -1257,6 +1272,11 @@ func (t *Translator) createListener(virtualHosts []*route.VirtualHost, isHTTPS b
 		CommonHttpProtocolOptions: &core.HttpProtocolOptions{
 			IdleTimeout: durationpb.New(t.routerConfig.HTTPListener.Timeouts.IdleTimeout),
 		},
+		// Resolve dot-segments and merge duplicate slashes before route matching (enabled unless
+		// explicitly disabled). Escaped slashes are handled separately via PathWithEscapedSlashesAction.
+		NormalizePath:                wrapperspb.Bool(!t.routerConfig.HTTPListener.DisablePathNormalization),
+		MergeSlashes:                 !t.routerConfig.HTTPListener.DisablePathNormalization,
+		PathWithEscapedSlashesAction: convertPathWithEscapedSlashesAction(t.routerConfig.HTTPListener.PathWithEscapedSlashesAction),
 	}
 
 	// Add access logs if enabled
@@ -1336,7 +1356,7 @@ func (t *Translator) createListener(virtualHosts []*route.VirtualHost, isHTTPS b
 				},
 			},
 		},
-		FilterChains: []*listener.FilterChain{filterChain},
+		FilterChains:                  []*listener.FilterChain{filterChain},
 		PerConnectionBufferLimitBytes: wrapperspb.UInt32(t.routerConfig.HTTPListener.PerConnectionBufferLimitBytes),
 	}, routeConfig, nil
 }

--- a/gateway/gateway-controller/pkg/xds/translator_test.go
+++ b/gateway/gateway-controller/pkg/xds/translator_test.go
@@ -375,8 +375,9 @@ func testRouterConfig() *config.RouterConfig {
 			Enabled: false,
 		},
 		HTTPListener: config.HTTPListenerConfig{
-			ServerHeaderTransformation: commonconstants.OVERWRITE,
+			ServerHeaderTransformation:    commonconstants.OVERWRITE,
 			PerConnectionBufferLimitBytes: 1048576,
+			PathWithEscapedSlashesAction:  commonconstants.KEEP_UNCHANGED,
 		},
 		LuaScriptPath: "../../lua/request_transformation.lua",
 	}
@@ -1264,6 +1265,98 @@ func TestTranslator_CreateListener_HCMTimeouts(t *testing.T) {
 			assert.Equal(t, tt.timeouts.StreamIdleTimeout, manager.GetStreamIdleTimeout().AsDuration(), "stream_idle_timeout")
 			require.NotNil(t, manager.GetCommonHttpProtocolOptions(), "common_http_protocol_options must be set")
 			assert.Equal(t, tt.timeouts.IdleTimeout, manager.GetCommonHttpProtocolOptions().GetIdleTimeout().AsDuration(), "idle_timeout")
+		})
+	}
+}
+
+func TestTranslator_CreateListener_PathNormalization(t *testing.T) {
+	tests := []struct {
+		name                     string
+		disablePathNormalization bool
+		wantNormalizePath        bool
+		wantMergeSlashes         bool
+	}{
+		{
+			name:                     "enabled by default",
+			disablePathNormalization: false,
+			wantNormalizePath:        true,
+			wantMergeSlashes:         true,
+		},
+		{
+			name:                     "disabled via config",
+			disablePathNormalization: true,
+			wantNormalizePath:        false,
+			wantMergeSlashes:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := createTestLogger()
+			routerCfg := testRouterConfig()
+			routerCfg.HTTPListener.DisablePathNormalization = tt.disablePathNormalization
+			cfg := testConfig()
+			cfg.Router = *routerCfg
+			translator := NewTranslator(logger, routerCfg, nil, cfg)
+
+			lis, _, err := translator.createListener(nil, false)
+			require.NoError(t, err)
+
+			manager := extractHCM(t, lis)
+			require.NotNil(t, manager.GetNormalizePath(), "normalize_path must be explicitly set")
+			assert.Equal(t, tt.wantNormalizePath, manager.GetNormalizePath().GetValue(), "normalize_path")
+			assert.Equal(t, tt.wantMergeSlashes, manager.GetMergeSlashes(), "merge_slashes")
+		})
+	}
+}
+
+func TestTranslator_CreateListener_PathWithEscapedSlashesAction(t *testing.T) {
+	tests := []struct {
+		name                         string
+		pathWithEscapedSlashesAction string
+		want                         hcm.HttpConnectionManager_PathWithEscapedSlashesAction
+	}{
+		{
+			name:                         "keeps unchanged by default",
+			pathWithEscapedSlashesAction: commonconstants.KEEP_UNCHANGED,
+			want:                         hcm.HttpConnectionManager_KEEP_UNCHANGED,
+		},
+		{
+			name:                         "configurable to reject",
+			pathWithEscapedSlashesAction: commonconstants.REJECT_REQUEST,
+			want:                         hcm.HttpConnectionManager_REJECT_REQUEST,
+		},
+		{
+			name:                         "configurable to unescape and forward",
+			pathWithEscapedSlashesAction: commonconstants.UNESCAPE_AND_FORWARD,
+			want:                         hcm.HttpConnectionManager_UNESCAPE_AND_FORWARD,
+		},
+		{
+			name:                         "configurable to unescape and redirect",
+			pathWithEscapedSlashesAction: commonconstants.UNESCAPE_AND_REDIRECT,
+			want:                         hcm.HttpConnectionManager_UNESCAPE_AND_REDIRECT,
+		},
+		{
+			name:                         "unknown value falls back to keep unchanged",
+			pathWithEscapedSlashesAction: "SOMETHING_UNKNOWN",
+			want:                         hcm.HttpConnectionManager_KEEP_UNCHANGED,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := createTestLogger()
+			routerCfg := testRouterConfig()
+			routerCfg.HTTPListener.PathWithEscapedSlashesAction = tt.pathWithEscapedSlashesAction
+			cfg := testConfig()
+			cfg.Router = *routerCfg
+			translator := NewTranslator(logger, routerCfg, nil, cfg)
+
+			lis, _, err := translator.createListener(nil, false)
+			require.NoError(t, err)
+
+			manager := extractHCM(t, lis)
+			assert.Equal(t, tt.want, manager.GetPathWithEscapedSlashesAction(), "path_with_escaped_slashes_action")
 		})
 	}
 }

--- a/gateway/it/features/path-normalization.feature
+++ b/gateway/it/features/path-normalization.feature
@@ -1,0 +1,133 @@
+# --------------------------------------------------------------------
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# --------------------------------------------------------------------
+
+Feature: Path Normalization
+  As an API developer
+  I want the gateway's default path normalization behavior to resolve dot-segments
+  and merge duplicate slashes before route matching, while leaving escaped slashes
+  and literal dots inside a path segment untouched
+  So that route matching cannot be bypassed via path tricks without breaking
+  legitimate resource identifiers that happen to contain "." or an encoded "/"
+
+  Background:
+    Given the gateway services are running
+    And I authenticate using basic auth as "admin"
+
+  Scenario: Default normalization resolves dot-segments and merges duplicate slashes
+    When I deploy this API configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: RestApi
+      metadata:
+        name: path-norm-api
+      spec:
+        displayName: Path-Norm-API
+        version: v1.0
+        context: /path-norm/$version
+        upstream:
+          main:
+            url: http://sample-backend:9080
+        operations:
+          - method: GET
+            path: /weather
+      """
+    Then the response should be successful
+    And I wait for 2 seconds
+
+    # A dot-segment traversal must be resolved to /weather before route matching
+    When I send a GET request to "http://localhost:8080/path-norm/v1.0/other/../weather"
+    Then the response status code should be 200
+    And the JSON response field "path" should be "/weather"
+
+    # Duplicate slashes must be merged to a single slash before route matching
+    When I send a GET request to "http://localhost:8080/path-norm/v1.0//weather"
+    Then the response status code should be 200
+    And the JSON response field "path" should be "/weather"
+
+    When I delete the API "path-norm-api"
+    Then the response should be successful
+
+  Scenario: Escaped slash (%2F) in a resource path segment is kept unchanged and is not treated as a path separator
+    When I deploy this API configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: RestApi
+      metadata:
+        name: path-escaped-slash-api
+      spec:
+        displayName: Path-Escaped-Slash-API
+        version: v1.0
+        context: /path-escaped-slash/$version
+        upstream:
+          main:
+            url: http://sample-backend:9080
+        operations:
+          - method: GET
+            path: /pets/{name}
+      """
+    Then the response should be successful
+    And I wait for 2 seconds
+
+    # %2F is kept unchanged (default path_with_escaped_slashes_action = KEEP_UNCHANGED), so
+    # "pet%2FFarm" is one opaque path segment and matches the single-segment {name} template.
+    When I send a GET request to "http://localhost:8080/path-escaped-slash/v1.0/pets/pet%2FFarm"
+    Then the response status code should be 200
+
+    # The literal (unescaped) equivalent has two path segments and must NOT match the
+    # single-segment {name} template — this contrast confirms %2F is not silently decoded.
+    When I send a GET request to "http://localhost:8080/path-escaped-slash/v1.0/pets/pet/Farm"
+    Then the response status code should be 404
+
+    When I delete the API "path-escaped-slash-api"
+    Then the response should be successful
+
+  Scenario: A path segment containing a literal dot is preserved by normalization
+    When I deploy this API configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: RestApi
+      metadata:
+        name: path-literal-dot-api
+      spec:
+        displayName: Path-Literal-Dot-API
+        version: v1.0
+        context: /path-literal-dot/$version
+        upstream:
+          main:
+            url: http://sample-backend:9080
+        operations:
+          - method: GET
+            path: /pet.api
+      """
+    Then the response should be successful
+    And I wait for 2 seconds
+
+    # "pet.api" is a normal path segment containing a dot, not a "." or ".." dot-segment,
+    # so normalization must leave it untouched.
+    When I send a GET request to "http://localhost:8080/path-literal-dot/v1.0/pet.api"
+    Then the response status code should be 200
+    And the JSON response field "path" should be "/pet.api"
+
+    # Combine both: a real "./" dot-segment ahead of the dotted resource name must still be
+    # resolved away, while "pet.api" itself remains untouched.
+    When I send a GET request to "http://localhost:8080/path-literal-dot/v1.0/./pet.api"
+    Then the response status code should be 200
+    And the JSON response field "path" should be "/pet.api"
+
+    When I delete the API "path-literal-dot-api"
+    Then the response should be successful

--- a/gateway/it/suite_test.go
+++ b/gateway/it/suite_test.go
@@ -144,6 +144,7 @@ func getFeaturePaths() []string {
 		"features/llm-provider-global-ratelimit.feature",
 		"features/log-message.feature",
 		"features/route-path-matching.feature",
+		"features/path-normalization.feature",
 		"features/header-routing.feature",
 		"features/secrets.feature",
 		"features/template-functions.feature",

--- a/kubernetes/helm/gateway-helm-chart/templates/gateway/gateway-config.yaml
+++ b/kubernetes/helm/gateway-helm-chart/templates/gateway/gateway-config.yaml
@@ -204,6 +204,8 @@ data:
     server_header_transformation = {{ $router.http_listener.server_header_transformation | quote }}
     server_header_value = {{ $router.http_listener.server_header_value | quote }}
     per_connection_buffer_limit_bytes = {{ $router.http_listener.per_connection_buffer_limit_bytes | int64 }}
+    disable_path_normalization = {{ $router.http_listener.disable_path_normalization }}
+    path_with_escaped_slashes_action = {{ $router.http_listener.path_with_escaped_slashes_action | quote }}
 
     [router.http_listener.timeouts]
     request_timeout = {{ $router.http_listener.timeouts.request_timeout | quote }}

--- a/kubernetes/helm/gateway-helm-chart/values.yaml
+++ b/kubernetes/helm/gateway-helm-chart/values.yaml
@@ -369,7 +369,7 @@ gateway:
           route_idle_timeout_ms: 300000
           connect_timeout_ms: 5000
 
-      # HTTP Connection Manager (downstream) configuration: server-header handling and timeouts
+      # HTTP Connection Manager (downstream) configuration: server-header, path handling, and timeouts
       http_listener:
         # Server header handling: APPEND_IF_ABSENT | OVERWRITE | PASS_THROUGH
         server_header_transformation: OVERWRITE
@@ -377,6 +377,11 @@ gateway:
         server_header_value: "WSO2 API Platform"
         # Downstream per-connection buffer limit in bytes
         per_connection_buffer_limit_bytes: 1048576
+        # Disable RFC 3986 dot-segment normalization and duplicate-slash merging
+        disable_path_normalization: false
+        # Escaped slash handling: KEEP_UNCHANGED | REJECT_REQUEST |
+        # UNESCAPE_AND_REDIRECT | UNESCAPE_AND_FORWARD
+        path_with_escaped_slashes_action: KEEP_UNCHANGED
 
         # Downstream (client-facing) timeouts. A value of "0s" disables the timeout.
         timeouts:

--- a/kubernetes/helm/operator-helm-chart/values.yaml
+++ b/kubernetes/helm/operator-helm-chart/values.yaml
@@ -305,12 +305,17 @@ gateway:
               route_idle_timeout_ms: 300000
               connect_timeout_ms: 5000
 
-          # HTTP Connection Manager (downstream) configuration: server-header handling and timeouts
+          # HTTP Connection Manager (downstream) configuration: server-header, path handling, and timeouts
           http_listener:
             # Server header handling: APPEND_IF_ABSENT | OVERWRITE | PASS_THROUGH
             server_header_transformation: OVERWRITE
             # Value written for the Server response header
             server_header_value: "WSO2 API Platform"
+            # Disable RFC 3986 dot-segment normalization and duplicate-slash merging
+            disable_path_normalization: false
+            # Escaped slash handling: KEEP_UNCHANGED | REJECT_REQUEST |
+            # UNESCAPE_AND_REDIRECT | UNESCAPE_AND_FORWARD
+            path_with_escaped_slashes_action: KEEP_UNCHANGED
 
             # Downstream (client-facing) timeouts. A value of "0s" disables the timeout.
             timeouts:


### PR DESCRIPTION
## Purpose

Enable Path Normalization and merging duplicate slashes by default. The user can disable that if required.
Paths with %2F like characters are not decoded at the gateway by default. But users can change the behavior. 

## Goals
> Describe **what solutions** this feature or fix introduces to address the problems outlined above.

## Approach
> Describe **how** you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
