### PR TITLE
[APIP] Tag upstream endpoints with peer.service metadata

### DIFF
--- a/gateway/gateway-controller/pkg/xds/translator.go
+++ b/gateway/gateway-controller/pkg/xds/translator.go
@@ -56,6 +56,8 @@ import (
 	otelresourcedetectorsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/tracers/opentelemetry/resource_detectors/v3"
 	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+	metadatav3 "github.com/envoyproxy/go-control-plane/envoy/type/metadata/v3"
+	tracingv3 "github.com/envoyproxy/go-control-plane/envoy/type/tracing/v3"
 	typev3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	"github.com/envoyproxy/go-control-plane/pkg/resource/v3"
@@ -77,6 +79,10 @@ const (
 	ExternalProcessorGRPCServiceClusterName = "ext-processor-grpc-service"
 	OTELCollectorClusterName                = "otel_collector"
 	WebSubHubInternalClusterName            = "WEBSUBHUB_INTERNAL_CLUSTER"
+
+	// Upstream endpoint metadata carrying the backend hostname for tracing peer identity.
+	envoyLBMetadataNamespace   = "envoy.lb"
+	envoyLBHostnameMetadataKey = "hostname"
 )
 
 func checkedUInt32FromPositiveInt(fieldName string, value int) (uint32, error) {
@@ -548,6 +554,12 @@ func (t *Translator) createWeightedCluster(
 			lb.LoadBalancingWeight = &wrapperspb.UInt32Value{Value: uint32(*ep.Weight)}
 		}
 
+		// Each endpoint in a weighted upstream can have a different hostname (round-robin/
+		// failover across distinct backends), so peer.service metadata is stamped per-endpoint
+		// here too, mirroring processEndpoint (the single-endpoint path). Without this, any
+		// upstream with more than one endpoint would have no peer.service tracing tag at all.
+		setEndpointPeerHostname(lb, ep.Host)
+
 		// When the upstream definition is HTTPS, dial each endpoint over TLS. Endpoints in a
 		// weighted definition can have different hostnames, so each gets its own transport
 		// socket match carrying an UpstreamTlsContext with that endpoint's SNI, and the
@@ -576,15 +588,7 @@ func (t *Translator) createWeightedCluster(
 						},
 					},
 				})
-				lb.Metadata = &core.Metadata{
-					FilterMetadata: map[string]*structpb.Struct{
-						constants.TransportSocketMatchKey: {
-							Fields: map[string]*structpb.Value{
-								constants.LoadBalancerIDKey: structpb.NewStringValue(matchID),
-							},
-						},
-					},
-				}
+				setEndpointTransportSocketMatchID(lb, matchID)
 			}
 		}
 
@@ -2420,6 +2424,8 @@ func (t *Translator) processEndpoint(
 		}},
 	}
 
