### PR TITLE
Minor Changes to the Fix added for Suppressing two Analytics Event per LLM proxy call and adding Integration and Unit Tests

### DIFF
--- a/gateway/gateway-controller/pkg/eventlistener/llm_provider_processor_test.go
+++ b/gateway/gateway-controller/pkg/eventlistener/llm_provider_processor_test.go
@@ -272,7 +272,7 @@ func TestHandleEvent_LLMProxyCreate_RehydratesConfigAndPolicyFromDB(t *testing.T
 	policyManager2 := policyxds.NewPolicyManager(snapshotMgr2, newTestLogger())
 
 	policyDefs := map[string]models.PolicyDefinition{
-		"rate-limit-v1.0.0": {Name: "rate-limit", Version: "v1.0.0"},
+		"rate-limit-v1.0.0":  {Name: "rate-limit", Version: "v1.0.0"},
 		"set-headers-v1.0.0": {Name: "set-headers", Version: "v1.0.0"},
 	}
 	listener := &EventListener{

--- a/gateway/gateway-runtime/policy-engine/internal/analytics/analytics.go
+++ b/gateway/gateway-runtime/policy-engine/internal/analytics/analytics.go
@@ -24,6 +24,7 @@ import (
 	"maps"
 	"net"
 	"strconv"
+	"sync"
 	"time"
 
 	v3 "github.com/envoyproxy/go-control-plane/envoy/data/accesslog/v3"
@@ -82,14 +83,12 @@ const (
 	// UserIDMetadataKey represents the user ID metadata key for analytics.
 	UserIDMetadataKey string = "x-wso2-user-id"
 
-	// InternalLoopbackMetadataKey is the analytics-metadata key carrying the marker that
-	// the proxy stamps on its internal loopback forward to the provider (surfaced by the
-	// analytics system policy from the x-wso2-internal-loopback request header).
+	// InternalLoopbackMetadataKey is the analytics metadata key for the marker added to the proxy's
+	// internal loopback request to the provider.
 	InternalLoopbackMetadataKey string = "x-wso2-internal-loopback"
 
-	// PropInternalLoopbackProvider is the event property set when a provider event is the
-	// internal loopback hop of a proxy call. Read by the Moesif publisher to skip it (avoids
-	// double-counting), while other publishers (traffic log) still emit it.
+	// PropInternalLoopbackProvider marks the provider-side loopback hop of a proxy call
+	// so Process can drop the duplicate event before publisher fan-out.
 	PropInternalLoopbackProvider string = "isInternalLoopbackProvider"
 )
 
@@ -99,6 +98,9 @@ type Analytics struct {
 	cfg *config.Config
 	// publishers represents the publishers.
 	publishers []analytics_publisher.Publisher
+	// missingDirectPeerWarn limits the "direct remote address unavailable" warning to one
+	// line per process which otherwise repeating it once per request would flood the logs
+	missingDirectPeerWarn sync.Once
 }
 
 // NewAnalytics creates a new instance of Analytics. Publishers are assembled from
@@ -157,9 +159,8 @@ func (c *Analytics) Process(event *v3.HTTPAccessLogEntry) {
 	analyticEvent := c.prepareAnalyticEvent(event)
 
 	// Suppress the internal loopback provider hop of an LLM proxy call so a single client
-	// call is counted once. Detection uses the x-wso2-internal-loopback marker the proxy
-	// stamps on its loopback forward (see prepareAnalyticEvent) — a direct provider call
-	// never carries it, so it is never suppressed.
+	// call is counted once, detecting using the marker header set by the proxy
+	// when carrying on its loopback forward
 	if v, ok := analyticEvent.Properties[PropInternalLoopbackProvider].(bool); ok && v {
 		correlationID := ""
 		if analyticEvent.MetaInfo != nil {
@@ -180,6 +181,31 @@ func (c *Analytics) Process(event *v3.HTTPAccessLogEntry) {
 		publisher.Publish(analyticEvent)
 	}
 
+}
+
+// isInternalLoopbackHop identifies the provider-side hop of an LLM proxy loopback call by requiring
+// both the proxy marker and the unforgeable direct TCP peer; if the peer is unavailable, it fails open, warns once, and allows duplicates.
+func (c *Analytics) isInternalLoopbackHop(apiType, marker, directRemoteIP, downstreamListener, correlationID string) bool {
+	if apiType != "LlmProvider" || marker != "true" {
+		return false
+	}
+	if directRemoteIP == "" {
+		// Warn once so the resulting duplicates are visible at the default (info) log level
+		c.missingDirectPeerWarn.Do(func() {
+			slog.Warn("Internal loopback marker present but downstream direct remote address is unavailable; not suppressing event (logged once per process)",
+				"apiType", apiType,
+				"correlationId", correlationID,
+			)
+		})
+		// Enabling debug shows whether this affects all traffic or only some ingress paths.
+		slog.Debug("Internal loopback marker present but downstream direct remote address is unavailable",
+			"apiType", apiType,
+			"downstreamListener", downstreamListener,
+			"correlationId", correlationID,
+		)
+		return false
+	}
+	return isLoopbackAddress(directRemoteIP)
 }
 
 // isLoopbackAddress reports whether ip is an IPv4/IPv6 loopback address.
@@ -364,11 +390,14 @@ func (c *Analytics) prepareAnalyticEvent(logEntry *v3.HTTPAccessLogEntry) *dto.E
 	if userIP == "" {
 		userIP = Unknown
 	}
-
-	directRemoteIP := logEntry.GetCommonProperties().GetDownstreamDirectRemoteAddress().GetSocketAddress().GetAddress()
 	if userAgent == "" {
 		userAgent = Unknown
 	}
+
+	// Physical socket peer of the downstream connection. Empty when Envoy did not report it.
+	directRemoteIP := logEntry.GetCommonProperties().GetDownstreamDirectRemoteAddress().GetSocketAddress().GetAddress()
+	// Address of the listener that accepted the connection. Only used to diagnose a missing directRemoteIP
+	downstreamListener := logEntry.GetCommonProperties().GetDownstreamLocalAddress().GetSocketAddress().GetAddress()
 
 	event.MetaInfo = &metaInfo
 	event.API = &extendedAPI
@@ -388,23 +417,11 @@ func (c *Analytics) prepareAnalyticEvent(logEntry *v3.HTTPAccessLogEntry) *dto.E
 		slog.Debug("Analytics: User ID set from metadata", "userID", userID)
 	}
 
-	// Flag the internal loopback provider hop of an LLM proxy call so the Moesif publisher
-	// can drop it (one counted event per client call) while the traffic log keeps it. The
-	// primary signal is the x-wso2-internal-loopback marker the proxy stamps on its loopback
-	// forward — a direct provider call never carries it, so it is never suppressed regardless
-	// of network topology. The loopback guard uses directRemoteIP (the physical TCP peer),
-	// NOT userIP, so a forged "X-Forwarded-For: 127.0.0.1" cannot fake an internal source.
-	if extendedAPI.APIType == "LlmProvider" &&
-		keyValuePairsFromMetadata[InternalLoopbackMetadataKey] == "true" {
-		switch {
-		case directRemoteIP == "":
-			slog.Warn("Internal loopback marker present but downstream direct remote address is unavailable; not suppressing event",
-				"apiType", extendedAPI.APIType,
-				"correlationId", metaInfo.CorrelationID,
-			)
-		case isLoopbackAddress(directRemoteIP):
-			event.Properties[PropInternalLoopbackProvider] = true
-		}
+	// Flag the internal loopback provider hop of an LLM proxy call — the duplicate of the
+	// proxy's own event — so a single client call is counted once.
+	if c.isInternalLoopbackHop(extendedAPI.APIType, keyValuePairsFromMetadata[InternalLoopbackMetadataKey],
+		directRemoteIP, downstreamListener, metaInfo.CorrelationID) {
+		event.Properties[PropInternalLoopbackProvider] = true
 	}
 
 	// Auth-context metadata (type, issuer, credential/token IDs, audience, scopes, custom

--- a/gateway/gateway-runtime/policy-engine/internal/analytics/analytics_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/analytics/analytics_test.go
@@ -451,6 +451,11 @@ func TestProcess_PublishesWhenDirectRemoteIPMissing(t *testing.T) {
 	analytics.Process(entry)
 
 	assert.True(t, mockPub.called, "event must still be published when the direct remote address is unavailable")
+	assert.Equal(t, 1, mockPub.count, "fail-open must publish the event exactly once, not drop or duplicate it")
+	require.NotNil(t, mockPub.event, "an event must have been published")
+	assert.Equal(t, "LlmProvider", mockPub.event.API.APIType)
+	assert.Nil(t, mockPub.event.Properties[PropInternalLoopbackProvider],
+		"the event must not be flagged when the peer address could not be verified")
 }
 
 func TestProcess_SuppressionLogsDebug(t *testing.T) {

--- a/gateway/gateway-runtime/policy-engine/internal/analytics/analytics_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/analytics/analytics_test.go
@@ -38,11 +38,15 @@ import (
 // mockPublisher is a test publisher that records whether Publish was called
 type mockPublisher struct {
 	called bool
-	event  *dto.Event
+	// count is how many events were published, needed to assert that a multi-hop call
+	// yields exactly one event — `called` cannot tell one event from two.
+	count int
+	event *dto.Event
 }
 
 func (m *mockPublisher) Publish(event *dto.Event) {
 	m.called = true
+	m.count++
 	m.event = event
 }
 
@@ -460,6 +464,42 @@ func TestProcess_SuppressionLogsDebug(t *testing.T) {
 
 	assert.False(t, mockPub.called)
 	assert.Contains(t, buf.String(), "Suppressing internal loopback provider analytics event")
+}
+
+// TestProcess_ProxyCallPublishesExactlyOneEvent is the end-to-end shape of the bug this
+// suppression exists for: a single client call to an LLM proxy traverses the listener twice, so
+// the access-log service delivers two entries. Exactly one event must reach the publishers, and
+// it must be the proxy's — that is the hop carrying the user identity, application and
+// subscription; the provider hop is anonymous.
+func TestProcess_ProxyCallPublishesExactlyOneEvent(t *testing.T) {
+	analytics := NewAnalytics(&config.Config{})
+	mockPub := &mockPublisher{}
+	analytics.publishers = append(analytics.publishers, mockPub)
+
+	// Hop 1 — the proxy's own event: real client peer, no marker.
+	analytics.Process(createLogEntryWithAPITypeAndAddr("LlmProxy", "203.0.113.7"))
+	// Hop 2 — the provider hop over the internal loopback: marker stamped by the proxy, and a
+	// genuinely loopback socket peer.
+	analytics.Process(loopbackEntry("LlmProvider", true))
+
+	assert.Equal(t, 1, mockPub.count, "one client call must publish exactly one analytics event")
+	require.NotNil(t, mockPub.event, "an event must have been published")
+	assert.Equal(t, "LlmProxy", mockPub.event.API.APIType,
+		"the surviving event must be the proxy's, not the anonymous provider hop")
+}
+
+// TestProcess_DirectProviderCallPublishesExactlyOneEvent is the counterpart: a provider invoked
+// directly is a single hop and must still be counted once — the suppression must not reach it.
+func TestProcess_DirectProviderCallPublishesExactlyOneEvent(t *testing.T) {
+	analytics := NewAnalytics(&config.Config{})
+	mockPub := &mockPublisher{}
+	analytics.publishers = append(analytics.publishers, mockPub)
+
+	analytics.Process(createLogEntryWithAPITypeAndAddr("LlmProvider", "203.0.113.7"))
+
+	assert.Equal(t, 1, mockPub.count, "a direct provider call must publish exactly one event")
+	require.NotNil(t, mockPub.event, "an event must have been published")
+	assert.Equal(t, "LlmProvider", mockPub.event.API.APIType)
 }
 
 func TestIsLoopbackAddress(t *testing.T) {

--- a/gateway/it/features/analytics-basic.feature
+++ b/gateway/it/features/analytics-basic.feature
@@ -91,3 +91,58 @@ Feature: Analytics - Basic Event Capture
     Then the response status code should be 200
     And I wait 5 seconds for analytics to be published
     And the analytics collector should have received at least 3 events
+
+  # An LLM proxy forwards to its provider over the gateway's internal loopback, so one client
+  # call traverses the listener twice and the access-log service delivers two entries. Only the
+  # proxy's own event may be published: it carries the user identity, and the loopback provider
+  # hop is its anonymous duplicate. Asserts an EXACT count — "at least 1" would pass while
+  # double-counting, which is the bug this guards.
+  Scenario: LLM proxy invocation generates exactly one analytics event
+    When I create this LLM provider:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: LlmProvider
+      metadata:
+        name: analytics-dedup-provider
+      spec:
+        displayName: Analytics Dedup Provider
+        version: v1.0
+        template: openai
+        context: /analytics-dedup-provider-ctx
+        upstream:
+          url: http://sample-backend:9080/analytics-dedup-upstream
+        accessControl:
+          mode: allow_all
+      """
+    Then the response status code should be 201
+    When I deploy this LLM proxy configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: LlmProxy
+      metadata:
+        name: analytics-dedup-proxy
+      spec:
+        displayName: Analytics Dedup Proxy
+        version: v1.0
+        context: /analytics-dedup-proxy
+        provider:
+          id: analytics-dedup-provider
+      """
+    Then the response status should be 201
+    And I wait for 3 seconds
+
+    # Reset after deployment so the count covers only the single invocation below. Readiness
+    # probes and deployment traffic would otherwise be counted too.
+    Given I reset the analytics collector
+    When I set header "Content-Type" to "application/json"
+    And I send a POST request to "http://localhost:8080/analytics-dedup-proxy/chat/completions" with body:
+      """
+      {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "Hello"}]}
+      """
+    Then the response status code should be 200
+    And I wait 5 seconds for analytics to be published
+    And the analytics collector should have received 1 event
+    # The surviving event must be the proxy's own, identified two ways: its request URI is the
+    # proxy context (not the provider's loopback context) and its api kind is LlmProxy.
+    And the latest analytics event should have request URI "/analytics-dedup-proxy/chat/completions"
+    And the latest analytics event should have metadata field "apiType" with value "LlmProxy"

--- a/gateway/it/features/analytics-basic.feature
+++ b/gateway/it/features/analytics-basic.feature
@@ -129,10 +129,9 @@ Feature: Analytics - Basic Event Capture
           id: analytics-dedup-provider
       """
     Then the response status should be 201
-    And I wait for 3 seconds
+    And I wait for the endpoint "http://localhost:8080/analytics-dedup-proxy/chat/completions" to be ready with method "POST" and body '{"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "Hello"}]}'
 
-    # Reset after deployment so the count covers only the single invocation below. Readiness
-    # probes and deployment traffic would otherwise be counted too.
+    And I wait 5 seconds for analytics to be published
     Given I reset the analytics collector
     When I set header "Content-Type" to "application/json"
     And I send a POST request to "http://localhost:8080/analytics-dedup-proxy/chat/completions" with body:

--- a/gateway/system-policies/analytics/analytics.go
+++ b/gateway/system-policies/analytics/analytics.go
@@ -28,7 +28,7 @@ const (
 	AIProviderDisplayNameMetadataKey = "ai:providerdisplayname"
 	ApplicationIDMetadataKey         = "x-wso2-application-id"
 	ApplicationNameMetadataKey       = "x-wso2-application-name"
-	InternalLoopbackMetadataKey = "x-wso2-internal-loopback"
+	InternalLoopbackMetadataKey      = "x-wso2-internal-loopback"
 
 	// Auth-context metadata keys. Populated generically (auth-type-agnostic, via
 	// SharedContext.AuthContext) by populateAuthAnalyticsMetadata below, so they work


### PR DESCRIPTION
## Purpose
This PR adds some minor improvements to the fix added for suppressing the  LLMProvider call analytics event emitted when invoking an LLMProxy. Along with that, this will add both unit tests and integration tests for verifying the intended behavior is provided.

Correctness / clarity
- Replaced the two-case switch in prepareAnalyticEvent with a named helper, isInternalLoopbackHop, using flat guard clauses — the empty-address case no longer sits as a switch branch alongside the "guard says yes" case
- Moved the direct-peer address extraction next to its comment explaining why it's trusted (never derived from X-Forwarded-For), and restored the userIP/userAgent normalisation pair that had been split apart
- Corrected the PropInternalLoopbackProvider doc comment: it claimed the Moesif publisher reads the flag and the traffic log still emits the event, neither of which is true — Process drops the event before the publisher fan-out

Logging / observability
- Throttled the "direct remote address unavailable" warning to once per process via a sync.Once on the Analytics struct — the condition holds for every proxied LLM call when it holds at all, so per-request logging would flood
- Added a per-request debug line for the same condition, so enabling debug reveals whether it affects all traffic or only one ingress path

Tests
- mockPublisher gained a count field; called bool couldn't distinguish one published event from two
- TestProcess_ProxyCallPublishesExactlyOneEvent — feeds both hops of a proxy call and asserts exactly one event survives, and that it's the LlmProxy one (the hop carrying user identity)
- TestProcess_DirectProviderCallPublishesExactlyOneEvent — the counterpart: a direct provider call is one hop and must still count once
- New IT scenario in analytics-basic.feature: deploys a provider + proxy, invokes once, asserts an exact count of 1 — every pre-existing analytics assertion uses at least N, which would pass straight through the original double-counting bug


## Related PRs
> - https://github.com/wso2/api-platform/pull/2879