### PR TITLE
Add Envoy OTEL environment resource detector for gateway tracing

### DIFF
--- a/docs/gateway/observability/tracing.md
+++ b/docs/gateway/observability/tracing.md
@@ -224,7 +224,7 @@ still works and no extra resource attributes are added.
 Set attributes on the **gateway-runtime** container (not the controller), for example:
 
 ```bash
-OTEL_RESOURCE_ATTRIBUTES=deployment.environment=prod,service.namespace=api-gw
+export OTEL_RESOURCE_ATTRIBUTES=deployment.environment=prod,service.namespace=api-gw
 ```
 
 With the Helm chart:

--- a/docs/gateway/observability/tracing.md
+++ b/docs/gateway/observability/tracing.md
@@ -214,6 +214,31 @@ max_export_batch_size = 1024    # Export up to 1024 spans per batch
 **Lower timeout**: Faster trace visibility, more network overhead
 **Higher timeout**: Better batching efficiency, slower trace visibility
 
+### OpenTelemetry Resource Attributes
+
+When tracing is enabled, the Envoy OpenTelemetry tracer is configured with the environment
+resource detector. It reads `OTEL_RESOURCE_ATTRIBUTES` from the Envoy (`gateway-runtime`)
+process and attaches those attributes to exported spans. If the variable is unset, tracing
+still works and no extra resource attributes are added.
+
+Set attributes on the **gateway-runtime** container (not the controller), for example:
+
+```bash
+OTEL_RESOURCE_ATTRIBUTES=deployment.environment=prod,service.namespace=api-gw
+```
+
+With the Helm chart:
+
+```yaml
+gateway:
+  gatewayRuntime:
+    deployment:
+      env:
+        otelResourceAttributes: "deployment.environment=prod,service.namespace=api-gw"
+```
+
+`OTEL_RESOURCE_ATTRIBUTES` is injected only when `otelResourceAttributes` is non-empty.
+
 ## Alternative Tracing Backends
 
 While the default setup uses Jaeger, the gateway components use OpenTelemetry and can export to any OTLP-compatible backend.

--- a/gateway/gateway-controller/pkg/xds/translator.go
+++ b/gateway/gateway-controller/pkg/xds/translator.go
@@ -52,6 +52,7 @@ import (
 	luav3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/lua/v3"
 	router "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	otelresourcedetectorsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/tracers/opentelemetry/resource_detectors/v3"
 	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	typev3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
@@ -2738,7 +2739,14 @@ func (t *Translator) createTracingConfig() (*hcm.HttpConnectionManager_Tracing, 
 	}
 	samplingPercentage := samplingRate * 100.0
 
-	// Create OpenTelemetry tracing configuration
+	envResourceDetector, err := createOTelEnvironmentResourceDetector()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create environment resource detector: %w", err)
+	}
+
+	// Create OpenTelemetry tracing configuration.
+	// The environment resource detector reads OTEL_RESOURCE_ATTRIBUTES from the Envoy
+	// process. When the variable is unset, the detector contributes no attributes.
 	otelConfig := &tracev3.OpenTelemetryConfig{
 		GrpcService: &core.GrpcService{
 			TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
@@ -2748,6 +2756,9 @@ func (t *Translator) createTracingConfig() (*hcm.HttpConnectionManager_Tracing, 
 			},
 		},
 		ServiceName: serviceName,
+		ResourceDetectors: []*core.TypedExtensionConfig{
+			envResourceDetector,
+		},
 	}
 
 	// Marshal to Any
@@ -2776,6 +2787,19 @@ func (t *Translator) createTracingConfig() (*hcm.HttpConnectionManager_Tracing, 
 		slog.String("collector_cluster", OTELCollectorClusterName))
 
 	return tracingConfig, nil
+}
+
+func createOTelEnvironmentResourceDetector() (*core.TypedExtensionConfig, error) {
+	envDetectorConfig := &otelresourcedetectorsv3.EnvironmentResourceDetectorConfig{}
+	envDetectorAny, err := anypb.New(envDetectorConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal environment resource detector config: %w", err)
+	}
+
+	return &core.TypedExtensionConfig{
+		Name:        "envoy.tracers.opentelemetry.resource_detectors.environment",
+		TypedConfig: envDetectorAny,
+	}, nil
 }
 
 // convertToInterface converts map[string]string to map[string]interface{} for structpb

