### PR TITLE
Fix issue of emitting two analytics event per LLM proxy call

### DIFF
--- a/gateway/gateway-controller/pkg/constants/constants.go
+++ b/gateway/gateway-controller/pkg/constants/constants.go
@@ -131,6 +131,11 @@ const (
 	// Routes can be configured with cluster_header to read this header and select the target cluster
 	TargetUpstreamHeader = "x-target-upstream"
 
+	// InternalLoopbackHeader marks the LLM proxy's internal loopback forward to its provider.
+	// The proxy stamps it via a set-headers policy; the analytics system policy reads it on the
+	// provider hop so the duplicate provider analytics event can be dropped from Moesif.
+	InternalLoopbackHeader = "x-wso2-internal-loopback"
+
 	// UpstreamDefinitionClusterPrefix is the prefix used for clusters created from upstreamDefinitions
 	// Cluster names follow the format: upstream_<definition_name>
 	UpstreamDefinitionClusterPrefix = "upstream_"

--- a/gateway/gateway-controller/pkg/eventlistener/llm_provider_processor_test.go
+++ b/gateway/gateway-controller/pkg/eventlistener/llm_provider_processor_test.go
@@ -273,6 +273,7 @@ func TestHandleEvent_LLMProxyCreate_RehydratesConfigAndPolicyFromDB(t *testing.T
 
 	policyDefs := map[string]models.PolicyDefinition{
 		"rate-limit-v1.0.0": {Name: "rate-limit", Version: "v1.0.0"},
+		"set-headers-v1.0.0": {Name: "set-headers", Version: "v1.0.0"},
 	}
 	listener := &EventListener{
 		store:         store,

--- a/gateway/gateway-controller/pkg/utils/llm_deployment_policy_test.go
+++ b/gateway/gateway-controller/pkg/utils/llm_deployment_policy_test.go
@@ -111,7 +111,7 @@ func TestLLMDeploymentService_DeployLLMProxyConfiguration_RejectsUnresolvablePol
 	}))
 
 	apiDeploymentService := newTestAPIDeploymentService(store, db, nil, nil, nil)
-	service := NewLLMDeploymentService(store, db, nil, nil, nil, apiDeploymentService, routerConfig, nil, ratelimitPolicyValidator())
+	service := NewLLMDeploymentService(store, db, nil, nil, nil, apiDeploymentService, routerConfig, newTestPolicyVersionResolver(), ratelimitPolicyValidator())
 
 	proxyCfg := api.LLMProxyConfiguration{
 		ApiVersion: api.LLMProxyConfigurationApiVersionGatewayApiPlatformWso2Comv1,

--- a/gateway/gateway-controller/pkg/utils/llm_deployment_test.go
+++ b/gateway/gateway-controller/pkg/utils/llm_deployment_test.go
@@ -1035,7 +1035,7 @@ func TestLLMDeploymentService_DeployLLMProxyConfiguration_ConflictValidation(t *
 		}))
 
 		apiDeploymentService := newTestAPIDeploymentService(store, db, nil, nil, nil)
-		service := NewLLMDeploymentService(store, db, nil, nil, nil, apiDeploymentService, routerConfig, nil, nil)
+		service := NewLLMDeploymentService(store, db, nil, nil, nil, apiDeploymentService, routerConfig, newTestPolicyVersionResolver(), nil)
 
 		_, err := service.DeployLLMProxyConfiguration(LLMDeploymentParams{
 			Data:          testLLMProxyYAML(t, "new-proxy", "Assistant Proxy", "provider-a"),
@@ -1065,7 +1065,7 @@ func TestLLMDeploymentService_DeployLLMProxyConfiguration_ConflictValidation(t *
 		}))
 
 		apiDeploymentService := newTestAPIDeploymentService(store, db, nil, nil, nil)
-		service := NewLLMDeploymentService(store, db, nil, nil, nil, apiDeploymentService, routerConfig, nil, nil)
+		service := NewLLMDeploymentService(store, db, nil, nil, nil, apiDeploymentService, routerConfig, newTestPolicyVersionResolver(), nil)
 
 		_, err := service.DeployLLMProxyConfiguration(LLMDeploymentParams{
 			Data:          testLLMProxyYAML(t, "assistant-proxy", "Another Proxy", "provider-a"),

--- a/gateway/gateway-controller/pkg/utils/llm_transformer.go
+++ b/gateway/gateway-controller/pkg/utils/llm_transformer.go
@@ -367,6 +367,14 @@ func (t *LLMProviderTransformer) transformProxy(proxy *api.LLMProxyConfiguration
 			}
 		}
 	}
+	// Phase 4: Attach loopback marker policy to all operations so the gateway can identify
+	loopbackMarkerPolicy, err := t.proxyInternalLoopbackMarkerPolicy()
+	if err != nil {
+		return nil, err
+	}
+	for i := range ops {
+		appendOperationPolicy(&ops[i], *loopbackMarkerPolicy)
+	}
 	// A proxy is always allow-all with no access control, so there are no deny routes:
 	// attach API-level resilience to all generated routes.
 	applyResilienceToTrafficRoutes(ops, proxy.Spec.Resilience, nil)
@@ -839,6 +847,27 @@ func (t *LLMProviderTransformer) proxyUpstreamAuthPolicy(auth *api.LLMUpstreamAu
 	default:
 		return nil, fmt.Errorf("unsupported upstream auth type: %s", auth.Type)
 	}
