### PR TITLE
Add project is_active lifecycle state to Platform API

### DIFF
--- a/platform-api/config/config.go
+++ b/platform-api/config/config.go
@@ -99,6 +99,19 @@ type Server struct {
 	Gateway     Gateway         `koanf:"gateway"`
 	EventHub    EventHub        `koanf:"event_hub"`
 	Webhook     Webhook         `koanf:"webhook"`
+	Projects    Projects        `koanf:"projects"`
+}
+
+// Projects groups project-lifecycle configuration.
+type Projects struct {
+	// ActivateOnCreate controls the initial state of newly created projects,
+	// including the organization's default project. When true (the default)
+	// projects are created active and immediately usable. Set it false in
+	// deployments that provision projects asynchronously against an external
+	// system (e.g. the cloud counterpart): the project is then created inactive
+	// and stays unusable until it is explicitly activated once provisioning
+	// completes.
+	ActivateOnCreate bool `koanf:"activate_on_create"`
 }
 
 // Authentication modes selectable via auth.mode. Exactly one mode is active;

--- a/platform-api/config/default_config.go
+++ b/platform-api/config/default_config.go
@@ -152,5 +152,11 @@ func defaultConfig() *Server {
 			MaxBodySize:        1 << 20, // 1 MiB
 			SignatureHeader:    "X-Devportal-Signature",
 		},
+		Projects: Projects{
+			// Projects are usable the moment they are created. Cloud deployments
+			// that mirror projects to an external system set this false so a
+			// project stays inactive until its counterpart is provisioned.
+			ActivateOnCreate: true,
+		},
 	}
 }

--- a/platform-api/internal/apperror/catalog.go
+++ b/platform-api/internal/apperror/catalog.go
@@ -140,6 +140,7 @@ var (
 	ProjectNotFound      = def(CodeProjectNotFound, http.StatusNotFound, "The specified project could not be found.")
 	ProjectRefNotFound   = def(CodeProjectRefNotFound, http.StatusBadRequest, "The referenced project could not be found.")
 	ProjectExists        = def(CodeProjectExists, http.StatusConflict, "A project with this name already exists in the organization.")
+	ProjectNotActive     = def(CodeProjectNotActive, http.StatusConflict, "The project is not active yet; its provisioning has not completed.")
 	ApplicationNotFound  = def(CodeApplicationNotFound, http.StatusNotFound, "The specified application could not be found.")
 	ApplicationExists    = def(CodeApplicationExists, http.StatusConflict, "An application with this name already exists.")
 )

--- a/platform-api/internal/apperror/codes.go
+++ b/platform-api/internal/apperror/codes.go
@@ -118,6 +118,7 @@ const (
 	CodeProjectNotFound    = "PROJECT_NOT_FOUND"
 	CodeProjectRefNotFound = "PROJECT_REF_NOT_FOUND"
 	CodeProjectExists      = "PROJECT_EXISTS"
+	CodeProjectNotActive   = "PROJECT_NOT_ACTIVE"
 )
 
 // Application domain codes.

