### PR TITLE
Add Integration Tests for New jwt-auth, mcp-auth and mcp-authz Improvements

### DIFF
--- a/gateway/it/features/jwt-auth.feature
+++ b/gateway/it/features/jwt-auth.feature
@@ -419,3 +419,464 @@ Feature: JWT Authentication
     And I set header "Authorization" to "Bearer"
     And I send a GET request to "http://localhost:8080/jwt-auth-bearer-only/v1.0/protected"
     Then the response status code should be 401
+
+  Scenario: scopes allOf requires every listed scope
+    Given I authenticate using basic auth as "admin"
+    When I deploy this API configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: RestApi
+      metadata:
+        name: jwt-auth-scopes-allof-api
+      spec:
+        displayName: JWT Auth Scopes AllOf API
+        version: v1.0
+        context: /jwt-auth-scopes-allof/$version
+        upstream:
+          main:
+            url: http://sample-backend:9080/api/v1
+        operations:
+          - method: GET
+            path: /health
+          - method: GET
+            path: /protected
+            policies:
+              - name: jwt-auth
+                version: v1
+                params:
+                  issuers:
+                    - mock-jwks
+                  scopes:
+                    allOf:
+                      - "api:read"
+                      - "api:deploy"
+      """
+    Then the response should be successful
+    And I wait for the endpoint "http://localhost:8080/jwt-auth-scopes-allof/v1.0/health" to be ready
+
+    # Token has both required scopes → authorized
+    When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token" and scope "api:read api:deploy api:write"
+    And I send a GET request to "http://localhost:8080/jwt-auth-scopes-allof/v1.0/protected" with the JWT token
+    Then the response status code should be 200
+
+    # Token missing one of the allOf scopes → rejected
+    When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token" and scope "api:read"
+    And I send a GET request to "http://localhost:8080/jwt-auth-scopes-allof/v1.0/protected" with the JWT token
+    Then the response status code should be 401
+    And the response body should contain "Authentication failed"
+
+  Scenario: scopes allOf and anyOf are combined
+    Given I authenticate using basic auth as "admin"
+    When I deploy this API configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: RestApi
+      metadata:
+        name: jwt-auth-scopes-combined-api
+      spec:
+        displayName: JWT Auth Scopes Combined API
+        version: v1.0
+        context: /jwt-auth-scopes-combined/$version
+        upstream:
+          main:
+            url: http://sample-backend:9080/api/v1
+        operations:
+          - method: GET
+            path: /health
+          - method: GET
+            path: /protected
+            policies:
+              - name: jwt-auth
+                version: v1
+                params:
+                  issuers:
+                    - mock-jwks
+                  scopes:
+                    allOf:
+                      - "api:read"
+                      - "api:deploy"
+                    anyOf:
+                      - "api:write"
+                      - "api:update"
+      """
+    Then the response should be successful
+    And I wait for the endpoint "http://localhost:8080/jwt-auth-scopes-combined/v1.0/health" to be ready
+
+    # allOf satisfied AND one anyOf scope present → authorized
+    When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token" and scope "api:read api:deploy api:update"
+    And I send a GET request to "http://localhost:8080/jwt-auth-scopes-combined/v1.0/protected" with the JWT token
+    Then the response status code should be 200
+
+    # allOf satisfied but no anyOf scope present → rejected
+    When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token" and scope "api:read api:deploy"
+    And I send a GET request to "http://localhost:8080/jwt-auth-scopes-combined/v1.0/protected" with the JWT token
+    Then the response status code should be 401
+
+  Scenario: scopes takes precedence over deprecated requiredScopes
+    Given I authenticate using basic auth as "admin"
+    When I deploy this API configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: RestApi
+      metadata:
+        name: jwt-auth-scopes-precedence-api
+      spec:
+        displayName: JWT Auth Scopes Precedence API
+        version: v1.0
+        context: /jwt-auth-scopes-precedence/$version
+        upstream:
+          main:
+            url: http://sample-backend:9080/api/v1
+        operations:
+          - method: GET
+            path: /health
+          - method: GET
+            path: /protected
+            policies:
+              - name: jwt-auth
+                version: v1
+                params:
+                  issuers:
+                    - mock-jwks
+                  requiredScopes:
+                    - "api:read"
+                  scopes:
+                    allOf:
+                      - "api:deploy"
+      """
+    Then the response should be successful
+    And I wait for the endpoint "http://localhost:8080/jwt-auth-scopes-precedence/v1.0/health" to be ready
+
+    # Token satisfies the deprecated requiredScopes ("api:read") but not the new scopes
+    # (allOf "api:deploy"). The new param wins → rejected.
+    When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token" and scope "api:read"
+    And I send a GET request to "http://localhost:8080/jwt-auth-scopes-precedence/v1.0/protected" with the JWT token
+    Then the response status code should be 401
+
+  Scenario: claims allOf and anyOf are combined
+    Given I authenticate using basic auth as "admin"
+    When I deploy this API configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: RestApi
+      metadata:
+        name: jwt-auth-claims-api
+      spec:
+        displayName: JWT Auth Claims API
+        version: v1.0
+        context: /jwt-auth-claims/$version
+        upstream:
+          main:
+            url: http://sample-backend:9080/api/v1
+        operations:
+          - method: GET
+            path: /health
+          - method: GET
+            path: /protected
+            policies:
+              - name: jwt-auth
+                version: v1
+                params:
+                  issuers:
+                    - mock-jwks
+                  claims:
+                    anyOf:
+                      - claim: department
+                        values:
+                          - platform
+                          - engineering
+                    allOf:
+                      - claim: status
+                        values:
+                          - suspended
+                      - claim: role
+                        values:
+                          - internal
+      """
+    Then the response should be successful
+    And I wait for the endpoint "http://localhost:8080/jwt-auth-claims/v1.0/health" to be ready
+
+    # department in {platform, engineering} AND status=suspended AND role=internal → authorized
+    When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token" and claims "department=platform,status=suspended,role=internal"
+    And I send a GET request to "http://localhost:8080/jwt-auth-claims/v1.0/protected" with the JWT token
+    Then the response status code should be 200
+
+    # role=external fails the allOf matcher → rejected
+    When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token" and claims "department=platform,status=suspended,role=external"
+    And I send a GET request to "http://localhost:8080/jwt-auth-claims/v1.0/protected" with the JWT token
+    Then the response status code should be 401
+    And the response body should contain "Authentication failed"
+
+    # department not in the anyOf set → rejected
+    When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token" and claims "department=sales,status=suspended,role=internal"
+    And I send a GET request to "http://localhost:8080/jwt-auth-claims/v1.0/protected" with the JWT token
+    Then the response status code should be 401
+
+  Scenario: claims takes precedence over deprecated requiredClaims
+    Given I authenticate using basic auth as "admin"
+    When I deploy this API configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: RestApi
+      metadata:
+        name: jwt-auth-claims-precedence-api
+      spec:
+        displayName: JWT Auth Claims Precedence API
+        version: v1.0
+        context: /jwt-auth-claims-precedence/$version
+        upstream:
+          main:
+            url: http://sample-backend:9080/api/v1
+        operations:
+          - method: GET
+            path: /health
+          - method: GET
+            path: /protected
+            policies:
+              - name: jwt-auth
+                version: v1
+                params:
+                  issuers:
+                    - mock-jwks
+                  requiredClaims:
+                    role: admin
+                  claims:
+                    allOf:
+                      - claim: role
+                        values:
+                          - superadmin
+      """
+    Then the response should be successful
+    And I wait for the endpoint "http://localhost:8080/jwt-auth-claims-precedence/v1.0/health" to be ready
+
+    # Token satisfies the deprecated requiredClaims (role=admin) but not the new claims
+    # (role must be superadmin). The new param wins → rejected.
+    When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token" and claims "role=admin"
+    And I send a GET request to "http://localhost:8080/jwt-auth-claims-precedence/v1.0/protected" with the JWT token
+    Then the response status code should be 401
+
+  Scenario: scopes and claims (both new params, allOf + anyOf) are enforced together
+    Given I authenticate using basic auth as "admin"
+    When I deploy this API configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: RestApi
+      metadata:
+        name: jwt-auth-scopes-claims-both-api
+      spec:
+        displayName: JWT Auth Scopes And Claims API
+        version: v1.0
+        context: /jwt-auth-scopes-claims-both/$version
+        upstream:
+          main:
+            url: http://sample-backend:9080/api/v1
+        operations:
+          - method: GET
+            path: /health
+          - method: GET
+            path: /protected
+            policies:
+              - name: jwt-auth
+                version: v1
+                params:
+                  issuers:
+                    - mock-jwks
+                  # SCOPES = (api:read AND api:deploy) AND (api:write OR api:update)
+                  scopes:
+                    allOf:
+                      - "api:read"
+                      - "api:deploy"
+                    anyOf:
+                      - "api:write"
+                      - "api:update"
+                  # CLAIMS = status=active AND (department in {platform, engineering})
+                  claims:
+                    allOf:
+                      - claim: status
+                        values:
+                          - active
+                    anyOf:
+                      - claim: department
+                        values:
+                          - platform
+                          - engineering
+      """
+    Then the response should be successful
+    And I wait for the endpoint "http://localhost:8080/jwt-auth-scopes-claims-both/v1.0/health" to be ready
+
+    # All satisfied: scope allOf+anyOf and claim allOf+anyOf → authorized
+    When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token", scope "api:read api:deploy api:write" and claims "status=active,department=platform"
+    And I send a GET request to "http://localhost:8080/jwt-auth-scopes-claims-both/v1.0/protected" with the JWT token
+    Then the response status code should be 200
+
+    # Scope allOf satisfied but anyOf (write/update) absent → rejected
+    When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token", scope "api:read api:deploy" and claims "status=active,department=engineering"
+    And I send a GET request to "http://localhost:8080/jwt-auth-scopes-claims-both/v1.0/protected" with the JWT token
+    Then the response status code should be 401
+
+    # Scope anyOf satisfied but allOf incomplete (api:deploy missing) → rejected
+    When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token", scope "api:read api:write" and claims "status=active,department=platform"
+    And I send a GET request to "http://localhost:8080/jwt-auth-scopes-claims-both/v1.0/protected" with the JWT token
+    Then the response status code should be 401
+
+    # Scopes fully satisfied but claim anyOf (department) not in set → rejected
+    When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token", scope "api:read api:deploy api:update" and claims "status=active,department=sales"
+    And I send a GET request to "http://localhost:8080/jwt-auth-scopes-claims-both/v1.0/protected" with the JWT token
+    Then the response status code should be 401
+
+    # Scopes fully satisfied and claim anyOf ok but claim allOf (status) fails → rejected
+    When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token", scope "api:read api:deploy api:write" and claims "status=inactive,department=platform"
+    And I send a GET request to "http://localhost:8080/jwt-auth-scopes-claims-both/v1.0/protected" with the JWT token
+    Then the response status code should be 401
+
+  Scenario: mixed old/new params across two operations on one API (allOf + anyOf)
+    Given I authenticate using basic auth as "admin"
+    When I deploy this API configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: RestApi
+      metadata:
+        name: jwt-auth-mixed-ops-api
+      spec:
+        displayName: JWT Auth Mixed Ops API
+        version: v1.0
+        context: /jwt-auth-mixed-ops/$version
+        upstream:
+          main:
+            url: http://sample-backend:9080/api/v1
+        operations:
+          - method: GET
+            path: /health
+          # op1: new scopes (allOf + anyOf) + deprecated requiredClaims
+          - method: GET
+            path: /op1
+            policies:
+              - name: jwt-auth
+                version: v1
+                params:
+                  issuers:
+                    - mock-jwks
+                  scopes:
+                    allOf:
+                      - "api:read"
+                    anyOf:
+                      - "api:write"
+                      - "api:update"
+                  requiredClaims:
+                    role: admin
+          # op2: deprecated requiredScopes + new claims (allOf + anyOf)
+          - method: GET
+            path: /op2
+            policies:
+              - name: jwt-auth
+                version: v1
+                params:
+                  issuers:
+                    - mock-jwks
+                  requiredScopes:
+                    - "api:read"
+                  claims:
+                    allOf:
+                      - claim: status
+                        values:
+                          - active
+                    anyOf:
+                      - claim: department
+                        values:
+                          - platform
+                          - engineering
+      """
+    Then the response should be successful
+    And I wait for the endpoint "http://localhost:8080/jwt-auth-mixed-ops/v1.0/health" to be ready
+
+    # Token A: scope "api:read api:write", role=admin, status=inactive, department=sales.
+    # op1: scope allOf(api:read) + anyOf(api:write) + requiredClaims role=admin → authorized.
+    When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token", scope "api:read api:write" and claims "role=admin,status=inactive,department=sales"
+    And I send a GET request to "http://localhost:8080/jwt-auth-mixed-ops/v1.0/op1" with the JWT token
+    Then the response status code should be 200
+
+    # Same Token A on op2: old requiredScopes ok, but new claim allOf status=inactive fails → rejected.
+    When I send a GET request to "http://localhost:8080/jwt-auth-mixed-ops/v1.0/op2" with the JWT token
+    Then the response status code should be 401
+
+    # Token B: scope "api:read" (no anyOf scope), role=user, status=active, department=engineering.
+    # op2: old requiredScopes ok, new claim allOf(status=active) + anyOf(department) → authorized.
+    When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token", scope "api:read" and claims "role=user,status=active,department=engineering"
+    And I send a GET request to "http://localhost:8080/jwt-auth-mixed-ops/v1.0/op2" with the JWT token
+    Then the response status code should be 200
+
+    # Same Token B on op1: scope allOf(api:read) ok but anyOf(write/update) absent → rejected.
+    When I send a GET request to "http://localhost:8080/jwt-auth-mixed-ops/v1.0/op1" with the JWT token
+    Then the response status code should be 401
+
+  Scenario: new params win over deprecated formats on one operation (allOf + anyOf)
+    Given I authenticate using basic auth as "admin"
+    When I deploy this API configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: RestApi
+      metadata:
+        name: jwt-auth-both-formats-api
+      spec:
+        displayName: JWT Auth Both Formats API
+        version: v1.0
+        context: /jwt-auth-both-formats/$version
+        upstream:
+          main:
+            url: http://sample-backend:9080/api/v1
+        operations:
+          - method: GET
+            path: /health
+          - method: GET
+            path: /protected
+            policies:
+              - name: jwt-auth
+                version: v1
+                params:
+                  issuers:
+                    - mock-jwks
+                  requiredScopes:
+                    - "api:legacy"
+                  requiredClaims:
+                    role: legacy
+                  scopes:
+                    allOf:
+                      - "api:read"
+                    anyOf:
+                      - "api:write"
+                      - "api:update"
+                  claims:
+                    allOf:
+                      - claim: status
+                        values:
+                          - active
+                    anyOf:
+                      - claim: department
+                        values:
+                          - platform
+                          - engineering
+      """
+    Then the response should be successful
+    And I wait for the endpoint "http://localhost:8080/jwt-auth-both-formats/v1.0/health" to be ready
+
+    # Satisfies the NEW params (scope allOf+anyOf, claim allOf+anyOf); fails the deprecated ones,
+    # which are ignored → authorized.
+    When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token", scope "api:read api:update" and claims "status=active,department=engineering"
+    And I send a GET request to "http://localhost:8080/jwt-auth-both-formats/v1.0/protected" with the JWT token
+    Then the response status code should be 200
+
+    # Satisfies only the deprecated params (scope api:legacy, role=legacy); fails the new ones,
+    # which take precedence → rejected.
+    When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token", scope "api:legacy" and claims "role=legacy"
+    And I send a GET request to "http://localhost:8080/jwt-auth-both-formats/v1.0/protected" with the JWT token
+    Then the response status code should be 401
+
+    # New scope allOf ok but anyOf (write/update) absent → rejected (proves anyOf enforced here too).
+    When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token", scope "api:read" and claims "status=active,department=platform"
+    And I send a GET request to "http://localhost:8080/jwt-auth-both-formats/v1.0/protected" with the JWT token
+    Then the response status code should be 401
+
+    # New scopes fully satisfied but claim anyOf (department) not in set → rejected.
+    When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token", scope "api:read api:write" and claims "status=active,department=sales"
+    And I send a GET request to "http://localhost:8080/jwt-auth-both-formats/v1.0/protected" with the JWT token
+    Then the response status code should be 401

