### PR TITLE
feat(sdk): add snapshot-with-fallback accessors to policy contexts

### DIFF
--- a/sdk/core/policy/v1alpha2/action.go
+++ b/sdk/core/policy/v1alpha2/action.go
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
 package policyv1alpha2
 
 // DropHeaderAction controls which headers appear in the analytics event.
@@ -170,14 +187,14 @@ func (ImmediateResponse) isResponseAction() {}
 // These ensure ImmediateResponse satisfies all sealed action interfaces and that
 // the concrete modification types satisfy their respective action interfaces.
 var (
-	_ RequestHeaderAction  = UpstreamRequestHeaderModifications{}
-	_ RequestHeaderAction  = ImmediateResponse{}
-	_ ResponseHeaderAction = DownstreamResponseHeaderModifications{}
-	_ ResponseHeaderAction = ImmediateResponse{}
-	_ RequestAction        = UpstreamRequestModifications{}
-	_ RequestAction        = ImmediateResponse{}
-	_ ResponseAction       = DownstreamResponseModifications{}
-	_ ResponseAction       = ImmediateResponse{}
+	_ RequestHeaderAction     = UpstreamRequestHeaderModifications{}
+	_ RequestHeaderAction     = ImmediateResponse{}
+	_ ResponseHeaderAction    = DownstreamResponseHeaderModifications{}
+	_ ResponseHeaderAction    = ImmediateResponse{}
+	_ RequestAction           = UpstreamRequestModifications{}
+	_ RequestAction           = ImmediateResponse{}
+	_ ResponseAction          = DownstreamResponseModifications{}
+	_ ResponseAction          = ImmediateResponse{}
 	_ StreamingRequestAction  = ForwardRequestChunk{}
 	_ StreamingResponseAction = ForwardResponseChunk{}
 	_ StreamingResponseAction = TerminateResponseChunk{}

--- a/sdk/core/policy/v1alpha2/auth_context.go
+++ b/sdk/core/policy/v1alpha2/auth_context.go
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
 package policyv1alpha2
 
 // AuthContext contains structured authentication information populated by auth policies.
@@ -40,7 +57,7 @@ type AuthContext struct {
 	Properties map[string]string
 
 	// TypedProperties stores additional properties which has complex structures which
-	// needs to be preserved in their original typed form (e.g. arrays or objects) 
+	// needs to be preserved in their original typed form (e.g. arrays or objects)
 	// preserving structure that Properties flattens to strings.
 	TypedProperties map[string]interface{}
 

--- a/sdk/core/policy/v1alpha2/context.go
+++ b/sdk/core/policy/v1alpha2/context.go
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
 package policyv1alpha2
 
 import policyenginev1 "github.com/wso2/api-platform/sdk/core/policyengine"
@@ -36,16 +53,16 @@ type DownstreamRequest struct {
 // UpstreamRequestContext identifies the route's resolved upstream target during
 // the request phase.
 type UpstreamRequestContext struct {
-	Name string
-	URL string
+	Name     string
+	URL      string
 	BasePath string
 }
 
 // UpstreamResponseContext identifies the route's resolved upstream target during
 // the response phase and carries a snapshot of the upstream response.
 type UpstreamResponseContext struct {
-	Name string
-	URL string
+	Name     string
+	URL      string
 	BasePath string
 	Response *UpstreamResponse
 }

--- a/sdk/core/policy/v1alpha2/context_accessors.go
+++ b/sdk/core/policy/v1alpha2/context_accessors.go
@@ -1,0 +1,163 @@
+package policyv1alpha2
+
+// This file provides convenience accessors that resolve the pre-mutation
+// request/response snapshots carried on each policy context, falling back to the
+// live (possibly peer-mutated) values on gateways built before the snapshot
+// feature.
+//
+// Use these for every read that feeds an authentication, authorization, or
+// gating decision. The kernel runs every policy's header phase before any
+// policy's body phase, mutating one shared header set in place, so a decision
+// that reads the live values can observe something another policy rewrote —
+// regardless of policy order. The snapshot always holds what the client
+// actually sent / what the upstream actually returned.
+//
+// The accessors are nil-safe: they may be called even when the Downstream/
+// Upstream context (or its Request/Response) is nil, which is the case on
+// gateways that predate the snapshot-header-context feature.
+
+// resolveDownstreamRequest returns the downstream request snapshot when the
+// gateway provides it, otherwise a snapshot synthesized from the live request
+// values so callers always get the same shape.
+func resolveDownstreamRequest(ds *DownstreamContext, liveHeaders *Headers, livePath, liveMethod, liveAuthority, liveScheme string) *DownstreamRequest {
+	if ds != nil && ds.Request != nil {
+		return ds.Request // fields may be nil/empty; Headers reads (Get/Has/Iterate) are nil-safe
+	}
+	return &DownstreamRequest{
+		Headers:   liveHeaders,
+		Path:      livePath,
+		Method:    liveMethod,
+		Authority: liveAuthority,
+		Scheme:    liveScheme,
+	}
+}
+
+// resolveUpstreamResponse returns the upstream response snapshot when the
+// gateway provides it, otherwise a snapshot synthesized from the live response
+// values.
+func resolveUpstreamResponse(us *UpstreamResponseContext, liveHeaders *Headers, liveStatus int) *UpstreamResponse {
+	if us != nil && us.Response != nil {
+		return us.Response // Headers may be nil; Headers reads are nil-safe
+	}
+	return &UpstreamResponse{
+		Headers:    liveHeaders,
+		StatusCode: liveStatus,
+	}
+}
+
+// ─── Request-phase accessors ─────────────────────────────────────────────────
+
+// DownstreamRequest returns the pre-mutation snapshot of the client request,
+// falling back to a snapshot built from the live request values on gateways
+// that predate the snapshot feature.
+func (c *RequestHeaderContext) DownstreamRequest() *DownstreamRequest {
+	return resolveDownstreamRequest(c.Downstream, c.Headers, c.Path, c.Method, c.Authority, c.Scheme)
+}
+
+// DownstreamHeaders is a shortcut for DownstreamRequest().Headers.
+func (c *RequestHeaderContext) DownstreamHeaders() *Headers {
+	return c.DownstreamRequest().Headers
+}
+
+// DownstreamRequest returns the pre-mutation snapshot of the client request,
+// falling back to a snapshot built from the live request values on gateways
+// that predate the snapshot feature.
+func (c *RequestContext) DownstreamRequest() *DownstreamRequest {
+	return resolveDownstreamRequest(c.Downstream, c.Headers, c.Path, c.Method, c.Authority, c.Scheme)
+}
+
+// DownstreamHeaders is a shortcut for DownstreamRequest().Headers.
+func (c *RequestContext) DownstreamHeaders() *Headers {
+	return c.DownstreamRequest().Headers
+}
+
+// DownstreamRequest returns the pre-mutation snapshot of the client request,
+// falling back to a snapshot built from the live request values on gateways
+// that predate the snapshot feature.
+func (c *RequestStreamContext) DownstreamRequest() *DownstreamRequest {
+	return resolveDownstreamRequest(c.Downstream, c.Headers, c.Path, c.Method, c.Authority, c.Scheme)
+}
+
+// DownstreamHeaders is a shortcut for DownstreamRequest().Headers.
+func (c *RequestStreamContext) DownstreamHeaders() *Headers {
+	return c.DownstreamRequest().Headers
+}
+
+// ─── Response-phase accessors ────────────────────────────────────────────────
+//
+// Response contexts carry only the live request echoes (RequestHeaders,
+// RequestPath, RequestMethod); there is no live Authority/Scheme to fall back
+// to, so those come from the snapshot only and are empty on pre-snapshot
+// gateways.
+
+// DownstreamRequest returns the pre-mutation snapshot of the client request,
+// falling back to the live request echoes on gateways that predate the snapshot
+// feature.
+func (c *ResponseHeaderContext) DownstreamRequest() *DownstreamRequest {
+	return resolveDownstreamRequest(c.Downstream, c.RequestHeaders, c.RequestPath, c.RequestMethod, "", "")
+}
+
+// DownstreamHeaders is a shortcut for DownstreamRequest().Headers.
+func (c *ResponseHeaderContext) DownstreamHeaders() *Headers {
+	return c.DownstreamRequest().Headers
+}
+
+// UpstreamResponse returns the pre-mutation snapshot of the upstream response,
+// falling back to a snapshot built from the live response values on gateways
+// that predate the snapshot feature.
+func (c *ResponseHeaderContext) UpstreamResponse() *UpstreamResponse {
+	return resolveUpstreamResponse(c.Upstream, c.ResponseHeaders, c.ResponseStatus)
+}
+
+// UpstreamHeaders is a shortcut for UpstreamResponse().Headers.
+func (c *ResponseHeaderContext) UpstreamHeaders() *Headers {
+	return c.UpstreamResponse().Headers
+}
+
+// DownstreamRequest returns the pre-mutation snapshot of the client request,
+// falling back to the live request echoes on gateways that predate the snapshot
+// feature.
+func (c *ResponseContext) DownstreamRequest() *DownstreamRequest {
+	return resolveDownstreamRequest(c.Downstream, c.RequestHeaders, c.RequestPath, c.RequestMethod, "", "")
+}
+
+// DownstreamHeaders is a shortcut for DownstreamRequest().Headers.
+func (c *ResponseContext) DownstreamHeaders() *Headers {
+	return c.DownstreamRequest().Headers
+}
+
+// UpstreamResponse returns the pre-mutation snapshot of the upstream response,
+// falling back to a snapshot built from the live response values on gateways
+// that predate the snapshot feature.
+func (c *ResponseContext) UpstreamResponse() *UpstreamResponse {
+	return resolveUpstreamResponse(c.Upstream, c.ResponseHeaders, c.ResponseStatus)
+}
+
+// UpstreamHeaders is a shortcut for UpstreamResponse().Headers.
+func (c *ResponseContext) UpstreamHeaders() *Headers {
+	return c.UpstreamResponse().Headers
+}
+
+// DownstreamRequest returns the pre-mutation snapshot of the client request,
+// falling back to the live request echoes on gateways that predate the snapshot
+// feature.
+func (c *ResponseStreamContext) DownstreamRequest() *DownstreamRequest {
+	return resolveDownstreamRequest(c.Downstream, c.RequestHeaders, c.RequestPath, c.RequestMethod, "", "")
+}
+
+// DownstreamHeaders is a shortcut for DownstreamRequest().Headers.
+func (c *ResponseStreamContext) DownstreamHeaders() *Headers {
+	return c.DownstreamRequest().Headers
+}
+
+// UpstreamResponse returns the pre-mutation snapshot of the upstream response,
+// falling back to a snapshot built from the live response values on gateways
+// that predate the snapshot feature.
+func (c *ResponseStreamContext) UpstreamResponse() *UpstreamResponse {
+	return resolveUpstreamResponse(c.Upstream, c.ResponseHeaders, c.ResponseStatus)
+}
+
+// UpstreamHeaders is a shortcut for UpstreamResponse().Headers.
+func (c *ResponseStreamContext) UpstreamHeaders() *Headers {
+	return c.UpstreamResponse().Headers
+}

--- a/sdk/core/policy/v1alpha2/context_accessors.go
+++ b/sdk/core/policy/v1alpha2/context_accessors.go
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
 package policyv1alpha2
 
 // This file provides convenience accessors that return the pre-mutation

--- a/sdk/core/policy/v1alpha2/context_accessors.go
+++ b/sdk/core/policy/v1alpha2/context_accessors.go
@@ -1,57 +1,67 @@
 package policyv1alpha2
 
-// This file provides convenience accessors that resolve the pre-mutation
-// request/response snapshots carried on each policy context, falling back to the
-// live (possibly peer-mutated) values on gateways built before the snapshot
-// feature.
+// This file provides convenience accessors that return the pre-mutation
+// request/response snapshot carried on each policy context, falling back to the
+// live values when the gateway does not provide a snapshot.
 //
-// Use these for every read that feeds an authentication, authorization, or
-// gating decision. The kernel runs every policy's header phase before any
-// policy's body phase, mutating one shared header set in place, so a decision
-// that reads the live values can observe something another policy rewrote —
-// regardless of policy order. The snapshot always holds what the client
-// actually sent / what the upstream actually returned.
+// Snapshots and live values carry DIFFERENT guarantees — do not treat the
+// accessor's return value as always being the unmutated client request /
+// upstream response:
 //
-// The accessors are nil-safe: they may be called even when the Downstream/
-// Upstream context (or its Request/Response) is nil, which is the case on
-// gateways that predate the snapshot-header-context feature.
+//   - When the gateway populates the snapshot (Downstream.Request /
+//     Upstream.Response present), the accessor returns it. This is what the
+//     client actually sent / what the upstream actually returned, immune to
+//     rewrites by earlier policies in the chain. The kernel runs every policy's
+//     header phase before any policy's body phase against one shared, mutable
+//     header set, so reading the live values can otherwise observe a value
+//     another policy rewrote — regardless of policy order. Prefer the snapshot
+//     for any authentication, authorization, or gating decision.
+//
+//   - When the gateway does NOT provide the snapshot (gateways released before
+//     the snapshot feature, where Downstream/Upstream — or its Request/Response
+//     — is nil), the accessor falls back to the live values. These are exactly
+//     what policies observed before this feature existed, and may already
+//     reflect an earlier in-chain mutation. The immunity guarantee above holds
+//     ONLY where the snapshot is present.
+//
+// The fallback is deliberate compatibility behaviour and does NOT fail closed:
+// on a gateway that never populates the snapshot, live is the only data that
+// exists, and refusing to return it would break every such deployment. A policy
+// that must have the unmutated values (and can require a snapshot-capable
+// gateway) should read the Downstream/Upstream snapshot directly and handle a
+// nil snapshot itself, rather than relying on the fallback.
+//
+// All accessors are nil-safe: they may be called even when Downstream/Upstream
+// (or its Request/Response) is nil.
 
-// resolveDownstreamRequest returns the downstream request snapshot when the
-// gateway provides it, otherwise a snapshot synthesized from the live request
-// values so callers always get the same shape.
-func resolveDownstreamRequest(ds *DownstreamContext, liveHeaders *Headers, livePath, liveMethod, liveAuthority, liveScheme string) *DownstreamRequest {
+// downstreamSnapshot returns the client request snapshot, or nil when the
+// gateway does not provide one. Single home for the snapshot-presence check.
+func downstreamSnapshot(ds *DownstreamContext) *DownstreamRequest {
 	if ds != nil && ds.Request != nil {
 		return ds.Request // fields may be nil/empty; Headers reads (Get/Has/Iterate) are nil-safe
 	}
-	return &DownstreamRequest{
-		Headers:   liveHeaders,
-		Path:      livePath,
-		Method:    liveMethod,
-		Authority: liveAuthority,
-		Scheme:    liveScheme,
-	}
+	return nil
 }
 
-// resolveUpstreamResponse returns the upstream response snapshot when the
-// gateway provides it, otherwise a snapshot synthesized from the live response
-// values.
-func resolveUpstreamResponse(us *UpstreamResponseContext, liveHeaders *Headers, liveStatus int) *UpstreamResponse {
+// upstreamSnapshot returns the upstream response snapshot, or nil when the
+// gateway does not provide one.
+func upstreamSnapshot(us *UpstreamResponseContext) *UpstreamResponse {
 	if us != nil && us.Response != nil {
 		return us.Response // Headers may be nil; Headers reads are nil-safe
 	}
-	return &UpstreamResponse{
-		Headers:    liveHeaders,
-		StatusCode: liveStatus,
-	}
+	return nil
 }
 
 // ─── Request-phase accessors ─────────────────────────────────────────────────
 
-// DownstreamRequest returns the pre-mutation snapshot of the client request,
-// falling back to a snapshot built from the live request values on gateways
-// that predate the snapshot feature.
+// DownstreamRequest returns the client request snapshot, or the live request
+// values when the gateway does not provide a snapshot. See the file header for
+// the guarantee difference between the two.
 func (c *RequestHeaderContext) DownstreamRequest() *DownstreamRequest {
-	return resolveDownstreamRequest(c.Downstream, c.Headers, c.Path, c.Method, c.Authority, c.Scheme)
+	if snap := downstreamSnapshot(c.Downstream); snap != nil {
+		return snap
+	}
+	return &DownstreamRequest{Headers: c.Headers, Path: c.Path, Method: c.Method, Authority: c.Authority, Scheme: c.Scheme}
 }
 
 // DownstreamHeaders is a shortcut for DownstreamRequest().Headers.
@@ -59,11 +69,13 @@ func (c *RequestHeaderContext) DownstreamHeaders() *Headers {
 	return c.DownstreamRequest().Headers
 }
 
-// DownstreamRequest returns the pre-mutation snapshot of the client request,
-// falling back to a snapshot built from the live request values on gateways
-// that predate the snapshot feature.
+// DownstreamRequest returns the client request snapshot, or the live request
+// values when the gateway does not provide a snapshot.
 func (c *RequestContext) DownstreamRequest() *DownstreamRequest {
-	return resolveDownstreamRequest(c.Downstream, c.Headers, c.Path, c.Method, c.Authority, c.Scheme)
+	if snap := downstreamSnapshot(c.Downstream); snap != nil {
+		return snap
+	}
+	return &DownstreamRequest{Headers: c.Headers, Path: c.Path, Method: c.Method, Authority: c.Authority, Scheme: c.Scheme}
 }
 
 // DownstreamHeaders is a shortcut for DownstreamRequest().Headers.
@@ -71,11 +83,13 @@ func (c *RequestContext) DownstreamHeaders() *Headers {
 	return c.DownstreamRequest().Headers
 }
 
-// DownstreamRequest returns the pre-mutation snapshot of the client request,
-// falling back to a snapshot built from the live request values on gateways
-// that predate the snapshot feature.
+// DownstreamRequest returns the client request snapshot, or the live request
+// values when the gateway does not provide a snapshot.
 func (c *RequestStreamContext) DownstreamRequest() *DownstreamRequest {
-	return resolveDownstreamRequest(c.Downstream, c.Headers, c.Path, c.Method, c.Authority, c.Scheme)
+	if snap := downstreamSnapshot(c.Downstream); snap != nil {
+		return snap
+	}
+	return &DownstreamRequest{Headers: c.Headers, Path: c.Path, Method: c.Method, Authority: c.Authority, Scheme: c.Scheme}
 }
 
 // DownstreamHeaders is a shortcut for DownstreamRequest().Headers.
@@ -87,14 +101,16 @@ func (c *RequestStreamContext) DownstreamHeaders() *Headers {
 //
 // Response contexts carry only the live request echoes (RequestHeaders,
 // RequestPath, RequestMethod); there is no live Authority/Scheme to fall back
-// to, so those come from the snapshot only and are empty on pre-snapshot
-// gateways.
+// to, so those come from the snapshot only and are empty when the gateway does
+// not provide a snapshot.
 
-// DownstreamRequest returns the pre-mutation snapshot of the client request,
-// falling back to the live request echoes on gateways that predate the snapshot
-// feature.
+// DownstreamRequest returns the client request snapshot, or the live request
+// echoes when the gateway does not provide a snapshot.
 func (c *ResponseHeaderContext) DownstreamRequest() *DownstreamRequest {
-	return resolveDownstreamRequest(c.Downstream, c.RequestHeaders, c.RequestPath, c.RequestMethod, "", "")
+	if snap := downstreamSnapshot(c.Downstream); snap != nil {
+		return snap
+	}
+	return &DownstreamRequest{Headers: c.RequestHeaders, Path: c.RequestPath, Method: c.RequestMethod}
 }
 
 // DownstreamHeaders is a shortcut for DownstreamRequest().Headers.
@@ -102,11 +118,13 @@ func (c *ResponseHeaderContext) DownstreamHeaders() *Headers {
 	return c.DownstreamRequest().Headers
 }
 
-// UpstreamResponse returns the pre-mutation snapshot of the upstream response,
-// falling back to a snapshot built from the live response values on gateways
-// that predate the snapshot feature.
+// UpstreamResponse returns the upstream response snapshot, or the live response
+// values when the gateway does not provide a snapshot.
 func (c *ResponseHeaderContext) UpstreamResponse() *UpstreamResponse {
-	return resolveUpstreamResponse(c.Upstream, c.ResponseHeaders, c.ResponseStatus)
+	if snap := upstreamSnapshot(c.Upstream); snap != nil {
+		return snap
+	}
+	return &UpstreamResponse{Headers: c.ResponseHeaders, StatusCode: c.ResponseStatus}
 }
 
 // UpstreamHeaders is a shortcut for UpstreamResponse().Headers.
@@ -114,11 +132,13 @@ func (c *ResponseHeaderContext) UpstreamHeaders() *Headers {
 	return c.UpstreamResponse().Headers
 }
 
-// DownstreamRequest returns the pre-mutation snapshot of the client request,
-// falling back to the live request echoes on gateways that predate the snapshot
-// feature.
+// DownstreamRequest returns the client request snapshot, or the live request
+// echoes when the gateway does not provide a snapshot.
 func (c *ResponseContext) DownstreamRequest() *DownstreamRequest {
-	return resolveDownstreamRequest(c.Downstream, c.RequestHeaders, c.RequestPath, c.RequestMethod, "", "")
+	if snap := downstreamSnapshot(c.Downstream); snap != nil {
+		return snap
+	}
+	return &DownstreamRequest{Headers: c.RequestHeaders, Path: c.RequestPath, Method: c.RequestMethod}
 }
 
 // DownstreamHeaders is a shortcut for DownstreamRequest().Headers.
@@ -126,11 +146,13 @@ func (c *ResponseContext) DownstreamHeaders() *Headers {
 	return c.DownstreamRequest().Headers
 }
 
-// UpstreamResponse returns the pre-mutation snapshot of the upstream response,
-// falling back to a snapshot built from the live response values on gateways
-// that predate the snapshot feature.
+// UpstreamResponse returns the upstream response snapshot, or the live response
+// values when the gateway does not provide a snapshot.
 func (c *ResponseContext) UpstreamResponse() *UpstreamResponse {
-	return resolveUpstreamResponse(c.Upstream, c.ResponseHeaders, c.ResponseStatus)
+	if snap := upstreamSnapshot(c.Upstream); snap != nil {
+		return snap
+	}
+	return &UpstreamResponse{Headers: c.ResponseHeaders, StatusCode: c.ResponseStatus}
 }
 
 // UpstreamHeaders is a shortcut for UpstreamResponse().Headers.
@@ -138,11 +160,13 @@ func (c *ResponseContext) UpstreamHeaders() *Headers {
 	return c.UpstreamResponse().Headers
 }
 
-// DownstreamRequest returns the pre-mutation snapshot of the client request,
-// falling back to the live request echoes on gateways that predate the snapshot
-// feature.
+// DownstreamRequest returns the client request snapshot, or the live request
+// echoes when the gateway does not provide a snapshot.
 func (c *ResponseStreamContext) DownstreamRequest() *DownstreamRequest {
-	return resolveDownstreamRequest(c.Downstream, c.RequestHeaders, c.RequestPath, c.RequestMethod, "", "")
+	if snap := downstreamSnapshot(c.Downstream); snap != nil {
+		return snap
+	}
+	return &DownstreamRequest{Headers: c.RequestHeaders, Path: c.RequestPath, Method: c.RequestMethod}
 }
 
 // DownstreamHeaders is a shortcut for DownstreamRequest().Headers.
@@ -150,11 +174,13 @@ func (c *ResponseStreamContext) DownstreamHeaders() *Headers {
 	return c.DownstreamRequest().Headers
 }
 
-// UpstreamResponse returns the pre-mutation snapshot of the upstream response,
-// falling back to a snapshot built from the live response values on gateways
-// that predate the snapshot feature.
+// UpstreamResponse returns the upstream response snapshot, or the live response
+// values when the gateway does not provide a snapshot.
 func (c *ResponseStreamContext) UpstreamResponse() *UpstreamResponse {
-	return resolveUpstreamResponse(c.Upstream, c.ResponseHeaders, c.ResponseStatus)
+	if snap := upstreamSnapshot(c.Upstream); snap != nil {
+		return snap
+	}
+	return &UpstreamResponse{Headers: c.ResponseHeaders, StatusCode: c.ResponseStatus}
 }
 
 // UpstreamHeaders is a shortcut for UpstreamResponse().Headers.

--- a/sdk/core/policy/v1alpha2/context_accessors_test.go
+++ b/sdk/core/policy/v1alpha2/context_accessors_test.go
@@ -34,82 +34,54 @@ func snapshotResponse() *UpstreamResponse {
 	}
 }
 
-// ─── resolveDownstreamRequest ────────────────────────────────────────────────
+// ─── downstreamSnapshot ──────────────────────────────────────────────────────
 
-func TestResolveDownstreamRequest_PrefersSnapshot(t *testing.T) {
-	ds := &DownstreamContext{Request: snapshotRequest()}
-	got := resolveDownstreamRequest(ds, liveRequestHeaders(), "/live", "GET", "live.example.com", "http")
-
-	if got != ds.Request {
-		t.Fatalf("expected the snapshot struct to be returned as-is")
-	}
-	if v := firstValue(got.Headers, "x-src"); v != "snapshot" {
-		t.Errorf("headers: got %q, want snapshot", v)
-	}
-	if got.Path != "/snap/path" || got.Method != "POST" || got.Authority != "snap.example.com" || got.Scheme != "https" {
-		t.Errorf("unexpected snapshot fields: %+v", got)
-	}
+func TestDownstreamSnapshot(t *testing.T) {
+	t.Run("returns snapshot as-is when present", func(t *testing.T) {
+		ds := &DownstreamContext{Request: snapshotRequest()}
+		if got := downstreamSnapshot(ds); got != ds.Request {
+			t.Fatalf("expected the snapshot struct to be returned as-is")
+		}
+	})
+	t.Run("nil when Downstream nil", func(t *testing.T) {
+		if got := downstreamSnapshot(nil); got != nil {
+			t.Errorf("expected nil, got %+v", got)
+		}
+	})
+	t.Run("nil when Request nil", func(t *testing.T) {
+		if got := downstreamSnapshot(&DownstreamContext{Request: nil}); got != nil {
+			t.Errorf("expected nil, got %+v", got)
+		}
+	})
 }
 
-func TestResolveDownstreamRequest_FallbackWhenDownstreamNil(t *testing.T) {
-	got := resolveDownstreamRequest(nil, liveRequestHeaders(), "/live", "GET", "live.example.com", "http")
+// ─── upstreamSnapshot ────────────────────────────────────────────────────────
 
-	if v := firstValue(got.Headers, "x-src"); v != "live" {
-		t.Errorf("headers: got %q, want live", v)
-	}
-	if got.Path != "/live" || got.Method != "GET" || got.Authority != "live.example.com" || got.Scheme != "http" {
-		t.Errorf("unexpected live fields: %+v", got)
-	}
+func TestUpstreamSnapshot(t *testing.T) {
+	t.Run("returns snapshot as-is when present", func(t *testing.T) {
+		us := &UpstreamResponseContext{Response: snapshotResponse()}
+		if got := upstreamSnapshot(us); got != us.Response {
+			t.Fatalf("expected the snapshot response to be returned as-is")
+		}
+	})
+	t.Run("nil when Upstream nil", func(t *testing.T) {
+		if got := upstreamSnapshot(nil); got != nil {
+			t.Errorf("expected nil, got %+v", got)
+		}
+	})
+	t.Run("nil when Response nil", func(t *testing.T) {
+		if got := upstreamSnapshot(&UpstreamResponseContext{Response: nil}); got != nil {
+			t.Errorf("expected nil, got %+v", got)
+		}
+	})
 }
 
-func TestResolveDownstreamRequest_FallbackWhenRequestNil(t *testing.T) {
-	ds := &DownstreamContext{Request: nil}
-	got := resolveDownstreamRequest(ds, liveRequestHeaders(), "/live", "GET", "", "")
-
-	if v := firstValue(got.Headers, "x-src"); v != "live" {
-		t.Errorf("headers: got %q, want live", v)
-	}
-	if got.Path != "/live" || got.Method != "GET" {
-		t.Errorf("unexpected live fields: %+v", got)
-	}
-}
-
-func TestResolveDownstreamRequest_NilLiveHeadersStillNilSafe(t *testing.T) {
-	got := resolveDownstreamRequest(nil, nil, "/live", "GET", "", "")
-	// Headers reads must be nil-safe even when the fallback headers are nil.
-	if got.Headers.Has("anything") {
+// TestDownstreamHeaders_NilLiveFallbackIsNilSafe verifies Headers reads stay
+// nil-safe when the gateway provides no snapshot and the live headers are nil.
+func TestDownstreamHeaders_NilLiveFallbackIsNilSafe(t *testing.T) {
+	c := &RequestHeaderContext{} // no Downstream, no live Headers
+	if c.DownstreamHeaders().Has("anything") {
 		t.Errorf("expected no headers on nil fallback")
-	}
-}
-
-// ─── resolveUpstreamResponse ─────────────────────────────────────────────────
-
-func TestResolveUpstreamResponse_PrefersSnapshot(t *testing.T) {
-	us := &UpstreamResponseContext{Response: snapshotResponse()}
-	got := resolveUpstreamResponse(us, NewHeaders(map[string][]string{"x-src": {"live"}}), 500)
-
-	if got != us.Response {
-		t.Fatalf("expected the snapshot response to be returned as-is")
-	}
-	if v := firstValue(got.Headers, "x-src"); v != "snapshot" || got.StatusCode != 201 {
-		t.Errorf("unexpected snapshot response: header=%q status=%d", v, got.StatusCode)
-	}
-}
-
-func TestResolveUpstreamResponse_FallbackWhenUpstreamNil(t *testing.T) {
-	got := resolveUpstreamResponse(nil, NewHeaders(map[string][]string{"x-src": {"live"}}), 500)
-
-	if v := firstValue(got.Headers, "x-src"); v != "live" || got.StatusCode != 500 {
-		t.Errorf("unexpected live response: header=%q status=%d", v, got.StatusCode)
-	}
-}
-
-func TestResolveUpstreamResponse_FallbackWhenResponseNil(t *testing.T) {
-	us := &UpstreamResponseContext{Response: nil}
-	got := resolveUpstreamResponse(us, NewHeaders(map[string][]string{"x-src": {"live"}}), 502)
-
-	if v := firstValue(got.Headers, "x-src"); v != "live" || got.StatusCode != 502 {
-		t.Errorf("unexpected live response: header=%q status=%d", v, got.StatusCode)
 	}
 }
 

--- a/sdk/core/policy/v1alpha2/context_accessors_test.go
+++ b/sdk/core/policy/v1alpha2/context_accessors_test.go
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
 package policyv1alpha2
 
 import "testing"

--- a/sdk/core/policy/v1alpha2/context_accessors_test.go
+++ b/sdk/core/policy/v1alpha2/context_accessors_test.go
@@ -1,0 +1,279 @@
+package policyv1alpha2
+
+import "testing"
+
+// firstValue returns the first value of header name, or "" if absent.
+func firstValue(h *Headers, name string) string {
+	vals := h.Get(name)
+	if len(vals) == 0 {
+		return ""
+	}
+	return vals[0]
+}
+
+// snapshotRequest / liveRequest give the two sources distinct marker values so a
+// test can tell which one an accessor returned.
+func snapshotRequest() *DownstreamRequest {
+	return &DownstreamRequest{
+		Headers:   NewHeaders(map[string][]string{"x-src": {"snapshot"}}),
+		Path:      "/snap/path",
+		Method:    "POST",
+		Authority: "snap.example.com",
+		Scheme:    "https",
+	}
+}
+
+func liveRequestHeaders() *Headers {
+	return NewHeaders(map[string][]string{"x-src": {"live"}})
+}
+
+func snapshotResponse() *UpstreamResponse {
+	return &UpstreamResponse{
+		Headers:    NewHeaders(map[string][]string{"x-src": {"snapshot"}}),
+		StatusCode: 201,
+	}
+}
+
+// ─── resolveDownstreamRequest ────────────────────────────────────────────────
+
+func TestResolveDownstreamRequest_PrefersSnapshot(t *testing.T) {
+	ds := &DownstreamContext{Request: snapshotRequest()}
+	got := resolveDownstreamRequest(ds, liveRequestHeaders(), "/live", "GET", "live.example.com", "http")
+
+	if got != ds.Request {
+		t.Fatalf("expected the snapshot struct to be returned as-is")
+	}
+	if v := firstValue(got.Headers, "x-src"); v != "snapshot" {
+		t.Errorf("headers: got %q, want snapshot", v)
+	}
+	if got.Path != "/snap/path" || got.Method != "POST" || got.Authority != "snap.example.com" || got.Scheme != "https" {
+		t.Errorf("unexpected snapshot fields: %+v", got)
+	}
+}
+
+func TestResolveDownstreamRequest_FallbackWhenDownstreamNil(t *testing.T) {
+	got := resolveDownstreamRequest(nil, liveRequestHeaders(), "/live", "GET", "live.example.com", "http")
+
+	if v := firstValue(got.Headers, "x-src"); v != "live" {
+		t.Errorf("headers: got %q, want live", v)
+	}
+	if got.Path != "/live" || got.Method != "GET" || got.Authority != "live.example.com" || got.Scheme != "http" {
+		t.Errorf("unexpected live fields: %+v", got)
+	}
+}
+
+func TestResolveDownstreamRequest_FallbackWhenRequestNil(t *testing.T) {
+	ds := &DownstreamContext{Request: nil}
+	got := resolveDownstreamRequest(ds, liveRequestHeaders(), "/live", "GET", "", "")
+
+	if v := firstValue(got.Headers, "x-src"); v != "live" {
+		t.Errorf("headers: got %q, want live", v)
+	}
+	if got.Path != "/live" || got.Method != "GET" {
+		t.Errorf("unexpected live fields: %+v", got)
+	}
+}
+
+func TestResolveDownstreamRequest_NilLiveHeadersStillNilSafe(t *testing.T) {
+	got := resolveDownstreamRequest(nil, nil, "/live", "GET", "", "")
+	// Headers reads must be nil-safe even when the fallback headers are nil.
+	if got.Headers.Has("anything") {
+		t.Errorf("expected no headers on nil fallback")
+	}
+}
+
+// ─── resolveUpstreamResponse ─────────────────────────────────────────────────
+
+func TestResolveUpstreamResponse_PrefersSnapshot(t *testing.T) {
+	us := &UpstreamResponseContext{Response: snapshotResponse()}
+	got := resolveUpstreamResponse(us, NewHeaders(map[string][]string{"x-src": {"live"}}), 500)
+
+	if got != us.Response {
+		t.Fatalf("expected the snapshot response to be returned as-is")
+	}
+	if v := firstValue(got.Headers, "x-src"); v != "snapshot" || got.StatusCode != 201 {
+		t.Errorf("unexpected snapshot response: header=%q status=%d", v, got.StatusCode)
+	}
+}
+
+func TestResolveUpstreamResponse_FallbackWhenUpstreamNil(t *testing.T) {
+	got := resolveUpstreamResponse(nil, NewHeaders(map[string][]string{"x-src": {"live"}}), 500)
+
+	if v := firstValue(got.Headers, "x-src"); v != "live" || got.StatusCode != 500 {
+		t.Errorf("unexpected live response: header=%q status=%d", v, got.StatusCode)
+	}
+}
+
+func TestResolveUpstreamResponse_FallbackWhenResponseNil(t *testing.T) {
+	us := &UpstreamResponseContext{Response: nil}
+	got := resolveUpstreamResponse(us, NewHeaders(map[string][]string{"x-src": {"live"}}), 502)
+
+	if v := firstValue(got.Headers, "x-src"); v != "live" || got.StatusCode != 502 {
+		t.Errorf("unexpected live response: header=%q status=%d", v, got.StatusCode)
+	}
+}
+
+// ─── Request-phase context wrappers ──────────────────────────────────────────
+
+func TestRequestContexts_DownstreamAccessors(t *testing.T) {
+	// Each request-phase context exposes the same live request fields
+	// (Headers/Path/Method/Authority/Scheme). Verify snapshot and fallback for
+	// all three via a common shape check.
+	liveHeaders := liveRequestHeaders()
+
+	assertSnapshot := func(t *testing.T, dr *DownstreamRequest, hdrs *Headers) {
+		t.Helper()
+		if firstValue(dr.Headers, "x-src") != "snapshot" || dr.Path != "/snap/path" ||
+			dr.Method != "POST" || dr.Authority != "snap.example.com" || dr.Scheme != "https" {
+			t.Errorf("expected snapshot fields, got %+v", dr)
+		}
+		if firstValue(hdrs, "x-src") != "snapshot" {
+			t.Errorf("DownstreamHeaders shortcut did not return snapshot headers")
+		}
+	}
+	assertFallback := func(t *testing.T, dr *DownstreamRequest, hdrs *Headers) {
+		t.Helper()
+		if firstValue(dr.Headers, "x-src") != "live" || dr.Path != "/live" ||
+			dr.Method != "GET" || dr.Authority != "live.example.com" || dr.Scheme != "http" {
+			t.Errorf("expected live fields, got %+v", dr)
+		}
+		if firstValue(hdrs, "x-src") != "live" {
+			t.Errorf("DownstreamHeaders shortcut did not return live headers")
+		}
+	}
+
+	t.Run("RequestHeaderContext snapshot", func(t *testing.T) {
+		c := &RequestHeaderContext{
+			Headers: liveHeaders, Path: "/live", Method: "GET", Authority: "live.example.com", Scheme: "http",
+			Downstream: &DownstreamContext{Request: snapshotRequest()},
+		}
+		assertSnapshot(t, c.DownstreamRequest(), c.DownstreamHeaders())
+	})
+	t.Run("RequestHeaderContext fallback", func(t *testing.T) {
+		c := &RequestHeaderContext{Headers: liveHeaders, Path: "/live", Method: "GET", Authority: "live.example.com", Scheme: "http"}
+		assertFallback(t, c.DownstreamRequest(), c.DownstreamHeaders())
+	})
+
+	t.Run("RequestContext snapshot", func(t *testing.T) {
+		c := &RequestContext{
+			Headers: liveHeaders, Path: "/live", Method: "GET", Authority: "live.example.com", Scheme: "http",
+			Downstream: &DownstreamContext{Request: snapshotRequest()},
+		}
+		assertSnapshot(t, c.DownstreamRequest(), c.DownstreamHeaders())
+	})
+	t.Run("RequestContext fallback", func(t *testing.T) {
+		c := &RequestContext{Headers: liveHeaders, Path: "/live", Method: "GET", Authority: "live.example.com", Scheme: "http"}
+		assertFallback(t, c.DownstreamRequest(), c.DownstreamHeaders())
+	})
+
+	t.Run("RequestStreamContext snapshot", func(t *testing.T) {
+		c := &RequestStreamContext{
+			Headers: liveHeaders, Path: "/live", Method: "GET", Authority: "live.example.com", Scheme: "http",
+			Downstream: &DownstreamContext{Request: snapshotRequest()},
+		}
+		assertSnapshot(t, c.DownstreamRequest(), c.DownstreamHeaders())
+	})
+	t.Run("RequestStreamContext fallback", func(t *testing.T) {
+		c := &RequestStreamContext{Headers: liveHeaders, Path: "/live", Method: "GET", Authority: "live.example.com", Scheme: "http"}
+		assertFallback(t, c.DownstreamRequest(), c.DownstreamHeaders())
+	})
+}
+
+// ─── Response-phase context wrappers ─────────────────────────────────────────
+
+func TestResponseContexts_DownstreamFallbackHasNoAuthorityOrScheme(t *testing.T) {
+	// Response contexts carry no live Authority/Scheme, so the fallback leaves
+	// them empty while still filling headers/path/method from the request echoes.
+	live := liveRequestHeaders()
+
+	check := func(t *testing.T, dr *DownstreamRequest, hdrs *Headers) {
+		t.Helper()
+		if firstValue(dr.Headers, "x-src") != "live" || dr.Path != "/live-req" || dr.Method != "GET" {
+			t.Errorf("expected live request echoes, got %+v", dr)
+		}
+		if dr.Authority != "" || dr.Scheme != "" {
+			t.Errorf("expected empty Authority/Scheme on response fallback, got authority=%q scheme=%q", dr.Authority, dr.Scheme)
+		}
+		if firstValue(hdrs, "x-src") != "live" {
+			t.Errorf("DownstreamHeaders shortcut mismatch")
+		}
+	}
+
+	t.Run("ResponseHeaderContext", func(t *testing.T) {
+		c := &ResponseHeaderContext{RequestHeaders: live, RequestPath: "/live-req", RequestMethod: "GET"}
+		check(t, c.DownstreamRequest(), c.DownstreamHeaders())
+	})
+	t.Run("ResponseContext", func(t *testing.T) {
+		c := &ResponseContext{RequestHeaders: live, RequestPath: "/live-req", RequestMethod: "GET"}
+		check(t, c.DownstreamRequest(), c.DownstreamHeaders())
+	})
+	t.Run("ResponseStreamContext", func(t *testing.T) {
+		c := &ResponseStreamContext{RequestHeaders: live, RequestPath: "/live-req", RequestMethod: "GET"}
+		check(t, c.DownstreamRequest(), c.DownstreamHeaders())
+	})
+}
+
+func TestResponseContexts_DownstreamPrefersSnapshot(t *testing.T) {
+	// With a snapshot present, response contexts do surface Authority/Scheme.
+	check := func(t *testing.T, dr *DownstreamRequest) {
+		t.Helper()
+		if firstValue(dr.Headers, "x-src") != "snapshot" || dr.Authority != "snap.example.com" || dr.Scheme != "https" {
+			t.Errorf("expected snapshot fields, got %+v", dr)
+		}
+	}
+
+	ds := func() *DownstreamContext { return &DownstreamContext{Request: snapshotRequest()} }
+	check(t, (&ResponseHeaderContext{RequestHeaders: liveRequestHeaders(), Downstream: ds()}).DownstreamRequest())
+	check(t, (&ResponseContext{RequestHeaders: liveRequestHeaders(), Downstream: ds()}).DownstreamRequest())
+	check(t, (&ResponseStreamContext{RequestHeaders: liveRequestHeaders(), Downstream: ds()}).DownstreamRequest())
+}
+
+func TestResponseContexts_UpstreamAccessors(t *testing.T) {
+	liveHeaders := NewHeaders(map[string][]string{"x-src": {"live"}})
+
+	assertSnapshot := func(t *testing.T, ur *UpstreamResponse, hdrs *Headers) {
+		t.Helper()
+		if firstValue(ur.Headers, "x-src") != "snapshot" || ur.StatusCode != 201 {
+			t.Errorf("expected snapshot response, got %+v", ur)
+		}
+		if firstValue(hdrs, "x-src") != "snapshot" {
+			t.Errorf("UpstreamHeaders shortcut did not return snapshot headers")
+		}
+	}
+	assertFallback := func(t *testing.T, ur *UpstreamResponse, hdrs *Headers) {
+		t.Helper()
+		if firstValue(ur.Headers, "x-src") != "live" || ur.StatusCode != 503 {
+			t.Errorf("expected live response, got %+v", ur)
+		}
+		if firstValue(hdrs, "x-src") != "live" {
+			t.Errorf("UpstreamHeaders shortcut did not return live headers")
+		}
+	}
+
+	t.Run("ResponseHeaderContext snapshot", func(t *testing.T) {
+		c := &ResponseHeaderContext{ResponseHeaders: liveHeaders, ResponseStatus: 503, Upstream: &UpstreamResponseContext{Response: snapshotResponse()}}
+		assertSnapshot(t, c.UpstreamResponse(), c.UpstreamHeaders())
+	})
+	t.Run("ResponseHeaderContext fallback", func(t *testing.T) {
+		c := &ResponseHeaderContext{ResponseHeaders: liveHeaders, ResponseStatus: 503}
+		assertFallback(t, c.UpstreamResponse(), c.UpstreamHeaders())
+	})
+
+	t.Run("ResponseContext snapshot", func(t *testing.T) {
+		c := &ResponseContext{ResponseHeaders: liveHeaders, ResponseStatus: 503, Upstream: &UpstreamResponseContext{Response: snapshotResponse()}}
+		assertSnapshot(t, c.UpstreamResponse(), c.UpstreamHeaders())
+	})
+	t.Run("ResponseContext fallback", func(t *testing.T) {
+		c := &ResponseContext{ResponseHeaders: liveHeaders, ResponseStatus: 503}
+		assertFallback(t, c.UpstreamResponse(), c.UpstreamHeaders())
+	})
+
+	t.Run("ResponseStreamContext snapshot", func(t *testing.T) {
+		c := &ResponseStreamContext{ResponseHeaders: liveHeaders, ResponseStatus: 503, Upstream: &UpstreamResponseContext{Response: snapshotResponse()}}
+		assertSnapshot(t, c.UpstreamResponse(), c.UpstreamHeaders())
+	})
+	t.Run("ResponseStreamContext fallback", func(t *testing.T) {
+		c := &ResponseStreamContext{ResponseHeaders: liveHeaders, ResponseStatus: 503}
+		assertFallback(t, c.UpstreamResponse(), c.UpstreamHeaders())
+	})
+}

--- a/sdk/core/policy/v1alpha2/definition.go
+++ b/sdk/core/policy/v1alpha2/definition.go
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
 package policyv1alpha2
 
 // PolicyParameters holds policy configuration with type-safe validated values

--- a/sdk/core/policy/v1alpha2/headers.go
+++ b/sdk/core/policy/v1alpha2/headers.go
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
 package policyv1alpha2
 
 import "strings"

--- a/sdk/core/policy/v1alpha2/interface.go
+++ b/sdk/core/policy/v1alpha2/interface.go
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
 // Package policyv1alpha2 provides the policy interface for the WSO2 API Gateway.
 //
 // Policies declare phase participation via Mode(), which is the authoritative

--- a/sdk/core/policy/v1alpha2/lazy_resource.go
+++ b/sdk/core/policy/v1alpha2/lazy_resource.go
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
 package policyv1alpha2
 
 import (

--- a/sdk/core/policy/v1alpha2/system_parameters.go
+++ b/sdk/core/policy/v1alpha2/system_parameters.go
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
 package policyv1alpha2
 
 const (

--- a/sdk/core/policy/v1alpha2/types.go
+++ b/sdk/core/policy/v1alpha2/types.go
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
 package policyv1alpha2
 
 import "time"

--- a/sdk/core/policyengine/config.go
+++ b/sdk/core/policyengine/config.go
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
 package policyengine
 
 // PolicyChain represents the configuration for a policy chain on a route.

--- a/sdk/core/policyengine/subscription_store.go
+++ b/sdk/core/policyengine/subscription_store.go
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
 package policyengine
 
 import (

--- a/sdk/core/policyengine/subscription_xds.go
+++ b/sdk/core/policyengine/subscription_xds.go
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
 package policyengine
 
 import "time"

--- a/sdk/core/policyengine/upstream.go
+++ b/sdk/core/policyengine/upstream.go
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
 package policyengine
 
 // UpstreamInfo identifies the resolved upstream target for one of an API's

--- a/sdk/core/policyengine/upstream_test.go
+++ b/sdk/core/policyengine/upstream_test.go
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
 package policyengine
 
 import "testing"

--- a/sdk/core/utils/jsonpath.go
+++ b/sdk/core/utils/jsonpath.go
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
 package utils
 
 import (


### PR DESCRIPTION
## Purpose

Reading request/response headers (and now path, method, authority, scheme, status) directly off a policy context is unsafe for auth and gating decisions: the kernel runs every policy's header phase before any body phase against one shared, mutable header set, so a decision that reads the live values can observe a value another policy rewrote — regardless of policy order. The `Downstream`/`Upstream` snapshots carry what the client actually sent and what the upstream actually returned, but reading them correctly requires nil-checks and a fallback to the live values on gateways built before the snapshot feature. That boilerplate was living in individual policies (e.g. jwt-auth's `getDownstreamHeaders`). This PR promotes it into the SDK so every policy can reuse it.

## Goals

Provide first-class, nil-safe accessors on the policy contexts that return the pre-mutation snapshot when available and transparently fall back to the live values otherwise, giving policy authors a single stable shape across gateway versions.

## Approach

- Add `DownstreamRequest()` and a `DownstreamHeaders()` shortcut to the request-phase contexts (`RequestHeaderContext`, `RequestContext`, `RequestStreamContext`).
- Add `DownstreamRequest()`/`DownstreamHeaders()` plus `UpstreamResponse()`/`UpstreamHeaders()` to the response-phase contexts (`ResponseHeaderContext`, `ResponseContext`, `ResponseStreamContext`).
- Each accessor returns the snapshot struct when the gateway provides it, else a snapshot synthesized from the live values, so callers get the same shape on any gateway version.
- Fallback logic lives once in two unexported helpers (`resolveDownstreamRequest`, `resolveUpstreamResponse`); the per-context methods are thin wrappers supplying the right live fields.
- Response-phase contexts have no live `Authority`/`Scheme` to fall back to, so those come from the snapshot only and are empty on pre-snapshot gateways — a graceful degradation, not a regression.
- No consumer (policy) changes in this PR; policies can adopt the accessors when they next bump the SDK dependency.

## User stories

As a policy author, I want a safe, single-call way to read the original client request (and upstream response) values so my auth/gating logic never observes another policy's in-place mutations.

## Documentation

N/A — internal SDK helper additions with no user-facing API surface; behaviour is documented in the accessors' godoc.

## Automation tests
 - Unit tests
   > Added `context_accessors_test.go` covering the snapshot-extraction helpers (`downstreamSnapshot`/`upstreamSnapshot`: snapshot-present returns the snapshot as-is, nil when the context or its Request/Response is nil) and every context wrapper across both request- and response-phase contexts — the snapshot path and the live-fallback path, the `DownstreamHeaders`/`UpstreamHeaders` shortcuts, nil-safe reads when the fallback headers are nil, and the response-phase gap where `Authority`/`Scheme` have no live source (empty on fallback). All pass with `go vet` clean.
 - Integration tests
   > N/A — no behavioural change to any running gateway; policies are unchanged.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no — Go SDK change; FindSecurityBugs is a Java/SpotBugs tool and does not apply.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

N/A

## Test environment

`go build`/`go vet` on the `sdk` module (Go workspace, darwin/arm64).

## Related Issues

N/A

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
