### PR TITLE
feat(sdk,policy-engine): improve decompression logic and extend context snapshot fields

### DIFF
--- a/gateway/configs/config-template.toml
+++ b/gateway/configs/config-template.toml
@@ -269,6 +269,15 @@ skip_verify = false
 # POLICY ENGINE CONFIGURATION
 # =============================================================================
 
+# max_decompressed_bytes caps decompressed bytes buffered per body (buffered
+# mode) or per chunk (streaming) — not cumulative, so long-lived streams such
+# as SSE are unaffected. Each direction is configured independently.
+[policy_engine.request]
+max_decompressed_bytes = 10485760
+
+[policy_engine.response]
+max_decompressed_bytes = 10485760
+
 [policy_engine.server]
 extproc_port = 9001
 

--- a/gateway/configs/config-template.toml
+++ b/gateway/configs/config-template.toml
@@ -272,10 +272,10 @@ skip_verify = false
 # max_decompressed_bytes caps decompressed bytes buffered per body (buffered
 # mode) or per chunk (streaming) — not cumulative, so long-lived streams such
 # as SSE are unaffected. Each direction is configured independently.
-[policy_engine.request]
+[policy_engine.request_body]
 max_decompressed_bytes = 10485760
 
-[policy_engine.response]
+[policy_engine.response_body]
 max_decompressed_bytes = 10485760
 
 [policy_engine.server]

--- a/gateway/gateway-runtime/policy-engine/cmd/policy-engine/main.go
+++ b/gateway/gateway-runtime/policy-engine/cmd/policy-engine/main.go
@@ -219,7 +219,7 @@ func main() {
 	}
 
 	// Create and start ext_proc gRPC server
-	extprocServer := kernel.NewExternalProcessorServer(k, chainExecutor, cfg.TracingConfig, cfg.PolicyEngine.TracingServiceName)
+	extprocServer := kernel.NewExternalProcessorServer(k, chainExecutor, cfg.TracingConfig, cfg.PolicyEngine.TracingServiceName, cfg.PolicyEngine.Request.MaxDecompressedBytes, cfg.PolicyEngine.Response.MaxDecompressedBytes)
 
 	// Create listener based on mode (same pattern as gateway-controller)
 	var lis net.Listener

--- a/gateway/gateway-runtime/policy-engine/cmd/policy-engine/main.go
+++ b/gateway/gateway-runtime/policy-engine/cmd/policy-engine/main.go
@@ -219,7 +219,7 @@ func main() {
 	}
 
 	// Create and start ext_proc gRPC server
-	extprocServer := kernel.NewExternalProcessorServer(k, chainExecutor, cfg.TracingConfig, cfg.PolicyEngine.TracingServiceName, cfg.PolicyEngine.Request.MaxDecompressedBytes, cfg.PolicyEngine.Response.MaxDecompressedBytes)
+	extprocServer := kernel.NewExternalProcessorServer(k, chainExecutor, cfg.TracingConfig, cfg.PolicyEngine.TracingServiceName, cfg.PolicyEngine.RequestBody.MaxDecompressedBytes, cfg.PolicyEngine.ResponseBody.MaxDecompressedBytes)
 
 	// Create listener based on mode (same pattern as gateway-controller)
 	var lis net.Listener

--- a/gateway/gateway-runtime/policy-engine/internal/analytics/analytics_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/analytics/analytics_test.go
@@ -60,6 +60,12 @@ func validAnalyticsConfigForValidation(analytics config.AnalyticsConfig) *config
 				Server:  config.PythonExecutorServerConfig{Port: 9010, Host: "localhost"},
 				Timeout: 30 * time.Second,
 			},
+			Request: config.BodyConfig{
+				MaxDecompressedBytes: config.DefaultMaxDecompressedBytes,
+			},
+			Response: config.BodyConfig{
+				MaxDecompressedBytes: config.DefaultMaxDecompressedBytes,
+			},
 		},
 		Analytics: analytics,
 	}

--- a/gateway/gateway-runtime/policy-engine/internal/analytics/analytics_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/analytics/analytics_test.go
@@ -60,10 +60,10 @@ func validAnalyticsConfigForValidation(analytics config.AnalyticsConfig) *config
 				Server:  config.PythonExecutorServerConfig{Port: 9010, Host: "localhost"},
 				Timeout: 30 * time.Second,
 			},
