### PR TITLE
Add TypedProperties to sdk AuthContext

### DIFF
--- a/sdk/core/policy/v1alpha2/auth_context.go
+++ b/sdk/core/policy/v1alpha2/auth_context.go
@@ -35,8 +35,14 @@ type AuthContext struct {
 	CredentialID string
 
 	// Properties holds additional claims or data that do not fit into the typed
-	// fields above (e.g., custom JWT claims).
+	// fields above (e.g., custom JWT claims). Values are flattened to a single string,
+	// so a multi-valued (array) claim is serialized (e.g., JSON) into one entry.
 	Properties map[string]string
+
+	// TypedProperties stores additional properties which has complex structures which
+	// needs to be preserved in their original typed form (e.g. arrays or objects) 
+	// preserving structure that Properties flattens to strings.
+	TypedProperties map[string]interface{}
 
 	// TokenId holds the unique identifier of a token (e.g. for a jwt it can be jti)
 	TokenId string


### PR DESCRIPTION
## Purpose
> This PR adds the new TypedProperties to the AuthContext to stores additional properties which has complex structures which needs to be preserved in their original typed form (e.g. arrays or objects) preserving structure that Properties flattens to strings. 

- Related with: https://github.com/wso2/api-platform/issues/2746