--- a/platform-api/internal/database/schema.postgres.sql
+++ b/platform-api/internal/database/schema.postgres.sql
@@ -37,6 +37,7 @@ CREATE TABLE IF NOT EXISTS projects (
     display_name VARCHAR(255) NOT NULL,
     organization_uuid VARCHAR(40) NOT NULL,
     description VARCHAR(1023),
+    is_active SMALLINT NOT NULL DEFAULT 1,
     data_version VARCHAR(20) NOT NULL DEFAULT '1.0',
     created_by VARCHAR(200),
     created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,

--- a/platform-api/internal/database/schema.sql
+++ b/platform-api/internal/database/schema.sql
@@ -37,6 +37,7 @@ CREATE TABLE IF NOT EXISTS projects (
     display_name VARCHAR(255) NOT NULL,
     organization_uuid VARCHAR(40) NOT NULL,
     description VARCHAR(1023),
+    is_active INTEGER NOT NULL DEFAULT 1,
     data_version VARCHAR(20) NOT NULL DEFAULT '1.0',
     created_by VARCHAR(200),
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,

--- a/platform-api/internal/database/schema.sqlite.sql
+++ b/platform-api/internal/database/schema.sqlite.sql
@@ -37,6 +37,7 @@ CREATE TABLE IF NOT EXISTS projects (
     display_name VARCHAR(255) NOT NULL,
     organization_uuid VARCHAR(40) NOT NULL,
     description VARCHAR(1023),
+    is_active INTEGER NOT NULL DEFAULT 1,
     data_version VARCHAR(20) NOT NULL DEFAULT '1.0',
     created_by VARCHAR(200),
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,

--- a/platform-api/internal/database/schema.sqlserver.sql
+++ b/platform-api/internal/database/schema.sqlserver.sql
@@ -38,6 +38,7 @@ CREATE TABLE dbo.projects (
     display_name VARCHAR(255) NOT NULL,
     organization_uuid VARCHAR(40) NOT NULL,
     description VARCHAR(1023),
+    is_active SMALLINT NOT NULL DEFAULT 1,
     data_version VARCHAR(20) NOT NULL DEFAULT '1.0',
     created_by VARCHAR(200),
     created_at DATETIME2(7) DEFAULT SYSUTCDATETIME(),

--- a/platform-api/internal/model/project.go
+++ b/platform-api/internal/model/project.go
@@ -28,6 +28,7 @@ type Project struct {
 	Name           string    `json:"displayName" db:"display_name"`
 	OrganizationID string    `json:"organizationId" db:"organization_uuid"` // FK to Organization.ID
 	Description    string    `json:"description" db:"description"`
+	IsActive       bool      `json:"isActive" db:"is_active"`
 	CreatedBy      string    `json:"createdBy,omitempty" db:"created_by"`
 	CreatedAt      time.Time `json:"createdAt" db:"created_at"`
 	UpdatedBy      string    `json:"updatedBy,omitempty" db:"updated_by"`

--- a/platform-api/internal/repository/interfaces.go
+++ b/platform-api/internal/repository/interfaces.go
@@ -47,6 +47,7 @@ type ProjectRepository interface {
 	GetProjectByHandleAndOrgID(handle, orgID string) (*model.Project, error)
 	GetProjectsByOrganizationID(orgID string) ([]*model.Project, error)
 	UpdateProject(project *model.Project) error
+	SetProjectActive(projectId string, isActive bool) error
 	DeleteProject(projectId string) error
 	ListProjects(orgID string, opts ListOptions) ([]*model.Project, error)
 	CountProjects(orgID, search string) (int, error)

--- a/platform-api/internal/repository/project.go
+++ b/platform-api/internal/repository/project.go
@@ -41,12 +41,18 @@ func (r *ProjectRepo) CreateProject(project *model.Project) error {
 	project.CreatedAt = time.Now().UTC()
 	project.UpdatedAt = time.Now().UTC()
 
+	// Convert bool to int for the SMALLINT/INTEGER column.
+	isActiveInt := 0
+	if project.IsActive {
+		isActiveInt = 1
+	}
+
 	query := `
-		INSERT INTO projects (uuid, handle, display_name, organization_uuid, description, created_by, created_at, updated_by, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO projects (uuid, handle, display_name, organization_uuid, description, is_active, created_by, created_at, updated_by, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`
 	_, err := r.db.Exec(r.db.Rebind(query), project.ID, project.Handle, project.Name, project.OrganizationID, project.Description,
-		project.CreatedBy, project.CreatedAt, project.UpdatedBy, project.UpdatedAt)
+		isActiveInt, project.CreatedBy, project.CreatedAt, project.UpdatedBy, project.UpdatedAt)
 	if err != nil {
 		return err
 	}
@@ -58,14 +64,15 @@ func (r *ProjectRepo) CreateProject(project *model.Project) error {
 func (r *ProjectRepo) GetProjectByUUID(projectId string) (*model.Project, error) {
 	project := &model.Project{}
 	query := `
-		SELECT uuid, handle, display_name, organization_uuid, description, created_by, created_at, updated_by, updated_at
+		SELECT uuid, handle, display_name, organization_uuid, description, is_active, created_by, created_at, updated_by, updated_at
 		FROM projects
 		WHERE uuid = ?
 	`
 	var createdBy, updatedBy sql.NullString
+	var isActive int
 	err := r.db.QueryRow(r.db.Rebind(query), projectId).Scan(
 		&project.ID, &project.Handle, &project.Name, &project.OrganizationID, &project.Description,
-		&createdBy, &project.CreatedAt, &updatedBy, &project.UpdatedAt,
+		&isActive, &createdBy, &project.CreatedAt, &updatedBy, &project.UpdatedAt,
 	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -73,6 +80,7 @@ func (r *ProjectRepo) GetProjectByUUID(projectId string) (*model.Project, error)
 		}
 		return nil, err
 	}
+	project.IsActive = isActive != 0
 	project.CreatedBy = createdBy.String
 	project.UpdatedBy = updatedBy.String
 	return project, nil
@@ -82,14 +90,15 @@ func (r *ProjectRepo) GetProjectByUUID(projectId string) (*model.Project, error)
 func (r *ProjectRepo) GetProjectByNameAndOrgID(name, orgID string) (*model.Project, error) {
 	project := &model.Project{}
 	query := `
-		SELECT uuid, handle, display_name, organization_uuid, description, created_by, created_at, updated_by, updated_at
+		SELECT uuid, handle, display_name, organization_uuid, description, is_active, created_by, created_at, updated_by, updated_at
 		FROM projects
 		WHERE display_name = ? AND organization_uuid = ?
 	`
 	var createdBy, updatedBy sql.NullString
+	var isActive int
 	err := r.db.QueryRow(r.db.Rebind(query), name, orgID).Scan(
 		&project.ID, &project.Handle, &project.Name, &project.OrganizationID, &project.Description,
-		&createdBy, &project.CreatedAt, &updatedBy, &project.UpdatedAt,
+		&isActive, &createdBy, &project.CreatedAt, &updatedBy, &project.UpdatedAt,
 	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -97,6 +106,7 @@ func (r *ProjectRepo) GetProjectByNameAndOrgID(name, orgID string) (*model.Proje
 		}
 		return nil, err
 	}
+	project.IsActive = isActive != 0
 	project.CreatedBy = createdBy.String
 	project.UpdatedBy = updatedBy.String
 	return project, nil
@@ -106,14 +116,15 @@ func (r *ProjectRepo) GetProjectByNameAndOrgID(name, orgID string) (*model.Proje
 func (r *ProjectRepo) GetProjectByHandleAndOrgID(handle, orgID string) (*model.Project, error) {
 	project := &model.Project{}
 	query := `
-		SELECT uuid, handle, display_name, organization_uuid, description, created_by, created_at, updated_by, updated_at
+		SELECT uuid, handle, display_name, organization_uuid, description, is_active, created_by, created_at, updated_by, updated_at
 		FROM projects
 		WHERE handle = ? AND organization_uuid = ?
 	`
 	var createdBy, updatedBy sql.NullString
+	var isActive int
 	err := r.db.QueryRow(r.db.Rebind(query), handle, orgID).Scan(
 		&project.ID, &project.Handle, &project.Name, &project.OrganizationID, &project.Description,
-		&createdBy, &project.CreatedAt, &updatedBy, &project.UpdatedAt,
+		&isActive, &createdBy, &project.CreatedAt, &updatedBy, &project.UpdatedAt,
 	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -121,6 +132,7 @@ func (r *ProjectRepo) GetProjectByHandleAndOrgID(handle, orgID string) (*model.P
 		}
 		return nil, err
 	}
+	project.IsActive = isActive != 0
 	project.CreatedBy = createdBy.String
 	project.UpdatedBy = updatedBy.String
 	return project, nil
@@ -129,7 +141,7 @@ func (r *ProjectRepo) GetProjectByHandleAndOrgID(handle, orgID string) (*model.P
 // GetProjectsByOrganizationID retrieves all projects for an organization
 func (r *ProjectRepo) GetProjectsByOrganizationID(orgID string) ([]*model.Project, error) {
 	query := `
-		SELECT uuid, handle, display_name, organization_uuid, description, created_by, created_at, updated_by, updated_at
+		SELECT uuid, handle, display_name, organization_uuid, description, is_active, created_by, created_at, updated_by, updated_at
 		FROM projects
 		WHERE organization_uuid = ?
 		ORDER BY created_at DESC
@@ -144,11 +156,13 @@ func (r *ProjectRepo) GetProjectsByOrganizationID(orgID string) ([]*model.Projec
 	for rows.Next() {
 		project := &model.Project{}
 		var createdBy, updatedBy sql.NullString
+		var isActive int
 		err := rows.Scan(&project.ID, &project.Handle, &project.Name, &project.OrganizationID, &project.Description,
-			&createdBy, &project.CreatedAt, &updatedBy, &project.UpdatedAt)
+			&isActive, &createdBy, &project.CreatedAt, &updatedBy, &project.UpdatedAt)
 		if err != nil {
 			return nil, err
 		}
+		project.IsActive = isActive != 0
 		project.CreatedBy = createdBy.String
 		project.UpdatedBy = updatedBy.String
 		projects = append(projects, project)
@@ -169,6 +183,22 @@ func (r *ProjectRepo) UpdateProject(project *model.Project) error {
 	return err
 }
 
+// SetProjectActive updates only the is_active state of a project. Used to mark a
+// project ready once its external provisioning (e.g. the cloud counterpart) completes.
+func (r *ProjectRepo) SetProjectActive(projectId string, isActive bool) error {
+	isActiveInt := 0
+	if isActive {
+		isActiveInt = 1
+	}
+	query := `
+		UPDATE projects
+		SET is_active = ?, updated_at = ?
+		WHERE uuid = ?
+	`
+	_, err := r.db.Exec(r.db.Rebind(query), isActiveInt, time.Now().UTC(), projectId)
+	return err
+}
+
 // DeleteProject removes a project
 func (r *ProjectRepo) DeleteProject(projectId string) error {
 	query := `DELETE FROM projects WHERE uuid = ?`
@@ -179,7 +209,7 @@ func (r *ProjectRepo) DeleteProject(projectId string) error {
 // ListProjects retrieves projects with pagination
 func (r *ProjectRepo) ListProjects(orgID string, opts ListOptions) ([]*model.Project, error) {
 	query := `
-		SELECT uuid, handle, display_name, organization_uuid, description, created_at, updated_at
+		SELECT uuid, handle, display_name, organization_uuid, description, is_active, created_at, updated_at
 		FROM projects
 		WHERE organization_uuid = ?`
 	args := []any{orgID}
@@ -200,11 +230,13 @@ func (r *ProjectRepo) ListProjects(orgID string, opts ListOptions) ([]*model.Pro
 	var projects []*model.Project
 	for rows.Next() {
 		project := &model.Project{}
+		var isActive int
 		err := rows.Scan(&project.ID, &project.Handle, &project.Name, &project.OrganizationID, &project.Description,
-			&project.CreatedAt, &project.UpdatedAt)
+			&isActive, &project.CreatedAt, &project.UpdatedAt)
 		if err != nil {
 			return nil, err
 		}
+		project.IsActive = isActive != 0
 		projects = append(projects, project)
 	}
 

--- a/platform-api/internal/repository/project_test.go
+++ b/platform-api/internal/repository/project_test.go
@@ -1,0 +1,155 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package repository
+
+import (
+	"testing"
+	"time"
+
+	"github.com/wso2/api-platform/platform-api/internal/database"
+	"github.com/wso2/api-platform/platform-api/internal/model"
+)
+
+func seedTestOrg(t *testing.T, db *database.DB, orgUUID string) {
+	t.Helper()
+	query := `
+		INSERT INTO organizations (uuid, handle, display_name, region, idp_organization_ref_uuid, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+	`
+	_, err := db.Exec(db.Rebind(query), orgUUID, "acme", "Acme", "us", "idp-"+orgUUID, time.Now(), time.Now())
+	if err != nil {
+		t.Fatalf("Failed to seed organization: %v", err)
+	}
+}
+
+func TestProjectRepo_CreateAndRead_IsActive(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	const orgUUID = "org-1"
+	seedTestOrg(t, db, orgUUID)
+	repo := NewProjectRepo(db)
+
+	cases := []struct {
+		name     string
+		uuid     string
+		handle   string
+		isActive bool
+	}{
+		{"active project", "proj-active", "active-proj", true},
+		{"inactive project", "proj-inactive", "inactive-proj", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &model.Project{
+				ID:             tc.uuid,
+				Handle:         tc.handle,
+				Name:           tc.handle,
+				OrganizationID: orgUUID,
+				IsActive:       tc.isActive,
+			}
+			if err := repo.CreateProject(p); err != nil {
+				t.Fatalf("CreateProject: %v", err)
+			}
+
+			byHandle, err := repo.GetProjectByHandleAndOrgID(tc.handle, orgUUID)
+			if err != nil || byHandle == nil {
+				t.Fatalf("GetProjectByHandleAndOrgID: %v (nil=%v)", err, byHandle == nil)
+			}
+			if byHandle.IsActive != tc.isActive {
+				t.Errorf("byHandle.IsActive = %v, want %v", byHandle.IsActive, tc.isActive)
+			}
+
+			byUUID, err := repo.GetProjectByUUID(tc.uuid)
+			if err != nil || byUUID == nil {
+				t.Fatalf("GetProjectByUUID: %v (nil=%v)", err, byUUID == nil)
+			}
+			if byUUID.IsActive != tc.isActive {
+				t.Errorf("byUUID.IsActive = %v, want %v", byUUID.IsActive, tc.isActive)
+			}
+		})
+	}
+
+	// The list paths must surface the flag too.
+	all, err := repo.GetProjectsByOrganizationID(orgUUID)
+	if err != nil {
+		t.Fatalf("GetProjectsByOrganizationID: %v", err)
+	}
+	got := map[string]bool{}
+	for _, p := range all {
+		got[p.Handle] = p.IsActive
+	}
+	if got["active-proj"] != true || got["inactive-proj"] != false {
+		t.Errorf("GetProjectsByOrganizationID is_active mismatch: %v", got)
+	}
+
+	listed, err := repo.ListProjects(orgUUID, ListOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("ListProjects: %v", err)
+	}
+	gotListed := map[string]bool{}
+	for _, p := range listed {
+		gotListed[p.Handle] = p.IsActive
+	}
+	if gotListed["active-proj"] != true || gotListed["inactive-proj"] != false {
+		t.Errorf("ListProjects is_active mismatch: %v", gotListed)
+	}
+}
+
+func TestProjectRepo_SetProjectActive(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	const orgUUID = "org-1"
+	seedTestOrg(t, db, orgUUID)
+	repo := NewProjectRepo(db)
+
+	p := &model.Project{
+		ID:             "proj-1",
+		Handle:         "proj",
+		Name:           "proj",
+		OrganizationID: orgUUID,
+		IsActive:       false,
+	}
+	if err := repo.CreateProject(p); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	if err := repo.SetProjectActive("proj-1", true); err != nil {
+		t.Fatalf("SetProjectActive(true): %v", err)
+	}
+	got, err := repo.GetProjectByUUID("proj-1")
+	if err != nil || got == nil {
+		t.Fatalf("GetProjectByUUID: %v (nil=%v)", err, got == nil)
+	}
+	if !got.IsActive {
+		t.Errorf("after SetProjectActive(true), IsActive = false, want true")
+	}
+
+	if err := repo.SetProjectActive("proj-1", false); err != nil {
+		t.Fatalf("SetProjectActive(false): %v", err)
+	}
+	got, err = repo.GetProjectByUUID("proj-1")
+	if err != nil || got == nil {
+		t.Fatalf("GetProjectByUUID: %v (nil=%v)", err, got == nil)
+	}
+	if got.IsActive {
+		t.Errorf("after SetProjectActive(false), IsActive = true, want false")
+	}
+}

--- a/platform-api/internal/server/server.go
+++ b/platform-api/internal/server/server.go
@@ -243,7 +243,7 @@ func StartPlatformAPIServer(cfg *config.Server, slogger *slog.Logger,
 		cfg,
 		slogger,
 	)
-	projectService := service.NewProjectService(projectRepo, orgRepo, apiRepo, mcpProxyRepo, appRepo, auditRepo, identityService, slogger)
+	projectService := service.NewProjectService(projectRepo, orgRepo, apiRepo, mcpProxyRepo, appRepo, auditRepo, identityService, cfg.Projects.ActivateOnCreate, slogger)
 	gatewayEventsService := service.NewGatewayEventsService(eventHub, identityService, slogger)
 	appService := service.NewApplicationService(appRepo, projectRepo, orgRepo, apiRepo, gatewayEventsService, auditRepo, identityService, slogger)
 	apiService := service.NewAPIService(apiRepo, projectRepo, orgRepo, gatewayRepo, deploymentRepo,
@@ -429,6 +429,7 @@ func StartPlatformAPIServer(cfg *config.Server, slogger *slog.Logger,
 	// signature drifts from the pdk interface, this stops building.
 	pdkDeps := &pdk.Deps{
 		Gateways: gatewayService,
+		Projects: projectService,
 		Config:   cfg,
 		Logger:   slogger,
 	}

--- a/platform-api/internal/service/api.go
+++ b/platform-api/internal/service/api.go
@@ -124,6 +124,9 @@ func (s *APIService) CreateAPI(req *api.CreateRESTAPIRequest, orgUUID, createdBy
 	if project == nil {
 		return nil, apperror.ProjectNotFound.New()
 	}
+	if !project.IsActive {
+		return nil, apperror.ProjectNotActive.New()
+	}
 
 	// Handle the API handle (user-facing identifier)
 	var handle string

--- a/platform-api/internal/service/application.go
+++ b/platform-api/internal/service/application.go
@@ -119,6 +119,9 @@ func (s *ApplicationService) CreateApplication(req *api.CreateApplicationRequest
 		if project == nil {
 			return nil, apperror.ProjectNotFound.New()
 		}
+		if !project.IsActive {
+			return nil, apperror.ProjectNotActive.New()
+		}
 		projectID = project.ID
 
 		existingByName, err := s.appRepo.GetApplicationByNameInProject(strings.TrimSpace(req.DisplayName), projectID, orgID)

--- a/platform-api/internal/service/artifact_import.go
+++ b/platform-api/internal/service/artifact_import.go
@@ -275,6 +275,9 @@ func (s *ArtifactImportService) importValidated(orgID, gatewayID string, req dto
 			return nil, apperror.ProjectNotFound.New().WithLogMessage(
 				fmt.Sprintf("project with handle %q does not exist in org %q", ictx.ProjectHandle, orgID))
 		}
+		if !project.IsActive {
+			return nil, apperror.ProjectNotActive.New()
+		}
 		ictx.ProjectID = project.ID
 	}
 

--- a/platform-api/internal/service/llm.go
+++ b/platform-api/internal/service/llm.go
@@ -1397,6 +1397,9 @@ func (s *LLMProxyService) Create(orgUUID, createdBy string, req *api.LLMProxy) (
 		if project == nil || project.OrganizationID != orgUUID {
 			return nil, apperror.ProjectNotFound.New()
 		}
+		if !project.IsActive {
+			return nil, apperror.ProjectNotActive.New()
+		}
 		projectUUID = project.ID
 	}
 

--- a/platform-api/internal/service/llm_test.go
+++ b/platform-api/internal/service/llm_test.go
@@ -1416,12 +1416,30 @@ func TestLLMProxyServiceCreateFailsWhenProviderNotFound(t *testing.T) {
 			return nil, nil
 		},
 	}
-	projectRepo := &mockProjectRepo{project: &model.Project{ID: "project-1", OrganizationID: "org-1"}}
+	projectRepo := &mockProjectRepo{project: &model.Project{ID: "project-1", OrganizationID: "org-1", IsActive: true}}
 	service := NewLLMProxyService(proxyRepo, providerRepo, projectRepo, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{}, newTestIdentityService())
 
 	_, err := service.Create("org-1", "alice", validProxyRequest("provider-1", "project-1"))
 	if !apperror.LLMProviderNotFound.Is(err) {
 		t.Fatalf("expected ErrLLMProviderNotFound, got: %v", err)
+	}
+}
+
+func TestLLMProxyServiceCreateFailsWhenProjectInactive(t *testing.T) {
+	proxyRepo := &mockLLMProxyRepo{}
+	// The provider lookup would succeed, so a PROJECT_NOT_ACTIVE result proves the
+	// inactive-project guard runs before (and independently of) provider validation.
+	providerRepo := &mockLLMProviderRepo{
+		getByIDFunc: func(providerID, orgUUID string) (*model.LLMProvider, error) {
+			return &model.LLMProvider{UUID: "provider-uuid", ID: providerID}, nil
+		},
+	}
+	projectRepo := &mockProjectRepo{project: &model.Project{ID: "project-1", OrganizationID: "org-1", IsActive: false}}
+	service := NewLLMProxyService(proxyRepo, providerRepo, projectRepo, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{}, newTestIdentityService())
+
+	_, err := service.Create("org-1", "alice", validProxyRequest("provider-1", "project-1"))
+	if !apperror.ProjectNotActive.Is(err) {
+		t.Fatalf("expected ProjectNotActive, got: %v", err)
 	}
 }
 

--- a/platform-api/internal/service/mcp.go
+++ b/platform-api/internal/service/mcp.go
@@ -126,6 +126,9 @@ func (s *MCPProxyService) Create(orgUUID, createdBy string, req *api.MCPProxy) (
 		if project == nil || project.OrganizationID != orgUUID {
 			return nil, apperror.ProjectRefNotFound.New()
 		}
+		if !project.IsActive {
+			return nil, apperror.ProjectNotActive.New()
+		}
 		projectUUID = &project.ID
 	}
 

--- a/platform-api/internal/service/organization.go
+++ b/platform-api/internal/service/organization.go
@@ -162,6 +162,7 @@ func (s *OrganizationService) RegisterOrganization(id string, handle string, nam
 		Name:           "default",
 		OrganizationID: id,
 		Description:    "Default project",
+		IsActive:       s.config.Projects.ActivateOnCreate,
 		CreatedAt:      time.Now(),
 		UpdatedAt:      time.Now(),
 	}

--- a/platform-api/internal/service/organization_test.go
+++ b/platform-api/internal/service/organization_test.go
@@ -26,6 +26,7 @@ import (
 
 	"database/sql"
 
+	"github.com/wso2/api-platform/platform-api/config"
 	"github.com/wso2/api-platform/platform-api/internal/database"
 	"github.com/wso2/api-platform/platform-api/internal/model"
 	"github.com/wso2/api-platform/platform-api/internal/repository"
@@ -63,6 +64,7 @@ func setupOrganizationTestEnv(t *testing.T) (*OrganizationService, *database.DB,
 		auditRepo:          &noopAuditRepo{},
 		userOrgMappingRepo: repository.NewUserOrganizationMappingRepo(db),
 		identity:           NewIdentityService(repository.NewUserIdentityMappingRepo(db)),
+		config:             &config.Server{Projects: config.Projects{ActivateOnCreate: true}},
 		slogger:            slog.Default(),
 	}
 

--- a/platform-api/internal/service/project.go
+++ b/platform-api/internal/service/project.go
@@ -40,25 +40,27 @@ type ProjectService struct {
 	apiRepo        repository.APIRepository
 	mcpProxyRepo   repository.MCPProxyRepository
 	appRepo        repository.ApplicationRepository
-	deletionGuards []ProjectDeletionGuard
-	auditRepo      repository.AuditRepository
-	identity       *IdentityService
-	slogger        *slog.Logger
+	deletionGuards   []ProjectDeletionGuard
+	auditRepo        repository.AuditRepository
+	identity         *IdentityService
+	activateOnCreate bool
+	slogger          *slog.Logger
 }
 
 func NewProjectService(projectRepo repository.ProjectRepository, orgRepo repository.OrganizationRepository,
 	apiRepo repository.APIRepository, mcpProxyRepo repository.MCPProxyRepository,
 	appRepo repository.ApplicationRepository, auditRepo repository.AuditRepository,
-	identity *IdentityService, slogger *slog.Logger) *ProjectService {
+	identity *IdentityService, activateOnCreate bool, slogger *slog.Logger) *ProjectService {
 	return &ProjectService{
-		projectRepo:  projectRepo,
-		orgRepo:      orgRepo,
-		apiRepo:      apiRepo,
-		mcpProxyRepo: mcpProxyRepo,
-		appRepo:      appRepo,
-		auditRepo:    auditRepo,
-		identity:     identity,
-		slogger:      slogger,
+		projectRepo:      projectRepo,
+		orgRepo:          orgRepo,
+		apiRepo:          apiRepo,
+		mcpProxyRepo:     mcpProxyRepo,
+		appRepo:          appRepo,
+		auditRepo:        auditRepo,
+		identity:         identity,
+		activateOnCreate: activateOnCreate,
+		slogger:          slogger,
 	}
 }
 
@@ -135,6 +137,7 @@ func (s *ProjectService) CreateProject(req *api.CreateProjectRequest, organizati
 	projectModel.ID = projectID
 	projectModel.Handle = handle
 	projectModel.OrganizationID = organizationID
+	projectModel.IsActive = s.activateOnCreate
 	projectModel.CreatedBy = actor
 	projectModel.UpdatedBy = actor
 
@@ -308,6 +311,39 @@ func (s *ProjectService) DeleteProject(handle, orgId, actor string) error {
 	}
 	_ = s.auditRepo.Record("DELETE", project.ID, "project", orgId, actor)
 	return nil
+}
+
+// SetProjectActive flips a project's active state. It exists so an external
+// provisioning flow (e.g. the cloud integrator, once the Platform API is made
+// extensible) can mark a project ready after its counterpart has been created.
+// In the OSS build projects are always created active, so this is unused there.
+func (s *ProjectService) SetProjectActive(handle, orgId, actor string, isActive bool) (*api.Project, error) {
+	project, err := s.projectRepo.GetProjectByHandleAndOrgID(handle, orgId)
+	if err != nil {
+		return nil, err
+	}
+	if project == nil {
+		return nil, apperror.ProjectNotFound.New()
+	}
+
+	if project.IsActive != isActive {
+		if err := s.projectRepo.SetProjectActive(project.ID, isActive); err != nil {
+			return nil, err
+		}
+		project.IsActive = isActive
+		_ = s.auditRepo.Record("UPDATE", project.ID, "project", orgId, actor)
+	}
+
+	org, err := s.orgRepo.GetOrganizationByUUID(orgId)
+	if err != nil {
+		return nil, err
+	}
+	orgHandle := ""
+	if org != nil {
+		orgHandle = org.Handle
+	}
+
+	return s.modelToAPI(project, orgHandle)
 }
 
 func (s *ProjectService) apiToModel(project *api.Project) *model.Project {

--- a/platform-api/pdk/deps.go
+++ b/platform-api/pdk/deps.go
@@ -37,8 +37,9 @@ import (
 // signature drifts, the server stops building.
 type Deps struct {
 	Gateways Gateways
+	Projects Projects
 	// add more capability groups as external plugins need them
-	// (APIs, Subscriptions, Applications, Projects, Organizations, LLM, MCP, …)
+	// (APIs, Subscriptions, Applications, Organizations, LLM, MCP, …)
 
 	Config *config.Server
 	Logger *slog.Logger
@@ -61,4 +62,28 @@ type Gateways interface {
 
 	// DeleteGateway removes a gateway within an organization (Delete).
 	DeleteGateway(gatewayID, orgID, deletedBy string) error
+}
+
+// Projects exposes project access scoped by organization. Every method mirrors an
+// existing ProjectService method verbatim and takes the organization id explicitly
+// — handlers MUST pass the org resolved from the request context, never one from
+// request input (GO-AUTH-005).
+//
+// SetProjectActive is the capability the cloud extension uses to flip a project to
+// active once its external counterpart (e.g. the OpenChoreo project) has been
+// provisioned; create/get/delete let the extension mirror projects created on the
+// external side. The is_active flag and the create-time default live in the core;
+// the provisioning workflow that drives them lives entirely in the external plugin.
+type Projects interface {
+	// CreateProject creates a project in an organization (Create).
+	CreateProject(req *api.CreateProjectRequest, organizationID, actor string) (*api.Project, error)
+
+	// GetProjectByHandle returns a single project by handle within an organization (Read).
+	GetProjectByHandle(handle, orgID string) (*api.Project, error)
+
+	// SetProjectActive flips a project's active state within an organization.
+	SetProjectActive(handle, orgID, actor string, isActive bool) (*api.Project, error)
+
+	// DeleteProject removes a project within an organization (Delete).
+	DeleteProject(handle, orgID, actor string) error
 }


### PR DESCRIPTION
## Purpose
Projects in the Platform API are created synchronously and are immediately usable,
with no notion of "provisioned elsewhere yet". The upcoming cloud deployment-pipeline
work needs every APIP project mirrored 1:1 to an external system (an OpenChoreo
project), and that mirroring is asynchronous — there is a window where the APIP
project row exists but its external counterpart does not. During that window the
project must not be usable.

This PR introduces a lifecycle state so a project can exist before its external
provisioning completes and only become usable once activated. It is a **behavioral
change to the Platform API** (project-scoped operations start depending on project
state), so it is intentionally minimal and behavior-preserving for OSS/on-prem.

Resolves N/A (tracked internally; discussion doc shared with the team).

## Goals
- Add an internal `is_active` flag to projects.
- Keep OSS/on-prem behavior identical: projects are created active by default, and
  every operation behaves exactly as before.
- Let a cloud build create projects inactive and activate them once their external
  counterpart is provisioned — driven entirely from an external plugin, with the
  smallest possible surface added to the public repo.

## Approach
- **Data model:** add an `is_active` column (default active) to all four dialect
  schemas and to `model.Project`; read/write it across every repository query path,
  plus a `SetProjectActive` method. The flag is **internal only** and is deliberately
  **not** exposed on the public `api.Project`/OpenAPI — on-prem projects are always
  active, so no public consumer needs it.
- **Default behavior:** new config `projects.activate_on_create` (default `true`)
  honored by `CreateProject` and by the org-bootstrap default project. A cloud build
  sets it `false`.
- **Gating:** creating/importing resources under an inactive project (REST API,
  application, LLM proxy, MCP proxy, artifact import) is rejected with
  `409 PROJECT_NOT_ACTIVE`. Reads, lists, and delete stay open.
- **Extensibility:** expose a `Projects` capability group on `pdk.Deps`
  (create / get / set-active / delete) — mirroring the existing `Gateways` group — so
  the cloud project-sync plugin (built on PR #2814's pluggable model, from a pinned
  version) can drive project lifecycle through the stable public contract. No cloud
  logic lands in this repo.

> ⚠️ **Migration note for reviewers:** the schema is applied via
> `CREATE TABLE IF NOT EXISTS` with no ALTER/versioned migration, so this additive
> column reaches **fresh installs** cleanly but **not existing deployments'** tables.
> An in-place upgrade would fail project queries until the column is added. A
> migration story (e.g. startup `ALTER TABLE … ADD COLUMN IF NOT EXISTS` per dialect)
> should be agreed before rollout to any existing environment — this is the first
> additive column to hit that gap and is worth settling as a general policy.

## User stories
- As a cloud operator, a project created via APIP is not usable until its external
  (OpenChoreo) counterpart has been provisioned.
- As an on-prem user, nothing changes — projects are usable the moment they are created.

## Documentation
N/A — no public API or user-facing surface changes (the flag is internal; the public
API response schema is unchanged).

## Automation tests
- Unit tests
  > Added `internal/repository/project_test.go` — `is_active` round-trip across all
  > read paths (get-by-uuid/handle, list, org list) and `SetProjectActive`.
  > Added `TestLLMProxyServiceCreateFailsWhenProjectInactive` — asserts the
  > `409 PROJECT_NOT_ACTIVE` guard fires (before provider validation).
  > Updated affected fixtures (`llm_test.go`, `organization_test.go`).
- Integration tests
  > N/A for this PR.

## Security checks
- Followed secure coding standards in the WSO2 secure engineering guidelines? yes
- Ran FindSecurityBugs plugin and verified report? no (no security-sensitive change; Go backend)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
- #2814 (pluggable Platform API / `pdk` model this builds on)

## Test environment
- Go (repo toolchain), SQLite (unit tests). `go build`, `go vet`, and `go test ./...`
  all pass; schema change authored for sqlite/postgres/sqlserver/generic dialects.
