### PR TITLE
feat(sdk): snapshot original path, method, authority, scheme and upstream status code

### DIFF
--- a/sdk-python/src/apip_sdk_core/policy/v1alpha2/types.py
+++ b/sdk-python/src/apip_sdk_core/policy/v1alpha2/types.py
@@ -143,6 +143,10 @@ class DownstreamRequest:
     """
 
     headers: Headers | None = None
+    path: str = ""
+    method: str = ""
+    authority: str = ""
+    scheme: str = ""
 
 
 @dataclass(slots=True)
@@ -182,6 +186,7 @@ class UpstreamResponse:
     """
 
     headers: Headers | None = None
+    status_code: int = 0
 
 
 @dataclass(slots=True)

--- a/sdk/core/policy/v1alpha2/context.go
+++ b/sdk/core/policy/v1alpha2/context.go
@@ -26,7 +26,11 @@ type DownstreamContext struct {
 // DownstreamRequest holds a snapshot of the request as received from the
 // downstream client, captured before any policy mutation is applied.
 type DownstreamRequest struct {
-	Headers *Headers
+	Headers   *Headers
+	Path      string
+	Method    string
+	Authority string
+	Scheme    string
 }
 
 // UpstreamRequestContext identifies the route's resolved upstream target during
@@ -49,7 +53,8 @@ type UpstreamResponseContext struct {
 // UpstreamResponse holds a snapshot of the response as received from the
 // upstream backend, captured before any policy mutation is applied.
 type UpstreamResponse struct {
-	Headers *Headers
+	Headers    *Headers
+	StatusCode int
 }
 
 // SharedContext contains data shared across request and response phases


### PR DESCRIPTION
## Purpose

Policies can mutate the request path, method, authority (via `UpstreamRequestHeaderModifications`/`UpstreamRequestModifications` `Path`/`Method`/`Host`) and the response status code (via `DownstreamResponseModifications.StatusCode`). A policy running later in the chain that needs the *original* client-sent value has no way to recover it — `ctx.Path`/`ctx.Method` already reflect the post-mutation state, and the kernel's downstream/upstream snapshots only captured headers, not these scalar fields.

This closes that gap in the SDK type surface so the snapshot model is symmetric: headers, path/method/authority/scheme (downstream), and status code (upstream) are all recoverable in their pre-mutation form.

This is the SDK-only part, released independently so policy authors can compile against the new fields. The policy-engine kernel wiring and the `python_executor.proto` change that populate them follow in a separate PR.

## Approach

- `DownstreamRequest` (Go + Python): add `Path`, `Method`, `Authority`, `Scheme` alongside the existing `Headers` snapshot.
- `UpstreamResponse` (Go + Python): add `StatusCode` alongside the existing `Headers` snapshot.
- Python uses `status_code: int = 0` (snake_case per convention; `0` default since the field is unset until the kernel populates it).
- No kernel/proto changes here — the new fields are zero-valued until the follow-up policy-engine PR wires them in `buildRequestContexts`/`buildResponseContexts` and the proto.

## Related Issues

Related #2914

The issue will be closed by the follow-up policy-engine PR, not this one.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks

Additive struct fields only — no behavior change and no breaking change for existing policies. Go builds clean; Python SDK tests pass (3/3).