### PR TITLE
fix(policy-engine): keep MCP response body mutations buffered, matching Envoy's negotiated mode

### DIFF
--- a/gateway/gateway-runtime/policy-engine/internal/kernel/execution_context.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/execution_context.go
@@ -196,9 +196,11 @@ func (ec *PolicyExecutionContext) handlePolicyError(
 }
 
 // getModeOverride returns the ProcessingMode override for this execution context.
-// Response body is always set to BUFFERED here (never FULL_DUPLEX_STREAMED).
-// The upgrade to streaming happens at response-headers phase via
-// getStreamingResponseModeOverride when a streaming upstream response is detected.
+// ec.isStreamingResponse is the single source of truth for whether the response body is
+// processed in streaming mode — it is set once in processResponseHeaders via
+// responseStreamingEnabled(), and this function must not re-derive that decision, or the
+// ModeOverride sent to Envoy could disagree with which body-phase handler actually runs
+// (see processResponseBody), which Envoy rejects as a content-length/body mismatch.
 func (ec *PolicyExecutionContext) getModeOverride() *extprocconfigv3.ProcessingMode {
 	mode := &extprocconfigv3.ProcessingMode{
 		ResponseHeaderMode: extprocconfigv3.ProcessingMode_SEND,
@@ -218,11 +220,7 @@ func (ec *PolicyExecutionContext) getModeOverride() *extprocconfigv3.ProcessingM
 	}
 
 	if ec.policyChain.RequiresResponseBody {
-		mode.ResponseBodyMode = extprocconfigv3.ProcessingMode_BUFFERED
-		if ec.isStreamingResponse && (ec.sharedCtx == nil || ec.sharedCtx.APIKind != policy.APIKindMCP) {
-			// Disable streaming for MCP APIs, as there is an issue with Envoy, when Upstream MCP server sends a Transfer Encoding Chunk
-			// response with empty body, Envoy is not sending a request to the Policy Engine.
-			// Hence skip MCP.
+		if ec.isStreamingResponse {
 			mode.ResponseBodyMode = extprocconfigv3.ProcessingMode_FULL_DUPLEX_STREAMED
 			slog.Debug("[mode] upgraded response body mode to FULL_DUPLEX_STREAMED",
 				"route", ec.routeKey,
@@ -640,18 +638,15 @@ func (ec *PolicyExecutionContext) processResponseHeaders(
 
 	// Detect streaming response: upgrade when chain supports streaming AND
 	// upstream signals chunked/SSE AND body is coming (not EndOfStream).
-	hasStreamingHeaders := isStreamingUpstreamResponse(ec.responseHeaderCtx.ResponseHeaders)
 	slog.Debug("[mode] response headers received — streaming detection",
 		"route", ec.routeKey,
 		"supports_response_streaming", ec.policyChain.SupportsResponseStreaming,
 		"headers_end_of_stream", headers.EndOfStream,
-		"streaming_headers_detected", hasStreamingHeaders,
+		"streaming_headers_detected", isStreamingUpstreamResponse(ec.responseHeaderCtx.ResponseHeaders),
 		"content_type", ec.responseHeaderCtx.ResponseHeaders.Get("content-type"),
 		"transfer_encoding", ec.responseHeaderCtx.ResponseHeaders.Get("transfer-encoding"),
 	)
-	if ec.policyChain.SupportsResponseStreaming && !headers.EndOfStream && hasStreamingHeaders {
-		ec.isStreamingResponse = true
-	}
+	ec.isStreamingResponse = ec.responseStreamingEnabled(headers.EndOfStream)
 	slog.Debug("[mode] streaming response decision",
 		"route", ec.routeKey,
 		"is_streaming_response", ec.isStreamingResponse,
@@ -1177,6 +1172,27 @@ func isStreamingUpstreamResponse(headers *policy.Headers) bool {
 		}
 	}
 	return false
+}
+
+// responseStreamingEnabled reports whether the response body should be processed in
+// streaming (FULL_DUPLEX_STREAMED) mode. This is the single source of truth: it decides
+// both the ModeOverride sent to Envoy (getModeOverride) and which body-phase handler runs
+// (processResponseBody), so the two can never disagree. Callable only once
+// responseHeaderCtx has been populated (i.e. from processResponseHeaders).
+func (ec *PolicyExecutionContext) responseStreamingEnabled(endOfStream bool) bool {
+	if !ec.policyChain.SupportsResponseStreaming || endOfStream {
+		return false
+	}
+	if !isStreamingUpstreamResponse(ec.responseHeaderCtx.ResponseHeaders) {
+		return false
+	}
+	// MCP is kept buffered: when an upstream MCP server sends a Transfer-Encoding: chunked
+	// response with an empty body, Envoy does not deliver the body phase to the policy
+	// engine in FULL_DUPLEX_STREAMED mode.
+	if ec.sharedCtx != nil && ec.sharedCtx.APIKind == policy.APIKindMCP {
+		return false
+	}
+	return true
 }
 
 // cloneHeaders returns an independent copy of h — both the map and every

--- a/gateway/gateway-runtime/policy-engine/internal/kernel/execution_context_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/execution_context_test.go
@@ -20,6 +20,7 @@ package kernel
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -196,6 +197,74 @@ func TestGetModeOverride_ResponseHeaderProcessing(t *testing.T) {
 
 	// Response header mode should still be SEND (optimization not implemented yet)
 	assert.Equal(t, extprocconfigv3.ProcessingMode_SEND, mode.ResponseHeaderMode)
+}
+
+// =============================================================================
+// responseStreamingEnabled / getModeOverride streaming-decision Tests
+//
+// Regression coverage: getModeOverride must derive ResponseBodyMode purely from ec.isStreamingResponse
+// (set once by responseStreamingEnabled in processResponseHeaders), never re-derive
+// its own decision — otherwise Envoy's negotiated body mode can disagree with which
+// body-phase handler the kernel actually runs, which Envoy rejects as a
+// content-length/mutated-body mismatch.
+// =============================================================================
+
+func TestGetModeOverride_MCPStreamingUpstreamStaysBuffered(t *testing.T) {
+	kernel := NewKernel()
+	server := NewExternalProcessorServer(kernel, executor.NewChainExecutor(nil, nil, nil), config.TracingConfig{}, "")
+
+	chain := &registry.PolicyChain{
+		RequiresResponseBody:      true,
+		SupportsResponseStreaming: true,
+	}
+	execCtx := newPolicyExecutionContext(server, "test-route", chain)
+
+	execCtx.buildRequestContexts(&extprocv3.HttpHeaders{Headers: &corev3.HeaderMap{}}, RouteMetadata{APIKind: string(policy.APIKindMCP)})
+	execCtx.buildResponseContexts(&extprocv3.HttpHeaders{
+		Headers: &corev3.HeaderMap{
+			Headers: []*corev3.HeaderValue{
+				{Key: ":status", RawValue: []byte("200")},
+				{Key: "content-type", RawValue: []byte("text/event-stream")},
+			},
+		},
+		EndOfStream: false,
+	})
+
+	execCtx.isStreamingResponse = execCtx.responseStreamingEnabled(false)
+	require.False(t, execCtx.isStreamingResponse, "MCP responses must never be upgraded to streaming")
+
+	execCtx.phase = phaseResponseHeaders
+	mode := execCtx.getModeOverride()
+	assert.Equal(t, extprocconfigv3.ProcessingMode_BUFFERED, mode.ResponseBodyMode)
+}
+
+func TestGetModeOverride_NonMCPStreamingUpstreamUpgrades(t *testing.T) {
+	kernel := NewKernel()
+	server := NewExternalProcessorServer(kernel, executor.NewChainExecutor(nil, nil, nil), config.TracingConfig{}, "")
+
+	chain := &registry.PolicyChain{
+		RequiresResponseBody:      true,
+		SupportsResponseStreaming: true,
+	}
+	execCtx := newPolicyExecutionContext(server, "test-route", chain)
+
+	execCtx.buildRequestContexts(&extprocv3.HttpHeaders{Headers: &corev3.HeaderMap{}}, RouteMetadata{APIKind: string(policy.APIKindRestApi)})
+	execCtx.buildResponseContexts(&extprocv3.HttpHeaders{
+		Headers: &corev3.HeaderMap{
+			Headers: []*corev3.HeaderValue{
+				{Key: ":status", RawValue: []byte("200")},
+				{Key: "content-type", RawValue: []byte("text/event-stream")},
+			},
+		},
+		EndOfStream: false,
+	})
+
+	execCtx.isStreamingResponse = execCtx.responseStreamingEnabled(false)
+	require.True(t, execCtx.isStreamingResponse, "non-MCP streaming upstream responses should still upgrade")
+
+	execCtx.phase = phaseResponseHeaders
+	mode := execCtx.getModeOverride()
+	assert.Equal(t, extprocconfigv3.ProcessingMode_FULL_DUPLEX_STREAMED, mode.ResponseBodyMode)
 }
 
 // =============================================================================
@@ -820,4 +889,93 @@ func TestProcessRequestBody_NoEncoding_PassesThrough(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, execCtx.requestBodyCtx.Body)
 	assert.Equal(t, plainJSON, execCtx.requestBodyCtx.Body.Content)
+}
+
+// =============================================================================
+// MCP SSE response body-mutation regression Tests
+//
+// Reproduces the exact configuration that triggered the HTTP 500
+// ("mismatch_between_content_length_and_the_length_of_the_mutated_body"): an MCP
+// proxy chain whose only response-body policy is streaming-capable (mirroring the
+// always-injected analytics system policy with no user policies attached), fronting
+// an upstream that replies with a chunked text/event-stream body. Before the fix,
+// isStreamingResponse was set to true independently of the MCP-only BUFFERED
+// ModeOverride, so processResponseBody dispatched to the streaming handler and
+// emitted a BodyMutation_StreamedResponse while Envoy was in a buffered body
+// callback — which Envoy rejects. After the fix, both decisions come from the same
+// responseStreamingEnabled() predicate, so a body-mutating policy's output always
+// arrives as a BodyMutation_Body with a matching content-length.
+// =============================================================================
+
+func TestProcessResponseBody_MCPSSEEmitsBufferedBodyMutation(t *testing.T) {
+	kernel := NewKernel()
+	server := NewExternalProcessorServer(kernel, newTestExecutor(), config.TracingConfig{}, "")
+
+	rewrittenBody := []byte("event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[]}}\n\n")
+	mockPolicy := &testutils.ConfigurableMockPolicy{
+		MockMode: policy.ProcessingMode{
+			ResponseBodyMode: policy.BodyModeBuffer,
+		},
+		OnRespFn: func(_ *policy.ResponseContext, _ map[string]interface{}) policy.ResponseAction {
+			return policy.DownstreamResponseModifications{Body: rewrittenBody}
+		},
+	}
+
+	chain := &registry.PolicyChain{
+		RequiresResponseBody: true,
+		// Mirrors a chain with no user MCP policies attached: the only response-body
+		// policy is the always-injected, streaming-capable analytics system policy.
+		SupportsResponseStreaming: true,
+		Policies:                  []policy.Policy{mockPolicy},
+		PolicySpecs:               []policy.PolicySpec{{Enabled: true}},
+	}
+	execCtx := newPolicyExecutionContext(server, "test-route", chain)
+
+	execCtx.buildRequestContexts(&extprocv3.HttpHeaders{
+		Headers: &corev3.HeaderMap{
+			Headers: []*corev3.HeaderValue{
+				{Key: ":path", RawValue: []byte("/everything/mcp")},
+				{Key: ":method", RawValue: []byte("POST")},
+			},
+		},
+	}, RouteMetadata{APIKind: string(policy.APIKindMCP)})
+
+	headersResp, err := execCtx.processResponseHeaders(context.Background(), &extprocv3.HttpHeaders{
+		Headers: &corev3.HeaderMap{
+			Headers: []*corev3.HeaderValue{
+				{Key: ":status", RawValue: []byte("200")},
+				{Key: "content-type", RawValue: []byte("text/event-stream")},
+				{Key: "transfer-encoding", RawValue: []byte("chunked")},
+			},
+		},
+		EndOfStream: false,
+	})
+	require.NoError(t, err)
+	require.False(t, execCtx.isStreamingResponse, "MCP responses must stay buffered end-to-end")
+	require.Equal(t, extprocconfigv3.ProcessingMode_BUFFERED, headersResp.ModeOverride.ResponseBodyMode)
+
+	upstreamBody := []byte("event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[{\"name\":\"add\"}]}}\n\n")
+	bodyResp, err := execCtx.processResponseBody(context.Background(), &extprocv3.HttpBody{
+		Body:        upstreamBody,
+		EndOfStream: true,
+	})
+	require.NoError(t, err)
+
+	respBody := bodyResp.GetResponseBody()
+	require.NotNil(t, respBody)
+	mutation := respBody.GetResponse().GetBodyMutation()
+	require.NotNil(t, mutation, "a body-mutating policy must produce a body mutation")
+
+	// The critical assertion: never a StreamedResponse mutation while Envoy is running
+	// this response in a buffered body callback (see processor_state.cc validateContentLength).
+	assert.Nil(t, mutation.GetStreamedResponse())
+	assert.Equal(t, rewrittenBody, mutation.GetBody())
+
+	contentLength := ""
+	for _, h := range respBody.GetResponse().GetHeaderMutation().GetSetHeaders() {
+		if h.GetHeader().GetKey() == "content-length" {
+			contentLength = string(h.GetHeader().GetRawValue())
+		}
+	}
+	assert.Equal(t, fmt.Sprintf("%d", len(rewrittenBody)), contentLength)
 }

--- a/gateway/it/docker-compose.test.postgres.yaml
+++ b/gateway/it/docker-compose.test.postgres.yaml
@@ -227,6 +227,18 @@ services:
     networks:
       - it-gateway-runtime-network
 
+  # Official MCP reference server (streamableHttp transport) — see docker-compose.test.yaml
+  mcp-streamable-backend:
+    container_name: mcp-streamable-backend
+    image: ghcr.io/wso2/api-platform/mock-mcp-everything-streamable:test
+    build:
+      context: ../../tests/mock-servers/mcp-everything-streamable
+      dockerfile: Dockerfile
+    ports:
+      - "3002:3001"
+    networks:
+      - it-gateway-runtime-network
+
   # Echo backend for testing cost extraction - returns request body in response JSON
   echo-backend:
     container_name: it-echo-backend

--- a/gateway/it/docker-compose.test.sqlserver.yaml
+++ b/gateway/it/docker-compose.test.sqlserver.yaml
@@ -209,6 +209,18 @@ services:
     networks:
       - it-gateway-runtime-network
 
+  # Official MCP reference server (streamableHttp transport) — see docker-compose.test.yaml
+  mcp-streamable-backend:
+    container_name: mcp-streamable-backend
+    image: ghcr.io/wso2/api-platform/mock-mcp-everything-streamable:test
+    build:
+      context: ../../tests/mock-servers/mcp-everything-streamable
+      dockerfile: Dockerfile
+    ports:
+      - "3002:3001"
+    networks:
+      - it-gateway-runtime-network
+
   # Echo backend for testing cost extraction - returns request body in response JSON
   echo-backend:
     container_name: it-echo-backend

--- a/gateway/it/docker-compose.test.yaml
+++ b/gateway/it/docker-compose.test.yaml
@@ -141,6 +141,21 @@ services:
     networks:
       - it-gateway-runtime-network
 
+  # Official MCP reference server (streamableHttp transport). Unlike
+  # mcp-server-backend above, its responses carry a content-length header on a
+  # chunked text/event-stream body, which triggers the Envoy content-length/
+  # mutated-body mismatch when the policy engine mis-negotiates streaming mode.
+  mcp-streamable-backend:
+    container_name: mcp-streamable-backend
+    image: ghcr.io/wso2/api-platform/mock-mcp-everything-streamable:test
+    build:
+      context: ../../tests/mock-servers/mcp-everything-streamable
+      dockerfile: Dockerfile
+    ports:
+      - "3002:3001"
+    networks:
+      - it-gateway-runtime-network
+
   # Echo backend for testing cost extraction - returns request body in response JSON
   echo-backend:
     container_name: it-echo-backend

--- a/gateway/it/features/mcp_deploy.feature
+++ b/gateway/it/features/mcp_deploy.feature
@@ -96,6 +96,52 @@ Feature: Test MCP CRUD and connectivity
         And the JSON response field "status" should be "success"
         And the JSON response field "count" should be 0
 
+    # Regression test: an MCP proxy with no policies attached fronting a Streamable-HTTP
+    # MCP server returned HTTP 500
+    # from Envoy ("mismatch_between_content_length_and_the_length_of_the_mutated_body")
+    # on messages around initialize. mcp-streamable-backend (the official MCP reference
+    # server) reproduces it because its responses carry a content-length header on a
+    # chunked text/event-stream body — unlike mcp-server-backend used elsewhere in this
+    # file, which does not trigger it.
+    Scenario: Deploy an MCP Proxy fronting a Streamable-HTTP server with no policies attached
+        Given I authenticate using basic auth as "admin"
+        When I deploy this MCP configuration:
+            """
+            apiVersion: gateway.api-platform.wso2.com/v1
+            kind: Mcp
+            metadata:
+              name: everything-streamable-mcp-v1.0
+            spec:
+              displayName: Everything Streamable
+              version: v1.0
+              context: /everything-streamable
+              specVersion: "2025-06-18"
+              upstream:
+                url: http://mcp-streamable-backend:3001/mcp
+              tools: []
+              resources: []
+              prompts: []
+            """
+        Then the response should be successful
+        And the response should be valid JSON
+        And the JSON response field "status" should be "success"
+        And I wait for 2 seconds
+
+        When I use the MCP Client to send an initialize request to "http://127.0.0.1:8080/everything-streamable/mcp"
+        Then the response should be successful
+        When I use the MCP Client to send a notifications/initialized notification to "http://127.0.0.1:8080/everything-streamable/mcp"
+        Then the response should be successful
+        When I use the MCP Client to send a tools/list request to "http://127.0.0.1:8080/everything-streamable/mcp"
+        Then the response should be successful
+        And the response should be valid JSON
+        And the JSON response should have field "result.tools"
+
+        # Cleanup
+        And I clear all headers
+        Given I authenticate using basic auth as "admin"
+        When I delete the MCP proxy "everything-streamable-mcp-v1.0"
+        Then the response should be successful
+
     Scenario: Deploy an MCP Proxy and send an invalid tools/call request
         Given I authenticate using basic auth as "admin"
         When I deploy this MCP configuration:

--- a/gateway/it/steps/http_steps.go
+++ b/gateway/it/steps/http_steps.go
@@ -519,7 +519,13 @@ func (h *HTTPSteps) SendMcpRequest(url string, body *godog.DocString) error {
 			}
 		}
 	}
-	h.headers["mcp-session-id"] = resp.Header.Get("mcp-session-id")
+	// Only overwrite the stored session ID when this response actually carries one — a
+	// notification response (e.g. notifications/initialized) has no mcp-session-id header,
+	// and an unconditional assignment here would clobber the session ID captured from the
+	// preceding initialize response before it's used by a later request.
+	if sessionID := resp.Header.Get("mcp-session-id"); sessionID != "" {
+		h.headers["mcp-session-id"] = sessionID
+	}
 	return nil
 }
 

--- a/gateway/it/steps_mcp.go
+++ b/gateway/it/steps_mcp.go
@@ -101,6 +101,14 @@ func RegisterMCPSteps(ctx *godog.ScenarioContext, state *TestState, httpSteps *s
 		})
 	})
 
