### PR TITLE
Add cloud extension seam for routing and navigation integration

### DIFF
--- a/portals/ai-workspace/.gitignore
+++ b/portals/ai-workspace/.gitignore
@@ -7,3 +7,7 @@ target
 api-platform.env
 resources/certificates/
 resources/keys/
+
+# Cloud extension overlay/vendor targets (SaaS-provided; extensions.stub.ts is the OSS default)
+src/cloud/ui/
+src/cloud/extensions.tsx

--- a/portals/ai-workspace/bff/internal/config/runtime_config.go
+++ b/portals/ai-workspace/bff/internal/config/runtime_config.go
@@ -37,6 +37,7 @@ var browserSafeKeys = []string{
 	"gateway.controlplane_host",
 	"gateway.platform_gateway_versions",
 	"logging.browser_debug",
+	"cloud_features",
 
 	// Claim names the SPA displays user/org identity from. The keys mirror the
 	// Platform API's [auth.claim_mappings] exactly — same claim, same name. Shared

--- a/portals/ai-workspace/src/App.tsx
+++ b/portals/ai-workspace/src/App.tsx
@@ -85,6 +85,12 @@ import { ChoreoUserProvider } from './contexts/ChoreoUserContext';
 import { useAppAuth } from './contexts/AppAuthContext';
 import { Box, Button, Stack, Typography } from '@wso2/oxygen-ui';
 import OoopsImage from './assets/images/Ooops.svg';
+import { cloudExtensions } from '@cloud-extensions';
+
+// Provider(s) contributed by a cloud extension, wrapped around the app shell. Falls
+// back to a pass-through so the standalone (stub) build adds no wrapper.
+const CloudProviders =
+  cloudExtensions.Providers ?? (({ children }: { children: React.ReactNode }) => <>{children}</>);
 
 /**
  * Only allow same-origin relative paths as return URLs to prevent open redirects.
@@ -253,7 +259,9 @@ function ProtectedAppShell() {
       <RoleProvider>
         <AIWorkspaceSnackbarProvider>
           <AppShellProvider userName={userName} userEmail={userEmail}>
-            <AppShellMain />
+            <CloudProviders>
+              <AppShellMain />
+            </CloudProviders>
           </AppShellProvider>
         </AIWorkspaceSnackbarProvider>
       </RoleProvider>
@@ -592,6 +600,16 @@ export default function App() {
                 />
               </Route>
             </Route>
+            {/* Cloud extension routes (org scope) */}
+            {cloudExtensions.routes
+              .filter((r) => r.scope === 'org' || r.scope === 'both')
+              .map((r) => (
+                <Route
+                  key={`cloud-org-${r.path}`}
+                  path={r.path}
+                  element={<WithPageBoundary>{r.element}</WithPageBoundary>}
+                />
+              ))}
             <Route path="projects/:projectSlug" element={<ProjectShell />}>
               <Route index element={<Navigate to="home" replace />} />
               <Route
