### PR TITLE
test(gateway/it): add test scenarios for token-based rate limiting fixes

### DIFF
--- a/gateway/build-manifest.yaml
+++ b/gateway/build-manifest.yaml
@@ -25,7 +25,7 @@ policies:
       version: v1.0.3
       gomodule: github.com/wso2/gateway-controllers/policies/basic-auth@v1
     - name: basic-ratelimit
-      version: v1.1.0
+      version: v1.1.1
       gomodule: github.com/wso2/gateway-controllers/policies/basic-ratelimit@v1
     - name: content-length-guardrail
       version: v1.0.1
@@ -55,7 +55,7 @@ policies:
       version: v1.1.0
       gomodule: github.com/wso2/gateway-controllers/policies/llm-cost@v1
     - name: llm-cost-based-ratelimit
-      version: v1.1.0
+      version: v1.1.1
       gomodule: github.com/wso2/gateway-controllers/policies/llm-cost-based-ratelimit@v1
     - name: llm-header-router
       version: v0.9.0
@@ -67,13 +67,13 @@ policies:
       version: v1.0.3
       gomodule: github.com/wso2/gateway-controllers/policies/mcp-acl-list@v1
     - name: mcp-auth
-      version: v1.1.2
+      version: v1.2.0
       gomodule: github.com/wso2/gateway-controllers/policies/mcp-auth@v1
     - name: mcp-authz
       version: v1.1.0
       gomodule: github.com/wso2/gateway-controllers/policies/mcp-authz@v1
     - name: mcp-ratelimit
-      version: v1.1.0
+      version: v1.1.1
       gomodule: github.com/wso2/gateway-controllers/policies/mcp-ratelimit@v1
     - name: mcp-rewrite
       version: v1.0.3
@@ -148,7 +148,7 @@ policies:
       version: v1.0.3
       gomodule: github.com/wso2/gateway-controllers/policies/subscription-validation@v1
     - name: token-based-ratelimit
-      version: v1.1.0
+      version: v1.1.1
       gomodule: github.com/wso2/gateway-controllers/policies/token-based-ratelimit@v1
     - name: url-guardrail
       version: v1.0.1

--- a/gateway/it/features/token-based-ratelimit.feature
+++ b/gateway/it/features/token-based-ratelimit.feature
@@ -1717,3 +1717,180 @@ Feature: Token-Based Rate Limiting
     Then the response status code should be 200
     When I delete the LLM provider template "completion-only-empty-limits-template"
     Then the response status code should be 200
