### PR TITLE
Fix GenAI application API key association

### DIFF
--- a/platform-api/internal/repository/application.go
+++ b/platform-api/internal/repository/application.go
@@ -351,13 +351,13 @@ func (r *ApplicationRepo) DeleteApplication(appID, orgID string) error {
 
 func (r *ApplicationRepo) GetAPIKeyByNameAndArtifactHandle(keyName, artifactHandle, orgID string) (*model.ApplicationAPIKey, error) {
 	row := r.db.QueryRow(r.db.Rebind(`
-		SELECT ak.uuid, ak.display_name, ak.artifact_uuid, src.handle, art.type, ak.status, ak.created_by, ak.created_at, ak.updated_at, ak.expires_at
+		SELECT ak.uuid, ak.handle, ak.artifact_uuid, src.handle, art.type, ak.status, ak.created_by, ak.created_at, ak.updated_at, ak.expires_at
 		FROM api_keys ak
 		INNER JOIN artifacts art ON art.uuid = ak.artifact_uuid
 		INNER JOIN (
 			`+r.reg.UnionAllSelect("uuid", "handle")+`
 		) src ON src.uuid = ak.artifact_uuid
-		WHERE art.organization_uuid = ? AND ak.display_name = ? AND src.handle = ?
+		WHERE art.organization_uuid = ? AND ak.handle = ? AND src.handle = ?
 	`), orgID, keyName, artifactHandle)
 
 	key, err := scanApplicationAPIKey(row)
@@ -392,7 +392,7 @@ func (r *ApplicationRepo) GetDeployedGatewayIDsByArtifactUUID(artifactUUID, orgI
 
 func (r *ApplicationRepo) ListMappedAPIKeys(applicationUUID string) ([]*model.ApplicationAPIKey, error) {
 	rows, err := r.db.Query(r.db.Rebind(`
-		SELECT ak.uuid, ak.display_name, ak.artifact_uuid, src.handle, art.type, ak.status, ak.created_by, ak.created_at, ak.updated_at, ak.expires_at
+		SELECT ak.uuid, ak.handle, ak.artifact_uuid, src.handle, art.type, ak.status, ak.created_by, ak.created_at, ak.updated_at, ak.expires_at
 		FROM application_api_key_mappings aak
 		INNER JOIN api_keys ak ON ak.uuid = aak.api_key_id
 		INNER JOIN artifacts art ON art.uuid = ak.artifact_uuid

--- a/platform-api/internal/repository/application_test.go
+++ b/platform-api/internal/repository/application_test.go
@@ -1,0 +1,140 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package repository
+
+import "testing"
+
+func TestGetAPIKeyByNameAndArtifactHandleResolvesKeyHandle(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	t.Cleanup(cleanup)
+
+	const (
+		orgUUID      = "org-application-api-key"
+		projectUUID  = "project-application-api-key"
+		artifactUUID = "artifact-application-api-key"
+		artifactID   = "new-openai-provider1"
+		keyUUID      = "api-key-application-api-key"
+		keyID        = "provider-new-key"
+		keyName      = "Provider New Key"
+	)
+
+	createTestOrganizationAndProject(t, db, orgUUID, projectUUID)
+
+	if _, err := db.Exec(
+		`INSERT INTO artifacts (uuid, type, organization_uuid) VALUES (?, ?, ?)`,
+		artifactUUID, "RestApi", orgUUID,
+	); err != nil {
+		t.Fatalf("create artifact: %v", err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO rest_apis (
+			uuid, organization_uuid, handle, display_name, version, project_uuid, configuration
+		) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		artifactUUID, orgUUID, artifactID, "New OpenAI Provider", "v1.0",
+		projectUUID, []byte("{}"),
+	); err != nil {
+		t.Fatalf("create artifact details: %v", err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO api_keys (
+			uuid, artifact_uuid, handle, display_name, masked_api_key, api_key_hashes
+		) VALUES (?, ?, ?, ?, ?, ?)`,
+		keyUUID, artifactUUID, keyID, keyName, "****key", []byte("{}"),
+	); err != nil {
+		t.Fatalf("create API key: %v", err)
+	}
+
+	repo := NewApplicationRepo(db, NewArtifactTableRegistry())
+	key, err := repo.GetAPIKeyByNameAndArtifactHandle(keyID, artifactID, orgUUID)
+	if err != nil {
+		t.Fatalf("resolve API key: %v", err)
+	}
+	if key == nil {
+		t.Fatal("expected API key to resolve by its handle")
+	}
+	if key.APIKeyUUID != keyUUID {
+		t.Fatalf("resolved API key UUID = %q, want %q", key.APIKeyUUID, keyUUID)
+	}
+	if key.Name != keyID {
+		t.Fatalf("resolved API key handle = %q, want %q", key.Name, keyID)
+	}
+}
+
+func TestListMappedAPIKeysReturnsKeyHandle(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	t.Cleanup(cleanup)
+
+	const (
+		orgUUID      = "org-mapped-api-key"
+		projectUUID  = "project-mapped-api-key"
+		artifactUUID = "artifact-mapped-api-key"
+		application  = "application-mapped-api-key"
+		keyUUID      = "api-key-mapped-api-key"
+		keyID        = "provider-new-key"
+	)
+
+	createTestOrganizationAndProject(t, db, orgUUID, projectUUID)
+
+	statements := []struct {
+		query string
+		args  []any
+	}{
+		{
+			`INSERT INTO artifacts (uuid, type, organization_uuid) VALUES (?, ?, ?)`,
+			[]any{artifactUUID, "RestApi", orgUUID},
+		},
+		{
+			`INSERT INTO rest_apis (
+				uuid, organization_uuid, handle, display_name, version, project_uuid, configuration
+			) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			[]any{artifactUUID, orgUUID, "new-openai-provider1", "New OpenAI Provider", "v1.0", projectUUID, []byte("{}")},
+		},
+		{
+			`INSERT INTO applications (
+				uuid, handle, project_uuid, organization_uuid, display_name, type
+			) VALUES (?, ?, ?, ?, ?, ?)`,
+			[]any{application, "new-application", projectUUID, orgUUID, "New Application", "GenAI"},
+		},
+		{
+			`INSERT INTO api_keys (
+				uuid, artifact_uuid, handle, display_name, masked_api_key, api_key_hashes
+			) VALUES (?, ?, ?, ?, ?, ?)`,
+			[]any{keyUUID, artifactUUID, keyID, "Provider New Key", "****key", []byte("{}")},
+		},
+		{
+			`INSERT INTO application_api_key_mappings (application_uuid, api_key_id) VALUES (?, ?)`,
+			[]any{application, keyUUID},
+		},
+	}
+	for _, statement := range statements {
+		if _, err := db.Exec(statement.query, statement.args...); err != nil {
+			t.Fatalf("prepare mapped API key: %v", err)
+		}
+	}
+
+	repo := NewApplicationRepo(db, NewArtifactTableRegistry())
+	keys, err := repo.ListMappedAPIKeys(application)
+	if err != nil {
+		t.Fatalf("list mapped API keys: %v", err)
+	}
+	if len(keys) != 1 {
+		t.Fatalf("mapped API key count = %d, want 1", len(keys))
+	}
+	if keys[0].Name != keyID {
+		t.Fatalf("mapped API key handle = %q, want %q", keys[0].Name, keyID)
+	}
+}


### PR DESCRIPTION
## Purpose

Fix API key association failures for GenAI applications. The application API received the API key handle as `keyId`, but the repository incorrectly searched using the API key display name, resulting in `APPLICATION_API_KEY_NOT_FOUND`.

Resolves #2809

## Goals

- Allow API keys to be associated with GenAI applications using their handles.
- Ensure mapped API key responses consistently return the key handle as `keyId`.
- Prevent failures when an API key’s handle and display name differ.

## Approach

- Updated API key lookup to match `keyId` against `api_keys.handle`.
- Updated mapped API key retrieval to return the handle instead of the display name.
- Added regression tests covering API keys with different handle and display-name values.

No UI changes are included.

## User stories

- As an AI Workspace user, I can associate an LLM provider or proxy API key with a GenAI application.
- As an AI Workspace user, I can manage mapped API keys even when their display names differ from their handles.

## Documentation

N/A — this fixes existing behavior without changing the public API or user workflow.

## Automation tests

- Unit tests
  - Added repository tests for resolving API keys by handle.
  - Added coverage verifying mapped API keys return the handle as `keyId`.
  - Repository and targeted application service tests passed.
- Integration tests
  - N/A — no new integration tests were added.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A — no sample changes are required.

## Related PRs

N/A

## Test environment

- macOS
- Go 1.26.5
- SQLite test database