+	ctx.Step(`^I use the MCP Client to send a notifications\/initialized notification to "([^"]*)"$`, func(url string) error {
+		httpSteps.SetHeader("Content-Type", "application/json")
+		payload := generateMcpPayload("notifications/initialized", "")
+		return httpSteps.SendMcpRequest(url, &godog.DocString{
+			Content: payload,
+		})
+	})
+
 	ctx.Step(`^I get the MCP proxy "([^"]*)"$`, func(name string) error {
 		return httpSteps.SendGETToService("gateway-controller", "/mcp-proxies/"+name)
 	})
@@ -143,6 +151,13 @@ func generateMcpPayload(method, tool string) string {
 				"capabilities":    map[string]interface{}{"roots": map[string]bool{"listChanged": true}},
 				"clientInfo":      map[string]string{"name": "gateway-it-client", "version": "1.0.0"},
 			},
+		}
+	case "notifications/initialized":
+		// A JSON-RPC notification carries no "id" (omitted via JsonRPCRequest's omitempty).
+		initRequest = JsonRPCRequest{
+			JSONRPC: "2.0",
+			Method:  method,
+			Params:  map[string]any{},
 		}
 	case "tools/list":
 		initRequest = JsonRPCRequest{

--- a/tests/mock-servers/mcp-everything-streamable/Dockerfile
+++ b/tests/mock-servers/mcp-everything-streamable/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:22-alpine
+
+WORKDIR /app
+
+# Pin the exact upstream version in package.json — never `npx -y` at container
+# start, so the test run does not depend on npm registry access at runtime.
+COPY package.json ./
+RUN npm install --omit=dev
+
+EXPOSE 3001
+
+CMD ["node", "node_modules/@modelcontextprotocol/server-everything/dist/index.js", "streamableHttp"]

--- a/tests/mock-servers/mcp-everything-streamable/package.json
+++ b/tests/mock-servers/mcp-everything-streamable/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "mock-mcp-everything-streamable",
+  "private": true,
+  "description": "Test fixture wrapping the official MCP reference server (streamableHttp transport) for gateway integration tests.",
+  "dependencies": {
+    "@modelcontextprotocol/server-everything": "2026.7.4"
+  }
+}


### PR DESCRIPTION
## Purpose

- Resolves: https://github.com/wso2/api-platform/issues/2885

MCP proxies were returning HTTP 500 (mismatch_between_content_length_and_the_length_of_the_mutated_body) on Streamable-HTTP servers whose responses carry a content-length header.

Two code paths independently decided whether an MCP response was "streaming," and could disagree: processResponseHeaders set isStreamingResponse from one condition, while getModeOverride separately forced Envoy into buffered mode for MCP. When they disagreed, the policy engine emitted a streamed body mutation while Envoy was running the response in a buffered callback, which Envoy rejects.

Fixed by introducing responseStreamingEnabled() as the single source of truth for both decisions, so Envoy's negotiated mode and the kernel's dispatch can never diverge.

Also adds a Streamable-HTTP MCP test backend and regression coverage (unit + integration) reproducing the original 500 and confirming the fix.

