### PR TITLE
ci: prompt for next dev version on release workflows

### DIFF
--- a/.github/workflows/ai-workspace-release.yaml
+++ b/.github/workflows/ai-workspace-release.yaml
@@ -13,6 +13,10 @@ on:
         required: true
         type: string
         default: ''
+      next_dev_version:
+        description: 'Next development version (with -SNAPSHOT suffix, e.g. 1.1.0-SNAPSHOT)'
+        required: true
+        type: string
 
 env:
   DOCKER_REGISTRY: ghcr.io/${{ github.repository_owner }}/api-platform
@@ -135,8 +139,20 @@ jobs:
           prerelease: ${{ contains(steps.version.outputs.version, '-') }}
           token: ${{ secrets.API_PLATFORM_BOT_TOKEN }}
 
-      - name: Bump to next dev version
-        run: make -C portals/ai-workspace version-bump-next-dev
+      - name: Set next dev version
+        env:
+          NEXT_DEV_VERSION: ${{ inputs.next_dev_version }}
+        run: |
+          if [ -z "${NEXT_DEV_VERSION}" ]; then
+            echo "Error: next_dev_version input is required"
+            exit 1
+          fi
+          if [[ "${NEXT_DEV_VERSION}" != *-SNAPSHOT ]]; then
+            echo "Error: next_dev_version must end with -SNAPSHOT (e.g. 1.1.0-SNAPSHOT)"
+            exit 1
+          fi
+          echo "Setting ai-workspace to next dev version: ${NEXT_DEV_VERSION}"
+          make -C portals/ai-workspace version-set "VERSION=${NEXT_DEV_VERSION}"
 
       - name: Commit version bump
         run: |
@@ -159,7 +175,7 @@ jobs:
           body: |
             Automated version bump after release `portals/ai-workspace/v${{ steps.version.outputs.version }}`
 
-            This PR bumps the ai-workspace version to the next development version.
+            This PR bumps the ai-workspace version to the next development version `${{ inputs.next_dev_version }}`.
           branch: ai-workspace-version-bump-${{ github.run_id }}
           base: main
           delete-branch: true

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -2,6 +2,11 @@ name: CLI Release
 
 on:
   workflow_dispatch:
+    inputs:
+      next_dev_version:
+        description: 'Next development version (with -SNAPSHOT suffix, e.g. 0.10.0-SNAPSHOT)'
+        required: true
+        type: string
 
 jobs:
   release:
