### PR TITLE
Mandate role claims in gateway-controller when IDP auth is enabled

### DIFF
--- a/common/authenticators/jwt_authenticator.go
+++ b/common/authenticators/jwt_authenticator.go
@@ -171,13 +171,15 @@ func (j *JWTAuthenticator) Authenticate(r *http.Request) (*AuthResult, error) {
 		}
 	}
 
-	// If no role claim is configured, set flag to skip authorization
-	// This allows authentication-only mode where all authenticated users can access resources
+	// Authorization is skipped ONLY when it has been explicitly disabled via DisableAuthorization (authentication-only)
 	var permissions []string
-	skipAuthz := false
+	skipAuthz := j.config.JWTConfig.DisableAuthorization
+	if skipAuthz {
+		j.logger.Warn("authorization is explicitly disabled for IDP auth (disable_authorization=true); " +
+			"every authenticated token is granted access to all routes without a per-route role check")
+	}
 	if j.config.JWTConfig.ScopeClaim == "" {
-		j.logger.Debug("No role claim configured, setting skip_authz flag")
-		skipAuthz = true
+		j.logger.Debug("no scope/roles claim configured; caller resolves to zero roles")
 		permissions = []string{}
 	} else {
 		permissions = j.resolvePermissions(claims)
@@ -259,7 +261,6 @@ func (j *JWTAuthenticator) resolvePermissions(claims jwt.MapClaims) []string {
 	}
 	return permissions
 }