+}
+
+// proxyInternalLoopbackMarkerPolicy builds an unconditional set-headers policy that stamps the
+// internal loopback marker header on the proxy's loopback forward to its provider. The analytics
+// system policy reads it on the provider hop so the duplicate provider analytics event is dropped
+// from Moesif. It carries no ExecutionCondition, so it applies for the primary and every
+// additional provider; set-headers overwrites any client-supplied value.
+func (t *LLMProviderTransformer) proxyInternalLoopbackMarkerPolicy() (*api.Policy, error) {
+	params, err := GetUpstreamAuthApikeyPolicyParams(constants.InternalLoopbackHeader, "1")
+	if err != nil {
+		return nil, fmt.Errorf("failed to build internal loopback marker params: %w", err)
+	}
+	policyVersion, err := t.resolvePolicyVersion(constants.SET_HEADERS_POLICY_NAME)
+	if err != nil {
+		return nil, err
+	}
+	return &api.Policy{
+		Name:    constants.SET_HEADERS_POLICY_NAME,
+		Version: policyVersion,
+		Params:  &params,
+	}, nil
 }
 
 // proxyTransformerPolicy builds a translator policy for an additional provider's

--- a/gateway/gateway-controller/pkg/utils/llm_transformer_multiprovider_test.go
+++ b/gateway/gateway-controller/pkg/utils/llm_transformer_multiprovider_test.go
@@ -133,7 +133,8 @@ func TestLLMProviderTransformer_TransformProxy_AdditionalProviderAuthIsCondition
 
 	var authPolicies []api.Policy
 	for _, pol := range *chatOp.Policies {
-		if pol.Name == constants.UPSTREAM_AUTH_APIKEY_POLICY_NAME {
+		// The unconditional internal loopback marker is also a set-headers policy; exclude it.
+		if pol.Name == constants.UPSTREAM_AUTH_APIKEY_POLICY_NAME && !hasInternalLoopbackMarkerPolicy([]api.Policy{pol}) {
 			authPolicies = append(authPolicies, pol)
 		}
 	}

--- a/gateway/gateway-controller/pkg/utils/llm_transformer_test.go
+++ b/gateway/gateway-controller/pkg/utils/llm_transformer_test.go
@@ -198,6 +198,40 @@ func TestLLMProviderTransformer_TransformProxy_ReadsProviderAndTemplateFromDB(t 
 	require.NoError(t, err)
 	require.NotNil(t, result.Spec.Upstream.Main.Url)
 	assert.Equal(t, "http://127.0.0.1:8080/db-provider", *result.Spec.Upstream.Main.Url)
+
+	// Every generated proxy operation must carry the internal loopback marker (unconditional),
+	// so the provider hop's analytics event can be dropped from Moesif.
+	require.NotEmpty(t, result.Spec.Operations, "proxy must generate operations")
+	for i := range result.Spec.Operations {
+		op := result.Spec.Operations[i]
+		require.NotNil(t, op.Policies, "operation %d must have policies", i)
+		assert.True(t, hasInternalLoopbackMarkerPolicy(*op.Policies),
+			"operation %d must carry the internal loopback marker set-headers policy", i)
+	}
+}
+
+// hasInternalLoopbackMarkerPolicy reports whether policies contain a set-headers policy that
+// stamps the internal loopback marker header.
+func hasInternalLoopbackMarkerPolicy(policies []api.Policy) bool {
+	for _, p := range policies {
+		if p.Name != constants.SET_HEADERS_POLICY_NAME || p.Params == nil {
+			continue
+		}
+		req, ok := (*p.Params)["request"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		headers, ok := req["headers"].([]interface{})
+		if !ok {
+			continue
+		}
+		for _, h := range headers {
+			if hm, ok := h.(map[string]interface{}); ok && hm["name"] == constants.InternalLoopbackHeader {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func TestGetUpstreamAuthApikeyPolicyParams_Extended(t *testing.T) {
@@ -2187,6 +2221,11 @@ func TestTransformProxy_OtherAndNoneUpstreamAuth(t *testing.T) {
 					continue
 				}
 				for _, p := range *op.Policies {
+					// The unconditional internal loopback marker is also a set-headers policy;
+					// it is always present and is not the upstream-auth policy under test.
+					if hasInternalLoopbackMarkerPolicy([]api.Policy{p}) {
+						continue
+					}
 					assert.NotEqual(t, constants.UPSTREAM_AUTH_APIKEY_POLICY_NAME, p.Name,
 						"proxy auth type %q should not attach an upstream auth policy", authType)
 				}

--- a/gateway/gateway-runtime/policy-engine/internal/analytics/analytics.go
+++ b/gateway/gateway-runtime/policy-engine/internal/analytics/analytics.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"net"
 	"strconv"
 	"time"
 
@@ -144,10 +145,47 @@ func (c *Analytics) Process(event *v3.HTTPAccessLogEntry) {
 	}
 
 	analyticEvent := c.prepareAnalyticEvent(event)
+
+	// Suppress internal loopback provider events to avoid double-counting in analytics.
+	if c.isInternalLoopbackProviderEvent(analyticEvent) {
+		correlationID := ""
+		if analyticEvent.MetaInfo != nil {
+			correlationID = analyticEvent.MetaInfo.CorrelationID
+		}
+		slog.Debug("Suppressing internal loopback provider analytics event",
+			"apiType", analyticEvent.API.APIType,
+			"correlationId", correlationID,
+		)
+		return
+	}
+
 	for _, publisher := range c.publishers {
 		publisher.Publish(analyticEvent)
 	}
 
+}
+
+// isInternalLoopbackProviderEvent checks if the event is an internal loopback provider event.
+
+func (c *Analytics) isInternalLoopbackProviderEvent(event *dto.Event) bool {
+	if event == nil || event.API == nil {
+		return false
+	}
+	if event.API.APIType != "LlmProvider" {
+		return false
+	}
+	return isLoopbackAddress(event.UserIP)
+}
+
+// isLoopbackAddress reports whether ip is an IPv4/IPv6 loopback address.
+func isLoopbackAddress(ip string) bool {
+	if ip == "127.0.0.1" || ip == "::1" {
+		return true
+	}
+	if parsed := net.ParseIP(ip); parsed != nil {
+		return parsed.IsLoopback()
+	}
+	return false
 }
 
 // isInvalid checks if the log entry is invalid.

--- a/gateway/gateway-runtime/policy-engine/internal/analytics/analytics.go
+++ b/gateway/gateway-runtime/policy-engine/internal/analytics/analytics.go
@@ -352,6 +352,8 @@ func (c *Analytics) prepareAnalyticEvent(logEntry *v3.HTTPAccessLogEntry) *dto.E
 	if userIP == "" {
 		userIP = Unknown
 	}
+
+	directRemoteIP := logEntry.GetCommonProperties().GetDownstreamDirectRemoteAddress().GetSocketAddress().GetAddress()
 	if userAgent == "" {
 		userAgent = Unknown
 	}
@@ -378,10 +380,11 @@ func (c *Analytics) prepareAnalyticEvent(logEntry *v3.HTTPAccessLogEntry) *dto.E
 	// can drop it (one counted event per client call) while the traffic log keeps it. The
 	// primary signal is the x-wso2-internal-loopback marker the proxy stamps on its loopback
 	// forward — a direct provider call never carries it, so it is never suppressed regardless
-	// of network topology. The loopback downstream address is a secondary spoof guard.
+	// of network topology. The loopback guard uses directRemoteIP (the physical TCP peer),
+	// NOT userIP, so a forged "X-Forwarded-For: 127.0.0.1" cannot fake an internal source.
 	if extendedAPI.APIType == "LlmProvider" &&
 		keyValuePairsFromMetadata[InternalLoopbackMetadataKey] == "true" &&
-		isLoopbackAddress(userIP) {
+		isLoopbackAddress(directRemoteIP) {
 		event.Properties[PropInternalLoopbackProvider] = true
 	}
 

--- a/gateway/gateway-runtime/policy-engine/internal/analytics/analytics.go
+++ b/gateway/gateway-runtime/policy-engine/internal/analytics/analytics.go
@@ -81,6 +81,16 @@ const (
 
 	// UserIDMetadataKey represents the user ID metadata key for analytics.
 	UserIDMetadataKey string = "x-wso2-user-id"
+
+	// InternalLoopbackMetadataKey is the analytics-metadata key carrying the marker that
+	// the proxy stamps on its internal loopback forward to the provider (surfaced by the
+	// analytics system policy from the x-wso2-internal-loopback request header).
+	InternalLoopbackMetadataKey string = "x-wso2-internal-loopback"
+
+	// PropInternalLoopbackProvider is the event property set when a provider event is the
+	// internal loopback hop of a proxy call. Read by the Moesif publisher to skip it (avoids
+	// double-counting), while other publishers (traffic log) still emit it.
+	PropInternalLoopbackProvider string = "isInternalLoopbackProvider"
 )
 
 // Analytics represents analytics collector service.
@@ -146,16 +156,11 @@ func (c *Analytics) Process(event *v3.HTTPAccessLogEntry) {
 
 	analyticEvent := c.prepareAnalyticEvent(event)
 
-	// Suppress internal loopback provider events to avoid double-counting in analytics.
-	if c.isInternalLoopbackProviderEvent(analyticEvent) {
-		correlationID := ""
-		if analyticEvent.MetaInfo != nil {
-			correlationID = analyticEvent.MetaInfo.CorrelationID
-		}
-		slog.Debug("Suppressing internal loopback provider analytics event",
-			"apiType", analyticEvent.API.APIType,
-			"correlationId", correlationID,
-		)
+	// Suppress the internal loopback provider hop of an LLM proxy call so a single client
+	// call is counted once. Detection uses the x-wso2-internal-loopback marker the proxy
+	// stamps on its loopback forward (see prepareAnalyticEvent) — a direct provider call
+	// never carries it, so it is never suppressed.
+	if v, ok := analyticEvent.Properties[PropInternalLoopbackProvider].(bool); ok && v {
 		return
 	}
 
@@ -163,18 +168,6 @@ func (c *Analytics) Process(event *v3.HTTPAccessLogEntry) {
 		publisher.Publish(analyticEvent)
 	}
 
-}
-
-// isInternalLoopbackProviderEvent checks if the event is an internal loopback provider event.
-
-func (c *Analytics) isInternalLoopbackProviderEvent(event *dto.Event) bool {
-	if event == nil || event.API == nil {
-		return false
-	}
-	if event.API.APIType != "LlmProvider" {
-		return false
-	}
-	return isLoopbackAddress(event.UserIP)
 }
 
 // isLoopbackAddress reports whether ip is an IPv4/IPv6 loopback address.
@@ -379,6 +372,17 @@ func (c *Analytics) prepareAnalyticEvent(logEntry *v3.HTTPAccessLogEntry) *dto.E
 	if userID, exists := keyValuePairsFromMetadata[UserIDMetadataKey]; exists && userID != "" {
 		event.Properties[UserIDMetadataKey] = userID
 		slog.Debug("Analytics: User ID set from metadata", "userID", userID)
+	}
+
+	// Flag the internal loopback provider hop of an LLM proxy call so the Moesif publisher
+	// can drop it (one counted event per client call) while the traffic log keeps it. The
+	// primary signal is the x-wso2-internal-loopback marker the proxy stamps on its loopback
+	// forward — a direct provider call never carries it, so it is never suppressed regardless
+	// of network topology. The loopback downstream address is a secondary spoof guard.
+	if extendedAPI.APIType == "LlmProvider" &&
+		keyValuePairsFromMetadata[InternalLoopbackMetadataKey] == "true" &&
+		isLoopbackAddress(userIP) {
+		event.Properties[PropInternalLoopbackProvider] = true
 	}
 
 	// Auth-context metadata (type, issuer, credential/token IDs, audience, scopes, custom

--- a/gateway/gateway-runtime/policy-engine/internal/analytics/analytics.go
+++ b/gateway/gateway-runtime/policy-engine/internal/analytics/analytics.go
@@ -161,6 +161,18 @@ func (c *Analytics) Process(event *v3.HTTPAccessLogEntry) {
 	// stamps on its loopback forward (see prepareAnalyticEvent) — a direct provider call
 	// never carries it, so it is never suppressed.
 	if v, ok := analyticEvent.Properties[PropInternalLoopbackProvider].(bool); ok && v {
+		correlationID := ""
+		if analyticEvent.MetaInfo != nil {
+			correlationID = analyticEvent.MetaInfo.CorrelationID
+		}
+		apiType := ""
+		if analyticEvent.API != nil {
+			apiType = analyticEvent.API.APIType
+		}
+		slog.Debug("Suppressing internal loopback provider analytics event",
+			"apiType", apiType,
+			"correlationId", correlationID,
+		)
 		return
 	}
 
@@ -383,9 +395,16 @@ func (c *Analytics) prepareAnalyticEvent(logEntry *v3.HTTPAccessLogEntry) *dto.E
 	// of network topology. The loopback guard uses directRemoteIP (the physical TCP peer),
 	// NOT userIP, so a forged "X-Forwarded-For: 127.0.0.1" cannot fake an internal source.
 	if extendedAPI.APIType == "LlmProvider" &&
-		keyValuePairsFromMetadata[InternalLoopbackMetadataKey] == "true" &&
-		isLoopbackAddress(directRemoteIP) {
-		event.Properties[PropInternalLoopbackProvider] = true
+		keyValuePairsFromMetadata[InternalLoopbackMetadataKey] == "true" {
+		switch {
+		case directRemoteIP == "":
+			slog.Warn("Internal loopback marker present but downstream direct remote address is unavailable; not suppressing event",
+				"apiType", extendedAPI.APIType,
+				"correlationId", metaInfo.CorrelationID,
+			)
+		case isLoopbackAddress(directRemoteIP):
+			event.Properties[PropInternalLoopbackProvider] = true
+		}
 	}
 
 	// Auth-context metadata (type, issuer, credential/token IDs, audience, scopes, custom

--- a/gateway/gateway-runtime/policy-engine/internal/analytics/analytics_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/analytics/analytics_test.go
@@ -295,38 +295,82 @@ func createLogEntryWithAPITypeAndAddr(apiType, downstreamAddr string) *v3.HTTPAc
 	return entry
 }
 
-func TestProcess_SuppressesLoopbackProviderEvent(t *testing.T) {
-	// An LlmProvider hop reached over the internal loopback (downstream 127.0.0.1) is the
-	// duplicate of the proxy's own event and must not be published.
-	analytics := NewAnalytics(&config.Config{})
-	mockPub := &mockPublisher{}
-	analytics.publishers = append(analytics.publishers, mockPub)
-
-	analytics.Process(createLogEntryWithAPITypeAndAddr("LlmProvider", "127.0.0.1"))
-
-	assert.False(t, mockPub.called, "loopback provider event must be suppressed")
+// buildProviderEvent runs prepareAnalyticEvent for the given api-kind, downstream address, and
+// optional internal-loopback marker, returning the built event so its Properties can be asserted.
+func buildProviderEvent(apiType, downstreamAddr string, marker bool) *dto.Event {
+	md := map[string]string{APITypeKey: apiType}
+	if marker {
+		md[InternalLoopbackMetadataKey] = "true"
+	}
+	entry := createLogEntryWithMetadata(md)
+	entry.CommonProperties.DownstreamRemoteAddress = &corev3.Address{
+		Address: &corev3.Address_SocketAddress{
+			SocketAddress: &corev3.SocketAddress{Address: downstreamAddr},
+		},
+	}
+	return NewAnalytics(&config.Config{}).prepareAnalyticEvent(entry)
 }
 
-func TestProcess_DirectProviderNotSuppressed(t *testing.T) {
-	// A directly-invoked provider (real client address) must still be published.
-	analytics := NewAnalytics(&config.Config{})
-	mockPub := &mockPublisher{}
-	analytics.publishers = append(analytics.publishers, mockPub)
-
-	analytics.Process(createLogEntryWithAPITypeAndAddr("LlmProvider", "192.168.1.1"))
-
-	assert.True(t, mockPub.called, "direct provider event must be published")
+func TestPrepareEvent_LoopbackProviderFlagged(t *testing.T) {
+	// LlmProvider hop carrying the marker over loopback → flagged for Moesif suppression.
+	e := buildProviderEvent("LlmProvider", "127.0.0.1", true)
+	assert.Equal(t, true, e.Properties[PropInternalLoopbackProvider])
 }
 
-func TestProcess_ProxyEventNotSuppressed(t *testing.T) {
-	// Only LlmProvider events are candidates for suppression; a proxy event is never dropped.
+func TestPrepareEvent_DirectProviderNotFlagged(t *testing.T) {
+	// No marker → a direct provider call is never flagged, even when it arrives over loopback
+	// (the sidecar/port-forward case the reviewer raised).
+	e := buildProviderEvent("LlmProvider", "127.0.0.1", false)
+	assert.Nil(t, e.Properties[PropInternalLoopbackProvider])
+}
+
+func TestPrepareEvent_ProviderMarkerRealIPNotFlagged(t *testing.T) {
+	// Marker present but downstream is a routable client address → not flagged (spoof guard).
+	e := buildProviderEvent("LlmProvider", "192.168.1.1", true)
+	assert.Nil(t, e.Properties[PropInternalLoopbackProvider])
+}
+
+func TestPrepareEvent_ProxyNotFlagged(t *testing.T) {
+	// Only LlmProvider events are candidates; a proxy event is never flagged.
+	e := buildProviderEvent("LlmProxy", "127.0.0.1", true)
+	assert.Nil(t, e.Properties[PropInternalLoopbackProvider])
+}
+
+// loopbackEntry builds an access-log entry for an LlmProvider/LlmProxy over loopback, with or
+// without the internal-loopback marker, for Process-level suppression tests.
+func loopbackEntry(apiType string, marker bool) *v3.HTTPAccessLogEntry {
+	md := map[string]string{APITypeKey: apiType}
+	if marker {
+		md[InternalLoopbackMetadataKey] = "true"
+	}
+	e := createLogEntryWithMetadata(md)
+	e.CommonProperties.DownstreamRemoteAddress = &corev3.Address{
+		Address: &corev3.Address_SocketAddress{SocketAddress: &corev3.SocketAddress{Address: "127.0.0.1"}},
+	}
+	return e
+}
+
+func TestProcess_SuppressesFlaggedLoopbackProvider(t *testing.T) {
+	// Marker + loopback + LlmProvider → the internal loopback hop is suppressed.
 	analytics := NewAnalytics(&config.Config{})
 	mockPub := &mockPublisher{}
 	analytics.publishers = append(analytics.publishers, mockPub)
 
-	analytics.Process(createLogEntryWithAPITypeAndAddr("LlmProxy", "127.0.0.1"))
+	analytics.Process(loopbackEntry("LlmProvider", true))
 
-	assert.True(t, mockPub.called, "proxy event must always be published")
+	assert.False(t, mockPub.called, "flagged internal loopback provider event must be suppressed")
+}
+
+func TestProcess_PublishesDirectProviderOverLoopback(t *testing.T) {
+	// No marker (a direct provider call) is never suppressed, even when it arrives over
+	// loopback — the sidecar/port-forward case the reviewer raised.
+	analytics := NewAnalytics(&config.Config{})
+	mockPub := &mockPublisher{}
+	analytics.publishers = append(analytics.publishers, mockPub)
+
+	analytics.Process(loopbackEntry("LlmProvider", false))
+
+	assert.True(t, mockPub.called, "direct provider call (no marker) must not be suppressed")
 }
 
 func TestIsLoopbackAddress(t *testing.T) {

--- a/gateway/gateway-runtime/policy-engine/internal/analytics/analytics_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/analytics/analytics_test.go
@@ -18,6 +18,8 @@
 package analytics
 
 import (
+	"bytes"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -388,6 +390,70 @@ func TestProcess_PublishesDirectProviderOverLoopback(t *testing.T) {
 	analytics.Process(loopbackEntry("LlmProvider", false))
 
 	assert.True(t, mockPub.called, "direct provider call (no marker) must not be suppressed")
+}
+
+// captureLogs redirects the package-level slog default (which analytics.go logs through) into a
+// buffer at debug level for the duration of the test, restoring the previous logger afterwards.
+func captureLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
+
+func TestPrepareEvent_MissingDirectRemoteIPNotFlagged(t *testing.T) {
+	// Envoy reported no direct downstream peer. The marker alone must not suppress the event:
+	// falling back to the (forgeable, XFF-derived) remote address would reopen the spoof hole.
+	e := buildProviderEventAddrs("LlmProvider", "127.0.0.1" /*remote*/, "" /*direct=unavailable*/, true)
+	assert.Nil(t, e.Properties[PropInternalLoopbackProvider],
+		"missing direct remote address must not fall back to the forgeable remote address")
+}
+
+func TestPrepareEvent_MissingDirectRemoteIPLogsWarn(t *testing.T) {
+	// The unevaluatable guard must leave a trail explaining the resulting duplicate event.
+	buf := captureLogs(t)
+	buildProviderEventAddrs("LlmProvider", "127.0.0.1", "", true)
+	assert.Contains(t, buf.String(), "direct remote address is unavailable")
+}
+
+func TestPrepareEvent_MissingDirectRemoteIPWithoutMarkerLogsNothing(t *testing.T) {
+	// The warn is scoped to the marker+provider case, so ordinary traffic with no direct
+	// remote address cannot spam the log.
+	buf := captureLogs(t)
+	buildProviderEventAddrs("LlmProxy", "127.0.0.1", "", false)
+	assert.NotContains(t, buf.String(), "direct remote address is unavailable")
+}
+
+func TestProcess_PublishesWhenDirectRemoteIPMissing(t *testing.T) {
+	// Fail open: without a trustworthy peer address the event is published (one possible
+	// duplicate) rather than suppressed on the strength of a forgeable marker alone.
+	analytics := NewAnalytics(&config.Config{})
+	mockPub := &mockPublisher{}
+	analytics.publishers = append(analytics.publishers, mockPub)
+
+	entry := createLogEntryWithMetadata(map[string]string{
+		APITypeKey:                  "LlmProvider",
+		InternalLoopbackMetadataKey: "true",
+	})
+	setDownstreamAddrs(entry, "127.0.0.1", "")
+	analytics.Process(entry)
+
+	assert.True(t, mockPub.called, "event must still be published when the direct remote address is unavailable")
+}
+
+func TestProcess_SuppressionLogsDebug(t *testing.T) {
+	// A suppressed hop must be traceable, otherwise "my analytics event is missing" has no trail.
+	buf := captureLogs(t)
+	analytics := NewAnalytics(&config.Config{})
+	mockPub := &mockPublisher{}
+	analytics.publishers = append(analytics.publishers, mockPub)
+
+	analytics.Process(loopbackEntry("LlmProvider", true))
+
+	assert.False(t, mockPub.called)
+	assert.Contains(t, buf.String(), "Suppressing internal loopback provider analytics event")
 }
 
 func TestIsLoopbackAddress(t *testing.T) {

--- a/gateway/gateway-runtime/policy-engine/internal/analytics/analytics_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/analytics/analytics_test.go
@@ -283,31 +283,36 @@ func TestProcess_PublishesEvent(t *testing.T) {
 	assert.True(t, mockPub.called, "publisher must be called")
 }
 
+func setDownstreamAddrs(entry *v3.HTTPAccessLogEntry, remoteAddr, directAddr string) {
+	entry.CommonProperties.DownstreamRemoteAddress = &corev3.Address{
+		Address: &corev3.Address_SocketAddress{SocketAddress: &corev3.SocketAddress{Address: remoteAddr}},
+	}
+	entry.CommonProperties.DownstreamDirectRemoteAddress = &corev3.Address{
+		Address: &corev3.Address_SocketAddress{SocketAddress: &corev3.SocketAddress{Address: directAddr}},
+	}
+}
+
 // createLogEntryWithAPITypeAndAddr builds an access-log entry with the given api-kind
-// (analytics_data metadata) and downstream remote address, for loopback-suppression tests.
+// (analytics_data metadata) and downstream addresses (remote==direct), for suppression tests.
 func createLogEntryWithAPITypeAndAddr(apiType, downstreamAddr string) *v3.HTTPAccessLogEntry {
 	entry := createLogEntryWithMetadata(map[string]string{APITypeKey: apiType})
-	entry.CommonProperties.DownstreamRemoteAddress = &corev3.Address{
-		Address: &corev3.Address_SocketAddress{
-			SocketAddress: &corev3.SocketAddress{Address: downstreamAddr},
-		},
-	}
+	setDownstreamAddrs(entry, downstreamAddr, downstreamAddr)
 	return entry
 }
 
-// buildProviderEvent runs prepareAnalyticEvent for the given api-kind, downstream address, and
-// optional internal-loopback marker, returning the built event so its Properties can be asserted.
+// buildProviderEvent runs prepareAnalyticEvent for the given api-kind, downstream address
+// (remote==direct), and optional internal-loopback marker.
 func buildProviderEvent(apiType, downstreamAddr string, marker bool) *dto.Event {
+	return buildProviderEventAddrs(apiType, downstreamAddr, downstreamAddr, marker)
+}
+
+func buildProviderEventAddrs(apiType, remoteAddr, directAddr string, marker bool) *dto.Event {
 	md := map[string]string{APITypeKey: apiType}
 	if marker {
 		md[InternalLoopbackMetadataKey] = "true"
 	}
 	entry := createLogEntryWithMetadata(md)
-	entry.CommonProperties.DownstreamRemoteAddress = &corev3.Address{
-		Address: &corev3.Address_SocketAddress{
-			SocketAddress: &corev3.SocketAddress{Address: downstreamAddr},
-		},
-	}
+	setDownstreamAddrs(entry, remoteAddr, directAddr)
 	return NewAnalytics(&config.Config{}).prepareAnalyticEvent(entry)
 }
 
@@ -336,6 +341,20 @@ func TestPrepareEvent_ProxyNotFlagged(t *testing.T) {
 	assert.Nil(t, e.Properties[PropInternalLoopbackProvider])
 }
 
+func TestPrepareEvent_ForgedXFFLoopbackNotFlagged(t *testing.T) {
+	// The internal-loopback marker is only applied by the proxy, so a forged X-Forwarded-For header (remote=spoofed) must not cause suppression.
+	e := buildProviderEventAddrs("LlmProvider", "127.0.0.1" /*remote=forged XFF*/, "172.18.0.9" /*direct=real peer*/, true /*forged marker*/)
+	assert.Nil(t, e.Properties[PropInternalLoopbackProvider],
+		"forged X-Forwarded-For + marker must not cause suppression")
+}
+
+func TestPrepareEvent_GenuineLoopbackWithForgedXFFStillFlagged(t *testing.T) {
+	// The legitimate proxy loopback hop: physical peer IS loopback (gateway self-call) and the
+	// marker is set by the controller. Still flagged regardless of the remote (XFF) value.
+	e := buildProviderEventAddrs("LlmProvider", "203.0.113.7" /*remote*/, "127.0.0.1" /*direct=loopback*/, true)
+	assert.Equal(t, true, e.Properties[PropInternalLoopbackProvider])
+}
+
 // loopbackEntry builds an access-log entry for an LlmProvider/LlmProxy over loopback, with or
 // without the internal-loopback marker, for Process-level suppression tests.
 func loopbackEntry(apiType string, marker bool) *v3.HTTPAccessLogEntry {
@@ -344,9 +363,7 @@ func loopbackEntry(apiType string, marker bool) *v3.HTTPAccessLogEntry {
 		md[InternalLoopbackMetadataKey] = "true"
 	}
 	e := createLogEntryWithMetadata(md)
-	e.CommonProperties.DownstreamRemoteAddress = &corev3.Address{
-		Address: &corev3.Address_SocketAddress{SocketAddress: &corev3.SocketAddress{Address: "127.0.0.1"}},
-	}
+	setDownstreamAddrs(e, "127.0.0.1", "127.0.0.1")
 	return e
 }
 

--- a/gateway/gateway-runtime/policy-engine/internal/analytics/analytics_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/analytics/analytics_test.go
@@ -283,6 +283,62 @@ func TestProcess_PublishesEvent(t *testing.T) {
 	assert.True(t, mockPub.called, "publisher must be called")
 }
 
+// createLogEntryWithAPITypeAndAddr builds an access-log entry with the given api-kind
+// (analytics_data metadata) and downstream remote address, for loopback-suppression tests.
+func createLogEntryWithAPITypeAndAddr(apiType, downstreamAddr string) *v3.HTTPAccessLogEntry {
+	entry := createLogEntryWithMetadata(map[string]string{APITypeKey: apiType})
+	entry.CommonProperties.DownstreamRemoteAddress = &corev3.Address{
+		Address: &corev3.Address_SocketAddress{
+			SocketAddress: &corev3.SocketAddress{Address: downstreamAddr},
+		},
+	}
+	return entry
+}
+
+func TestProcess_SuppressesLoopbackProviderEvent(t *testing.T) {
+	// An LlmProvider hop reached over the internal loopback (downstream 127.0.0.1) is the
+	// duplicate of the proxy's own event and must not be published.
+	analytics := NewAnalytics(&config.Config{})
+	mockPub := &mockPublisher{}
+	analytics.publishers = append(analytics.publishers, mockPub)
+
+	analytics.Process(createLogEntryWithAPITypeAndAddr("LlmProvider", "127.0.0.1"))
+
+	assert.False(t, mockPub.called, "loopback provider event must be suppressed")
+}
+
+func TestProcess_DirectProviderNotSuppressed(t *testing.T) {
+	// A directly-invoked provider (real client address) must still be published.
+	analytics := NewAnalytics(&config.Config{})
+	mockPub := &mockPublisher{}
+	analytics.publishers = append(analytics.publishers, mockPub)
+
+	analytics.Process(createLogEntryWithAPITypeAndAddr("LlmProvider", "192.168.1.1"))
+
+	assert.True(t, mockPub.called, "direct provider event must be published")
+}
+
+func TestProcess_ProxyEventNotSuppressed(t *testing.T) {
+	// Only LlmProvider events are candidates for suppression; a proxy event is never dropped.
+	analytics := NewAnalytics(&config.Config{})
+	mockPub := &mockPublisher{}
+	analytics.publishers = append(analytics.publishers, mockPub)
+
+	analytics.Process(createLogEntryWithAPITypeAndAddr("LlmProxy", "127.0.0.1"))
+
+	assert.True(t, mockPub.called, "proxy event must always be published")
+}
+
+func TestIsLoopbackAddress(t *testing.T) {
+	assert.True(t, isLoopbackAddress("127.0.0.1"))
+	assert.True(t, isLoopbackAddress("::1"))
+	assert.True(t, isLoopbackAddress("127.0.0.5"))
+	assert.False(t, isLoopbackAddress("192.168.1.1"))
+	assert.False(t, isLoopbackAddress("10.0.0.1"))
+	assert.False(t, isLoopbackAddress(""))
+	assert.False(t, isLoopbackAddress("not-an-ip"))
+}
+
 func TestProcess_PanicRecovery(t *testing.T) {
 	cfg := &config.Config{}
 	analytics := NewAnalytics(cfg)

--- a/gateway/gateway-runtime/policy-engine/internal/analytics/publishers/moesif.go
+++ b/gateway/gateway-runtime/policy-engine/internal/analytics/publishers/moesif.go
@@ -196,8 +196,9 @@ func (m *Moesif) Publish(event *dto.Event) {
 	metadataMap["apiId"] = event.API.APIID
 	metadataMap["projectId"] = event.API.ProjectID
 
-	// AI Metadata
-	if event.API.APIType == "LlmProvider" {
+	// AI Metadata.
+	// Only include aiMetadata and aiTokenUsage for LlmProvider and LlmProxy events.
+	if event.API.APIType == "LlmProvider" || event.API.APIType == "LlmProxy" {
 		// Safely extract aiMetadata with nil check
 		if aiMetadataVal, exists := event.Properties["aiMetadata"]; exists && aiMetadataVal != nil {
 			if aiMetadata, ok := aiMetadataVal.(dto.AIMetadata); ok {

--- a/gateway/gateway-runtime/policy-engine/internal/analytics/publishers/moesif_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/analytics/publishers/moesif_test.go
@@ -275,6 +275,36 @@ func TestPublish_LlmProviderWithAIMetadata(t *testing.T) {
 	assert.Equal(t, 50, tokenUsage.CompletionToken)
 }
 
+func TestPublish_LlmProxyWithAIMetadata(t *testing.T) {
+	moesif := createTestMoesifWithoutAPI()
+
+	event := createBaseEvent()
+	event.API.APIType = "LlmProxy"
+	event.Properties["aiMetadata"] = dto.AIMetadata{
+		Model:      "gpt-4",
+		VendorName: "openai",
+	}
+	event.Properties["aiTokenUsage"] = dto.AITokenUsage{
+		PromptToken:     100,
+		CompletionToken: 50,
+		TotalToken:      150,
+	}
+
+	moesif.Publish(event)
+
+	assert.Len(t, moesif.events, 1)
+	metadata := getMetadata(moesif.events[0])
+	assert.NotNil(t, metadata["aiMetadata"])
+	assert.NotNil(t, metadata["aiTokenUsage"])
+
+	aiMeta := metadata["aiMetadata"].(dto.AIMetadata)
+	assert.Equal(t, "gpt-4", aiMeta.Model)
+	assert.Equal(t, "openai", aiMeta.VendorName)
+
+	tokenUsage := metadata["aiTokenUsage"].(dto.AITokenUsage)
+	assert.Equal(t, 150, tokenUsage.TotalToken)
+}
+
 func TestPublish_LlmProviderMissingAIMetadata(t *testing.T) {
 	moesif := createTestMoesifWithoutAPI()
 

--- a/gateway/system-policies/analytics/analytics.go
+++ b/gateway/system-policies/analytics/analytics.go
@@ -26,6 +26,7 @@ const (
 	AIProviderDisplayNameMetadataKey = "ai:providerdisplayname"
 	ApplicationIDMetadataKey         = "x-wso2-application-id"
 	ApplicationNameMetadataKey       = "x-wso2-application-name"
+	InternalLoopbackMetadataKey = "x-wso2-internal-loopback"
 
 	// Auth-context metadata keys. Populated generically (auth-type-agnostic, via
 	// SharedContext.AuthContext) by populateAuthAnalyticsMetadata below, so they work
@@ -171,6 +172,11 @@ func (a *AnalyticsPolicy) OnRequestHeaders(_ context.Context, reqCtx *policy.Req
 		}
 		if appNames := reqCtx.Headers.Get("x-wso2-application-name"); len(appNames) > 0 {
 			analyticsMetadata[ApplicationNameMetadataKey] = appNames[0]
+		}
+		// Marker stamped by the proxy on its internal loopback forward to the provider.
+		// Normalized to "true" so the policy-engine can drop the duplicate provider hop.
+		if loopback := reqCtx.Headers.Get(InternalLoopbackMetadataKey); len(loopback) > 0 && loopback[0] != "" {
+			analyticsMetadata[InternalLoopbackMetadataKey] = "true"
 		}
 	}
 

--- a/gateway/system-policies/analytics/analytics_test.go
+++ b/gateway/system-policies/analytics/analytics_test.go
@@ -30,6 +30,39 @@ func TestDeriveMCPCapability(t *testing.T) {
 	}
 }
 
+// OnRequestHeaders stamps the internal loopback marker into analytics metadata when the
+// proxy's loopback forward carries the x-wso2-internal-loopback header, so the policy-engine
+// can drop the duplicate provider event from Moesif. A request without the header does not.
+func TestOnRequestHeaders_StampsInternalLoopbackMarker(t *testing.T) {
+	t.Run("marker present", func(t *testing.T) {
+		reqCtx := &policy.RequestHeaderContext{
+			SharedContext: &policy.SharedContext{APIKind: policy.APIKindLlmProvider},
+			Headers:       policy.NewHeaders(map[string][]string{InternalLoopbackMetadataKey: {"1"}}),
+		}
+		action := (&AnalyticsPolicy{}).OnRequestHeaders(context.Background(), reqCtx, nil)
+		mods, ok := action.(policy.UpstreamRequestHeaderModifications)
+		if !ok {
+			t.Fatalf("expected UpstreamRequestHeaderModifications, got %T", action)
+		}
+		if got := mods.AnalyticsMetadata[InternalLoopbackMetadataKey]; got != "true" {
+			t.Errorf("%s = %v, want true", InternalLoopbackMetadataKey, got)
+		}
+	})
+
+	t.Run("marker absent", func(t *testing.T) {
+		reqCtx := &policy.RequestHeaderContext{
+			SharedContext: &policy.SharedContext{APIKind: policy.APIKindLlmProvider},
+			Headers:       policy.NewHeaders(map[string][]string{}),
+		}
+		action := (&AnalyticsPolicy{}).OnRequestHeaders(context.Background(), reqCtx, nil)
+		if mods, ok := action.(policy.UpstreamRequestHeaderModifications); ok {
+			if _, exists := mods.AnalyticsMetadata[InternalLoopbackMetadataKey]; exists {
+				t.Errorf("marker must not be stamped when the header is absent")
+			}
+		}
+	})
+}
+
 // OnResponseHeaders must capture the response content type for every API kind (not just
 // MCP), since the Envoy access log carries no response headers. It reads it from the live
 // response headers and emits it as response_content_type analytics metadata.


### PR DESCRIPTION
## Problem

Invoking an LLM proxy produced **two** analytics events for a single client call, because the proxy forwards to its provider over an internal loopback on the same Envoy listener. This caused:

- **Double-counted requests** in Moesif — e.g. "Total Requests" showed 12 for ~6 calls,
  while the per-API "AI API Details" panel showed the correct count.
- **Split data** — the proxy (ingress) event carried the user identity but no token usage;
  the provider (loopback) event carried token/cost/model but showed the user as `anonymous`.

## Fix 

1. Token usage/cost/model is already extracted on the proxy route (the LLM response returns through it) and present in `event.Properties`, but the publisher only emitted it for `LlmProvider`. The guard now includes `LlmProxy`, so the proxy event is a complete AI record.

2. Before publishing, an `LlmProvider` event whose downstream remote address is loopback(`127.0.0.1`/`::1`) is dropped, since it is the internal hop of a proxy call, not a real client request. Directly invoked providers (real client address) are unaffected and still publish.

## Moesif Dashboard

When I send 3 requests from the proxy and 4 requests from the provider, the analytics dashboard is showing as below.
<img width="1575" height="536" alt="image" src="https://github.com/user-attachments/assets/bb3c941f-502c-4119-83a4-244c9c919759" />
<img width="1568" height="739" alt="image" src="https://github.com/user-attachments/assets/9997ff50-c9f7-44a2-9c39-2b5ed8988345" />
<img width="1554" height="890" alt="image" src="https://github.com/user-attachments/assets/f9efc808-b538-4d75-a00f-a41d4e429ea5" />


Resolved: https://github.com/wso2/api-platform/issues/2441