### PR TITLE
Show full version in Gateway manifest

### DIFF
--- a/portals/ai-workspace/src/Components/GatewayDeploy/GatewayDeployEnvCard.tsx
+++ b/portals/ai-workspace/src/Components/GatewayDeploy/GatewayDeployEnvCard.tsx
@@ -11,13 +11,17 @@
  * associated services.
  */
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Box, Button, IconButton, Typography } from '@wso2/oxygen-ui';
 import { SquarePen } from 'lucide-react';
 import { useGatewayDeploy } from '../../contexts/GatewayDeployContext';
 import GatewayDeploymentSelector from './GatewayDeploymentSelector';
 import { HybridGateway } from '../../apis/gateway/types';
 import NoData from '../../assets/images/NoData.svg';
+import {
+  getActiveColorScheme,
+  subscribeToColorSchemeChanges,
+} from '../../utils/colorScheme';
 
 const STATUS_REASON_MESSAGES: Record<string, string> = {
   GATEWAY_PROCESSING_ERROR: 'Failed to process deployment. Please check gateway logs.',
@@ -50,6 +54,13 @@ export default function GatewayDeployEnvCard({
   const isThisGatewayDeploying = deployingGatewayId === gateway.id;
   const isPolling = isPollingGateway(gateway.id);
   const [selectorOpen, setSelectorOpen] = useState(false);
+  const [activeColorScheme, setActiveColorScheme] = useState(
+    getActiveColorScheme,
+  );
+
+  useEffect(() => {
+    return subscribeToColorSchemeChanges(setActiveColorScheme);
+  }, []);
 
   // Compute current deployment for this gateway
   const { currentDeployment, deploymentStatus } = useMemo(() => {
@@ -236,17 +247,29 @@ export default function GatewayDeployEnvCard({
           py: 1.5,
           mb: (isFailed && currentDeployment?.statusReason) ? 0 : 2,
           borderRadius: 1,
-          bgcolor: isNotActive
-            ? 'grey.100'
-            : isDeployed
-              ? 'rgba(46, 125, 50, 0.08)'
-              : isUndeployed
-                ? 'grey.100'
-                : (isDeploying || isUndeploying)
-                  ? 'rgba(237, 108, 2, 0.08)'
-                  : isFailed
-                    ? 'rgba(211, 47, 47, 0.08)'
-                    : 'action.hover',
+          bgcolor: (theme) => {
+            const isDarkMode = activeColorScheme === 'dark';
+
+            if (isNotActive || isUndeployed) {
+              return isDarkMode ? 'rgba(255, 255, 255, 0.12)' : theme.palette.grey[100];
+            }
+            if (isDeployed) {
+              return isDarkMode
+                ? 'rgba(46, 125, 50, 0.24)'
+                : 'rgba(46, 125, 50, 0.08)';
+            }
+            if (isDeploying || isUndeploying) {
+              return isDarkMode
+                ? 'rgba(237, 108, 2, 0.20)'
+                : 'rgba(237, 108, 2, 0.08)';
+            }
+            if (isFailed) {
+              return isDarkMode
+                ? 'rgba(211, 47, 47, 0.20)'
+                : 'rgba(211, 47, 47, 0.08)';
+            }
+            return theme.palette.action.hover;
+          },
         }}
       >
         <Typography variant="body2" sx={{ fontWeight: 600 }}>
@@ -257,11 +280,11 @@ export default function GatewayDeployEnvCard({
           sx={{
             fontWeight: 600,
             color: isNotActive
-              ? '#7E7E7E'
+              ? 'text.secondary'
               : isDeployed
                 ? 'success.main'
                 : isUndeployed
-                  ? '#7E7E7E'
+                  ? 'text.secondary'
                   : (isDeploying || isUndeploying)
                     ? 'warning.main'
                     : isFailed

--- a/portals/ai-workspace/src/contexts/GatewayPoliciesContext.tsx
+++ b/portals/ai-workspace/src/contexts/GatewayPoliciesContext.tsx
@@ -22,7 +22,6 @@ export type GatewayPolicyRow = {
   policyName: string;
   name: string;
   version: string;
-  displayVersion: string;
   description: string;
   policyType: "Policy Hub" | "Custom";
   syncStatus: "N/A" | "Synced" | "Not synced";
@@ -41,7 +40,6 @@ type GatewayPoliciesContextValue = {
 const GatewayPoliciesContext = createContext<GatewayPoliciesContextValue | null>(null);
 
 const normalizedVersion = (version: string) => version.replace(/^v/i, "");
-const displayVersion = (version: string) => normalizedVersion(version).split(".")[0];
 const policyKey = (name: string, version: string) =>
   `${name.trim().toLowerCase()}@${normalizedVersion(version)}`;
 const isCustomManifestPolicy = (policy: GatewayManifestPolicy) => {
@@ -75,7 +73,6 @@ function mergePolicies(
       // Keep the controller-reported value (for example, "v1.0.0") for API
       // calls because SyncCustomPolicy matches the stored manifest version.
       version: policy.version,
-      displayVersion: displayVersion(policy.version),
       description: policy.description || hubPolicy?.description || "—",
       policyType: isCustomPolicy ? "Custom" : "Policy Hub",
       syncStatus: isCustomPolicy ? (syncedPolicy ? "Synced" : "Not synced") : "N/A",

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/gateways/GatewayPolicies.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/gateways/GatewayPolicies.tsx
@@ -117,7 +117,7 @@ export default function GatewayPolicies() {
               </TableCell>
               <TableCell>
                 <Chip
-                  label={`v${policy.displayVersion}`}
+                  label={policy.version}
                   size="small"
                   variant="outlined"
                   sx={{ minWidth: 72 }}


### PR DESCRIPTION
This pull request introduces improvements to the `GatewayDeployEnvCard` component for better dark mode support and simplifies the policy version handling in the gateway policies context and UI. The most important changes are grouped below:

Issue: https://github.com/wso2/api-platform/issues/2929

<img width="1560" height="519" alt="Screenshot 2026-07-28 at 12 59 37" src="https://github.com/user-attachments/assets/b8414a70-3332-40c8-9501-2837cfc3208e" />


**Dark Mode Support Enhancements:**

* Updated the `GatewayDeployEnvCard` component to dynamically adjust background colors and text colors based on the current color scheme (light or dark mode), using new utility functions and React state. This ensures better visual consistency and accessibility in dark mode. [[1]](diffhunk://#diff-02d25f59a0a0ed1bbe34413f475352eedc6f25f150adede4825dd3e224837410L14-R24) [[2]](diffhunk://#diff-02d25f59a0a0ed1bbe34413f475352eedc6f25f150adede4825dd3e224837410R57-R63) [[3]](diffhunk://#diff-02d25f59a0a0ed1bbe34413f475352eedc6f25f150adede4825dd3e224837410L239-R272) [[4]](diffhunk://#diff-02d25f59a0a0ed1bbe34413f475352eedc6f25f150adede4825dd3e224837410L260-R287)

**Gateway Policy Version Handling Simplification:**

* Removed the `displayVersion` field from the `GatewayPolicyRow` type and related logic, now consistently using the full `version` string throughout the codebase. [[1]](diffhunk://#diff-8719d7783c4285bbffb305300f1efcd54d791ba3c7f5ed9d5e5c97af145d6902L25) [[2]](diffhunk://#diff-8719d7783c4285bbffb305300f1efcd54d791ba3c7f5ed9d5e5c97af145d6902L44) [[3]](diffhunk://#diff-8719d7783c4285bbffb305300f1efcd54d791ba3c7f5ed9d5e5c97af145d6902L78) [[4]](diffhunk://#diff-845525bb575790af418c5d5f630b1955670ca080e9a7eaa0bddab1e14a56f17cL120-R120)

These changes improve maintainability and user experience, especially for users working in dark mode and when viewing policy versions.