### PR TITLE
Set empty as the default value for number fields

### DIFF
--- a/portals/ai-workspace/src/pages/appShell/PolicyParameterEditor/schemaUtils.ts
+++ b/portals/ai-workspace/src/pages/appShell/PolicyParameterEditor/schemaUtils.ts
@@ -247,7 +247,7 @@ export function initializeDefaultValues(
           propSchema.type === 'number' ||
           propSchema.type === 'integer'
         ) {
-          result[key] = propSchema.default ?? 0;
+          result[key] = propSchema.default ?? '';
         } else {
           result[key] = '';
         }


### PR DESCRIPTION
This pull request makes a small change to the `initializeDefaultValues` function in `schemaUtils.ts`. The default value for properties of type `number` or `integer` is now set to an empty string (`''`) instead of `0` when no default is specified.

- Resolves: https://github.com/wso2/api-platform/issues/2826