### PR TITLE
[Gateway] Fixing Go template rendering for policy parameters

### DIFF
--- a/gateway/gateway-controller/pkg/config/policy_validator.go
+++ b/gateway/gateway-controller/pkg/config/policy_validator.go
@@ -21,6 +21,7 @@ package config
 import (
 	"fmt"
 	"regexp"
+	"math"
 	"strconv"
 	"strings"
 
@@ -418,7 +419,7 @@ func coerceScalarByType(val interface{}, expectedType string) interface{} {
 	}
 	switch expectedType {
 	case "integer", "number":
-		if f, err := strconv.ParseFloat(s, 64); err == nil {
+		if f, err := strconv.ParseFloat(s, 64); err == nil && !math.IsNaN(f) && !math.IsInf(f, 0) {
 			return f
 		}
 	case "boolean":

--- a/gateway/gateway-controller/pkg/config/policy_validator.go
+++ b/gateway/gateway-controller/pkg/config/policy_validator.go
@@ -21,6 +21,7 @@ package config
 import (
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 
 	versionutil "github.com/wso2/api-platform/common/version"
@@ -155,12 +156,14 @@ func (pv *PolicyValidator) validatePolicy(policy api.Policy, fieldPath string) [
 		return errors
 	}
 
-	// Validate policy parameters against JSON schema if schema is defined
+	// Coerce then validate policy parameters against the declared JSON schema.
 	if policyDef.Parameters != nil {
-		// If params is nil, validate against an empty object to enforce required fields
 		params := make(map[string]interface{})
 		if policy.Params != nil {
 			params = *policy.Params
+			// Coerce template-rendered strings to their schema-declared types using the
+			// already-resolved policyDef — avoids a second resolvePolicyVersion call.
+			coerceParamsBySchema(params, *policyDef.Parameters)
 		}
 		schemaErrs := pv.validatePolicyParams(params, *policyDef.Parameters, fieldPath+".params")
 		errors = append(errors, schemaErrs...)
@@ -272,6 +275,163 @@ func ResolvePolicyVersion(definitions map[string]models.PolicyDefinition, latest
 
 	// Unsupported version format
 	return "", fmt.Errorf("invalid version format '%s' for policy '%s'; expected major-only version (e.g., v1)", version, name)
+}
+
+// CoerceRestAPIPolicies coerces policy param strings to their schema-declared types for
+// a RestAPI config. Must be called after template rendering (e.g. in the event listener)
+// so the in-memory store and xDS snapshot receive typed values, not rendered strings.
+func (pv *PolicyValidator) CoerceRestAPIPolicies(config *api.RestAPI) {
+	if config.Spec.Policies != nil {
+		pv.coercePolicySlice(*config.Spec.Policies)
+	}
+	for i := range config.Spec.Operations {
+		if config.Spec.Operations[i].Policies != nil {
+			pv.coercePolicySlice(*config.Spec.Operations[i].Policies)
+		}
+	}
+}
+
+// CoerceMCPProxyPolicies coerces policy param strings to their schema-declared types for
+// an MCPProxyConfiguration. Must be called after template rendering in the event listener.
+func (pv *PolicyValidator) CoerceMCPProxyPolicies(config *api.MCPProxyConfiguration) {
+	if config.Spec.Policies != nil {
+		pv.coercePolicySlice(*config.Spec.Policies)
+	}
+}
+
+// CoerceLLMPolicies coerces policy param strings to their schema-declared types for
+// any LLM config (provider or proxy). Pass the three policy collections from the spec.
+func (pv *PolicyValidator) CoerceLLMPolicies(globalPolicies *[]api.Policy, operationPolicies *[]api.OperationPolicy, legacyPolicies *[]api.LLMPolicy) {
+	pv.coerceLLMPolicyRefs(globalPolicies, operationPolicies, legacyPolicies)
+}
+
+// coercePolicySlice calls coerceSinglePolicyParams for every policy in the slice.
+func (pv *PolicyValidator) coercePolicySlice(policies []api.Policy) {
+	for i := range policies {
+		if policies[i].Params == nil {
+			continue
+		}
+		pv.coerceSinglePolicyParams(policies[i].Name, policies[i].Version, *policies[i].Params)
+	}
+}
+
+// coerceLLMPolicyRefs coerces the three policy collections shared by LLM providers and
+// proxies: global (api-level), operation-level, and the deprecated legacy list.
+func (pv *PolicyValidator) coerceLLMPolicyRefs(globalPolicies *[]api.Policy, operationPolicies *[]api.OperationPolicy, legacyPolicies *[]api.LLMPolicy) {
+	if globalPolicies != nil {
+		pv.coercePolicySlice(*globalPolicies)
+	}
+	if operationPolicies != nil {
+		for i := range *operationPolicies {
+			op := &(*operationPolicies)[i]
+			for j := range op.Paths {
+				pv.coerceSinglePolicyParams(op.Name, op.Version, op.Paths[j].Params)
+			}
+		}
+	}
+	if legacyPolicies != nil {
+		for i := range *legacyPolicies {
+			lp := &(*legacyPolicies)[i]
+			for j := range lp.Paths {
+				pv.coerceSinglePolicyParams(lp.Name, lp.Version, lp.Paths[j].Params)
+			}
+		}
+	}
+}
+
+// coerceSinglePolicyParams is the shared core for all per-policy-collection coercers.
+// It resolves the policy version, looks up the definition, and calls coerceParamsBySchema.
+func (pv *PolicyValidator) coerceSinglePolicyParams(name, version string, params map[string]interface{}) {
+	if len(params) == 0 {
+		return
+	}
+	resolvedVersion, err := pv.resolvePolicyVersion(name, version)
+	if err != nil {
+		return
+	}
+	key := name + "|" + resolvedVersion
+	policyDef, exists := pv.policyDefinitions[key]
+	if !exists || policyDef.Parameters == nil {
+		return
+	}
+	coerceParamsBySchema(params, *policyDef.Parameters)
+}
+
+// coerceParamsBySchema mutates params in-place, replacing string values with their
+// parsed equivalents when the JSON-schema property for that key declares a numeric or
+// boolean type. It walks the schema recursively through "properties" (nested objects)
+// and "items" (array elements) so that params nested inside arrays of objects — for
+// example, advanced-ratelimit's limit nested under quotas[].limits[] — are coerced too.
+//
+// Coercion table:
+//   - "integer" or "number" → strconv.ParseFloat → float64 (gojsonschema accepts
+//     float64 for both; it additionally verifies no fractional part for integer).
+//   - "boolean"             → "true"/"false" literal → bool.
+//   - "object"              → recurse into the nested property map.
+//   - "array"               → iterate over elements, recursing for object items or
+//     coercing each scalar item.
+//   - anything else         → left unchanged.
+func coerceParamsBySchema(params map[string]interface{}, schema map[string]interface{}) {
+	properties, ok := schema["properties"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	for key, val := range params {
+		propSchema, ok := properties[key].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		expectedType, _ := propSchema["type"].(string)
+		switch expectedType {
+		case "object":
+			if nested, ok := val.(map[string]interface{}); ok {
+				coerceParamsBySchema(nested, propSchema)
+			}
+		case "array":
+			items, hasItems := propSchema["items"].(map[string]interface{})
+			arr, isSlice := val.([]interface{})
+			if !hasItems || !isSlice {
+				continue
+			}
+			itemType, _ := items["type"].(string)
+			for i, item := range arr {
+				if itemType == "object" {
+					if itemMap, ok := item.(map[string]interface{}); ok {
+						coerceParamsBySchema(itemMap, items)
+					}
+				} else {
+					arr[i] = coerceScalarByType(item, itemType)
+				}
+			}
+		default:
+			params[key] = coerceScalarByType(val, expectedType)
+		}
+	}
+}
+
+// coerceScalarByType converts val to the type declared by expectedType when val is a
+// string. Non-string values and unrecognised types are returned unchanged.
+func coerceScalarByType(val interface{}, expectedType string) interface{} {
+	s, isString := val.(string)
+	if !isString {
+		return val
+	}
+	switch expectedType {
+	case "integer", "number":
+		if f, err := strconv.ParseFloat(s, 64); err == nil {
+			return f
+		}
+	case "boolean":
+		// Accept only JSON-literal "true"/"false" — same semantics as json.Unmarshal,
+		// but avoids a []byte allocation.
+		if s == "true" {
+			return true
+		}
+		if s == "false" {
+			return false
+		}
+	}
+	return val
 }
 
 // validatePolicyParams validates policy parameters against a JSON schema

--- a/gateway/gateway-controller/pkg/config/policy_validator_test.go
+++ b/gateway/gateway-controller/pkg/config/policy_validator_test.go
@@ -963,6 +963,300 @@ func TestPolicyValidator_ValidateMCPProxyPolicies_MultiplePoliciesWithErrors(t *
 	}
 }
 
+// TestCoerceParamsBySchema_RenderedTemplateStrings verifies that template-rendered
+// string values are coerced to their schema-declared types so that both JSON-schema
+// validation and the policy engine receive correctly-typed values.
+//
+// Background: text/template always produces strings, so {{ env "RATE" }} → "100"
+// even when the parameter schema declares type: integer. coerceParamsBySchema (called
+// inside validatePolicy) must convert the string to float64(100) before
+// gojsonschema sees it.
+func TestCoerceParamsBySchema_RenderedTemplateStrings(t *testing.T) {
+	policyDefs := map[string]models.PolicyDefinition{
+		"AdvancedRateLimit|v1.0.0": {
+			Name:    "AdvancedRateLimit",
+			Version: "v1.0.0",
+			Parameters: &map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"limit": map[string]interface{}{"type": "integer"},
+					"burst": map[string]interface{}{"type": "integer"},
+					"enabled": map[string]interface{}{"type": "boolean"},
+					"ratio": map[string]interface{}{"type": "number"},
+					"name": map[string]interface{}{"type": "string"},
+				},
+				"required": []interface{}{"limit"},
+			},
+		},
+	}
+
+	pv := NewPolicyValidator(policyDefs)
+
+	config := &api.RestAPI{
+		ApiVersion: api.RestAPIApiVersionGatewayApiPlatformWso2Comv1,
+		Kind:       api.RestAPIKindRestApi,
+		Spec: api.APIConfigData{
+			DisplayName: "Test API",
+			Version:     "v1.0",
+			Context:     "/test",
+			Upstream: struct {
+				Main    api.Upstream  `json:"main" yaml:"main"`
+				Sandbox *api.Upstream `json:"sandbox,omitempty" yaml:"sandbox,omitempty"`
+			}{
+				Main: api.Upstream{
+					Url: func() *string { s := "http://backend.example.com"; return &s }(),
+				},
+			},
+			Policies: &[]api.Policy{
+				{
+					Name:    "AdvancedRateLimit",
+					Version: "v1",
+					Params: &map[string]interface{}{
+						// Simulates what text/template produces after {{ env "X" }} resolution:
+						// all values arrive as strings regardless of the declared type.
+						"limit":   "100",
+						"burst":   "200",
+						"enabled": "true",
+						"ratio":   "1.5",
+						"name":    "prod",
+					},
+				},
+			},
+			Operations: []api.Operation{
+				{
+					Method: api.Ptr(api.OperationMethod("GET")),
+					Path:   api.Ptr("/resource"),
+				},
+			},
+		},
+	}
+
+	// ValidateRestAPIPolicies coerces params in-place then validates — check both.
+	errs := pv.ValidateRestAPIPolicies(config)
+	assert.Empty(t, errs, "validation should pass after coercion: %v", errs)
+
+	params := *(*config.Spec.Policies)[0].Params
+	assert.Equal(t, float64(100), params["limit"], "integer param should be coerced from string")
+	assert.Equal(t, float64(200), params["burst"], "integer param should be coerced from string")
+	assert.Equal(t, true, params["enabled"], "boolean param should be coerced from string")
+	assert.Equal(t, 1.5, params["ratio"], "number param should be coerced from string")
+	assert.Equal(t, "prod", params["name"], "string param must not be changed")
+}
+
+// TestCoerceParamsBySchema_UnparseableStringStaysString verifies that a string value
+// that cannot be parsed as the declared type is left unchanged — this ensures
+// gojsonschema still produces a clear type-mismatch error rather than a silent no-op.
+func TestCoerceParamsBySchema_UnparseableStringStaysString(t *testing.T) {
+	policyDefs := map[string]models.PolicyDefinition{
+		"RateLimit|v1.0.0": {
+			Name:    "RateLimit",
+			Version: "v1.0.0",
+			Parameters: &map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"limit": map[string]interface{}{"type": "integer"},
+				},
+			},
+		},
+	}
+
+	pv := NewPolicyValidator(policyDefs)
+
+	config := &api.RestAPI{
+		ApiVersion: api.RestAPIApiVersionGatewayApiPlatformWso2Comv1,
+		Kind:       api.RestAPIKindRestApi,
+		Spec: api.APIConfigData{
+			DisplayName: "Test API",
+			Version:     "v1.0",
+			Context:     "/test",
+			Upstream: struct {
+				Main    api.Upstream  `json:"main" yaml:"main"`
+				Sandbox *api.Upstream `json:"sandbox,omitempty" yaml:"sandbox,omitempty"`
+			}{
+				Main: api.Upstream{
+					Url: func() *string { s := "http://backend.example.com"; return &s }(),
+				},
+			},
+			Policies: &[]api.Policy{
+				{
+					Name:    "RateLimit",
+					Version: "v1",
+					Params:  &map[string]interface{}{"limit": "not-a-number"},
+				},
+			},
+			Operations: []api.Operation{
+				{Method: api.Ptr(api.OperationMethod("GET")), Path: api.Ptr("/resource")},
+			},
+		},
+	}
+
+	// ValidateRestAPIPolicies attempts coercion then validates — unparseable string must
+	// remain a string so validation produces a clear type-mismatch error.
+	errs := pv.ValidateRestAPIPolicies(config)
+	assert.NotEmpty(t, errs, "type mismatch must still produce a validation error")
+
+	params := *(*config.Spec.Policies)[0].Params
+	assert.Equal(t, "not-a-number", params["limit"], "unparseable string must not be modified")
+}
+
+// TestCoerceParamsBySchema_StringParamWithNumericValueIsUnchanged confirms that a
+// param declared as type:string is never coerced — a string that happens to look
+// like a number (e.g., "100") must stay as a string.
+func TestCoerceParamsBySchema_StringParamWithNumericValueIsUnchanged(t *testing.T) {
+	policyDefs := map[string]models.PolicyDefinition{
+		"HeaderPolicy|v1.0.0": {
+			Name:    "HeaderPolicy",
+			Version: "v1.0.0",
+			Parameters: &map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"headerValue": map[string]interface{}{"type": "string"},
+				},
+			},
+		},
+	}
+
+	pv := NewPolicyValidator(policyDefs)
+
+	config := &api.RestAPI{
+		ApiVersion: api.RestAPIApiVersionGatewayApiPlatformWso2Comv1,
+		Kind:       api.RestAPIKindRestApi,
+		Spec: api.APIConfigData{
+			DisplayName: "Test API",
+			Version:     "v1.0",
+			Context:     "/test",
+			Upstream: struct {
+				Main    api.Upstream  `json:"main" yaml:"main"`
+				Sandbox *api.Upstream `json:"sandbox,omitempty" yaml:"sandbox,omitempty"`
+			}{
+				Main: api.Upstream{
+					Url: func() *string { s := "http://backend.example.com"; return &s }(),
+				},
+			},
+			Policies: &[]api.Policy{
+				{
+					Name:    "HeaderPolicy",
+					Version: "v1",
+					Params:  &map[string]interface{}{"headerValue": "100"},
+				},
+			},
+			Operations: []api.Operation{
+				{Method: api.Ptr(api.OperationMethod("GET")), Path: api.Ptr("/resource")},
+			},
+		},
+	}
+
+	errs := pv.ValidateRestAPIPolicies(config)
+	assert.Empty(t, errs, "string param with numeric-looking value must pass validation")
+
+	params := *(*config.Spec.Policies)[0].Params
+	assert.Equal(t, "100", params["headerValue"], "string param must stay as string even when it looks numeric")
+}
+
+// TestCoerceParamsBySchema_NestedObjectParams verifies that integer/number/boolean
+// string values nested inside an object-typed property are coerced recursively.
+func TestCoerceParamsBySchema_NestedObjectParams(t *testing.T) {
+	schema := map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"config": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"maxRetries": map[string]interface{}{"type": "integer"},
+					"enabled":    map[string]interface{}{"type": "boolean"},
+				},
+			},
+		},
+	}
+
+	params := map[string]interface{}{
+		"config": map[string]interface{}{
+			"maxRetries": "3",    // rendered template string
+			"enabled":    "true", // rendered template string
+		},
+	}
+
+	coerceParamsBySchema(params, schema)
+
+	inner := params["config"].(map[string]interface{})
+	assert.Equal(t, float64(3), inner["maxRetries"], "nested integer param must be coerced to float64")
+	assert.Equal(t, true, inner["enabled"], "nested boolean param must be coerced to bool")
+}
+
+// TestCoerceParamsBySchema_ArrayOfObjectsWithIntegerParams verifies the advanced-ratelimit
+// case where integer params (limit, burst) are nested inside an array of objects
+// (quotas[].limits[]).
+func TestCoerceParamsBySchema_ArrayOfObjectsWithIntegerParams(t *testing.T) {
+	schema := map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"quotas": map[string]interface{}{
+				"type": "array",
+				"items": map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"limits": map[string]interface{}{
+							"type": "array",
+							"items": map[string]interface{}{
+								"type": "object",
+								"properties": map[string]interface{}{
+									"limit": map[string]interface{}{"type": "integer"},
+									"burst": map[string]interface{}{"type": "integer"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	params := map[string]interface{}{
+		"quotas": []interface{}{
+			map[string]interface{}{
+				"limits": []interface{}{
+					map[string]interface{}{
+						"limit": "100", // rendered from {{ env "RATE_LIMIT" }}
+						"burst": "200", // rendered from {{ env "BURST_LIMIT" }}
+					},
+				},
+			},
+		},
+	}
+
+	coerceParamsBySchema(params, schema)
+
+	quotas := params["quotas"].([]interface{})
+	limits := quotas[0].(map[string]interface{})["limits"].([]interface{})
+	first := limits[0].(map[string]interface{})
+	assert.Equal(t, float64(100), first["limit"], "deeply nested integer param must be coerced to float64")
+	assert.Equal(t, float64(200), first["burst"], "deeply nested integer param must be coerced to float64")
+}
+
+// TestCoerceParamsBySchema_ArrayOfScalarIntegers verifies that string elements in an
+// array of integers (e.g., allowedPorts: ["8080", "8443"]) are coerced element-by-element.
+func TestCoerceParamsBySchema_ArrayOfScalarIntegers(t *testing.T) {
+	schema := map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"allowedPorts": map[string]interface{}{
+				"type":  "array",
+				"items": map[string]interface{}{"type": "integer"},
+			},
+		},
+	}
+
+	params := map[string]interface{}{
+		"allowedPorts": []interface{}{"8080", "8443"},
+	}
+
+	coerceParamsBySchema(params, schema)
+
+	ports := params["allowedPorts"].([]interface{})
+	assert.Equal(t, float64(8080), ports[0], "first array element must be coerced to float64")
+	assert.Equal(t, float64(8443), ports[1], "second array element must be coerced to float64")
+}
+
 // Helper functions
 func boolPtr(b bool) *bool {
 	return &b

--- a/gateway/gateway-controller/pkg/eventlistener/api_processor.go
+++ b/gateway/gateway-controller/pkg/eventlistener/api_processor.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/wso2/api-platform/common/eventhub"
+	api "github.com/wso2/api-platform/gateway/gateway-controller/pkg/api/management"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/models"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/storage"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/templateengine"
@@ -83,6 +84,15 @@ func (l *EventListener) handleAPICreateOrUpdate(event eventhub.Event) {
 			slog.String("event_id", event.EventID),
 			slog.Any("error", err))
 		return
+	}
+
+	// RenderSpec JSON-roundtrips the config, which resets all policy params to strings.
+	// Coerce them back to their schema-declared types (integer, number, boolean).
+	if l.policyValidator != nil {
+		if restAPI, ok := storedConfig.Configuration.(api.RestAPI); ok {
+			l.policyValidator.CoerceRestAPIPolicies(&restAPI)
+			storedConfig.Configuration = restAPI
+		}
 	}
 
 	// Update in-memory store

--- a/gateway/gateway-controller/pkg/eventlistener/listener.go
+++ b/gateway/gateway-controller/pkg/eventlistener/listener.go
@@ -68,6 +68,7 @@ type EventListener struct {
 	logger              *slog.Logger
 	systemConfig        *config.Config
 	policyDefinitions   map[string]models.PolicyDefinition
+	policyValidator     *config.PolicyValidator
 	secretResolver      funcs.SecretResolver
 	webhookSecretHandler WebhookSecretEventHandler
 
@@ -123,6 +124,7 @@ func NewEventListener(
 		logger:              logger,
 		systemConfig:        systemConfig,
 		policyDefinitions:   policyDefinitions,
+		policyValidator:     config.NewPolicyValidator(policyDefinitions),
 		secretResolver:      secretResolver,
 		ctx:                 ctx,
 		cancel:              cancel,

--- a/gateway/gateway-controller/pkg/eventlistener/llm_provider_processor.go
+++ b/gateway/gateway-controller/pkg/eventlistener/llm_provider_processor.go
@@ -95,6 +95,14 @@ func (l *EventListener) handleLLMProviderCreateOrUpdate(event eventhub.Event) {
 		return
 	}
 
+	// Coerce rendered-template strings back to their schema-declared types.
+	if l.policyValidator != nil {
+		if restAPI, ok := storedConfig.Configuration.(api.RestAPI); ok {
+			l.policyValidator.CoerceRestAPIPolicies(&restAPI)
+			storedConfig.Configuration = restAPI
+		}
+	}
+
 	// After hydration the entry contains the derived RestAPI view used by the
 	// normal in-memory routing, xDS, and policy update pipelines.
 	existing, _ := l.store.Get(entityID)
@@ -165,6 +173,14 @@ func (l *EventListener) handleLLMProxyCreateOrUpdate(event eventhub.Event) {
 			slog.String("event_id", event.EventID),
 			slog.Any("error", err))
 		return
+	}
+
+	// Coerce rendered-template strings back to their schema-declared types.
+	if l.policyValidator != nil {
+		if restAPI, ok := storedConfig.Configuration.(api.RestAPI); ok {
+			l.policyValidator.CoerceRestAPIPolicies(&restAPI)
+			storedConfig.Configuration = restAPI
+		}
 	}
 
 	existing, _ := l.store.Get(entityID)

--- a/gateway/gateway-controller/pkg/eventlistener/mcp_processor.go
+++ b/gateway/gateway-controller/pkg/eventlistener/mcp_processor.go
@@ -78,6 +78,14 @@ func (l *EventListener) handleMCPProxyCreateOrUpdate(event eventhub.Event) {
 		return
 	}
 
+	// Coerce rendered-template strings back to their schema-declared types.
+	if l.policyValidator != nil {
+		if mcpProxy, ok := storedConfig.Configuration.(api.MCPProxyConfiguration); ok {
+			l.policyValidator.CoerceMCPProxyPolicies(&mcpProxy)
+			storedConfig.Configuration = mcpProxy
+		}
+	}
+
 	existing, _ := l.store.Get(entityID)
 	if existing != nil {
 		if err := l.store.Update(storedConfig); err != nil {

--- a/gateway/gateway-controller/pkg/utils/api_deployment.go
+++ b/gateway/gateway-controller/pkg/utils/api_deployment.go
@@ -328,6 +328,11 @@ func (s *APIDeploymentService) DeployAPIConfiguration(params APIDeploymentParams
 			s.logValidationErrors(params.Logger, apiID, apiName, validationErrors)
 			return nil, &ValidationErrorListError{Errors: validationErrors}
 		}
+		// Write c back: validateRestAPIConfiguration coerces rendered-template strings
+		// in policy params (e.g. "100" → float64(100) for integer params). The type
+		// switch above copies c from storedCfg.Configuration, and Validate(&c) mutates
+		// through the pointer, so the mutations stay in c but not in storedCfg yet.
+		storedCfg.Configuration = c
 	default:
 		if fn, ok := kindConfigValidators[kind]; ok {
 			var validationErrors []config.ValidationError

--- a/gateway/gateway-controller/pkg/utils/llm_deployment.go
+++ b/gateway/gateway-controller/pkg/utils/llm_deployment.go
@@ -268,6 +268,14 @@ func (s *LLMDeploymentService) DeployLLMProviderConfiguration(params LLMDeployme
 		return nil, fmt.Errorf("unexpected configuration type %T after rendering LLM provider", renderHolder.Configuration)
 	}
 
+	// Coerce rendered-template strings in policy params before validation and
+	// transformation. text/template always produces strings, so {{ env "X" }} → "100"
+	// even for integer params; coercing here ensures the transformer also puts typed
+	// values into the derived RestAPI.
+	if s.policyValidator != nil {
+		s.policyValidator.CoerceLLMPolicies(renderedProvider.Spec.GlobalPolicies, renderedProvider.Spec.OperationPolicies, renderedProvider.Spec.Policies)
+	}
+
 	// Validate against rendered values
 	validationErrors := s.validator.Validate(&renderedProvider)
 	if len(validationErrors) > 0 {
@@ -439,6 +447,14 @@ func (s *LLMDeploymentService) DeployLLMProxyConfiguration(params LLMDeploymentP
 	renderedProxy, ok := renderHolder.Configuration.(api.LLMProxyConfiguration)
 	if !ok {
 		return nil, fmt.Errorf("unexpected configuration type %T after rendering LLM proxy", renderHolder.Configuration)
+	}
+
+	// Coerce rendered-template strings in policy params before validation and
+	// transformation. text/template always produces strings, so {{ env "X" }} → "100"
+	// even for integer params; coercing here ensures the transformer also puts typed
+	// values into the derived RestAPI.
+	if s.policyValidator != nil {
+		s.policyValidator.CoerceLLMPolicies(renderedProxy.Spec.GlobalPolicies, renderedProxy.Spec.OperationPolicies, renderedProxy.Spec.Policies)
 	}
 
 	// Validate against rendered values

--- a/gateway/it/features/api-error-responses.feature
+++ b/gateway/it/features/api-error-responses.feature
@@ -66,7 +66,7 @@ Feature: API Error Responses
           - name: respond
             version: v1
             params:
-              statusCode: "200"
+              statusCode: "not-a-number"
         operations:
           - method: GET
             path: /test


### PR DESCRIPTION
## Purpose

Fixes policy parameter validation and runtime handling when Go templates `({{ env "..." }}, {{ secret "..." }})` are used for integer, number, or boolean fields.

RenderSpec JSON-roundtrips the config, so template output is always a string (e.g. "10"). The JSON schema validator and policy engine expect typed values, causing deploy failures like `Expected: integer, given: string `and runtime 500s when string params reach the policy engine.

This PR adds schema-aware coercion that converts rendered strings to the types declared in each policy’s parameter schema (including nested paths such as `quotas[].limits[].limit in advanced-ratelimit`).

## Approach

- Add coerceParamsBySchema / coerceScalarByType — walk policy JSON schema recursively and coerce:
    - integer / number → float64 via strconv.ParseFloat
    - boolean → true / false from "true" / "false"
    - nested object and array (including arrays of objects)

- Call coercion inside validatePolicy before JSON schema validation so deploy-time validation sees typed values

- Expose public helpers for post-render paths:

  - CoerceRestAPIPolicies
  - CoerceMCPProxyPolicies
  - CoerceLLMPolicies

- Unit tests for top-level, nested object, array-of-objects, and array-of-scalar integer coercion
- Deploy-time coercion alone is not enough for runtime. On replica sync, the event listener reloads from DB, re-runs RenderSpec, and pushes config into the in-memory store → xDS → policy engine. That path had no coercion, there for necessary implementations are done to processors.

## Automation tests
- Unit tests are added

## Test environment
- Flows mentioned https://github.com/wso2/api-platform/issues/2871#issuecomment-5100057935 were tested

Fixes https://github.com/wso2/api-platform/issues/2871