-			Request: config.BodyConfig{
+			RequestBody: config.BodyConfig{
 				MaxDecompressedBytes: config.DefaultMaxDecompressedBytes,
 			},
-			Response: config.BodyConfig{
+			ResponseBody: config.BodyConfig{
 				MaxDecompressedBytes: config.DefaultMaxDecompressedBytes,
 			},
 		},

--- a/gateway/gateway-runtime/policy-engine/internal/config/config.go
+++ b/gateway/gateway-runtime/policy-engine/internal/config/config.go
@@ -35,6 +35,13 @@ import (
 	"github.com/wso2/api-platform/common/configinterpolate"
 )
 
+const (
+	// DefaultMaxDecompressedBytes is the default cap on decompressed bytes buffered
+	// from a Content-Encoded body — the whole body when buffered, each chunk when
+	// streaming. Applied when max_decompressed_bytes is unset for a direction.
+	DefaultMaxDecompressedBytes int64 = 10 * 1024 * 1024 // 10 MiB
+)
+
 // defaultFileSourceAllowlist is the policy-engine's default set of directories that
 // a {{ file "..." }} config-interpolation token may read from. It uses the
 // operator-visible container name (gateway-runtime), and can be overridden via the
@@ -161,10 +168,26 @@ type PolicyEngine struct {
 	// Tracing holds OpenTelemetry exporter configuration
 	TracingServiceName string `koanf:"tracing_service_name"`
 
+	// TODO: (decompress-fix) Body Config variable name should be changed. Generic to include header specific data as well.
+	// Request and Response hold direction-specific body-processing limits (e.g. the
+	// decompression ceiling), letting an operator set a different ceiling for request
+	// bodies than for response bodies. See BodyConfig.
+	Request  BodyConfig `koanf:"request"`
+	Response BodyConfig `koanf:"response"`
+
 	// RawConfig holds the complete raw configuration map including custom fields
 	// This is used for resolving ${config} CEL expressions in policy systemParameters
 	// Note: No struct tag - populated manually via k.Raw()
 	RawConfig map[string]interface{}
+}
+
+// BodyConfig holds body-processing limits for one direction
+// ([policy_engine.request] or [policy_engine.response]).
+type BodyConfig struct {
+	// MaxDecompressedBytes caps decompressed bytes buffered per body (buffered mode)
+	// or per chunk (streaming) — not cumulative, so long-lived streams such as SSE
+	// are unaffected. Defaults to DefaultMaxDecompressedBytes when unset.
+	MaxDecompressedBytes int64 `koanf:"max_decompressed_bytes"`
 }
 
 // MetricsConfig holds Prometheus metrics server configuration
@@ -535,6 +558,12 @@ func defaultConfig() *Config {
 				Timeout: 30 * time.Second,
 			},
 			TracingServiceName: "policy-engine",
+			Request: BodyConfig{
+				MaxDecompressedBytes: DefaultMaxDecompressedBytes,
+			},
+			Response: BodyConfig{
+				MaxDecompressedBytes: DefaultMaxDecompressedBytes,
+			},
 		},
 		Collector: CollectorConfig{
 			RequestBody:  false,
@@ -646,6 +675,14 @@ func (c *Config) Validate() error {
 		if c.PolicyEngine.Metrics.Port == c.PolicyEngine.Admin.Port {
 			return fmt.Errorf("metrics.port cannot be same as admin.port")
 		}
+	}
+
+	// Validate decompression ceilings (independent per direction)
+	if c.PolicyEngine.Request.MaxDecompressedBytes <= 0 {
+		return fmt.Errorf("policy_engine.request.max_decompressed_bytes must be positive, got %d", c.PolicyEngine.Request.MaxDecompressedBytes)
+	}
+	if c.PolicyEngine.Response.MaxDecompressedBytes <= 0 {
+		return fmt.Errorf("policy_engine.response.max_decompressed_bytes must be positive, got %d", c.PolicyEngine.Response.MaxDecompressedBytes)
 	}
 
 	// Validate config mode

--- a/gateway/gateway-runtime/policy-engine/internal/config/config.go
+++ b/gateway/gateway-runtime/policy-engine/internal/config/config.go
@@ -168,11 +168,10 @@ type PolicyEngine struct {
 	// Tracing holds OpenTelemetry exporter configuration
 	TracingServiceName string `koanf:"tracing_service_name"`
 
-	// TODO: (decompress-fix) Body Config variable name should be changed. Generic to include header specific data as well.
-	// Request and Response hold body-processing limits per direction, so request
-	// bodies can be bounded differently from response bodies.
-	Request  BodyConfig `koanf:"request"`
-	Response BodyConfig `koanf:"response"`
+	// RequestBody and ResponseBody hold body-processing limits per direction, so
+	// request bodies can be bounded differently from response bodies.
+	RequestBody  BodyConfig `koanf:"request_body"`
+	ResponseBody BodyConfig `koanf:"response_body"`
 
 	// RawConfig holds the complete raw configuration map including custom fields
 	// This is used for resolving ${config} CEL expressions in policy systemParameters
@@ -181,7 +180,7 @@ type PolicyEngine struct {
 }
 
 // BodyConfig holds body-processing limits for one direction
-// ([policy_engine.request] or [policy_engine.response]).
+// ([policy_engine.request_body] or [policy_engine.response_body]).
 type BodyConfig struct {
 	// MaxDecompressedBytes caps decompressed bytes buffered per body (buffered mode)
 	// or per chunk (streaming) — not cumulative, so long-lived streams such as SSE
@@ -557,10 +556,10 @@ func defaultConfig() *Config {
 				Timeout: 30 * time.Second,
 			},
 			TracingServiceName: "policy-engine",
-			Request: BodyConfig{
+			RequestBody: BodyConfig{
 				MaxDecompressedBytes: DefaultMaxDecompressedBytes,
 			},
-			Response: BodyConfig{
+			ResponseBody: BodyConfig{
 				MaxDecompressedBytes: DefaultMaxDecompressedBytes,
 			},
 		},
@@ -676,11 +675,11 @@ func (c *Config) Validate() error {
 		}
 	}
 
-	if c.PolicyEngine.Request.MaxDecompressedBytes <= 0 {
-		return fmt.Errorf("policy_engine.request.max_decompressed_bytes must be positive, got %d", c.PolicyEngine.Request.MaxDecompressedBytes)
+	if c.PolicyEngine.RequestBody.MaxDecompressedBytes <= 0 {
+		return fmt.Errorf("policy_engine.request_body.max_decompressed_bytes must be positive, got %d", c.PolicyEngine.RequestBody.MaxDecompressedBytes)
 	}
-	if c.PolicyEngine.Response.MaxDecompressedBytes <= 0 {
-		return fmt.Errorf("policy_engine.response.max_decompressed_bytes must be positive, got %d", c.PolicyEngine.Response.MaxDecompressedBytes)
+	if c.PolicyEngine.ResponseBody.MaxDecompressedBytes <= 0 {
+		return fmt.Errorf("policy_engine.response_body.max_decompressed_bytes must be positive, got %d", c.PolicyEngine.ResponseBody.MaxDecompressedBytes)
 	}
 
 	// Validate config mode

--- a/gateway/gateway-runtime/policy-engine/internal/config/config.go
+++ b/gateway/gateway-runtime/policy-engine/internal/config/config.go
@@ -169,9 +169,8 @@ type PolicyEngine struct {
 	TracingServiceName string `koanf:"tracing_service_name"`
 
 	// TODO: (decompress-fix) Body Config variable name should be changed. Generic to include header specific data as well.
-	// Request and Response hold direction-specific body-processing limits (e.g. the
-	// decompression ceiling), letting an operator set a different ceiling for request
-	// bodies than for response bodies. See BodyConfig.
+	// Request and Response hold body-processing limits per direction, so request
+	// bodies can be bounded differently from response bodies.
 	Request  BodyConfig `koanf:"request"`
 	Response BodyConfig `koanf:"response"`
 
@@ -677,7 +676,6 @@ func (c *Config) Validate() error {
 		}
 	}
 
-	// Validate decompression ceilings (independent per direction)
 	if c.PolicyEngine.Request.MaxDecompressedBytes <= 0 {
 		return fmt.Errorf("policy_engine.request.max_decompressed_bytes must be positive, got %d", c.PolicyEngine.Request.MaxDecompressedBytes)
 	}

--- a/gateway/gateway-runtime/policy-engine/internal/config/config_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/config/config_test.go
@@ -68,10 +68,10 @@ func validConfig() *Config {
 				},
 				Timeout: 30 * time.Second,
 			},
-			Request: BodyConfig{
+			RequestBody: BodyConfig{
 				MaxDecompressedBytes: DefaultMaxDecompressedBytes,
 			},
-			Response: BodyConfig{
+			ResponseBody: BodyConfig{
 				MaxDecompressedBytes: DefaultMaxDecompressedBytes,
 			},
 		},
@@ -116,8 +116,8 @@ func TestValidate_MaxDecompressedBytes(t *testing.T) {
 		name string
 		set  func(cfg *Config, v int64)
 	}{
-		{name: "request", set: func(cfg *Config, v int64) { cfg.PolicyEngine.Request.MaxDecompressedBytes = v }},
-		{name: "response", set: func(cfg *Config, v int64) { cfg.PolicyEngine.Response.MaxDecompressedBytes = v }},
+		{name: "request", set: func(cfg *Config, v int64) { cfg.PolicyEngine.RequestBody.MaxDecompressedBytes = v }},
+		{name: "response", set: func(cfg *Config, v int64) { cfg.PolicyEngine.ResponseBody.MaxDecompressedBytes = v }},
 	}
 
 	for _, dir := range directions {
@@ -142,10 +142,10 @@ func TestValidate_MaxDecompressedBytes(t *testing.T) {
 // directions so the decompression guard is active out of the box.
 func TestDefaultConfig_MaxDecompressedBytes(t *testing.T) {
 	cfg := defaultConfig()
-	assert.Equal(t, DefaultMaxDecompressedBytes, cfg.PolicyEngine.Request.MaxDecompressedBytes)
-	assert.Positive(t, cfg.PolicyEngine.Request.MaxDecompressedBytes)
-	assert.Equal(t, DefaultMaxDecompressedBytes, cfg.PolicyEngine.Response.MaxDecompressedBytes)
-	assert.Positive(t, cfg.PolicyEngine.Response.MaxDecompressedBytes)
+	assert.Equal(t, DefaultMaxDecompressedBytes, cfg.PolicyEngine.RequestBody.MaxDecompressedBytes)
+	assert.Positive(t, cfg.PolicyEngine.RequestBody.MaxDecompressedBytes)
+	assert.Equal(t, DefaultMaxDecompressedBytes, cfg.PolicyEngine.ResponseBody.MaxDecompressedBytes)
+	assert.Positive(t, cfg.PolicyEngine.ResponseBody.MaxDecompressedBytes)
 }
 
 // TestValidate_ExtProcPort tests extproc port validation (TCP mode only)

--- a/gateway/gateway-runtime/policy-engine/internal/config/config_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/config/config_test.go
@@ -98,7 +98,6 @@ func TestValidate_ValidConfig(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// TestValidate_MaxDecompressedBytes tests the decompression ceiling validation.
 func TestValidate_MaxDecompressedBytes(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/gateway/gateway-runtime/policy-engine/internal/config/config_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/config/config_test.go
@@ -68,6 +68,12 @@ func validConfig() *Config {
 				},
 				Timeout: 30 * time.Second,
 			},
+			Request: BodyConfig{
+				MaxDecompressedBytes: DefaultMaxDecompressedBytes,
+			},
+			Response: BodyConfig{
+				MaxDecompressedBytes: DefaultMaxDecompressedBytes,
+			},
 		},
 		// The collector is implicit (active whenever a consumer is enabled). ALS
 		// receiver defaults mirror production so transport validation passes and the
@@ -90,6 +96,57 @@ func TestValidate_ValidConfig(t *testing.T) {
 	cfg := validConfig()
 	err := cfg.Validate()
 	assert.NoError(t, err)
+}
+
+// TestValidate_MaxDecompressedBytes tests the decompression ceiling validation.
+func TestValidate_MaxDecompressedBytes(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     int64
+		expectErr bool
+	}{
+		{name: "default value", value: DefaultMaxDecompressedBytes, expectErr: false},
+		{name: "small positive", value: 1, expectErr: false},
+		{name: "zero", value: 0, expectErr: true},
+		{name: "negative", value: -1, expectErr: true},
+	}
+
+	// The request and response ceilings are validated independently; exercise each
+	// direction on its own so a missing check on either side is caught.
+	directions := []struct {
+		name string
+		set  func(cfg *Config, v int64)
+	}{
+		{name: "request", set: func(cfg *Config, v int64) { cfg.PolicyEngine.Request.MaxDecompressedBytes = v }},
+		{name: "response", set: func(cfg *Config, v int64) { cfg.PolicyEngine.Response.MaxDecompressedBytes = v }},
+	}
+
+	for _, dir := range directions {
+		for _, tt := range tests {
+			t.Run(dir.name+"/"+tt.name, func(t *testing.T) {
+				cfg := validConfig()
+				dir.set(cfg, tt.value)
+
+				err := cfg.Validate()
+				if tt.expectErr {
+					assert.Error(t, err)
+					assert.Contains(t, err.Error(), "max_decompressed_bytes must be positive")
+				} else {
+					assert.NoError(t, err)
+				}
+			})
+		}
+	}
+}
+
+// TestDefaultConfig_MaxDecompressedBytes verifies the default is applied to both
+// directions so the decompression guard is active out of the box.
+func TestDefaultConfig_MaxDecompressedBytes(t *testing.T) {
+	cfg := defaultConfig()
+	assert.Equal(t, DefaultMaxDecompressedBytes, cfg.PolicyEngine.Request.MaxDecompressedBytes)
+	assert.Positive(t, cfg.PolicyEngine.Request.MaxDecompressedBytes)
+	assert.Equal(t, DefaultMaxDecompressedBytes, cfg.PolicyEngine.Response.MaxDecompressedBytes)
+	assert.Positive(t, cfg.PolicyEngine.Response.MaxDecompressedBytes)
 }
 
 // TestValidate_ExtProcPort tests extproc port validation (TCP mode only)

--- a/gateway/gateway-runtime/policy-engine/internal/kernel/decompression.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/decompression.go
@@ -263,9 +263,9 @@ func (sd *streamDecompressor) FeedChunk(chunk []byte, endOfStream bool) ([]byte,
 			return nil, sd.decoderError()
 		}
 
-		// Wait until the decoder requests input beyond this chunk. This boundary
-		// replaces the former scheduler yield: once consumed closes, every output
-		// block the decoder could produce from the available input is already queued.
+		// Wait until the decoder requests input beyond this chunk: once consumed
+		// closes, every output block the decoder could produce from the available
+		// input is already queued.
 		for consumed != nil {
 			select {
 			case data, ok := <-sd.outChan:
@@ -295,7 +295,7 @@ func (sd *streamDecompressor) FeedChunk(chunk []byte, endOfStream bool) ([]byte,
 	}
 
 	// The consumed boundary guarantees no more output can be queued until the next
-	// input chunk arrives, so this drain is deterministic rather than scheduler-based.
+	// input chunk arrives, so this non-blocking drain sees everything available.
 	for {
 		select {
 		case data, ok := <-sd.outChan:
@@ -327,7 +327,6 @@ func (sd *streamDecompressor) appendOutput(result *[]byte, data []byte) error {
 	return nil
 }
 
-// decoderError returns an error reported by the decoder, if any.
 func (sd *streamDecompressor) decoderError() error {
 	select {
 	case err := <-sd.errChan:

--- a/gateway/gateway-runtime/policy-engine/internal/kernel/decompression.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/decompression.go
@@ -21,16 +21,23 @@ package kernel
 import (
 	"bytes"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
-	"runtime"
+	"sync"
 
 	"github.com/andybalholm/brotli"
 )
 
+// ErrDecompressedTooLarge is returned when decompressed output exceeds the
+// configured ceiling — the signature of a decompression bomb.
+var ErrDecompressedTooLarge = errors.New("decompressed body exceeds maximum allowed size")
+
 // decompressBody decompresses body bytes based on the Content-Encoding value.
 // Supported encodings: "gzip", "br" (Brotli). Unknown encodings are returned as-is.
-func decompressBody(body []byte, encoding string) ([]byte, error) {
+// Output is capped at maxBytes (<= 0 means unbounded); exceeding it returns
+// ErrDecompressedTooLarge, never a truncated body.
+func decompressBody(body []byte, encoding string, maxBytes int64) ([]byte, error) {
 	switch encoding {
 	case "gzip":
 		r, err := gzip.NewReader(bytes.NewReader(body))
@@ -38,55 +45,168 @@ func decompressBody(body []byte, encoding string) ([]byte, error) {
 			return nil, fmt.Errorf("gzip reader: %w", err)
 		}
 		defer r.Close()
-		return io.ReadAll(r)
+		return readLimited(r, maxBytes)
 	case "br":
 		r := brotli.NewReader(bytes.NewReader(body))
-		return io.ReadAll(r)
+		return readLimited(r, maxBytes)
 	default:
 		return body, nil
 	}
 }
 
-// streamDecompressor provides true per-chunk streaming decompression using an io.Pipe
-// and a persistent decoder goroutine. Incoming compressed chunks are written to the
-// pipe; the goroutine owns the stateful gzip/brotli reader and pushes decompressed
-// bytes to an output channel as complete blocks become available.
+// readLimited reads all of r, returning ErrDecompressedTooLarge if the input
+// exceeds maxBytes — never a truncated result. maxBytes <= 0 means unbounded.
+func readLimited(r io.Reader, maxBytes int64) ([]byte, error) {
+	if maxBytes <= 0 {
+		return io.ReadAll(r)
+	}
+	// Read at most maxBytes first, then probe the underlying reader for one more
+	// byte. This avoids maxBytes+1 overflowing when maxBytes is math.MaxInt64.
+	data, err := io.ReadAll(io.LimitReader(r, maxBytes))
+	if err != nil {
+		return nil, err
+	}
+	var extra [1]byte
+	n, err := r.Read(extra[:])
+	if n > 0 {
+		return nil, ErrDecompressedTooLarge
+	}
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, err
+	}
+	return data, nil
+}
+
+// decoderInputChunk is one compressed input chunk and a boundary notification.
+// consumed is closed when the decoder asks for input beyond this chunk, after all
+// output it could produce without more input has been queued.
+type decoderInputChunk struct {
+	data     []byte
+	consumed chan struct{}
+}
+
+// decoderInput is a resumable io.Reader for the persistent gzip/brotli decoder.
+// Unlike io.Pipe, it exposes deterministic chunk boundaries: the decoder cannot
+// receive the next chunk until FeedChunk has drained all output from the previous
+// one.
+type decoderInput struct {
+	chunks chan decoderInputChunk
+	done   chan struct{}
+	once   sync.Once
+	err    error
+
+	// current and consumed are owned exclusively by the decoder goroutine.
+	current  []byte
+	consumed chan struct{}
+}
+
+func newDecoderInput() *decoderInput {
+	return &decoderInput{
+		chunks: make(chan decoderInputChunk),
+		done:   make(chan struct{}),
+	}
+}
+
+func (in *decoderInput) Read(p []byte) (int, error) {
+	// An error close must abort even when part of the current compressed chunk
+	// remains, otherwise a bomb would continue consuming CPU after detection.
+	select {
+	case <-in.done:
+		return 0, in.closeError()
+	default:
+	}
+
+	if len(in.current) == 0 {
+		if in.consumed != nil {
+			close(in.consumed)
+			in.consumed = nil
+		}
+
+		select {
+		case <-in.done:
+			return 0, in.closeError()
+		case chunk := <-in.chunks:
+			in.current = chunk.data
+			in.consumed = chunk.consumed
+		}
+	}
+
+	n := copy(p, in.current)
+	in.current = in.current[n:]
+	return n, nil
+}
+
+func (in *decoderInput) closeWithError(err error) {
+	in.once.Do(func() {
+		in.err = err
+		close(in.done)
+	})
+}
+
+func (in *decoderInput) closeError() error {
+	if in.err != nil {
+		return in.err
+	}
+	return io.EOF
+}
+
+// streamDecompressor provides true per-chunk streaming decompression using a
+// persistent decoder goroutine. Incoming compressed chunks are handed to a
+// boundary-aware reader; the goroutine owns the stateful gzip/brotli reader and
+// pushes decompressed bytes to an output channel as complete blocks become
+// available.
 type streamDecompressor struct {
-	pipeWriter *io.PipeWriter
-	outChan    chan []byte
-	errChan    chan error
+	input       *decoderInput
+	outChan     chan []byte
+	errChan     chan error
+	decoderDone chan struct{}
+
+	maxBytes int64
 }
 
 // newStreamDecompressor starts the background decoder goroutine and returns a
-// streamDecompressor ready to accept chunks via FeedChunk.
-func newStreamDecompressor(encoding string) *streamDecompressor {
-	pr, pw := io.Pipe()
+// streamDecompressor ready to accept chunks via FeedChunk. maxBytes caps the
+// decompressed output of each FeedChunk call (<= 0 disables the cap).
+func newStreamDecompressor(encoding string, maxBytes int64) *streamDecompressor {
+	input := newDecoderInput()
+	// Buffer a bounded number of decoder blocks so the decoder can continue working
+	// while FeedChunk handles its boundary notification. At
+	// the default 32 KiB block size this queue is capped at 2 MiB; for ceilings below
+	// 32 KiB the block size is reduced below, shrinking the queue proportionally.
 	outChan := make(chan []byte, 64)
 	errChan := make(chan error, 1)
+	decoderDone := make(chan struct{})
 
 	go func() {
 		defer close(outChan)
+		defer close(decoderDone)
 		var r io.Reader
 		switch encoding {
 		case "gzip":
-			gr, err := gzip.NewReader(pr)
+			gr, err := gzip.NewReader(input)
 			if err != nil {
 				select {
 				case errChan <- fmt.Errorf("gzip.NewReader: %w", err):
 				default:
 				}
-				_ = pr.CloseWithError(err)
 				return
 			}
 			defer gr.Close()
 			r = gr
 		case "br":
-			r = brotli.NewReader(pr)
+			r = brotli.NewReader(input)
 		default:
-			r = pr
+			r = input
 		}
 
-		buf := make([]byte, 32*1024)
+		bufSize := 32 * 1024
+		if maxBytes > 0 && maxBytes < int64(bufSize) {
+			// Reading at most maxBytes+1 lets appendOutput detect overflow while
+			// keeping the decoder's single in-flight block proportional to a small
+			// configured ceiling.
+			bufSize = int(maxBytes) + 1
+		}
+		buf := make([]byte, bufSize)
 		for {
 			n, err := r.Read(buf)
 			if n > 0 {
@@ -107,7 +227,13 @@ func newStreamDecompressor(encoding string) *streamDecompressor {
 		}
 	}()
 
-	return &streamDecompressor{pipeWriter: pw, outChan: outChan, errChan: errChan}
+	return &streamDecompressor{
+		input:       input,
+		outChan:     outChan,
+		errChan:     errChan,
+		decoderDone: decoderDone,
+		maxBytes:    maxBytes,
+	}
 }
 
 // FeedChunk writes compressed bytes into the decoder and returns whatever decompressed
@@ -116,54 +242,105 @@ func newStreamDecompressor(encoding string) *streamDecompressor {
 // For intermediate chunks the output may be empty — the decoder needs more input before
 // a full DEFLATE/brotli block can be decoded. Callers must tolerate empty output.
 //
-// On endOfStream=true the pipe writer is closed and FeedChunk blocks until all remaining
-// decompressed bytes have been flushed by the goroutine.
+// On endOfStream=true the decoder input is closed and FeedChunk blocks until all
+// remaining decompressed bytes have been flushed by the goroutine.
+//
+// Decompressed output per call is capped at sd.maxBytes; crossing the cap returns
+// ErrDecompressedTooLarge. The cap is per call, not cumulative, so long-lived
+// streams keep flowing while peak memory stays bounded. After an error the caller
+// must Close() the decompressor to drain the goroutine.
 func (sd *streamDecompressor) FeedChunk(chunk []byte, endOfStream bool) ([]byte, error) {
+	var result []byte
+
 	if len(chunk) > 0 {
-		if _, err := sd.pipeWriter.Write(chunk); err != nil {
-			return nil, fmt.Errorf("stream decompressor write: %w", err)
+		consumed := make(chan struct{})
+		inputChunk := decoderInputChunk{data: chunk, consumed: consumed}
+		select {
+		case sd.input.chunks <- inputChunk:
+		case <-sd.input.done:
+			return nil, fmt.Errorf("stream decompressor input: %w", sd.input.closeError())
+		case <-sd.decoderDone:
+			return nil, sd.decoderError()
+		}
+
+		// Wait until the decoder requests input beyond this chunk. This boundary
+		// replaces the former scheduler yield: once consumed closes, every output
+		// block the decoder could produce from the available input is already queued.
+		for consumed != nil {
+			select {
+			case data, ok := <-sd.outChan:
+				if !ok {
+					return result, sd.decoderError()
+				}
+				if err := sd.appendOutput(&result, data); err != nil {
+					return nil, err
+				}
+			case <-consumed:
+				consumed = nil
+			}
 		}
 	}
 
 	if endOfStream {
-		_ = sd.pipeWriter.Close()
-		var result []byte
+		sd.input.closeWithError(nil)
 		for data := range sd.outChan {
-			result = append(result, data...)
-		}
-		select {
-		case err := <-sd.errChan:
-			if err != nil {
-				return result, err
+			if err := sd.appendOutput(&result, data); err != nil {
+				return nil, err
 			}
-		default:
+		}
+		if err := sd.decoderError(); err != nil {
+			return result, err
 		}
 		return result, nil
 	}
 
-	// pw.Write blocks until the goroutine's pr.Read has consumed all our bytes.
-	// Yield so the goroutine can finish its r.Read call and push decoded output to
-	// outChan before we do the non-blocking drain below.
-	runtime.Gosched()
-
-	var result []byte
+	// The consumed boundary guarantees no more output can be queued until the next
+	// input chunk arrives, so this drain is deterministic rather than scheduler-based.
 	for {
 		select {
 		case data, ok := <-sd.outChan:
 			if !ok {
+				// Decoder exited before end-of-stream — surface its error so the
+				// caller can reject the stream.
+				if err := sd.decoderError(); err != nil {
+					return result, err
+				}
 				return result, nil
 			}
-			result = append(result, data...)
+			if err := sd.appendOutput(&result, data); err != nil {
+				return nil, err
+			}
 		default:
 			return result, nil
 		}
 	}
 }
 
-// Close releases the decompressor's pipe and drains the goroutine. Call this on
+// appendOutput appends one decoder block to result, enforcing the per-call
+// maxBytes cap. Closing the input on overflow aborts the decoder promptly.
+func (sd *streamDecompressor) appendOutput(result *[]byte, data []byte) error {
+	if sd.maxBytes > 0 && int64(len(data)) > sd.maxBytes-int64(len(*result)) {
+		sd.input.closeWithError(ErrDecompressedTooLarge)
+		return ErrDecompressedTooLarge
+	}
+	*result = append(*result, data...)
+	return nil
+}
+
+// decoderError returns an error reported by the decoder, if any.
+func (sd *streamDecompressor) decoderError() error {
+	select {
+	case err := <-sd.errChan:
+		return err
+	default:
+		return nil
+	}
+}
+
+// Close releases the decompressor's input and drains the goroutine. Call this on
 // error paths where endOfStream will never arrive.
 func (sd *streamDecompressor) Close() {
-	_ = sd.pipeWriter.CloseWithError(io.ErrClosedPipe)
+	sd.input.closeWithError(io.ErrClosedPipe)
 	for range sd.outChan {
 	}
 }

--- a/gateway/gateway-runtime/policy-engine/internal/kernel/decompression_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/decompression_test.go
@@ -21,6 +21,7 @@ package kernel
 import (
 	"bytes"
 	"compress/gzip"
+	"math"
 	"testing"
 	"time"
 
@@ -28,6 +29,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// testMaxDecompressedBytes is a generous decompression ceiling used by tests that
+// exercise correctness rather than the bomb guard itself.
+const testMaxDecompressedBytes int64 = 10 * 1024 * 1024
 
 // gzipCompress is a test helper that gzip-compresses a byte slice.
 func gzipCompress(data []byte) []byte {
@@ -55,7 +60,7 @@ func TestDecompressBody_Gzip(t *testing.T) {
 	original := []byte(`{"model":"gpt-4","usage":{"prompt_tokens":10,"completion_tokens":20}}`)
 	compressed := gzipCompress(original)
 
-	result, err := decompressBody(compressed, "gzip")
+	result, err := decompressBody(compressed, "gzip", testMaxDecompressedBytes)
 
 	require.NoError(t, err)
 	assert.Equal(t, original, result)
@@ -65,7 +70,7 @@ func TestDecompressBody_Brotli(t *testing.T) {
 	original := []byte(`{"model":"claude-3","usage":{"input_tokens":5,"output_tokens":15}}`)
 	compressed := brotliCompress(original)
 
-	result, err := decompressBody(compressed, "br")
+	result, err := decompressBody(compressed, "br", testMaxDecompressedBytes)
 
 	require.NoError(t, err)
 	assert.Equal(t, original, result)
@@ -74,7 +79,7 @@ func TestDecompressBody_Brotli(t *testing.T) {
 func TestDecompressBody_UnknownEncoding_PassesThrough(t *testing.T) {
 	original := []byte(`{"model":"gemini-pro"}`)
 
-	result, err := decompressBody(original, "identity")
+	result, err := decompressBody(original, "identity", testMaxDecompressedBytes)
 
 	require.NoError(t, err)
 	assert.Equal(t, original, result)
@@ -83,7 +88,7 @@ func TestDecompressBody_UnknownEncoding_PassesThrough(t *testing.T) {
 func TestDecompressBody_EmptyEncoding_PassesThrough(t *testing.T) {
 	original := []byte(`{"model":"gemini-pro"}`)
 
-	result, err := decompressBody(original, "")
+	result, err := decompressBody(original, "", testMaxDecompressedBytes)
 
 	require.NoError(t, err)
 	assert.Equal(t, original, result)
@@ -92,7 +97,7 @@ func TestDecompressBody_EmptyEncoding_PassesThrough(t *testing.T) {
 func TestDecompressBody_InvalidGzip_ReturnsError(t *testing.T) {
 	garbage := []byte("this is not gzip data")
 
-	_, err := decompressBody(garbage, "gzip")
+	_, err := decompressBody(garbage, "gzip", testMaxDecompressedBytes)
 
 	assert.Error(t, err)
 }
@@ -109,7 +114,7 @@ func TestRecompressBody_Gzip_RoundTrip(t *testing.T) {
 	assert.NotEqual(t, original, compressed)
 
 	// Decompress and verify we get the original back
-	restored, err := decompressBody(compressed, "gzip")
+	restored, err := decompressBody(compressed, "gzip", testMaxDecompressedBytes)
 	require.NoError(t, err)
 	assert.Equal(t, original, restored)
 }
@@ -122,7 +127,7 @@ func TestRecompressBody_Brotli_RoundTrip(t *testing.T) {
 	assert.NotEqual(t, original, compressed)
 
 	// Decompress and verify we get the original back
-	restored, err := decompressBody(compressed, "br")
+	restored, err := decompressBody(compressed, "br", testMaxDecompressedBytes)
 	require.NoError(t, err)
 	assert.Equal(t, original, restored)
 }
@@ -155,7 +160,7 @@ func TestStreamDecompressor_Gzip_AllInOneChunk(t *testing.T) {
 	original := []byte(`{"model":"claude","usage":{"input_tokens":10,"output_tokens":20}}`)
 	compressed := gzipCompress(original)
 
-	sd := newStreamDecompressor("gzip")
+	sd := newStreamDecompressor("gzip", testMaxDecompressedBytes)
 	result, err := sd.FeedChunk(compressed, true)
 
 	require.NoError(t, err)
@@ -169,7 +174,7 @@ func TestStreamDecompressor_Gzip_MultipleChunks(t *testing.T) {
 	original := []byte(`{"model":"claude","usage":{"input_tokens":10,"output_tokens":20}}`)
 	compressed := gzipCompress(original)
 
-	sd := newStreamDecompressor("gzip")
+	sd := newStreamDecompressor("gzip", testMaxDecompressedBytes)
 
 	half := len(compressed) / 2
 	chunk1, err := sd.FeedChunk(compressed[:half], false)
@@ -189,7 +194,7 @@ func TestStreamDecompressor_Brotli_AllInOneChunk(t *testing.T) {
 	original := []byte(`{"model":"claude","usage":{"input_tokens":5,"output_tokens":15}}`)
 	compressed := brotliCompress(original)
 
-	sd := newStreamDecompressor("br")
+	sd := newStreamDecompressor("br", testMaxDecompressedBytes)
 	result, err := sd.FeedChunk(compressed, true)
 
 	require.NoError(t, err)
@@ -201,7 +206,7 @@ func TestStreamDecompressor_Brotli_MultipleChunks(t *testing.T) {
 	original := []byte(`{"model":"claude","usage":{"input_tokens":5,"output_tokens":15}}`)
 	compressed := brotliCompress(original)
 
-	sd := newStreamDecompressor("br")
+	sd := newStreamDecompressor("br", testMaxDecompressedBytes)
 
 	half := len(compressed) / 2
 	chunk1, err := sd.FeedChunk(compressed[:half], false)
@@ -217,7 +222,7 @@ func TestStreamDecompressor_Brotli_MultipleChunks(t *testing.T) {
 // non-EOS chunk returns empty output without error — this happens when the
 // decoder needs more input before a full DEFLATE block can be produced.
 func TestStreamDecompressor_EmptyNonEOSChunk(t *testing.T) {
-	sd := newStreamDecompressor("gzip")
+	sd := newStreamDecompressor("gzip", testMaxDecompressedBytes)
 
 	result, err := sd.FeedChunk(nil, false)
 
@@ -232,7 +237,7 @@ func TestStreamDecompressor_EmptyNonEOSChunk(t *testing.T) {
 func TestStreamDecompressor_UnknownEncoding_Passthrough(t *testing.T) {
 	original := []byte(`plain text, not compressed`)
 
-	sd := newStreamDecompressor("identity")
+	sd := newStreamDecompressor("identity", testMaxDecompressedBytes)
 	result, err := sd.FeedChunk(original, true)
 
 	require.NoError(t, err)
@@ -242,7 +247,7 @@ func TestStreamDecompressor_UnknownEncoding_Passthrough(t *testing.T) {
 // TestStreamDecompressor_Close_DoesNotHang verifies that Close() terminates
 // the background goroutine promptly even when no data has been fed.
 func TestStreamDecompressor_Close_DoesNotHang(t *testing.T) {
-	sd := newStreamDecompressor("gzip")
+	sd := newStreamDecompressor("gzip", testMaxDecompressedBytes)
 
 	done := make(chan struct{})
 	go func() {
@@ -266,7 +271,7 @@ func TestStreamDecompressor_RoundTrip(t *testing.T) {
 	compressed := gzipCompress(original)
 
 	// Decompress (as processStreamingResponseBody does)
-	sd := newStreamDecompressor("gzip")
+	sd := newStreamDecompressor("gzip", testMaxDecompressedBytes)
 	decompressed, err := sd.FeedChunk(compressed, true)
 	require.NoError(t, err)
 	assert.Equal(t, original, decompressed)
@@ -276,7 +281,227 @@ func TestStreamDecompressor_RoundTrip(t *testing.T) {
 	require.NoError(t, err)
 
 	// Must be valid gzip that decodes back to original
-	final, err := decompressBody(recompressed, "gzip")
+	final, err := decompressBody(recompressed, "gzip", testMaxDecompressedBytes)
 	require.NoError(t, err)
 	assert.Equal(t, original, final)
+}
+
+// =============================================================================
+// Decompression-bomb guard tests
+// =============================================================================
+
+// bombLimit is a small ceiling used to trigger the guard deterministically.
+const bombLimit int64 = 1024
+
+// TestDecompressBody_Gzip_ExceedsLimit_ReturnsError feeds a highly compressible
+// payload (1 MiB of zeros → a few hundred compressed bytes) that expands far past
+// the ceiling — the classic decompression bomb. It must be rejected, not buffered.
+func TestDecompressBody_Gzip_ExceedsLimit_ReturnsError(t *testing.T) {
+	original := make([]byte, 1024*1024)
+	compressed := gzipCompress(original)
+
+	_, err := decompressBody(compressed, "gzip", bombLimit)
+
+	require.ErrorIs(t, err, ErrDecompressedTooLarge)
+}
+
+// TestDecompressBody_Brotli_ExceedsLimit_ReturnsError is the brotli counterpart.
+func TestDecompressBody_Brotli_ExceedsLimit_ReturnsError(t *testing.T) {
+	original := make([]byte, 1024*1024)
+	compressed := brotliCompress(original)
+
+	_, err := decompressBody(compressed, "br", bombLimit)
+
+	require.ErrorIs(t, err, ErrDecompressedTooLarge)
+}
+
+// TestDecompressBody_ExactlyAtLimit_Succeeds verifies the boundary is inclusive:
+// a body whose decompressed size equals the limit is accepted in full.
+func TestDecompressBody_ExactlyAtLimit_Succeeds(t *testing.T) {
+	original := make([]byte, bombLimit)
+	for i := range original {
+		original[i] = byte(i)
+	}
+	compressed := gzipCompress(original)
+
+	result, err := decompressBody(compressed, "gzip", bombLimit)
+
+	require.NoError(t, err)
+	assert.Len(t, result, int(bombLimit))
+}
+
+// TestDecompressBody_OneOverLimit_ReturnsError verifies a body one byte past the
+// limit is rejected (no silent truncation).
+func TestDecompressBody_OneOverLimit_ReturnsError(t *testing.T) {
+	original := make([]byte, bombLimit+1)
+	for i := range original {
+		original[i] = byte(i)
+	}
+	compressed := gzipCompress(original)
+
+	_, err := decompressBody(compressed, "gzip", bombLimit)
+
+	require.ErrorIs(t, err, ErrDecompressedTooLarge)
+}
+
+// TestDecompressBody_ZeroLimit_Unbounded verifies maxBytes <= 0 disables the bound.
+func TestDecompressBody_ZeroLimit_Unbounded(t *testing.T) {
+	original := make([]byte, 1024*1024)
+	compressed := gzipCompress(original)
+
+	result, err := decompressBody(compressed, "gzip", 0)
+
+	require.NoError(t, err)
+	assert.Len(t, result, len(original))
+}
+
+// TestDecompressBody_MaxIntLimit_DoesNotOverflow verifies that the one-byte
+// overflow probe remains correct at the largest accepted int64 ceiling.
+func TestDecompressBody_MaxIntLimit_DoesNotOverflow(t *testing.T) {
+	original := []byte("small compressed payload")
+	compressed := gzipCompress(original)
+
+	result, err := decompressBody(compressed, "gzip", math.MaxInt64)
+
+	require.NoError(t, err)
+	assert.Equal(t, original, result)
+}
+
+// TestStreamDecompressor_SingleBombChunk_ReturnsError verifies a single streamed
+// chunk that expands beyond the per-chunk ceiling is rejected with the sentinel.
+func TestStreamDecompressor_SingleBombChunk_ReturnsError(t *testing.T) {
+	original := make([]byte, 1024*1024)
+	compressed := gzipCompress(original)
+
+	sd := newStreamDecompressor("gzip", bombLimit)
+	defer sd.Close()
+
+	_, err := sd.FeedChunk(compressed, true)
+
+	require.ErrorIs(t, err, ErrDecompressedTooLarge)
+}
+
+// TestStreamDecompressor_NonEOSChunkExceedsLimitImmediately verifies that an
+// oversized non-terminal chunk is charged to its own FeedChunk call. The former
+// scheduler-based drain could leave part of this output queued for a later call.
+func TestStreamDecompressor_NonEOSChunkExceedsLimitImmediately(t *testing.T) {
+	const limit int64 = 64 * 1024
+	chunk := make([]byte, limit+1)
+
+	sd := newStreamDecompressor("identity", limit)
+	defer sd.Close()
+
+	_, err := sd.FeedChunk(chunk, false)
+
+	require.ErrorIs(t, err, ErrDecompressedTooLarge)
+}
+
+// TestStreamDecompressor_OutputBeyondChannelCapacity_DoesNotDeadlock verifies
+// FeedChunk drains decoder output while writing input. The decoder channel holds
+// 2 MiB, so a write-then-drain sequence would stall on this 3 MiB chunk even though
+// it is below the configured limit.
+func TestStreamDecompressor_OutputBeyondChannelCapacity_DoesNotDeadlock(t *testing.T) {
+	const chunkSize = 3 * 1024 * 1024
+	const limit int64 = 4 * 1024 * 1024
+
+	sd := newStreamDecompressor("identity", limit)
+	defer sd.Close()
+
+	type result struct {
+		body []byte
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		body, err := sd.FeedChunk(make([]byte, chunkSize), true)
+		done <- result{body: body, err: err}
+	}()
+
+	select {
+	case got := <-done:
+		require.NoError(t, got.err)
+		assert.Len(t, got.body, chunkSize)
+	case <-time.After(2 * time.Second):
+		t.Fatal("FeedChunk deadlocked after decoder output filled outChan")
+	}
+}
+
+// TestStreamDecompressor_OverflowBeyondChannelCapacity_ReturnsError verifies
+// the limit is still enforced when output crosses it only after filling the
+// decoder channel.
+func TestStreamDecompressor_OverflowBeyondChannelCapacity_ReturnsError(t *testing.T) {
+	const chunkSize = 3 * 1024 * 1024
+	const limit int64 = 2 * 1024 * 1024
+
+	sd := newStreamDecompressor("identity", limit)
+	defer sd.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := sd.FeedChunk(make([]byte, chunkSize), true)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, ErrDecompressedTooLarge)
+	case <-time.After(2 * time.Second):
+		t.Fatal("FeedChunk deadlocked before enforcing the decompression limit")
+	}
+}
+
+// TestStreamDecompressor_LargeStreamUnderPerChunkLimit_Succeeds proves the guard is
+// per-chunk, not a lifetime total: the cumulative output far exceeds the ceiling, yet
+// because no single FeedChunk exceeds it, every chunk passes. A cumulative limit
+// would wrongly reject this — the exact large-streaming case the design must allow.
+//
+// The decoder-input boundary ensures each call receives exactly its own identity
+// output rather than output left queued by a previous call.
+func TestStreamDecompressor_LargeStreamUnderPerChunkLimit_Succeeds(t *testing.T) {
+	const limit int64 = 100 * 1024
+	chunk := make([]byte, 10*1024) // 10 KiB — well under the per-chunk limit
+
+	// identity passthrough: each FeedChunk returns exactly the bytes fed, making
+	// the accounting deterministic.
+	sd := newStreamDecompressor("identity", limit)
+	defer sd.Close()
+
+	var total int
+	const chunks = 50 // 50 * 10 KiB = 500 KiB cumulative, 5x the per-chunk limit
+	for i := 0; i < chunks; i++ {
+		out, err := sd.FeedChunk(chunk, false)
+		require.NoError(t, err)
+		assert.Len(t, out, len(chunk), "chunk %d output must not be deferred to another call", i)
+		total += len(out)
+	}
+	final, err := sd.FeedChunk(nil, true)
+	require.NoError(t, err)
+	total += len(final)
+
+	assert.Equal(t, chunks*len(chunk), total, "all bytes should pass through despite exceeding the limit cumulatively")
+	assert.Greater(t, int64(total), limit, "cumulative output must exceed the per-chunk limit for this test to be meaningful")
+}
+
+// TestStreamDecompressor_BombChunkAcrossFeeds_ReturnsError verifies the bomb is
+// caught even when the compressed input is split across several non-EOS feeds
+// before the terminating chunk.
+func TestStreamDecompressor_BombChunkAcrossFeeds_ReturnsError(t *testing.T) {
+	original := make([]byte, 1024*1024)
+	compressed := gzipCompress(original)
+
+	sd := newStreamDecompressor("gzip", bombLimit)
+	defer sd.Close()
+
+	var err error
+	third := len(compressed) / 3
+	for _, part := range [][]byte{compressed[:third], compressed[third : 2*third], compressed[2*third:]} {
+		if _, err = sd.FeedChunk(part, false); err != nil {
+			break
+		}
+	}
+	if err == nil {
+		_, err = sd.FeedChunk(nil, true)
+	}
+
+	require.ErrorIs(t, err, ErrDecompressedTooLarge)
 }

--- a/gateway/gateway-runtime/policy-engine/internal/kernel/decompression_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/decompression_test.go
@@ -305,7 +305,6 @@ func TestDecompressBody_Gzip_ExceedsLimit_ReturnsError(t *testing.T) {
 	require.ErrorIs(t, err, ErrDecompressedTooLarge)
 }
 
-// TestDecompressBody_Brotli_ExceedsLimit_ReturnsError is the brotli counterpart.
 func TestDecompressBody_Brotli_ExceedsLimit_ReturnsError(t *testing.T) {
 	original := make([]byte, 1024*1024)
 	compressed := brotliCompress(original)
@@ -382,8 +381,8 @@ func TestStreamDecompressor_SingleBombChunk_ReturnsError(t *testing.T) {
 }
 
 // TestStreamDecompressor_NonEOSChunkExceedsLimitImmediately verifies that an
-// oversized non-terminal chunk is charged to its own FeedChunk call. The former
-// scheduler-based drain could leave part of this output queued for a later call.
+// oversized non-terminal chunk is charged to its own FeedChunk call, rather than
+// leaving part of its output queued for a later call.
 func TestStreamDecompressor_NonEOSChunkExceedsLimitImmediately(t *testing.T) {
 	const limit int64 = 64 * 1024
 	chunk := make([]byte, limit+1)

--- a/gateway/gateway-runtime/policy-engine/internal/kernel/downstream_upstream_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/downstream_upstream_test.go
@@ -37,7 +37,7 @@ import (
 func newDownstreamTestExecCtx() *PolicyExecutionContext {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 	return newPolicyExecutionContext(server, "test-route", &registry.PolicyChain{})
 }
 

--- a/gateway/gateway-runtime/policy-engine/internal/kernel/execution_context.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/execution_context.go
@@ -20,6 +20,7 @@ package kernel
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -134,9 +135,8 @@ type PolicyExecutionContext struct {
 	// response bodies. Nil when the response is not Content-Encoded.
 	responseStreamDecomp *streamDecompressor
 	// streamTerminated is set when a policy returns TerminateStream=true. Any
-	// subsequent upstream chunks that Envoy delivers after we have already sent
-	// EndOfStream downstream are silently suppressed — the downstream connection
-	// is already closed and forwarding more data would be undefined behaviour.
+	// subsequent upstream chunks that Envoy delivers after EndOfStream was sent
+	// downstream are silently suppressed — forwarding more data would be undefined.
 	streamTerminated bool
 
 	// Reference to server components
@@ -158,6 +158,20 @@ func newPolicyExecutionContext(
 		policyChain:       chain,
 		analyticsMetadata: make(map[string]interface{}),
 		dynamicMetadata:   make(map[string]map[string]interface{}),
+	}
+}
+
+// closeStreamDecompressors releases decoder goroutines when the ext_proc stream
+// ends before an encoded body reaches EOS (client cancellation, send/receive
+// failure, or a policy short-circuit).
+func (ec *PolicyExecutionContext) closeStreamDecompressors() {
+	if ec.requestStreamDecomp != nil {
+		ec.requestStreamDecomp.Close()
+		ec.requestStreamDecomp = nil
+	}
+	if ec.responseStreamDecomp != nil {
+		ec.responseStreamDecomp.Close()
+		ec.responseStreamDecomp = nil
 	}
 }
 
@@ -193,6 +207,88 @@ func (ec *PolicyExecutionContext) handlePolicyError(
 			},
 		},
 	}
+}
+
+// handlePayloadTooLarge builds an HTTP 413 immediate response for a buffered
+// request body that exceeded the decompression ceiling. The client payload stays
+// generic (no limit value, no internals); specifics are logged under the
+// correlation id. Streaming bodies fail the ext_proc stream closed instead,
+// because an HTTP response cannot be guaranteed after full-duplex forwarding starts.
+func (ec *PolicyExecutionContext) handlePayloadTooLarge(
+	ctx context.Context,
+	err error,
+	phase string,
+) *extprocv3.ProcessingResponse {
+	errorID := uuid.New().String()
+
+	slog.WarnContext(ctx, "Rejecting body: decompressed payload exceeds configured limit",
+		"error_id", errorID,
+		"request_id", ec.requestID,
+		"phase", phase,
+		"route_key", ec.routeKey,
+		"error", err,
+	)
+
+	errorBody := fmt.Sprintf(`{"error":"Payload Too Large","error_id":"%s"}`, errorID)
+
+	return &extprocv3.ProcessingResponse{
+		Response: &extprocv3.ProcessingResponse_ImmediateResponse{
+			ImmediateResponse: &extprocv3.ImmediateResponse{
+				Status: &typev3.HttpStatus{
+					Code: typev3.StatusCode_PayloadTooLarge,
+				},
+				Headers: buildHeaderValueOptions(map[string]string{
+					"content-type": "application/json",
+					"x-error-id":   errorID,
+				}),
+				Body: []byte(errorBody),
+			},
+		},
+	}
+}
+
+// responsePayloadTooLargeError fails the ext_proc stream closed when an upstream
+// response exceeds the decompression ceiling. A response-body ImmediateResponse
+// cannot reliably replace an upstream response because its headers may already
+// have reached the downstream codec. Returning an error lets Envoy's fail-closed
+// ext_proc configuration terminate the response instead of promising a late 413.
+func (ec *PolicyExecutionContext) responsePayloadTooLargeError(
+	ctx context.Context,
+	err error,
+	phase string,
+) error {
+	errorID := uuid.New().String()
+
+	slog.WarnContext(ctx, "Rejecting upstream response: decompressed payload exceeds configured limit",
+		"error_id", errorID,
+		"request_id", ec.requestID,
+		"phase", phase,
+		"route_key", ec.routeKey,
+		"error", err,
+	)
+
+	return fmt.Errorf("upstream response decompression limit exceeded (error_id=%s): %w", errorID, err)
+}
+
+// requestPayloadTooLargeError fails a full-duplex request closed when its
+// decompressed output exceeds the ceiling. Earlier request chunks may already be
+// upstream, so an ImmediateResponse cannot reliably promise an HTTP 413.
+func (ec *PolicyExecutionContext) requestPayloadTooLargeError(
+	ctx context.Context,
+	err error,
+	phase string,
+) error {
+	errorID := uuid.New().String()
+
+	slog.WarnContext(ctx, "Rejecting streaming request: decompressed payload exceeds configured limit",
+		"error_id", errorID,
+		"request_id", ec.requestID,
+		"phase", phase,
+		"route_key", ec.routeKey,
+		"error", err,
+	)
+
+	return fmt.Errorf("streaming request decompression limit exceeded (error_id=%s): %w", errorID, err)
 }
 
 // getModeOverride returns the ProcessingMode override for this execution context.
@@ -418,8 +514,12 @@ func (ec *PolicyExecutionContext) processRequestBody(
 		// Decompress body if Content-Encoding was set, so policies receive plain bytes.
 		bodyContent := body.Body
 		if ec.requestContentEncoding != "" {
-			decompressed, err := decompressBody(body.Body, ec.requestContentEncoding)
+			decompressed, err := decompressBody(body.Body, ec.requestContentEncoding, ec.server.maxRequestDecompressedBytes)
 			if err != nil {
+				// Over-limit bodies must be rejected, never forwarded raw.
+				if errors.Is(err, ErrDecompressedTooLarge) {
+					return ec.handlePayloadTooLarge(ctx, err, "request_body"), nil
+				}
 				slog.Warn("Failed to decompress request body, passing raw bytes to policies",
 					"request_id", ec.requestID,
 					"encoding", ec.requestContentEncoding,
@@ -477,18 +577,23 @@ func (ec *PolicyExecutionContext) processStreamingRequestBody(
 	// handle their own internal state across chunks.
 	if ec.requestContentEncoding != "" {
 		if ec.requestStreamDecomp == nil {
-			ec.requestStreamDecomp = newStreamDecompressor(ec.requestContentEncoding)
+			ec.requestStreamDecomp = newStreamDecompressor(ec.requestContentEncoding, ec.server.maxRequestDecompressedBytes)
 		}
 		decompressed, err := ec.requestStreamDecomp.FeedChunk(chunk.Chunk, chunk.EndOfStream)
 		if err != nil {
-			slog.Warn("[streaming] per-chunk request decompression error; disabling decompression",
+			ec.requestStreamDecomp.Close()
+			ec.requestStreamDecomp = nil
+			// Full-duplex request chunks may already be upstream, so fail closed
+			// instead of promising a late HTTP 413 that Envoy may have to reset.
+			if errors.Is(err, ErrDecompressedTooLarge) {
+				return nil, ec.requestPayloadTooLargeError(ctx, err, "request_body_streaming")
+			}
+			slog.Warn("[streaming] per-chunk request decompression error; failing stream closed",
 				"request_id", ec.requestID,
 				"encoding", ec.requestContentEncoding,
 				"error", err,
 			)
-			ec.requestStreamDecomp.Close()
-			ec.requestStreamDecomp = nil
-			ec.requestContentEncoding = ""
+			return nil, fmt.Errorf("streaming request decompression failed: %w", err)
 		} else {
 			chunk.Chunk = decompressed
 		}
@@ -707,8 +812,14 @@ func (ec *PolicyExecutionContext) processResponseBody(
 		// Decompress body if Content-Encoding was set, so policies receive plain JSON.
 		bodyContent := body.Body
 		if ec.responseContentEncoding != "" {
-			decompressed, err := decompressBody(body.Body, ec.responseContentEncoding)
+			decompressed, err := decompressBody(body.Body, ec.responseContentEncoding, ec.server.maxResponseDecompressedBytes)
 			if err != nil {
+				// Response headers may already be committed by the time Envoy sends the
+				// buffered body. Fail the ext_proc stream closed instead of returning a
+				// late ImmediateResponse whose status cannot reliably replace them.
+				if errors.Is(err, ErrDecompressedTooLarge) {
+					return nil, ec.responsePayloadTooLargeError(ctx, err, "response_body")
+				}
 				slog.Warn("Failed to decompress response body, passing raw bytes to policies",
 					"request_id", ec.requestID,
 					"encoding", ec.responseContentEncoding,
@@ -756,10 +867,10 @@ func (ec *PolicyExecutionContext) processStreamingResponseBody(
 	ctx context.Context,
 	body *extprocv3.HttpBody,
 ) (*extprocv3.ProcessingResponse, error) {
-	// A policy previously terminated the stream (TerminateStream=true). Envoy may
-	// still deliver buffered upstream chunks after we have already sent EndOfStream
-	// downstream — suppress them with an empty streamed response so we do not attempt
-	// to write to a closed downstream connection.
+	// A policy previously terminated the stream. Envoy may still deliver buffered
+	// upstream chunks after processing has been terminated. Keep suppressing them
+	// while mirroring the upstream EndOfStream flag; Envoy's StreamedBodyResponse
+	// contract does not permit us to invent an early EOS.
 	if ec.streamTerminated {
 		slog.Warn("[streaming] received upstream chunk after stream was already terminated; suppressing",
 			"route", ec.routeKey,
@@ -772,7 +883,9 @@ func (ec *PolicyExecutionContext) processStreamingResponseBody(
 					Response: &extprocv3.CommonResponse{
 						BodyMutation: &extprocv3.BodyMutation{
 							Mutation: &extprocv3.BodyMutation_StreamedResponse{
-								StreamedResponse: &extprocv3.StreamedBodyResponse{},
+								StreamedResponse: &extprocv3.StreamedBodyResponse{
+									EndOfStream: body.EndOfStream,
+								},
 							},
 						},
 					},
@@ -791,18 +904,24 @@ func (ec *PolicyExecutionContext) processStreamingResponseBody(
 	// handle their own internal state across chunks.
 	if ec.responseContentEncoding != "" {
 		if ec.responseStreamDecomp == nil {
-			ec.responseStreamDecomp = newStreamDecompressor(ec.responseContentEncoding)
+			ec.responseStreamDecomp = newStreamDecompressor(ec.responseContentEncoding, ec.server.maxResponseDecompressedBytes)
 		}
 		decompressed, err := ec.responseStreamDecomp.FeedChunk(chunk.Chunk, chunk.EndOfStream)
 		if err != nil {
-			slog.Warn("[streaming] per-chunk response decompression error; disabling decompression",
+			// Response headers and prior chunks may already be committed downstream.
+			// Failing the ext_proc stream makes Envoy reset the response; suppressing
+			// until upstream EOS would turn the failure into a successful truncated body.
+			slog.Warn("[streaming] per-chunk response decompression error; failing stream closed",
 				"request_id", ec.requestID,
 				"encoding", ec.responseContentEncoding,
 				"error", err,
 			)
 			ec.responseStreamDecomp.Close()
 			ec.responseStreamDecomp = nil
-			ec.responseContentEncoding = ""
+			if errors.Is(err, ErrDecompressedTooLarge) {
+				return nil, ec.responsePayloadTooLargeError(ctx, err, "response_body_streaming")
+			}
+			return nil, fmt.Errorf("streaming upstream response decompression failed: %w", err)
 		} else {
 			chunk.Chunk = decompressed
 		}

--- a/gateway/gateway-runtime/policy-engine/internal/kernel/execution_context.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/execution_context.go
@@ -583,8 +583,6 @@ func (ec *PolicyExecutionContext) processStreamingRequestBody(
 		if err != nil {
 			ec.requestStreamDecomp.Close()
 			ec.requestStreamDecomp = nil
-			// Full-duplex request chunks may already be upstream, so fail closed
-			// instead of promising a late HTTP 413 that Envoy may have to reset.
 			if errors.Is(err, ErrDecompressedTooLarge) {
 				return nil, ec.requestPayloadTooLargeError(ctx, err, "request_body_streaming")
 			}
@@ -814,9 +812,6 @@ func (ec *PolicyExecutionContext) processResponseBody(
 		if ec.responseContentEncoding != "" {
 			decompressed, err := decompressBody(body.Body, ec.responseContentEncoding, ec.server.maxResponseDecompressedBytes)
 			if err != nil {
-				// Response headers may already be committed by the time Envoy sends the
-				// buffered body. Fail the ext_proc stream closed instead of returning a
-				// late ImmediateResponse whose status cannot reliably replace them.
 				if errors.Is(err, ErrDecompressedTooLarge) {
 					return nil, ec.responsePayloadTooLargeError(ctx, err, "response_body")
 				}
@@ -908,7 +903,6 @@ func (ec *PolicyExecutionContext) processStreamingResponseBody(
 		}
 		decompressed, err := ec.responseStreamDecomp.FeedChunk(chunk.Chunk, chunk.EndOfStream)
 		if err != nil {
-			// Response headers and prior chunks may already be committed downstream.
 			// Failing the ext_proc stream makes Envoy reset the response; suppressing
 			// until upstream EOS would turn the failure into a successful truncated body.
 			slog.Warn("[streaming] per-chunk response decompression error; failing stream closed",

--- a/gateway/gateway-runtime/policy-engine/internal/kernel/execution_context_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/execution_context_test.go
@@ -22,10 +22,12 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extprocconfigv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_proc/v3"
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	typev3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace/noop"
@@ -50,7 +52,7 @@ func newTestExecutor() *executor.ChainExecutor {
 func TestNewPolicyExecutionContext(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	chain := &registry.PolicyChain{
 		Policies:    []policy.Policy{},
@@ -66,6 +68,31 @@ func TestNewPolicyExecutionContext(t *testing.T) {
 	assert.Empty(t, execCtx.analyticsMetadata)
 }
 
+func TestPolicyExecutionContext_CloseStreamDecompressors(t *testing.T) {
+	requestDecomp := newStreamDecompressor("gzip", testMaxDecompressedBytes)
+	responseDecomp := newStreamDecompressor("br", testMaxDecompressedBytes)
+	execCtx := &PolicyExecutionContext{
+		requestStreamDecomp:  requestDecomp,
+		responseStreamDecomp: responseDecomp,
+	}
+
+	execCtx.closeStreamDecompressors()
+	execCtx.closeStreamDecompressors() // cleanup is idempotent
+
+	assert.Nil(t, execCtx.requestStreamDecomp)
+	assert.Nil(t, execCtx.responseStreamDecomp)
+	select {
+	case <-requestDecomp.decoderDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("request decoder goroutine was not stopped")
+	}
+	select {
+	case <-responseDecomp.decoderDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("response decoder goroutine was not stopped")
+	}
+}
+
 // =============================================================================
 // handlePolicyError Tests
 // =============================================================================
@@ -73,7 +100,7 @@ func TestNewPolicyExecutionContext(t *testing.T) {
 func TestHandlePolicyError(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	chain := &registry.PolicyChain{}
 	execCtx := newPolicyExecutionContext(server, "test-route", chain)
@@ -103,7 +130,7 @@ func TestHandlePolicyError(t *testing.T) {
 func TestGetModeOverride_NoBodyRequired(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	chain := &registry.PolicyChain{
 		RequiresRequestBody:  false,
@@ -125,7 +152,7 @@ func TestGetModeOverride_NoBodyRequired(t *testing.T) {
 func TestGetModeOverride_RequestBodyRequired(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	chain := &registry.PolicyChain{
 		RequiresRequestBody:  true,
@@ -143,7 +170,7 @@ func TestGetModeOverride_RequestBodyRequired(t *testing.T) {
 func TestGetModeOverride_ResponseBodyRequired(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	chain := &registry.PolicyChain{
 		RequiresRequestBody:  false,
@@ -161,7 +188,7 @@ func TestGetModeOverride_ResponseBodyRequired(t *testing.T) {
 func TestGetModeOverride_BothBodiesRequired(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	chain := &registry.PolicyChain{
 		RequiresRequestBody:  true,
@@ -179,7 +206,7 @@ func TestGetModeOverride_BothBodiesRequired(t *testing.T) {
 func TestGetModeOverride_ResponseHeaderProcessing(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	mockPol := &testutils.ConfigurableMockPolicy{
 		MockMode: policy.ProcessingMode{
@@ -211,7 +238,7 @@ func TestGetModeOverride_ResponseHeaderProcessing(t *testing.T) {
 
 func TestGetModeOverride_MCPStreamingUpstreamStaysBuffered(t *testing.T) {
 	kernel := NewKernel()
-	server := NewExternalProcessorServer(kernel, executor.NewChainExecutor(nil, nil, nil), config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, executor.NewChainExecutor(nil, nil, nil), config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	chain := &registry.PolicyChain{
 		RequiresResponseBody:      true,
@@ -240,7 +267,7 @@ func TestGetModeOverride_MCPStreamingUpstreamStaysBuffered(t *testing.T) {
 
 func TestGetModeOverride_NonMCPStreamingUpstreamUpgrades(t *testing.T) {
 	kernel := NewKernel()
-	server := NewExternalProcessorServer(kernel, executor.NewChainExecutor(nil, nil, nil), config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, executor.NewChainExecutor(nil, nil, nil), config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	chain := &registry.PolicyChain{
 		RequiresResponseBody:      true,
@@ -274,7 +301,7 @@ func TestGetModeOverride_NonMCPStreamingUpstreamUpgrades(t *testing.T) {
 func TestBuildRequestContext_BasicHeaders(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	chain := &registry.PolicyChain{}
 	execCtx := newPolicyExecutionContext(server, "test-route", chain)
@@ -321,7 +348,7 @@ func TestBuildRequestContext_BasicHeaders(t *testing.T) {
 func TestBuildRequestContext_WithRequestID(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	chain := &registry.PolicyChain{}
 	execCtx := newPolicyExecutionContext(server, "test-route", chain)
@@ -345,7 +372,7 @@ func TestBuildRequestContext_WithRequestID(t *testing.T) {
 func TestBuildRequestContext_EndOfStream(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	chain := &registry.PolicyChain{}
 	execCtx := newPolicyExecutionContext(server, "test-route", chain)
@@ -371,7 +398,7 @@ func TestBuildRequestContext_EndOfStream(t *testing.T) {
 func TestBuildRequestContext_WithTemplateAndProvider(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	chain := &registry.PolicyChain{}
 	execCtx := newPolicyExecutionContext(server, "test-route", chain)
@@ -403,7 +430,7 @@ func TestBuildRequestContext_WithTemplateAndProvider(t *testing.T) {
 func TestBuildRequestContext_MultipleHeaderValues(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	chain := &registry.PolicyChain{}
 	execCtx := newPolicyExecutionContext(server, "test-route", chain)
@@ -434,7 +461,7 @@ func TestBuildRequestContext_MultipleHeaderValues(t *testing.T) {
 func TestBuildResponseContext_BasicHeaders(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	chain := &registry.PolicyChain{}
 	execCtx := newPolicyExecutionContext(server, "test-route", chain)
@@ -477,7 +504,7 @@ func TestBuildResponseContext_BasicHeaders(t *testing.T) {
 func TestBuildResponseContext_EndOfStream(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	chain := &registry.PolicyChain{}
 	execCtx := newPolicyExecutionContext(server, "test-route", chain)
@@ -508,7 +535,7 @@ func TestBuildResponseContext_EndOfStream(t *testing.T) {
 func TestBuildResponseContext_InvalidStatus(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	chain := &registry.PolicyChain{}
 	execCtx := newPolicyExecutionContext(server, "test-route", chain)
@@ -541,7 +568,7 @@ func TestBuildResponseContext_InvalidStatus(t *testing.T) {
 func TestBuildRequestContext_DetectsContentEncoding(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	chain := &registry.PolicyChain{}
 	execCtx := newPolicyExecutionContext(server, "test-route", chain)
@@ -563,7 +590,7 @@ func TestBuildRequestContext_DetectsContentEncoding(t *testing.T) {
 func TestBuildRequestContext_DetectsBrotliEncoding(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	chain := &registry.PolicyChain{}
 	execCtx := newPolicyExecutionContext(server, "test-route", chain)
@@ -585,7 +612,7 @@ func TestBuildRequestContext_DetectsBrotliEncoding(t *testing.T) {
 func TestBuildRequestContext_NoContentEncoding(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	chain := &registry.PolicyChain{}
 	execCtx := newPolicyExecutionContext(server, "test-route", chain)
@@ -607,7 +634,7 @@ func TestBuildRequestContext_NoContentEncoding(t *testing.T) {
 func TestBuildResponseContext_DetectsContentEncoding(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	chain := &registry.PolicyChain{}
 	execCtx := newPolicyExecutionContext(server, "test-route", chain)
@@ -631,7 +658,7 @@ func TestBuildResponseContext_DetectsContentEncoding(t *testing.T) {
 func TestBuildResponseContext_DetectsBrotliEncoding(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	chain := &registry.PolicyChain{}
 	execCtx := newPolicyExecutionContext(server, "test-route", chain)
@@ -655,7 +682,7 @@ func TestBuildResponseContext_DetectsBrotliEncoding(t *testing.T) {
 func TestBuildResponseContext_NoContentEncoding(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	chain := &registry.PolicyChain{}
 	execCtx := newPolicyExecutionContext(server, "test-route", chain)
@@ -682,7 +709,7 @@ func TestBuildResponseContext_NoContentEncoding(t *testing.T) {
 
 func TestProcessResponseBody_DecompressesGzip(t *testing.T) {
 	kernel := NewKernel()
-	server := NewExternalProcessorServer(kernel, newTestExecutor(), config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, newTestExecutor(), config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	// Policy that requires and captures the response body
 	var capturedBody []byte
@@ -733,7 +760,7 @@ func TestProcessResponseBody_DecompressesGzip(t *testing.T) {
 
 func TestProcessResponseBody_DecompressesBrotli(t *testing.T) {
 	kernel := NewKernel()
-	server := NewExternalProcessorServer(kernel, newTestExecutor(), config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, newTestExecutor(), config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	var capturedBody []byte
 	mockPolicy := &testutils.ConfigurableMockPolicy{
@@ -777,9 +804,78 @@ func TestProcessResponseBody_DecompressesBrotli(t *testing.T) {
 	assert.Equal(t, originalJSON, capturedBody)
 }
 
+func TestProcessStreamingResponseBody_DecompressionErrorFailsClosed(t *testing.T) {
+	const maxChunkBytes int64 = 64
+
+	kernel := NewKernel()
+	server := NewExternalProcessorServer(kernel, newTestExecutor(), config.TracingConfig{}, "", testMaxDecompressedBytes, maxChunkBytes)
+	chain := &registry.PolicyChain{}
+	execCtx := newPolicyExecutionContext(server, "test-route", chain)
+
+	execCtx.buildRequestContexts(&extprocv3.HttpHeaders{Headers: &corev3.HeaderMap{}}, RouteMetadata{})
+	execCtx.buildResponseContexts(&extprocv3.HttpHeaders{
+		Headers: &corev3.HeaderMap{
+			Headers: []*corev3.HeaderValue{
+				{Key: ":status", RawValue: []byte("200")},
+				{Key: "content-encoding", RawValue: []byte("gzip")},
+			},
+		},
+	})
+
+	// Feed a real gzip stream without signaling EOS. Splitting the compressed bytes
+	// exercises decoder state and boundary accounting across calls. Once enough
+	// compressed input has arrived, the ext_proc stream must fail instead of
+	// returning a normal empty body and later ending as a successful truncation.
+	compressed := gzipCompress(make([]byte, 1024))
+	var resp *extprocv3.ProcessingResponse
+	var err error
+	for i := 0; i < len(compressed) && err == nil; i++ {
+		resp, err = execCtx.processStreamingResponseBody(context.Background(), &extprocv3.HttpBody{
+			Body:        compressed[i : i+1],
+			EndOfStream: false,
+		})
+	}
+
+	assert.Nil(t, resp, "a decompression failure must not be translated into a normal body response")
+	require.ErrorIs(t, err, ErrDecompressedTooLarge)
+	assert.False(t, execCtx.streamTerminated, "kernel errors terminate ext_proc instead of using policy EOS suppression")
+	assert.Nil(t, execCtx.responseStreamDecomp)
+}
+
+func TestProcessResponseBody_DecompressionLimitFailsClosed(t *testing.T) {
+	const responseLimit int64 = 64
+
+	kernel := NewKernel()
+	server := NewExternalProcessorServer(kernel, newTestExecutor(), config.TracingConfig{}, "", testMaxDecompressedBytes, responseLimit)
+	chain := &registry.PolicyChain{
+		RequiresResponseBody: true,
+		Policies:             []policy.Policy{&testutils.NoopPolicy{}},
+		PolicySpecs:          []policy.PolicySpec{{Enabled: true}},
+	}
+	execCtx := newPolicyExecutionContext(server, "test-route", chain)
+
+	execCtx.buildRequestContexts(&extprocv3.HttpHeaders{Headers: &corev3.HeaderMap{}}, RouteMetadata{})
+	execCtx.buildResponseContexts(&extprocv3.HttpHeaders{
+		Headers: &corev3.HeaderMap{
+			Headers: []*corev3.HeaderValue{
+				{Key: ":status", RawValue: []byte("200")},
+				{Key: "content-encoding", RawValue: []byte("gzip")},
+			},
+		},
+	})
+
+	resp, err := execCtx.processResponseBody(context.Background(), &extprocv3.HttpBody{
+		Body:        gzipCompress(make([]byte, 1024)),
+		EndOfStream: true,
+	})
+
+	assert.Nil(t, resp)
+	require.ErrorIs(t, err, ErrDecompressedTooLarge)
+}
+
 func TestProcessResponseBody_NoEncoding_PassesThrough(t *testing.T) {
 	kernel := NewKernel()
-	server := NewExternalProcessorServer(kernel, newTestExecutor(), config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, newTestExecutor(), config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	var capturedBody []byte
 	mockPolicy := &testutils.ConfigurableMockPolicy{
@@ -827,7 +923,7 @@ func TestProcessResponseBody_NoEncoding_PassesThrough(t *testing.T) {
 
 func TestProcessRequestBody_DecompressesGzip(t *testing.T) {
 	kernel := NewKernel()
-	server := NewExternalProcessorServer(kernel, newTestExecutor(), config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, newTestExecutor(), config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	chain := &registry.PolicyChain{
 		RequiresRequestBody: true,
@@ -862,7 +958,7 @@ func TestProcessRequestBody_DecompressesGzip(t *testing.T) {
 
 func TestProcessRequestBody_NoEncoding_PassesThrough(t *testing.T) {
 	kernel := NewKernel()
-	server := NewExternalProcessorServer(kernel, newTestExecutor(), config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, newTestExecutor(), config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	chain := &registry.PolicyChain{
 		RequiresRequestBody: true,
@@ -909,7 +1005,7 @@ func TestProcessRequestBody_NoEncoding_PassesThrough(t *testing.T) {
 
 func TestProcessResponseBody_MCPSSEEmitsBufferedBodyMutation(t *testing.T) {
 	kernel := NewKernel()
-	server := NewExternalProcessorServer(kernel, newTestExecutor(), config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, newTestExecutor(), config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	rewrittenBody := []byte("event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[]}}\n\n")
 	mockPolicy := &testutils.ConfigurableMockPolicy{
@@ -978,4 +1074,105 @@ func TestProcessResponseBody_MCPSSEEmitsBufferedBodyMutation(t *testing.T) {
 		}
 	}
 	assert.Equal(t, fmt.Sprintf("%d", len(rewrittenBody)), contentLength)
+}
+
+func TestProcessRequestBody_DecompressionLimitReturns413(t *testing.T) {
+	const requestLimit int64 = 64
+
+	kernel := NewKernel()
+	server := NewExternalProcessorServer(kernel, newTestExecutor(), config.TracingConfig{}, "", requestLimit, testMaxDecompressedBytes)
+	chain := &registry.PolicyChain{
+		RequiresRequestBody: true,
+		Policies:            []policy.Policy{&testutils.NoopPolicy{}},
+		PolicySpecs:         []policy.PolicySpec{{Enabled: true}},
+	}
+	execCtx := newPolicyExecutionContext(server, "test-route", chain)
+	execCtx.buildRequestContexts(&extprocv3.HttpHeaders{
+		Headers: &corev3.HeaderMap{
+			Headers: []*corev3.HeaderValue{
+				{Key: ":path", RawValue: []byte("/api/chat")},
+				{Key: "content-encoding", RawValue: []byte("gzip")},
+			},
+		},
+	}, RouteMetadata{})
+
+	resp, err := execCtx.processRequestBody(context.Background(), &extprocv3.HttpBody{
+		Body:        gzipCompress(make([]byte, 1024)),
+		EndOfStream: true,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.GetImmediateResponse())
+	assert.Equal(t, typev3.StatusCode_PayloadTooLarge, resp.GetImmediateResponse().Status.Code)
+}
+
+func TestProcessStreamingRequestBody_DecompressionLimitFailsClosed(t *testing.T) {
+	const requestLimit int64 = 64
+
+	kernel := NewKernel()
+	server := NewExternalProcessorServer(kernel, newTestExecutor(), config.TracingConfig{}, "", requestLimit, testMaxDecompressedBytes)
+	chain := &registry.PolicyChain{
+		RequiresRequestBody:      true,
+		SupportsRequestStreaming: true,
+		Policies:                 []policy.Policy{&testutils.NoopPolicy{}},
+		PolicySpecs:              []policy.PolicySpec{{Enabled: true}},
+	}
+	execCtx := newPolicyExecutionContext(server, "test-route", chain)
+	execCtx.buildRequestContexts(&extprocv3.HttpHeaders{
+		Headers: &corev3.HeaderMap{
+			Headers: []*corev3.HeaderValue{
+				{Key: ":path", RawValue: []byte("/api/chat")},
+				{Key: "content-encoding", RawValue: []byte("gzip")},
+				{Key: "transfer-encoding", RawValue: []byte("chunked")},
+			},
+		},
+	}, RouteMetadata{})
+
+	compressed := gzipCompress(make([]byte, 1024))
+	var resp *extprocv3.ProcessingResponse
+	var err error
+	for i := 0; i < len(compressed) && err == nil; i++ {
+		resp, err = execCtx.processStreamingRequestBody(context.Background(), &extprocv3.HttpBody{
+			Body:        compressed[i : i+1],
+			EndOfStream: false,
+		})
+	}
+
+	assert.Nil(t, resp, "full-duplex limit failures must not promise a late ImmediateResponse")
+	require.ErrorIs(t, err, ErrDecompressedTooLarge)
+	assert.Nil(t, execCtx.requestStreamDecomp)
+}
+
+func TestProcessStreamingRequestBody_MalformedEncodingFailsClosed(t *testing.T) {
+	kernel := NewKernel()
+	server := NewExternalProcessorServer(kernel, newTestExecutor(), config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
+	chain := &registry.PolicyChain{
+		RequiresRequestBody:      true,
+		SupportsRequestStreaming: true,
+		Policies:                 []policy.Policy{&testutils.NoopPolicy{}},
+		PolicySpecs:              []policy.PolicySpec{{Enabled: true}},
+	}
+	execCtx := newPolicyExecutionContext(server, "test-route", chain)
+	execCtx.buildRequestContexts(&extprocv3.HttpHeaders{
+		Headers: &corev3.HeaderMap{
+			Headers: []*corev3.HeaderValue{
+				{Key: ":path", RawValue: []byte("/api/chat")},
+				{Key: "content-encoding", RawValue: []byte("gzip")},
+				{Key: "transfer-encoding", RawValue: []byte("chunked")},
+			},
+		},
+	}, RouteMetadata{})
+
+	compressed := gzipCompress([]byte("valid body with a corrupted trailer"))
+	compressed[len(compressed)-1] ^= 0xff
+	resp, err := execCtx.processStreamingRequestBody(context.Background(), &extprocv3.HttpBody{
+		Body:        compressed,
+		EndOfStream: true,
+	})
+
+	assert.Nil(t, resp, "malformed compressed fragments must never be forwarded raw")
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrDecompressedTooLarge)
+	assert.Nil(t, execCtx.requestStreamDecomp)
 }

--- a/gateway/gateway-runtime/policy-engine/internal/kernel/extproc.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/extproc.go
@@ -55,10 +55,16 @@ type ExternalProcessorServer struct {
 	kernel   *Kernel
 	executor *executor.ChainExecutor
 	tracer   trace.Tracer
+
+	// Per-direction caps on decompressed bytes buffered per body (buffered mode)
+	// or per chunk (streaming), from policy_engine.request/.response config.
+	// A value <= 0 disables the cap.
+	maxRequestDecompressedBytes  int64
+	maxResponseDecompressedBytes int64
 }
 
 // NewExternalProcessorServer creates a new ExternalProcessorServer
-func NewExternalProcessorServer(kernel *Kernel, chainExecutor *executor.ChainExecutor, tracingConfig config.TracingConfig, tracingServiceName string) *ExternalProcessorServer {
+func NewExternalProcessorServer(kernel *Kernel, chainExecutor *executor.ChainExecutor, tracingConfig config.TracingConfig, tracingServiceName string, maxRequestDecompressedBytes int64, maxResponseDecompressedBytes int64) *ExternalProcessorServer {
 	// Initialize tracer once - will be NoOp if tracing is disabled
 	serviceName := tracingServiceName
 	if serviceName == "" {
@@ -66,9 +72,11 @@ func NewExternalProcessorServer(kernel *Kernel, chainExecutor *executor.ChainExe
 	}
 
 	return &ExternalProcessorServer{
-		kernel:   kernel,
-		executor: chainExecutor,
-		tracer:   otel.Tracer(serviceName),
+		kernel:                       kernel,
+		executor:                     chainExecutor,
+		tracer:                       otel.Tracer(serviceName),
+		maxRequestDecompressedBytes:  maxRequestDecompressedBytes,
+		maxResponseDecompressedBytes: maxResponseDecompressedBytes,
 	}
 }
 
@@ -92,6 +100,11 @@ func (s *ExternalProcessorServer) Process(stream extprocv3.ExternalProcessor_Pro
 	// Lives until response complete, then garbage collected when stream ends.
 	// One stream = one HTTP request, so this is allocated once per request.
 	var execCtx *PolicyExecutionContext
+	defer func() {
+		if execCtx != nil {
+			execCtx.closeStreamDecompressors()
+		}
+	}()
 
 	for {
 		// Receive request from Envoy

--- a/gateway/gateway-runtime/policy-engine/internal/kernel/extproc.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/extproc.go
@@ -57,7 +57,7 @@ type ExternalProcessorServer struct {
 	tracer   trace.Tracer
 
 	// Per-direction caps on decompressed bytes buffered per body (buffered mode)
-	// or per chunk (streaming), from policy_engine.request/.response config.
+	// or per chunk (streaming), from policy_engine.request_body/.response_body config.
 	// A value <= 0 disables the cap.
 	maxRequestDecompressedBytes  int64
 	maxResponseDecompressedBytes int64

--- a/gateway/gateway-runtime/policy-engine/internal/kernel/extproc_bench_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/extproc_bench_test.go
@@ -197,6 +197,8 @@ func newBenchServer(routes map[string]*registry.PolicyChain) *ExternalProcessorS
 		chainExecutor,
 		config.TracingConfig{Enabled: false},
 		"bench-policy-engine",
+		testMaxDecompressedBytes,
+		testMaxDecompressedBytes,
 	)
 }
 

--- a/gateway/gateway-runtime/policy-engine/internal/kernel/extproc_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/extproc_test.go
@@ -98,7 +98,7 @@ func TestNewExternalProcessorServer(t *testing.T) {
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
 	tracingConfig := config.TracingConfig{}
 
-	server := NewExternalProcessorServer(kernel, chainExecutor, tracingConfig, "test-service")
+	server := NewExternalProcessorServer(kernel, chainExecutor, tracingConfig, "test-service", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	require.NotNil(t, server)
 	assert.Equal(t, kernel, server.kernel)
@@ -111,7 +111,7 @@ func TestNewExternalProcessorServer_DefaultServiceName(t *testing.T) {
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
 	tracingConfig := config.TracingConfig{}
 
-	server := NewExternalProcessorServer(kernel, chainExecutor, tracingConfig, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, tracingConfig, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	require.NotNil(t, server)
 	// Tracer should be created with default name
@@ -125,7 +125,7 @@ func TestNewExternalProcessorServer_DefaultServiceName(t *testing.T) {
 func TestGenerateRequestID(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	id1 := server.generateRequestID()
 	id2 := server.generateRequestID()
@@ -144,7 +144,7 @@ func TestGenerateRequestID(t *testing.T) {
 func TestSkipAllProcessing(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	routeMetadata := RouteMetadata{
 		RouteName:  "test-route",
@@ -179,7 +179,7 @@ func TestSkipAllProcessing(t *testing.T) {
 func TestProcess_EmptyStream(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	stream := newMockStream([]*extprocv3.ProcessingRequest{})
 
@@ -192,7 +192,7 @@ func TestProcess_EmptyStream(t *testing.T) {
 func TestProcess_RequestHeaders_NoPolicyChain(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	req := &extprocv3.ProcessingRequest{
 		Request: &extprocv3.ProcessingRequest_RequestHeaders{
@@ -225,7 +225,7 @@ func TestProcess_RequestHeaders_NoPolicyChain(t *testing.T) {
 func TestProcess_UnknownRequestType(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	// Create a request with nil Request field
 	req := &extprocv3.ProcessingRequest{}
@@ -247,7 +247,7 @@ func TestProcess_UnknownRequestType(t *testing.T) {
 func TestProcess_RecvError(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	stream := newMockStream([]*extprocv3.ProcessingRequest{})
 	stream.recvErr = errors.New("receive error")
@@ -260,7 +260,7 @@ func TestProcess_RecvError(t *testing.T) {
 func TestProcess_ContextCanceled(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	stream := newMockStream([]*extprocv3.ProcessingRequest{})
 	stream.recvErr = context.Canceled
@@ -274,7 +274,7 @@ func TestProcess_ContextCanceled(t *testing.T) {
 func TestProcess_SendError(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	req := &extprocv3.ProcessingRequest{
 		Request: &extprocv3.ProcessingRequest_RequestHeaders{
@@ -297,7 +297,7 @@ func TestProcess_SendError(t *testing.T) {
 func TestHandleProcessingPhase_RequestBody_NoContext(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	req := &extprocv3.ProcessingRequest{
 		Request: &extprocv3.ProcessingRequest_RequestBody{
@@ -329,7 +329,7 @@ func TestHandleProcessingPhase_RequestBody_NoContext(t *testing.T) {
 func TestHandleProcessingPhase_ResponseHeaders_NoContext(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	req := &extprocv3.ProcessingRequest{
 		Request: &extprocv3.ProcessingRequest_ResponseHeaders{
@@ -364,7 +364,7 @@ func TestHandleProcessingPhase_ResponseHeaders_NoContext(t *testing.T) {
 func TestHandleProcessingPhase_ResponseBody_NoContext(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	req := &extprocv3.ProcessingRequest{
 		Request: &extprocv3.ProcessingRequest_ResponseBody{
@@ -396,7 +396,7 @@ func TestHandleProcessingPhase_ResponseBody_NoContext(t *testing.T) {
 func TestInitializeExecutionContext_NoPolicyChain(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	req := &extprocv3.ProcessingRequest{
 		Request: &extprocv3.ProcessingRequest_RequestHeaders{
@@ -438,7 +438,7 @@ func TestInitializeExecutionContext_WithPolicyChain(t *testing.T) {
 	})
 
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	req := &extprocv3.ProcessingRequest{
 		Request: &extprocv3.ProcessingRequest_RequestHeaders{

--- a/gateway/gateway-runtime/policy-engine/internal/kernel/translator_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/translator_test.go
@@ -418,7 +418,7 @@ func TestBuildDynamicMetadata_WithPath(t *testing.T) {
 func TestTranslateRequestActionsCore_EmptyResult(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	chain := &registry.PolicyChain{}
 	execCtx := newPolicyExecutionContext(server, "test-route", chain)
@@ -445,7 +445,7 @@ func TestTranslateRequestActionsCore_EmptyResult(t *testing.T) {
 func TestTranslateRequestActionsCore_WithSetHeaders(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	chain := &registry.PolicyChain{}
 	execCtx := newPolicyExecutionContext(server, "test-route", chain)
@@ -479,7 +479,7 @@ func TestTranslateRequestActionsCore_WithSetHeaders(t *testing.T) {
 func TestTranslateRequestActionsCore_WithBodyModification(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	chain := &registry.PolicyChain{}
 	execCtx := newPolicyExecutionContext(server, "test-route", chain)
@@ -521,7 +521,7 @@ func TestTranslateRequestActionsCore_WithBodyModification(t *testing.T) {
 func TestTranslateRequestActionsCore_ShortCircuit(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	chain := &registry.PolicyChain{}
 	execCtx := newPolicyExecutionContext(server, "test-route", chain)
@@ -555,7 +555,7 @@ func TestTranslateRequestActionsCore_ShortCircuit(t *testing.T) {
 func TestTranslateRequestActionsCore_ShortCircuit_PreservesPriorRequestAnalyticsMetadata(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	chain := &registry.PolicyChain{}
 	execCtx := newPolicyExecutionContext(server, "test-route", chain)
@@ -619,7 +619,7 @@ func TestTranslateRequestActionsCore_ShortCircuit_PreservesPriorRequestAnalytics
 func TestTranslateRequestHeaderActions_ShortCircuit_PreservesPriorAnalyticsMetadata(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	chain := &registry.PolicyChain{}
 	execCtx := newPolicyExecutionContext(server, "test-route", chain)
@@ -678,7 +678,7 @@ func TestTranslateRequestHeaderActions_ShortCircuit_PreservesPriorAnalyticsMetad
 func TestTranslateRequestActionsCore_SkippedPolicy(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	chain := &registry.PolicyChain{}
 	execCtx := newPolicyExecutionContext(server, "test-route", chain)
@@ -711,7 +711,7 @@ func TestTranslateRequestActionsCore_SkippedPolicy(t *testing.T) {
 func TestTranslateRequestActionsCore_WithQueryParams(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	chain := &registry.PolicyChain{}
 	execCtx := newPolicyExecutionContext(server, "test-route", chain)
@@ -744,7 +744,7 @@ func TestTranslateRequestActionsCore_WithQueryParams(t *testing.T) {
 func TestTranslateRequestActionsCore_WithPathOverride(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	chain := &registry.PolicyChain{}
 	execCtx := newPolicyExecutionContext(server, "test-route", chain)
@@ -780,7 +780,7 @@ func TestTranslateRequestActionsCore_WithPathOverride(t *testing.T) {
 func TestTranslateResponseActionsCore_ShortCircuit(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	chain := &registry.PolicyChain{}
 	execCtx := newPolicyExecutionContext(server, "test-route", chain)
@@ -820,7 +820,7 @@ func TestTranslateResponseActionsCore_ShortCircuit(t *testing.T) {
 func TestTranslateResponseActionsCore_NoShortCircuit(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 
 	chain := &registry.PolicyChain{}
 	execCtx := newPolicyExecutionContext(server, "test-route", chain)
@@ -869,7 +869,7 @@ func TestTranslateRequestHeaderActions_DynamicEndpoint(t *testing.T) {
 	newExecCtx := func() *PolicyExecutionContext {
 		kernel := NewKernel()
 		chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-		server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+		server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 		execCtx := newPolicyExecutionContext(server, "test-route", &registry.PolicyChain{})
 		execCtx.sharedCtx = &policy.SharedContext{APIKind: "API", APIId: "api-123"}
 		execCtx.requestBodyCtx = &policy.RequestContext{
@@ -944,7 +944,7 @@ func TestTranslateRequestHeaderActionsWithBodyMerge_DynamicEndpoint(t *testing.T
 	newExecCtx := func() *PolicyExecutionContext {
 		kernel := NewKernel()
 		chainExecutor := executor.NewChainExecutor(nil, nil, nil)
-		server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+		server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "", testMaxDecompressedBytes, testMaxDecompressedBytes)
 		execCtx := newPolicyExecutionContext(server, "test-route", &registry.PolicyChain{})
 		execCtx.sharedCtx = &policy.SharedContext{APIKind: "API", APIId: "api-123"}
 		execCtx.requestBodyCtx = &policy.RequestContext{

--- a/sdk-python/src/apip_sdk_core/policy/v1alpha2/types.py
+++ b/sdk-python/src/apip_sdk_core/policy/v1alpha2/types.py
@@ -143,6 +143,10 @@ class DownstreamRequest:
     """
 
     headers: Headers | None = None
+    path: str = ""
+    method: str = ""
+    authority: str = ""
+    scheme: str = ""
 
 
 @dataclass(slots=True)
@@ -182,6 +186,7 @@ class UpstreamResponse:
     """
 
     headers: Headers | None = None
+    status_code: int = 0
 
 
 @dataclass(slots=True)

--- a/sdk/core/policy/v1alpha2/context.go
+++ b/sdk/core/policy/v1alpha2/context.go
@@ -26,7 +26,11 @@ type DownstreamContext struct {
 // DownstreamRequest holds a snapshot of the request as received from the
 // downstream client, captured before any policy mutation is applied.
 type DownstreamRequest struct {
-	Headers *Headers
+	Headers   *Headers
+	Path      string
+	Method    string
+	Authority string
+	Scheme    string
 }
 
 // UpstreamRequestContext identifies the route's resolved upstream target during
@@ -49,7 +53,8 @@ type UpstreamResponseContext struct {
 // UpstreamResponse holds a snapshot of the response as received from the
 // upstream backend, captured before any policy mutation is applied.
 type UpstreamResponse struct {
-	Headers *Headers
+	Headers    *Headers
+	StatusCode int
 }
 
 // SharedContext contains data shared across request and response phases


### PR DESCRIPTION
## Purpose

Two independent improvements shipped together on this branch:

1. **Decompression improvements** — correctness and config refactoring in the policy engine's request/response body decompression path.
2. **SDK context snapshot completeness** — `DownstreamRequest` and `UpstreamResponse` only snapshotted `Headers`, leaving no way for a downstream policy to access the original client path/method or the original upstream status code when an earlier policy rewrote them.

## Goals

- Policies that run after a path-rewriting or method-rewriting policy can now read the original client values via `Downstream.Request.Path`, `.Method`, `.Authority`, `.Scheme`.
- Policies that run after a status-code-rewriting policy can read the original upstream status via `Upstream.Response.StatusCode` (Go) / `upstream.response.status_code` (Python).
- Decompression logic is cleaner and better configured.

## Approach

**Decompression (policy engine):**
- Improvements to decompression logic correctness
- Config refactor and removal of unnecessary comments

**SDK (Go + Python):**
- `DownstreamRequest` gains `Path`, `Method`, `Authority`, `Scheme` in `sdk/core/policy/v1alpha2/context.go` and `sdk-python/src/apip_sdk_core/policy/v1alpha2/types.py`
- `UpstreamResponse` gains `StatusCode` (Go) / `status_code` (Python)
- Fields default to zero values; kernel wiring and proto update are deferred to the follow-up policy engine PR

## Related Issues

Related #2914 (will be closed by the follow-up policy engine PR that wires the kernel and updates the proto)

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (Go/Python)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes