### PR TITLE
[FIX] Correct model limits and policy sync waits

### DIFF
--- a/gateway/configs/llm-pricing/model_prices.json
+++ b/gateway/configs/llm-pricing/model_prices.json
@@ -8027,8 +8027,8 @@
   "moonshotai.kimi-k2.5": {
     "input_cost_per_token": 6e-07,
     "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "max_tokens": 262144,
+    "max_output_tokens": 16384,
+    "max_tokens": 16384,
     "output_cost_per_token": 0.000003,
     "provider": "bedrock"
   },

--- a/gateway/it/features/model-round-robin-multi-provider.feature
+++ b/gateway/it/features/model-round-robin-multi-provider.feature
@@ -129,7 +129,7 @@ Feature: Model Round-Robin Multi-Provider Routing
                   suspendDuration: 60
       """
     Then the response status should be 201
-    And I wait for 3 seconds
+    And I wait for policy snapshot sync
 
     # Request 1 -> primary provider (no provider on target), model gpt-4o
     When I set header "Content-Type" to "application/json"
@@ -252,7 +252,7 @@ Feature: Model Round-Robin Multi-Provider Routing
                   suspendDuration: 30
       """
     Then the response status should be 201
-    And I wait for 3 seconds
+    And I wait for policy snapshot sync
 
     # Request 1 -> primary/shared-model, healthy
     When I set header "Content-Type" to "application/json"
@@ -365,7 +365,7 @@ Feature: Model Round-Robin Multi-Provider Routing
                     - model: model-two
       """
     Then the response status should be 201
-    And I wait for 3 seconds
+    And I wait for policy snapshot sync
 
     When I set header "Content-Type" to "application/json"
     And I send a POST request to "http://localhost:8080/mp-default-proxy/chat/completions" with body:

--- a/gateway/it/features/model-weighted-round-robin-multi-provider.feature
+++ b/gateway/it/features/model-weighted-round-robin-multi-provider.feature
@@ -125,7 +125,7 @@ Feature: Model Weighted Round-Robin Multi-Provider Routing
                   suspendDuration: 60
       """
     Then the response status should be 201
-    And I wait for 3 seconds
+    And I wait for policy snapshot sync
 
     # Request 1 -> gpt-4o on the primary provider (weight slot 1 of 2)
     When I set header "Content-Type" to "application/json"
@@ -258,7 +258,7 @@ Feature: Model Weighted Round-Robin Multi-Provider Routing
                   suspendDuration: 30
       """
     Then the response status should be 201
-    And I wait for 3 seconds
+    And I wait for policy snapshot sync
 
     # Request 1 -> primary/shared-model, healthy
     When I set header "Content-Type" to "application/json"
@@ -372,7 +372,7 @@ Feature: Model Weighted Round-Robin Multi-Provider Routing
                       weight: 1
       """
     Then the response status should be 201
-    And I wait for 3 seconds
+    And I wait for policy snapshot sync
 
     When I set header "Content-Type" to "application/json"
     And I send a POST request to "http://localhost:8080/mpw-default-proxy/chat/completions" with body:

--- a/kubernetes/helm/gateway-helm-chart/files/llm-pricing/model_prices.json
+++ b/kubernetes/helm/gateway-helm-chart/files/llm-pricing/model_prices.json
@@ -8027,8 +8027,8 @@
   "moonshotai.kimi-k2.5": {
     "input_cost_per_token": 6e-07,
     "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "max_tokens": 262144,
+    "max_output_tokens": 16384,
+    "max_tokens": 16384,
     "output_cost_per_token": 0.000003,
     "provider": "bedrock"
   },


### PR DESCRIPTION
## Related PR

Follow-up fixes for [wso2/api-platform#2952](https://github.com/wso2/api-platform/pull/2952).

This PR targets the `bedrock-support` branch and addresses the CodeRabbit review feedback in #2952:

- Corrects the AWS Bedrock Kimi K2.5 maximum output-token limit.
- Replaces fixed integration-test waits with policy snapshot synchronization.