### PR TITLE
 [Gateway] Preserve selected upstream across request phases

### DIFF
--- a/gateway/gateway-runtime/policy-engine/internal/kernel/translator.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/translator.go
@@ -277,6 +277,16 @@ func translateRequestActionsCore(result *executor.RequestExecutionResult, execCt
 	bodyModified := false
 	var directive upstreamRedirectDirective // Track the last dynamic-routing directive
 
+	// A routing directive selected during request headers remains active during
+	// request-body processing unless a body-phase policy explicitly replaces it.
+	// UpstreamName == nil means "no change"; applying the default upstream here
+	// would otherwise undo a header-phase additional-provider selection.
+	if namespace := execCtx.dynamicMetadata[constants.ExtProcFilterName]; namespace != nil {
+		if name, ok := namespace[constants.TargetUpstreamNameKey].(string); ok && name != "" {
+			directive.set(&name)
+		}
+	}
+
 	// Seed analyticsData from execution context so data set in a previous phase
 	// (e.g. request_headers captured during the request-headers phase) is carried
 	// forward when this function is called again for the request-body phase.

--- a/gateway/gateway-runtime/policy-engine/internal/kernel/translator_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/translator_test.go
@@ -518,6 +518,58 @@ func TestTranslateRequestActionsCore_WithBodyModification(t *testing.T) {
 	assert.True(t, foundContentLength)
 }
 
+func TestTranslateRequestActionsCore_BodyPreservesHeaderPhaseUpstream(t *testing.T) {
+	kernel := NewKernel()
+	chainExecutor := executor.NewChainExecutor(nil, nil, nil)
+	server := NewExternalProcessorServer(kernel, chainExecutor, config.TracingConfig{}, "")
+
+	chain := &registry.PolicyChain{}
+	execCtx := newPolicyExecutionContext(server, "test-route", chain)
+	execCtx.sharedCtx = &policy.SharedContext{
+		APIKind: "LlmProxy",
+		APIId:   "proxy-123",
+	}
+	execCtx.requestBodyCtx = &policy.RequestContext{
+		Path:          "/proxy/chat/completions",
+		SharedContext: execCtx.sharedCtx,
+	}
+	execCtx.apiContext = "/proxy"
+	execCtx.upstreamBasePath = "/primary-provider"
+	execCtx.defaultUpstreamCluster = "upstream_main_127.0.0.1_8080"
+	execCtx.upstreamDefinitionPaths = map[string]string{
+		"anthropic-provider": "/anthropic-provider",
+	}
+	execCtx.dynamicMetadata[constants.ExtProcFilterName] = map[string]interface{}{
+		constants.TargetUpstreamNameKey: "anthropic-provider",
+	}
+
+	result := &executor.RequestExecutionResult{
+		Results: []executor.RequestPolicyResult{{
+			Action: policy.UpstreamRequestModifications{
+				Body: []byte(`{"model":"claude"}`),
+			},
+		}},
+	}
+
+	rsl, err := translateRequestActionsCore(result, execCtx)
+	require.NoError(t, err)
+	require.NotNil(t, rsl.HeaderMutation)
+
+	expectedCluster := constants.UpstreamDefinitionClusterPrefix +
+		"LlmProxy_proxy-123_anthropic-provider"
+	var targetCluster string
+	for _, h := range rsl.HeaderMutation.SetHeaders {
+		if h.Header.Key == constants.TargetUpstreamHeader {
+			targetCluster = string(h.Header.RawValue)
+		}
+	}
+	assert.Equal(t, expectedCluster, targetCluster)
+	require.NotNil(t, rsl.Mutations.Path)
+	assert.Equal(t, "/proxy/chat/completions", *rsl.Mutations.Path)
+	assert.Equal(t, "/anthropic-provider",
+		rsl.DynamicMetadata[constants.ExtProcFilterName]["target_upstream_base_path"])
+}
+
 func TestTranslateRequestActionsCore_ShortCircuit(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)


### PR DESCRIPTION

## Purpose

A named upstream selected during request-header processing could be lost when request-body policies were executed. The body phase initialized routing without considering the upstream selected during the header phase, potentially causing the request to fall back to the default upstream.

This affects multi-phase policies that select an upstream during header processing and modify the request payload during body processing.

Resolves N/A.

## Goals

- Preserve a named upstream selected during request-header processing.
- Prevent request-body processing from resetting the selected upstream.
- Allow body-phase policies to explicitly replace the selected upstream.
- Preserve existing behavior when no upstream has previously been selected.

## Approach

Updated the policy-engine request-action translator to initialize its upstream routing directive using the upstream name stored in dynamic metadata.

When request-body processing begins:

- An upstream previously selected during the header phase is retained.
- A body-phase policy can still explicitly replace the selected upstream.
- If no upstream was previously selected, the existing default behavior is preserved.

A regression test was added to verify that the header-phase upstream remains selected during body processing.

## User stories

- As a policy developer, I want an upstream selected during header processing to remain active while body policies execute.
- As an API developer, I want multi-phase routing policies to consistently send requests to the selected backend.
- As a gateway user, I want body-modification policies to avoid unintentionally falling back to the default upstream.

## Documentation

N/A — this fixes internal policy-engine routing behavior and does not introduce or modify any user-facing configuration.

## Automation tests

- Unit tests
  - Added coverage for preserving a header-phase upstream selection during request-body processing.
  - Verified the policy-engine kernel test suite:

    ```bash
    go test ./gateway/gateway-runtime/policy-engine/internal/kernel
    ```

  - All focused tests passed.
  - Code coverage was not measured separately.

- Integration tests
  - No new integration tests are included in this PR.
  - Multi-provider model round-robin integration coverage is handled separately.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **Yes**
- Ran FindSecurityBugs plugin and verified report? **N/A — this is a Go change, and FindSecurityBugs applies to Java projects**
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **Yes**

## Samples

N/A — this is an internal policy-engine bug fix and does not require a new sample.

## Related PRs

- https://github.com/wso2/api-platform/pull/2915
- https://github.com/wso2/api-platform/pull/2894
- https://github.com/wso2/gateway-controllers/pull/249

## Test environment

- Operating system: macOS
- Go: Project-configured Go version
- JDK: N/A
- Database: N/A
- Browser: N/A
`