### PR TITLE
Make groupId and version immutable of LLM provider Templates

### DIFF
--- a/gateway/gateway-controller/pkg/utils/llm_deployment.go
+++ b/gateway/gateway-controller/pkg/utils/llm_deployment.go
@@ -866,6 +866,14 @@ func (s *LLMDeploymentService) UpdateLLMProviderTemplate(handle string, params L
 		return nil, fmt.Errorf("%w: cannot change template handle from '%s' to '%s'; use create/delete instead", ErrLLMTemplateValidation, oldHandle, newHandle)
 	}
 
+	proposed := &models.StoredLLMProviderTemplate{Configuration: *tmpl}
+	if oldGroupID, newGroupID := existing.GetGroupID(), proposed.GetGroupID(); oldGroupID != newGroupID {
+		return nil, fmt.Errorf("%w: cannot change template groupId from '%s' to '%s'; groupId is immutable", ErrLLMTemplateValidation, oldGroupID, newGroupID)
+	}
+	if oldVersion, newVersion := existing.GetVersion(), proposed.GetVersion(); oldVersion != newVersion {
+		return nil, fmt.Errorf("%w: cannot change template version from '%s' to '%s'; version is immutable", ErrLLMTemplateValidation, oldVersion, newVersion)
+	}
+
 	updated := &models.StoredLLMProviderTemplate{
 		UUID:          existing.UUID,
 		Configuration: *tmpl,

--- a/gateway/gateway-controller/pkg/utils/llm_deployment_test.go
+++ b/gateway/gateway-controller/pkg/utils/llm_deployment_test.go
@@ -512,7 +512,7 @@ func TestLLMDeploymentService_UpdateLLMProviderTemplate_NotFound(t *testing.T) {
 	}
 
 	_, err := service.UpdateLLMProviderTemplate("0000-non-existent-0000-000000000000", params)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 }
 
@@ -553,8 +553,140 @@ spec:
 	}
 
 	_, err := service.UpdateLLMProviderTemplate("original-handle", params)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot change template handle")
