### PR TITLE
[Devportal] Support repeatable --config flag

### DIFF
--- a/portals/developer-portal/configs/config-template.toml
+++ b/portals/developer-portal/configs/config-template.toml
@@ -6,9 +6,15 @@
 # concrete file this project actually ships, which wires some of these same
 # keys up to environment variables using the syntax below.
 #
+# Config files are loaded via a required, repeatable `--config <path>` flag —
+# at least one is mandatory (no default path, no silent-defaults fallback), and
+# passing it more than once layers overlays with last-wins precedence. Nested
+# tables deep-merge; list/array values are replaced wholesale by a later file.
+#
 # Precedence (lowest to highest):
 #   1. Built-in defaults (src/config/configDefaults.js)
-#   2. configs/config.toml, with any {{ env }} / {{ file }} references resolved
+#   2. The merged --config files, with any {{ env }} / {{ file }} references
+#      resolved once after the merge
 #
 # There is no automatic environment-variable override. A key's value comes
 # from an env var or a file ONLY if you explicitly say so, using Handlebars-

--- a/portals/developer-portal/configs/config.toml
+++ b/portals/developer-portal/configs/config.toml
@@ -4,9 +4,21 @@
 # see configs/config-template.toml for the full list of available keys and
 # their default values.
 #
+# This file is loaded via a required, repeatable `--config <path>` flag (the JS
+# counterpart to the Go components' `-config`) — e.g. the container entrypoint
+# runs `node src/server.js --config /app/configs/config.toml`. At least one
+# --config is mandatory: there is no default path and no silent fallback to the
+# built-in defaults. Pass --config more than once to layer thin overlays over a
+# base file; later files override earlier ones, key by key.
+#
 # Precedence (lowest to highest):
 #   1. Built-in defaults (src/config/configDefaults.js)
-#   2. This file, with any {{ env }} / {{ file }} references resolved
+#   2. The merged --config files (this file, plus any later overlays), with any
+#      {{ env }} / {{ file }} references resolved once after the merge
+#
+# Merge semantics when layering multiple --config files: nested tables
+# deep-merge, but list/array values are REPLACED wholesale — an overlay that
+# sets a list key replaces the base list rather than appending to it.
 #
 # There is no automatic APIP_DP_* environment-variable override — an env var (or
 # a mounted file) only takes effect where a key below explicitly references it,
@@ -34,9 +46,10 @@
 # e.g. server.https.enabled defaults to true here (a real cert is bind-mounted at
 # /etc/devportal/tls) vs. false in configDefaults.js (no cert available for a
 # bare `npm start`). configDefaults.js's DEFAULTS only take effect for keys this
-# file doesn't list at all (idp, organization, uploads, etc.), or if this file
-# itself were absent entirely (e.g. the packaged `pkg` binary run standalone) —
-# see configDefaults.js's own comment for why its values stay generic.
+# file doesn't list at all (idp, organization, uploads, etc.). A config file is
+# always required, so DEFAULTS never drive the app on their own — they only fill
+# the gaps for keys no --config file sets. See configDefaults.js's own comment
+# for why its values stay generic.
 #
 # Running locally without Docker? Use `npm run start:local` instead of
 # `npm start` (package.json) — it overrides server.https.enabled and auth.local.* to

--- a/portals/developer-portal/docker-entrypoint.sh
+++ b/portals/developer-portal/docker-entrypoint.sh
@@ -23,6 +23,13 @@ set -e
 CERT_DIR=/etc/devportal/tls
 TLS_ENABLED="${APIP_DP_SERVER_HTTPS_ENABLED:-false}"
 
+# The server now requires an explicit --config (repeatable, last-wins) — there is
+# no default path and no silent-defaults fallback. The base config is mounted at
+# /app/configs/config.toml (docker-compose bind mount / helm configMap). Override
+# the base path with APIP_DP_CONFIG_PATH, and append overlay files by passing
+# extra `--config <path>` arguments to the container (forwarded via "$@" below).
+CONFIG_PATH="${APIP_DP_CONFIG_PATH:-/app/configs/config.toml}"
+
 # Fail closed: certificates are generated once by ./setup.sh (host-side, into a
 # bind-mounted directory), never here. Startup only checks that they exist —
 # it never generates a fallback, matching every other required secret.
@@ -34,4 +41,4 @@ if [ "$TLS_ENABLED" = "true" ]; then
   echo "[entrypoint] TLS certificate found at $CERT_DIR"
 fi
 
