### PR TITLE
Enhance API settings with managed label picker and submission

### DIFF
--- a/portals/developer-portal/src/controllers/viewConfigureController.js
+++ b/portals/developer-portal/src/controllers/viewConfigureController.js
@@ -123,6 +123,7 @@ const loadSettingsPage = async (req, res) => {
             apiStatus: api.status,
             productionUrl: api.production_url,
             sandboxUrl: api.sandbox_url,
+            labels: (api.dp_labels || []).map(label => label.handle),
             tags: (api.dp_tags || []).map(tag => tag.name),
             agentVisibility: api.agent_visibility,
             subscriptionPlans: (api.dp_subscription_plans || []).map(p => p.display_name),

--- a/portals/developer-portal/src/pages/settings/partials/cfg-apis-panel.hbs
+++ b/portals/developer-portal/src/pages/settings/partials/cfg-apis-panel.hbs
@@ -221,7 +221,22 @@
               <p class="cfg-form-section-title">Labels &amp; Visibility</p>
               <div class="cfg-form-grid">
                 <div class="cfg-form-group cfg-form-group-full">
-                  <label for="wz-tags">Labels</label>
+                  <label>Labels</label>
+                  {{#if orgLabels.length}}
+                  <div id="wz-labels" class="cfg-label-picker" role="group" aria-label="API labels">
+                    {{#orgLabels}}
+                    <button type="button" class="cfg-label-toggle" data-value="{{id}}" aria-pressed="false">
+                      <i class="bi bi-check2"></i><span>{{displayName}}</span>
+                    </button>
+                    {{/orgLabels}}
+                  </div>
+                  <p class="cfg-field-hint">APIs appear in views that use any of the selected labels.</p>
+                  {{else}}
+                  <p class="cfg-field-hint">No labels yet — create labels in Manage Labels before attaching them to an API.</p>
+                  {{/if}}
+                </div>
+                <div class="cfg-form-group cfg-form-group-full">
+                  <label for="wz-tags">Tags</label>
                   <input type="text" id="wz-tags" class="cfg-form-input" placeholder="booking, travel  (comma separated)" />
                 </div>
                 <div class="cfg-form-group">

--- a/portals/developer-portal/src/scripts/settings-apis.js
+++ b/portals/developer-portal/src/scripts/settings-apis.js
@@ -59,6 +59,35 @@
   function sv(id,val){ var e=document.getElementById(id); if(e) e.value=val||''; }
   function sel(id,val){ var e=document.getElementById(id); if(e) e.value=val; }
 
+  /* Managed labels control which views include an API. */
+  var labelPicker = document.getElementById('wz-labels');
+  if (labelPicker) {
+    labelPicker.addEventListener('click', function(e) {
+      var chip = e.target.closest('.cfg-label-toggle');
+      if (!chip) return;
+      var selected = chip.getAttribute('aria-pressed') === 'true';
+      chip.setAttribute('aria-pressed', selected ? 'false' : 'true');
+      chip.classList.toggle('selected', !selected);
+    });
+  }
+  function setSelectedLabels(labels) {
+    if (!labelPicker) return;
+    var selected = Object.create(null);
+    (labels || []).forEach(function(label) { selected[label] = true; });
+    labelPicker.querySelectorAll('.cfg-label-toggle').forEach(function(chip) {
+      var isSelected = !!selected[chip.dataset.value];
+      chip.setAttribute('aria-pressed', isSelected ? 'true' : 'false');
+      chip.classList.toggle('selected', isSelected);
+    });
+  }
+  function selectedLabels() {
+    if (!labelPicker) return [];
+    return Array.prototype.map.call(
+      labelPicker.querySelectorAll('.cfg-label-toggle[aria-pressed="true"]'),
+      function(chip) { return chip.dataset.value; }
+    );
+  }
+
   /* type-color map */
   var typeMap = {
     RestApi:   { av:'cfg-api-avatar--rest',    tb:'cfg-type-badge--rest',    label:'REST' },
@@ -239,6 +268,7 @@
       sel('wz-type',      api.apiType);
       sel('wz-status',    api.apiStatus === 'DEPRECATED' ? 'DEPRECATED' : 'PUBLISHED');
       sv('wz-desc',       api.apiDescription);
+      setSelectedLabels(api.labels || []);
       sv('wz-tags',       (api.tags && api.tags.length) ? (Array.isArray(api.tags) ? api.tags.join(', ') : api.tags) : '');
       sv('wz-prod',       api.productionUrl);
       sv('wz-sandbox',    api.sandboxUrl);
@@ -257,6 +287,9 @@
       editingId = null;
       document.getElementById('cfg-wizard-title').textContent = isMcp ? 'Add MCP Server' : 'Add API';
       ['wz-name','wz-version','wz-handle','wz-desc','wz-tags','wz-prod','wz-sandbox','wz-tech-owner','wz-tech-email','wz-biz-owner','wz-biz-email'].forEach(function(id){ sv(id,''); });
+      // Keep the API visible in the standard view unless the admin chooses
+      // a different set of managed labels.
+      setSelectedLabels(['default']);
       sel('wz-type', isMcp ? 'Mcp' : 'RestApi'); sel('wz-status','PUBLISHED');
       agentVis = 'Visible';
       document.getElementById('wz-vis-visible').classList.add('active');
@@ -347,6 +380,7 @@
       type:        document.getElementById('wz-type').value,
       status:      document.getElementById('wz-status').value,
       description: v('wz-desc'),
+      labels:         selectedLabels(),
       tags:           v('wz-tags') ? v('wz-tags').split(',').map(function(t){return t.trim();}).filter(Boolean) : [],
       agentVisibility: agentVis,
       owners: {


### PR DESCRIPTION
## Purpose

APIs configured with labels through **Admin Settings → APIs** were not associated with the managed labels used by Developer Portal Views. The existing field was labelled “Labels” but submitted its values as API tags, so APIs did not appear in Views configured with the corresponding labels.

Resolves #2966 

## Goals

- Allow administrators to associate APIs with existing managed labels.
- Ensure labelled APIs appear in Views configured with matching labels.
- Clearly distinguish managed labels from free-form API tags.
- Preserve API label selections when editing an API.

## Approach

- Added a managed-label picker to the API create/edit wizard.
- Loaded existing API label mappings into the settings-page API data.
- Restored selected labels when editing an API.
- Included selected labels in API create and update requests.
- Renamed the existing comma-separated field to **Tags** to avoid confusion.
- Selected the `default` label initially for newly created APIs.

**UI screenshot/GIF:** To be attached to the PR.

## User stories

- As an administrator, I can assign managed labels to an API.
- As an administrator, I can see and update an API’s existing label assignments.
- As a portal user, I can see APIs in Views whose labels match the API’s assigned labels.
- As an administrator, I can distinguish API tags from labels used for View visibility.

## Documentation

N/A — this fixes existing Developer Portal behaviour and clarifies the existing UI without introducing new product concepts or APIs.

## Automation tests

- Unit tests
  - All 40 Developer Portal unit tests passed.
  - Code coverage was not measured as part of this change.

- Integration tests
  - Existing integration tests cover API label mappings and label-based View filtering.
  - The integration test suite was not executed locally for this change.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **Yes**
- Ran FindSecurityBugs plugin and verified report? **No — not applicable to this JavaScript/UI-only change**
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **Yes**

## Samples

N/A — no samples are required for this bug fix.

## Related PRs

N/A

## Test environment

- JDK: N/A
- Operating system: macOS 26.5.2
- Node.js: 24.6.0
- npm: 11.5.1
- Database: N/A for the executed unit tests
- Browser: No manual browser testing performed