### PR TITLE
Change image tag to '1.2.0-beta' for gateway components

### DIFF
--- a/kubernetes/helm/gateway-helm-chart/Chart.yaml
+++ b/kubernetes/helm/gateway-helm-chart/Chart.yaml
@@ -3,7 +3,7 @@ name: gateway
 kubeVersion: ">=1.24.0-0"
 description: Helm chart for deploying the Gateway Operator components
 version: 1.2.0-beta
-appVersion: "1.2.0-beta-SNAPSHOT"
+appVersion: "1.2.0-beta"
 type: application
 home: https://github.com/wso2/api-platform
 sources:

--- a/kubernetes/helm/gateway-helm-chart/values.yaml
+++ b/kubernetes/helm/gateway-helm-chart/values.yaml
@@ -672,7 +672,7 @@ gateway:
   controller:
     image:
       repository: ghcr.io/wso2/api-platform/gateway-controller
-      tag: "1.2.0-beta-SNAPSHOT"
+      tag: "1.2.0-beta"
       pullPolicy: Always
     imagePullSecrets: []
     service:
@@ -934,7 +934,7 @@ gateway:
   gatewayRuntime:
     image:
       repository: ghcr.io/wso2/api-platform/gateway-runtime
-      tag: "1.2.0-beta-SNAPSHOT"
+      tag: "1.2.0-beta"
       pullPolicy: Always
     imagePullSecrets: []
     service:


### PR DESCRIPTION
Updated the image tag for the gateway controller and runtime from '1.2.0-beta-SNAPSHOT' to '1.2.0-beta'.
