### PR TITLE
Fix policy definition version normalization

### DIFF
--- a/.github/workflows/ai-workspace-pr-check.yml
+++ b/.github/workflows/ai-workspace-pr-check.yml
@@ -28,13 +28,7 @@ jobs:
           node-version: '20'
 
       - name: Build AI Workspace image
-        run: |
-          AI_WORKSPACE_VERSION="$(tr -d '[:space:]' < VERSION)"
-          make build VERSION="${AI_WORKSPACE_VERSION}"
-          echo "Pinning ai-workspace compose to ai-workspace:${AI_WORKSPACE_VERSION}"
-          sed -i.bak -E "s#image: .*/ai-workspace:.*#image: ghcr.io/wso2/api-platform/ai-workspace:${AI_WORKSPACE_VERSION}#" \
-            docker-compose.yaml
-          rm -f docker-compose.yaml.bak
+        run: make build
         working-directory: portals/ai-workspace
 
       # AI Workspace E2E depends on platform-api changes that ship in this PR but

--- a/.github/workflows/ai-workspace-pr-check.yml
+++ b/.github/workflows/ai-workspace-pr-check.yml
@@ -28,7 +28,13 @@ jobs:
           node-version: '20'
 
       - name: Build AI Workspace image
-        run: make build
+        run: |
+          AI_WORKSPACE_VERSION="$(tr -d '[:space:]' < VERSION)"
+          make build VERSION="${AI_WORKSPACE_VERSION}"
+          echo "Pinning ai-workspace compose to ai-workspace:${AI_WORKSPACE_VERSION}"
+          sed -i.bak -E "s#image: .*/ai-workspace:.*#image: ghcr.io/wso2/api-platform/ai-workspace:${AI_WORKSPACE_VERSION}#" \
+            docker-compose.yaml
+          rm -f docker-compose.yaml.bak
         working-directory: portals/ai-workspace
 
       # AI Workspace E2E depends on platform-api changes that ship in this PR but

--- a/portals/ai-workspace/src/apis/policyHubApis.ts
+++ b/portals/ai-workspace/src/apis/policyHubApis.ts
@@ -60,7 +60,10 @@ export const getPolicyDefinition = async (
   version: string
 ): Promise<string> => {
   const encodedName = encodeURIComponent(name);
-  const encodedVersion = encodeURIComponent(version);
+  const normalizedVersion = version.replace(/^v/i, '');
+  const encodedVersion = encodeURIComponent(
+    normalizedVersion.includes('.') ? normalizedVersion : `${normalizedVersion}.0`
+  );
   return getText(
     `/policies/${encodedName}/versions/${encodedVersion}/definition`,
     undefined,


### PR DESCRIPTION
## Purpose

Applied policies in AI Workspace may store versions using the gateway format, such as `v1`. Policy Hub expects the corresponding definition version as `1.0`, causing requests such as `/versions/v1/definition` to fail.

Fixes #2855

## Goals

Ensure policy definitions load correctly when users inspect an applied policy in AI Workspace.

## Approach

Normalize policy versions in the shared Policy Hub definition API helper:

- Remove a leading `v`.
- Expand major-only versions to `major.minor`.
- Preserve versions that already include a minor component.

For example:

- `v1` → `1.0`
- `v1.0` → `1.0`
- `1.0` → `1.0`

Because the normalization is implemented in the shared helper, it applies to both LLM Provider and LLM Proxy policy drawers.

## User stories

As an AI Workspace user, I can inspect an applied policy and view its parameters without the policy definition request failing because of incompatible version formatting.

## Documentation

N/A — this fixes internal request construction and does not change documented product behavior.

## Automation tests

- Unit tests
  - Not added; the AI Workspace project currently has no unit-test script configured for this helper.
- Integration tests
  - Not run.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — frontend-only TypeScript change
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

N/A

## Test environment

Static validation completed with `git diff --check`. The production build could not be run because project dependencies are not installed in the local environment.