### PR TITLE
gateway/it: add semantic-cache cross-caller isolation scenario

### DIFF
--- a/gateway/build-manifest.yaml
+++ b/gateway/build-manifest.yaml
@@ -1,13 +1,13 @@
 version: v1
 policies:
     - name: advanced-ratelimit
-      version: v1.1.1
+      version: v1.1.2
       gomodule: github.com/wso2/gateway-controllers/policies/advanced-ratelimit@v1
     - name: analytics-header-filter
       version: v1.0.1
       gomodule: github.com/wso2/gateway-controllers/policies/analytics-header-filter@v1
     - name: api-key-auth
-      version: v1.2.0
+      version: v1.2.1
       gomodule: github.com/wso2/gateway-controllers/policies/api-key-auth@v1
     - name: aws-authentication
       version: v0.10.0
@@ -19,10 +19,10 @@ policies:
       version: v1.0.2
       gomodule: github.com/wso2/gateway-controllers/policies/azure-content-safety-content-moderation@v1
     - name: backend-jwt
-      version: v1.0.0
+      version: v1.0.1
       gomodule: github.com/wso2/gateway-controllers/policies/backend-jwt@v1
     - name: basic-auth
-      version: v1.0.2
+      version: v1.0.3
       gomodule: github.com/wso2/gateway-controllers/policies/basic-auth@v1
     - name: basic-ratelimit
       version: v1.1.0
@@ -31,7 +31,7 @@ policies:
       version: v1.0.1
       gomodule: github.com/wso2/gateway-controllers/policies/content-length-guardrail@v1
     - name: cors
-      version: v1.0.1
+      version: v1.0.2
       gomodule: github.com/wso2/gateway-controllers/policies/cors@v1
     - name: dynamic-endpoint
       version: v1.0.1
@@ -40,16 +40,16 @@ policies:
       version: v1.0.1
       gomodule: github.com/wso2/gateway-controllers/policies/host-rewrite@v1
     - name: interceptor-service
-      version: v1.0.0
+      version: v1.0.1
       gomodule: github.com/wso2/gateway-controllers/policies/interceptor-service@v1
     - name: json-schema-guardrail
       version: v1.0.1
       gomodule: github.com/wso2/gateway-controllers/policies/json-schema-guardrail@v1
     - name: json-xml-mediator
-      version: v1.0.3
+      version: v1.0.4
       gomodule: github.com/wso2/gateway-controllers/policies/json-xml-mediator@v1
     - name: jwt-auth
-      version: v1.2.3
+      version: v1.3.0
       gomodule: github.com/wso2/gateway-controllers/policies/jwt-auth@v1
     - name: llm-cost
       version: v1.1.0
@@ -61,31 +61,31 @@ policies:
       version: v0.9.0
       gomodule: github.com/wso2/gateway-controllers/policies/llm-header-router@v0
     - name: log-message
-      version: v1.0.2
+      version: v1.0.3
       gomodule: github.com/wso2/gateway-controllers/policies/log-message@v1
     - name: mcp-acl-list
-      version: v1.0.2
+      version: v1.0.3
       gomodule: github.com/wso2/gateway-controllers/policies/mcp-acl-list@v1
     - name: mcp-auth
       version: v1.1.2
       gomodule: github.com/wso2/gateway-controllers/policies/mcp-auth@v1
     - name: mcp-authz
-      version: v1.0.2
+      version: v1.1.0
       gomodule: github.com/wso2/gateway-controllers/policies/mcp-authz@v1
     - name: mcp-ratelimit
       version: v1.1.0
       gomodule: github.com/wso2/gateway-controllers/policies/mcp-ratelimit@v1
     - name: mcp-rewrite
-      version: v1.0.2
+      version: v1.0.3
       gomodule: github.com/wso2/gateway-controllers/policies/mcp-rewrite@v1
     - name: model-round-robin
-      version: v1.1.0
+      version: v1.1.1
       gomodule: github.com/wso2/gateway-controllers/policies/model-round-robin@v1
     - name: model-weighted-round-robin
-      version: v1.1.0
+      version: v1.1.1
       gomodule: github.com/wso2/gateway-controllers/policies/model-weighted-round-robin@v1
     - name: opaque-token-auth
