### PR TITLE
feat: support repeatable, required -config flag across config loaders

### DIFF
--- a/gateway/gateway-controller/cmd/controller/main.go
+++ b/gateway/gateway-controller/cmd/controller/main.go
@@ -95,22 +95,37 @@ func toBackendConfig(cfg *config.Config) storage.BackendConfig {
 	}
 }
 
+// stringSliceFlag collects a repeatable string flag into a slice, preserving the
+// order in which the flags were supplied on the command line.
+type stringSliceFlag []string
+
+func (s *stringSliceFlag) String() string { return strings.Join(*s, ", ") }
+
+func (s *stringSliceFlag) Set(value string) error {
+	*s = append(*s, value)
+	return nil
+}
+
 func main() {
-	// Parse command-line flags
-	configPath := flag.String("config", "", "Path to configuration file (required)")
+	// Parse command-line flags. -config is repeatable: files are merged in the
+	// order given with last-wins precedence (a key set in a later file overrides
+	// the same key from an earlier file).
+	var configPaths stringSliceFlag
+	flag.Var(&configPaths, "config",
+		"Path to a configuration file (required; repeatable, merged in order with last-wins precedence)")
 	flag.Parse()
 
-	// Validate that config file is provided
-	if *configPath == "" {
+	// Validate that at least one config file is provided
+	if len(configPaths) == 0 {
 		fmt.Fprintf(os.Stderr, "Error: -config flag is required\n")
-		fmt.Fprintf(os.Stderr, "Usage: %s -config <path-to-config.toml>\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Usage: %s -config <path-to-config.toml> [-config <overlay.toml> ...]\n", os.Args[0])
 		os.Exit(1)
 	}
 
 	// Load configuration
-	cfg, err := config.LoadConfig(*configPath)
+	cfg, err := config.LoadConfig(configPaths...)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to load configuration from %s: %v\n", *configPath, err)
+		fmt.Fprintf(os.Stderr, "Failed to load configuration from %s: %v\n", strings.Join(configPaths, ", "), err)
 		os.Exit(1)
 	}
 
@@ -129,7 +144,7 @@ func main() {
 		slog.String("version", version.Version),
 		slog.String("git_commit", version.GitCommit),
 		slog.String("build_date", version.BuildDate),
-		slog.String("config_file", *configPath),
+		slog.Any("config_files", []string(configPaths)),
 		slog.String("storage_type", cfg.Controller.Storage.Type),
 		slog.Bool("access_logs_enabled", cfg.Router.AccessLogs.Enabled),
 		slog.String("control_plane_host", cfg.Controller.ControlPlane.Host),

--- a/gateway/gateway-controller/pkg/config/config.go
+++ b/gateway/gateway-controller/pkg/config/config.go
@@ -688,16 +688,34 @@ type EncryptionKeyConfig struct {
 	FilePath string `koanf:"file"`    // Path to raw binary key file
 }
 
-// LoadConfig loads configuration from a file layered over built-in defaults.
-// Priority: Config file > Defaults.
-func LoadConfig(configPath string) (*Config, error) {
+// LoadConfig loads configuration from one or more files layered over built-in
+// defaults. Priority: Config files > Defaults.
+//
+// Files are merged in the order given with last-wins precedence: a key set in a
+// later file overrides the same key from an earlier file. Merge semantics follow
+// koanf — nested tables (maps) deep-merge, while list/array values are replaced
+// wholesale, not appended. StrictMerge is enabled, so a type-mismatched override
+// of the same key across files fails loudly rather than being silently coerced.
+//
+// {{ env }} / {{ file }} interpolation runs once, after all files are merged, so a
+// token declared in an earlier file can be resolved by a later overlay.
+func LoadConfig(configPaths ...string) (*Config, error) {
 	cfg := defaultConfig()
 
-	k := koanf.New(".")
+	if len(configPaths) == 0 {
+		return nil, fmt.Errorf("at least one config file path is required")
+	}
 
-	// Load config file if path is provided
-	if err := k.Load(file.Provider(configPath), toml.Parser()); err != nil {
-		return nil, fmt.Errorf("failed to load config file: %w", err)
+	// StrictMerge: when two files set the same key with different value types, fail
+	// loudly instead of silently coercing the later value into the earlier's type.
+	k := koanf.NewWithConf(koanf.Conf{Delim: ".", StrictMerge: true})
+
+	// Load each config file in order. Successive loads deep-merge maps and replace
+	// arrays, giving last-wins precedence for keys set in more than one file.
+	for _, configPath := range configPaths {
+		if err := k.Load(file.Provider(configPath), toml.Parser()); err != nil {
+			return nil, fmt.Errorf("failed to load config file %q: %w", configPath, err)
+		}
 	}
 
 	// Resolve Go template tokens ({{ env }} / {{ file }}) in string leaves of the

--- a/gateway/gateway-controller/pkg/config/config.go
+++ b/gateway/gateway-controller/pkg/config/config.go
@@ -694,8 +694,10 @@ type EncryptionKeyConfig struct {
 // Files are merged in the order given with last-wins precedence: a key set in a
 // later file overrides the same key from an earlier file. Merge semantics follow
 // koanf — nested tables (maps) deep-merge, while list/array values are replaced
-// wholesale, not appended. StrictMerge is enabled, so a type-mismatched override
-// of the same key across files fails loudly rather than being silently coerced.
+// wholesale, not appended. A field may be overridden across files with a different
+// representation — e.g. a numeric value in the base and an {{ env }} token (a string)
+// in an overlay — and still resolve, because types are only checked after
+// interpolation by the weakly-typed unmarshal (a non-coercible value still fails there).
 //
 // {{ env }} / {{ file }} interpolation runs once, after all files are merged, so a
 // token declared in an earlier file can be resolved by a later overlay.
@@ -706,9 +708,13 @@ func LoadConfig(configPaths ...string) (*Config, error) {
 		return nil, fmt.Errorf("at least one config file path is required")
 	}
 
-	// StrictMerge: when two files set the same key with different value types, fail
-	// loudly instead of silently coercing the later value into the earlier's type.
-	k := koanf.NewWithConf(koanf.Conf{Delim: ".", StrictMerge: true})
+	// Deliberately NOT koanf StrictMerge: strict merging compares the raw parsed
+	// types across files, but an {{ env }} / {{ file }} interpolation token is a
+	// string until it is resolved after the merge — so strict merging would reject a
+	// numeric/bool field that one file sets natively and another overrides with a
+	// token. Cross-file type errors are instead caught downstream by the weakly-typed
+	// unmarshal and Validate.
+	k := koanf.New(".")
 
 	// Load each config file in order. Successive loads deep-merge maps and replace
 	// arrays, giving last-wins precedence for keys set in more than one file.

--- a/gateway/gateway-controller/pkg/config/config_multifile_test.go
+++ b/gateway/gateway-controller/pkg/config/config_multifile_test.go
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeTOML writes contents to a uniquely-named .toml file under dir and returns
+// its path.
+func writeTOML(t *testing.T, dir, name, contents string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o644))
+	return path
+}
+
+// TestLoadConfig_MultiFile_DeepMergeLastWins verifies that when the same nested
+// table is set across two files, keys deep-merge and a key present in both files
+// takes the later file's value (last-wins), while a key only in the base survives.
+func TestLoadConfig_MultiFile_DeepMergeLastWins(t *testing.T) {
+	dir := t.TempDir()
+	base := writeTOML(t, dir, "base.toml", `
+[controller.server]
+api_port = 9999
+
+[controller.logging]
+level = "info"
+format = "json"
+`)
+	overlay := writeTOML(t, dir, "overlay.toml", `
+[controller.logging]
+level = "debug"
+`)
+
+	cfg, err := LoadConfig(base, overlay)
+	require.NoError(t, err)
+
+	// Overridden in the overlay.
+	assert.Equal(t, "debug", cfg.Controller.Logging.Level, "later file must win for a shared key")
+	// Only set in the base — must survive the merge.
+	assert.EqualValues(t, 9999, cfg.Controller.Server.APIPort, "base-only key must survive")
+	// Set in the base, not touched by the overlay — deep-merge must keep it.
+	assert.Equal(t, "json", cfg.Controller.Logging.Format, "sibling key in a merged table must survive")
+}
+
+// TestLoadConfig_MultiFile_ArrayReplaceNotAppend verifies koanf semantics for
+// list values: a later file replaces the base list wholesale rather than
+// appending to it.
+func TestLoadConfig_MultiFile_ArrayReplaceNotAppend(t *testing.T) {
+	dir := t.TempDir()
+	base := writeTOML(t, dir, "base.toml", `
+[collector]
+ignore_path_prefixes = ["/health", "/metrics", "/ready"]
+`)
+	overlay := writeTOML(t, dir, "overlay.toml", `
+[collector]
+ignore_path_prefixes = ["/livez"]
+`)
+
+	cfg, err := LoadConfig(base, overlay)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"/livez"}, cfg.Collector.IgnorePathPrefixes,
+		"array value must be replaced by the later file, not appended")
+}
+
+// TestLoadConfig_MultiFile_StrictMergeTypeMismatchFails verifies that StrictMerge
+// makes a type-mismatched override of the same key across files fail loudly.
+func TestLoadConfig_MultiFile_StrictMergeTypeMismatchFails(t *testing.T) {
+	dir := t.TempDir()
+	base := writeTOML(t, dir, "base.toml", `
+[controller.server]
+api_port = 8080
+`)
+	overlay := writeTOML(t, dir, "overlay.toml", `
+[controller.server]
+api_port = "not-a-number"
+`)
+
+	_, err := LoadConfig(base, overlay)
+	require.Error(t, err, "a type-mismatched override across files must fail loudly under StrictMerge")
+}
+
+// TestLoadConfig_MultiFile_InterpolationAfterMerge verifies that {{ env }}
+// interpolation runs once, after all files are merged: a token declared in the
+// base is resolved even when a later overlay overrides an unrelated key.
+func TestLoadConfig_MultiFile_InterpolationAfterMerge(t *testing.T) {
+	dir := t.TempDir()
+	base := writeTOML(t, dir, "base.toml", `
+[controller.logging]
+level = '{{ env "APIP_TEST_LOG_LEVEL" "info" }}'
+`)
+	overlay := writeTOML(t, dir, "overlay.toml", `
+[controller.logging]
+format = "text"
+`)
+
+	t.Setenv("APIP_TEST_LOG_LEVEL", "warn")
+
+	cfg, err := LoadConfig(base, overlay)
+	require.NoError(t, err)
+
+	assert.Equal(t, "warn", cfg.Controller.Logging.Level, "token in base must resolve after merge")
+	assert.Equal(t, "text", cfg.Controller.Logging.Format, "overlay override must apply alongside interpolation")
+}
+
+// TestLoadConfig_MultiFile_OrderMatters verifies precedence follows argument
+// order: swapping the two files flips which value wins.
+func TestLoadConfig_MultiFile_OrderMatters(t *testing.T) {
+	dir := t.TempDir()
+	a := writeTOML(t, dir, "a.toml", `
+[controller.logging]
+level = "debug"
+`)
+	b := writeTOML(t, dir, "b.toml", `
+[controller.logging]
+level = "error"
+`)
+
+	cfgAB, err := LoadConfig(a, b)
+	require.NoError(t, err)
+	assert.Equal(t, "error", cfgAB.Controller.Logging.Level, "last file (b) must win")
+
+	cfgBA, err := LoadConfig(b, a)
+	require.NoError(t, err)
+	assert.Equal(t, "debug", cfgBA.Controller.Logging.Level, "last file (a) must win when order is swapped")
+}
+
+// TestLoadConfig_MultiFile_SingleFileUnchanged is a regression guard that the
+// common single-file case still loads and validates as before.
+func TestLoadConfig_MultiFile_SingleFileUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	single := writeTOML(t, dir, "config.toml", `
+[controller.logging]
+level = "info"
+`)
+
+	cfg, err := LoadConfig(single)
+	require.NoError(t, err)
+	assert.Equal(t, "info", cfg.Controller.Logging.Level)
+}
+
+// TestLoadConfig_NoFiles verifies LoadConfig rejects an empty path list.
+func TestLoadConfig_NoFiles(t *testing.T) {
+	_, err := LoadConfig()
+	require.Error(t, err, "LoadConfig must require at least one config file path")
+}

--- a/gateway/gateway-controller/pkg/config/config_multifile_test.go
+++ b/gateway/gateway-controller/pkg/config/config_multifile_test.go
@@ -86,9 +86,11 @@ ignore_path_prefixes = ["/livez"]
 		"array value must be replaced by the later file, not appended")
 }
 
-// TestLoadConfig_MultiFile_StrictMergeTypeMismatchFails verifies that StrictMerge
-// makes a type-mismatched override of the same key across files fail loudly.
-func TestLoadConfig_MultiFile_StrictMergeTypeMismatchFails(t *testing.T) {
+// TestLoadConfig_MultiFile_TypeMismatchFails verifies that a genuinely invalid
+// cross-file override — a non-numeric string for a numeric field — still fails. The
+// loader does not use koanf StrictMerge (see LoadConfig), so this is caught by the
+// weakly-typed unmarshal after the merge rather than at merge time.
+func TestLoadConfig_MultiFile_TypeMismatchFails(t *testing.T) {
 	dir := t.TempDir()
 	base := writeTOML(t, dir, "base.toml", `
 [controller.server]
@@ -100,7 +102,51 @@ api_port = "not-a-number"
 `)
 
 	_, err := LoadConfig(base, overlay)
-	require.Error(t, err, "a type-mismatched override across files must fail loudly under StrictMerge")
+	require.Error(t, err, "a non-coercible cross-file override must still fail (at unmarshal)")
+}
+
+// TestLoadConfig_MultiFile_NumericOverriddenByEnvToken verifies that a numeric field
+// set natively in the base can be overridden by an {{ env }} interpolation token (a
+// TOML string) in an overlay — the token resolves and coerces to the numeric field.
+// This is the reason the loader does not use koanf StrictMerge: a strict type check
+// would reject the int-vs-string collision before interpolation runs.
+func TestLoadConfig_MultiFile_NumericOverriddenByEnvToken(t *testing.T) {
+	dir := t.TempDir()
+	base := writeTOML(t, dir, "base.toml", `
+[controller.server]
+api_port = 8080
+`)
+	overlay := writeTOML(t, dir, "overlay.toml", `
+[controller.server]
+api_port = '{{ env "APIP_TEST_API_PORT" "9090" }}'
+`)
+	t.Setenv("APIP_TEST_API_PORT", "9091")
+
+	cfg, err := LoadConfig(base, overlay)
+	require.NoError(t, err)
+	assert.EqualValues(t, 9091, cfg.Controller.Server.APIPort,
+		"an {{ env }} token in an overlay must override a native numeric base value")
+}
+
+// TestLoadConfig_MultiFile_EnvTokenResolvingToNonNumberFails verifies that
+// interpolation does not bypass the type check: a numeric field whose {{ env }}
+// token resolves to a non-numeric value still fails loudly, at the weakly-typed
+// unmarshal after the token is expanded. (An unset/empty required token is a
+// separate fail-closed path, covered by interpolate_test.go.)
+func TestLoadConfig_MultiFile_EnvTokenResolvingToNonNumberFails(t *testing.T) {
+	dir := t.TempDir()
+	base := writeTOML(t, dir, "base.toml", `
+[controller.server]
+api_port = 8080
+`)
+	overlay := writeTOML(t, dir, "overlay.toml", `
+[controller.server]
+api_port = '{{ env "APIP_TEST_API_PORT" }}'
+`)
+	t.Setenv("APIP_TEST_API_PORT", "bar")
+
+	_, err := LoadConfig(base, overlay)
+	require.Error(t, err, "an env token resolving to a non-number must still fail (at unmarshal)")
 }
 
 // TestLoadConfig_MultiFile_InterpolationAfterMerge verifies that {{ env }}

--- a/gateway/gateway-runtime/policy-engine/cmd/policy-engine/main.go
+++ b/gateway/gateway-runtime/policy-engine/cmd/policy-engine/main.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"strings"
 	"syscall"
 	"time"
 
@@ -55,11 +56,27 @@ var (
 	BuildDate = "unknown"
 )
 
+// stringSliceFlag collects a repeatable string flag into a slice, preserving the
+// order in which the flags were supplied on the command line.
+type stringSliceFlag []string
+
+func (s *stringSliceFlag) String() string { return strings.Join(*s, ", ") }
+
+func (s *stringSliceFlag) Set(value string) error {
+	*s = append(*s, value)
+	return nil
+}
+
 var (
-	configFile       = flag.String("config", "", "Path to configuration file (required)")
+	configFiles      stringSliceFlag
 	policyChainsFile = flag.String("policy-chains-file", "", "Path to policy chains file (enables file mode)")
 	xdsServerAddr    = flag.String("xds-server", "", "xDS server address (e.g., localhost:18000)")
 )
+
+func init() {
+	flag.Var(&configFiles, "config",
+		"Path to a configuration file (required; repeatable, merged in order with last-wins precedence)")
+}
 
 type noOpXDSSyncStatusProvider struct{}
 
@@ -76,17 +93,17 @@ func (alwaysHealthyProvider) IsHealthy() bool {
 func main() {
 	flag.Parse()
 
-	// Validate that config file is provided
-	if *configFile == "" {
+	// Validate that at least one config file is provided
+	if len(configFiles) == 0 {
 		fmt.Fprintf(os.Stderr, "Error: -config flag is required\n")
-		fmt.Fprintf(os.Stderr, "Usage: %s -config <path-to-config.toml>\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Usage: %s -config <path-to-config.toml> [-config <overlay.toml> ...]\n", os.Args[0])
 		os.Exit(1)
 	}
 
-	// Load configuration from file
-	cfg, err := config.Load(*configFile)
+	// Load configuration from the file(s), merged in order with last-wins precedence
+	cfg, err := config.Load(configFiles...)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to load configuration from %s: %v\n", *configFile, err)
+		fmt.Fprintf(os.Stderr, "Failed to load configuration from %s: %v\n", strings.Join(configFiles, ", "), err)
 		os.Exit(1)
 	}
 
@@ -113,7 +130,7 @@ func main() {
 			"version", Version,
 			"git_commit", GitCommit,
 			"build_date", BuildDate,
-			"config_file", *configFile,
+			"config_files", []string(configFiles),
 			"config_mode", cfg.PolicyEngine.ConfigMode.Mode,
 			"server_mode", serverMode,
 			"extproc_socket", constants.DefaultPolicyEngineSocketPath)
@@ -122,7 +139,7 @@ func main() {
 			"version", Version,
 			"git_commit", GitCommit,
 			"build_date", BuildDate,
-			"config_file", *configFile,
+			"config_files", []string(configFiles),
 			"config_mode", cfg.PolicyEngine.ConfigMode.Mode,
 			"server_mode", serverMode,
 			"extproc_port", cfg.PolicyEngine.Server.ExtProcPort)

--- a/gateway/gateway-runtime/policy-engine/internal/config/config.go
+++ b/gateway/gateway-runtime/policy-engine/internal/config/config.go
@@ -336,21 +336,39 @@ type AccessLogsServiceConfig struct {
 	ExtProcMaxHeaderLimit int           `koanf:"max_header_limit"`
 }
 
-// Load loads configuration from a file layered over built-in defaults.
-// Priority: Config file > Defaults.
+// Load loads configuration from one or more files layered over built-in defaults.
+// Priority: Config files > Defaults.
+//
+// Files are merged in the order given with last-wins precedence: a key set in a
+// later file overrides the same key from an earlier file. Merge semantics follow
+// koanf — nested tables (maps) deep-merge, while list/array values are replaced
+// wholesale, not appended. StrictMerge is enabled, so a type-mismatched override
+// of the same key across files fails loudly rather than being silently coerced.
+//
+// At least one config file path is required; each must exist and parse. The loader
+// fails closed rather than silently running on built-in defaults when no file is
+// supplied. {{ env }} / {{ file }} interpolation runs once, after all files are
+// merged, so a token declared in an earlier file can be resolved by a later overlay.
 //
 // The configuration supports Go-style duration strings (e.g., "10s", "5m", "1h")
 // for all duration fields. The DecodeHook automatically converts string durations
 // to time.Duration values before assignment.
-func Load(configPath string) (*Config, error) {
+func Load(configPaths ...string) (*Config, error) {
 	cfg := defaultConfig()
 
-	k := koanf.New(".")
+	if len(configPaths) == 0 {
+		return nil, fmt.Errorf("at least one config file path is required")
+	}
 
-	// Load config file if path is provided
-	if configPath != "" {
+	// StrictMerge: when two files set the same key with different value types, fail
+	// loudly instead of silently coercing the later value into the earlier's type.
+	k := koanf.NewWithConf(koanf.Conf{Delim: ".", StrictMerge: true})
+
+	// Load each config file in order. Successive loads deep-merge maps and replace
+	// arrays, giving last-wins precedence for keys set in more than one file.
+	for _, configPath := range configPaths {
 		if err := k.Load(file.Provider(configPath), toml.Parser()); err != nil {
-			return nil, fmt.Errorf("failed to load config file: %w", err)
+			return nil, fmt.Errorf("failed to load config file %q: %w", configPath, err)
 		}
 	}
 

--- a/gateway/gateway-runtime/policy-engine/internal/config/config.go
+++ b/gateway/gateway-runtime/policy-engine/internal/config/config.go
@@ -342,8 +342,10 @@ type AccessLogsServiceConfig struct {
 // Files are merged in the order given with last-wins precedence: a key set in a
 // later file overrides the same key from an earlier file. Merge semantics follow
 // koanf — nested tables (maps) deep-merge, while list/array values are replaced
-// wholesale, not appended. StrictMerge is enabled, so a type-mismatched override
-// of the same key across files fails loudly rather than being silently coerced.
+// wholesale, not appended. A field may be overridden across files with a different
+// representation — e.g. a numeric value in the base and an {{ env }} token (a string)
+// in an overlay — and still resolve, because types are only checked after
+// interpolation by the weakly-typed unmarshal (a non-coercible value still fails there).
 //
 // At least one config file path is required; each must exist and parse. The loader
 // fails closed rather than silently running on built-in defaults when no file is
@@ -360,9 +362,13 @@ func Load(configPaths ...string) (*Config, error) {
 		return nil, fmt.Errorf("at least one config file path is required")
 	}
 
-	// StrictMerge: when two files set the same key with different value types, fail
-	// loudly instead of silently coercing the later value into the earlier's type.
-	k := koanf.NewWithConf(koanf.Conf{Delim: ".", StrictMerge: true})
+	// Deliberately NOT koanf StrictMerge: strict merging compares the raw parsed
+	// types across files, but an {{ env }} / {{ file }} interpolation token is a
+	// string until it is resolved after the merge — so strict merging would reject a
+	// numeric/bool field that one file sets natively and another overrides with a
+	// token. Cross-file type errors are instead caught downstream by the weakly-typed
+	// unmarshal and Validate.
+	k := koanf.New(".")
 
 	// Load each config file in order. Successive loads deep-merge maps and replace
 	// arrays, giving last-wins precedence for keys set in more than one file.

--- a/gateway/gateway-runtime/policy-engine/internal/config/config_multifile_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/config/config_multifile_test.go
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeMultiTOML writes contents to a uniquely-named .toml file under dir and
+// returns its path.
+func writeMultiTOML(t *testing.T, dir, name, contents string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o644))
+	return path
+}
+
+// TestLoad_MultiFile_DeepMergeLastWins verifies that when the same nested table is
+// set across two files, keys deep-merge and a key present in both files takes the
+// later file's value (last-wins), while a key only in the base survives.
+func TestLoad_MultiFile_DeepMergeLastWins(t *testing.T) {
+	dir := t.TempDir()
+	base := writeMultiTOML(t, dir, "base.toml", `
+[policy_engine.server]
+extproc_port = 9111
+
+[policy_engine.logging]
+level = "info"
+format = "json"
+`)
+	overlay := writeMultiTOML(t, dir, "overlay.toml", `
+[policy_engine.logging]
+level = "debug"
+`)
+
+	cfg, err := Load(base, overlay)
+	require.NoError(t, err)
+
+	// Overridden in the overlay.
+	assert.Equal(t, "debug", cfg.PolicyEngine.Logging.Level, "later file must win for a shared key")
+	// Only set in the base — must survive the merge.
+	assert.Equal(t, 9111, cfg.PolicyEngine.Server.ExtProcPort, "base-only key must survive")
+	// Set in the base, not touched by the overlay — deep-merge must keep it.
+	assert.Equal(t, "json", cfg.PolicyEngine.Logging.Format, "sibling key in a merged table must survive")
+}
+
+// TestLoad_MultiFile_ArrayReplaceNotAppend verifies koanf semantics for list
+// values: a later file replaces the base list wholesale rather than appending.
+func TestLoad_MultiFile_ArrayReplaceNotAppend(t *testing.T) {
+	dir := t.TempDir()
+	base := writeMultiTOML(t, dir, "base.toml", `
+[traffic_logging]
+masked_headers = ["authorization", "cookie", "x-api-key"]
+`)
+	overlay := writeMultiTOML(t, dir, "overlay.toml", `
+[traffic_logging]
+masked_headers = ["authorization"]
+`)
+
+	cfg, err := Load(base, overlay)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"authorization"}, cfg.TrafficLogging.MaskedHeaders,
+		"array value must be replaced by the later file, not appended")
+}
+
+// TestLoad_MultiFile_StrictMergeTypeMismatchFails verifies that StrictMerge makes a
+// type-mismatched override of the same key across files fail loudly.
+func TestLoad_MultiFile_StrictMergeTypeMismatchFails(t *testing.T) {
+	dir := t.TempDir()
+	base := writeMultiTOML(t, dir, "base.toml", `
+[policy_engine.server]
+extproc_port = 9001
+`)
+	overlay := writeMultiTOML(t, dir, "overlay.toml", `
+[policy_engine.server]
+extproc_port = "not-a-number"
+`)
+
+	_, err := Load(base, overlay)
+	require.Error(t, err, "a type-mismatched override across files must fail loudly under StrictMerge")
+}
+
+// TestLoad_MultiFile_InterpolationAfterMerge verifies that {{ env }} interpolation
+// runs once, after all files are merged: a token declared in the base is resolved
+// even when a later overlay overrides an unrelated key.
+func TestLoad_MultiFile_InterpolationAfterMerge(t *testing.T) {
+	dir := t.TempDir()
+	base := writeMultiTOML(t, dir, "base.toml", `
+[policy_engine.logging]
+level = '{{ env "APIP_TEST_PE_LOG_LEVEL" "info" }}'
+`)
+	overlay := writeMultiTOML(t, dir, "overlay.toml", `
+[policy_engine.logging]
+format = "text"
+`)
+
+	t.Setenv("APIP_TEST_PE_LOG_LEVEL", "warn")
+
+	cfg, err := Load(base, overlay)
+	require.NoError(t, err)
+
+	assert.Equal(t, "warn", cfg.PolicyEngine.Logging.Level, "token in base must resolve after merge")
+	assert.Equal(t, "text", cfg.PolicyEngine.Logging.Format, "overlay override must apply alongside interpolation")
+}
+
+// TestLoad_MultiFile_OrderMatters verifies precedence follows argument order:
+// swapping the two files flips which value wins.
+func TestLoad_MultiFile_OrderMatters(t *testing.T) {
+	dir := t.TempDir()
+	a := writeMultiTOML(t, dir, "a.toml", `
+[policy_engine.logging]
+level = "debug"
+`)
+	b := writeMultiTOML(t, dir, "b.toml", `
+[policy_engine.logging]
+level = "error"
+`)
+
+	cfgAB, err := Load(a, b)
+	require.NoError(t, err)
+	assert.Equal(t, "error", cfgAB.PolicyEngine.Logging.Level, "last file (b) must win")
+
+	cfgBA, err := Load(b, a)
+	require.NoError(t, err)
+	assert.Equal(t, "debug", cfgBA.PolicyEngine.Logging.Level, "last file (a) must win when order is swapped")
+}

--- a/gateway/gateway-runtime/policy-engine/internal/config/config_multifile_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/config/config_multifile_test.go
@@ -85,9 +85,11 @@ masked_headers = ["authorization"]
 		"array value must be replaced by the later file, not appended")
 }
 
-// TestLoad_MultiFile_StrictMergeTypeMismatchFails verifies that StrictMerge makes a
-// type-mismatched override of the same key across files fail loudly.
-func TestLoad_MultiFile_StrictMergeTypeMismatchFails(t *testing.T) {
+// TestLoad_MultiFile_TypeMismatchFails verifies that a genuinely invalid cross-file
+// override — a non-numeric string for a numeric field — still fails. The loader does
+// not use koanf StrictMerge (see Load), so this is caught by the weakly-typed
+// unmarshal after the merge rather than at merge time.
+func TestLoad_MultiFile_TypeMismatchFails(t *testing.T) {
 	dir := t.TempDir()
 	base := writeMultiTOML(t, dir, "base.toml", `
 [policy_engine.server]
@@ -99,7 +101,51 @@ extproc_port = "not-a-number"
 `)
 
 	_, err := Load(base, overlay)
-	require.Error(t, err, "a type-mismatched override across files must fail loudly under StrictMerge")
+	require.Error(t, err, "a non-coercible cross-file override must still fail (at unmarshal)")
+}
+
+// TestLoad_MultiFile_NumericOverriddenByEnvToken verifies that a numeric field set
+// natively in the base can be overridden by an {{ env }} interpolation token (a TOML
+// string) in an overlay — the token resolves and coerces to the numeric field. This
+// is the reason the loader does not use koanf StrictMerge: a strict type check would
+// reject the int-vs-string collision before interpolation runs.
+func TestLoad_MultiFile_NumericOverriddenByEnvToken(t *testing.T) {
+	dir := t.TempDir()
+	base := writeMultiTOML(t, dir, "base.toml", `
+[policy_engine.server]
+extproc_port = 9001
+`)
+	overlay := writeMultiTOML(t, dir, "overlay.toml", `
+[policy_engine.server]
+extproc_port = '{{ env "APIP_TEST_PE_EXTPROC_PORT" "9001" }}'
+`)
+	t.Setenv("APIP_TEST_PE_EXTPROC_PORT", "9091")
+
+	cfg, err := Load(base, overlay)
+	require.NoError(t, err)
+	assert.Equal(t, 9091, cfg.PolicyEngine.Server.ExtProcPort,
+		"an {{ env }} token in an overlay must override a native numeric base value")
+}
+
+// TestLoad_MultiFile_EnvTokenResolvingToNonNumberFails verifies that interpolation
+// does not bypass the type check: a numeric field whose {{ env }} token resolves to
+// a non-numeric value still fails loudly, at the weakly-typed unmarshal after the
+// token is expanded. (An unset/empty required token is a separate fail-closed path,
+// covered by interpolate_test.go.)
+func TestLoad_MultiFile_EnvTokenResolvingToNonNumberFails(t *testing.T) {
+	dir := t.TempDir()
+	base := writeMultiTOML(t, dir, "base.toml", `
+[policy_engine.server]
+extproc_port = 9001
+`)
+	overlay := writeMultiTOML(t, dir, "overlay.toml", `
+[policy_engine.server]
+extproc_port = '{{ env "APIP_TEST_PE_EXTPROC_PORT" }}'
+`)
+	t.Setenv("APIP_TEST_PE_EXTPROC_PORT", "bar")
+
+	_, err := Load(base, overlay)
+	require.Error(t, err, "an env token resolving to a non-number must still fail (at unmarshal)")
 }
 
 // TestLoad_MultiFile_InterpolationAfterMerge verifies that {{ env }} interpolation

--- a/gateway/gateway-runtime/policy-engine/internal/config/config_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/config/config_test.go
@@ -1478,15 +1478,20 @@ level = "info"
 	assert.Equal(t, "info", cfg.PolicyEngine.Logging.Level, "APIP_GW_ env must not override a token-free key")
 }
 
-// TestLoad_EmptyPath tests loading with empty path (defaults only)
+// TestLoad_NoFiles verifies the fail-closed contract: with no config file path,
+// Load must error rather than silently run on built-in defaults.
+func TestLoad_NoFiles(t *testing.T) {
+	cfg, err := Load()
+	require.Error(t, err, "Load must require at least one config file path")
+	assert.Nil(t, cfg)
+}
+
+// TestLoad_EmptyPath verifies that an empty-string path is treated as an invalid
+// file (fail closed), not as a request to run on defaults.
 func TestLoad_EmptyPath(t *testing.T) {
 	cfg, err := Load("")
-	require.NoError(t, err)
-	assert.NotNil(t, cfg)
-	// Should have default values
-	assert.Equal(t, 9001, cfg.PolicyEngine.Server.ExtProcPort)
-	assert.Equal(t, 9002, cfg.PolicyEngine.Admin.Port)
-	assert.Equal(t, "xds", cfg.PolicyEngine.ConfigMode.Mode)
+	assert.Error(t, err)
+	assert.Nil(t, cfg)
 }
 
 // TestLoad_NonExistentFile tests loading a non-existent file

--- a/platform-api/cmd/main.go
+++ b/platform-api/cmd/main.go
@@ -19,20 +19,44 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
+	"strings"
+
 	"github.com/wso2/api-platform/platform-api/config"
 	"github.com/wso2/api-platform/platform-api/internal/builtins"
 	"github.com/wso2/api-platform/platform-api/internal/logger"
 	"github.com/wso2/api-platform/platform-api/internal/server"
 )
 
