### PR TITLE
[ap/0.8.x] Force GOTOOLCHAIN=auto for gateway-builder

### DIFF
--- a/cli/src/cmd/gateway/image/build.go
+++ b/cli/src/cmd/gateway/image/build.go
@@ -57,6 +57,7 @@ var (
 	noCache                  bool
 	platform                 string
 	outputDir                string
+	goToolchain              string
 
 	// Computed values
 	imageTag string
@@ -84,6 +85,7 @@ func init() {
 	buildCmd.Flags().BoolVar(&noCache, "no-cache", false, "Build without using cache")
 	buildCmd.Flags().StringVar(&platform, "platform", "", "Target platform (e.g., linux/amd64)")
 	buildCmd.Flags().StringVar(&outputDir, "output-dir", "", "Output directory for build artifacts")
+	buildCmd.Flags().StringVar(&goToolchain, "go-toolchain", "", "GOTOOLCHAIN for the gateway-builder (e.g. auto, go1.26.5, go1.26.2+auto); overrides gateway.goToolchain in build.yaml (default: auto)")
 }
 
 // initializeDefaults sets smart defaults for gateway name and constructs the image tag
@@ -121,6 +123,10 @@ func initializeDefaults(buildFile *policy.BuildFile) error {
 	} else {
 		gatewayRuntimeBaseImg = fmt.Sprintf(utils.DefaultGatewayRuntime, gatewayVersion)
 	}
+
+	// Resolve GOTOOLCHAIN for the builder container.
+	// Precedence: --go-toolchain flag > build.yaml gateway.goToolchain > "auto".
+	goToolchain = gateway.ResolveGoToolchain(goToolchain, buildFile.Gateway.GoToolchain)
 
 	// Construct the full image tag: repository/name:version
 	imageTag = fmt.Sprintf("%s/%s:%s", imageRepository, gatewayName, gatewayVersion)
@@ -311,6 +317,7 @@ func runDockerBuild(tempDir string) error {
 		Push:                       push,
 		LogFilePath:                logFilePath,
 		OutputCopyDir:              outputDir,
+		GoToolchain:                goToolchain,
 	}
 
 	// Run the build

--- a/cli/src/cmd/gateway/image/build.md
+++ b/cli/src/cmd/gateway/image/build.md
@@ -10,7 +10,8 @@ ap gateway image build \
   [--push] \
   [--no-cache] \
   [--platform <platform>] \
-  [--output-dir <output_dir>]
+  [--output-dir <output_dir>] \
+  [--go-toolchain <gotoolchain>]
 ```
 
 ### Optional Flags & Defaults
@@ -21,6 +22,7 @@ ap gateway image build \
 - `--push`: `false` - Push image to registry after build
 - `--no-cache`: `false` - Build without using cache
 - `--output-dir`: No output (empty) - Output directory for build artifacts
+- `--go-toolchain`: `auto` - `GOTOOLCHAIN` for the gateway-builder container (e.g. `auto`, `go1.26.5`, `go1.26.2+auto`). Overrides `gateway.goToolchain` in `build.yaml`. Precedence: flag > `build.yaml` > `auto`.
 
 ### Directory Structure Requirements
 The `--path` flag must point to a directory containing:
@@ -47,6 +49,7 @@ policies:
 version: v1
 gateway:
   version: "1.0.4"    # Required: Gateway version
+  goToolchain: auto   # Optional: GOTOOLCHAIN for the builder (default: auto)
   images:             # Optional: Custom image paths
     builder: "internal-registry.company.com/wso2/gateway-builder:1.0.4"
     controller: "internal-registry.company.com/wso2/gateway-controller:1.0.4"
@@ -60,6 +63,7 @@ policies:
 - `gateway.version`: Gateway version for the build
 
 ### Optional Fields
+- `gateway.goToolchain`: `GOTOOLCHAIN` for the gateway-builder container (defaults to `auto`). Controls which Go toolchain compiles the policies; `auto` downloads a newer toolchain when a policy's `go.mod` requires one. Accepts any Go `GOTOOLCHAIN` value, e.g. `auto`, `go1.26.5` (pin), or `go1.26.2+auto` (minimum, upgrade if needed). The `--go-toolchain` flag overrides this value.
 - `gateway.images.builder`: Custom gateway builder image (defaults to `ghcr.io/wso2/api-platform/gateway-builder:<version>`)
 - `gateway.images.controller`: Custom gateway controller base image (defaults to `ghcr.io/wso2/api-platform/gateway-controller:<version>`)
 - `gateway.images.runtime`: Custom gateway runtime base image (defaults to `ghcr.io/wso2/api-platform/gateway-runtime:<version>`)

--- a/cli/src/internal/gateway/docker_build.go
+++ b/cli/src/internal/gateway/docker_build.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/wso2/api-platform/cli/internal/terminal"
 	"github.com/wso2/api-platform/cli/utils"
@@ -42,6 +43,7 @@ type DockerBuildConfig struct {
 	Push                       bool
 	LogFilePath                string
 	OutputCopyDir              string
+	GoToolchain 			   string
 }
 
 // BuildGatewayImages executes the docker build process for gateway images
@@ -96,9 +98,43 @@ func BuildGatewayImages(config DockerBuildConfig) error {
 	return nil
 }
 
+// DefaultGoToolchain is the GOTOOLCHAIN value used for the gateway-builder
+// container when neither the --go-toolchain flag nor build.yaml specifies one.
+//
+// The official golang base image used by gateway-builder pins
+// GOTOOLCHAIN=local, which makes the build fail when a policy's go.mod declares
+// a newer Go version than the builder ships (see issue #2796). "auto" lets the
+// builder's go toolchain download and use the required version on the fly.
+const DefaultGoToolchain = "auto"
+
+// ResolveGoToolchain picks the GOTOOLCHAIN value for the builder container.
+//
+// Precedence: flag value > build.yaml value > DefaultGoToolchain ("auto"). It
+// intentionally does NOT read the host's GOTOOLCHAIN — a developer's global Go
+// setting (e.g. a pinned "go1.26.2" for their own projects) must not silently
+// leak into the gateway build.
+func ResolveGoToolchain(flagVal, buildFileVal string) string {
+	if v := strings.TrimSpace(flagVal); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(buildFileVal); v != "" {
+		return v
+	}
+	return DefaultGoToolchain
+}
+
 // runGatewayBuilder runs the gateway-builder container
 func runGatewayBuilder(config DockerBuildConfig, logFile *os.File) error {
-	args := []string{"run", "--rm", "-v", config.TempDir + ":/workspace", config.GatewayBuilder,
+	toolchain := strings.TrimSpace(config.GoToolchain)
+	if toolchain == "" {
+		toolchain = DefaultGoToolchain
+	}
+
+	args := []string{"run", "--rm",
+		"-v", config.TempDir + ":/workspace",
+		// Override the builder base image's GOTOOLCHAIN=local
+		"-e", "GOTOOLCHAIN=" + toolchain,
+		config.GatewayBuilder,
 		"-gateway-controller-base-image", config.GatewayControllerBaseImage,
 		"-gateway-runtime-base-image", config.GatewayRuntimeBaseImage,
 	}

--- a/cli/src/internal/gateway/docker_build_test.go
+++ b/cli/src/internal/gateway/docker_build_test.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package gateway
+
+import "testing"
+
+func TestResolveGoToolchain(t *testing.T) {
+	cases := []struct {
+		name         string
+		flagVal      string
+		buildFileVal string
+		want         string
+	}{
+		{name: "both empty defaults to auto", flagVal: "", buildFileVal: "", want: "auto"},
+		{name: "whitespace-only defaults to auto", flagVal: "  ", buildFileVal: "\t", want: "auto"},
+		{name: "build.yaml used when flag empty", flagVal: "", buildFileVal: "go1.26.5", want: "go1.26.5"},
+		{name: "flag wins over build.yaml", flagVal: "go1.26.2+auto", buildFileVal: "go1.26.5", want: "go1.26.2+auto"},
+		{name: "flag used when build.yaml empty", flagVal: "auto", buildFileVal: "", want: "auto"},
+		{name: "values are trimmed", flagVal: "  go1.26.6  ", buildFileVal: "", want: "go1.26.6"},
+		{name: "build.yaml trimmed when flag blank", flagVal: "   ", buildFileVal: "  go1.26.5 ", want: "go1.26.5"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ResolveGoToolchain(tc.flagVal, tc.buildFileVal); got != tc.want {
+				t.Errorf("ResolveGoToolchain(%q, %q) = %q, want %q", tc.flagVal, tc.buildFileVal, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveGoToolchainIgnoresHostEnv guards the intentional design choice
+// that the host's GOTOOLCHAIN must never influence the builder container.
+func TestResolveGoToolchainIgnoresHostEnv(t *testing.T) {
+	t.Setenv("GOTOOLCHAIN", "go1.20.0")
+	if got := ResolveGoToolchain("", ""); got != "auto" {
+		t.Errorf("ResolveGoToolchain ignored inputs but read host GOTOOLCHAIN: got %q, want %q", got, "auto")
+	}
+}

--- a/cli/src/internal/policy/types.go
+++ b/cli/src/internal/policy/types.go
@@ -30,6 +30,7 @@ type BuildFile struct {
 type GatewayConfig struct {
 	Version string        `yaml:"version"`
 	Images  GatewayImages `yaml:"images,omitempty"`
+	GoToolchain string `yaml:"goToolchain,omitempty"`
 }
 
 // GatewayImages represents optional custom image paths in the build file

--- a/docs/cli/customizing-gateway-policies.md
+++ b/docs/cli/customizing-gateway-policies.md
@@ -10,7 +10,8 @@ ap gateway image build \
   [--push] \
   [--no-cache] \
   [--platform <platform>] \
-  [--output-dir <output_dir>]
+  [--output-dir <output_dir>] \
+  [--go-toolchain <gotoolchain>]
 ```
 
 ## Sample Command
@@ -33,6 +34,10 @@ A `build.yaml` file is mandatory. By default, the CLI expects this file to be pr
 version: v1
 gateway:
   version: 1.0.4
+  # Optional: GOTOOLCHAIN for the gateway-builder container (defaults to "auto").
+  # Accepts any Go GOTOOLCHAIN value, e.g. "auto", "go1.26.5" (pin a version),
+  # or "go1.26.2+auto" (minimum version, upgrade if a policy requires newer).
+  goToolchain: auto
   # Optional: override base images
   images:
     builder: "internal-registry.company.com/wso2/gateway-builder:1.0.5" # Optional: override base image
@@ -61,3 +66,4 @@ Even an output directory is not explicitly specified, the built images are cache
 - `push`: Pushes the built images to Docker.
 - `no-cache`: Disables Docker build cache usage.
 - `--platform`: Specifies the target platform. By default, the host platform is used.
+- `--go-toolchain`: Sets `GOTOOLCHAIN` for the gateway-builder container, controlling which Go toolchain compiles the policies. Defaults to `auto`, which downloads and uses a newer Go toolchain when a policy requires one (e.g. a policy whose `go.mod` declares a newer Go version than the builder ships). Accepts any Go `GOTOOLCHAIN` value: `auto`, a pinned version like `go1.26.5`, or a minimum-with-upgrade form like `go1.26.2+auto`. When provided, this flag takes precedence over `gateway.goToolchain` in `build.yaml`.


### PR DESCRIPTION
## Description

- Fixes gateway image builds that fail when a policy requires a newer Go than the gateway-builder image ships.
- Add doc changes
- Related issues: https://github.com/wso2/api-platform/issues/2857

### Behavior

| Invocation | Effective GOTOOLCHAIN | Result |
|---|---|---|
| `ap gateway image build` | `auto` | ✅ downloads the required toolchain |
| `--go-toolchain go1.26.5` | `go1.26.5` (pin) | ✅ |
| `--go-toolchain go1.26.2+auto` | `go1.26.2+auto` (floor) | ✅ |
| `--go-toolchain go1.26.2` | `go1.26.2` (hard pin) | ❌ fails if a policy needs newer — by design |
| `gateway.goToolchain: go1.26.5` in build.yaml | `go1.26.5` | ✅ |