-exec node src/server.js
+exec node src/server.js --config "$CONFIG_PATH" "$@"

--- a/portals/developer-portal/package.json
+++ b/portals/developer-portal/package.json
@@ -4,9 +4,9 @@
   "description": "WSO2 API Platform Developer Portal",
   "main": "src/server.js",
   "scripts": {
-    "start": "npm rebuild better-sqlite3 --ignore-scripts=false && NODE_ENV=development nodemon src/server.js",
+    "start": "npm rebuild better-sqlite3 --ignore-scripts=false && NODE_ENV=development nodemon src/server.js --config configs/config.toml",
     "start:local": "APIP_DP_SERVER_HTTPS_ENABLED=false APIP_DP_AUTH_LOCAL_PLATFORM_API_URL=https://localhost:9243 APIP_DP_AUTH_LOCAL_TLS_SKIP_VERIFY=true APIP_DP_AUTH_LOCAL_PUBLIC_KEY_PATH=./resources/keys/jwt_public.pem APIP_DP_DATABASE_PATH=./devportal.db npm run start",
-    "debug": "nodemon --inspect src/server.js",
+    "debug": "nodemon --inspect src/server.js --config configs/config.toml",
     "test": "node --test 'src/**/*.test.js'",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"

--- a/portals/developer-portal/src/config/configLoader.js
+++ b/portals/developer-portal/src/config/configLoader.js
@@ -23,6 +23,7 @@ const fs = require('fs');
 const toml = require('smol-toml');
 const Handlebars = require('handlebars');
 const { DEFAULTS } = require('./configDefaults');
+const { snakeToCamelDeep, mergeOver, parseConfigPaths } = require('./configMerge');
 
 // Load api-platform.env if present (silently ignored if absent)
 try {
@@ -30,45 +31,42 @@ try {
 } catch (_) {}
 
 /**
- * Recursively convert snake_case keys to camelCase (e.g. "base_url" -> "baseUrl").
- * Applied to the parsed TOML tree so config.toml can use snake_case while the
- * in-code struct and every consumer use camelCase.
- */
-function snakeToCamel(key) {
-    return key.replace(/_([a-z0-9])/g, (_, c) => c.toUpperCase());
-}
-
-function snakeToCamelDeep(value) {
-    if (Array.isArray(value)) {
-        return value.map(snakeToCamelDeep);
-    }
-    if (value !== null && typeof value === 'object') {
-        const out = {};
-        for (const [k, v] of Object.entries(value)) {
-            out[snakeToCamel(k)] = snakeToCamelDeep(v);
-        }
-        return out;
-    }
-    return value;
-}
-
-/**
- * Load configs/config.toml (snake_case), converted to camelCase.
- * Returns an empty object if the file does not exist, so DEFAULTS alone can
- * drive the app.
+ * Load and deep-merge one or more config.toml files, in the order given, with
+ * last-wins precedence — the layered pattern the Go components already use via a
+ * repeatable `-config` flag. Nested tables deep-merge; list/array values are
+ * replaced wholesale (see mergeOver in configMerge.js). Interpolation of
+ * {{ env }} / {{ file }} tokens is deliberately NOT done here — it runs once on
+ * the fully merged tree (see below), so a token declared in a base file can be
+ * overridden by a later overlay before either is resolved.
  *
  * Every key lives under the single [developer_portal] table. That wrapper is
  * unwrapped here so the in-code config tree stays flat (config.server,
  * config.security, …); anything outside the [developer_portal] table is ignored.
+ *
+ * There is NO silent fallback: a missing, unreadable, or unparseable file throws
+ * — the module bootstrap turns that into a fatal, non-zero exit at startup
+ * rather than booting on pure built-in DEFAULTS.
  */
-function loadTomlConfig() {
-    const tomlPath = path.join(process.cwd(), 'configs', 'config.toml');
-
-    if (fs.existsSync(tomlPath)) {
-        const raw = fs.readFileSync(tomlPath, 'utf8');
-        return snakeToCamelDeep(toml.parse(raw)).developerPortal || {};
+function loadConfigFiles(paths) {
+    let merged = {};
+    for (const p of paths) {
+        const resolvedPath = path.resolve(p);
+        let raw;
+        try {
+            raw = fs.readFileSync(resolvedPath, 'utf8');
+        } catch (err) {
+            throw new Error(`config file "${p}" could not be read: ${err.message}`);
+        }
+        let parsed;
+        try {
+            parsed = toml.parse(raw);
+        } catch (err) {
+            throw new Error(`config file "${p}" is not valid TOML: ${err.message}`);
+        }
+        const tree = snakeToCamelDeep(parsed).developerPortal || {};
+        merged = mergeOver(merged, tree);
     }
-    return {};
+    return merged;
 }
 
 // ---------------------------------------------------------------------------
@@ -270,41 +268,63 @@ function interpolateTree(value, fieldPath) {
     return interpolateLeaf(value, fieldPath);
 }
 
-/**
- * Prototype-pollution guard, applied to the DEFAULTS<-config.toml merge below.
- */
-const BLOCKED_KEYS = new Set(['__proto__', 'prototype', 'constructor']);
+// ---------------------------------------------------------------------------
+// Startup config resolution
+// ---------------------------------------------------------------------------
+//
+// Resolved once, at module load, from the repeatable `--config` flag — the JS
+// counterpart to the Go components' `-config`. At least one `--config` is
+// REQUIRED: there is no default path and no silent fallback to built-in
+// DEFAULTS. Because env vars reach config only through explicit {{ env }} tokens
+// in a file (there is no APIP_DP_* env-prefix provider), a missing config file
+// means "running on pure built-in defaults" — unacceptable for a portal handling
+// auth/session/secret config, so it fails fast with a non-zero exit here, before
+// the server binds. process.exit is used (not a thrown error) because the logger
+// is not yet initialised and several consumers require this module for its side
+// effect of producing a ready `config`.
 
-/**
- * Deep-merge src into dst (src wins on conflicts) — used to layer the
- * interpolated config.toml tree over a clone of DEFAULTS.
- */
-function mergeOver(dst, src) {
-    for (const [k, v] of Object.entries(src)) {
-        if (BLOCKED_KEYS.has(k)) continue;
-        if (v !== null && typeof v === 'object' && !Array.isArray(v) &&
-            dst[k] !== null && typeof dst[k] === 'object' && !Array.isArray(dst[k])) {
-            mergeOver(dst[k], v);
-        } else {
-            dst[k] = v;
-        }
-    }
-    return dst;
+function fatalConfig(message) {
+    // logger is not yet initialised at this point — write to stderr directly.
+    process.stderr.write(`[FATAL] ${message}\n`);
+    process.exit(1);
 }
 
-const rawTomlConfig = loadTomlConfig();
+let configPaths;
+try {
+    configPaths = parseConfigPaths(process.argv.slice(2));
+} catch (err) {
+    fatalConfig(err.message);
+}
 
+if (configPaths.length === 0) {
+    fatalConfig(
+        'no configuration file provided. Pass at least one --config <path> ' +
+        '(repeatable; later files override earlier ones, key by key), e.g. ' +
+        '--config configs/config.toml. There is no default path and no ' +
+        'silent-defaults fallback.'
+    );
+}
+
+let rawTomlConfig;
+try {
+    rawTomlConfig = loadConfigFiles(configPaths);
+} catch (err) {
+    fatalConfig(err.message);
+}
+
+// {{ env }} / {{ file }} interpolation runs ONCE, here, on the fully merged tree
+// — after every --config file has been layered — so a token can be declared in a
+// base file and left in place (or overridden) by a later overlay before it is
+// resolved.
 let interpolatedTomlConfig;
 try {
     interpolatedTomlConfig = interpolateTree(rawTomlConfig, '');
 } catch (err) {
-    // Use process.stderr directly — logger is not yet initialised at this point
-    process.stderr.write(`[FATAL] ${err.message}\n`);
-    process.exit(1);
+    fatalConfig(err.message);
 }
 
-// Precedence: DEFAULTS (source of truth) → configs/config.toml, with {{ env }}/
-// {{ file }} references resolved before the merge.
+// Precedence: DEFAULTS (source of truth) → merged --config files, with {{ env }}/
+// {{ file }} references resolved before this final merge.
 const config = mergeOver(JSON.parse(JSON.stringify(DEFAULTS)), interpolatedTomlConfig);
 
 if (fieldCount > 0) {

--- a/portals/developer-portal/src/config/configLoader.js
+++ b/portals/developer-portal/src/config/configLoader.js
@@ -66,6 +66,17 @@ function loadConfigFiles(paths) {
         const tree = snakeToCamelDeep(parsed).developerPortal || {};
         merged = mergeOver(merged, tree);
     }
+    // Every --config file layered and nothing came out: no file carried a
+    // [developer_portal] table at all. Returning {} here would boot on pure
+    // built-in DEFAULTS — the exact silent fallback this loader exists to
+    // prevent — so fail here, where the cause is still nameable.
+    if (Object.keys(merged).length === 0) {
+        throw new Error(
+            `config file(s) ${paths.map(p => `"${p}"`).join(', ')} produced an empty ` +
+            'configuration: no [developer_portal] table found. Refusing to start on ' +
+            'built-in defaults alone.'
+        );
+    }
     return merged;
 }
 

--- a/portals/developer-portal/src/config/configMerge.js
+++ b/portals/developer-portal/src/config/configMerge.js
@@ -36,6 +36,11 @@ function snakeToCamelDeep(value) {
     if (Array.isArray(value)) {
         return value.map(snakeToCamelDeep);
     }
+    if (value instanceof Date) {
+        // TOML date/date-time values parse to Date objects (smol-toml's TomlDate);
+        // recursing into one would flatten it to {}.
+        return value;
+    }
     if (value !== null && typeof value === 'object') {
         const out = {};
         for (const [k, v] of Object.entries(value)) {

--- a/portals/developer-portal/src/config/configMerge.js
+++ b/portals/developer-portal/src/config/configMerge.js
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+'use strict';
+
+// Side-effect-free helpers for the layered config loader (see configLoader.js).
+// Kept in their own module so they can be unit-tested (configMerge.test.js)
+// without triggering configLoader's module-load bootstrap, which resolves the
+// real config from `--config` flags and exits the process when none are given.
+
+/**
+ * Recursively convert snake_case keys to camelCase (e.g. "base_url" -> "baseUrl").
+ * Applied to the parsed TOML tree so config.toml can use snake_case while the
+ * in-code struct and every consumer use camelCase.
+ */
+function snakeToCamel(key) {
+    return key.replace(/_([a-z0-9])/g, (_, c) => c.toUpperCase());
+}
+
+function snakeToCamelDeep(value) {
+    if (Array.isArray(value)) {
+        return value.map(snakeToCamelDeep);
+    }
+    if (value !== null && typeof value === 'object') {
+        const out = {};
+        for (const [k, v] of Object.entries(value)) {
+            out[snakeToCamel(k)] = snakeToCamelDeep(v);
+        }
+        return out;
+    }
+    return value;
+}
+
+/**
+ * Prototype-pollution guard, applied to every mergeOver() below.
+ */
+const BLOCKED_KEYS = new Set(['__proto__', 'prototype', 'constructor']);
+
+/**
+ * Deep-merge src into dst (src wins on conflicts), returning dst.
+ *
+ * Merge semantics — used both to layer config files over each other (last-wins)
+ * and to layer the merged result over DEFAULTS:
+ *   - Nested tables (plain objects) deep-merge, key by key.
+ *   - List/array values are REPLACED wholesale, never appended or merged
+ *     index-wise. An overlay that sets a list key replaces the base list — so a
+ *     later --config file listing e.g. auth.scopes = ["a"] overrides the base
+ *     list entirely rather than concatenating.
+ *   - A scalar overrides whatever occupied the key before it.
+ */
+function mergeOver(dst, src) {
+    for (const [k, v] of Object.entries(src)) {
+        if (BLOCKED_KEYS.has(k)) continue;
+        if (v !== null && typeof v === 'object' && !Array.isArray(v) &&
+            dst[k] !== null && typeof dst[k] === 'object' && !Array.isArray(dst[k])) {
+            mergeOver(dst[k], v);
+        } else {
+            dst[k] = v;
+        }
+    }
+    return dst;
+}
+
+/**
+ * Parse repeatable `--config <path>` / `--config=<path>` flags out of an argv
+ * slice (pass process.argv.slice(2)), preserving order. Mirrors the Go
+ * components' repeatable `-config` flag; order matters because files are merged
+ * last-wins downstream. Every other argument is ignored (nodemon and the Node
+ * runtime pass their own flags through here). Returns the list of paths, which
+ * may be empty — the caller enforces the "at least one required" rule.
+ */
+function parseConfigPaths(argv) {
+    const paths = [];
+    for (let i = 0; i < argv.length; i++) {
+        const arg = argv[i];
+        if (arg === '--config') {
+            const value = argv[i + 1];
+            if (value === undefined || value.startsWith('--')) {
+                throw new Error('--config flag requires a file path argument');
+            }
+            paths.push(value);
+            i++; // skip the value we just consumed
+        } else if (arg.startsWith('--config=')) {
+            const value = arg.slice('--config='.length);
+            if (!value) {
+                throw new Error('--config= flag requires a non-empty file path');
+            }
+            paths.push(value);
+        }
+    }
+    return paths;
+}
+
+module.exports = { snakeToCamel, snakeToCamelDeep, mergeOver, parseConfigPaths, BLOCKED_KEYS };

--- a/portals/developer-portal/src/config/configMerge.test.js
+++ b/portals/developer-portal/src/config/configMerge.test.js
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { snakeToCamelDeep, mergeOver, parseConfigPaths } = require('./configMerge');
+
+test('parseConfigPaths collects repeatable --config flags in order', () => {
+    assert.deepEqual(
+        parseConfigPaths(['--config', 'base.toml', '--config', 'overlay.toml']),
+        ['base.toml', 'overlay.toml'],
+    );
+});
+
+test('parseConfigPaths supports the --config=<path> form', () => {
+    assert.deepEqual(parseConfigPaths(['--config=base.toml']), ['base.toml']);
+});
+
+test('parseConfigPaths ignores unrelated arguments', () => {
+    assert.deepEqual(
+        parseConfigPaths(['--inspect', '--config', 'base.toml', 'extra']),
+        ['base.toml'],
+    );
+});
+
+test('parseConfigPaths returns an empty list when no --config is present', () => {
+    assert.deepEqual(parseConfigPaths(['--inspect']), []);
+});
+
+test('parseConfigPaths throws when --config has no value', () => {
+    assert.throws(() => parseConfigPaths(['--config']), /requires a file path/);
+    assert.throws(() => parseConfigPaths(['--config', '--other']), /requires a file path/);
+    assert.throws(() => parseConfigPaths(['--config=']), /non-empty file path/);
+});
+
+test('mergeOver deep-merges nested tables key by key', () => {
+    const dst = { server: { port: 9543, host: 'a' } };
+    mergeOver(dst, { server: { host: 'b' } });
+    assert.deepEqual(dst, { server: { port: 9543, host: 'b' } });
+});
+
+test('mergeOver replaces arrays wholesale rather than merging index-wise', () => {
+    const dst = { scopes: ['read', 'write', 'admin'] };
+    mergeOver(dst, { scopes: ['read'] });
+    assert.deepEqual(dst.scopes, ['read']);
+});
+
+test('mergeOver applied sequentially gives last-wins layering', () => {
+    const merged = [
+        { a: 1, nested: { x: 1, y: 1 } },
+        { a: 2, nested: { y: 2 } },
+        { nested: { z: 3 } },
+    ].reduce((acc, file) => mergeOver(acc, file), {});
+    assert.deepEqual(merged, { a: 2, nested: { x: 1, y: 2, z: 3 } });
+});
+
+test('mergeOver ignores prototype-polluting keys', () => {
+    const dst = {};
+    mergeOver(dst, JSON.parse('{"__proto__": {"polluted": true}}'));
+    assert.equal({}.polluted, undefined);
+});
+
+test('snakeToCamelDeep converts nested keys and preserves arrays', () => {
+    assert.deepEqual(
+        snakeToCamelDeep({ base_url: 'x', nested_table: { max_open_conns: 5 }, list_key: [{ a_b: 1 }] }),
+        { baseUrl: 'x', nestedTable: { maxOpenConns: 5 }, listKey: [{ aB: 1 }] },
+    );
+});


### PR DESCRIPTION
## Purpose
Fix https://github.com/wso2/api-platform/issues/2876

## Summary

- The portal used to read config from one fixed path, configs/config.toml. The path is now given explicitly: --config <path>.
- --config can be passed several times. Files stack in order, later ones winning per key — so one shared base file plus a small per-environment overlay, instead of a full copy per environment. (Nested tables merge; a list in an overlay replaces the base list, it doesn't append.)
- The flag is required. Before, a missing config file meant the portal quietly started on built-in defaults — bad, since that file holds session secrets, encryption keys, and IdP settings. Now no config (or missing / bad TOML / no [developer_portal] table) prints why and exits 1 before the port is bound.
- Built-in defaults no longer run the app on their own; they only fill gaps for keys the config files don't set.
- {{ env }} / {{ file }} tokens are resolved once, after all files merge, instead of per file. That's what lets an overlay override a value the base file wrote as {{ env "..." }}.
- Everything in this repo that starts the portal passes the flag: the Docker entrypoint (base path overridable via APIP_DP_CONFIG_PATH) and the start / debug npm scripts.

