### PR TITLE
Fix helm chart release version and name of the workflow for umbrella charts

### DIFF
--- a/.github/workflows/ai-workspace-helm-release.yml
+++ b/.github/workflows/ai-workspace-helm-release.yml
@@ -1,4 +1,4 @@
-name: Release AI Workspace Umbrella Helm Chart
+name: Release AI Workspace Helm Chart
 
 # Publishes the AI Workspace product umbrella (Platform API + AI Workspace UI) to
 # GHCR as an OCI artifact. Its component dependencies reference the OCI registry

--- a/.github/workflows/developer-portal-helm-release.yml
+++ b/.github/workflows/developer-portal-helm-release.yml
@@ -1,4 +1,4 @@
-name: Release Developer Portal Umbrella Helm Chart
+name: Release Developer Portal Helm Chart
 
 # Publishes the Developer Portal product umbrella (Platform API + Developer Portal
 # UI) to GHCR as an OCI artifact. Its component dependencies reference the OCI

--- a/kubernetes/helm/ai-workspace-helm-chart/Chart.yaml
+++ b/kubernetes/helm/ai-workspace-helm-chart/Chart.yaml
@@ -6,8 +6,8 @@ description: >-
   profile is the shared Platform API control plane plus the AI Workspace UI. Each
   component is a separately-released chart pulled as an OCI dependency; add other
   components (e.g. the Developer Portal) later by appending a dependency.
-version: 1.0.0-alpha2
-appVersion: "1.0.0-alpha2"
+version: 1.0.0-alpha
+appVersion: "1.0.0-alpha"
 type: application
 home: https://github.com/wso2/api-platform
 sources:

--- a/kubernetes/helm/developer-portal-helm-chart/Chart.yaml
+++ b/kubernetes/helm/developer-portal-helm-chart/Chart.yaml
@@ -6,8 +6,8 @@ description: >-
   default profile is the shared Platform API control plane plus the Developer
   Portal. Each component is a separately-released chart pulled as an OCI
   dependency; add other components (e.g. AI Workspace) later by appending a dependency.
-version: 1.0.0-alpha2
-appVersion: "1.0.0-alpha2"
+version: 1.0.0-alpha
+appVersion: "1.0.0-alpha"
 type: application
 home: https://github.com/wso2/api-platform
 sources:


### PR DESCRIPTION
This pull request updates the Helm chart release workflows and chart metadata for both the AI Workspace and Developer Portal. The changes mainly focus on standardizing chart names and resetting the version numbers to the initial alpha release.

**Helm Chart Metadata Updates:**

* [`kubernetes/helm/ai-workspace-helm-chart/Chart.yaml`](diffhunk://#diff-493619037cdd1f3f8b14bd565c95b375da16d4d910013cc5e4eb388e5b60bd27L9-R10): Reset `version` and `appVersion` from `1.0.0-alpha2` to `1.0.0-alpha` to reflect the initial alpha release.
* [`kubernetes/helm/developer-portal-helm-chart/Chart.yaml`](diffhunk://#diff-e50d5f40da32e06cb2bedb6076e0b425b6c89e77300da6a543e0ad0f66435aa3L9-R10): Reset `version` and `appVersion` from `1.0.0-alpha2` to `1.0.0-alpha`.

**Workflow Naming Standardization:**

* [`.github/workflows/ai-workspace-helm-release.yml`](diffhunk://#diff-c23f81932383a23cc37973bcc1c293e76c4bd5dddc5a8b4f7ff29acccdceacb4L1-R1): Renamed workflow from "Release AI Workspace Umbrella Helm Chart" to "Release AI Workspace Helm Chart" for consistency.
* [`.github/workflows/developer-portal-helm-release.yml`](diffhunk://#diff-dcc0719f05cfd7965f5302ecd25e0d7a7780a8b63f24225eded7e5d373ea98a6L1-R1): Renamed workflow from "Release Developer Portal Umbrella Helm Chart" to "Release Developer Portal Helm Chart".