+// stringSliceFlag collects a repeatable string flag into a slice, preserving the
+// order in which the flags were supplied on the command line.
+type stringSliceFlag []string
+
+func (s *stringSliceFlag) String() string { return strings.Join(*s, ", ") }
+
+func (s *stringSliceFlag) Set(value string) error {
+	*s = append(*s, value)
+	return nil
+}
+
 func main() {
-	configFile := flag.String("config", "", "path to config.toml file (optional; env vars take priority over the file)")
+	// -config is repeatable: files are merged in the order given with last-wins
+	// precedence. Env values reach config only through explicit {{ env }}
+	// interpolation tokens in the file(s) — there is no independent env provider —
+	// so at least one config file is required and there is no default path.
+	var configFiles stringSliceFlag
+	flag.Var(&configFiles, "config",
+		"Path to a configuration file (required; repeatable, merged in order with last-wins precedence)")
 	flag.Parse()
 
-	if *configFile != "" {
-		config.SetConfigPath(*configFile)
+	if len(configFiles) == 0 {
+		fmt.Fprintf(os.Stderr, "Error: -config flag is required\n")
+		fmt.Fprintf(os.Stderr, "Usage: %s -config <path-to-config.toml> [-config <overlay.toml> ...]\n", os.Args[0])
+		os.Exit(1)
 	}
+
+	config.SetConfigPaths(configFiles...)
 
 	cfg := config.GetConfig()
 

--- a/platform-api/config/config.go
+++ b/platform-api/config/config.go
@@ -373,22 +373,30 @@ type Security struct {
 
 // package-level singleton.
 var (
-	configFilePath  string
+	configFilePaths []string
 	processOnce     sync.Once
 	settingInstance *Server
 )
 
-// SetConfigPath configures the path to a config.toml file.
-// Must be called before the first GetConfig() if a config file is used.
+// SetConfigPath configures a single config.toml path. Retained for backward
+// compatibility; SetConfigPaths is the repeatable form. Must be called before the
+// first GetConfig() if a config file is used.
 func SetConfigPath(path string) {
-	configFilePath = path
+	configFilePaths = []string{path}
+}
+
+// SetConfigPaths configures one or more config.toml paths, merged in order with
+// last-wins precedence. Must be called before the first GetConfig() if config
+// files are used.
+func SetConfigPaths(paths ...string) {
+	configFilePaths = paths
 }
 
 // GetConfig returns the singleton config instance, loading it on first call.
 func GetConfig() *Server {
 	var err error
 	processOnce.Do(func() {
-		settingInstance, err = LoadConfig(configFilePath)
+		settingInstance, err = LoadConfig(configFilePaths...)
 	})
 	if err != nil {
 		panic(err)
@@ -410,13 +418,32 @@ var defaultFileSourceAllowlist = []string{
 // sections in a shared deployment config.
 const platformAPIConfigKey = "platform_api"
 
-// LoadConfig loads configuration with priority: config file > defaults.
-// configPath may be empty — when omitted only env vars and defaults are used.
-func LoadConfig(configPath string) (*Server, error) {
+// LoadConfig loads configuration with priority: config files > defaults.
+//
+// configPaths is repeatable: files are merged in the order given with last-wins
+// precedence (a key set in a later file overrides the same key from an earlier
+// file). Merge semantics follow koanf — nested tables (maps) deep-merge, while
+// list/array values are replaced wholesale, not appended. StrictMerge is enabled,
+// so a type-mismatched override of the same key across files fails loudly rather
+// than being silently coerced.
+//
+// Zero paths is permitted (the embeddable library API and callers supplying an
+// already-built config via the platform façade rely on this) — with no files,
+// only the {{ env }}-resolved defaults apply. The `platform-api` binary itself
+// requires at least one -config file (enforced in cmd/main.go), so it never
+// silently boots on defaults. Any path that is given must exist and parse.
+func LoadConfig(configPaths ...string) (*Server, error) {
 	cfg := defaultConfig()
-	k := koanf.New(".")
+	// StrictMerge: when two files set the same key with different value types, fail
+	// loudly instead of silently coercing the later value into the earlier's type.
+	k := koanf.NewWithConf(koanf.Conf{Delim: ".", StrictMerge: true})
 
-	if configPath != "" {
+	// Load each config file in order. Successive loads deep-merge maps and replace
+	// arrays, giving last-wins precedence for keys set in more than one file.
+	for _, configPath := range configPaths {
+		if configPath == "" {
+			continue
+		}
 		if err := k.Load(file.Provider(configPath), toml.Parser()); err != nil {
 			return nil, fmt.Errorf("failed to load config file %q: %w", configPath, err)
 		}

--- a/platform-api/config/config.go
+++ b/platform-api/config/config.go
@@ -423,9 +423,10 @@ const platformAPIConfigKey = "platform_api"
 // configPaths is repeatable: files are merged in the order given with last-wins
 // precedence (a key set in a later file overrides the same key from an earlier
 // file). Merge semantics follow koanf — nested tables (maps) deep-merge, while
-// list/array values are replaced wholesale, not appended. StrictMerge is enabled,
-// so a type-mismatched override of the same key across files fails loudly rather
-// than being silently coerced.
+// list/array values are replaced wholesale, not appended. A field may be overridden
+// across files with a different representation — e.g. a numeric value in the base and
+// an {{ env }} token (a string) in an overlay — and still resolve, because types are
+// only checked after interpolation by the weakly-typed unmarshal.
 //
 // Zero paths is permitted (the embeddable library API and callers supplying an
 // already-built config via the platform façade rely on this) — with no files,
@@ -434,9 +435,13 @@ const platformAPIConfigKey = "platform_api"
 // silently boots on defaults. Any path that is given must exist and parse.
 func LoadConfig(configPaths ...string) (*Server, error) {
 	cfg := defaultConfig()
-	// StrictMerge: when two files set the same key with different value types, fail
-	// loudly instead of silently coercing the later value into the earlier's type.
-	k := koanf.NewWithConf(koanf.Conf{Delim: ".", StrictMerge: true})
+	// Deliberately NOT koanf StrictMerge: strict merging compares the raw parsed
+	// types across files, but an {{ env }} / {{ file }} interpolation token is a
+	// string until it is resolved after the merge — so strict merging would reject a
+	// numeric/bool field that one file sets natively and another overrides with a
+	// token. Cross-file type errors are instead caught downstream by the weakly-typed
+	// unmarshal and Validate.
+	k := koanf.New(".")
 
 	// Load each config file in order. Successive loads deep-merge maps and replace
 	// arrays, giving last-wins precedence for keys set in more than one file.

--- a/platform-api/config/config.go
+++ b/platform-api/config/config.go
@@ -442,7 +442,12 @@ func LoadConfig(configPaths ...string) (*Server, error) {
 	// arrays, giving last-wins precedence for keys set in more than one file.
 	for _, configPath := range configPaths {
 		if configPath == "" {
-			continue
+			// A zero-length variadic call (no files) is the legitimate "defaults
+			// only" path for embedders; an explicit empty-string path (e.g. the
+			// binary invoked with `-config=`) is a malformed input that must fail
+			// fast rather than silently degrade to defaults — matching the other
+			// loaders, which reject "" via file.Provider.
+			return nil, fmt.Errorf("config path must not be empty")
 		}
 		if err := k.Load(file.Provider(configPath), toml.Parser()); err != nil {
 			return nil, fmt.Errorf("failed to load config file %q: %w", configPath, err)

--- a/platform-api/config/config_multifile_test.go
+++ b/platform-api/config/config_multifile_test.go
@@ -1,0 +1,123 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeMultiTOML writes contents to a uniquely-named .toml file under dir and
+// returns its path.
+func writeMultiTOML(t *testing.T, dir, name, contents string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+	return path
+}
+
+// loadTwoWithKeys sets the required secret env vars, writes a base file (with the
+// valid-keys secret tokens prepended) plus an overlay, and loads both through
+// LoadConfig — the multi-file analogue of loadWithKeys.
+func loadTwoWithKeys(t *testing.T, baseExtra, overlay string) (*Server, error) {
+	t.Helper()
+	t.Setenv("APIP_CP_ENCRYPTION_KEY", validInlineKey)
+	t.Setenv("APIP_CP_AUTH_JWT_PUBLIC_KEY_FILE", validJWTPublicKeyFile)
+	dir := t.TempDir()
+	base := writeMultiTOML(t, dir, "base.toml", validKeysBase+baseExtra)
+	over := writeMultiTOML(t, dir, "overlay.toml", overlay)
+	return LoadConfig(base, over)
+}
+
+// TestLoadConfig_MultiFile_DeepMergeLastWins verifies that when the same nested
+// table is set across two files, keys deep-merge and a key present in both files
+// takes the later file's value (last-wins), while a key only in the base survives.
+func TestLoadConfig_MultiFile_DeepMergeLastWins(t *testing.T) {
+	cfg, err := loadTwoWithKeys(t,
+		"\n[platform_api.logging]\nlevel = \"info\"\nformat = \"json\"\n",
+		"\n[platform_api.logging]\nlevel = \"debug\"\n",
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "debug", cfg.Logging.Level, "later file must win for a shared key")
+	assert.Equal(t, "json", cfg.Logging.Format, "sibling key in a merged table must survive")
+}
+
+// TestLoadConfig_MultiFile_ArrayReplaceNotAppend verifies koanf semantics for list
+// values: a later file replaces the base list wholesale rather than appending.
+func TestLoadConfig_MultiFile_ArrayReplaceNotAppend(t *testing.T) {
+	cfg, err := loadTwoWithKeys(t,
+		"\n[platform_api.auth]\nskip_paths = [\"/health\", \"/metrics\", \"/ready\"]\n",
+		"\n[platform_api.auth]\nskip_paths = [\"/livez\"]\n",
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"/livez"}, cfg.Auth.SkipPaths,
+		"array value must be replaced by the later file, not appended")
+}
+
+// TestLoadConfig_MultiFile_StrictMergeTypeMismatchFails verifies that StrictMerge
+// makes a type-mismatched override of the same key across files fail loudly. The
+// merge fails before validation, so no valid-keys base is required here.
+func TestLoadConfig_MultiFile_StrictMergeTypeMismatchFails(t *testing.T) {
+	dir := t.TempDir()
+	base := writeMultiTOML(t, dir, "base.toml", "[platform_api.auth]\nscope_validation = true\n")
+	over := writeMultiTOML(t, dir, "overlay.toml", "[platform_api.auth]\nscope_validation = \"maybe\"\n")
+
+	_, err := LoadConfig(base, over)
+	require.Error(t, err, "a type-mismatched override across files must fail loudly under StrictMerge")
+}
+
+// TestLoadConfig_MultiFile_InterpolationAfterMerge verifies that {{ env }}
+// interpolation runs once, after all files are merged (and after the platform_api
+// subtree Cut): a token declared in the base resolves even when a later overlay
+// overrides an unrelated key.
+func TestLoadConfig_MultiFile_InterpolationAfterMerge(t *testing.T) {
+	t.Setenv("APIP_TEST_PAPI_LOG", "warn")
+	cfg, err := loadTwoWithKeys(t,
+		"\n[platform_api.logging]\nlevel = '{{ env \"APIP_TEST_PAPI_LOG\" \"info\" }}'\n",
+		"\n[platform_api.logging]\nformat = \"text\"\n",
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "warn", cfg.Logging.Level, "token in base must resolve after merge")
+	assert.Equal(t, "text", cfg.Logging.Format, "overlay override must apply alongside interpolation")
+}
+
+// TestLoadConfig_MultiFile_OrderMatters verifies precedence follows argument order:
+// swapping the two files flips which value wins. The secret tokens live in file a,
+// so both orderings still validate because a is present in both.
+func TestLoadConfig_MultiFile_OrderMatters(t *testing.T) {
+	t.Setenv("APIP_CP_ENCRYPTION_KEY", validInlineKey)
+	t.Setenv("APIP_CP_AUTH_JWT_PUBLIC_KEY_FILE", validJWTPublicKeyFile)
+	dir := t.TempDir()
+	a := writeMultiTOML(t, dir, "a.toml", validKeysBase+"\n[platform_api.logging]\nlevel = \"debug\"\n")
+	b := writeMultiTOML(t, dir, "b.toml", "[platform_api.logging]\nlevel = \"error\"\n")
+
+	cfgAB, err := LoadConfig(a, b)
+	require.NoError(t, err)
+	assert.Equal(t, "error", cfgAB.Logging.Level, "last file (b) must win")
+
+	cfgBA, err := LoadConfig(b, a)
+	require.NoError(t, err)
+	assert.Equal(t, "debug", cfgBA.Logging.Level, "last file (a) must win when order is swapped")
+}

--- a/platform-api/config/config_multifile_test.go
+++ b/platform-api/config/config_multifile_test.go
@@ -75,16 +75,48 @@ func TestLoadConfig_MultiFile_ArrayReplaceNotAppend(t *testing.T) {
 		"array value must be replaced by the later file, not appended")
 }
 
-// TestLoadConfig_MultiFile_StrictMergeTypeMismatchFails verifies that StrictMerge
-// makes a type-mismatched override of the same key across files fail loudly. The
-// merge fails before validation, so no valid-keys base is required here.
-func TestLoadConfig_MultiFile_StrictMergeTypeMismatchFails(t *testing.T) {
+// TestLoadConfig_MultiFile_TypeMismatchFails verifies that a genuinely invalid
+// cross-file override — a non-boolean string for a boolean field — still fails. The
+// loader does not use koanf StrictMerge (see LoadConfig), so this is caught by the
+// weakly-typed unmarshal after the merge rather than at merge time.
+func TestLoadConfig_MultiFile_TypeMismatchFails(t *testing.T) {
 	dir := t.TempDir()
 	base := writeMultiTOML(t, dir, "base.toml", "[platform_api.auth]\nscope_validation = true\n")
 	over := writeMultiTOML(t, dir, "overlay.toml", "[platform_api.auth]\nscope_validation = \"maybe\"\n")
 
 	_, err := LoadConfig(base, over)
-	require.Error(t, err, "a type-mismatched override across files must fail loudly under StrictMerge")
+	require.Error(t, err, "a non-coercible cross-file override must still fail (at unmarshal)")
+}
+
+// TestLoadConfig_MultiFile_NumericOverriddenByEnvToken verifies that a numeric field
+// set natively in the base can be overridden by an {{ env }} interpolation token (a
+// TOML string) in an overlay — the token resolves and coerces to the numeric field.
+// This is the reason the loader does not use koanf StrictMerge: a strict type check
+// would reject the int-vs-string collision before interpolation runs.
+func TestLoadConfig_MultiFile_NumericOverriddenByEnvToken(t *testing.T) {
+	t.Setenv("APIP_TEST_HTTP_PORT", "9250")
+	cfg, err := loadTwoWithKeys(t,
+		"\n[platform_api.server.http]\nport = 9243\n",
+		"\n[platform_api.server.http]\nport = '{{ env \"APIP_TEST_HTTP_PORT\" \"9243\" }}'\n",
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, 9250, cfg.Listeners.HTTP.Port,
+		"an {{ env }} token in an overlay must override a native numeric base value")
+}
+
+// TestLoadConfig_MultiFile_EnvTokenResolvingToNonNumberFails verifies that
+// interpolation does not bypass the type check: a numeric field whose {{ env }}
+// token resolves to a non-numeric value still fails loudly, at the weakly-typed
+// unmarshal after the token is expanded. (An unset/empty required token is a
+// separate fail-closed interpolation path.)
+func TestLoadConfig_MultiFile_EnvTokenResolvingToNonNumberFails(t *testing.T) {
+	t.Setenv("APIP_TEST_HTTP_PORT", "bar")
+	_, err := loadTwoWithKeys(t,
+		"\n[platform_api.server.http]\nport = 9243\n",
+		"\n[platform_api.server.http]\nport = '{{ env \"APIP_TEST_HTTP_PORT\" }}'\n",
+	)
+	require.Error(t, err, "an env token resolving to a non-number must still fail (at unmarshal)")
 }
 
 // TestLoadConfig_MultiFile_InterpolationAfterMerge verifies that {{ env }}

--- a/platform-api/config/config_multifile_test.go
+++ b/platform-api/config/config_multifile_test.go
@@ -103,6 +103,17 @@ func TestLoadConfig_MultiFile_InterpolationAfterMerge(t *testing.T) {
 	assert.Equal(t, "text", cfg.Logging.Format, "overlay override must apply alongside interpolation")
 }
 
+// TestLoadConfig_EmptyPathFails verifies that an explicit empty-string path (e.g.
+// the binary invoked with `-config=`) is rejected at the path check with a clear
+// error, rather than being skipped and surfacing a confusing downstream validation
+// error (or, if defaults were ever valid, silently booting on them).
+func TestLoadConfig_EmptyPathFails(t *testing.T) {
+	_, err := LoadConfig("")
+	require.Error(t, err, `LoadConfig("") must reject an empty config path, not skip it`)
+	assert.Contains(t, err.Error(), "config path must not be empty",
+		"the failure must be the explicit empty-path check, not an unrelated downstream error")
+}
+
 // TestLoadConfig_MultiFile_OrderMatters verifies precedence follows argument order:
 // swapping the two files flips which value wins. The secret tokens live in file a,
 // so both orderings still validate because a is present in both.

--- a/platform-api/platform/options.go
+++ b/platform-api/platform/options.go
@@ -43,6 +43,18 @@ func WithConfigPath(path string) Option {
 	}
 }
 
+// WithConfigPaths loads platform-api config from one or more TOML files, merged in
+// order with last-wins precedence (a key set in a later file overrides the same
+// key from an earlier file). It is the repeatable form of WithConfigPath; the
+// config is materialized in New. WithConfig takes precedence over this.
+func WithConfigPaths(paths ...string) Option {
+	return func(a *App) {
+		if len(paths) > 0 {
+			config.SetConfigPaths(paths...)
+		}
+	}
+}
+
 // WithConfig supplies an already-built config, taking precedence over
 // WithConfigPath.
 func WithConfig(cfg *config.Server) Option {

--- a/platform-api/spec/impls/platform-bootstrap.md
+++ b/platform-api/spec/impls/platform-bootstrap.md
@@ -4,7 +4,7 @@
 
 - `platform-api/cmd/main.go` – loads configuration and starts the HTTPS server.
 - `platform-api/internal/server/server.go` – wires repositories, services, and Gin router before serving TLS.
-- `platform-api/config/config.go` – parses environment variables and sets SQLite defaults.
+- `platform-api/config/config.go` – merges the layered `-config` file(s) over built-in defaults and resolves `{{ env }}` / `{{ file }}` interpolation tokens (there is no environment-variable provider; env values enter only through those tokens).
 - `platform-api/internal/database/connection.go` – opens the database connection and enforces schema initialization.
 
 ## Behaviour
@@ -15,4 +15,4 @@
 
 ## Verification
 
-- Build and run `go run ./cmd/main.go` within `platform-api`; confirm log output shows schema load and HTTPS startup.
+- Build and run `go run ./cmd/main.go -config config/config.toml` within `platform-api`; confirm log output shows schema load and HTTPS startup. The `-config` flag is now **required** and repeatable (`-config base.toml -config overlay.toml`, merged last-wins) — the binary exits non-zero if no `-config` is given rather than booting on built-in defaults.

--- a/portals/ai-workspace/Dockerfile
+++ b/portals/ai-workspace/Dockerfile
@@ -65,7 +65,8 @@ USER $USER_UID
 # match what this image needs (static dir /app, listener :9643, self-signed TLS,
 # in-memory sessions, Secure/Lax cookies). Configure a deployment by mounting a
 # config.toml at /etc/ai-workspace/config.toml; its '{{ env "APIP_AIW_..." }}' tokens
-# are what pull values in from the environment.
+# are what pull values in from the environment. The -config flag is required (there is
+# no default path), so the ENTRYPOINT passes the mounted path explicitly.
 
 EXPOSE 9643 9680
 
@@ -75,4 +76,4 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD curl -fk https://localhost:9643/healthz || curl -f http://localhost:9643/healthz || exit 1
 
 STOPSIGNAL SIGTERM
-ENTRYPOINT ["/usr/local/bin/bff"]
+ENTRYPOINT ["/usr/local/bin/bff", "-config", "/etc/ai-workspace/config.toml"]

--- a/portals/ai-workspace/bff/internal/config/config.go
+++ b/portals/ai-workspace/bff/internal/config/config.go
@@ -239,8 +239,10 @@ const defaultOIDCScopes = "openid profile email offline_access" +
 // is required and each must exist and parse — there is no default path and no
 // silent fallback to built-in defaults (the container ENTRYPOINT and `make bff-run`
 // both pass -config explicitly). Files are merged in the order given with last-wins
-// precedence: nested tables deep-merge, arrays replace, and a type-mismatched
-// override across files fails loudly under StrictMerge. It loads defaults, overlays
+// precedence: nested tables deep-merge and arrays replace. A field may be overridden
+// across files with a different representation — e.g. a numeric value in the base and
+// an {{ env }} token (a string) in an overlay — and still resolve, because types are
+// only checked after interpolation by the weakly-typed unmarshal. It loads defaults, overlays
 // the merged file(s) (with their {{ env }} / {{ file }} tokens expanded), normalizes
 // derived fields, then validates — so any key, the OIDC client secret in particular,
 // can be pulled from an environment variable or a mounted secret file instead of

--- a/portals/ai-workspace/bff/internal/config/config.go
+++ b/portals/ai-workspace/bff/internal/config/config.go
@@ -235,21 +235,21 @@ const defaultOIDCScopes = "openid profile email offline_access" +
 	" ap:secret:read ap:secret:create ap:secret:update ap:secret:delete ap:secret:manage" +
 	" ap:git:read"
 
-// DefaultConfigFile is where the container mounts config.toml. It is the path used
-// unless -config names another one.
-const DefaultConfigFile = "/etc/ai-workspace/config.toml"
-
-// Load resolves configuration from the config.toml at path, or from the mounted
-// DefaultConfigFile when path is empty. It loads defaults, overlays the file (with its
-// {{ env }} / {{ file }} tokens expanded), normalizes derived fields, then validates —
-// so any key, the OIDC client secret in particular, can be pulled from an environment
-// variable or a mounted secret file instead of being written in the clear, and a key
-// not present in the file falls back to its default.
-func Load(path string) (*Config, error) {
-	if path == "" {
-		path = DefaultConfigFile
+// Load resolves configuration from one or more config.toml files. At least one path
+// is required and each must exist and parse — there is no default path and no
+// silent fallback to built-in defaults (the container ENTRYPOINT and `make bff-run`
+// both pass -config explicitly). Files are merged in the order given with last-wins
+// precedence: nested tables deep-merge, arrays replace, and a type-mismatched
+// override across files fails loudly under StrictMerge. It loads defaults, overlays
+// the merged file(s) (with their {{ env }} / {{ file }} tokens expanded), normalizes
+// derived fields, then validates — so any key, the OIDC client secret in particular,
+// can be pulled from an environment variable or a mounted secret file instead of
+// being written in the clear, and a key not present in any file keeps its default.
+func Load(paths ...string) (*Config, error) {
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("at least one config file path is required")
 	}
-	k, err := loadConfigKoanf(path)
+	k, err := loadConfigKoanf(paths...)
 	if err != nil {
 		return nil, err
 	}

--- a/portals/ai-workspace/bff/internal/config/config_multifile_test.go
+++ b/portals/ai-workspace/bff/internal/config/config_multifile_test.go
@@ -23,8 +23,9 @@ import "testing"
 // The AI Workspace config has no list/array-typed keys, so koanf's array-replace
 // semantics are exercised by the gateway-controller, policy-engine, and platform-api
 // suites instead. These tests cover the merge behaviour that does apply here:
-// deep-merge/last-wins on nested tables, StrictMerge type-mismatch, interpolation
-// after merge, argument-order precedence, and the fail-closed no-files contract.
+// deep-merge/last-wins on nested tables, cross-file type-mismatch (caught at
+// unmarshal), a numeric field overridden by an {{ env }} token, interpolation after
+// merge, argument-order precedence, and the fail-closed no-files contract.
 
 const cpURL = "\n[ai_workspace.control_plane]\nurl = \"https://platform-api:9243\"\n"
 
@@ -47,15 +48,50 @@ func TestLoad_MultiFile_DeepMergeLastWins(t *testing.T) {
 	}
 }
 
-// TestLoad_MultiFile_StrictMergeTypeMismatchFails verifies that StrictMerge makes a
-// type-mismatched override of the same key across files fail loudly. The merge fails
-// before validation, so no otherwise-valid config is required here.
-func TestLoad_MultiFile_StrictMergeTypeMismatchFails(t *testing.T) {
+// TestLoad_MultiFile_TypeMismatchFails verifies that a genuinely invalid cross-file
+// override — a non-numeric string for a numeric field — still fails. The loader does
+// not use koanf StrictMerge (see loadConfigKoanf), so this is caught by the
+// weakly-typed unmarshal after the merge rather than at merge time.
+func TestLoad_MultiFile_TypeMismatchFails(t *testing.T) {
 	base := writeConfig(t, "[ai_workspace.server.http]\nport = 9643\n")
 	overlay := writeConfig(t, "[ai_workspace.server.http]\nport = \"not-a-number\"\n")
 
 	if _, err := Load(base, overlay); err == nil {
-		t.Fatal("Load() succeeded, want an error for a type-mismatched override under StrictMerge")
+		t.Fatal("Load() succeeded, want an error for a non-coercible cross-file override")
+	}
+}
+
+// TestLoad_MultiFile_NumericOverriddenByEnvToken verifies that a numeric field set
+// natively in the base can be overridden by an {{ env }} interpolation token (a TOML
+// string) in an overlay — the token resolves and coerces to the numeric field. This
+// is the reason the loader does not use koanf StrictMerge: a strict type check would
+// reject the int-vs-string collision before interpolation runs.
+func TestLoad_MultiFile_NumericOverriddenByEnvToken(t *testing.T) {
+	t.Setenv("APIP_TEST_AIW_PORT", "9644")
+	base := writeConfig(t, "[ai_workspace.server.http]\nport = 9643\n"+cpURL)
+	overlay := writeConfig(t, "[ai_workspace.server.http]\nport = '{{ env \"APIP_TEST_AIW_PORT\" \"9643\" }}'\n")
+
+	cfg, err := Load(base, overlay)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Server.HTTP.Port != 9644 {
+		t.Errorf("Server.HTTP.Port = %d, want 9644 (an {{ env }} token in an overlay must override a native numeric base value)", cfg.Server.HTTP.Port)
+	}
+}
+
+// TestLoad_MultiFile_EnvTokenResolvingToNonNumberFails verifies that interpolation
+// does not bypass the type check: a numeric field whose {{ env }} token resolves to
+// a non-numeric value still fails loudly, at the weakly-typed unmarshal after the
+// token is expanded. (An unset/empty required token is a separate fail-closed path,
+// covered by config_test.go.)
+func TestLoad_MultiFile_EnvTokenResolvingToNonNumberFails(t *testing.T) {
+	t.Setenv("APIP_TEST_AIW_PORT", "bar")
+	base := writeConfig(t, "[ai_workspace.server.http]\nport = 9643\n"+cpURL)
+	overlay := writeConfig(t, "[ai_workspace.server.http]\nport = '{{ env \"APIP_TEST_AIW_PORT\" }}'\n")
+
+	if _, err := Load(base, overlay); err == nil {
+		t.Fatal("Load() succeeded, want an error for an env token resolving to a non-number")
 	}
 }
 

--- a/portals/ai-workspace/bff/internal/config/config_multifile_test.go
+++ b/portals/ai-workspace/bff/internal/config/config_multifile_test.go
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package config
+
+import "testing"
+
+// The AI Workspace config has no list/array-typed keys, so koanf's array-replace
+// semantics are exercised by the gateway-controller, policy-engine, and platform-api
+// suites instead. These tests cover the merge behaviour that does apply here:
+// deep-merge/last-wins on nested tables, StrictMerge type-mismatch, interpolation
+// after merge, argument-order precedence, and the fail-closed no-files contract.
+
+const cpURL = "\n[ai_workspace.control_plane]\nurl = \"https://platform-api:9243\"\n"
+
+// TestLoad_MultiFile_DeepMergeLastWins verifies that when the same nested table is
+// set across two files, keys deep-merge and a key present in both files takes the
+// later file's value (last-wins), while a key only in the base survives.
+func TestLoad_MultiFile_DeepMergeLastWins(t *testing.T) {
+	base := writeConfig(t, "[ai_workspace.logging]\nlevel = \"info\"\nformat = \"json\"\n"+cpURL)
+	overlay := writeConfig(t, "[ai_workspace.logging]\nlevel = \"debug\"\n")
+
+	cfg, err := Load(base, overlay)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Logging.Level != "debug" {
+		t.Errorf("Logging.Level = %q, want %q (later file must win)", cfg.Logging.Level, "debug")
+	}
+	if cfg.Logging.Format != "json" {
+		t.Errorf("Logging.Format = %q, want %q (sibling key in a merged table must survive)", cfg.Logging.Format, "json")
+	}
+}
+
+// TestLoad_MultiFile_StrictMergeTypeMismatchFails verifies that StrictMerge makes a
+// type-mismatched override of the same key across files fail loudly. The merge fails
+// before validation, so no otherwise-valid config is required here.
+func TestLoad_MultiFile_StrictMergeTypeMismatchFails(t *testing.T) {
+	base := writeConfig(t, "[ai_workspace.server.http]\nport = 9643\n")
+	overlay := writeConfig(t, "[ai_workspace.server.http]\nport = \"not-a-number\"\n")
+
+	if _, err := Load(base, overlay); err == nil {
+		t.Fatal("Load() succeeded, want an error for a type-mismatched override under StrictMerge")
+	}
+}
+
+// TestLoad_MultiFile_InterpolationAfterMerge verifies that {{ env }} interpolation
+// runs once, after all files are merged (and after the ai_workspace subtree Cut): a
+// token declared in the base resolves even when a later overlay overrides an
+// unrelated key.
+func TestLoad_MultiFile_InterpolationAfterMerge(t *testing.T) {
+	t.Setenv("APIP_TEST_AIW_LOG", "warn")
+	base := writeConfig(t, "[ai_workspace.logging]\nlevel = '{{ env \"APIP_TEST_AIW_LOG\" \"info\" }}'\n"+cpURL)
+	overlay := writeConfig(t, "[ai_workspace.logging]\nformat = \"text\"\n")
+
+	cfg, err := Load(base, overlay)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Logging.Level != "warn" {
+		t.Errorf("Logging.Level = %q, want %q (token in base must resolve after merge)", cfg.Logging.Level, "warn")
+	}
+	if cfg.Logging.Format != "text" {
+		t.Errorf("Logging.Format = %q, want %q (overlay override must apply alongside interpolation)", cfg.Logging.Format, "text")
+	}
+}
+
+// TestLoad_MultiFile_OrderMatters verifies precedence follows argument order:
+// swapping the two files flips which value wins. The required control_plane.url lives
+// in file a, so both orderings validate because a is present in both.
+func TestLoad_MultiFile_OrderMatters(t *testing.T) {
+	a := writeConfig(t, "[ai_workspace.logging]\nlevel = \"debug\"\n"+cpURL)
+	b := writeConfig(t, "[ai_workspace.logging]\nlevel = \"error\"\n")
+
+	cfgAB, err := Load(a, b)
+	if err != nil {
+		t.Fatalf("Load(a, b) error = %v", err)
+	}
+	if cfgAB.Logging.Level != "error" {
+		t.Errorf("Logging.Level = %q, want %q (last file b must win)", cfgAB.Logging.Level, "error")
+	}
+
+	cfgBA, err := Load(b, a)
+	if err != nil {
+		t.Fatalf("Load(b, a) error = %v", err)
+	}
+	if cfgBA.Logging.Level != "debug" {
+		t.Errorf("Logging.Level = %q, want %q (last file a must win when order is swapped)", cfgBA.Logging.Level, "debug")
+	}
+}
+
+// TestLoad_NoFiles verifies the fail-closed contract: with no config file path, Load
+// must error rather than silently run on built-in defaults.
+func TestLoad_NoFiles(t *testing.T) {
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() succeeded, want an error when no config file path is given")
+	}
+}
+
+// TestLoad_MissingFileFails verifies that an explicitly-passed missing file is a hard
+// error, not a silent no-op (there is no default fallback).
+func TestLoad_MissingFileFails(t *testing.T) {
+	if _, err := Load("/nonexistent/path/config.toml"); err == nil {
+		t.Fatal("Load() succeeded, want an error for a missing config file")
+	}
+}

--- a/portals/ai-workspace/bff/internal/config/settings.go
+++ b/portals/ai-workspace/bff/internal/config/settings.go
@@ -70,9 +70,13 @@ var defaultFileSourceAllowlist = []string{
 // A missing config.toml is not an error: the returned instance is empty, so every key
 // falls back to defaultConfig() and Load fails only on the required ones.
 func loadConfigKoanf(tomlPaths ...string) (*koanf.Koanf, error) {
-	// StrictMerge: when two files set the same key with different value types, fail
-	// loudly instead of silently coercing the later value into the earlier's type.
-	k := koanf.NewWithConf(koanf.Conf{Delim: ".", StrictMerge: true})
+	// Deliberately NOT koanf StrictMerge: strict merging compares the raw parsed
+	// types across files, but an {{ env }} / {{ file }} interpolation token is a
+	// string until it is resolved after the merge — so strict merging would reject a
+	// numeric/bool field that one file sets natively and another overrides with a
+	// token. Cross-file type errors are instead caught downstream by the weakly-typed
+	// unmarshal and validation.
+	k := koanf.New(".")
 
 	// Load each config file in order. Successive loads deep-merge maps and replace
 	// arrays, giving last-wins precedence for keys set in more than one file. Each

--- a/portals/ai-workspace/bff/internal/config/settings.go
+++ b/portals/ai-workspace/bff/internal/config/settings.go
@@ -19,7 +19,6 @@ package config
 import (
 	"fmt"
 	"log/slog"
-	"os"
 
 	tomlparser "github.com/knadh/koanf/parsers/toml/v2"
 	"github.com/knadh/koanf/providers/confmap"
@@ -70,17 +69,19 @@ var defaultFileSourceAllowlist = []string{
 //
 // A missing config.toml is not an error: the returned instance is empty, so every key
 // falls back to defaultConfig() and Load fails only on the required ones.
-func loadConfigKoanf(tomlPath string) (*koanf.Koanf, error) {
-	k := koanf.New(".")
+func loadConfigKoanf(tomlPaths ...string) (*koanf.Koanf, error) {
+	// StrictMerge: when two files set the same key with different value types, fail
+	// loudly instead of silently coercing the later value into the earlier's type.
+	k := koanf.NewWithConf(koanf.Conf{Delim: ".", StrictMerge: true})
 
-	// Stat first so a missing file stays a no-op (defaults apply) rather than a koanf
-	// load error; anything else (e.g. a permission problem) is surfaced.
-	if _, statErr := os.Stat(tomlPath); statErr == nil {
+	// Load each config file in order. Successive loads deep-merge maps and replace
+	// arrays, giving last-wins precedence for keys set in more than one file. Each
+	// path is explicitly requested (there is no default), so a missing file is a hard
+	// error rather than a silent no-op.
+	for _, tomlPath := range tomlPaths {
 		if err := k.Load(file.Provider(tomlPath), tomlparser.Parser()); err != nil {
 			return nil, fmt.Errorf("failed to parse config file %q: %w", tomlPath, err)
 		}
-	} else if !os.IsNotExist(statErr) {
-		return nil, fmt.Errorf("failed to read config file %q: %w", tomlPath, statErr)
 	}
 
 	// Narrow to this component's own subtree BEFORE interpolating, so a shared

--- a/portals/ai-workspace/bff/main.go
+++ b/portals/ai-workspace/bff/main.go
@@ -92,10 +92,24 @@ func portalURL(addr, domain string, tlsEnabled bool) string {
 	return scheme + "://" + net.JoinHostPort(host, port)
 }
 
+// stringSliceFlag collects a repeatable string flag into a slice, preserving the
+// order in which the flags were supplied on the command line.
+type stringSliceFlag []string
+
+func (s *stringSliceFlag) String() string { return strings.Join(*s, ", ") }
+
+func (s *stringSliceFlag) Set(value string) error {
+	*s = append(*s, value)
+	return nil
+}
+
 func main() {
-	// The container reads its mounted config.toml, so -config is only needed to run
-	// the BFF outside one (see `make bff-run`).
-	configFile := flag.String("config", config.DefaultConfigFile, "path to config.toml")
+	// -config is repeatable and required: files are merged in the order given with
+	// last-wins precedence. There is no default path — the container and `make
+	// bff-run` both pass -config explicitly (see the image ENTRYPOINT and Makefile).
+	var configFiles stringSliceFlag
+	flag.Var(&configFiles, "config",
+		"Path to a configuration file (required; repeatable, merged in order with last-wins precedence)")
 	// The shipped config.toml has no {{ env }} token for static_dir — the container
 	// always serves the SPA baked in at /app, so there's nothing for an operator to
 	// override. `make bff-run` is the one caller that needs a different directory
@@ -104,7 +118,13 @@ func main() {
 	staticDir := flag.String("static-dir", "", "override the directory serving the built SPA (local dev only, e.g. `make bff-run`)")
 	flag.Parse()
 
-	cfg, err := config.Load(*configFile)
+	if len(configFiles) == 0 {
+		slog.SetDefault(logger.NewLogger(logger.Config{Level: "info", Format: "text"}))
+		slog.Error("configuration error", "err", "the -config flag is required (repeatable; e.g. -config base.toml -config overlay.toml)")
+		os.Exit(1)
+	}
+
+	cfg, err := config.Load(configFiles...)
 	if err != nil {
 		slog.SetDefault(logger.NewLogger(logger.Config{Level: "info", Format: "text"}))
 		slog.Error("configuration error", "err", err)

--- a/portals/ai-workspace/docker-compose.yaml
+++ b/portals/ai-workspace/docker-compose.yaml
@@ -34,7 +34,7 @@ services:
       retries: 3
 
   ai-workspace:
-    image: ghcr.io/wso2/api-platform/ai-workspace:1.0.0-rc
+    image: ghcr.io/wso2/api-platform/ai-workspace:1.0.0-rc-SNAPSHOT
     container_name: ai-workspace
     restart: unless-stopped
     depends_on:


### PR DESCRIPTION
## Purpose

Unify configuration loading across the platform's Go components behind a repeatable, required `-config` flag, so config can be layered as a complete base file plus thin environment/deployment overlays instead of a single monolithic file.

Resolves #2865. Related #2873, #2874 (follow-ups for the AI Workspace BFF and Platform API, both included here) and #2876 (Developer Portal, tracked separately).

## Goals

- Accept multiple `-config` files, merged in order with **last-wins** precedence (maps deep-merge, arrays replace) via koanf `StrictMerge`, so a type-mismatched override across files fails loudly.
- `{{ env }}` / `{{ file }}` interpolation runs once, after all files are merged, so a token in the base can be resolved by a later overlay.
- Standardize on **required, no default path, no silent-defaults fallback**: a missing `-config` (or a passed file that does not exist/parse) fails fast rather than silently booting on built-in defaults — consistent with the repo's fail-closed startup posture (GO-AUTH-011). There is no env-var provider; env reaches config only through explicit `{{ env }}` tokens, which is exactly why a missing config file must fail fast.

## Approach

- **gateway-controller** (`c6b343a8`): repeatable `flag.Var`; `LoadConfig` variadic with StrictMerge last-wins loop.
- **policy-engine** (`073cb77b`): same flag change; `Load` variadic; dropped the loader's optional-file branch so it fails closed instead of silently running on defaults.
- **platform-api** (`28d3466f`): repeatable + required flag; `LoadConfig` variadic; `configFilePath` singleton became a slice with `SetConfigPaths`; added a `WithConfigPaths` façade option. The embeddable library API/`platform` façade still permits zero files (env + defaults via `WithConfig`); only the binary requires `-config`. Corrected the misleading "env vars take priority" flag help. **Breaking** (flag was optional).
- **ai-workspace-bff** (`443c1595`): repeatable + required flag; `Load`/`loadConfigKoanf` variadic with StrictMerge; dropped the `DefaultConfigFile` fallback and the missing-file no-op; updated the image ENTRYPOINT to pass `-config` explicitly (the Helm chart inherits it). **Breaking** (had a default path).
- **docs** (`0a76a8da`): updated the platform-api bootstrap spec.
- Added multi-file test suites per component (deep-merge/last-wins, array-replace, StrictMerge type-mismatch, interpolation-after-merge, order precedence, fail-closed no-files/missing-file).

Both real deployment paths for each affected binary already pass `-config` (all-in-one compose, the platform-api and BFF Helm charts / image ENTRYPOINTs), so there is no runtime breakage.

## User stories

As an operator, I want to keep a shared base config and apply thin per-environment overlays, so I don't duplicate a full monolithic config per deployment.

## Documentation

Updated `platform-api/spec/impls/platform-bootstrap.md`. The `-config` flag help text documents the repeatable + last-wins behavior in each binary. Developer Portal docs are out of scope (tracked in #2876).

## Automation tests

- **Unit tests**: new `config_multifile_test.go` in gateway-controller, policy-engine, platform-api, and ai-workspace/bff — covering deep-merge/last-wins, array-replace, StrictMerge type-mismatch, interpolation-after-merge, order precedence, and the fail-closed no-files/missing-file paths. Existing single-path callers keep working via the variadic signatures. Full `config` suites, `go vet`, and builds pass for each module.
- **Integration tests**: N/A — no new runtime endpoints; behavior covered by unit tests and existing deployment paths.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? no (Go modules; not applicable)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

N/A

## Test environment

Go 1.26 (module toolchains), macOS (darwin). `go build`, `go vet`, and `go test ./.../config/...` for each affected module.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)