--- a/gateway/it/features/mcp_policies.feature
+++ b/gateway/it/features/mcp_policies.feature
@@ -181,6 +181,236 @@ Feature: Test how MCP Proxies behave when various policies are applied.
         When I delete the MCP proxy "mcp-auth-tools-only-test"
         Then the response should be successful
 
+    # Issue #2867: mcp-auth exposes jwt-auth's token-forwarding parameters (forwardToken,
+    # forwardedTokenHeader, forwardTokenStripScheme, userIdClaim). This verifies those parameters are
+    # accepted by the policy and the end-to-end authentication flow is preserved when they are set.
+    # (The mock MCP backend does not echo request headers, so what actually reaches the upstream under
+    # forwardedTokenHeader is covered by the policy's unit tests; here we guard config acceptance and
+    # that forwarding does not break authentication.)
+    Scenario: mcp-auth accepts token-forwarding parameters and preserves the auth flow
+        Given I authenticate using basic auth as "admin"
+        When I deploy this MCP configuration:
+            """
+            apiVersion: gateway.api-platform.wso2.com/v1
+            kind: Mcp
+            metadata:
+              name: mcp-auth-forward-token-test
+            spec:
+              displayName: MCP Auth Forward Token Test
+              version: v1.0
+              context: /mcpforwardtoken
+              specVersion: "2025-06-18"
+              upstream:
+                url: http://mcp-server-backend:3001/mcp
+              policies:
+                - name: mcp-auth
+                  version: v1
+                  params:
+                    issuers:
+                      - mock-jwks
+                    forwardToken: true
+                    forwardedTokenHeader: x-forwarded-authorization
+                    forwardTokenStripScheme: true
+                    userIdClaim: email
+              tools: []
+              resources: []
+              prompts: []
+            """
+        Then the response should be successful
+        And the response should be valid JSON
+        And the JSON response field "status" should be "success"
+        And I wait for 2 seconds
+
+        # Authentication is still enforced with the forwarding parameters configured.
+        When I use the MCP Client to send an initialize request to "http://127.0.0.1:8080/mcpforwardtoken/mcp"
+        Then the response status code should be 401
+
+        # A valid token authenticates successfully — the forwarding configuration does not break the flow.
+        When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token" and claims "email=alice@example.com"
+        And I use the MCP Client to send an initialize request to "http://localhost:8080/mcpforwardtoken/mcp" with the JWT token
+        Then the response should be successful
+        And I use the MCP Client to send a tools/call request to "http://localhost:8080/mcpforwardtoken/mcp" with the JWT token
+        Then the response should be successful
+
+        # Cleanup
+        And I clear all headers
+        Given I authenticate using basic auth as "admin"
+        When I delete the MCP proxy "mcp-auth-forward-token-test"
+        Then the response should be successful
+
+    # Issue #2866: a peer policy (set-headers) that overwrites the live Authorization header during the
+    # header phase must not break mcp-auth. mcp-auth validates the client's ORIGINAL Authorization from
+    # the downstream request snapshot, not the peer-mutated live value. Here set-headers replaces
+    # Authorization with a non-token backend credential; the client's valid JWT must still authenticate.
+    Scenario: mcp-auth authenticates the client token even when set-headers overwrites Authorization
+        Given I authenticate using basic auth as "admin"
+        When I deploy this MCP configuration:
+            """
+            apiVersion: gateway.api-platform.wso2.com/v1
+            kind: Mcp
+            metadata:
+              name: mcp-auth-set-headers-test
+            spec:
+              displayName: MCP Auth Set-Headers Test
+              version: v1.0
+              context: /mcpsetheaders
+              specVersion: "2025-06-18"
+              upstream:
+                url: http://mcp-server-backend:3001/mcp
+              policies:
+                - name: mcp-auth
+                  version: v1
+                  params:
+                    issuers:
+                      - mock-jwks
+                - name: set-headers
+                  version: v1
+                  params:
+                    request:
+                      headers:
+                        - name: Authorization
+                          value: "Bearer backend-service-credential"
+              tools: []
+              resources: []
+              prompts: []
+            """
+        Then the response should be successful
+        And the response should be valid JSON
+        And the JSON response field "status" should be "success"
+        And I wait for 2 seconds
+
+        # The client's valid JWT authenticates even though set-headers overwrites the live Authorization
+        # header with a non-token value — mcp-auth validates the client's snapshot token, not the live one.
+        When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token"
+        And I use the MCP Client to send an initialize request to "http://localhost:8080/mcpsetheaders/mcp" with the JWT token
+        Then the response should be successful
+        And I use the MCP Client to send a tools/call request to "http://localhost:8080/mcpsetheaders/mcp" with the JWT token
+        Then the response should be successful
+
+        # Cleanup
+        And I clear all headers
+        Given I authenticate using basic auth as "admin"
+        When I delete the MCP proxy "mcp-auth-set-headers-test"
+        Then the response should be successful
+
+    # Issue #2866 (the exact failing combination): mcp-auth token forwarding AND set-headers together.
+    # set-headers injects a backend Authorization in the header phase; mcp-auth (forwardToken: true)
+    # validates the client's snapshot token and forwards it under a DIFFERENT header
+    # (x-forwarded-authorization) while leaving the peer-owned Authorization in place. Exercises the
+    # preserveTokenHeader + snapshot-validation path with forwarding enabled; the client's valid JWT
+    # must authenticate. (The backend does not echo headers, so this asserts the client-observable
+    # outcome — the forwarded/preserved header values themselves are covered by the policy unit tests.)
+    Scenario: mcp-auth forwardToken coexists with set-headers injecting Authorization
+        Given I authenticate using basic auth as "admin"
+        When I deploy this MCP configuration:
+            """
+            apiVersion: gateway.api-platform.wso2.com/v1
+            kind: Mcp
+            metadata:
+              name: mcp-auth-forward-setheaders-test
+            spec:
+              displayName: MCP Auth Forward and Set-Headers Test
+              version: v1.0
+              context: /mcpforwardsetheaders
+              specVersion: "2025-06-18"
+              upstream:
+                url: http://mcp-server-backend:3001/mcp
+              policies:
+                - name: mcp-auth
+                  version: v1
+                  params:
+                    issuers:
+                      - mock-jwks
+                    forwardToken: true
+                    forwardedTokenHeader: x-forwarded-authorization
+                - name: set-headers
+                  version: v1
+                  params:
+                    request:
+                      headers:
+                        - name: Authorization
+                          value: "Bearer backend-service-credential"
+              tools: []
+              resources: []
+              prompts: []
+            """
+        Then the response should be successful
+        And the response should be valid JSON
+        And the JSON response field "status" should be "success"
+        And I wait for 2 seconds
+
+        # The client's valid JWT authenticates: mcp-auth validates the snapshot token (not the
+        # set-headers value) and forwards it under x-forwarded-authorization, leaving the peer-owned
+        # Authorization header untouched.
+        When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token"
+        And I use the MCP Client to send an initialize request to "http://localhost:8080/mcpforwardsetheaders/mcp" with the JWT token
+        Then the response should be successful
+        And I use the MCP Client to send a tools/call request to "http://localhost:8080/mcpforwardsetheaders/mcp" with the JWT token
+        Then the response should be successful
+
+        # Cleanup
+        And I clear all headers
+        Given I authenticate using basic auth as "admin"
+        When I delete the MCP proxy "mcp-auth-forward-setheaders-test"
+        Then the response should be successful
+
+    # Issue #2866 (collision variant): forwardedTokenHeader names the SAME header set-headers owns
+    # (Authorization). mcp-auth must not forward the validated token over a peer-claimed header — it
+    # skips forwarding (logging a warning) and must not strip the peer's value. Because mcp-auth still
+    # validates the client's snapshot token, the client's valid JWT must authenticate.
+    Scenario: mcp-auth skips forwarding when forwardedTokenHeader collides with a set-headers-owned header
+        Given I authenticate using basic auth as "admin"
+        When I deploy this MCP configuration:
+            """
+            apiVersion: gateway.api-platform.wso2.com/v1
+            kind: Mcp
+            metadata:
+              name: mcp-auth-forward-collision-test
+            spec:
+              displayName: MCP Auth Forward Collision Test
+              version: v1.0
+              context: /mcpforwardcollision
+              specVersion: "2025-06-18"
+              upstream:
+                url: http://mcp-server-backend:3001/mcp
+              policies:
+                - name: mcp-auth
+                  version: v1
+                  params:
+                    issuers:
+                      - mock-jwks
+                    forwardToken: true
+                    forwardedTokenHeader: Authorization
+                - name: set-headers
+                  version: v1
+                  params:
+                    request:
+                      headers:
+                        - name: Authorization
+                          value: "Bearer backend-service-credential"
+              tools: []
+              resources: []
+              prompts: []
+            """
+        Then the response should be successful
+        And the response should be valid JSON
+        And the JSON response field "status" should be "success"
+        And I wait for 2 seconds
+
+        # Authorization is owned by set-headers, so mcp-auth skips forwarding under that name; the
+        # client's valid JWT still authenticates via the snapshot token.
+        When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token"
+        And I use the MCP Client to send an initialize request to "http://localhost:8080/mcpforwardcollision/mcp" with the JWT token
+        Then the response should be successful
+        And I use the MCP Client to send a tools/call request to "http://localhost:8080/mcpforwardcollision/mcp" with the JWT token
+        Then the response should be successful
+
+        # Cleanup
+        And I clear all headers
+        Given I authenticate using basic auth as "admin"
+        When I delete the MCP proxy "mcp-auth-forward-collision-test"
+        Then the response should be successful
+
     Scenario: Deploy an MCP proxy with mcp-authz policy and verify whether 403 is returned for unauthorized access
         Given I authenticate using basic auth as "admin"
         When I deploy this MCP configuration:
@@ -288,6 +518,497 @@ Feature: Test how MCP Proxies behave when various policies are applied.
         And I clear all headers
         Given I authenticate using basic auth as "admin"
         When I delete the MCP proxy "mcp-authz-valid-token-test"
+        Then the response should be successful
+
+    Scenario: mcp-authz new scopes format (allOf + anyOf) is enforced
+        Given I authenticate using basic auth as "admin"
+        When I deploy this MCP configuration:
+            """
+            apiVersion: gateway.api-platform.wso2.com/v1
+            kind: Mcp
+            metadata:
+              name: mcp-authz-scopes
+            spec:
+              displayName: MCP AuthZ Scopes
+              version: v1.0
+              context: /mcpauthzscopes
+              specVersion: "2025-06-18"
+              upstream:
+                url: http://mcp-server-backend:3001/mcp
+              policies:
+                - name: mcp-auth
+                  version: v1
+                  params:
+                    issuers:
+                      - mock-jwks
+                - name: mcp-authz
+                  version: v1
+                  params:
+                    tools:
+                      - name: "add"
+                        scopes:
+                          allOf:
+                            - "s-read"
+                            - "s-deploy"
+                          anyOf:
+                            - "s-write"
+                            - "s-update"
+            """
+        Then the response should be successful
+        And the JSON response field "status" should be "success"
+        And I wait for 2 seconds
+
+        # allOf satisfied AND one anyOf present → authorized
+        When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token" and scope "s-read s-deploy s-write"
+        And I use the MCP Client to send an initialize request to "http://localhost:8080/mcpauthzscopes/mcp" with the JWT token
+        Then the response should be successful
+        And I use the MCP Client to send a tools/call request to "http://localhost:8080/mcpauthzscopes/mcp" with the JWT token
+        Then the response should be successful
+
+        # allOf satisfied but no anyOf scope present → 403 (challenge advertises an anyOf scope)
+        When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token" and scope "s-read s-deploy"
+        And I use the MCP Client to send a tools/call request to "http://localhost:8080/mcpauthzscopes/mcp" with the JWT token
+        Then the response status code should be 403
+        And the response header "WWW-Authenticate" should contain "s-write"
+
+        # anyOf present but allOf incomplete (missing s-deploy) → 403 (challenge advertises s-deploy)
+        When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token" and scope "s-read s-write"
+        And I use the MCP Client to send a tools/call request to "http://localhost:8080/mcpauthzscopes/mcp" with the JWT token
+        Then the response status code should be 403
+        And the response header "WWW-Authenticate" should contain "s-deploy"
+
+        # neither allOf nor anyOf satisfied → 403
+        When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token" and scope "unrelated"
+        And I use the MCP Client to send a tools/call request to "http://localhost:8080/mcpauthzscopes/mcp" with the JWT token
+        Then the response status code should be 403
+
+        # Cleanup
+        And I clear all headers
+        Given I authenticate using basic auth as "admin"
+        When I delete the MCP proxy "mcp-authz-scopes"
+        Then the response should be successful
+
+    Scenario: mcp-authz new claims format (allOf + anyOf) is enforced
+        Given I authenticate using basic auth as "admin"
+        When I deploy this MCP configuration:
+            """
+            apiVersion: gateway.api-platform.wso2.com/v1
+            kind: Mcp
+            metadata:
+              name: mcp-authz-claims
+            spec:
+              displayName: MCP AuthZ Claims
+              version: v1.0
+              context: /mcpauthzclaims
+              specVersion: "2025-06-18"
+              upstream:
+                url: http://mcp-server-backend:3001/mcp
+              policies:
+                - name: mcp-auth
+                  version: v1
+                  params:
+                    issuers:
+                      - mock-jwks
+                - name: mcp-authz
+                  version: v1
+                  params:
+                    tools:
+                      - name: "add"
+                        claims:
+                          allOf:
+                            - claim: department
+                              values:
+                                - platform
+                          anyOf:
+                            - claim: role
+                              values:
+                                - admin
+                                - superadmin
+            """
+        Then the response should be successful
+        And the JSON response field "status" should be "success"
+        And I wait for 2 seconds
+
+        # department=platform AND role in {admin, superadmin} → authorized
+        When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token" and claims "department=platform,role=admin"
+        And I use the MCP Client to send an initialize request to "http://localhost:8080/mcpauthzclaims/mcp" with the JWT token
+        Then the response should be successful
+        And I use the MCP Client to send a tools/call request to "http://localhost:8080/mcpauthzclaims/mcp" with the JWT token
+        Then the response should be successful
+
+        # anyOf claim not matched (role=viewer) → 403
+        When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token" and claims "department=platform,role=viewer"
+        And I use the MCP Client to send a tools/call request to "http://localhost:8080/mcpauthzclaims/mcp" with the JWT token
+        Then the response status code should be 403
+
+        # allOf claim not matched (department=sales) → 403
+        When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token" and claims "department=sales,role=admin"
+        And I use the MCP Client to send a tools/call request to "http://localhost:8080/mcpauthzclaims/mcp" with the JWT token
+        Then the response status code should be 403
+
+        # required claim entirely absent (no department) → 403 (fail-closed)
+        When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token" and claims "role=admin"
+        And I use the MCP Client to send a tools/call request to "http://localhost:8080/mcpauthzclaims/mcp" with the JWT token
+        Then the response status code should be 403
+
+        # Cleanup
+        And I clear all headers
+        Given I authenticate using basic auth as "admin"
+        When I delete the MCP proxy "mcp-authz-claims"
+        Then the response should be successful
+
+    Scenario: mcp-authz new scopes take precedence over deprecated requiredScopes
+        Given I authenticate using basic auth as "admin"
+        When I deploy this MCP configuration:
+            """
+            apiVersion: gateway.api-platform.wso2.com/v1
+            kind: Mcp
+            metadata:
+              name: mcp-authz-scope-prec
+            spec:
+              displayName: MCP AuthZ Scope Precedence
+              version: v1.0
+              context: /mcpauthzscopeprec
+              specVersion: "2025-06-18"
+              upstream:
+                url: http://mcp-server-backend:3001/mcp
+              policies:
+                - name: mcp-auth
+                  version: v1
+                  params:
+                    issuers:
+                      - mock-jwks
+                - name: mcp-authz
+                  version: v1
+                  params:
+                    tools:
+                      - name: "add"
+                        requiredScopes:
+                          - "old-scope"
+                        scopes:
+                          allOf:
+                            - "new-scope"
+            """
+        Then the response should be successful
+        And the JSON response field "status" should be "success"
+        And I wait for 2 seconds
+
+        # Token has the new scope → authorized (new format enforced)
+        When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token" and scope "new-scope"
+        And I use the MCP Client to send an initialize request to "http://localhost:8080/mcpauthzscopeprec/mcp" with the JWT token
+        Then the response should be successful
+        And I use the MCP Client to send a tools/call request to "http://localhost:8080/mcpauthzscopeprec/mcp" with the JWT token
+        Then the response should be successful
+
+        # Token satisfies only the deprecated requiredScopes → 403 (deprecated is ignored, new wins)
+        When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token" and scope "old-scope"
+        And I use the MCP Client to send a tools/call request to "http://localhost:8080/mcpauthzscopeprec/mcp" with the JWT token
+        Then the response status code should be 403
+        And the response header "WWW-Authenticate" should contain "new-scope"
+
+        # Cleanup
+        And I clear all headers
+        Given I authenticate using basic auth as "admin"
+        When I delete the MCP proxy "mcp-authz-scope-prec"
+        Then the response should be successful
+
+    Scenario: mcp-authz new claims take precedence over deprecated requiredClaims
+        Given I authenticate using basic auth as "admin"
+        When I deploy this MCP configuration:
+            """
+            apiVersion: gateway.api-platform.wso2.com/v1
+            kind: Mcp
+            metadata:
+              name: mcp-authz-claim-prec
+            spec:
+              displayName: MCP AuthZ Claim Precedence
+              version: v1.0
+              context: /mcpauthzclaimprec
+              specVersion: "2025-06-18"
+              upstream:
+                url: http://mcp-server-backend:3001/mcp
+              policies:
+                - name: mcp-auth
+                  version: v1
+                  params:
+                    issuers:
+                      - mock-jwks
+                - name: mcp-authz
+                  version: v1
+                  params:
+                    tools:
+                      - name: "add"
+                        requiredClaims:
+                          department: platform
+                        claims:
+                          allOf:
+                            - claim: department
+                              values:
+                                - engineering
+            """
+        Then the response should be successful
+        And the JSON response field "status" should be "success"
+        And I wait for 2 seconds
+
+        # Token satisfies the new claim (department=engineering) → authorized
+        When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token" and claims "department=engineering"
+        And I use the MCP Client to send an initialize request to "http://localhost:8080/mcpauthzclaimprec/mcp" with the JWT token
+        Then the response should be successful
+        And I use the MCP Client to send a tools/call request to "http://localhost:8080/mcpauthzclaimprec/mcp" with the JWT token
+        Then the response should be successful
+
+        # Token satisfies only the deprecated requiredClaims (department=platform) → 403 (new wins)
+        When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token" and claims "department=platform"
+        And I use the MCP Client to send a tools/call request to "http://localhost:8080/mcpauthzclaimprec/mcp" with the JWT token
+        Then the response status code should be 403
+
+        # Cleanup
+        And I clear all headers
+        Given I authenticate using basic auth as "admin"
+        When I delete the MCP proxy "mcp-authz-claim-prec"
+        Then the response should be successful
+
+    Scenario: mcp-authz requires all matching rules to pass (specific rule AND wildcard rule)
+        Given I authenticate using basic auth as "admin"
+        When I deploy this MCP configuration:
+            """
+            apiVersion: gateway.api-platform.wso2.com/v1
+            kind: Mcp
+            metadata:
+              name: mcp-authz-multirule
+            spec:
+              displayName: MCP AuthZ Multi Rule
+              version: v1.0
+              context: /mcpauthzmultirule
+              specVersion: "2025-06-18"
+              upstream:
+                url: http://mcp-server-backend:3001/mcp
+              policies:
+                - name: mcp-auth
+                  version: v1
+                  params:
+                    issuers:
+                      - mock-jwks
+                - name: mcp-authz
+                  version: v1
+                  params:
+                    tools:
+                      - name: "*"
+                        scopes:
+                          allOf:
+                            - "base-scope"
+                      - name: "add"
+                        scopes:
+                          allOf:
+                            - "add-scope"
+            """
+        Then the response should be successful
+        And the JSON response field "status" should be "success"
+        And I wait for 2 seconds
+
+        # Both the wildcard rule and the specific rule are satisfied → authorized
+        When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token" and scope "base-scope add-scope"
+        And I use the MCP Client to send an initialize request to "http://localhost:8080/mcpauthzmultirule/mcp" with the JWT token
+        Then the response should be successful
+        And I use the MCP Client to send a tools/call request to "http://localhost:8080/mcpauthzmultirule/mcp" with the JWT token
+        Then the response should be successful
+
+        # Specific rule passes but the wildcard rule fails (no base-scope) → 403
+        When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token" and scope "add-scope"
+        And I use the MCP Client to send a tools/call request to "http://localhost:8080/mcpauthzmultirule/mcp" with the JWT token
+        Then the response status code should be 403
+        And the response header "WWW-Authenticate" should contain "base-scope"
+
+        # Wildcard rule passes but the specific rule fails (no add-scope) → 403
+        When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token" and scope "base-scope"
+        And I use the MCP Client to send a tools/call request to "http://localhost:8080/mcpauthzmultirule/mcp" with the JWT token
+        Then the response status code should be 403
+        And the response header "WWW-Authenticate" should contain "add-scope"
+
+        # Cleanup
+        And I clear all headers
+        Given I authenticate using basic auth as "admin"
+        When I delete the MCP proxy "mcp-authz-multirule"
+        Then the response should be successful
+
+    Scenario: mcp-authz mixes new scopes with deprecated requiredClaims on one rule
+        Given I authenticate using basic auth as "admin"
+        When I deploy this MCP configuration:
+            """
+            apiVersion: gateway.api-platform.wso2.com/v1
+            kind: Mcp
+            metadata:
+              name: mcp-authz-mixed
+            spec:
+              displayName: MCP AuthZ Mixed
+              version: v1.0
+              context: /mcpauthzmixed
+              specVersion: "2025-06-18"
+              upstream:
+                url: http://mcp-server-backend:3001/mcp
+              policies:
+                - name: mcp-auth
+                  version: v1
+                  params:
+                    issuers:
+                      - mock-jwks
+                - name: mcp-authz
+                  version: v1
+                  params:
+                    tools:
+                      - name: "add"
+                        scopes:
+                          allOf:
+                            - "api:read"
+                        requiredClaims:
+                          department: platform
+            """
+        Then the response should be successful
+        And the JSON response field "status" should be "success"
+        And I wait for 2 seconds
+
+        # Both the new scope and the deprecated claim are satisfied → authorized
+        When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token", scope "api:read" and claims "department=platform"
+        And I use the MCP Client to send an initialize request to "http://localhost:8080/mcpauthzmixed/mcp" with the JWT token
+        Then the response should be successful
+        And I use the MCP Client to send a tools/call request to "http://localhost:8080/mcpauthzmixed/mcp" with the JWT token
+        Then the response should be successful
+
+        # Scope satisfied but the deprecated claim fails (department=sales) → 403
+        When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token", scope "api:read" and claims "department=sales"
+        And I use the MCP Client to send a tools/call request to "http://localhost:8080/mcpauthzmixed/mcp" with the JWT token
+        Then the response status code should be 403
+
+        # Claim satisfied but the new scope fails (no api:read) → 403
+        When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token", scope "unrelated" and claims "department=platform"
+        And I use the MCP Client to send a tools/call request to "http://localhost:8080/mcpauthzmixed/mcp" with the JWT token
+        Then the response status code should be 403
+        And the response header "WWW-Authenticate" should contain "api:read"
+
+        # Cleanup
+        And I clear all headers
+        Given I authenticate using basic auth as "admin"
+        When I delete the MCP proxy "mcp-authz-mixed"
+        Then the response should be successful
+
+    # Issue #2842: mcp-authz must decide governance by rule matching BEFORE consulting identity. A
+    # capability that no rule targets is not governed and passes through untouched — even with no
+    # authenticated context — while a governed capability still fails closed. Here mcp-authz alone
+    # (no mcp-auth) governs "add" only.
+    Scenario: mcp-authz passes through capabilities no rule targets and fails closed on governed ones
+        Given I authenticate using basic auth as "admin"
+        When I deploy this MCP configuration:
+            """
+            apiVersion: gateway.api-platform.wso2.com/v1
+            kind: Mcp
+            metadata:
+              name: mcp-authz-passthrough
+            spec:
+              displayName: MCP AuthZ Passthrough
+              version: v1.0
+              context: /mcpauthzpassthrough
+              specVersion: "2025-06-18"
+              upstream:
+                url: http://mcp-server-backend:3001/mcp
+              policies:
+                - name: mcp-authz
+                  version: v1
+                  params:
+                    tools:
+                      - name: "add"
+                        requiredScopes:
+                          - "add-scope"
+              tools: []
+              resources: []
+              prompts: []
+            """
+        Then the response should be successful
+        And the response should be valid JSON
+        And the JSON response field "status" should be "success"
+        And I wait for 2 seconds
+
+        # Handshake and an untargeted capability pass through without any authentication.
+        When I use the MCP Client to send an initialize request to "http://localhost:8080/mcpauthzpassthrough/mcp"
+        Then the response should be successful
+        And I use the MCP Client to send "echo" tools/call request to "http://localhost:8080/mcpauthzpassthrough/mcp"
+        Then the response should be successful
+
+        # The governed capability ("add") still fails closed with 401 when no identity is present.
+        And I use the MCP Client to send "add" tools/call request to "http://localhost:8080/mcpauthzpassthrough/mcp"
+        Then the response status code should be 401
+
+        # Cleanup
+        And I clear all headers
+        Given I authenticate using basic auth as "admin"
+        When I delete the MCP proxy "mcp-authz-passthrough"
+        Then the response should be successful
+
+    # Issue #2842: a capability the mcp-auth policy excludes from authentication (tools.exceptions)
+    # and that mcp-authz does not govern must not be blocked by mcp-authz — it legitimately arrives
+    # with no AuthContext. The protected, governed capability must still be enforced (backward compat).
+    Scenario: mcp-authz does not block an mcp-auth-excluded tool while still enforcing governed tools
+        Given I authenticate using basic auth as "admin"
+        When I deploy this MCP configuration:
+            """
+            apiVersion: gateway.api-platform.wso2.com/v1
+            kind: Mcp
+            metadata:
+              name: mcp-authz-excluded-tool
+            spec:
+              displayName: MCP AuthZ Excluded Tool
+              version: v1.0
+              context: /mcpauthzexcluded
+              specVersion: "2025-06-18"
+              upstream:
+                url: http://mcp-server-backend:3001/mcp
+              policies:
+                - name: mcp-auth
+                  version: v1
+                  params:
+                    issuers:
+                      - mock-jwks
+                    methods:
+                      enabled: false
+                    tools:
+                      exceptions:
+                        - echo
+                - name: mcp-authz
+                  version: v1
+                  params:
+                    tools:
+                      - name: "add"
+                        requiredScopes:
+                          - "add-scope"
+              tools: []
+              resources: []
+              prompts: []
+            """
+        Then the response should be successful
+        And the response should be valid JSON
+        And the JSON response field "status" should be "success"
+        And I wait for 2 seconds
+
+        # Handshake works unauthenticated (methods.enabled: false).
+        When I use the MCP Client to send an initialize request to "http://localhost:8080/mcpauthzexcluded/mcp"
+        Then the response should be successful
+
+        # "echo" is auth-excluded in mcp-auth and not governed by mcp-authz → passes through unauthenticated.
+        And I use the MCP Client to send "echo" tools/call request to "http://localhost:8080/mcpauthzexcluded/mcp"
+        Then the response should be successful
+
+        # "add" is protected → 401 without a token (backward compatibility preserved).
+        And I use the MCP Client to send "add" tools/call request to "http://localhost:8080/mcpauthzexcluded/mcp"
+        Then the response status code should be 401
+
+        # "add" with a token carrying the required scope → authorized.
+        When I get a JWT token from the mock JWKS server with issuer "http://mock-jwks:8080/token" and scope "add-scope"
+        And I use the MCP Client to send a tools/call request to "http://localhost:8080/mcpauthzexcluded/mcp" with the JWT token
+        Then the response should be successful
+
+        # Cleanup
+        And I clear all headers
+        Given I authenticate using basic auth as "admin"
+        When I delete the MCP proxy "mcp-authz-excluded-tool"
         Then the response should be successful
 
     Scenario: Deploy an MCP Proxy with mcp-acl-list policy and verify modes with exceptions