@@ -169,8 +174,20 @@ jobs:
           name: ap-release-zips-${{ steps.version.outputs.version }}
           path: release-artifacts/*.zip
 
-      - name: Bump to next dev version
-        run: make -C cli/src version-bump-next-dev
+      - name: Set next dev version
+        env:
+          NEXT_DEV_VERSION: ${{ inputs.next_dev_version }}
+        run: |
+          if [ -z "${NEXT_DEV_VERSION}" ]; then
+            echo "Error: next_dev_version input is required"
+            exit 1
+          fi
+          if [[ "${NEXT_DEV_VERSION}" != *-SNAPSHOT ]]; then
+            echo "Error: next_dev_version must end with -SNAPSHOT (e.g. 0.10.0-SNAPSHOT)"
+            exit 1
+          fi
+          echo "Setting CLI to next dev version: ${NEXT_DEV_VERSION}"
+          make -C cli/src version-set "VERSION=${NEXT_DEV_VERSION}"
 
       - name: Commit version bump
         run: |
@@ -189,7 +206,7 @@ jobs:
           body: |
             Automated version bump after release `ap/v${{ steps.version.outputs.version }}`
 
-            This PR bumps the CLI version to the next development version.
+            This PR bumps the CLI version to the next development version `${{ inputs.next_dev_version }}`.
           branch: cli-version-bump-${{ github.run_id }}
           base: main
           delete-branch: true

--- a/.github/workflows/devportal-release.yml
+++ b/.github/workflows/devportal-release.yml
@@ -13,6 +13,10 @@ on:
         required: true
         type: string
         default: ''
+      next_dev_version:
+        description: 'Next development version (with -SNAPSHOT suffix, e.g. 1.1.0-SNAPSHOT)'
+        required: true
+        type: string
 
 env:
   DOCKER_REGISTRY: ghcr.io/${{ github.repository_owner }}/api-platform
@@ -133,8 +137,20 @@ jobs:
           prerelease: ${{ contains(steps.version.outputs.version, '-') }}
           token: ${{ secrets.API_PLATFORM_BOT_TOKEN }}
 
-      - name: Bump to next dev version
-        run: make -C portals/developer-portal version-bump-next-dev
+      - name: Set next dev version
+        env:
+          NEXT_DEV_VERSION: ${{ inputs.next_dev_version }}
+        run: |
+          if [ -z "${NEXT_DEV_VERSION}" ]; then
+            echo "Error: next_dev_version input is required"
+            exit 1
+          fi
+          if [[ "${NEXT_DEV_VERSION}" != *-SNAPSHOT ]]; then
+            echo "Error: next_dev_version must end with -SNAPSHOT (e.g. 1.1.0-SNAPSHOT)"
+            exit 1
+          fi
+          echo "Setting developer-portal to next dev version: ${NEXT_DEV_VERSION}"
+          make -C portals/developer-portal version-set "VERSION=${NEXT_DEV_VERSION}"
 
       - name: Commit version bump
         run: |
@@ -153,7 +169,7 @@ jobs:
           body: |
             Automated version bump after release `developer-portal/v${{ steps.version.outputs.version }}`
 
-            This PR bumps the developer-portal version to the next development version.
+            This PR bumps the developer-portal version to the next development version `${{ inputs.next_dev_version }}`.
           branch: version-bump-${{ github.run_id }}
           base: main
           delete-branch: true

--- a/.github/workflows/event-gateway-release.yml
+++ b/.github/workflows/event-gateway-release.yml
@@ -2,6 +2,11 @@ name: Event Gateway Release
 
 on:
   workflow_dispatch:
+    inputs:
+      next_dev_version:
+        description: 'Next development version (with -SNAPSHOT suffix, e.g. 0.11.0-SNAPSHOT)'
+        required: true
+        type: string
 
 env:
   DOCKER_REGISTRY: ghcr.io/wso2/api-platform
@@ -72,8 +77,20 @@ jobs:
           git tag -a event-gateway/v${{ steps.version.outputs.version }} -m "Event Gateway ${{ steps.version.outputs.version }}"
           git push origin event-gateway/v${{ steps.version.outputs.version }}
 
-      - name: Bump to next dev version
-        run: make -C event-gateway version-bump-next-dev
+      - name: Set next dev version
+        env:
+          NEXT_DEV_VERSION: ${{ inputs.next_dev_version }}
+        run: |
+          if [ -z "${NEXT_DEV_VERSION}" ]; then
+            echo "Error: next_dev_version input is required"
+            exit 1
+          fi
+          if [[ "${NEXT_DEV_VERSION}" != *-SNAPSHOT ]]; then
+            echo "Error: next_dev_version must end with -SNAPSHOT (e.g. 0.11.0-SNAPSHOT)"
+            exit 1
+          fi
+          echo "Setting event-gateway to next dev version: ${NEXT_DEV_VERSION}"
+          make -C event-gateway version-set "VERSION=${NEXT_DEV_VERSION}"
 
       - name: Commit version bump
         run: |
@@ -92,7 +109,7 @@ jobs:
           body: |
             Automated version bump after release `event-gateway/v${{ steps.version.outputs.version }}`
 
-            This PR bumps the event-gateway version to the next development version.
+            This PR bumps the event-gateway version to the next development version `${{ inputs.next_dev_version }}`.
           branch: version-bump-${{ github.run_id }}
           base: main
           delete-branch: true

--- a/.github/workflows/platform-api-release.yml
+++ b/.github/workflows/platform-api-release.yml
@@ -7,6 +7,10 @@ on:
         description: 'Version to release (e.g., 0.1.0)'
         required: true
         type: string
+      next_dev_version:
+        description: 'Next development version (with -SNAPSHOT suffix, e.g. 0.15.0-SNAPSHOT)'
+        required: true
+        type: string
 
 env:
   DOCKER_REGISTRY: ghcr.io/wso2/api-platform
@@ -19,9 +23,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set version
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          VERSION=${{ inputs.version }}
-          make -C platform-api version-set VERSION=${VERSION}
+          make -C platform-api version-set "VERSION=${VERSION}"
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -50,16 +55,30 @@ jobs:
         run: make build-and-push-platform-api-multiarch
 
       - name: Create and push tag
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git commit -am "Release platform-api version ${{ inputs.version }}"
-          git tag -a platform-api/v${{ inputs.version }} -m "Platform API ${{ inputs.version }}"
-          git push origin platform-api/v${{ inputs.version }}
+          git commit -am "Release platform-api version ${VERSION}"
+          git tag -a "platform-api/v${VERSION}" -m "Platform API ${VERSION}"
+          git push origin "platform-api/v${VERSION}"
 
 
-      - name: Bump to next dev version
-        run: make -C platform-api version-bump-next-dev
+      - name: Set next dev version
+        env:
+          NEXT_DEV_VERSION: ${{ inputs.next_dev_version }}
+        run: |
+          if [ -z "${NEXT_DEV_VERSION}" ]; then
+            echo "Error: next_dev_version input is required"
+            exit 1
+          fi
+          if [[ "${NEXT_DEV_VERSION}" != *-SNAPSHOT ]]; then
+            echo "Error: next_dev_version must end with -SNAPSHOT (e.g. 0.15.0-SNAPSHOT)"
+            exit 1
+          fi
+          echo "Setting platform-api to next dev version: ${NEXT_DEV_VERSION}"
+          make -C platform-api version-set "VERSION=${NEXT_DEV_VERSION}"
 
       - name: Commit version bump
         run: |
@@ -78,7 +97,7 @@ jobs:
           body: |
             Automated version bump after release `platform-api/v${{ inputs.version }}`
 
-            This PR bumps the platform-api version to the next development version.
+            This PR bumps the platform-api version to the next development version `${{ inputs.next_dev_version }}`.
           branch: platform-api-version-bump-${{ github.run_id }}
           base: main
           delete-branch: true


### PR DESCRIPTION
## Purpose

The release workflows for ai-workspace, platform-api, developer-portal, CLI, and event-gateway each bump to the next development version automatically (minor + 1, with `-SNAPSHOT`) via `make version-bump-next-dev`. This removes control over the version chosen for the next development cycle — for example when it should be a patch, a specific minor, or carry an `-rc`/`-beta` pre-release qualifier. This PR makes the next development version an explicit, maintainer-provided input at release time, unifying the behaviour already introduced for the gateway release workflow (#2870).

## Goals

Let the maintainer specify the exact next development version when triggering each release workflow, instead of having it computed automatically — consistently across all release workflows that perform a next-dev bump.

## Approach

For each of the ai-workspace, platform-api, developer-portal, CLI, and event-gateway release workflows:

- Add a required `next_dev_version` `workflow_dispatch` input (documented to include the `-SNAPSHOT` suffix).
- Replace the `make ... version-bump-next-dev` step with a step that:
  - passes the input via `env:` (rather than interpolating `${{ inputs.* }}` directly into shell — avoids GitHub Actions template/script injection, per `zizmor`),
  - validates the value is non-empty and ends with `-SNAPSHOT` (a loose suffix check, so pre-release qualifiers like `1.2.0-rc-SNAPSHOT` / `1.0.0-beta-SNAPSHOT` remain valid),
  - applies it via `make ... version-set "VERSION=<input>"` (quoted).
- Reference the chosen version in the automated version-bump PR body.

Additionally, in `platform-api-release.yml`, harden the pre-existing `version` input handling (the `Set version` and `Create and push tag` steps) to pass the input via `env:` and quote it in shell, instead of interpolating the workflow input directly into the script.

The release version itself is still derived automatically from each component's `VERSION` file (or, for platform-api, from its existing `version` input); only the next development version is now prompted.

## Related Issues

N/A

## Related PRs

wso2/api-platform#2870 — the same change for the gateway release workflow.

## Documentation

N/A — internal release automation change with no product documentation impact.

## Automation tests

- Unit tests
  > N/A — GitHub Actions workflow changes; no application code affected.
- Integration tests
  > N/A — verified by inspection; exercised on the next manual release dispatch of each workflow.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (no Java/source code changes)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)