-
 
 // Name returns the authenticator name
 func (j *JWTAuthenticator) Name() string {

--- a/common/authenticators/jwt_authenticator.go
+++ b/common/authenticators/jwt_authenticator.go
@@ -56,6 +56,10 @@ func NewJWTAuthenticator(config *models.AuthConfig, logger *slog.Logger) (*JWTAu
 // newJWTAuthenticatorWithJWKS creates a new JWT authenticator with optional JWKS initialization
 // This is useful for testing where JWKS is not needed
 func newJWTAuthenticatorWithJWKS(config *models.AuthConfig, logger *slog.Logger, initJWKS bool) (*JWTAuthenticator, error) {
+	if config.JWTConfig != nil && config.JWTConfig.DisableAuthorization {
+		logger.Warn("authorization is explicitly disabled for IDP auth (disable_authorization=true); " +
+			"every authenticated token is granted access to all routes without a per-route role check")
+	}
 	var jwks keyfunc.Keyfunc
 	if config.JWTConfig != nil && initJWKS {
 		if config.JWTConfig.IssuerURL == "" {
@@ -174,10 +178,6 @@ func (j *JWTAuthenticator) Authenticate(r *http.Request) (*AuthResult, error) {
 	// Authorization is skipped ONLY when it has been explicitly disabled via DisableAuthorization (authentication-only)
 	var permissions []string
 	skipAuthz := j.config.JWTConfig.DisableAuthorization
-	if skipAuthz {
-		j.logger.Warn("authorization is explicitly disabled for IDP auth (disable_authorization=true); " +
-			"every authenticated token is granted access to all routes without a per-route role check")
-	}
 	if j.config.JWTConfig.ScopeClaim == "" {
 		j.logger.Debug("no scope/roles claim configured; caller resolves to zero roles")
 		permissions = []string{}

--- a/common/authenticators/jwt_authenticator_test.go
+++ b/common/authenticators/jwt_authenticator_test.go
@@ -265,3 +265,67 @@ func TestJWTAuthenticator_Authenticate_ExpiredTokenRejected_WithIssuerValidation
 	_, err = a.Authenticate(req)
 	assert.ErrorIs(t, err, ErrExpiredToken)
 }
+
+// authenticateWithConfig signs a valid token for the given issuer and runs it
+// through a JWTAuthenticator built on the supplied IDP config, using a static
+// key so no JWKS endpoint is needed.
+func authenticateWithConfig(t *testing.T, idp *models.IDPConfig) *AuthResult {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	secret := []byte("test-secret")
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"iss": idp.IssuerURL,
+		"sub": "user123",
+		"exp": time.Now().Add(1 * time.Hour).Unix(),
+	})
+	tokenString, err := tok.SignedString(secret)
+	assert.NoError(t, err)
+
+	a := &JWTAuthenticator{
+		config: &models.AuthConfig{JWTConfig: idp},
+		logger: logger,
+		jwks:   staticKeyfunc{key: secret},
+	}
+	req, _ := http.NewRequest("GET", "/", nil)
+	req.Header.Set(constants.AuthorizationHeader, constants.BearerPrefix+tokenString)
+
+	result, err := a.Authenticate(req)
+	assert.NoError(t, err)
+	return result
+}
+
+// TestJWTAuthenticator_Authenticate_EmptyScopeClaim_DoesNotSkipAuthz verifies
+// the Layer 2 fix: an unset scope/roles claim must NOT disable authorization.
+// The caller resolves to zero roles so the authz middleware denies by default,
+// rather than the token being granted blanket access to every route.
+func TestJWTAuthenticator_Authenticate_EmptyScopeClaim_DoesNotSkipAuthz(t *testing.T) {
+	issuer := "https://issuer.example.com"
+	result := authenticateWithConfig(t, &models.IDPConfig{
+		Enabled:    true,
+		IssuerURL:  issuer,
+		ScopeClaim: "", // no roles claim configured
+		// DisableAuthorization intentionally left false (the default)
+	})
+
+	assert.True(t, result.Success)
+	assert.False(t, result.SkipAuthorization,
+		"an empty scope claim must not skip authorization — it must fail closed to zero roles")
+	assert.Empty(t, result.Roles)
+}
+
+// TestJWTAuthenticator_Authenticate_DisableAuthorization_SkipsAuthz verifies
+// that authentication-only mode still works, but only via the explicit
+// opt-in flag.
+func TestJWTAuthenticator_Authenticate_DisableAuthorization_SkipsAuthz(t *testing.T) {
+	issuer := "https://issuer.example.com"
+	result := authenticateWithConfig(t, &models.IDPConfig{
+		Enabled:              true,
+		IssuerURL:            issuer,
+		ScopeClaim:           "",
+		DisableAuthorization: true, // explicit opt-in to authentication-only mode
+	})
+
+	assert.True(t, result.Success)
+	assert.True(t, result.SkipAuthorization,
+		"disable_authorization=true must skip authorization (explicit auth-only mode)")
+}

--- a/common/authenticators/jwt_authenticator_test.go
+++ b/common/authenticators/jwt_authenticator_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/MicahParks/jwkset"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/wso2/api-platform/common/constants"
 	"github.com/wso2/api-platform/common/models"
 )
@@ -279,7 +280,7 @@ func authenticateWithConfig(t *testing.T, idp *models.IDPConfig) *AuthResult {
 		"exp": time.Now().Add(1 * time.Hour).Unix(),
 	})
 	tokenString, err := tok.SignedString(secret)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	a := &JWTAuthenticator{
 		config: &models.AuthConfig{JWTConfig: idp},
@@ -290,7 +291,7 @@ func authenticateWithConfig(t *testing.T, idp *models.IDPConfig) *AuthResult {
 	req.Header.Set(constants.AuthorizationHeader, constants.BearerPrefix+tokenString)
 
 	result, err := a.Authenticate(req)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	return result
 }
 

--- a/common/models/models.go
+++ b/common/models/models.go
@@ -65,15 +65,16 @@ type User struct {
 
 // IDPConfig holds identity provider configuration
 type IDPConfig struct {
-	Enabled                bool                 `json:"enabled"`
-	IssuerURL              string               `json:"issuer_url"`
-	JWKSUrl                string               `json:"jwks_url"`
-	ScopeClaim             string               `json:"scope_claim"`
-	UsernameClaim          string               `json:"username_claim"`
-	Audience               *[]string            `json:"audience"`
-	Certificate            *string              `json:"certificate"`
-	ClaimMapping           *map[string]string   `json:"claim_mapping"`
-	PermissionMapping      *map[string][]string `json:"permission_mapping"`
-	InsecureSkipVerifyTLS  bool                 `json:"insecure_skip_verify_tls"`
-	JWTLeeway             *time.Duration        `json:"jwt_leeway"`
+	Enabled               bool                 `json:"enabled"`
+	IssuerURL             string               `json:"issuer_url"`
+	JWKSUrl               string               `json:"jwks_url"`
+	ScopeClaim            string               `json:"scope_claim"`
+	UsernameClaim         string               `json:"username_claim"`
+	Audience              *[]string            `json:"audience"`
+	Certificate           *string              `json:"certificate"`
+	ClaimMapping          *map[string]string   `json:"claim_mapping"`
+	PermissionMapping     *map[string][]string `json:"permission_mapping"`
+	InsecureSkipVerifyTLS bool                 `json:"insecure_skip_verify_tls"`
+	JWTLeeway             *time.Duration       `json:"jwt_leeway"`
+	DisableAuthorization  bool                 `json:"disable_authorization"`
 }

--- a/gateway/configs/config-template.toml
+++ b/gateway/configs/config-template.toml
@@ -155,6 +155,8 @@ roles           = ["admin"]
 enabled = false
 jwks_url = ""
 issuer = ""
+roles_claim = "roles"
+audience = []
 
 [api_key]
 api_keys_per_user_per_api = 10

--- a/gateway/gateway-controller/cmd/controller/main.go
+++ b/gateway/gateway-controller/cmd/controller/main.go
@@ -566,6 +566,10 @@ func main() {
 	igw := immutable.NewImmutableGW(cfg.ImmutableGateway, restAPIService, llmSvc, mcpSvc)
 
 	authConfig := generateAuthConfig(cfg)
+	if cfg.Controller.Auth.IDP.Enabled && len(cfg.Controller.Auth.IDP.Audience) == 0 {
+		log.Warn("IDP auth is enabled but no auth.idp.audience is configured - token audience ('aud') will NOT be " +
+			"validated; set auth.idp.audience to the expected audience(s) to restrict this")
+	}
 	authMiddleWare, err := authenticators.AuthMiddleware(authConfig, log)
 	if err != nil {
 		log.Error("Failed to create auth middleware", slog.Any("error", err))
@@ -929,6 +933,9 @@ func generateAuthConfig(config *config.Config) commonmodels.AuthConfig {
 			JWKSUrl:           config.Controller.Auth.IDP.JWKSURL,
 			ScopeClaim:        config.Controller.Auth.IDP.RolesClaim,
 			PermissionMapping: &config.Controller.Auth.IDP.RoleMapping,
+		}
+		if len(config.Controller.Auth.IDP.Audience) > 0 {
+			idpAuth.Audience = &config.Controller.Auth.IDP.Audience
 		}
 	}
 	authConfig := commonmodels.AuthConfig{BasicAuth: &basicAuth,

--- a/gateway/gateway-controller/cmd/controller/main_test.go
+++ b/gateway/gateway-controller/cmd/controller/main_test.go
@@ -628,6 +628,7 @@ func TestGenerateAuthConfig(t *testing.T) {
 						JWKSURL:     "https://idp.example.com/.well-known/jwks.json",
 						RolesClaim:  "roles",
 						RoleMapping: roleMapping,
+						Audience:    []string{"gateway-controller"},
 					},
 				},
 			},
@@ -641,6 +642,31 @@ func TestGenerateAuthConfig(t *testing.T) {
 		assert.Equal(t, "https://idp.example.com/.well-known/jwks.json", authConfig.JWTConfig.JWKSUrl)
 		assert.Equal(t, "roles", authConfig.JWTConfig.ScopeClaim)
 		assert.NotNil(t, authConfig.JWTConfig.PermissionMapping)
+		require.NotNil(t, authConfig.JWTConfig.Audience)
+		assert.Equal(t, []string{"gateway-controller"}, *authConfig.JWTConfig.Audience)
+	})
+
+	t.Run("IDP auth enabled without audience leaves audience unset", func(t *testing.T) {
+		cfg := &config.Config{
+			Controller: config.Controller{
+				Auth: config.AuthConfig{
+					Basic: config.BasicAuth{Enabled: false},
+					IDP: config.IDPConfig{
+						Enabled:    true,
+						Issuer:     "https://idp.example.com",
+						JWKSURL:    "https://idp.example.com/.well-known/jwks.json",
+						RolesClaim: "roles",
+						// Audience intentionally empty — validation is skipped.
+					},
+				},
+			},
+		}
+
+		authConfig := generateAuthConfig(cfg)
+
+		assert.True(t, authConfig.JWTConfig.Enabled)
+		assert.Nil(t, authConfig.JWTConfig.Audience,
+			"empty audience must leave the common Audience nil so validation is skipped")
 	})
 
 	t.Run("Both basic and IDP auth enabled", func(t *testing.T) {

--- a/gateway/gateway-controller/pkg/config/config.go
+++ b/gateway/gateway-controller/pkg/config/config.go
@@ -261,6 +261,7 @@ type IDPConfig struct {
 	Issuer      string              `koanf:"issuer"`
 	RolesClaim  string              `koanf:"roles_claim"`
 	RoleMapping map[string][]string `koanf:"role_mapping"` // local role -> idp roles
+	Audience    []string            `koanf:"audience"`
 }
 
 // TracingConfig holds OpenTelemetry tracing configuration
@@ -874,8 +875,9 @@ func defaultConfig() *Config {
 					Enabled:     false,
 					JWKSURL:     "",
 					Issuer:      "",
-					RolesClaim:  "",
+					RolesClaim:  "roles",
 					RoleMapping: map[string][]string{},
+					Audience:    []string{},
 				},
 			},
 			Logging: LoggingConfig{
@@ -1946,6 +1948,12 @@ func (c *Config) validateAuthConfig() error {
 					"(sets APIP_GW_CONTROLLER_AUTH_BASIC_ADMIN_USERNAME and APIP_GW_CONTROLLER_AUTH_BASIC_ADMIN_PASSWORD_HASH)", i+1)
 			}
 		}
+	}
+
+	if c.Controller.Auth.IDP.Enabled && strings.TrimSpace(c.Controller.Auth.IDP.RolesClaim) == "" {
+		return fmt.Errorf("auth.idp.roles_claim is empty while auth.idp.enabled=true - " +
+			"Set auth.idp.roles_claim to the token claim carrying the caller's roles/scopes " +
+			"(and configure auth.idp.role_mapping to map them to local roles)")
 	}
 
 	// Validate IDP role mapping for multiple wildcards

--- a/gateway/gateway-controller/pkg/config/config_test.go
+++ b/gateway/gateway-controller/pkg/config/config_test.go
@@ -1504,20 +1504,23 @@ func TestConfig_ValidateAuthConfig(t *testing.T) {
 	tests := []struct {
 		name        string
 		idpEnabled  bool
+		rolesClaim  string
 		roleMapping map[string][]string
 		wantErr     bool
 		errContains string
 	}{
 		{name: "IDP disabled", idpEnabled: false, wantErr: false},
-		{name: "IDP enabled no role mapping", idpEnabled: true, roleMapping: nil, wantErr: false},
-		{name: "IDP enabled single wildcard", idpEnabled: true, roleMapping: map[string][]string{"admin": {"*"}}, wantErr: false},
-		{name: "IDP enabled multiple wildcards", idpEnabled: true, roleMapping: map[string][]string{"admin": {"*"}, "user": {"*"}}, wantErr: true, errContains: "multiple wildcard ('*') mappings detected"},
+		{name: "IDP enabled no role mapping", idpEnabled: true, rolesClaim: "roles", roleMapping: nil, wantErr: false},
+		{name: "IDP enabled single wildcard", idpEnabled: true, rolesClaim: "roles", roleMapping: map[string][]string{"admin": {"*"}}, wantErr: false},
+		{name: "IDP enabled multiple wildcards", idpEnabled: true, rolesClaim: "roles", roleMapping: map[string][]string{"admin": {"*"}, "user": {"*"}}, wantErr: true, errContains: "multiple wildcard ('*') mappings detected"},
+		{name: "IDP enabled empty roles claim fails closed", idpEnabled: true, rolesClaim: "", roleMapping: nil, wantErr: true, errContains: "roles_claim is empty"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := validConfig()
 			cfg.Controller.Auth.IDP.Enabled = tt.idpEnabled
+			cfg.Controller.Auth.IDP.RolesClaim = tt.rolesClaim
 			cfg.Controller.Auth.IDP.RoleMapping = tt.roleMapping
 			err := cfg.Validate()
 			if tt.wantErr {

--- a/gateway/gateway-controller/pkg/config/validator_test.go
+++ b/gateway/gateway-controller/pkg/config/validator_test.go
@@ -199,8 +199,9 @@ func TestValidateAuthConfig_IDPAuthEnabled(t *testing.T) {
 					Enabled: false,
 				},
 				IDP: IDPConfig{
-					Enabled: true,
-					JWKSURL: "https://idp.example.com/jwks",
+					Enabled:    true,
+					JWKSURL:    "https://idp.example.com/jwks",
+					RolesClaim: "roles",
 				},
 			},
 		},
@@ -208,6 +209,28 @@ func TestValidateAuthConfig_IDPAuthEnabled(t *testing.T) {
 
 	err := config.validateAuthConfig()
 	assert.NoError(t, err)
+}
+
+func TestValidateAuthConfig_IDPAuthEnabledEmptyRolesClaim_FailsClosed(t *testing.T) {
+	// IDP enabled with an empty roles_claim silently disables authorization
+	// (the JWT authenticator sets skip-authz, bypassing the per-route role
+	// check), granting every valid token full admin access. Refuse to start.
+	config := &Config{
+		Controller: Controller{
+			Auth: AuthConfig{
+				Basic: BasicAuth{Enabled: false},
+				IDP: IDPConfig{
+					Enabled:    true,
+					JWKSURL:    "https://idp.example.com/jwks",
+					RolesClaim: "",
+				},
+			},
+		},
+	}
+
+	err := config.validateAuthConfig()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "roles_claim is empty")
 }
 
 func TestValidateAuthConfig_BothAuthEnabled(t *testing.T) {
@@ -222,8 +245,9 @@ func TestValidateAuthConfig_BothAuthEnabled(t *testing.T) {
 					},
 				},
 				IDP: IDPConfig{
-					Enabled: true,
-					JWKSURL: "https://idp.example.com/jwks",
+					Enabled:    true,
+					JWKSURL:    "https://idp.example.com/jwks",
+					RolesClaim: "roles",
 				},
 			},
 		},

--- a/gateway/gateway-controller/pkg/config/validator_test.go
+++ b/gateway/gateway-controller/pkg/config/validator_test.go
@@ -212,9 +212,10 @@ func TestValidateAuthConfig_IDPAuthEnabled(t *testing.T) {
 }
 
 func TestValidateAuthConfig_IDPAuthEnabledEmptyRolesClaim_FailsClosed(t *testing.T) {
-	// IDP enabled with an empty roles_claim silently disables authorization
-	// (the JWT authenticator sets skip-authz, bypassing the per-route role
-	// check), granting every valid token full admin access. Refuse to start.
+	// IDP enabled with an empty roles_claim is almost always a misconfiguration:
+	// the JWT authenticator retains authorization and resolves such tokens to
+	// zero roles, so every role-protected route would deny by default. Fail fast
+	// at startup with a clear error rather than starting in that state.
 	config := &Config{
 		Controller: Controller{
 			Auth: AuthConfig{


### PR DESCRIPTION
### Purpose

Improve IDP/JWT auth configuration in the gateway-controller: `roles_claim` had no default, and token audience (aud) wasn't configurable at the controller level.

### Goals

- Default `roles_claim` to "roles" and validate it's non-empty when IDP is enabled.
- Add configurable audience (aud) validation to the controller.

### Approach

- pkg/config: `roles_claim` defaults to "roles"; validateAuthConfig fails startup if empty while `idp.enabled=true`.
- pkg/config/cmd/controller: added audience field, wired into the existing authenticator audience check; logs a note at startup if left unset.

### User stories

- As an operator, enabling IDP auth with a minimal config should enforce role-based authorization by default.
- As an operator, an incomplete IDP config should fail at startup with a clear error.
- As an operator, I want to optionally restrict accepted tokens by audience.

### Documentation

Config-template updated (gateway/configs/config-template.toml).

### Samples

[controller.auth.idp]
roles_claim = "roles"   # required (defaulted) when enabled = true
audience = []           # optional; restricts accepted token audiences when set