+	setEndpointPeerHostname(localityLbEndpoints.LbEndpoints[0], upstreamURL.Hostname())
+
 	if upstreamURL.Scheme == constants.SchemeHTTPS {
 		var epCert []byte
 		if cert, found := upstreamCerts[upstreamURL.String()]; found {
@@ -2457,15 +2463,7 @@ func (t *Translator) processEndpoint(
 
 		// Set metadata for transport socket matching
 		// This metadata links the endpoint to its transport socket configuration
-		localityLbEndpoints.LbEndpoints[0].Metadata = &core.Metadata{
-			FilterMetadata: map[string]*structpb.Struct{
-				constants.TransportSocketMatchKey: {
-					Fields: map[string]*structpb.Value{
-						constants.LoadBalancerIDKey: structpb.NewStringValue(matchID),
-					},
-				},
-			},
-		}
+		setEndpointTransportSocketMatchID(localityLbEndpoints.LbEndpoints[0], matchID)
 
 		return []*endpoint.LocalityLbEndpoints{localityLbEndpoints}, transportSocketMatch
 	}
@@ -2764,7 +2762,9 @@ func (t *Translator) createTracingConfig() (*hcm.HttpConnectionManager_Tracing, 
 		return nil, fmt.Errorf("failed to marshal OpenTelemetry config: %w", err)
 	}
 
-	// Create tracing configuration
+	// Tracing essentials for Datadog Dependencies:
+	// 1) spawn_upstream_span → CLIENT child span for the upstream call
+	// 2) peer.service → backend hostname Datadog can aggregate as a peer
 	tracingConfig := &hcm.HttpConnectionManager_Tracing{
 		Provider: &tracev3.Tracing_Http{
 			Name: "envoy.tracers.opentelemetry",
@@ -2776,6 +2776,7 @@ func (t *Translator) createTracingConfig() (*hcm.HttpConnectionManager_Tracing, 
 		RandomSampling: &typev3.Percent{
 			Value: samplingPercentage,
 		},
+		CustomTags: createTracingUpstreamPeerCustomTags(),
 	}
 
 	t.logger.Info("Tracing configuration created",
@@ -2840,6 +2841,84 @@ func createOTelStaticResourceDetector(attributes map[string]string) (*core.Typed
 		Name:        "envoy.tracers.opentelemetry.resource_detectors.static_config",
 		TypedConfig: staticDetectorAny,
 	}, nil
+}
+
+// createTracingUpstreamPeerCustomTags builds the peer identity tag Datadog uses to infer
+// downstream dependencies. The value comes from the selected upstream host's metadata rather
+// than the Host header, so it stays correct for upstreams configured with hostRewrite: manual.
+// A single tag is enough: peer.service is Datadog's highest-priority peer attribute.
+func createTracingUpstreamPeerCustomTags() []*tracingv3.CustomTag {
+	return []*tracingv3.CustomTag{
+		{
+			Tag: "peer.service",
+			Type: &tracingv3.CustomTag_Metadata_{
+				Metadata: &tracingv3.CustomTag_Metadata{
+					Kind: &metadatav3.MetadataKind{
+						Kind: &metadatav3.MetadataKind_Host_{
+							Host: &metadatav3.MetadataKind_Host{},
+						},
+					},
+					MetadataKey: &metadatav3.MetadataKey{
+						Key: envoyLBMetadataNamespace,
+						Path: []*metadatav3.MetadataKey_PathSegment{
+							{
+								Segment: &metadatav3.MetadataKey_PathSegment_Key{
+									Key: envoyLBHostnameMetadataKey,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// ensureFilterMetadata returns lbEndpoint's FilterMetadata map, allocating Metadata/
+// FilterMetadata on demand. Every filter-metadata writer goes through this helper so no
+// writer depends on another having run first or on call ordering within a single endpoint.
+func ensureFilterMetadata(lbEndpoint *endpoint.LbEndpoint) map[string]*structpb.Struct {
+	if lbEndpoint.Metadata == nil {
+		lbEndpoint.Metadata = &core.Metadata{}
+	}
+	if lbEndpoint.Metadata.FilterMetadata == nil {
+		lbEndpoint.Metadata.FilterMetadata = map[string]*structpb.Struct{}
+	}
+	return lbEndpoint.Metadata.FilterMetadata
+}
+
+// setEndpointPeerHostname stamps the upstream hostname on an endpoint under the envoy.lb
+// namespace so the peer.service custom tag (createTracingUpstreamPeerCustomTags) can read it
+// as the upstream CLIENT span's peer identity. Routing is unaffected. Applies to both plaintext
+// and TLS endpoints — peer.service tracing doesn't depend on transport security. A nil endpoint
+// or empty hostname is a no-op, checked before any allocation, so an endpoint that genuinely has
+// no resolvable hostname doesn't gain an empty Metadata shell.
+func setEndpointPeerHostname(lbEndpoint *endpoint.LbEndpoint, hostname string) {
+	if lbEndpoint == nil || hostname == "" {
+		return
+	}
+
+	ensureFilterMetadata(lbEndpoint)[envoyLBMetadataNamespace] = &structpb.Struct{
+		Fields: map[string]*structpb.Value{
+			envoyLBHostnameMetadataKey: structpb.NewStringValue(hostname),
+		},
+	}
+}
+
+// setEndpointTransportSocketMatchID tags an endpoint with the lb_id its Cluster_
+// TransportSocketMatch was registered under, so Envoy selects the matching per-endpoint TLS
+// transport socket. Shared by the single-endpoint (processEndpoint) and weighted
+// (createWeightedCluster) cluster-building paths.
+func setEndpointTransportSocketMatchID(lbEndpoint *endpoint.LbEndpoint, matchID string) {
+	if lbEndpoint == nil {
+		return
+	}
+
+	ensureFilterMetadata(lbEndpoint)[constants.TransportSocketMatchKey] = &structpb.Struct{
+		Fields: map[string]*structpb.Value{
+			constants.LoadBalancerIDKey: structpb.NewStringValue(matchID),
+		},
+	}
 }
 
 // convertToInterface converts map[string]string to map[string]interface{} for structpb

--- a/gateway/gateway-controller/pkg/xds/translator_test.go
+++ b/gateway/gateway-controller/pkg/xds/translator_test.go
@@ -36,6 +36,8 @@ import (
 	otelresourcedetectorsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/tracers/opentelemetry/resource_detectors/v3"
 	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+	metadatav3 "github.com/envoyproxy/go-control-plane/envoy/type/metadata/v3"
+	tracingv3 "github.com/envoyproxy/go-control-plane/envoy/type/tracing/v3"
 	resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1701,6 +1703,44 @@ func TestTranslator_CreateTracingConfig_ResourceAttributes(t *testing.T) {
 	}, staticDetector.GetAttributes())
 }
 
+// TestTranslator_CreateTracingConfig_PeerServiceCustomTag guards the fix for GH issue #2883:
+// with tracing enabled, the HCM tracing config must carry exactly one custom tag, "peer.service",
+// sourced from host metadata under the envoy.lb/hostname key set by setEndpointPeerHostname —
+// without this, Datadog APM has no peer attribute on upstream CLIENT spans to build the
+// Dependencies view / service map from. This pins the wire shape so a go-control-plane version
+// bump can't silently reshape it without a test failure.
+func TestTranslator_CreateTracingConfig_PeerServiceCustomTag(t *testing.T) {
+	logger := createTestLogger()
+	routerCfg := testRouterConfig()
+	cfg := testConfig()
+	cfg.TracingConfig.Enabled = true
+	cfg.TracingConfig.Endpoint = "otel-collector:4317"
+	translator := NewTranslator(logger, routerCfg, nil, cfg)
+
+	tracingCfg, err := translator.createTracingConfig()
+	require.NoError(t, err)
+	require.NotNil(t, tracingCfg)
+
+	customTags := tracingCfg.GetCustomTags()
+	require.Len(t, customTags, 1, "exactly one custom tag (peer.service) is expected")
+
+	tag := customTags[0]
+	assert.Equal(t, "peer.service", tag.GetTag())
+
+	metaTag, ok := tag.GetType().(*tracingv3.CustomTag_Metadata_)
+	require.True(t, ok, "peer.service must be sourced from metadata, got %T", tag.GetType())
+
+	hostKind, ok := metaTag.Metadata.GetKind().GetKind().(*metadatav3.MetadataKind_Host_)
+	require.True(t, ok, "peer.service must read HOST metadata (the selected upstream endpoint), got %T",
+		metaTag.Metadata.GetKind().GetKind())
+	assert.NotNil(t, hostKind)
+
+	key := metaTag.Metadata.GetMetadataKey()
+	assert.Equal(t, "envoy.lb", key.GetKey())
+	require.Len(t, key.GetPath(), 1)
+	assert.Equal(t, "hostname", key.GetPath()[0].GetKey())
+}
+
 func TestTranslator_CreateOTELCollectorCluster(t *testing.T) {
 	logger := createTestLogger()
 	routerCfg := testRouterConfig()
@@ -2411,6 +2451,46 @@ func createTestTranslator() *Translator {
 	return NewTranslator(logger, routerCfg, nil, cfg)
 }
 
+// TestProcessEndpoint_PeerHostnameMetadata guards the fix for GH issue #2883 (Datadog
+// Dependencies view needs a peer.service tag on upstream CLIENT spans). processEndpoint must
+// stamp the upstream hostname under the envoy.lb/hostname metadata key so the peer.service
+// custom tag (createTracingUpstreamPeerCustomTags) can read it, for both plaintext and HTTPS
+// endpoints — and, for HTTPS, alongside (not instead of) the existing
+// envoy.transport_socket_match/lb_id metadata that TLS transport-socket matching depends on.
+func TestProcessEndpoint_PeerHostnameMetadata(t *testing.T) {
+	translator := createTestTranslator()
+
+	t.Run("http endpoint gets peer hostname metadata, no transport socket metadata", func(t *testing.T) {
+		u, err := url.Parse("http://backend.default.svc.cluster.local:8080/v1")
+		require.NoError(t, err)
+
+		endpoints, tsm := translator.processEndpoint(u, nil)
+		require.Len(t, endpoints, 1)
+		lb := endpoints[0].GetLbEndpoints()[0]
+
+		assert.Nil(t, tsm, "plaintext endpoint must not produce a transport socket match")
+		md := lb.GetMetadata().GetFilterMetadata()
+		assert.Equal(t, "backend.default.svc.cluster.local", md["envoy.lb"].GetFields()["hostname"].GetStringValue())
+		assert.Nil(t, md["envoy.transport_socket_match"], "plaintext endpoint must not carry transport-socket metadata")
+	})
+
+	t.Run("https endpoint gets peer hostname metadata alongside transport socket metadata", func(t *testing.T) {
+		u, err := url.Parse("https://api.example.com/v1")
+		require.NoError(t, err)
+
+		endpoints, tsm := translator.processEndpoint(u, nil)
+		require.Len(t, endpoints, 1)
+		lb := endpoints[0].GetLbEndpoints()[0]
+
+		require.NotNil(t, tsm, "https endpoint must produce a transport socket match")
+		md := lb.GetMetadata().GetFilterMetadata()
+		assert.Equal(t, "api.example.com", md["envoy.lb"].GetFields()["hostname"].GetStringValue())
+		require.NotNil(t, md["envoy.transport_socket_match"],
+			"https endpoint must still carry transport-socket metadata alongside peer hostname metadata")
+		assert.Equal(t, constants.DefaultMatchID, md["envoy.transport_socket_match"].GetFields()["lb_id"].GetStringValue())
+	})
+}
+
 // TestCreateWeightedCluster_TLS guards the fix for the reviewer concern
 // "Configure TLS for weighted HTTPS upstreams." A multi-endpoint (weighted) upstream
 // definition whose endpoints are HTTPS must be dialed over TLS, mirroring the single-endpoint
@@ -2469,9 +2549,55 @@ func TestCreateWeightedCluster_TLS(t *testing.T) {
 			require.NotNil(t, c)
 			assert.Empty(t, c.GetTransportSocketMatches(),
 				"plaintext weighted upstream must not get transport socket matches")
-			for _, lb := range c.GetLoadAssignment().GetEndpoints()[0].GetLbEndpoints() {
-				assert.Nil(t, lb.GetMetadata(), "plaintext endpoint must not carry transport-socket metadata")
+			for i, lb := range c.GetLoadAssignment().GetEndpoints()[0].GetLbEndpoints() {
+				assert.Nil(t, lb.GetMetadata().GetFilterMetadata()["envoy.transport_socket_match"],
+					"plaintext endpoint must not carry transport-socket metadata")
+				// peer.service hostname metadata is independent of TLS and must still be present.
+				assert.Equal(t, plain[i].Host,
+					lb.GetMetadata().GetFilterMetadata()["envoy.lb"].GetFields()["hostname"].GetStringValue())
 			}
+		}
+	})
+}
+
+// TestCreateWeightedCluster_PeerHostnameMetadata guards the multi-endpoint half of the fix for
+// GH issue #2883: a weighted (multi-endpoint) upstream cluster is exactly as common as a
+// single-endpoint one (round-robin/failover across distinct backends), so every LbEndpoint
+// createWeightedCluster produces must carry its own envoy.lb/hostname metadata — not just the
+// single-endpoint processEndpoint path. Before this fix, any upstream with more than one
+// endpoint had no peer.service tracing tag whatsoever.
+func TestCreateWeightedCluster_PeerHostnameMetadata(t *testing.T) {
+	translator := createTestTranslator()
+	w := func(n int) *int { return &n }
+	endpoints := []models.Endpoint{
+		{Host: "a.example.com", Port: 443, Weight: w(70)},
+		{Host: "b.example.com", Port: 443, Weight: w(30)},
+	}
+
+	t.Run("each endpoint carries its own hostname, distinct from its siblings", func(t *testing.T) {
+		c := translator.createWeightedCluster("upstream_secure", endpoints, &models.UpstreamTLS{Enabled: true}, nil)
+		require.NotNil(t, c)
+
+		lbs := c.GetLoadAssignment().GetEndpoints()[0].GetLbEndpoints()
+		require.Len(t, lbs, len(endpoints))
+		for i, lb := range lbs {
+			md := lb.GetMetadata().GetFilterMetadata()
+			assert.Equal(t, endpoints[i].Host, md["envoy.lb"].GetFields()["hostname"].GetStringValue(),
+				"endpoint %d must carry its own hostname as peer.service metadata", i)
+			require.NotNil(t, md["envoy.transport_socket_match"])
+			assert.Equal(t, strconv.Itoa(i), md["envoy.transport_socket_match"].GetFields()["lb_id"].GetStringValue())
+		}
+	})
+
+	t.Run("plaintext weighted endpoints still get hostname metadata", func(t *testing.T) {
+		c := translator.createWeightedCluster("upstream_plain", endpoints, nil, nil)
+		require.NotNil(t, c)
+
+		lbs := c.GetLoadAssignment().GetEndpoints()[0].GetLbEndpoints()
+		require.Len(t, lbs, len(endpoints))
+		for i, lb := range lbs {
+			assert.Equal(t, endpoints[i].Host,
+				lb.GetMetadata().GetFilterMetadata()["envoy.lb"].GetFields()["hostname"].GetStringValue())
 		}
 	})
 }
@@ -2592,4 +2718,51 @@ func TestTranslator_TranslateRuntimeConfig_AppliesConnectTimeout(t *testing.T) {
 		"an explicit per-upstream connect timeout must be applied to the Envoy cluster")
 	assert.Equal(t, 5*time.Second, got["without_timeout"],
 		"a nil connect timeout must fall back to the router global default (5s), not be dropped to zero")
+}
+
+// TestTranslateRuntimeConfig_PeerHostnameOnEveryEndpoint is the end-to-end invariant guard for
+// GH issue #2883: translateRuntimeConfig builds clusters via two different endpoint-construction
+// paths depending on endpoint count (createCluster/processEndpoint for one endpoint,
+// createWeightedCluster for more than one) — every LbEndpoint produced by either path must carry
+// non-empty envoy.lb/hostname metadata. This is the test that keeps gap #1 (multi-endpoint
+// upstreams silently getting no peer.service tag) from being reintroduced if a third
+// endpoint-building path is ever added without also calling setEndpointPeerHostname.
+func TestTranslateRuntimeConfig_PeerHostnameOnEveryEndpoint(t *testing.T) {
+	translator := createTestTranslator()
+	w := func(n int) *int { return &n }
+	rdc := &models.RuntimeDeployConfig{
+		Metadata: models.Metadata{UUID: "u", Kind: "RestApi"},
+		Routes:   map[string]*models.Route{},
+		UpstreamClusters: map[string]*models.UpstreamCluster{
+			"single": {
+				BasePath:  "/",
+				Endpoints: []models.Endpoint{{Host: "solo.example.com", Port: 8080}},
+			},
+			"weighted": {
+				BasePath: "/",
+				Endpoints: []models.Endpoint{
+					{Host: "primary.example.com", Port: 8080, Weight: w(80)},
+					{Host: "secondary.example.com", Port: 8080, Weight: w(15)},
+					{Host: "tertiary.example.com", Port: 8080, Weight: w(5)},
+				},
+			},
+		},
+	}
+
+	_, clusters, err := translator.translateRuntimeConfig(rdc)
+	require.NoError(t, err)
+	require.Len(t, clusters, 2)
+
+	checked := 0
+	for _, c := range clusters {
+		for _, localityLb := range c.GetLoadAssignment().GetEndpoints() {
+			for _, lb := range localityLb.GetLbEndpoints() {
+				hostname := lb.GetMetadata().GetFilterMetadata()["envoy.lb"].GetFields()["hostname"].GetStringValue()
+				assert.NotEmpty(t, hostname,
+					"cluster %q: every LbEndpoint must carry a non-empty peer.service hostname", c.GetName())
+				checked++
+			}
+		}
+	}
+	assert.Equal(t, 4, checked, "expected to have checked all 4 endpoints across both clusters (1 + 3)")
 }


### PR DESCRIPTION


Envoy's HCM tracing config had no custom tags, so upstream CLIENT spans carried no peer identity — Datadog APM's Dependencies view had nothing to build a service-map edge from (issue #2883).

Adds a peer.service custom tag sourced from HOST metadata, and stamps envoy.lb/hostname on every LbEndpoint via two small shared helpers (ensureFilterMetadata, setEndpointPeerHostname,
setEndpointTransportSocketMatchID) used by both endpoint-construction paths: the single-endpoint path (processEndpoint) and the multi-endpoint weighted path (createWeightedCluster). The weighted path previously had no hostname metadata at all, so any upstream with more than one endpoint would have gotten no peer.service tag.
