### PR TITLE
Implement go worker pools for DP to CP sync

### DIFF
--- a/gateway/configs/config-template.toml
+++ b/gateway/configs/config-template.toml
@@ -57,6 +57,28 @@ polling_interval = "15m"
 insecure_skip_verify = '{{ env "APIP_GW_CONTROLLER_CONTROLPLANE_INSECURE_SKIP_VERIFY" "true" }}'
 # Enable two-way artifact/deployment sync with the control plane (default: true)
 deployment_sync_enabled = '{{ env "APIP_GW_CONTROLLER_CONTROLPLANE_DEPLOYMENT_SYNC_ENABLED" "true" }}'
+# Number of deployment artifacts fetched and processed per batch during the
+# CP->DP sync (startup and periodic). Must be positive — the controller refuses
+# to start on 0 or a negative value.
+sync_batch_size = 50
+# Concurrency caps for the two background DP->CP sync worker pools. Both default
+# to unlimited/unbounded, which exactly preserves the historical "one goroutine
+# per operation" behaviour; set a positive pool size only when the upstream needs
+# protecting from a large artifact burst (e.g. an on-prem APIM that stalls under
+# many concurrent publishes).
+#   *_pool_size  = 0 (or unset) -> unlimited: a goroutine per task, no bound on
+#                  concurrency or backlog. > 0 -> exactly that many workers.
+#   *_queue_size = 0 (or unset) -> unbounded pending queue (work is never
+#                  rejected). > 0 caps the backlog and rejects submissions once
+#                  full; only meaningful when the matching pool size is > 0.
+# Workers for the on-prem APIM bottom-up sync
+apim_sync_pool_size = 0
+# Max pending on-prem APIM sync tasks
+apim_sync_queue_size = 0
+# Workers for the platform-API (AI Workspace) artifact push
+ai_workspace_sync_pool_size = 0
+# Max pending artifact push tasks
+ai_workspace_sync_queue_size = 0
 # Option 1: Client Credentials Flow (OAuth2) — APIM OAuth2 Client ID
 apim_oauth2_client_id = '{{ env "APIP_GW_CONTROLLER_CONTROLPLANE_APIM_OAUTH2_CLIENT_ID" "" }}'
 # APIM OAuth2 Client secret