+}
+
+func TestLLMDeploymentService_UpdateLLMProviderTemplate_GroupIDChange(t *testing.T) {
+	store := storage.NewConfigStore()
+	routerConfig := &config.RouterConfig{ListenerPort: 8080}
+	db := newTestMockDB()
+	apiDeploymentService := newTestAPIDeploymentService(store, db, nil, nil, nil)
+	service := NewLLMDeploymentService(store, db, nil, nil, nil, apiDeploymentService, routerConfig, nil, nil)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	template := &models.StoredLLMProviderTemplate{
+		UUID: "0000-template-1-0000-000000000000",
+		Configuration: api.LLMProviderTemplate{
+			Metadata: api.Metadata{Name: "original-handle"},
+			Spec: api.LLMProviderTemplateData{
+				DisplayName: "Original Template",
+				GroupId:     stringPtr("group-a"),
+				Version:     stringPtr("v1.0"),
+			},
+		},
+	}
+	db.SaveLLMProviderTemplate(template)
+	store.AddTemplate(template)
+
+	// Same handle and version, but a changed groupId — must be rejected.
+	yamlData := `
+apiVersion: gateway.api-platform.wso2.com/v1
+kind: LlmProviderTemplate
+metadata:
+  name: original-handle
+spec:
+  displayName: Updated Template
+  groupId: group-b
+  version: v1.0
+`
+	params := LLMTemplateParams{
+		Spec:        []byte(yamlData),
+		ContentType: "application/yaml",
+		Logger:      logger,
+	}
+
+	_, err := service.UpdateLLMProviderTemplate("original-handle", params)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot change template groupId")
+}
+
+func TestLLMDeploymentService_UpdateLLMProviderTemplate_VersionChange(t *testing.T) {
+	store := storage.NewConfigStore()
+	routerConfig := &config.RouterConfig{ListenerPort: 8080}
+	db := newTestMockDB()
+	apiDeploymentService := newTestAPIDeploymentService(store, db, nil, nil, nil)
+	service := NewLLMDeploymentService(store, db, nil, nil, nil, apiDeploymentService, routerConfig, nil, nil)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	template := &models.StoredLLMProviderTemplate{
+		UUID: "0000-template-1-0000-000000000000",
+		Configuration: api.LLMProviderTemplate{
+			Metadata: api.Metadata{Name: "original-handle"},
+			Spec: api.LLMProviderTemplateData{
+				DisplayName: "Original Template",
+				GroupId:     stringPtr("group-a"),
+				Version:     stringPtr("v1.0"),
+			},
+		},
+	}
+	db.SaveLLMProviderTemplate(template)
+	store.AddTemplate(template)
+
+	// Same handle and groupId, but a changed version — must be rejected.
+	yamlData := `
+apiVersion: gateway.api-platform.wso2.com/v1
+kind: LlmProviderTemplate
+metadata:
+  name: original-handle
+spec:
+  displayName: Updated Template
+  groupId: group-a
+  version: v2.0
+`
+	params := LLMTemplateParams{
+		Spec:        []byte(yamlData),
+		ContentType: "application/yaml",
+		Logger:      logger,
+	}
+
+	_, err := service.UpdateLLMProviderTemplate("original-handle", params)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot change template version")
+}
+
+func TestLLMDeploymentService_UpdateLLMProviderTemplate_SameGroupIDAndVersionSucceeds(t *testing.T) {
+	store := storage.NewConfigStore()
+	routerConfig := &config.RouterConfig{ListenerPort: 8080}
+	db := newTestMockDB()
+	apiDeploymentService := newTestAPIDeploymentService(store, db, nil, nil, nil)
+	service := NewLLMDeploymentService(store, db, nil, nil, nil, apiDeploymentService, routerConfig, nil, nil)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	template := &models.StoredLLMProviderTemplate{
+		UUID: "0000-template-1-0000-000000000000",
+		Configuration: api.LLMProviderTemplate{
+			Metadata: api.Metadata{Name: "original-handle"},
+			Spec: api.LLMProviderTemplateData{
+				DisplayName: "Original Template",
+				GroupId:     stringPtr("group-a"),
+				Version:     stringPtr("v1.0"),
+			},
+		},
+	}
+	db.SaveLLMProviderTemplate(template)
+	store.AddTemplate(template)
+
+	// Unchanged identity fields, only the display name edited — must succeed.
+	yamlData := `
+apiVersion: gateway.api-platform.wso2.com/v1
+kind: LlmProviderTemplate
+metadata:
+  name: original-handle
+spec:
+  displayName: Updated Template
+  groupId: group-a
+  version: v1.0
+`
+	params := LLMTemplateParams{
+		Spec:        []byte(yamlData),
+		ContentType: "application/yaml",
+		Logger:      logger,
+	}
+
+	updated, err := service.UpdateLLMProviderTemplate("original-handle", params)
+	require.NoError(t, err)
+	assert.Equal(t, "Updated Template", updated.Configuration.Spec.DisplayName)
 }
 
 func TestLLMDeploymentService_DeleteLLMProviderTemplate_NotFound(t *testing.T) {


### PR DESCRIPTION
This pull request strengthens the immutability guarantees for LLM provider templates by enforcing that the `groupId` and `version` fields cannot be changed during an update. It also adds comprehensive tests to verify these constraints and ensure correct behavior when these fields are modified or left unchanged.

- Resolves: https://github.com/wso2/api-platform/issues/2843

**Immutability enforcement:**

* The `UpdateLLMProviderTemplate` method in `llm_deployment.go` now returns an error if an update attempts to change the `groupId` or `version` of an existing template, making these fields immutable after creation.

**Testing improvements:**

* Added tests to `llm_deployment_test.go` to verify:
  - Updates that change `groupId` are rejected.
  - Updates that change `version` are rejected.
  - Updates that only change mutable fields (e.g., `displayName`) succeed when `groupId` and `version` are unchanged.