### PR TITLE
Add subType metadata to API event and ensure consistency with apiType

### DIFF
--- a/gateway/gateway-runtime/policy-engine/internal/analytics/publishers/moesif.go
+++ b/gateway/gateway-runtime/policy-engine/internal/analytics/publishers/moesif.go
@@ -193,6 +193,8 @@ func (m *Moesif) Publish(event *dto.Event) {
 	metadataMap["apiName"] = event.API.APIName
 	metadataMap["apiVersion"] = event.API.APIVersion
 	metadataMap["apiType"] = event.API.APIType
+	// subType mirrors apiType
+	metadataMap["subType"] = event.API.APIType
 	metadataMap["apiId"] = event.API.APIID
 	metadataMap["projectId"] = event.API.ProjectID
 

--- a/gateway/gateway-runtime/policy-engine/internal/analytics/publishers/moesif_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/analytics/publishers/moesif_test.go
@@ -509,6 +509,25 @@ func TestPublish_MetadataContainsAPIInfo(t *testing.T) {
 	assert.Equal(t, "test-api", metadata["apiName"])
 	assert.Equal(t, "v1.0", metadata["apiVersion"])
 	assert.Equal(t, "Rest", metadata["apiType"])
+	assert.Equal(t, "Rest", metadata["subType"])
 	assert.Equal(t, "api-123", metadata["apiId"])
 	assert.Equal(t, "project-123", metadata["projectId"])
+}
+
+// Test that the subType in metadata mirrors the APIType for various API types.
+func TestPublish_SubTypeMirrorsAPIType(t *testing.T) {
+	for _, apiType := range []string{"Rest", "LlmProvider", "LlmProxy", "Mcp"} {
+		t.Run(apiType, func(t *testing.T) {
+			moesif := createTestMoesifWithoutAPI()
+
+			event := createBaseEvent()
+			event.API.APIType = apiType
+			moesif.Publish(event)
+
+			assert.Len(t, moesif.events, 1)
+			metadata := getMetadata(moesif.events[0])
+			assert.Equal(t, apiType, metadata["subType"])
+			assert.Equal(t, metadata["apiType"], metadata["subType"])
+		})
+	}
 }


### PR DESCRIPTION
## Purpose
Include a `subType` field in the metadata published to Moesif for API analytics events. It mirrors the existing `apiType` value, keeping the two consistent so downstream analytics can rely on `subType` alongside `apiType`.

Resolves:https://github.com/wso2/api-platform/issues/2930