--- a/gateway/it/steps_jwt.go
+++ b/gateway/it/steps_jwt.go
@@ -24,6 +24,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/cucumber/godog"
 	"github.com/wso2/api-platform/gateway/it/steps"
@@ -54,6 +55,8 @@ func (j *JWTSteps) Register(ctx *godog.ScenarioContext) {
 	ctx.Step(`^I send a POST request to "([^"]*)" with the JWT token$`, j.iSendPOSTRequestWithJWTToken)
 	ctx.Step(`^I send a GET request to "([^"]*)" with JWT in header "([^"]*)"$`, j.iSendGETRequestWithJWTInHeader)
 	ctx.Step(`^I get a JWT token from the mock JWKS server with issuer "([^"]*)" and scope "([^"]*)"$`, j.iGetJWTTokenWithIssuerAndScope)
+	ctx.Step(`^I get a JWT token from the mock JWKS server with issuer "([^"]*)" and claims "([^"]*)"$`, j.iGetJWTTokenWithIssuerAndClaims)
+	ctx.Step(`^I get a JWT token from the mock JWKS server with issuer "([^"]*)", scope "([^"]*)" and claims "([^"]*)"$`, j.iGetJWTTokenWithIssuerScopeAndClaims)
 }
 
 // Reset clears JWT state between scenarios