@@ -803,6 +821,16 @@ export default function App() {
                   />
                 </Route>
               </Route>
+              {/* Cloud extension routes (project scope) */}
+              {cloudExtensions.routes
+                .filter((r) => r.scope === 'project' || r.scope === 'both')
+                .map((r) => (
+                  <Route
+                    key={`cloud-project-${r.path}`}
+                    path={r.path}
+                    element={<WithPageBoundary>{r.element}</WithPageBoundary>}
+                  />
+                ))}
             </Route>
           </Route>
         </Route>

--- a/portals/ai-workspace/src/cloud/extensions.stub.ts
+++ b/portals/ai-workspace/src/cloud/extensions.stub.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Cloud extension seam for the AI Workspace.
+ *
+ * The app imports `cloudExtensions` from `@cloud-extensions`. In the OSS/standalone
+ * build that alias resolves to THIS file — a no-op default that contributes nothing,
+ * so the standalone app renders exactly as before. A cloud build points the alias at
+ * a real module (via the APIP_AIW_CLOUD_EXTENSIONS build var) that returns populated
+ * `routes` and `navItems`. TypeScript always type-checks against the interface here,
+ * so any real module must satisfy this contract.
+ */
+import type { ComponentType, ReactNode } from 'react';
+
+/** Where a contributed route/nav item is mounted. */
+export type CloudScope = 'org' | 'project' | 'both';
+
+/**
+ * A route contributed into the app's route tree. `path` is relative to the org or
+ * project scope root (e.g. `widgets/*`), mirroring the existing `gateways/*`
+ * splat: the element owns its own nested `<Routes>`.
+ */
+export interface CloudRoute {
+  path: string;
+  element: ReactNode;
+  scope: CloudScope;
+}
+
+/**
+ * A sidebar nav item. `id` MUST equal the first segment of `path` (e.g. id
+ * `widgets` for path `/widgets`) so the shell's active-item sync can match
+ * the current URL to this item.
+ */
+export interface CloudNavItem {
+  id: string;
+  label: string;
+  icon: ComponentType<{ size?: number }>;
+  path: string;
+  scope: CloudScope;
+  category?: string;
+  requiredScope?: string;
+}
+
+/** Props passed to a cloud-contributed field in the Add Gateway form. */
+export interface GatewayCreateFieldProps {
+  /** Current field value (opaque to the host). */
+  value: string;
+  /** Update the field value. */
+  onChange: (value: string) => void;
+}
+
+/** Context handed to the persist hook after a gateway is created. */
+export interface GatewayCreatedContext {
+  orgId: string;
+  gatewayId: string;
+  /** The value collected by the contributed field. */
+  value: string;
+}
+
+/**
+ * A field a cloud module contributes to the Add Gateway form. The host renders
+ * `Field` inside its form and, after the gateway is created, calls
+ * `onGatewayCreated` so the module can persist any association tied to the new
+ * gateway. Absent in the standalone build, so the form is unchanged there.
+ */
+export interface GatewayCreateExtension {
+  Field: ComponentType<GatewayCreateFieldProps>;
+  /** When true, the host blocks submission until the field has a value. */
+  required?: boolean;
+  onGatewayCreated: (ctx: GatewayCreatedContext) => void | Promise<void>;
+}
+
+/** The whole contribution surface a cloud module returns. */
+export interface CloudExtensions {
+  routes: CloudRoute[];
+  navItems: CloudNavItem[];
+  /** Optional provider(s) wrapped around the authenticated app shell. */
+  Providers?: ComponentType<{ children: ReactNode }>;
+  /** Optional field injected into the Add Gateway form. */
+  gatewayCreate?: GatewayCreateExtension;
+}
+
+export const cloudExtensions: CloudExtensions = {
+  routes: [],
+  navItems: [],
+};

--- a/portals/ai-workspace/src/config.env.ts
+++ b/portals/ai-workspace/src/config.env.ts
@@ -56,6 +56,11 @@ export const ORG_HANDLE_CLAIM = getEnvOrDefault('APIP_AIW_AUTH_CLAIM_MAPPINGS_OR
 export const USERNAME_CLAIM = getEnvOrDefault('APIP_AIW_AUTH_CLAIM_MAPPINGS_USERNAME', 'username');
 export const EMAIL_CLAIM = getEnvOrDefault('APIP_AIW_AUTH_CLAIM_MAPPINGS_EMAIL', 'email');
 
+// Runtime gate for cloud-only extensions contributed via the extension seam. The
+// standalone build ships the no-op stub and never sets this; a cloud build may flip
+// it via window.__RUNTIME_CONFIG__ to turn the bundled cloud feature on/off without
+// a rebuild. The real extensions module reads this to self-gate.
+export const CLOUD_FEATURES = getEnvOrDefault('APIP_AIW_CLOUD_FEATURES', false);
 //Static OIDC configuration — set these to match the root-org OIDC app in your IDP.
 // Authority is the issuer URL; the OIDC client will auto-discover endpoints from {authority}/.well-known/openid-configuration.
 export const OIDC_AUTHORITY  = getEnvOrDefault('APIP_AIW_OIDC_AUTHORITY', '');

--- a/portals/ai-workspace/src/pages/appShell/AppSidebar.tsx
+++ b/portals/ai-workspace/src/pages/appShell/AppSidebar.tsx
@@ -35,6 +35,7 @@ import { useAppShell } from '../../contexts/AppShellContext';
 import { useAppAuth } from '../../contexts/AppAuthContext';
 import { SCOPES } from '../../auth/permissions';
 import { buildOrgPath, buildProjectPath } from '../../utils/projectRouting';
+import { cloudExtensions } from '@cloud-extensions';
 import QuickStartIntroPopup, {
   QS_INTRO_STORAGE_KEY,
 } from './QuickStartIntroPopup';
@@ -127,6 +128,19 @@ export default function AppSidebar({
   const settingsPath = currentProject
     ? buildProjectPath(currentOrganization, currentProject, '/settings')
     : orgSettingsPath;
+
+  // Cloud extension nav items, filtered to the current scope and the caller's
+  // permissions. Empty in the standalone (stub) build.
+  const cloudNavItems = cloudExtensions.navItems.filter((item) => {
+    const scopeOk = currentProject
+      ? item.scope === 'project' || item.scope === 'both'
+      : item.scope === 'org' || item.scope === 'both';
+    return scopeOk && (!item.requiredScope || hasPermission(item.requiredScope));
+  });
+  const cloudNavPath = (path: string) =>
+    currentProject
+      ? buildProjectPath(currentOrganization, currentProject, path)
+      : buildOrgPath(currentOrganization, path);
   return (
     <Sidebar
       collapsed={shellState.sidebarCollapsed}
@@ -300,6 +314,28 @@ export default function AppSidebar({
               </NavLink>
             )}
           </Sidebar.Category>
+
+          {cloudNavItems.length > 0 && (
+            <Sidebar.Category>
+              {cloudNavItems.map((item) => {
+                const Icon = item.icon;
+                return (
+                  <NavLink
+                    key={item.id}
+                    to={cloudNavPath(item.path)}
+                    style={navLinkStyle}
+                  >
+                    <Sidebar.Item id={item.id}>
+                      <Sidebar.ItemIcon>
+                        <Icon size={20} />
+                      </Sidebar.ItemIcon>
+                      <Sidebar.ItemLabel>{item.label}</Sidebar.ItemLabel>
+                    </Sidebar.Item>
+                  </NavLink>
+                );
+              })}
+            </Sidebar.Category>
+          )}
         </Box>
       </Sidebar.Nav>
 

--- a/portals/ai-workspace/src/pages/appShell/appShellMain.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellMain.tsx
@@ -45,6 +45,17 @@ import {
   getProjectSlug,
   buildOrgPath,
 } from '../../utils/projectRouting';
+import { cloudExtensions } from '@cloud-extensions';
+
+// Maps a URL segment contributed by a cloud nav item (first segment of its path) to
+// the sidebar item id, so the active-item sync highlights cloud routes too. Empty in
+// the standalone (stub) build.
+const cloudSegmentToId = new Map(
+  cloudExtensions.navItems.map((item) => [
+    item.path.replace(/^\/+/, '').split('/')[0],
+    item.id,
+  ])
+);
 import { logger } from '../../utils/logger';
 import { FormattedMessage } from 'react-intl';
 import OoopsImage from '../../assets/images/Ooops.svg';
@@ -200,6 +211,10 @@ export default function AppLayout(): JSX.Element {
         shellActions.setActiveMenuItem('quick-start');
         return;
       }
+      if (cloudSegmentToId.has(tertiarySegment)) {
+        shellActions.setActiveMenuItem(cloudSegmentToId.get(tertiarySegment)!);
+        return;
+      }
       if (tertiarySegment === 'settings') {
         shellActions.setActiveMenuItem('settings');
       }
@@ -235,6 +250,10 @@ export default function AppLayout(): JSX.Element {
     }
     if (primarySegment === 'insights') {
       shellActions.setActiveMenuItem('insights');
+      return;
+    }
+    if (cloudSegmentToId.has(primarySegment)) {
+      shellActions.setActiveMenuItem(cloudSegmentToId.get(primarySegment)!);
       return;
     }
     if (primarySegment === 'settings') {

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/gateways/AddGateway.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/gateways/AddGateway.tsx
@@ -41,6 +41,7 @@ import { setRegistrationToken } from "./registrationTokenStore";
 import { useAIWorkspaceSnackbar } from "../../../../hooks/aiWorkspaceSnackbar";
 import { PLATFORM_GATEWAY_VERSIONS } from "../../../../config.env";
 import type { GatewayVersionEntry } from "../../../../config.env";
+import { cloudExtensions } from "@cloud-extensions";
 
 // Validation constants
 const MAX_NAME_LENGTH = 255;
@@ -104,6 +105,11 @@ export default function AddGateway() {
     () => PLATFORM_GATEWAY_VERSIONS[0] ?? null,
   );
 
+  // Optional cloud-only field contributed via the extension seam. Absent in the
+  // standalone build.
+  const gatewayCreate = cloudExtensions.gatewayCreate;
+  const [cloudFieldValue, setCloudFieldValue] = useState("");
+
   // Always use AI gateway type
   const functionalityType = "ai";
 
@@ -119,6 +125,7 @@ export default function AddGateway() {
     if (description.length > MAX_DESCRIPTION_LENGTH) return false;
     const normalizedVhost = normalizeVhost(vhost || "");
     if (!normalizedVhost || normalizedVhost.length === 0) return false;
+    if (gatewayCreate?.required && !cloudFieldValue) return false;
     return true;
   };
 
@@ -139,6 +146,16 @@ export default function AddGateway() {
         description: description || undefined,
         version: selectedVersion!.version,
       });
+
+      // Persist any cloud-only association tied to the new gateway. No-op in the
+      // standalone build.
+      if (gatewayCreate) {
+        await gatewayCreate.onGatewayCreated({
+          orgId: currentOrganization?.uuid ?? "",
+          gatewayId: createdGateway.id,
+          value: cloudFieldValue,
+        });
+      }
 
       showSnackbar("AI Gateway registered successfully", "success");
 
@@ -319,6 +336,15 @@ export default function AddGateway() {
                 />
               </FormControl>
             </Grid>
+
+            {gatewayCreate && (
+              <Grid size={{ xs: 12 }}>
+                <gatewayCreate.Field
+                  value={cloudFieldValue}
+                  onChange={setCloudFieldValue}
+                />
+              </Grid>
+            )}
           </Grid>
 
           <Box

--- a/portals/ai-workspace/tsconfig.json
+++ b/portals/ai-workspace/tsconfig.json
@@ -16,7 +16,11 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "types": ["vite/client", "node"]
+    "types": ["vite/client", "node"],
+    "paths": {
+      "@cloud-extensions": ["./src/cloud/extensions.stub.ts"],
+      "@cloud-ui/*": ["./src/cloud/ui/*"]
+    }
   },
   "include": ["src"]
 }

--- a/portals/ai-workspace/vite.config.ts
+++ b/portals/ai-workspace/vite.config.ts
@@ -80,6 +80,7 @@ const browserSafeEnvVars = [
   'APIP_AIW_MOESIF_APP_API_KEY',     // Moesif publishable Application Id
   'APIP_AIW_PLATFORM_API_BASE_URL',
   'APIP_AIW_PORTAL_API_BASE_URL',
+  'APIP_AIW_CLOUD_FEATURES',          // runtime gate for cloud-only extensions
 ]
 
 const plugins: PluginOption[] = [
@@ -98,6 +99,18 @@ export default defineConfig({
   envPrefix: browserSafeEnvVars,
   resolve: {
     dedupe: ['react', 'react-dom', 'react/jsx-runtime', 'react/jsx-dev-runtime'],
+    alias: {
+      // Cloud extension seam. Defaults to a no-op stub so the standalone/OSS build
+      // contributes nothing; a cloud build sets APIP_AIW_CLOUD_EXTENSIONS (a path
+      // relative to this portal, e.g. src/cloud/extensions.tsx supplied by the SaaS
+      // overlay) to swap in the real module. `@cloud-ui` is where the reusable
+      // feature components live (always in this repo; only imported when a real
+      // extensions module references them).
+      '@cloud-extensions': process.env.APIP_AIW_CLOUD_EXTENSIONS
+        ? path.resolve(__dirname, process.env.APIP_AIW_CLOUD_EXTENSIONS)
+        : path.resolve(__dirname, 'src/cloud/extensions.stub.ts'),
+      '@cloud-ui': path.resolve(__dirname, 'src/cloud/ui'),
+    },
   },
   server: {
     port: 9643,


### PR DESCRIPTION
This pull request introduces a flexible "cloud extension seam" to the AI Workspace portal, allowing cloud-only features (such as routes, navigation items, and form fields) to be contributed by external modules in SaaS builds, while leaving the open-source/standalone build unchanged. The extension seam is implemented via a TypeScript interface and a stub module, with build-time and runtime toggles to enable or disable cloud features. The main codebase is updated to dynamically consume contributed routes, nav items, and form fields if present.

The most important changes are:

**Cloud Extension Infrastructure:**

* Added a TypeScript interface and stub implementation in `src/cloud/extensions.stub.ts` describing the contract for cloud extension modules, including routes, nav items, providers, and form fields. The app imports `cloudExtensions` from the `@cloud-extensions` alias, which resolves to the stub by default and to a real module in cloud builds.
* Updated `tsconfig.json` and `vite.config.ts` to define and resolve the `@cloud-extensions` and `@cloud-ui` module aliases, with `@cloud-extensions` pointing to either the stub or a real extension module based on the build environment. [[1]](diffhunk://#diff-9a1a4affdbb321410ea74f9559dbc745cfe86888fa3dc7c2447f9e45f2120896L19-R23) [[2]](diffhunk://#diff-1ef5194a590b8c01873a3658aa23e9e54a7ffb66d434e809aff413dd84995e44R102-R113)
* Added a runtime configuration flag (`CLOUD_FEATURES`/`APIP_AIW_CLOUD_FEATURES`) to gate cloud-only features, and exposed it to the SPA and build system. [[1]](diffhunk://#diff-4ec88cb1c9fe3be176602bdf4e9e86a4f8e9ebf979fa85fee06db3f4c191495eR59-R63) [[2]](diffhunk://#diff-564cfdf2b07ba17ed149bc9c68d86e20c60acc918a2b9f4b12f1e3e92e8b8580R40) [[3]](diffhunk://#diff-1ef5194a590b8c01873a3658aa23e9e54a7ffb66d434e809aff413dd84995e44R83)

**Dynamic Cloud Feature Integration:**

* Updated the main app shell (`App.tsx`) to wrap the shell with optional cloud-provided providers, and to inject cloud-contributed routes into the org and project route trees. [[1]](diffhunk://#diff-4da7d52c0f032f6c555c67000c9107432507d795d0dd6a5d757e04a75c2d11d3R88-R93) [[2]](diffhunk://#diff-4da7d52c0f032f6c555c67000c9107432507d795d0dd6a5d757e04a75c2d11d3R262-R264) [[3]](diffhunk://#diff-4da7d52c0f032f6c555c67000c9107432507d795d0dd6a5d757e04a75c2d11d3R603-R612) [[4]](diffhunk://#diff-4da7d52c0f032f6c555c67000c9107432507d795d0dd6a5d757e04a75c2d11d3R824-R833)
* Enhanced the sidebar (`AppSidebar.tsx`) to dynamically render cloud-contributed nav items, filtered by scope and user permissions, and to compute their navigation paths. [[1]](diffhunk://#diff-b66ed1a354b06c8db170f136461281126bd16f38b2f0a76d0fe8d80aa20956dfR38) [[2]](diffhunk://#diff-b66ed1a354b06c8db170f136461281126bd16f38b2f0a76d0fe8d80aa20956dfR131-R143) [[3]](diffhunk://#diff-b66ed1a354b06c8db170f136461281126bd16f38b2f0a76d0fe8d80aa20956dfR317-R338)
* Updated active menu item logic in `appShellMain.tsx` to highlight the correct sidebar item for cloud-contributed routes. [[1]](diffhunk://#diff-7b7a33d1dac18ffc176bd79bc777f55eebdc79965799fc30dbbdc5afdb369cfbR48-R58) [[2]](diffhunk://#diff-7b7a33d1dac18ffc176bd79bc777f55eebdc79965799fc30dbbdc5afdb369cfbR214-R217) [[3]](diffhunk://#diff-7b7a33d1dac18ffc176bd79bc777f55eebdc79965799fc30dbbdc5afdb369cfbR255-R258)

**Cloud Extension Points in Forms:**

* Extended the Add Gateway form to render a cloud-contributed field (if present), enforce its requiredness, and call a cloud-provided persistence hook after gateway creation. This is a no-op in the standalone build. [[1]](diffhunk://#diff-eb4c5ffe43f66cda586900b34df9e76d7e44cd654360b58ea4d694717adde37fR44) [[2]](diffhunk://#diff-eb4c5ffe43f66cda586900b34df9e76d7e44cd654360b58ea4d694717adde37fR108-R112) [[3]](diffhunk://#diff-eb4c5ffe43f66cda586900b34df9e76d7e44cd654360b58ea4d694717adde37fR128) [[4]](diffhunk://#diff-eb4c5ffe43f66cda586900b34df9e76d7e44cd654360b58ea4d694717adde37fR150-R159) [[5]](diffhunk://#diff-eb4c5ffe43f66cda586900b34df9e76d7e44cd654360b58ea4d694717adde37fR339-R347)

**Build and Ignore Rules:**

* Updated `.gitignore` to exclude cloud extension overlay/vendor targets, ensuring OSS and SaaS builds remain cleanly separated.