### PR TITLE
ci(gateway): prompt for next dev version on release

### DIFF
--- a/.github/workflows/gateway-release.yml
+++ b/.github/workflows/gateway-release.yml
@@ -75,14 +75,19 @@ jobs:
 
 
       - name: Set next dev version
+        env:
+          NEXT_DEV_VERSION: ${{ inputs.next_dev_version }}
         run: |
-          NEXT_DEV_VERSION="${{ inputs.next_dev_version }}"
           if [ -z "${NEXT_DEV_VERSION}" ]; then
             echo "Error: next_dev_version input is required"
             exit 1
           fi
+          if [[ "${NEXT_DEV_VERSION}" != *-SNAPSHOT ]]; then
+            echo "Error: next_dev_version must end with -SNAPSHOT (e.g. 1.3.0-SNAPSHOT)"
+            exit 1
+          fi
           echo "Setting gateway to next dev version: ${NEXT_DEV_VERSION}"
-          make -C gateway version-set VERSION=${NEXT_DEV_VERSION}
+          make -C gateway version-set "VERSION=${NEXT_DEV_VERSION}"
 
       - name: Commit version bump
         run: |

--- a/.github/workflows/gateway-release.yml
+++ b/.github/workflows/gateway-release.yml
@@ -2,6 +2,11 @@ name: Gateway Release
 
 on:
   workflow_dispatch:
+    inputs:
+      next_dev_version:
+        description: 'Next development version (with -SNAPSHOT suffix, e.g. 1.3.0-SNAPSHOT)'
+        required: true
+        type: string
 
 env:
   DOCKER_REGISTRY: ghcr.io/wso2/api-platform
@@ -69,8 +74,15 @@ jobs:
           git push origin ai-gateway/v${{ steps.version.outputs.version }}
 
 
-      - name: Bump to next dev version
-        run: make -C gateway version-bump-next-dev
+      - name: Set next dev version
+        run: |
+          NEXT_DEV_VERSION="${{ inputs.next_dev_version }}"
+          if [ -z "${NEXT_DEV_VERSION}" ]; then
+            echo "Error: next_dev_version input is required"
+            exit 1
+          fi
+          echo "Setting gateway to next dev version: ${NEXT_DEV_VERSION}"
+          make -C gateway version-set VERSION=${NEXT_DEV_VERSION}
 
       - name: Commit version bump
         run: |
@@ -89,7 +101,7 @@ jobs:
           body: |
             Automated version bump after release `gateway/v${{ steps.version.outputs.version }}`
 
-            This PR bumps the gateway version to the next development version.
+            This PR bumps the gateway version to the next development version `${{ inputs.next_dev_version }}`.
           branch: version-bump-${{ github.run_id }}
           base: main
           delete-branch: true


### PR DESCRIPTION
## Purpose

The gateway release workflow currently bumps to the next development version automatically (minor + 1, with `-SNAPSHOT`) via `make version-bump-next-dev`. This removes control over the version chosen after a release — for example when the next cycle should be a patch, a specific minor, or carry an `-rc` pre-release qualifier. This PR makes the next development version an explicit, maintainer-provided input at release time.

## Goals

Let the maintainer specify the exact next development version when triggering the Gateway Release workflow, instead of having it computed automatically.

## Approach

- Add a required `next_dev_version` input to the `workflow_dispatch` trigger (string, documented to include the `-SNAPSHOT` suffix, e.g. `1.3.0-SNAPSHOT`).
- Replace the `make -C gateway version-bump-next-dev` step with a step that validates the input and applies it via `make -C gateway version-set VERSION=<input>`.
- Reference the chosen version in the automated version-bump PR body.

The release version itself is still derived automatically from the `VERSION` file (with `-SNAPSHOT` stripped); only the next development version is now prompted.

## Related Issues

N/A

## Documentation

N/A — internal release automation change with no product documentation impact.

## Automation tests

- Unit tests
  > N/A — GitHub Actions workflow change; no application code affected.
- Integration tests
  > N/A — verified by inspection of the workflow; exercised on the next manual release dispatch.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (no Java/source code changes)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs

N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)