+
+  Scenario: Provider-wide total token quota charges actual token usage and is shared across resources
+    # Anthropic's Messages API response has no total-token field, so the built-in "anthropic"
+    # template defines only promptTokens/completionTokens. The total_tokens quota must fall
+    # back to summing them (50 input + 25 output = 75) instead of charging a flat 1 per request.
+    # Attached provider-wide (globalPolicies), the quota must also be shared across every
+    # resource of the provider, not siloed per path.
+    Given I authenticate using basic auth as "admin"
+    When I create this LLM provider:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: LlmProvider
+      metadata:
+        name: prov-wide-anthropic-provider
+      spec:
+        displayName: Provider Wide Anthropic Provider
+        version: v1.0
+        context: /prov-wide-anthropic
+        template: anthropic
+        upstream:
+          url: http://mock-openapi:4010
+          auth:
+            type: api-key
+            header: Authorization
+            value: test-key
+        accessControl:
+          mode: allow_all
+        globalPolicies:
+          - name: token-based-ratelimit
+            version: v1
+            params:
+              totalTokenLimits:
+                - count: 75
+                  duration: "1h"
+      """
+    Then the response status code should be 201
+    And I wait for 2 seconds
+    And I wait for policy snapshot sync
+
+    Given I set header "Content-Type" to "application/json"
+
+    # Consumes 75 tokens (50 input + 25 output) of the 75-token quota — remaining hits 0.
+    # Before the fix, this would charge 1 and leave remaining at 74.
+    When I send a POST request to "http://localhost:8080/prov-wide-anthropic/anthropic/v1/messages" with body:
+      """ json
+      {"model": "claude-3-5-haiku-20241022", "messages": [{"role": "user", "content": "Hello"}], "max_tokens": 100}
+      """
+    Then the response status code should be 200
+    And the response header "X-Ratelimit-Remaining" should be "0"
+
+    # Quota is already exhausted — blocked at the pre-flight check before reaching upstream.
+    When I send a POST request to "http://localhost:8080/prov-wide-anthropic/anthropic/v1/messages" with body:
+      """ json
+      {"model": "claude-3-5-haiku-20241022", "messages": [{"role": "user", "content": "Hello"}], "max_tokens": 100}
+      """
+    Then the response status code should be 429
+
+    # KEY ASSERTION: a DIFFERENT resource on the same provider is also blocked — proves the
+    # quota is one shared apiname-keyed bucket, not an independent per-route bucket.
+    When I send a POST request to "http://localhost:8080/prov-wide-anthropic/anthropic/v1/messages-web-search" with body:
+      """ json
+      {"model": "claude-3-5-haiku-20241022", "messages": [{"role": "user", "content": "search"}], "max_tokens": 100}
+      """
+    Then the response status code should be 429
+
+    # Cleanup
+    Given I authenticate using basic auth as "admin"
+    When I delete the LLM provider "prov-wide-anthropic-provider"
+    Then the response status code should be 200
+
+  Scenario: Total token quota does not double-count when the template already defines totalTokens
+    # Regression guard: the "mistralai" built-in template defines promptTokens, completionTokens,
+    # AND totalTokens. The total_tokens quota must be charged from totalTokens alone (150) —
+    # never the sum of all three (300) — so templates that already worked correctly are not
+    # broken by the fallback added for templates like Anthropic that have no totalTokens.
+    Given I authenticate using basic auth as "admin"
+    When I create this LLM provider:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: LlmProvider
+      metadata:
+        name: prov-wide-mistral-provider
+      spec:
+        displayName: Provider Wide Mistral Provider
+        version: v1.0
+        context: /prov-wide-mistral
+        template: mistralai
+        upstream:
+          url: http://mock-openapi:4010
+          auth:
+            type: api-key
+            header: Authorization
+            value: test-key
+        accessControl:
+          mode: allow_all
+        globalPolicies:
+          - name: token-based-ratelimit
+            version: v1
+            params:
+              totalTokenLimits:
+                - count: 1000
+                  duration: "1h"
+      """
+    Then the response status code should be 201
+    And I wait for 2 seconds
+    And I wait for policy snapshot sync
+
+    Given I set header "Content-Type" to "application/json"
+
+    # 100 prompt + 50 completion = 150 total_tokens. If double-counted (150+100+50=300),
+    # remaining would be 700 instead of 850.
+    When I send a POST request to "http://localhost:8080/prov-wide-mistral/mistral/v1/chat/completions" with body:
+      """ json
+      {"model": "mistral-small-latest", "messages": [{"role": "user", "content": "Hello"}]}
+      """
+    Then the response status code should be 200
+    And the response header "X-Ratelimit-Remaining" should be "850"
+
+    # Cleanup
+    Given I authenticate using basic auth as "admin"
+    When I delete the LLM provider "prov-wide-mistral-provider"
+    Then the response status code should be 200
+
+  Scenario: Consumer-level total token quota also charges actual token usage, not a flat 1 per request
+    Given I authenticate using basic auth as "admin"
+    When I create this LLM provider:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: LlmProvider
+      metadata:
+        name: consumer-anthropic-provider
+      spec:
+        displayName: Consumer Anthropic Provider
+        version: v1.0
+        context: /consumer-anthropic
+        template: anthropic
+        upstream:
+          url: http://mock-openapi:4010
+          auth:
+            type: api-key
+            header: Authorization
+            value: test-key
+        accessControl:
+          mode: allow_all
+        policies:
+          - name: token-based-ratelimit
+            version: v1
+            paths:
+              - path: /*
+                methods: ['*']
+                params:
+                  totalTokenLimits:
+                    - count: 1000
+                      duration: "1h"
+                  algorithm: fixed-window
+                  backend: memory
+                  consumerBased: true
+      """
+    Then the response status code should be 201
+    And I wait for 2 seconds
+    And I wait for policy snapshot sync
+
+    Given I set header "Content-Type" to "application/json"
+
+    # 50 input + 25 output = 75 tokens consumed of the 1000-token quota — remaining is 925.
+    # Before the fix, this would charge 1 and leave remaining at 999.
+    When I send a POST request to "http://localhost:8080/consumer-anthropic/anthropic/v1/messages" with body:
+      """ json
+      {"model": "claude-3-5-haiku-20241022", "messages": [{"role": "user", "content": "Hello"}], "max_tokens": 100}
+      """
+    Then the response status code should be 200
+    And the response header "X-Ratelimit-Remaining" should be "925"
+
+    # Cleanup
+    Given I authenticate using basic auth as "admin"
+    When I delete the LLM provider "consumer-anthropic-provider"
+    Then the response status code should be 200


### PR DESCRIPTION
## Purpose

- Related gateway-controllers policy PR: https://github.com/wso2/gateway-controllers/pull/260
- Resolves: https://github.com/wso2/api-platform/issues/2932

Companion test-only PR for the fix in [`wso2/gateway-controllers#260`](https://github.com/wso2/gateway-controllers/pull/260), which fixes a provider-wide Token Count rate limit charging 1 per request instead of the actual token count reported by the response.

---

## What's added

Three new integration test scenarios in `gateway/it/features/token-based-ratelimit.feature`:

1. **Provider-Wide Quota Charge Accuracy & Sharing**: Uses the built-in `anthropic` template (which lacks a `totalTokens` field), attaches the policy via `globalPolicies`, and asserts the quota charges the real token count (50 input + 25 output = 75) shared across two different resources of the same provider.
2. **Double-Counting Regression Guard**: Uses the built-in `mistralai` template (which defines `promptTokens`, `completionTokens`, AND `totalTokens`), asserting the quota charges from `totalTokens` alone rather than summing all three fields.
3. **Consumer-Level Quota Charge Accuracy**: Validates exact token charge calculations at the per-consumer (`consumerBased: true`, operation-level) attachment layer.

---

## Testing

Verified end-to-end locally using the standard dev-policies override workflow (`gateway/dev-policies/`):

* **Pre-fix (RED)**: Provider-wide and consumer-level scenarios failed as expected (`X-Ratelimit-Remaining` showed `74`/`999` instead of `0`/`925`), while the `mistralai` regression-guard scenario passed.
* **Post-fix (GREEN)**: All 23 scenarios in `token-based-ratelimit.feature` passed cleanly.
* **Collateral Check**: All 39 scenarios across `llm-provider-global-ratelimit.feature` and `llm-cost-based-ratelimit.feature` passed, confirming the `apiname` keying change in the controller fix has no adverse impacts on sibling policies.