-      version: v1.0.0
+      version: v1.0.1
       gomodule: github.com/wso2/gateway-controllers/policies/opaque-token-auth@v1
     - name: openai-to-anthropic-transformer
       version: v0.9.0
@@ -94,7 +94,7 @@ policies:
       version: v0.9.0
       gomodule: github.com/wso2/gateway-controllers/policies/openai-to-azure-openai-transformer@v0
     - name: openai-to-bedrock-transformer
-      version: v0.9.0
+      version: v0.9.1
       gomodule: github.com/wso2/gateway-controllers/policies/openai-to-bedrock-transformer@v0
     - name: openai-to-gemini-transformer
       version: v0.9.0
@@ -103,7 +103,7 @@ policies:
       version: v0.9.0
       gomodule: github.com/wso2/gateway-controllers/policies/openai-to-mistral-transformer@v0
     - name: pii-masking-regex
-      version: v1.0.1
+      version: v1.0.3
       gomodule: github.com/wso2/gateway-controllers/policies/pii-masking-regex@v1
     - name: prompt-compressor
       version: v0.9.0
@@ -115,7 +115,7 @@ policies:
       version: v1.0.1
       gomodule: github.com/wso2/gateway-controllers/policies/prompt-template@v1
     - name: redirect
-      version: v0.9.0
+      version: v0.9.1
       gomodule: github.com/wso2/gateway-controllers/policies/redirect@v0
     - name: regex-guardrail
       version: v1.0.1
@@ -124,13 +124,13 @@ policies:
       version: v1.0.1
       gomodule: github.com/wso2/gateway-controllers/policies/remove-headers@v1
     - name: request-rewrite
-      version: v1.0.1
+      version: v1.0.2
       gomodule: github.com/wso2/gateway-controllers/policies/request-rewrite@v1
     - name: respond
       version: v1.0.1
       gomodule: github.com/wso2/gateway-controllers/policies/respond@v1
     - name: semantic-cache
-      version: v1.0.1
+      version: v1.1.0
       gomodule: github.com/wso2/gateway-controllers/policies/semantic-cache@v1
     - name: semantic-prompt-guard
       version: v1.0.1
@@ -145,7 +145,7 @@ policies:
       version: v1.1.0
       gomodule: github.com/wso2/gateway-controllers/policies/set-headers@v1
     - name: subscription-validation
-      version: v1.0.2
+      version: v1.0.3
       gomodule: github.com/wso2/gateway-controllers/policies/subscription-validation@v1
     - name: token-based-ratelimit
       version: v1.1.0