--- a/gateway/gateway-controller/pkg/api/handlers/handlerkit/handlerkit.go
+++ b/gateway/gateway-controller/pkg/api/handlers/handlerkit/handlerkit.go
@@ -114,6 +114,9 @@ type DeploymentPusher struct {
 //
 // minDeployedAt is the DeployedAt of the deployment this push was triggered for.
 func (p *DeploymentPusher) WaitForDeploymentAndPush(configID string, correlationID string, minDeployedAt *time.Time, log *slog.Logger) {
+	if p.ControlPlaneClient != nil && p.ControlPlaneClient.IsOnPrem() {
+		return
+	}
 	if correlationID != "" {
 		log = log.With(slog.String("correlation_id", correlationID))
 	}
@@ -171,15 +174,17 @@ func (p *DeploymentPusher) PushArtifactUndeploy(cfg *models.StoredConfig, log *s
 	if cfg == nil || cfg.Origin != models.OriginGatewayAPI {
 		return
 	}
-	if p.ControlPlaneClient != nil && p.ControlPlaneClient.IsConnected() && p.SystemConfig.Controller.ControlPlane.DeploymentSyncEnabled {
+	if p.ControlPlaneClient != nil && p.ControlPlaneClient.IsConnected() && !p.ControlPlaneClient.IsOnPrem() &&
+		p.SystemConfig.Controller.ControlPlane.DeploymentSyncEnabled {
 		undeploy := *cfg
 		undeploy.DesiredState = models.StateUndeployed
-		go func(uc models.StoredConfig) {
+		p.ControlPlaneClient.SubmitArtifactPush(func() {
+			uc := undeploy
 			if err := p.ControlPlaneClient.PushArtifact(uc.UUID, &uc, uc.DeploymentID); err != nil {
 				log.Error("Failed to push artifact undeploy to control plane",
 					slog.String("artifact_id", uc.UUID), slog.Any("error", err))
 			}
-		}(undeploy)
+		})
 	}
 }
 

--- a/gateway/gateway-controller/pkg/api/handlers/handlers_test.go
+++ b/gateway/gateway-controller/pkg/api/handlers/handlers_test.go
@@ -1046,6 +1046,30 @@ func (m *MockControlPlaneClient) SyncArtifactsToOnPremAPIM(apimConfig *utils.API
 	return nil
 }
 
+// SubmitAPIMSync runs the task in a goroutine, mirroring the previous per-op
+// goroutine behavior so existing eventual-consistency test assertions still hold.
+func (m *MockControlPlaneClient) SubmitAPIMSync(task func()) {
+	if task != nil {
+		go task()
+	}
+}
+
+// SubmitAPIMSyncAndWait runs the task inline (blocking), matching the real
+// client's blocking semantics used on the delete path.
+func (m *MockControlPlaneClient) SubmitAPIMSyncAndWait(task func()) {
+	if task != nil {
+		task()
+	}
+}
+
+// SubmitArtifactPush runs the task in a goroutine, mirroring the previous per-op
+// goroutine behavior so existing eventual-consistency test assertions still hold.
+func (m *MockControlPlaneClient) SubmitArtifactPush(task func()) {
+	if task != nil {
+		go task()
+	}
+}
+
 func (m *MockControlPlaneClient) IsOnPrem() bool {
 	return false
 }

--- a/gateway/gateway-controller/pkg/config/config.go
+++ b/gateway/gateway-controller/pkg/config/config.go
@@ -660,6 +660,11 @@ type ControlPlaneConfig struct {
 	InsecureSkipVerify    bool          `koanf:"insecure_skip_verify"`    // Skip TLS certificate verification (insecure, dev/test only)
 	DeploymentSyncEnabled bool          `koanf:"deployment_sync_enabled"` // Enable two-way artifact/deployment sync with the control plane: DP->CP push and CP->DP pull (default: true)
 	SyncBatchSize         int           `koanf:"sync_batch_size"`         // Number of deployments to fetch per batch request during startup sync (default: 50)
+	// Optional worker pools that cap the concurrency of DP->CP sync work
+	APIMSyncPoolSize         int `koanf:"apim_sync_pool_size"`          // Workers for on-prem APIM bottom-up sync (0/unset = unlimited)
+	APIMSyncQueueSize        int `koanf:"apim_sync_queue_size"`         // Max pending APIM sync tasks when pool size > 0 (0/unset = unbounded)
+	AIWorkspaceSyncPoolSize  int `koanf:"ai_workspace_sync_pool_size"`  // Workers for platform-API (AI Workspace) artifact push (0/unset = unlimited)
+	AIWorkspaceSyncQueueSize int `koanf:"ai_workspace_sync_queue_size"` // Max pending artifact push tasks when pool size > 0 (0/unset = unbounded)
 	// OAuth2 credentials for on-prem APIM API import (for bottom-up API deployment)
 	ApimOAuth2ClientID     string `koanf:"apim_oauth2_client_id"`     // APIM OAuth2 client ID
 	ApimOAuth2ClientSecret string `koanf:"apim_oauth2_client_secret"` // APIM OAuth2 client secret
@@ -880,14 +885,18 @@ func defaultConfig() *Config {
 				Port:    9091,
 			},
 			ControlPlane: ControlPlaneConfig{
-				Host:                  "",
-				Token:                 "",
-				ReconnectInitial:      1 * time.Second,
-				ReconnectMax:          5 * time.Minute,
-				PollingInterval:       15 * time.Minute,
-				InsecureSkipVerify:    true,
-				DeploymentSyncEnabled: true,
-				SyncBatchSize:         50,
+				Host:                     "",
+				Token:                    "",
+				ReconnectInitial:         1 * time.Second,
+				ReconnectMax:             5 * time.Minute,
+				PollingInterval:          15 * time.Minute,
+				InsecureSkipVerify:       true,
+				DeploymentSyncEnabled:    true,
+				SyncBatchSize:            50,
+				APIMSyncPoolSize:         0,
+				APIMSyncQueueSize:        0,
+				AIWorkspaceSyncPoolSize:  0,
+				AIWorkspaceSyncQueueSize: 0,
 			},
 			EventHub: EventHubConfig{
 				PollInterval:    3 * time.Second,

--- a/gateway/gateway-controller/pkg/controlplane/client.go
+++ b/gateway/gateway-controller/pkg/controlplane/client.go
@@ -583,15 +583,14 @@ func (c *Client) SubmitAPIMSyncAndWait(task func()) {
 		return
 	}
 	done := make(chan struct{})
-	if c.apimSyncPool.Submit(func() {
+	if !c.apimSyncPool.Submit(func() {
 		defer close(done)
 		task()
 	}) {
-		<-done
+		c.logger.Warn("APIM sync (blocking) not scheduled: worker pool queue full; skipping (will retry on next resync)")
 		return
 	}
-	c.logger.Warn("APIM sync (blocking) not scheduled on pool (queue full); running inline")
-	task()
+	<-done
 }
 
 // SubmitArtifactPush schedules a platform-API (AI Workspace) artifact push task on the bounded artifact-push worker pool.

--- a/gateway/gateway-controller/pkg/controlplane/client.go
+++ b/gateway/gateway-controller/pkg/controlplane/client.go
@@ -47,6 +47,7 @@ import (
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/storage"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/utils"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/version"
+	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/workerpool"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/xds"
 )
 
@@ -100,6 +101,9 @@ type ControlPlaneClient interface {
 	SyncArtifactsToOnPremAPIM(apimConfig *utils.APIMConfig) error
 	IsOnPrem() bool
 	GetAPIMConfig() *utils.APIMConfig
+	SubmitAPIMSync(task func())
+	SubmitAPIMSyncAndWait(task func())
+	SubmitArtifactPush(task func())
 }
 
 // secretSyncer is the narrow interface the sync loop needs from the secrets service.
@@ -160,6 +164,10 @@ type Client struct {
 	pushMaxAttempts   int
 	pushRetryBaseWait time.Duration
 	pushRetryMaxWait  time.Duration
+
+	// apimSyncPool for on-prem APIM bottom-up sync, aiWorkspaceSyncPool for platform-API (AI Workspace) artifact pushes.
+	apimSyncPool        *workerpool.Pool
+	aiWorkspaceSyncPool *workerpool.Pool
 }
 
 // NewClient creates a new control plane client
@@ -241,6 +249,9 @@ func NewClient(
 	}
 
 	client.isFirstConnect.Store(true)
+
+	client.apimSyncPool = workerpool.New("apim-sync", cfg.APIMSyncPoolSize, cfg.APIMSyncQueueSize, logger)
+	client.aiWorkspaceSyncPool = workerpool.New("ai-workspace-sync", cfg.AIWorkspaceSyncPoolSize, cfg.AIWorkspaceSyncQueueSize, logger)
 
 	// If the secretResolver also satisfies secretSyncer, store it so syncSecrets can
 	// upsert Platform API-sourced secrets into local encrypted storage.
@@ -366,6 +377,14 @@ func (c *Client) Stop() {
 	// Wait for goroutines to finish
 	c.wg.Wait()
 
+	// Drain and stop the DP->CP sync worker pools
+	if c.apimSyncPool != nil {
+		c.apimSyncPool.Stop()
+	}
+	if c.aiWorkspaceSyncPool != nil {
+		c.aiWorkspaceSyncPool.Stop()
+	}
+
 	c.logger.Info("Control plane client stopped")
 }
 
@@ -478,17 +497,19 @@ func (c *Client) Connect() error {
 			// Sync secrets before deployments so {{ secret "..." }} placeholders
 			// in API configs resolve correctly during the first render pass.
 			c.syncSecrets()
-			if c.config.DeploymentSyncEnabled {
+			if c.config.DeploymentSyncEnabled && !c.IsOnPrem() {
 				c.syncDeployments(gwID)
 			}
 			// Bottom-up sync: push gateway-created APIs to on-prem control plane
 			if c.IsOnPrem() && c.config.DeploymentSyncEnabled {
-				if err := c.SyncArtifactsToOnPremAPIM(c.GetAPIMConfig()); err != nil {
-					c.logger.Error("Failed to sync artifacts to on-prem APIM", slog.Any("error", err))
-				}
+				c.SubmitAPIMSync(func() {
+					if err := c.SyncArtifactsToOnPremAPIM(c.GetAPIMConfig()); err != nil {
+						c.logger.Error("Failed to sync artifacts to on-prem APIM", slog.Any("error", err))
+					}
+				})
 			}
 			// Push gateway-originated artifacts up to the platform-API control plane.
-			c.PushGatewayArtifactsToControlPlane()
+			c.SubmitArtifactPush(c.PushGatewayArtifactsToControlPlane)
 			c.syncSubscriptionPlans(gwID)
 			c.syncSubscriptionsForExistingAPIs(gwID)
 			// Sync API keys for LlmProvider, LlmProxy, and RestApi artifacts.
@@ -504,16 +525,18 @@ func (c *Client) Connect() error {
 			defer c.wg.Done()
 			// Bottom-up sync on reconnect
 			if c.IsOnPrem() && c.config.DeploymentSyncEnabled {
-				if err := c.SyncArtifactsToOnPremAPIM(c.GetAPIMConfig()); err != nil {
-					c.logger.Error("Failed to sync artifacts to on-prem APIM", slog.Any("error", err))
-				}
+				c.SubmitAPIMSync(func() {
+					if err := c.SyncArtifactsToOnPremAPIM(c.GetAPIMConfig()); err != nil {
+						c.logger.Error("Failed to sync artifacts to on-prem APIM", slog.Any("error", err))
+					}
+				})
 			}
 			// Re-sync secrets on reconnect so any rotated or newly added secrets
 			// are picked up. Hash-based change detection ensures only changed
 			// secrets trigger a plaintext fetch.
 			c.syncSecrets()
 			// Push gateway-originated artifacts up to the platform-API control plane.
-			c.PushGatewayArtifactsToControlPlane()
+			c.SubmitArtifactPush(c.PushGatewayArtifactsToControlPlane)
 			c.syncSubscriptionPlans(gwID)
 			c.syncSubscriptionsForExistingAPIs(gwID)
 			// Sync API keys for LlmProvider, LlmProxy, and RestApi artifacts.
@@ -533,6 +556,56 @@ func (c *Client) Connect() error {
 	go c.heartbeatMonitor()
 
 	return nil
+}
+
+// SubmitAPIMSync schedules an on-prem APIM bottom-up sync task on the bounded APIM-sync worker pool.
+func (c *Client) SubmitAPIMSync(task func()) {
+	if task == nil {
+		return
+	}
+	if c.apimSyncPool == nil {
+		go task()
+		return
+	}
+	if !c.apimSyncPool.Submit(task) {
+		c.logger.Warn("APIM sync task rejected: worker pool queue full; will retry on next resync")
+	}
+}
+
+// SubmitAPIMSyncAndWait runs an on-prem APIM sync task on the APIM-sync worker
+// pool and blocks until it completes.
+func (c *Client) SubmitAPIMSyncAndWait(task func()) {
+	if task == nil {
+		return
+	}
+	if c.apimSyncPool == nil {
+		task()
+		return
+	}
+	done := make(chan struct{})
+	if c.apimSyncPool.Submit(func() {
+		defer close(done)
+		task()
+	}) {
+		<-done
+		return
+	}
+	c.logger.Warn("APIM sync (blocking) not scheduled on pool (queue full); running inline")
+	task()
+}
+
+// SubmitArtifactPush schedules a platform-API (AI Workspace) artifact push task on the bounded artifact-push worker pool.
+func (c *Client) SubmitArtifactPush(task func()) {
+	if task == nil {
+		return
+	}
+	if c.aiWorkspaceSyncPool == nil {
+		go task()
+		return
+	}
+	if !c.aiWorkspaceSyncPool.Submit(task) {
+		c.logger.Warn("Artifact push task rejected: worker pool queue full; will retry on next resync")
+	}
 }
 
 // gatewayWellKnownResponse matches APIM well-known JSON: {"gatewayPath":"internal/data/v1"}.
@@ -3738,6 +3811,12 @@ func (c *Client) PushArtifact(apiID string, apiConfig *models.StoredConfig, depl
 	// Check if connected to control plane
 	if !c.IsConnected() {
 		c.logger.Debug("Not connected to control plane, skipping artifact push",
+			slog.String("artifact_id", apiID))
+		return nil
+	}
+
+	if c.IsOnPrem() {
+		c.logger.Debug("On-prem control plane; skipping platform-api artifact push (handled by APIM bottom-up sync)",
 			slog.String("artifact_id", apiID))
 		return nil
 	}

--- a/gateway/gateway-controller/pkg/controlplane/sync.go
+++ b/gateway/gateway-controller/pkg/controlplane/sync.go
@@ -617,7 +617,7 @@ func parseCPSyncInfo(cpSyncInfo string) (apiID, revisionID string) {
 // This is distinct from SyncArtifactsToOnPremAPIM, which targets the legacy on-prem APIM
 // product. Both may run; this one is gated only on deployment_sync_enabled.
 func (c *Client) PushGatewayArtifactsToControlPlane() {
-	if c.IsConnected() && c.config.DeploymentSyncEnabled {
+	if c.IsConnected() && c.config.DeploymentSyncEnabled && !c.IsOnPrem() {
 		c.pushGatewayArtifacts()
 	}
 }

--- a/gateway/gateway-controller/pkg/controlplane/sync_secrets.go
+++ b/gateway/gateway-controller/pkg/controlplane/sync_secrets.go
@@ -34,6 +34,10 @@ import (
 // Reconnect (warm cache): metadata-only request, then per-secret /value calls only
 // for secrets whose hash has changed since last sync.
 func (c *Client) syncSecrets() {
+	if c.IsOnPrem() {
+		c.logger.Debug("Skipping secret sync: on-prem control plane detected")
+		return
+	}
 	if c.apiUtilsService == nil {
 		c.logger.Debug("Skipping secret sync: apiUtilsService is nil")
 		return

--- a/gateway/gateway-controller/pkg/controlplane/sync_secrets_test.go
+++ b/gateway/gateway-controller/pkg/controlplane/sync_secrets_test.go
@@ -62,6 +62,9 @@ func stubClient(syncer secretSyncer) *Client {
 	return &Client{
 		logger:       slog.Default(),
 		secretSyncer: syncer,
+		// state must be non-nil so isOnPrem()/GetGatewayPath() can read the
+		// (empty) gateway path without a nil deref. Empty path => not on-prem.
+		state: &ConnectionState{},
 	}
 }
 

--- a/gateway/gateway-controller/pkg/service/restapi/service.go
+++ b/gateway/gateway-controller/pkg/service/restapi/service.go
@@ -187,16 +187,21 @@ func (s *RestAPIService) Create(params CreateParams) (*CreateResult, error) {
 		// Trigger bottom-up sync immediately if connected and control plane type is on-prem
 		if s.controlPlaneClient != nil && s.controlPlaneClient.IsConnected() && s.controlPlaneClient.IsOnPrem() &&
 			s.systemConfig.Controller.ControlPlane.DeploymentSyncEnabled {
-			go func() {
+			s.controlPlaneClient.SubmitAPIMSync(func() {
 				if err := s.controlPlaneClient.SyncArtifactsToOnPremAPIM(s.controlPlaneClient.GetAPIMConfig()); err != nil {
 					log.Error("Failed to sync API to on-prem APIM", slog.Any("error", err))
 				}
-			}()
+			})
 		}
 
 		// Push to control plane asynchronously if connected
-		if s.controlPlaneClient != nil && s.controlPlaneClient.IsConnected() && s.systemConfig.Controller.ControlPlane.DeploymentSyncEnabled {
-			go s.waitForDeploymentAndPush(result.StoredConfig.UUID, params.CorrelationID, result.StoredConfig.DeployedAt, log)
+		if s.controlPlaneClient != nil && s.controlPlaneClient.IsConnected() && !s.controlPlaneClient.IsOnPrem() &&
+			s.systemConfig.Controller.ControlPlane.DeploymentSyncEnabled {
+			cfgID := result.StoredConfig.UUID
+			deployedAt := result.StoredConfig.DeployedAt
+			s.controlPlaneClient.SubmitArtifactPush(func() {
+				s.waitForDeploymentAndPush(cfgID, params.CorrelationID, deployedAt, log)
+			})
 		}
 	}
 
@@ -365,17 +370,22 @@ func (s *RestAPIService) Update(params UpdateParams) (*UpdateResult, error) {
 	// Trigger bottom-up sync if enabled and connected
 	if existing.Origin == models.OriginGatewayAPI && s.controlPlaneClient != nil && s.controlPlaneClient.IsConnected() &&
 		s.controlPlaneClient.IsOnPrem() && s.systemConfig.Controller.ControlPlane.DeploymentSyncEnabled {
-		go func() {
+		s.controlPlaneClient.SubmitAPIMSync(func() {
 			if err := s.controlPlaneClient.SyncArtifactsToOnPremAPIM(s.controlPlaneClient.GetAPIMConfig()); err != nil {
 				log.Error("Failed to sync API to on-prem APIM", slog.Any("error", err))
 			}
-		}()
+		})
 	}
 
 	// Push to control plane asynchronously if connected
 	if existing.Origin == models.OriginGatewayAPI && s.controlPlaneClient != nil &&
-		s.controlPlaneClient.IsConnected() && s.systemConfig.Controller.ControlPlane.DeploymentSyncEnabled {
-		go s.waitForDeploymentAndPush(existing.UUID, params.CorrelationID, existing.DeployedAt, log)
+		s.controlPlaneClient.IsConnected() && !s.controlPlaneClient.IsOnPrem() &&
+		s.systemConfig.Controller.ControlPlane.DeploymentSyncEnabled {
+		cfgID := existing.UUID
+		deployedAt := existing.DeployedAt
+		s.controlPlaneClient.SubmitArtifactPush(func() {
+			s.waitForDeploymentAndPush(cfgID, params.CorrelationID, deployedAt, log)
+		})
 	}
 
 	log.Info("API configuration updated",
@@ -470,12 +480,15 @@ func (s *RestAPIService) undeployFromAPIMBeforeDelete(cfg *models.StoredConfig, 
 		return
 	}
 
-	if err := s.controlPlaneClient.SyncArtifactsToOnPremAPIM(apimCfg); err != nil {
-		log.Error("Failed to undeploy API from on-prem APIM before deletion",
-			slog.String("uuid", cfg.UUID),
-			slog.String("handle", cfg.Handle),
-			slog.Any("error", err))
-	}
+	// Run on the APIM-sync pool but block until done: this serializes the undeploy with other pooled APIM syncs
+	s.controlPlaneClient.SubmitAPIMSyncAndWait(func() {
+		if err := s.controlPlaneClient.SyncArtifactsToOnPremAPIM(apimCfg); err != nil {
+			log.Error("Failed to undeploy API from on-prem APIM before deletion",
+				slog.String("uuid", cfg.UUID),
+				slog.String("handle", cfg.Handle),
+				slog.Any("error", err))
+		}
+	})
 }
 
 // updatePolicyForConfig upserts the runtime config for an API into the policy engine.

--- a/gateway/gateway-controller/pkg/utils/cp_push.go
+++ b/gateway/gateway-controller/pkg/utils/cp_push.go
@@ -34,7 +34,9 @@ import (
 // cannot import controlplane without creating an import cycle.
 type ArtifactPusher interface {
 	IsConnected() bool
+	IsOnPrem() bool
 	PushArtifact(artifactID string, artifact *models.StoredConfig, deploymentID string) error
+	SubmitArtifactPush(task func())
 }
 
 // cpSyncStatusForOrigin returns the initial cp_sync_status for a newly created/updated

--- a/gateway/gateway-controller/pkg/utils/llm_deployment.go
+++ b/gateway/gateway-controller/pkg/utils/llm_deployment.go
@@ -1334,12 +1334,12 @@ func (s *LLMDeploymentService) pushTemplateToControlPlane(stored *models.StoredL
 		UpdatedAt:           stored.UpdatedAt,
 	}
 	pusher := s.controlPlaneClient
-	go func(c *models.StoredConfig) {
-		if err := pusher.PushArtifact(c.UUID, c, ""); err != nil {
+	pusher.SubmitArtifactPush(func() {
+		if err := pusher.PushArtifact(cfg.UUID, cfg, ""); err != nil {
 			log.Error("Failed to push LLM provider template to control plane",
-				slog.String("uuid", c.UUID), slog.Any("error", err))
+				slog.String("uuid", cfg.UUID), slog.Any("error", err))
 		}
-	}(cfg)
+	})
 }
 
 // pushDeployableArtifact forwards a freshly created or updated, gateway-originated deployable
@@ -1349,11 +1349,18 @@ func (s *LLMDeploymentService) pushDeployableArtifact(result *APIDeploymentResul
 		return
 	}
 	if result.StoredConfig.Origin == models.OriginGatewayAPI && s.canPushToControlPlane() {
-		go waitForDeploymentAndPush(s.store, s.controlPlaneClient, result.StoredConfig.UUID, correlationID, result.StoredConfig.DeployedAt, log)
+		pusher := s.controlPlaneClient
+		store := s.store
+		cfgID := result.StoredConfig.UUID
+		deployedAt := result.StoredConfig.DeployedAt
+		pusher.SubmitArtifactPush(func() {
+			waitForDeploymentAndPush(store, pusher, cfgID, correlationID, deployedAt, log)
+		})
 	}
 }
 
 // canPushToControlPlane reports whether a DP->CP push should be attempted now.
 func (s *LLMDeploymentService) canPushToControlPlane() bool {
-	return s.deploymentPushEnabled && s.controlPlaneClient != nil && s.controlPlaneClient.IsConnected()
+	return s.deploymentPushEnabled && s.controlPlaneClient != nil &&
+		s.controlPlaneClient.IsConnected() && !s.controlPlaneClient.IsOnPrem()
 }

--- a/gateway/gateway-controller/pkg/utils/mcp_deployment.go
+++ b/gateway/gateway-controller/pkg/utils/mcp_deployment.go
@@ -536,11 +536,18 @@ func (s *MCPDeploymentService) pushDeployableArtifact(result *APIDeploymentResul
 		return
 	}
 	if result.StoredConfig.Origin == models.OriginGatewayAPI && s.canPushToControlPlane() {
-		go waitForDeploymentAndPush(s.store, s.controlPlaneClient, result.StoredConfig.UUID, correlationID, result.StoredConfig.DeployedAt, log)
+		pusher := s.controlPlaneClient
+		store := s.store
+		cfgID := result.StoredConfig.UUID
+		deployedAt := result.StoredConfig.DeployedAt
+		pusher.SubmitArtifactPush(func() {
+			waitForDeploymentAndPush(store, pusher, cfgID, correlationID, deployedAt, log)
+		})
 	}
 }
 
 // canPushToControlPlane reports whether a DP->CP push should be attempted now.
 func (s *MCPDeploymentService) canPushToControlPlane() bool {
-	return s.deploymentPushEnabled && s.controlPlaneClient != nil && s.controlPlaneClient.IsConnected()
+	return s.deploymentPushEnabled && s.controlPlaneClient != nil &&
+		s.controlPlaneClient.IsConnected() && !s.controlPlaneClient.IsOnPrem()
 }

--- a/gateway/gateway-controller/pkg/workerpool/pool.go
+++ b/gateway/gateway-controller/pkg/workerpool/pool.go
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Package workerpool provides a worker pool used to optionally cap the
+// concurrency of background work (e.g. DP->CP artifact sync).
+//
+// By default (workers <= 0) the pool runs in unlimited mode: every submitted
+// task gets its own goroutine, exactly preserving the historical
+// "one goroutine per operation" behaviour with no bound on concurrency or
+// backlog. When an operator configures a positive worker count the pool runs a
+// fixed set of workers instead; the pending queue is unbounded unless a positive
+// queue size is configured, in which case excess work is rejected once the queue
+// is full (see the go-network-service-hardening rule, directive 3).
+package workerpool
+
+import (
+	"log/slog"
+	"sync"
+	"sync/atomic"
+)
+
+// Pool is a worker pool. In unlimited mode it spawns a goroutine per task; in
+// bounded mode a fixed number of workers drain a FIFO queue (bounded or
+// unbounded). It is safe for concurrent use.
+type Pool struct {
+	name      string
+	logger    *slog.Logger
+	unlimited bool
+	maxQueue  int // 0 = unbounded; only meaningful in bounded mode
+
+	mu      sync.Mutex
+	cond    *sync.Cond
+	queue   []func()
+	head    int // index of the next task to run in queue
+	stopped bool
+	wg      sync.WaitGroup
+
+	// unlimitedActive tracks the number of in-flight goroutines in unlimited mode so Stop can wait for them to drain.
+	unlimitedActive sync.WaitGroup
+	unlimitedStop   atomic.Bool
+}
+
+// New creates and starts a worker pool identified by name.
+//
+//   - workers <= 0: unlimited mode — a goroutine per task, no bound on
+//     concurrency or backlog (the default).
+//   - workers > 0: exactly that many workers. queueSize <= 0 means an unbounded
+//     pending queue (work is never rejected); queueSize > 0 caps the backlog and
+//     Submit rejects once it is full.
+//
+// The pool must be shut down with Stop to release its resources.
+func New(name string, workers, queueSize int, logger *slog.Logger) *Pool {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	p := &Pool{name: name, logger: logger}
+	p.cond = sync.NewCond(&p.mu)
+
+	if workers <= 0 {
+		p.unlimited = true
+		logger.Info("Started worker pool (unlimited: goroutine per task)",
+			slog.String("pool", name),
+		)
+		return p
+	}
+
+	if queueSize < 0 {
+		queueSize = 0
+	}
+	p.maxQueue = queueSize
+	for range workers {
+		p.wg.Add(1)
+		go p.worker()
+	}
+	queueLabel := "unbounded"
+	if queueSize > 0 {
+		queueLabel = ""
+	}
+	logger.Info("Started worker pool",
+		slog.String("pool", name),
+		slog.Int("workers", workers),
+		slog.Int("queue_size", queueSize),
+		slog.String("queue_mode", queueLabel),
+	)
+	return p
+}
+
+func (p *Pool) worker() {
+	defer p.wg.Done()
+	for {
+		p.mu.Lock()
+		for p.head >= len(p.queue) && !p.stopped {
+			p.cond.Wait()
+		}
+		if p.head >= len(p.queue) && p.stopped {
+			p.mu.Unlock()
+			return
+		}
+		task := p.queue[p.head]
+		p.queue[p.head] = nil
+		p.head++
+		// Compact the backing array once the consumed prefix dominates it so the
+		// slice header doesn't pin an ever-growing, mostly-drained array.
+		if p.head > 32 && p.head*2 >= len(p.queue) {
+			p.queue = append(p.queue[:0:0], p.queue[p.head:]...)
+			p.head = 0
+		}
+		p.mu.Unlock()
+		p.runSafely(task)
+	}
+}
+
+// runSafely executes a single task, recovering from any panic so one bad task
+// cannot take down a worker goroutine (which would permanently shrink the pool).
+func (p *Pool) runSafely(task func()) {
+	defer func() {
+		if r := recover(); r != nil {
+			p.logger.Error("Worker pool task panicked",
+				slog.String("pool", p.name),
+				slog.Any("panic", r),
+			)
+		}
+	}()
+	task()
+}
+
+// Submit enqueues a task for execution and returns true when it was accepted.
+//
+// In unlimited mode it always accepts (spawning a goroutine) unless the pool has
+// been stopped. In bounded mode with a configured queue cap it returns false
+// (dropping the task) if the queue is currently full. A false return is not an
+// error: the caller must treat it as "not scheduled" — for DP->CP sync the
+// affected artifact stays in its pending/failed cp_sync_status and is retried on
+// the next (re)connect full resync.
+func (p *Pool) Submit(task func()) bool {
+	if task == nil {
+		return false
+	}
+
+	if p.unlimited {
+		if p.unlimitedStop.Load() {
+			return false
+		}
+		p.unlimitedActive.Go(func() {
+			p.runSafely(task)
+		})
+		return true
+	}
+
+	p.mu.Lock()
+	if p.stopped {
+		p.mu.Unlock()
+		return false
+	}
+	if p.maxQueue > 0 && (len(p.queue)-p.head) >= p.maxQueue {
+		p.mu.Unlock()
+		p.logger.Warn("Worker pool queue full; rejecting task",
+			slog.String("pool", p.name),
+			slog.Int("queue_size", p.maxQueue),
+		)
+		return false
+	}
+	p.queue = append(p.queue, task)
+	p.cond.Signal()
+	p.mu.Unlock()
+	return true
+}
+
+// Stop stops accepting new tasks and blocks until all in-flight (and, in bounded
+// mode, queued) tasks have finished and every worker goroutine has exited. It is
+// idempotent.
+func (p *Pool) Stop() {
+	if p.unlimited {
+		if p.unlimitedStop.Swap(true) {
+			return
+		}
+		p.unlimitedActive.Wait()
+		p.logger.Info("Stopped worker pool", slog.String("pool", p.name))
+		return
+	}
+
+	p.mu.Lock()
+	if p.stopped {
+		p.mu.Unlock()
+		return
+	}
+	p.stopped = true
+	p.cond.Broadcast()
+	p.mu.Unlock()
+	p.wg.Wait()
+	p.logger.Info("Stopped worker pool", slog.String("pool", p.name))
+}

--- a/gateway/gateway-controller/pkg/workerpool/pool.go
+++ b/gateway/gateway-controller/pkg/workerpool/pool.go
@@ -31,7 +31,6 @@ package workerpool
 import (
 	"log/slog"
 	"sync"
-	"sync/atomic"
 )
 
 // Pool is a worker pool. In unlimited mode it spawns a goroutine per task; in
@@ -46,13 +45,12 @@ type Pool struct {
 	mu      sync.Mutex
 	cond    *sync.Cond
 	queue   []func()
-	head    int // index of the next task to run in queue
-	stopped bool
+	head    int  // index of the next task to run in queue
+	stopped bool // guarded by mu; set by Stop for both modes
 	wg      sync.WaitGroup
 
 	// unlimitedActive tracks the number of in-flight goroutines in unlimited mode so Stop can wait for them to drain.
 	unlimitedActive sync.WaitGroup
-	unlimitedStop   atomic.Bool
 }
 
 // New creates and starts a worker pool identified by name.
@@ -89,7 +87,7 @@ func New(name string, workers, queueSize int, logger *slog.Logger) *Pool {
 	}
 	queueLabel := "unbounded"
 	if queueSize > 0 {
-		queueLabel = ""
+		queueLabel = "bounded"
 	}
 	logger.Info("Started worker pool",
 		slog.String("pool", name),
@@ -153,12 +151,17 @@ func (p *Pool) Submit(task func()) bool {
 	}
 
 	if p.unlimited {
-		if p.unlimitedStop.Load() {
+		p.mu.Lock()
+		if p.stopped {
+			p.mu.Unlock()
 			return false
 		}
-		p.unlimitedActive.Go(func() {
+		p.unlimitedActive.Add(1)
+		p.mu.Unlock()
+		go func() {
+			defer p.unlimitedActive.Done()
 			p.runSafely(task)
-		})
+		}()
 		return true
 	}
 
@@ -185,23 +188,21 @@ func (p *Pool) Submit(task func()) bool {
 // mode, queued) tasks have finished and every worker goroutine has exited. It is
 // idempotent.
 func (p *Pool) Stop() {
-	if p.unlimited {
-		if p.unlimitedStop.Swap(true) {
-			return
-		}
-		p.unlimitedActive.Wait()
-		p.logger.Info("Stopped worker pool", slog.String("pool", p.name))
-		return
-	}
-
 	p.mu.Lock()
 	if p.stopped {
 		p.mu.Unlock()
 		return
 	}
 	p.stopped = true
-	p.cond.Broadcast()
+	if !p.unlimited {
+		p.cond.Broadcast()
+	}
 	p.mu.Unlock()
-	p.wg.Wait()
+
+	if p.unlimited {
+		p.unlimitedActive.Wait()
+	} else {
+		p.wg.Wait()
+	}
 	p.logger.Info("Stopped worker pool", slog.String("pool", p.name))
 }

--- a/gateway/gateway-controller/pkg/workerpool/pool_test.go
+++ b/gateway/gateway-controller/pkg/workerpool/pool_test.go
@@ -167,6 +167,30 @@ func TestPool_RejectsWhenQueueFull(t *testing.T) {
 	close(release)
 }
 
+// TestPool_UnlimitedSubmitStopRace exercises concurrent Submit and Stop on an
+// unlimited pool: the stopped-check and WaitGroup increment must be synchronized
+// so no task is admitted after Stop begins (no Add-after-Wait). Run under -race.
+func TestPool_UnlimitedSubmitStopRace(t *testing.T) {
+	p := New("test", 0, 0, testLogger()) // unlimited
+
+	var ran atomic.Int64
+	var submitters sync.WaitGroup
+	for range 8 {
+		submitters.Go(func() {
+			for range 50 {
+				p.Submit(func() { ran.Add(1) })
+			}
+		})
+	}
+
+	p.Stop() // races with the in-flight Submits; must not panic or leak a task past Stop
+	submitters.Wait()
+	// Any further submits after Stop must be rejected.
+	if p.Submit(func() { ran.Add(1) }) {
+		t.Fatal("submit after Stop must be rejected")
+	}
+}
+
 // TestPool_SubmitAfterStopRejects verifies a stopped pool accepts no new work.
 func TestPool_SubmitAfterStopRejects(t *testing.T) {
 	p := New("test", 2, 8, testLogger())

--- a/gateway/gateway-controller/pkg/workerpool/pool_test.go
+++ b/gateway/gateway-controller/pkg/workerpool/pool_test.go
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package workerpool
+
+import (
+	"io"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// TestPool_RunsAllSubmittedTasks verifies every accepted task executes exactly once.
+func TestPool_RunsAllSubmittedTasks(t *testing.T) {
+	p := New("test", 4, 128, testLogger())
+	defer p.Stop()
+
+	var counter atomic.Int64
+	var wg sync.WaitGroup
+	const n = 100
+	wg.Add(n)
+	for range n {
+		accepted := p.Submit(func() {
+			defer wg.Done()
+			counter.Add(1)
+		})
+		if !accepted {
+			t.Fatal("task unexpectedly rejected")
+		}
+	}
+	wg.Wait()
+	if got := counter.Load(); got != n {
+		t.Fatalf("expected %d tasks run, got %d", n, got)
+	}
+}
+
+// TestPool_BoundsConcurrency verifies no more than the configured number of
+// workers run simultaneously — the core property that fixes the concurrent-sync
+// deadlock (#2903) when the pool is sized to 1.
+func TestPool_BoundsConcurrency(t *testing.T) {
+	const workers = 2
+	p := New("test", workers, 128, testLogger())
+	defer p.Stop()
+
+	var inFlight atomic.Int64
+	var maxInFlight atomic.Int64
+	var wg sync.WaitGroup
+	const n = 20
+	wg.Add(n)
+	for range n {
+		p.Submit(func() {
+			defer wg.Done()
+			cur := inFlight.Add(1)
+			for {
+				old := maxInFlight.Load()
+				if cur <= old || maxInFlight.CompareAndSwap(old, cur) {
+					break
+				}
+			}
+			time.Sleep(5 * time.Millisecond)
+			inFlight.Add(-1)
+		})
+	}
+	wg.Wait()
+	if got := maxInFlight.Load(); got > workers {
+		t.Fatalf("concurrency exceeded pool size: max in-flight %d > workers %d", got, workers)
+	}
+}
+
+// TestPool_UnlimitedRunsEveryTask verifies the default (workers <= 0) unlimited
+// mode runs every submitted task, never rejecting — preserving the historical
+// per-operation goroutine behaviour.
+func TestPool_UnlimitedRunsEveryTask(t *testing.T) {
+	p := New("test", 0, 0, testLogger()) // 0 workers => unlimited
+	defer p.Stop()
+
+	var counter atomic.Int64
+	var wg sync.WaitGroup
+	const n = 200
+	wg.Add(n)
+	for range n {
+		if !p.Submit(func() {
+			defer wg.Done()
+			counter.Add(1)
+		}) {
+			t.Fatal("unlimited pool must never reject a task")
+		}
+	}
+	wg.Wait()
+	if got := counter.Load(); got != n {
+		t.Fatalf("expected %d tasks run, got %d", n, got)
+	}
+}
+
+// TestPool_UnboundedQueueNeverRejects verifies that bounded workers with an
+// unconfigured (<=0) queue size never reject work.
+func TestPool_UnboundedQueueNeverRejects(t *testing.T) {
+	// One worker, unbounded queue. Block the worker, then flood the queue.
+	p := New("test", 1, 0, testLogger())
+	release := make(chan struct{})
+	started := make(chan struct{})
+	if !p.Submit(func() {
+		close(started)
+		<-release
+	}) {
+		t.Fatal("first task should be accepted")
+	}
+	<-started
+
+	const n = 1000
+	for range n {
+		if !p.Submit(func() {}) {
+			t.Fatal("unbounded queue must never reject a task")
+		}
+	}
+	close(release)
+	p.Stop() // drains the queue
+}
+
+// TestPool_RejectsWhenQueueFull verifies the bounded queue rejects excess work
+// instead of buffering it without limit.
+func TestPool_RejectsWhenQueueFull(t *testing.T) {
+	// One worker, queue of one. Block the worker so the queue fills.
+	p := New("test", 1, 1, testLogger())
+	defer p.Stop()
+
+	release := make(chan struct{})
+	started := make(chan struct{})
+	// Occupy the single worker.
+	if !p.Submit(func() {
+		close(started)
+		<-release
+	}) {
+		t.Fatal("first task should be accepted")
+	}
+	<-started
+
+	// Fill the single queue slot.
+	if !p.Submit(func() { <-release }) {
+		t.Fatal("second task should fill the queue")
+	}
+	// Now both worker and queue are occupied → next submit must be rejected.
+	if p.Submit(func() {}) {
+		t.Fatal("third task should be rejected when the queue is full")
+	}
+	close(release)
+}
+
+// TestPool_SubmitAfterStopRejects verifies a stopped pool accepts no new work.
+func TestPool_SubmitAfterStopRejects(t *testing.T) {
+	p := New("test", 2, 8, testLogger())
+	p.Stop()
+	if p.Submit(func() {}) {
+		t.Fatal("submit after Stop must be rejected")
+	}
+	// Stop is idempotent.
+	p.Stop()
+}
+
+// TestPool_RecoversFromPanic verifies a panicking task doesn't kill the worker.
+func TestPool_RecoversFromPanic(t *testing.T) {
+	p := New("test", 1, 8, testLogger())
+	defer p.Stop()
+
+	if !p.Submit(func() { panic("boom") }) {
+		t.Fatal("panicking task should be accepted")
+	}
+	done := make(chan struct{})
+	if !p.Submit(func() { close(done) }) {
+		t.Fatal("follow-up task should be accepted")
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker did not survive a panicking task")
+	}
+}


### PR DESCRIPTION
### Purpose

When a platform gateway is connected to an on-prem WSO2 API-M control plane, the data-plane→control-plane (DP→CP) artifact sync had three defects that surfaced under a realistic bulk workload (creating many REST APIs):

1. Unbounded concurrency → APIM registry deadlocks. The gateway spawned one goroutine per REST API create/update and per (re)connect resync to run the on-prem APIM bottom-up sync. A burst of creates fired many concurrent Publisher API imports into APIM, producing PostgreSQL/registry deadlocks (JDBCResourceDAO … RegistryPersistenceImpl.updateAPI) and AM_API unique-constraint violations.
2. Platform-api push fired against classic APIM. The AI-Workspace bulk-import push (POST /…/artifacts/import-gateway-artifacts) ran even when the control plane was on-prem APIM, which has no such endpoint → repeated 404 and clobbered cp_sync_status.
3. Platform-api pulls fired against classic APIM on connect. syncDeployments (GET /…/deployments) and syncSecrets ran on connect against APIM, which lacks those endpoints → spurious 404 on every gateway connect.

- Resolves: wso2/api-platform#2903

### Goals

- Replace unbounded per-operation goroutines with bounded, configurable worker pools for DP→CP sync, so a burst of creates cannot stampede the control plane (and can be serialized to eliminate the APIM deadlock).
- Cleanly separate the two control-plane types so platform-api operations never run against on-prem APIM (and vice-versa) — across every artifact kind (REST API, LLM provider template, LLM provider, LLM proxy, MCP proxy), operation (create / update / undeploy), and entry point (gateway REST API, immutable-gateway loader, connect/reconnect sync).

### Approach

- New pkg/workerpool — a small bounded pool (N workers + bounded/unbounded FIFO queue, per-task panic recovery, reject-when-full). Two pools on the control-plane client — apim-sync and ai-workspace-sync — sized from four new [controller.controlplane] config keys. Default is unlimited (goroutine-per-task) to preserve existing behaviour; set apim_sync_pool_size = 1 to serialize APIM imports and remove the deadlock.
- Single choke points for the push. Every DP→CP push funnels through Client.PushArtifact (single) or Client.PushGatewayArtifactsToControlPlane (bulk). Added the pools' SubmitAPIMSync / SubmitArtifactPush methods and a blocking SubmitAPIMSyncAndWait for the delete→undeploy-before-delete path (serialized yet ordered).
- On-prem guarding on both directions. Gated every platform-api operation on !IsOnPrem(): push side (PushArtifact, PushGatewayArtifactsToControlPlane, REST create/update sites, LLM/MCP canPushToControlPlane, handlerkit undeploy/wait) and pull side (syncDeployments, syncSecrets). Added IsOnPrem() to the utils.ArtifactPusher interface so the LLM/MCP services can guard explicitly. On-prem REST APIs continue to sync via SyncArtifactsToOnPremAPIM (Publisher API); kinds APIM doesn't model are correctly not pushed anywhere.

No UI changes.

### User stories

- As an operator running a platform gateway against on-prem APIM, I can bulk-create/update APIs and have them sync reliably without registry deadlocks or unique-constraint errors.
- As an operator, I can tune (or serialize) DP→CP sync concurrency via configuration without code changes.
- As an operator, connecting a gateway to on-prem APIM no longer produces spurious 404s from control-plane-type-mismatched sync calls.

### Documentation

Updated the gateway configuration reference / docs/gateway/dp-to-cp-sync.md.

### Automation tests

- Unit tests
  - New pkg/workerpool/pool_test.go: runs-all-submitted, bounds-concurrency (proves size-1 serialization), unlimited-never-rejects, unbounded-queue-never-rejects, reject-when-queue-full, panic-recovery, stop-idempotent/rejects-after-stop.
  - Updated the MockControlPlaneClient (new interface methods) and the stubClient test helper.
  - go build ./..., go vet, and go test ./... for the gateway-controller module pass; the touched packages (controlplane, api/handlers, utils, workerpool) also pass under -race. (Exact coverage % not captured; the new package is exercised by the tests above.)
- Integration tests
  - Existing gateway/it/features/dp-to-cp.feature covers the platform-api push path against a mock control plane and continues to pass.
  - The on-prem-APIM path and pool behaviour were validated manually end-to-end (bulk REST-API create → APIM Publisher import with apim_sync_pool_size=1). A dedicated on-prem IT scenario is not added in this PR.

### Security checks

- Followed secure coding standards (WSO2 Secure Engineering Guidelines)? yes
- Ran FindSecurityBugs plugin and verified report? N/A — FindSecurityBugs is a Java/SpotBugs plugin; this is a Go module. Ran go vet ./... (clean) instead.
- Confirmed this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes — all credentials are sourced from env/config; none are hardcoded or committed.