--- a/gateway/gateway-controller/pkg/xds/translator_test.go
+++ b/gateway/gateway-controller/pkg/xds/translator_test.go
@@ -31,7 +31,9 @@ import (
 	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	tracev3 "github.com/envoyproxy/go-control-plane/envoy/config/trace/v3"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	otelresourcedetectorsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/tracers/opentelemetry/resource_detectors/v3"
 	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
@@ -1642,7 +1644,20 @@ func TestTranslator_CreateTracingConfig_Enabled(t *testing.T) {
 
 	tracingCfg, err := translator.createTracingConfig()
 	assert.NoError(t, err)
-	assert.NotNil(t, tracingCfg)
+	require.NotNil(t, tracingCfg)
+	assert.True(t, tracingCfg.GetSpawnUpstreamSpan().GetValue())
+
+	otelConfig := &tracev3.OpenTelemetryConfig{}
+	err = tracingCfg.GetProvider().GetTypedConfig().UnmarshalTo(otelConfig)
+	require.NoError(t, err)
+	assert.Equal(t, "test-service", otelConfig.GetServiceName())
+	require.Len(t, otelConfig.GetResourceDetectors(), 1)
+	assert.Equal(t, "envoy.tracers.opentelemetry.resource_detectors.environment",
+		otelConfig.GetResourceDetectors()[0].GetName())
+
+	envDetector := &otelresourcedetectorsv3.EnvironmentResourceDetectorConfig{}
+	err = otelConfig.GetResourceDetectors()[0].GetTypedConfig().UnmarshalTo(envDetector)
+	require.NoError(t, err)
 }
 
 func TestTranslator_CreateOTELCollectorCluster(t *testing.T) {

--- a/kubernetes/helm/gateway-helm-chart/templates/gateway/gateway-runtime/deployment.yaml
+++ b/kubernetes/helm/gateway-helm-chart/templates/gateway/gateway-runtime/deployment.yaml
@@ -97,6 +97,10 @@ spec:
             - name: MOESIF_KEY
               value: {{ $deployment.env.moesifKey | quote }}
             {{- end }}
+            {{- if $deployment.env.otelResourceAttributes }}
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: {{ $deployment.env.otelResourceAttributes | quote }}
+            {{- end }}
             {{- range $deployment.extraEnv }}
             - {{- toYaml . | nindent 14 }}
             {{- end }}

--- a/kubernetes/helm/gateway-helm-chart/values.yaml
+++ b/kubernetes/helm/gateway-helm-chart/values.yaml
@@ -995,6 +995,10 @@ gateway:
         gatewayControllerHost: ""
         logLevel: info
         moesifKey: ""
+        # OpenTelemetry resource attributes read by Envoy's environment resource detector
+        # when tracing is enabled. Only injected when non-empty.
+        # Example: "deployment.environment=prod,service.namespace=api-gw"
+        otelResourceAttributes: ""
       extraEnv: []
       # extraEnvFrom:
       #   - configMapRef:


### PR DESCRIPTION
## Purpose
When tracing is enabled, Envoy did not use the OpenTelemetry environment resource detector, so OTEL_RESOURCE_ATTRIBUTES on the gateway-runtime pod was ignored. That meant router spans could not carry deployment.environment (and similar resource attributes) needed to tag/filter traces by environment in backends like Datadog.

**Changes**
Configure Envoy’s environment resource detector whenever gateway tracing is enabled.
Optionally inject OTEL_RESOURCE_ATTRIBUTES via Helm when otelResourceAttributes is set.
Document how to set the env var on gateway-runtime.

**Why this matters**
Without this, environment must be inferred from other tags or is missing entirely. With it, setting e.g. OTEL_RESOURCE_ATTRIBUTES=deployment.environment=test on the runtime pod attaches that environment to Envoy spans. If the env var is unset, behavior is unchanged.

## Approach
Envoy ignored `OTEL_RESOURCE_ATTRIBUTES`, so router spans could not carry `deployment.environment` (and similar) for backends like Datadog.

When tracing is enabled, configure Envoy’s OpenTelemetry **environment resource detector**. It reads `OTEL_RESOURCE_ATTRIBUTES` from the gateway-runtime process and attaches those resource attributes to exported spans. Unset env var = no-op.

Helm optionally injects the env var via `gateway.gatewayRuntime.deployment.env.otelResourceAttributes`.

## Documentation
Added

## Automation tests
Added


## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
Added

## Related PRs
N/A