--- a/gateway/it/features/semantic-cache.feature
+++ b/gateway/it/features/semantic-cache.feature
@@ -560,6 +560,7 @@ Feature: Semantic Cache Policy
       """
     Then the response should be successful
     And I wait for the endpoint "http://localhost:8080/semantic-cache-isolation/v1.0/health" to be ready
+    And I wait for policy snapshot sync
 
     # Provision caller A's API key
     When I send a POST request to the "gateway-controller" service at "/rest-apis/semantic-cache-isolation-api/api-keys" with body:

--- a/gateway/it/features/semantic-cache.feature
+++ b/gateway/it/features/semantic-cache.feature
@@ -524,3 +524,90 @@ Feature: Semantic Cache Policy
     Given I authenticate using basic auth as "admin"
     When I delete the API "semantic-cache-embed-error-api"
     Then the response should be successful
+
+  # Category 5: Cross-Caller Isolation
+
+  Scenario: A different authenticated caller does not receive another caller's cached response
+    Given I authenticate using basic auth as "admin"
+    When I deploy this API configuration:
+      """
+      apiVersion: gateway.api-platform.wso2.com/v1
+      kind: RestApi
+      metadata:
+        name: semantic-cache-isolation-api
+      spec:
+        displayName: Semantic Cache - Cross-Caller Isolation
+        version: v1.0
+        context: /semantic-cache-isolation/$version
+        upstream:
+          main:
+            url: http://sample-backend:9080/api/v1
+        operations:
+          - method: GET
+            path: /health
+          - method: POST
+            path: /chat
+            policies:
+              - name: api-key-auth
+                version: v1
+                params:
+                  key: API-Key
+                  in: header
+              - name: semantic-cache
+                version: v1
+                params:
+                  similarityThreshold: 0.9
+      """
+    Then the response should be successful
+    And I wait for the endpoint "http://localhost:8080/semantic-cache-isolation/v1.0/health" to be ready
+
+    # Provision caller A's API key
+    When I send a POST request to the "gateway-controller" service at "/rest-apis/semantic-cache-isolation-api/api-keys" with body:
+      """
+      {"name": "isolation-caller-a"}
+      """
+    Then the response status should be 201
+    And I set header "API-Key" to the JSON response field "apiKey.apiKey"
+    And I wait for 2 seconds
+
+    # Caller A - first request is a cache miss
+    When I set header "Content-Type" to "application/json"
+    And I send a POST request to "http://localhost:8080/semantic-cache-isolation/v1.0/chat" with body:
+      """
+      {"prompt": "isolation test prompt about coral reefs"}
+      """
+    Then the response status code should be 200
+    And the response header "X-Cache-Status" should not exist
+
+    # Caller A - identical repeat is a cache hit on their own entry
+    When I set header "Content-Type" to "application/json"
+    And I send a POST request to "http://localhost:8080/semantic-cache-isolation/v1.0/chat" with body:
+      """
+      {"prompt": "isolation test prompt about coral reefs"}
+      """
+    Then the response status code should be 200
+    And the response header "X-Cache-Status" should be "HIT"
+
+    # Provision caller B's API key
+    Given I authenticate using basic auth as "admin"
+    When I send a POST request to the "gateway-controller" service at "/rest-apis/semantic-cache-isolation-api/api-keys" with body:
+      """
+      {"name": "isolation-caller-b"}
+      """
+    Then the response status should be 201
+    And I set header "API-Key" to the JSON response field "apiKey.apiKey"
+    And I wait for 2 seconds
+
+    # Caller B - identical prompt must still be a cache miss
+    When I set header "Content-Type" to "application/json"
+    And I send a POST request to "http://localhost:8080/semantic-cache-isolation/v1.0/chat" with body:
+      """
+      {"prompt": "isolation test prompt about coral reefs"}
+      """
+    Then the response status code should be 200
+    And the response header "X-Cache-Status" should not exist
+
+    # Cleanup
+    Given I authenticate using basic auth as "admin"
+    When I delete the API "semantic-cache-isolation-api"
+    Then the response should be successful

--- a/gateway/it/steps/http_steps.go
+++ b/gateway/it/steps/http_steps.go
@@ -58,6 +58,7 @@ func NewHTTPSteps(client *http.Client, baseURLs map[string]string) *HTTPSteps {
 func (h *HTTPSteps) Register(ctx *godog.ScenarioContext) {
 	// Request building steps
 	ctx.Step(`^I set header "([^"]*)" to "([^"]*)"$`, h.iSetHeader)
+	ctx.Step(`^I set header "([^"]*)" to the JSON response field "([^"]*)"$`, h.iSetHeaderFromJSONField)
 	ctx.Step(`^I set the following headers:$`, h.iSetHeaders)
 	ctx.Step(`^I clear all headers$`, h.iClearHeaders)
 	ctx.Step(`^I set request host to "([^"]*)"$`, h.iSetRequestHost)
@@ -143,6 +144,35 @@ func (h *HTTPSteps) LastBody() []byte {
 
 // iSetHeader sets a single header
 func (h *HTTPSteps) iSetHeader(name, value string) error {
+	h.headers[name] = value
+	return nil
+}
+
+// iSetHeaderFromJSONField sets a header from a field in the last JSON response (dot notation).
+func (h *HTTPSteps) iSetHeaderFromJSONField(name, field string) error {
+	var data map[string]interface{}
+	if err := json.Unmarshal(h.lastBody, &data); err != nil {
+		return fmt.Errorf("failed to parse last response as JSON: %w", err)
+	}
+
+	var current interface{} = data
+	for _, part := range strings.Split(field, ".") {
+		m, ok := current.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("expected a JSON object while resolving field %q, got %T", field, current)
+		}
+		v, exists := m[part]
+		if !exists {
+			return fmt.Errorf("field %q not found in last JSON response", field)
+		}
+		current = v
+	}
+
+	value, ok := current.(string)
+	if !ok {
+		return fmt.Errorf("field %q is not a string (got %T)", field, current)
+	}
+
 	h.headers[name] = value
 	return nil
 }

--- a/gateway/it/steps/http_steps.go
+++ b/gateway/it/steps/http_steps.go
@@ -28,11 +28,45 @@ import (
 	"log"
 	"net/http"
 	"net/http/httputil"
+	"regexp"
 	"strings"
 	"time"
 
 	"github.com/cucumber/godog"
 )
+
+// sensitiveHeaderNames are redacted from logged request dumps; the request
+// itself keeps the real value.
+var sensitiveHeaderNames = map[string]bool{
+	"authorization": true,
+	"api-key":       true,
+}
+
+// sensitiveBodyFieldPattern matches common secret-bearing JSON fields (e.g.
+// key-provisioning responses) so their values never reach test logs.
+var sensitiveBodyFieldPattern = regexp.MustCompile(`(?i)"(api[_-]?key|token|secret|password|credential)"\s*:\s*"[^"]*"`)
+
+// redactRequestDump masks sensitive header values in a httputil.DumpRequestOut
+// dump before it's logged.
+func redactRequestDump(dump []byte) []byte {
+	lines := strings.Split(string(dump), "\r\n")
+	for i, line := range lines {
+		idx := strings.Index(line, ":")
+		if idx <= 0 {
+			continue
+		}
+		if sensitiveHeaderNames[strings.ToLower(strings.TrimSpace(line[:idx]))] {
+			lines[i] = line[:idx+1] + " [REDACTED]"
+		}
+	}
+	return []byte(strings.Join(lines, "\r\n"))
+}
+
+// redactSensitiveBodyFields masks secret-bearing JSON field values before a
+// response body is logged.
+func redactSensitiveBodyFields(body string) string {
+	return sensitiveBodyFieldPattern.ReplaceAllString(body, `"$1":"[REDACTED]"`)
+}
 
 // HTTPSteps provides common HTTP request step definitions
 type HTTPSteps struct {
@@ -371,7 +405,7 @@ func (h *HTTPSteps) sendRequestWithTempHeader(method, url string, body []byte, h
 	h.lastRequest = req
 
 	reqDump, _ := httputil.DumpRequestOut(req, true)
-	fmt.Printf("REQUEST:\n%s\n", string(reqDump))
+	fmt.Printf("REQUEST:\n%s\n", string(redactRequestDump(reqDump)))
 	log.Printf("DEBUG: Sending %s request to %s", method, url)
 
 	resp, err := h.client.Do(req)
@@ -398,7 +432,7 @@ func (h *HTTPSteps) sendRequestWithTempHeader(method, url string, body []byte, h
 	}
 
 	// Log response body for debugging (truncate if too large)
-	bodyStr := string(h.lastBody)
+	bodyStr := redactSensitiveBodyFields(string(h.lastBody))
 	if len(bodyStr) > 500 {
 		bodyStr = bodyStr[:500] + "..."
 	}
@@ -439,7 +473,7 @@ func (h *HTTPSteps) sendRequest(method, url string, body []byte) error {
 	h.lastRequest = req
 
 	reqDump, _ := httputil.DumpRequestOut(req, true)
-	fmt.Printf("REQUEST:\n%s\n", string(reqDump))
+	fmt.Printf("REQUEST:\n%s\n", string(redactRequestDump(reqDump)))
 	// Log the request for debugging
 	log.Printf("DEBUG: Sending %s request to %s", method, url)
 
@@ -467,7 +501,7 @@ func (h *HTTPSteps) sendRequest(method, url string, body []byte) error {
 	}
 
 	// Log response body for debugging (truncate if too large)
-	bodyStr := string(h.lastBody)
+	bodyStr := redactSensitiveBodyFields(string(h.lastBody))
 	if len(bodyStr) > 500 {
 		bodyStr = bodyStr[:500] + "..."
 	}


### PR DESCRIPTION
## Purpose

- Followup test PR of https://github.com/wso2/api-platform/pull/2970
- Related policy PR: https://github.com/wso2/gateway-controllers/pull/257

This pull request introduces a new integration test scenario to ensure cross-caller isolation for the semantic cache policy, and adds supporting step definitions to the test framework.

**New test scenario for cross-caller cache isolation:**

* Added a scenario to `semantic-cache.feature` that provisions two separate API keys, verifies that caller A receives a cache hit only on their own requests, and ensures caller B does not receive a cache hit for an identical prompt, confirming isolation between callers.