@@ -111,6 +114,76 @@ func (j *JWTSteps) iGetJWTTokenWithIssuerAndScope(issuer, scope string) error {
 		tokenURL = tokenURL + "scope=" + url.QueryEscape(scope)
 	}
 
+	log.Printf("DEBUG: Fetching JWT token from %s", tokenURL)
+
+	resp, err := j.state.HTTPClient.Get(tokenURL)
+	if err != nil {
+		return fmt.Errorf("failed to get JWT token from mock JWKS server: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("mock JWKS server returned status %d", resp.StatusCode)
+	}
+
+	tokenBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read token response: %w", err)
+	}
+
+	j.currentToken = string(tokenBytes)
+	log.Printf("DEBUG: Obtained JWT token (length: %d)", len(j.currentToken))
+
+	return nil
+}
+
+// iGetJWTTokenWithIssuerAndClaims fetches a token carrying arbitrary custom claims. The claims
+// argument is a comma-separated list of key=value pairs (e.g. "department=platform,role=internal").
+func (j *JWTSteps) iGetJWTTokenWithIssuerAndClaims(issuer, claims string) error {
+	return j.iGetJWTTokenWithIssuerScopeAndClaims(issuer, "", claims)
+}
+
+// iGetJWTTokenWithIssuerScopeAndClaims fetches a token carrying both a scope and arbitrary custom
+// claims, needed to exercise policies that combine the `scopes` and `claims` params on one
+// operation. claims is a comma-separated list of key=value pairs; each becomes a claim_<key>=<value>
+// query param on the mock server.
+func (j *JWTSteps) iGetJWTTokenWithIssuerScopeAndClaims(issuer, scope, claims string) error {
+	q := url.Values{}
+	if issuer != "" {
+		q.Set("issuer", issuer)
+	}
+	if scope != "" {
+		q.Set("scope", scope)
+	}
+	if err := addClaimParams(q, claims); err != nil {
+		return err
+	}
+
+	tokenURL := j.mockJWKSURL + "/token"
+	if enc := q.Encode(); enc != "" {
+		tokenURL = tokenURL + "?" + enc
+	}
+	return j.fetchTokenFrom(tokenURL)
+}
+
+// addClaimParams parses a comma-separated "key=value" list into claim_<key>=<value> query params.
+func addClaimParams(q url.Values, claims string) error {
+	for _, pair := range strings.Split(claims, ",") {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+		kv := strings.SplitN(pair, "=", 2)
+		if len(kv) != 2 {
+			return fmt.Errorf("invalid claim pair %q, expected key=value", pair)
+		}
+		q.Set("claim_"+strings.TrimSpace(kv[0]), strings.TrimSpace(kv[1]))
+	}
+	return nil
+}
+
+// fetchTokenFrom retrieves a token from the mock server URL and stores it as the current token.
+func (j *JWTSteps) fetchTokenFrom(tokenURL string) error {
 	log.Printf("DEBUG: Fetching JWT token from %s", tokenURL)
 
 	resp, err := j.state.HTTPClient.Get(tokenURL)

--- a/tests/mock-servers/mock-jwks/main.go
+++ b/tests/mock-servers/mock-jwks/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/go-jose/go-jose/v4"
@@ -70,6 +71,15 @@ func tokenHandler(w http.ResponseWriter, r *http.Request) {
 		scope = scopeParam
 	}
 
+	// Arbitrary extra claims via query params of the form claim_<name>=<value> (single string
+	// value), enabling integration tests for the jwt-auth `claims` policy parameter.
+	extraClaims := map[string]interface{}{}
+	for key, vals := range r.URL.Query() {
+		if strings.HasPrefix(key, "claim_") && len(vals) > 0 {
+			extraClaims[strings.TrimPrefix(key, "claim_")] = vals[0]
+		}
+	}
+
 	claims := jwt.Claims{
 		Subject:   "test-user",
 		Issuer:    issuer,
@@ -78,7 +88,11 @@ func tokenHandler(w http.ResponseWriter, r *http.Request) {
 		Audience:  jwt.Audience{"test-audience"},
 	}
 
-	raw, err := jwt.Signed(signer).Claims(claims).Claims(tokenClaims{Scope: scope}).Serialize()
+	builder := jwt.Signed(signer).Claims(claims).Claims(tokenClaims{Scope: scope})
+	if len(extraClaims) > 0 {
+		builder = builder.Claims(extraClaims)
+	}
+	raw, err := builder.Serialize()
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Failed to sign token: %v", err), http.StatusInternalServerError)
 		return


### PR DESCRIPTION
## Purpose
This PR adds some additional integration test scenarios to test and ensure the functionality of the jwt-auth, mcp-auth and mcp-authz policies after the improvements made for addressing the following set of issues
- https://github.com/wso2/api-platform/issues/2841
- https://github.com/wso2/api-platform/issues/2867
- https://github.com/wso2/api-platform/issues/2866
- https://github.com/wso2/api-platform/issues/2842
- https://github.com/wso2/api-platform/issues/2746