### PR TITLE
[APIP] Fix route path not showing under datadog resource

### DIFF
--- a/gateway/gateway-controller/pkg/xds/translator.go
+++ b/gateway/gateway-controller/pkg/xds/translator.go
@@ -2854,16 +2854,18 @@ func createOTelStaticResourceDetector(attributes map[string]string) (*core.Typed
 
 // createTracingCustomTags builds the HCM-level tracing custom tags:
 //
-//   - peer.service: the identity tag Datadog uses to infer downstream dependencies. The
-//     value comes from the selected upstream host's metadata rather than the Host header,
-//     so it stays correct for upstreams configured with hostRewrite: manual. peer.service
-//     is Datadog's highest-priority peer attribute.
+//   - peer.service: a standard OTel semantic-convention attribute identifying the
+//     upstream dependency. The value comes from the selected upstream host's metadata
+//     rather than the Host header, so it stays correct for upstreams configured with
+//     hostRewrite: manual.
 //   - http.route: the route's path template (e.g. "/reading-list/v1.0/{id}"), read from
-//     route metadata set by setRouteHTTPRoute. Datadog derives a span's resource name as
-//     "<http.method> <http.route>", falling back to the bare method when http.route is
-//     absent — which is what previously left the Traces table Resource column showing
-//     just "GET". Sourced from route (not host) metadata, since the path template is a
-//     property of the matched route, not the selected upstream endpoint.
+//     route metadata set by setRouteHTTPRoute. This is the standard OTel semantic
+//     convention attribute for the matched route template, distinct from http.url/
+//     http.target which carry the concrete request path. APM backends commonly derive a
+//     span's display name/resource from "<http.method> <http.route>" and fall back to the
+//     bare method when http.route is absent. Sourced from route (not host) metadata,
+//     since the path template is a property of the matched route, not the selected
+//     upstream endpoint.
 func createTracingCustomTags() []*tracingv3.CustomTag {
 	return []*tracingv3.CustomTag{
 		{
@@ -2960,13 +2962,13 @@ func ensureRouteFilterMetadata(r *route.Route) map[string]*structpb.Struct {
 
 // setRouteHTTPRoute records the route's path template under wso2.route/http.route so the
 // HCM tracing custom tag (see createTracingCustomTags) can surface it as the OTel
-// http.route attribute. Datadog derives a span's resource name from
-// "<http.method> <http.route>"; without http.route it falls back to the bare method,
-// which is what left the Datadog Traces table Resource column showing just "GET".
-// A nil route or empty template is a no-op, so a route with nothing to report doesn't
-// gain an empty Metadata shell. Merges into any existing wso2.route namespace struct
-// rather than overwriting it, so this can run regardless of whether a caller (e.g.
-// createRoutePerTopic) already wrote other keys under the same namespace.
+// http.route attribute — the standard semantic-convention attribute for the matched
+// route template, as distinct from the concrete request path. Without it, APM backends
+// that key a span's display name/resource off "<http.method> <http.route>" fall back to
+// the bare method. A nil route or empty template is a no-op, so a route with nothing to
+// report doesn't gain an empty Metadata shell. Merges into any existing wso2.route
+// namespace struct rather than overwriting it, so this can run regardless of whether a
+// caller (e.g. createRoutePerTopic) already wrote other keys under the same namespace.
 func setRouteHTTPRoute(r *route.Route, pathTemplate string) {
 	if r == nil || pathTemplate == "" {
 		return

--- a/gateway/gateway-controller/pkg/xds/translator.go
+++ b/gateway/gateway-controller/pkg/xds/translator.go
@@ -83,6 +83,11 @@ const (
 	// Upstream endpoint metadata carrying the backend hostname for tracing peer identity.
 	envoyLBMetadataNamespace   = "envoy.lb"
 	envoyLBHostnameMetadataKey = "hostname"
+
+	// Route filter metadata carrying the route's path template for tracing (http.route)
+	// and other route-scoped consumers.
+	envoyRouteMetadataNamespace = "wso2.route"
+	envoyRouteHTTPRouteKey      = "http.route"
 )
 
 func checkedUInt32FromPositiveInt(fieldName string, value int) (uint32, error) {
@@ -370,6 +375,7 @@ func (t *Translator) createRouteFromRDC(routeKey string, rdcRoute *models.Route,
 	// route match identical requests).
 	r.Match.Headers = buildMatchHeaders(method, rdcRoute)
 	t.setMatchPathSpecifier(r.Match, fullPath, operationPath, rdcRoute)
+	setRouteHTTPRoute(r, fullPath)
 
 	// Compute regex rewrite to strip context and prepend upstream path
 	upstreamPath := ""
@@ -1668,6 +1674,7 @@ func (t *Translator) createRoute(apiId, apiName, apiVersion, context, method, pa
 			},
 		}
 	}
+	setRouteHTTPRoute(r, fullPath)
 
 	// Add path rewriting if upstream has a path prefix
 	// Strip the API context (with version if included) and prepend the upstream path
@@ -1742,6 +1749,7 @@ func (t *Translator) createRoute(apiId, apiName, apiVersion, context, method, pa
 // createRoutePerTopic creates a route for an operation
 func (t *Translator) createRoutePerTopic(apiId, apiName, apiVersion, context, method, channelName, clusterName, vhost, apiKind, projectID string) *route.Route {
 	routeName := GenerateRouteName(method, context, apiVersion, channelName, vhost)
+	fullPath := ConstructFullPath(context, apiVersion, channelName)
 	r := &route.Route{
 		Name: routeName,
 		Match: &route.RouteMatch{
@@ -1784,12 +1792,13 @@ func (t *Translator) createRoutePerTopic(apiId, apiName, apiVersion, context, me
 
 	if metaStruct, err := structpb.NewStruct(metaMap); err == nil {
 		r.Metadata = &core.Metadata{FilterMetadata: map[string]*structpb.Struct{
-			"wso2.route": metaStruct,
+			envoyRouteMetadataNamespace: metaStruct,
 		}}
 	}
+	setRouteHTTPRoute(r, fullPath)
 
 	r.Match.PathSpecifier = &route.RouteMatch_Path{
-		Path: ConstructFullPath(context, apiVersion, channelName),
+		Path: fullPath,
 	}
 
 	r.GetRoute().PrefixRewrite = "/hub"
@@ -2776,7 +2785,7 @@ func (t *Translator) createTracingConfig() (*hcm.HttpConnectionManager_Tracing, 
 		RandomSampling: &typev3.Percent{
 			Value: samplingPercentage,
 		},
-		CustomTags: createTracingUpstreamPeerCustomTags(),
+		CustomTags: createTracingCustomTags(),
 	}
 
 	t.logger.Info("Tracing configuration created",
@@ -2843,11 +2852,19 @@ func createOTelStaticResourceDetector(attributes map[string]string) (*core.Typed
 	}, nil
 }
 
-// createTracingUpstreamPeerCustomTags builds the peer identity tag Datadog uses to infer
-// downstream dependencies. The value comes from the selected upstream host's metadata rather
-// than the Host header, so it stays correct for upstreams configured with hostRewrite: manual.
-// A single tag is enough: peer.service is Datadog's highest-priority peer attribute.
-func createTracingUpstreamPeerCustomTags() []*tracingv3.CustomTag {
+// createTracingCustomTags builds the HCM-level tracing custom tags:
+//
+//   - peer.service: the identity tag Datadog uses to infer downstream dependencies. The
+//     value comes from the selected upstream host's metadata rather than the Host header,
+//     so it stays correct for upstreams configured with hostRewrite: manual. peer.service
+//     is Datadog's highest-priority peer attribute.
+//   - http.route: the route's path template (e.g. "/reading-list/v1.0/{id}"), read from
+//     route metadata set by setRouteHTTPRoute. Datadog derives a span's resource name as
+//     "<http.method> <http.route>", falling back to the bare method when http.route is
+//     absent — which is what previously left the Traces table Resource column showing
+//     just "GET". Sourced from route (not host) metadata, since the path template is a
+//     property of the matched route, not the selected upstream endpoint.
+func createTracingCustomTags() []*tracingv3.CustomTag {
 	return []*tracingv3.CustomTag{
 		{
 			Tag: "peer.service",
@@ -2864,6 +2881,28 @@ func createTracingUpstreamPeerCustomTags() []*tracingv3.CustomTag {
 							{
 								Segment: &metadatav3.MetadataKey_PathSegment_Key{
 									Key: envoyLBHostnameMetadataKey,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Tag: envoyRouteHTTPRouteKey,
+			Type: &tracingv3.CustomTag_Metadata_{
+				Metadata: &tracingv3.CustomTag_Metadata{
+					Kind: &metadatav3.MetadataKind{
+						Kind: &metadatav3.MetadataKind_Route_{
+							Route: &metadatav3.MetadataKind_Route{},
+						},
+					},
+					MetadataKey: &metadatav3.MetadataKey{
+						Key: envoyRouteMetadataNamespace,
+						Path: []*metadatav3.MetadataKey_PathSegment{
+							{
+								Segment: &metadatav3.MetadataKey_PathSegment_Key{
+									Key: envoyRouteHTTPRouteKey,
 								},
 							},
 						},
@@ -2888,7 +2927,7 @@ func ensureFilterMetadata(lbEndpoint *endpoint.LbEndpoint) map[string]*structpb.
 }
 
 // setEndpointPeerHostname stamps the upstream hostname on an endpoint under the envoy.lb
-// namespace so the peer.service custom tag (createTracingUpstreamPeerCustomTags) can read it
+// namespace so the peer.service custom tag (createTracingCustomTags) can read it
 // as the upstream CLIENT span's peer identity. Routing is unaffected. Applies to both plaintext
 // and TLS endpoints — peer.service tracing doesn't depend on transport security. A nil endpoint
 // or empty hostname is a no-op, checked before any allocation, so an endpoint that genuinely has
@@ -2903,6 +2942,45 @@ func setEndpointPeerHostname(lbEndpoint *endpoint.LbEndpoint, hostname string) {
 			envoyLBHostnameMetadataKey: structpb.NewStringValue(hostname),
 		},
 	}
+}
+
+// ensureRouteFilterMetadata returns route r's FilterMetadata map, allocating Metadata/
+// FilterMetadata on demand — mirrors ensureFilterMetadata but for routes rather than
+// endpoints, so multiple writers (e.g. createRoutePerTopic's own metadata block and
+// setRouteHTTPRoute) can populate the same route without depending on call order.
+func ensureRouteFilterMetadata(r *route.Route) map[string]*structpb.Struct {
+	if r.Metadata == nil {
+		r.Metadata = &core.Metadata{}
+	}
+	if r.Metadata.FilterMetadata == nil {
+		r.Metadata.FilterMetadata = map[string]*structpb.Struct{}
+	}
+	return r.Metadata.FilterMetadata
+}
+
+// setRouteHTTPRoute records the route's path template under wso2.route/http.route so the
+// HCM tracing custom tag (see createTracingCustomTags) can surface it as the OTel
+// http.route attribute. Datadog derives a span's resource name from
+// "<http.method> <http.route>"; without http.route it falls back to the bare method,
+// which is what left the Datadog Traces table Resource column showing just "GET".
+// A nil route or empty template is a no-op, so a route with nothing to report doesn't
+// gain an empty Metadata shell. Merges into any existing wso2.route namespace struct
+// rather than overwriting it, so this can run regardless of whether a caller (e.g.
+// createRoutePerTopic) already wrote other keys under the same namespace.
+func setRouteHTTPRoute(r *route.Route, pathTemplate string) {
+	if r == nil || pathTemplate == "" {
+		return
+	}
+
+	filterMetadata := ensureRouteFilterMetadata(r)
+	routeMeta := filterMetadata[envoyRouteMetadataNamespace]
+	if routeMeta == nil {
+		routeMeta = &structpb.Struct{Fields: map[string]*structpb.Value{}}
+		filterMetadata[envoyRouteMetadataNamespace] = routeMeta
+	} else if routeMeta.Fields == nil {
+		routeMeta.Fields = map[string]*structpb.Value{}
+	}
+	routeMeta.Fields[envoyRouteHTTPRouteKey] = structpb.NewStringValue(pathTemplate)
 }
 
 // setEndpointTransportSocketMatchID tags an endpoint with the lb_id its Cluster_

--- a/gateway/gateway-controller/pkg/xds/translator_test.go
+++ b/gateway/gateway-controller/pkg/xds/translator_test.go
@@ -1704,11 +1704,15 @@ func TestTranslator_CreateTracingConfig_ResourceAttributes(t *testing.T) {
 }
 
 // TestTranslator_CreateTracingConfig_PeerServiceCustomTag guards the fix for GH issue #2883:
-// with tracing enabled, the HCM tracing config must carry exactly one custom tag, "peer.service",
-// sourced from host metadata under the envoy.lb/hostname key set by setEndpointPeerHostname —
-// without this, Datadog APM has no peer attribute on upstream CLIENT spans to build the
-// Dependencies view / service map from. This pins the wire shape so a go-control-plane version
-// bump can't silently reshape it without a test failure.
+// with tracing enabled, the HCM tracing config must carry a "peer.service" custom tag, sourced
+// from host metadata under the envoy.lb/hostname key set by setEndpointPeerHostname — without
+// this, Datadog APM has no peer attribute on upstream CLIENT spans to build the Dependencies
+// view / service map from. This pins the wire shape so a go-control-plane version bump can't
+// silently reshape it without a test failure.
+//
+// Also guards http.route (Datadog Traces table Resource column, see setRouteHTTPRoute), sourced
+// from ROUTE metadata under the wso2.route/http.route key. Tags are looked up by name rather
+// than asserted by count/order — new tags may be added alongside these two over time.
 func TestTranslator_CreateTracingConfig_PeerServiceCustomTag(t *testing.T) {
 	logger := createTestLogger()
 	routerCfg := testRouterConfig()
@@ -1721,14 +1725,16 @@ func TestTranslator_CreateTracingConfig_PeerServiceCustomTag(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, tracingCfg)
 
-	customTags := tracingCfg.GetCustomTags()
-	require.Len(t, customTags, 1, "exactly one custom tag (peer.service) is expected")
+	tagsByName := make(map[string]*tracingv3.CustomTag)
+	for _, tag := range tracingCfg.GetCustomTags() {
+		tagsByName[tag.GetTag()] = tag
+	}
 
-	tag := customTags[0]
-	assert.Equal(t, "peer.service", tag.GetTag())
+	peerServiceTag, ok := tagsByName["peer.service"]
+	require.True(t, ok, "expected a peer.service custom tag")
 
-	metaTag, ok := tag.GetType().(*tracingv3.CustomTag_Metadata_)
-	require.True(t, ok, "peer.service must be sourced from metadata, got %T", tag.GetType())
+	metaTag, ok := peerServiceTag.GetType().(*tracingv3.CustomTag_Metadata_)
+	require.True(t, ok, "peer.service must be sourced from metadata, got %T", peerServiceTag.GetType())
 
 	hostKind, ok := metaTag.Metadata.GetKind().GetKind().(*metadatav3.MetadataKind_Host_)
 	require.True(t, ok, "peer.service must read HOST metadata (the selected upstream endpoint), got %T",
@@ -1739,6 +1745,22 @@ func TestTranslator_CreateTracingConfig_PeerServiceCustomTag(t *testing.T) {
 	assert.Equal(t, "envoy.lb", key.GetKey())
 	require.Len(t, key.GetPath(), 1)
 	assert.Equal(t, "hostname", key.GetPath()[0].GetKey())
+
+	httpRouteTag, ok := tagsByName["http.route"]
+	require.True(t, ok, "expected an http.route custom tag")
+
+	routeMetaTag, ok := httpRouteTag.GetType().(*tracingv3.CustomTag_Metadata_)
+	require.True(t, ok, "http.route must be sourced from metadata, got %T", httpRouteTag.GetType())
+
+	routeKind, ok := routeMetaTag.Metadata.GetKind().GetKind().(*metadatav3.MetadataKind_Route_)
+	require.True(t, ok, "http.route must read ROUTE metadata (the matched route), got %T",
+		routeMetaTag.Metadata.GetKind().GetKind())
+	assert.NotNil(t, routeKind)
+
+	routeKey := routeMetaTag.Metadata.GetMetadataKey()
+	assert.Equal(t, "wso2.route", routeKey.GetKey())
+	require.Len(t, routeKey.GetPath(), 1)
+	assert.Equal(t, "http.route", routeKey.GetPath()[0].GetKey())
 }
 
 func TestTranslator_CreateOTELCollectorCluster(t *testing.T) {
@@ -2256,6 +2278,46 @@ func TestTranslator_CreateRoute_Basic(t *testing.T) {
 	assert.NotNil(t, route)
 	assert.Contains(t, route.Name, "GET")
 	assert.Contains(t, route.Name, "/api/users")
+
+	// Guards the Datadog Traces table Resource column fix: the route's path template
+	// must be recorded as route metadata so createTracingCustomTags' http.route tag can
+	// read it (see setRouteHTTPRoute).
+	require.NotNil(t, route.Metadata)
+	assert.Equal(t, "/api/users",
+		route.Metadata.FilterMetadata["wso2.route"].Fields["http.route"].GetStringValue())
+}
+
+// TestTranslator_CreateRouteFromRDC_HTTPRouteMetadata guards the Datadog Traces table
+// Resource column fix: createRouteFromRDC must record the route's full path *template*
+// (not a concrete matched path) as wso2.route/http.route metadata, so the HCM tracing
+// http.route custom tag (createTracingCustomTags) can surface it. Without this, Datadog
+// derives the span resource as the bare HTTP method.
+func TestTranslator_CreateRouteFromRDC_HTTPRouteMetadata(t *testing.T) {
+	logger := createTestLogger()
+	routerCfg := testRouterConfig()
+	cfg := testConfig()
+	translator := NewTranslator(logger, routerCfg, nil, cfg)
+
+	rdc := &models.RuntimeDeployConfig{
+		UpstreamClusters: map[string]*models.UpstreamCluster{
+			"main": {Endpoints: []models.Endpoint{{Host: "echo", Port: 80}}},
+		},
+	}
+	rdcRoute := &models.Route{
+		Method:          "GET",
+		Path:            "/pets/v1.0/{id}",
+		OperationPath:   "/{id}",
+		AutoHostRewrite: true,
+		Upstream:        models.RouteUpstream{ClusterKey: "main"},
+	}
+
+	r := translator.createRouteFromRDC("GET|/pets/v1.0/{id}|", rdcRoute, rdc)
+	require.NotNil(t, r)
+	require.NotNil(t, r.Metadata)
+
+	// The templated path, not a concrete request path, must be stored.
+	assert.Equal(t, "/pets/v1.0/{id}",
+		r.Metadata.FilterMetadata["wso2.route"].Fields["http.route"].GetStringValue())
 }
 
 // TestTranslator_CreateRoute_DynamicRouting pins the cluster specifier createRoute emits:
@@ -2389,6 +2451,12 @@ func TestTranslator_CreateRoutePerTopic(t *testing.T) {
 		assert.NotNil(t, route.Metadata)
 		metadata := route.Metadata.FilterMetadata["wso2.route"]
 		assert.NotNil(t, metadata)
+
+		// setRouteHTTPRoute must merge into the same wso2.route namespace rather than
+		// overwrite it — pre-existing keys and the new http.route key must both survive.
+		assert.Equal(t, "api-123", metadata.Fields["api_id"].GetStringValue())
+		assert.Equal(t, "project-123", metadata.Fields["project_id"].GetStringValue())
+		assert.Equal(t, "/test/channel1", metadata.Fields["http.route"].GetStringValue())
 	})
 
 	t.Run("Create route with version placeholder in context", func(t *testing.T) {
@@ -2410,6 +2478,8 @@ func TestTranslator_CreateRoutePerTopic(t *testing.T) {
 		assert.NotNil(t, route)
 		// ConstructFullPath replaces $version with actual version
 		assert.Equal(t, "/test/v1.0.0/channel1", route.GetMatch().GetPath())
+		assert.Equal(t, "/test/v1.0.0/channel1",
+			route.Metadata.FilterMetadata["wso2.route"].Fields["http.route"].GetStringValue())
 	})
 }
 
@@ -2454,7 +2524,7 @@ func createTestTranslator() *Translator {
 // TestProcessEndpoint_PeerHostnameMetadata guards the fix for GH issue #2883 (Datadog
 // Dependencies view needs a peer.service tag on upstream CLIENT spans). processEndpoint must
 // stamp the upstream hostname under the envoy.lb/hostname metadata key so the peer.service
-// custom tag (createTracingUpstreamPeerCustomTags) can read it, for both plaintext and HTTPS
+// custom tag (createTracingCustomTags) can read it, for both plaintext and HTTPS
 // endpoints — and, for HTTPS, alongside (not instead of) the existing
 // envoy.transport_socket_match/lb_id metadata that TLS transport-socket matching depends on.
 func TestProcessEndpoint_PeerHostnameMetadata(t *testing.T) {

--- a/gateway/gateway-controller/pkg/xds/translator_test.go
+++ b/gateway/gateway-controller/pkg/xds/translator_test.go
@@ -1706,13 +1706,14 @@ func TestTranslator_CreateTracingConfig_ResourceAttributes(t *testing.T) {
 // TestTranslator_CreateTracingConfig_PeerServiceCustomTag guards the fix for GH issue #2883:
 // with tracing enabled, the HCM tracing config must carry a "peer.service" custom tag, sourced
 // from host metadata under the envoy.lb/hostname key set by setEndpointPeerHostname — without
-// this, Datadog APM has no peer attribute on upstream CLIENT spans to build the Dependencies
-// view / service map from. This pins the wire shape so a go-control-plane version bump can't
+// this, APM backends have no peer attribute on upstream CLIENT spans to build a service
+// dependency map from. This pins the wire shape so a go-control-plane version bump can't
 // silently reshape it without a test failure.
 //
-// Also guards http.route (Datadog Traces table Resource column, see setRouteHTTPRoute), sourced
-// from ROUTE metadata under the wso2.route/http.route key. Tags are looked up by name rather
-// than asserted by count/order — new tags may be added alongside these two over time.
+// Also guards http.route (the OTel semantic-convention attribute for the matched route
+// template, see setRouteHTTPRoute), sourced from ROUTE metadata under the
+// wso2.route/http.route key. Tags are looked up by name rather than asserted by
+// count/order — new tags may be added alongside these two over time.
 func TestTranslator_CreateTracingConfig_PeerServiceCustomTag(t *testing.T) {
 	logger := createTestLogger()
 	routerCfg := testRouterConfig()
@@ -2279,19 +2280,20 @@ func TestTranslator_CreateRoute_Basic(t *testing.T) {
 	assert.Contains(t, route.Name, "GET")
 	assert.Contains(t, route.Name, "/api/users")
 
-	// Guards the Datadog Traces table Resource column fix: the route's path template
-	// must be recorded as route metadata so createTracingCustomTags' http.route tag can
-	// read it (see setRouteHTTPRoute).
+	// Guards the http.route tracing fix: the route's path template must be recorded as
+	// route metadata so createTracingCustomTags' http.route tag can read it (see
+	// setRouteHTTPRoute).
 	require.NotNil(t, route.Metadata)
 	assert.Equal(t, "/api/users",
 		route.Metadata.FilterMetadata["wso2.route"].Fields["http.route"].GetStringValue())
 }
 
-// TestTranslator_CreateRouteFromRDC_HTTPRouteMetadata guards the Datadog Traces table
-// Resource column fix: createRouteFromRDC must record the route's full path *template*
-// (not a concrete matched path) as wso2.route/http.route metadata, so the HCM tracing
-// http.route custom tag (createTracingCustomTags) can surface it. Without this, Datadog
-// derives the span resource as the bare HTTP method.
+// TestTranslator_CreateRouteFromRDC_HTTPRouteMetadata guards the http.route tracing fix:
+// createRouteFromRDC must record the route's full path *template* (not a concrete matched
+// path) as wso2.route/http.route metadata, so the HCM tracing http.route custom tag
+// (createTracingCustomTags) can surface it. Without this, APM backends that derive a
+// span's resource/display name from "<http.method> <http.route>" fall back to the bare
+// HTTP method.
 func TestTranslator_CreateRouteFromRDC_HTTPRouteMetadata(t *testing.T) {
 	logger := createTestLogger()
 	routerCfg := testRouterConfig()


### PR DESCRIPTION

- Introduced http.route metadata under wso2.route for route path templates to enhance tracing capabilities in Datadog.
- Updated tests to validate the presence of http.route metadata alongside peer.service.

