### PR TITLE
Disable admin server by default across configurations and allow only for tests

### DIFF
--- a/gateway/configs/config-template.toml
+++ b/gateway/configs/config-template.toml
@@ -14,8 +14,8 @@ shutdown_timeout = "15s"
 gateway_id = '{{ env "APIP_GW_CONTROLLER_SERVER_GATEWAY_ID" "platform-gateway-id" }}'
 
 [controller.admin_server]
-# Dedicated admin/debug HTTP server for config dump and xDS sync endpoints
-enabled = true
+# Dedicated admin/debug HTTP server for config dump and xDS sync endpoints.
+enabled = false
 port = 9092
 allowed_ips = ["*"]
 

--- a/gateway/gateway-controller/pkg/config/config.go
+++ b/gateway/gateway-controller/pkg/config/config.go
@@ -824,8 +824,9 @@ func defaultConfig() *Config {
 				GatewayID:                       constants.PlatformGatewayId,
 				SkipInvalidDeploymentsOnStartup: false,
 			},
+			// The admin server exposes configuration and xDS state
 			AdminServer: AdminServerConfig{
-				Enabled:    true,
+				Enabled:    false,
 				Port:       9092,
 				AllowedIPs: []string{"*"},
 				Pprof: PprofConfig{

--- a/gateway/gateway-controller/pkg/config/config_test.go
+++ b/gateway/gateway-controller/pkg/config/config_test.go
@@ -740,7 +740,12 @@ func TestConfig_Validate_RouterListenerPort(t *testing.T) {
 
 func TestDefaultConfig_AdminServerDefaults(t *testing.T) {
 	cfg := defaultConfig()
-	assert.True(t, cfg.Controller.AdminServer.Enabled)
+	// The admin server exposes configuration and xDS state and applies no
+	// authentication of its own, so it must stay off unless an operator enables
+	// it deliberately. This assertion is the guard against that default being
+	// flipped back.
+	assert.False(t, cfg.Controller.AdminServer.Enabled,
+		"the admin/debug server must be disabled by default")
 	assert.Equal(t, 9092, cfg.Controller.AdminServer.Port)
 	assert.Equal(t, []string{"*"}, cfg.Controller.AdminServer.AllowedIPs)
 }

--- a/gateway/it/test-config.toml
+++ b/gateway/it/test-config.toml
@@ -73,6 +73,16 @@ deployment_sync_enabled = '{{ env "APIP_GW_CONTROLLER_CONTROLPLANE_DEPLOYMENT_SY
 # Faster poll interval for test responsiveness (default: 3s)
 poll_interval = "200ms"
 
+# The admin/debug server is off by default (see pkg/config/config.go). The
+# config-dump, startup-db-bootstrap and metrics features exercise its endpoints,
+# so the test stack opts in explicitly. allowed_ips stays permissive here because
+# the suite reaches the published port from the host, not from loopback inside
+# the container.
+[controller.admin_server]
+enabled = true
+port = 9092
+allowed_ips = ["*"]
+
 [controller.auth.basic]
 enabled = true
 

--- a/kubernetes/helm/gateway-helm-chart/values.yaml
+++ b/kubernetes/helm/gateway-helm-chart/values.yaml
@@ -78,12 +78,9 @@ gateway:
         # deployment fails startup loudly so the issue can't go unnoticed.
         skip_invalid_deployments_on_startup: false
 
-      # Dedicated admin/debug HTTP server (config dump, xDS sync status). Already
-      # effectively active today even though this block was previously absent from
-      # config.toml — see defaultConfig() in pkg/config/config.go. Adding it here
-      # only makes the existing implicit default explicit and overridable.
+      # Dedicated admin/debug HTTP server (config dump, xDS sync status).
       admin_server:
-        enabled: true
+        enabled: false
         port: 9092
         allowed_ips: ["*"]
         pprof:


### PR DESCRIPTION
## Purpose
$subject
