### PR TITLE
Fix issues in MCP registry

### DIFF
--- a/portals/developer-portal/src/middlewares/authMiddleware.js
+++ b/portals/developer-portal/src/middlewares/authMiddleware.js
@@ -413,4 +413,5 @@ module.exports = {
     OAuth2Security,
     apiKeyAuth,
     resolveUserUuid,
+    verifyBearerToken,
 };

--- a/portals/developer-portal/src/middlewares/ensureAuthenticated.js
+++ b/portals/developer-portal/src/middlewares/ensureAuthenticated.js
@@ -20,14 +20,13 @@ const constants = require('../utils/constants');
 const { config } = require('../config/configLoader');
 const orgDao = require('../dao/organizationDao');
 const { validationResult } = require('express-validator');
-const { jwtVerify, createRemoteJWKSet } = require('jose');
 const util = require('../utils/util');
 const { CustomError } = require('../utils/errors/customErrors');
 const { safeDecodeJwt } = require('../utils/jwtDecode');
 const logger = require('../config/logger');
 const { decodePlatformJwtClaims } = require('../utils/platformJwt');
-const { accessTokenPresent, refreshAccessToken, verifyWithCertificate } = require('../utils/tokenUtil');
-const { resolveUserUuid } = require('./authMiddleware');
+const { accessTokenPresent } = require('../utils/tokenUtil');
+const { resolveUserUuid, verifyBearerToken } = require('./authMiddleware');
 
 // System page-access gates (constants.js) merged with any deployer-supplied additions
 // (config.pageAccessRules, via config.toml) — the config side only ever adds patterns,
@@ -40,6 +39,18 @@ const AUTHORIZED_PAGES = [
     ...constants.ROUTE.SYSTEM_AUTHORIZED_PAGES,
     ...(config.pageAccessRules?.authorized || []),
 ];
+
+// Accepts either a single scope string or an array of candidate scopes and reports
+// whether the token satisfies any one of them — the same any-of semantics the
+// OpenAPI-validator-driven /api/v0.9 security handlers apply to a spec operation's
+// declared scope list (e.g. dp:mcp_update OR dp:mcp_manage), so a route gated by
+// enforceSecurity([...]) grants access to exactly the same principals a /api/v0.9
+// CRUD operation on the same resource would.
+function matchesAnyScope(tokenScopes, requiredScope) {
+    if (!requiredScope) return true;
+    const required = Array.isArray(requiredScope) ? requiredScope : [requiredScope];
+    return required.some((s) => tokenScopes.includes(s));
+}
 
 function enforceSecurity(scope) {
     return async function (req, res, next) {
@@ -57,7 +68,7 @@ function enforceSecurity(scope) {
                 const platformToken = req.user[constants.ACCESS_TOKEN];
                 if (!platformToken) return util.handleError(res, new CustomError(401, constants.ERROR_CODE[401], constants.ERROR_MESSAGE.UNAUTHENTICATED));
                 const tokenScopes = decodePlatformJwtClaims(platformToken)?.scopes ?? [];
-                if (!scope || tokenScopes.includes(scope)) return next();
+                if (matchesAnyScope(tokenScopes, scope)) return next();
                 return util.handleError(res, new CustomError(403, constants.ERROR_CODE[403], constants.ERROR_MESSAGE.FORBIDDEN));
             }
             const token = accessTokenPresent(req);
@@ -306,19 +317,20 @@ const ensureAuthenticated = async (req, res, next) => {
     };
 };
 
+// Reuses the exact bearer-token verification the /api/v0.9 REST API's authResolver
+// applies (authMiddleware.js's verifyBearerToken): local-auth mode verifies against the
+// Platform API's own RS256 public key (config.auth.local.publicKeyPath), idp mode verifies
+// via IDP.certificate/jwksUrl — so a bearer JWT gated by enforceSecurity is authenticated
+// identically to one calling /api/v0.9, regardless of which auth.mode is active.
+//
+// Does NOT re-run util.validateRequestParameters() — enforceSecurity (this function's only
+// caller) already ran that sanitizer over req.params/req.query before delegating here.
+// Running param('*').escape() a second time double-escapes any already-escaped character:
+// a route param containing '/' (e.g. a reverse-DNS MCP server identifier segment) becomes
+// '&#x2F;' on the first pass and '&amp;#x2F;' on a second, which callers' unescapeParam-style
+// reversal (a single-pass '&#x2F;' -> '/' replace) can no longer undo.
 function validateAuthentication(scope) {
     return async function (req, res, next) {
-        const rules = util.validateRequestParameters();
-        for (let validation of rules) {
-            await validation.run(req);
-        }
-        const errors = validationResult(req);
-        if (!errors.isEmpty()) {
-            return res.status(400).json(util.getErrors(errors));
-        }
-        let IDP, valid, scopes;
-        IDP = config.auth.idp || {};
-
         let accessToken;
         if (req.isAuthenticated() && req.user) {
             accessToken = req.user[constants.ACCESS_TOKEN];
@@ -326,16 +338,11 @@ function validateAuthentication(scope) {
             accessToken = req.headers.authorization && req.headers.authorization.split(' ')[1];
         }
 
-        if (IDP.certificate) {
-            ({ valid, scopes } = await verifyWithCertificate(accessToken, IDP.certificate));
-        } else if (IDP.jwksUrl) {
-            ({ valid, scopes } = await validateWithJwks(accessToken, IDP.jwksUrl, req));
-        } else {
-            valid = false;
-        }
+        const { valid, scopes } = await verifyBearerToken(accessToken, req);
 
         if (valid) {
-            if (String(scopes || '').split(' ').includes(scope)) {
+            const tokenScopes = String(scopes || '').split(' ');
+            if (matchesAnyScope(tokenScopes, scope)) {
                 return next();
             }
             return util.handleError(res, new CustomError(403, constants.ERROR_CODE[403], constants.ERROR_MESSAGE.FORBIDDEN));
@@ -346,32 +353,6 @@ function validateAuthentication(scope) {
         return util.handleError(res, new CustomError(401, constants.ERROR_CODE[401], constants.ERROR_MESSAGE.UNAUTHENTICATED));
     }
 }
-
-const validateWithJwks = async (token, jwksURL, req) => {
-    try {
-        const jwks = await createRemoteJWKSet(new URL(jwksURL));
-        const jwtVerifyOptions = { algorithms: constants.JWT_ASYMMETRIC_ALGORITHMS };
-        if (config.auth.idp?.issuer) jwtVerifyOptions.issuer = config.auth.idp.issuer;
-        if (config.auth.idp?.audience) jwtVerifyOptions.audience = config.auth.idp.audience;
-        const { payload } = await jwtVerify(token, jwks, jwtVerifyOptions);
-        return { valid: true, scopes: payload.scope || '' };
-    } catch (err) {
-        logger.error("Invalid token", { error: err.message, stack: err.stack, operation: "tokenValidation" });
-        if (err.code === 'ERR_JWT_EXPIRED' && req.user && req.user.refreshToken) {
-            try {
-                logger.info("Access token expired, triggering refresh token flow");
-                const response = await refreshAccessToken(req.user.refreshToken);
-                req.user[constants.ACCESS_TOKEN] = response.access_token;
-                req.user[constants.REFRESH_TOKEN] = response.refresh_token;
-                return { valid: true, scopes: response.scope || '' };
-            } catch (error) {
-                logger.error("Error refreshing access token", { error: error.message, stack: error.stack, operation: "refreshToken" });
-                return { valid: false, scopes: '' };
-            }
-        }
-        return { valid: false, scopes: '' };
-    }
-};
 
 const enforceMTLS = (req, res, next) => {
     const clientCert = req.socket?.getPeerCertificate?.(true);

--- a/portals/developer-portal/src/middlewares/ensureAuthenticated.js
+++ b/portals/developer-portal/src/middlewares/ensureAuthenticated.js
@@ -68,6 +68,7 @@ function enforceSecurity(scope) {
                 const platformToken = req.user[constants.ACCESS_TOKEN];
                 if (!platformToken) return util.handleError(res, new CustomError(401, constants.ERROR_CODE[401], constants.ERROR_MESSAGE.UNAUTHENTICATED));
                 const tokenScopes = decodePlatformJwtClaims(platformToken)?.scopes ?? [];
+                req.tokenScopes = tokenScopes;
                 if (matchesAnyScope(tokenScopes, scope)) return next();
                 return util.handleError(res, new CustomError(403, constants.ERROR_CODE[403], constants.ERROR_MESSAGE.FORBIDDEN));
             }
@@ -342,15 +343,21 @@ function validateAuthentication(scope) {
 
         if (valid) {
             const tokenScopes = String(scopes || '').split(' ');
+            req.tokenScopes = tokenScopes;
             if (matchesAnyScope(tokenScopes, scope)) {
                 return next();
             }
             return util.handleError(res, new CustomError(403, constants.ERROR_CODE[403], constants.ERROR_MESSAGE.FORBIDDEN));
         }
-        if (req.user) {
-            return res.redirect('login');
-        }
-        return util.handleError(res, new CustomError(401, constants.ERROR_CODE[401], constants.ERROR_MESSAGE.UNAUTHENTICATED));
+        // Uniform response regardless of req.user (js-error-handling.md directive 4, same
+        // shape tryoutProxyRoute.js's unauthorizedJson uses) — this gate protects API routes
+        // (mcpRegistryRoute.js), not browser pages, so a stale session cookie must not divert
+        // a rejected bearer token into an HTML login redirect instead of the same JSON body a
+        // header-only caller gets.
+        return res.status(401).json({
+            error: 'unauthorized',
+            message: 'Invalid or expired credentials.',
+        });
     }
 }
 
@@ -393,5 +400,6 @@ const enforceAPIKey = (req, res, next) => {
 module.exports = {
     ensureAuthenticated,
     validateAuthentication,
-    enforceSecurity
+    enforceSecurity,
+    matchesAnyScope,
 }

--- a/portals/developer-portal/src/routes/pages/mcpRegistryRoute.js
+++ b/portals/developer-portal/src/routes/pages/mcpRegistryRoute.js
@@ -37,10 +37,18 @@ router.get('/v0.1/servers/:serverName/versions/:version', mcpRegistryService.get
 
 // Publishing endpoints — gated by the same dp:mcp_* scopes the admin /api/v0.9/mcp-servers*
 // CRUD operations require (see constants.SCOPES.MCP_*), via bearer JWT or local-auth session
-// (enforceSecurity), same as every other devportal write route. publishServer is an upsert
-// (create-or-update), so it accepts either the create or update scope group; status changes
-// have no dedicated admin-API scope of their own — per the OpenAPI spec, they go through the
-// same PUT /mcp-servers/{id} operation as a plain update, so they're gated identically here.
+// (enforceSecurity), same as every other devportal write route. Status changes have no
+// dedicated admin-API scope of their own — per the OpenAPI spec, they go through the same
+// PUT /mcp-servers/{id} operation as a plain update, so they're gated identically here.
+//
+// publishServer is an upsert (create-or-update), and MCP_PUBLISH_SCOPES here is only a
+// coarse pre-filter — proof the caller holds SOME MCP-publishing scope — not the final
+// authorization decision: whether this specific request creates or updates isn't knowable
+// until publishServer looks up the target name/version/proxyId, so mcpRegistryService.js's
+// publishServer re-checks req.tokenScopes against the precise create-vs-update scope once
+// it has determined which operation this request actually performs. A caller with only
+// dp:mcp_create must not be able to update an existing server via this coarse gate alone,
+// and vice versa for dp:mcp_update against creating a new one.
 const MCP_PUBLISH_SCOPES = [...constants.SCOPES.MCP_CREATE, ...constants.SCOPES.MCP_UPDATE];
 router.post('/v0.1/publish', enforceSecurity(MCP_PUBLISH_SCOPES), mcpRegistryService.publishServer);
 router.put('/v0.1/servers/:serverName/versions/:version', enforceSecurity(constants.SCOPES.MCP_UPDATE), mcpRegistryService.updateVersion);

--- a/portals/developer-portal/src/routes/pages/mcpRegistryRoute.js
+++ b/portals/developer-portal/src/routes/pages/mcpRegistryRoute.js
@@ -35,11 +35,17 @@ router.get('/v0.1/servers', mcpRegistryService.listServers);
 router.get('/v0.1/servers/:serverName/versions', mcpRegistryService.listVersions);
 router.get('/v0.1/servers/:serverName/versions/:version', mcpRegistryService.getVersion);
 
-// Publishing endpoints (API key or session auth — same as all other devportal write routes)
-router.post('/v0.1/publish', enforceSecurity(constants.SCOPES.DEVELOPER), mcpRegistryService.publishServer);
-router.put('/v0.1/servers/:serverName/versions/:version', enforceSecurity(constants.SCOPES.DEVELOPER), mcpRegistryService.updateVersion);
-router.delete('/v0.1/servers/:serverName/versions/:version', enforceSecurity(constants.SCOPES.DEVELOPER), mcpRegistryService.deleteVersion);
-router.patch('/v0.1/servers/:serverName/versions/:version/status', enforceSecurity(constants.SCOPES.DEVELOPER), mcpRegistryService.updateVersionStatus);
-router.patch('/v0.1/servers/:serverName/status', enforceSecurity(constants.SCOPES.DEVELOPER), mcpRegistryService.updateAllVersionsStatus);
+// Publishing endpoints — gated by the same dp:mcp_* scopes the admin /api/v0.9/mcp-servers*
+// CRUD operations require (see constants.SCOPES.MCP_*), via bearer JWT or local-auth session
+// (enforceSecurity), same as every other devportal write route. publishServer is an upsert
+// (create-or-update), so it accepts either the create or update scope group; status changes
+// have no dedicated admin-API scope of their own — per the OpenAPI spec, they go through the
+// same PUT /mcp-servers/{id} operation as a plain update, so they're gated identically here.
+const MCP_PUBLISH_SCOPES = [...constants.SCOPES.MCP_CREATE, ...constants.SCOPES.MCP_UPDATE];
+router.post('/v0.1/publish', enforceSecurity(MCP_PUBLISH_SCOPES), mcpRegistryService.publishServer);
+router.put('/v0.1/servers/:serverName/versions/:version', enforceSecurity(constants.SCOPES.MCP_UPDATE), mcpRegistryService.updateVersion);
+router.delete('/v0.1/servers/:serverName/versions/:version', enforceSecurity(constants.SCOPES.MCP_DELETE), mcpRegistryService.deleteVersion);
+router.patch('/v0.1/servers/:serverName/versions/:version/status', enforceSecurity(constants.SCOPES.MCP_UPDATE), mcpRegistryService.updateVersionStatus);
+router.patch('/v0.1/servers/:serverName/status', enforceSecurity(constants.SCOPES.MCP_UPDATE), mcpRegistryService.updateAllVersionsStatus);
 
 module.exports = router;

--- a/portals/developer-portal/src/services/mcpRegistryService.js
+++ b/portals/developer-portal/src/services/mcpRegistryService.js
@@ -27,6 +27,7 @@ const logger = require('../config/logger');
 const constants = require('../utils/constants');
 const util = require('../utils/util');
 const yaml = require('../utils/yaml');
+const { matchesAnyScope } = require('../middlewares/ensureAuthenticated');
 
 const MCP_STATUSES = ['active', 'deprecated', 'deleted'];
 const SERVER_NAME_PATTERN = /^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/;
@@ -41,19 +42,49 @@ const SCHEMA_FILE_NAME = constants.FILE_NAME.SCHEMA_DEFINITION_YAML_FILE_NAME;
 
 const API_METADATA_TABLE = 'dp_api_metadata';
 
-// metadata_search is JSONB on postgres and TEXT on sqlite/mssql — the ->> text-extraction
-// operator used below is postgres syntax, but sqlite (3.38+, via better-sqlite3) also
-// implements '->>' as a JSON accessor on TEXT columns, so this expression happens to work
-// on both. This mirrors the previous Sequelize implementation, which used raw
-// `sequelize.literal("metadata_search->>'proxyId'")` for the same reason.
-const PROXY_ID_EXPR = "metadata_search->>'proxyId'";
-const PUBLISHED_AT_EXPR = "(metadata_search->>'publishedAt')";
+// Resolved once — db.getDialect() is static for the life of the process, so every
+// dialect-conditional expression below is computed a single time at module load
+// rather than re-branching per query.
+const DIALECT = db.getDialect();
+
+// metadata_search is JSONB on postgres, TEXT on sqlite, and NVARCHAR(MAX) on mssql
+// (see database/schema.*.sql). Postgres's '->>' text-extraction operator also happens to
+// work unmodified on sqlite (3.38+, via better-sqlite3, which implements '->>' as a JSON
+// accessor on TEXT columns too), but SQL Server has no '->>' operator at all — the
+// equivalent there is JSON_VALUE() against the same NVARCHAR(MAX) JSON text. This mirrors
+// the previous Sequelize implementation, which used raw
+// `sequelize.literal("metadata_search->>'proxyId'")` for postgres.
+const PROXY_ID_EXPR = DIALECT === 'mssql'
+    ? "JSON_VALUE(metadata_search, '$.proxyId')"
+    : "metadata_search->>'proxyId'";
+const PUBLISHED_AT_EXPR = DIALECT === 'mssql'
+    ? "JSON_VALUE(metadata_search, '$.publishedAt')"
+    : "(metadata_search->>'publishedAt')";
+
+// SQL Server has no NULLS LAST syntax (unlike postgres and sqlite 3.30+) — emulate it with
+// a leading CASE that sorts NULL published-at values after every non-NULL one, then the
+// same DESC ordering on the real value for ties within each group.
+const ORDER_BY_PUBLISHED_AT_DESC = DIALECT === 'mssql'
+    ? `ORDER BY CASE WHEN ${PUBLISHED_AT_EXPR} IS NULL THEN 1 ELSE 0 END, ${PUBLISHED_AT_EXPR} DESC`
+    : `ORDER BY ${PUBLISHED_AT_EXPR} DESC NULLS LAST`;
 
 // ILIKE is postgres-only syntax — sqlite has no ILIKE operator at all (a bare LIKE is
 // already case-insensitive for ASCII there), and mssql's LIKE case-sensitivity depends on
-// the column/database collation rather than a keyword. Branch once per dialect rather than
-// hardcoding ILIKE, so `search` doesn't hard-fail with a SQL syntax error on non-postgres.
-const SEARCH_LIKE_OP = db.getDialect() === 'postgres' ? 'ILIKE' : 'LIKE';
+// the column/database collation rather than a keyword, so LIKE is the correct fallback for
+// both. Branch once per dialect rather than hardcoding ILIKE, so `search` doesn't hard-fail
+// with a SQL syntax error on non-postgres.
+const SEARCH_LIKE_OP = DIALECT === 'postgres' ? 'ILIKE' : 'LIKE';
+
+// SQL Server has no FOR UPDATE — the equivalent is a WITH (UPDLOCK, ROWLOCK) table hint
+// placed directly after the table name, not appended to WHERE like postgres's FOR UPDATE,
+// so the lock has to be expressed as part of the FROM target rather than a query suffix.
+// SQLite needs neither hint: it already serializes all writes through a single
+// connection/lock (see driver.js), so omitting one there doesn't reintroduce the race that
+// FOR UPDATE/UPDLOCK guards against on postgres/mssql.
+const LOCKABLE_METADATA_TABLE = DIALECT === 'mssql'
+    ? `${API_METADATA_TABLE} WITH (UPDLOCK, ROWLOCK)`
+    : API_METADATA_TABLE;
+const FOR_UPDATE_SUFFIX = DIALECT === 'postgres' ? ' FOR UPDATE' : '';
 
 // Map registry spec status values to DB STATUS values
 const REGISTRY_TO_DB_STATUS = {
@@ -293,11 +324,16 @@ const listServers = async (req, res) => {
             params.push(`%${search}%`, `%${search}%`);
         }
 
+        // db.paginationClause emits dialect-correct row-limiting syntax — mssql has no
+        // LIMIT/OFFSET keyword at all (it uses ANSI OFFSET ... FETCH NEXT), so this can't be
+        // a hardcoded "LIMIT ? OFFSET ?" string the way the rest of this file's postgres/sqlite
+        // expressions can share one spelling.
+        const { clause: paginationClause, params: paginationParams } = db.paginationClause(limit + 1, currentOffset);
         const rows = await db.query(
             `SELECT * FROM ${API_METADATA_TABLE} WHERE ${conditions.join(' AND ')}
-             ORDER BY ${PUBLISHED_AT_EXPR} DESC NULLS LAST
-             LIMIT ? OFFSET ?`,
-            [...params, limit + 1, currentOffset]
+             ${ORDER_BY_PUBLISHED_AT_DESC}
+             ${paginationClause}`,
+            [...params, ...paginationParams]
         );
 
         const hasMore = rows.length > limit;
@@ -332,14 +368,14 @@ const listVersions = async (req, res) => {
 
         let rows = await db.query(
             `SELECT * FROM ${API_METADATA_TABLE} WHERE ${baseWhereSql} AND ${PROXY_ID_EXPR} = ?
-             ORDER BY ${PUBLISHED_AT_EXPR} DESC NULLS LAST`,
+             ${ORDER_BY_PUBLISHED_AT_DESC}`,
             [...baseParams, serverIdentifier]
         );
 
         if (rows.length === 0) {
             rows = await db.query(
                 `SELECT * FROM ${API_METADATA_TABLE} WHERE ${baseWhereSql} AND name = ?
-                 ORDER BY ${PUBLISHED_AT_EXPR} DESC NULLS LAST`,
+                 ${ORDER_BY_PUBLISHED_AT_DESC}`,
                 [...baseParams, serverIdentifier]
             );
         }
@@ -385,6 +421,26 @@ const getVersion = async (req, res) => {
 
 // ─── Write endpoints ──────────────────────────────────────────────────────────
 
+// Shared by publishServer's pre-authorization existence check and its transactional
+// upsert, so the "does this name/version/proxyId already exist" lookup has one
+// implementation instead of two copies that could silently drift apart.
+async function findExistingMcpVersion(exec, orgId, name, version, proxyId) {
+    let existing = null;
+    if (proxyId) {
+        existing = await exec.queryOne(
+            `SELECT * FROM ${API_METADATA_TABLE} WHERE org_uuid = ? AND type = ? AND version = ? AND ${PROXY_ID_EXPR} = ?`,
+            [orgId, constants.API_TYPE.MCP, version, proxyId]
+        );
+    }
+    if (!existing) {
+        existing = await exec.queryOne(
+            `SELECT * FROM ${API_METADATA_TABLE} WHERE org_uuid = ? AND type = ? AND name = ? AND version = ?`,
+            [orgId, constants.API_TYPE.MCP, name, version]
+        );
+    }
+    return existing;
+}
+
 const publishServer = async (req, res) => {
     try {
         const orgHandle = req.params.orgHandle;
@@ -409,25 +465,25 @@ const publishServer = async (req, res) => {
             ? Buffer.from(yaml.dump(toFlatSchema(tools, resources, prompts)), 'utf-8')
             : null;
 
+        // publish is an upsert — a caller must hold the scope matching whichever operation
+        // will ACTUALLY happen, not just either one: dp:mcp_create alone must not be able to
+        // update an existing server, and dp:mcp_update alone must not be able to create a new
+        // one. Route-level enforceSecurity(MCP_PUBLISH_SCOPES) only proves the caller has SOME
+        // MCP-publishing capability; this is the precise, per-operation check (GO-AUTH-007 /
+        // GO-AUTH-015 — the specific check belongs at the point the operation is decided, not
+        // only in route middleware that can't yet know which operation this request performs).
+        const willUpdate = !!(await findExistingMcpVersion(db, orgId, name, version, proxyId));
+        const requiredScope = willUpdate ? constants.SCOPES.MCP_UPDATE : constants.SCOPES.MCP_CREATE;
+        if (!matchesAnyScope(req.tokenScopes || [], requiredScope)) {
+            return sendError(res, 403, 'Forbidden');
+        }
+
         let row;
         let created = false;
         let existingApiId = null;
 
         await db.withTransaction(async (t) => {
-            let existing = null;
-            if (proxyId) {
-                existing = await t.queryOne(
-                    `SELECT * FROM ${API_METADATA_TABLE} WHERE org_uuid = ? AND type = ? AND version = ? AND ${PROXY_ID_EXPR} = ?`,
-                    [orgId, constants.API_TYPE.MCP, version, proxyId]
-                );
-            }
-
-            if (!existing) {
-                existing = await t.queryOne(
-                    `SELECT * FROM ${API_METADATA_TABLE} WHERE org_uuid = ? AND type = ? AND name = ? AND version = ?`,
-                    [orgId, constants.API_TYPE.MCP, name, version]
-                );
-            }
+            const existing = await findExistingMcpVersion(t, orgId, name, version, proxyId);
 
             if (existing) {
                 existingApiId = existing.uuid;
@@ -610,26 +666,21 @@ const updateAllVersionsStatus = async (req, res) => {
         const dbStatus = REGISTRY_TO_DB_STATUS[status];
         let updated;
 
-        // FOR UPDATE is postgres-only syntax (sqlite/mssql reject it outright, same as the
-        // ILIKE case above) — row-locking is only needed to guard against a concurrent writer
-        // on postgres; sqlite already serializes all writes through a single connection/lock
-        // (see driver.js), so omitting the clause there doesn't reintroduce the race. Mirrors
-        // the identical dialect branch in eventDao.js's claim queries.
-        const lockClause = db.getDialect() === 'postgres' ? ' FOR UPDATE' : '';
-
         await db.withTransaction(async (t) => {
-            // FOR UPDATE row-locks every candidate row for the duration of this transaction,
-            // so a concurrent updateAllVersionsStatus/publishServer call on the same server
-            // can't race this bulk status change.
+            // Row-locks every candidate row for the duration of this transaction, so a
+            // concurrent updateAllVersionsStatus/publishServer call on the same server can't
+            // race this bulk status change — FOR_UPDATE_SUFFIX (postgres) / the WITH
+            // (UPDLOCK, ROWLOCK) hint baked into LOCKABLE_METADATA_TABLE (mssql) / neither
+            // (sqlite, which already serializes writes through a single connection).
             let existing = await t.query(
-                `SELECT * FROM ${API_METADATA_TABLE}
-                 WHERE org_uuid = ? AND type = ? AND ref_id IS NULL AND ${PROXY_ID_EXPR} = ?${lockClause}`,
+                `SELECT * FROM ${LOCKABLE_METADATA_TABLE}
+                 WHERE org_uuid = ? AND type = ? AND ref_id IS NULL AND ${PROXY_ID_EXPR} = ?${FOR_UPDATE_SUFFIX}`,
                 [orgId, constants.API_TYPE.MCP, serverIdentifier]
             );
             if (existing.length === 0) {
                 existing = await t.query(
-                    `SELECT * FROM ${API_METADATA_TABLE}
-                     WHERE org_uuid = ? AND type = ? AND ref_id IS NULL AND name = ?${lockClause}`,
+                    `SELECT * FROM ${LOCKABLE_METADATA_TABLE}
+                     WHERE org_uuid = ? AND type = ? AND ref_id IS NULL AND name = ?${FOR_UPDATE_SUFFIX}`,
                     [orgId, constants.API_TYPE.MCP, serverIdentifier]
                 );
             }

--- a/portals/developer-portal/src/services/mcpRegistryService.js
+++ b/portals/developer-portal/src/services/mcpRegistryService.js
@@ -41,13 +41,19 @@ const SCHEMA_FILE_NAME = constants.FILE_NAME.SCHEMA_DEFINITION_YAML_FILE_NAME;
 
 const API_METADATA_TABLE = 'dp_api_metadata';
 
-// metadata_search is JSONB on postgres — the ->> text-extraction operator used below
-// is postgres-specific. This mirrors the previous Sequelize implementation, which used
-// raw `sequelize.literal("metadata_search->>'proxyId'")` for the same reason: the MCP
-// registry's proxyId/publishedAt lookups have only ever been postgres-only (same for the
-// ILIKE case-insensitive search and the `FOR UPDATE` row lock further below).
+// metadata_search is JSONB on postgres and TEXT on sqlite/mssql — the ->> text-extraction
+// operator used below is postgres syntax, but sqlite (3.38+, via better-sqlite3) also
+// implements '->>' as a JSON accessor on TEXT columns, so this expression happens to work
+// on both. This mirrors the previous Sequelize implementation, which used raw
+// `sequelize.literal("metadata_search->>'proxyId'")` for the same reason.
 const PROXY_ID_EXPR = "metadata_search->>'proxyId'";
 const PUBLISHED_AT_EXPR = "(metadata_search->>'publishedAt')";
+
+// ILIKE is postgres-only syntax — sqlite has no ILIKE operator at all (a bare LIKE is
+// already case-insensitive for ASCII there), and mssql's LIKE case-sensitivity depends on
+// the column/database collation rather than a keyword. Branch once per dialect rather than
+// hardcoding ILIKE, so `search` doesn't hard-fail with a SQL syntax error on non-postgres.
+const SEARCH_LIKE_OP = db.getDialect() === 'postgres' ? 'ILIKE' : 'LIKE';
 
 // Map registry spec status values to DB STATUS values
 const REGISTRY_TO_DB_STATUS = {
@@ -283,7 +289,7 @@ const listServers = async (req, res) => {
             conditions.push("status != 'DELETED'");
         }
         if (search) {
-            conditions.push(`(name ILIKE ? OR ${PROXY_ID_EXPR} ILIKE ?)`);
+            conditions.push(`(name ${SEARCH_LIKE_OP} ? OR ${PROXY_ID_EXPR} ${SEARCH_LIKE_OP} ?)`);
             params.push(`%${search}%`, `%${search}%`);
         }
 
@@ -604,19 +610,26 @@ const updateAllVersionsStatus = async (req, res) => {
         const dbStatus = REGISTRY_TO_DB_STATUS[status];
         let updated;
 
+        // FOR UPDATE is postgres-only syntax (sqlite/mssql reject it outright, same as the
+        // ILIKE case above) — row-locking is only needed to guard against a concurrent writer
+        // on postgres; sqlite already serializes all writes through a single connection/lock
+        // (see driver.js), so omitting the clause there doesn't reintroduce the race. Mirrors
+        // the identical dialect branch in eventDao.js's claim queries.
+        const lockClause = db.getDialect() === 'postgres' ? ' FOR UPDATE' : '';
+
         await db.withTransaction(async (t) => {
             // FOR UPDATE row-locks every candidate row for the duration of this transaction,
             // so a concurrent updateAllVersionsStatus/publishServer call on the same server
-            // can't race this bulk status change (postgres-only, per this file's own note above).
+            // can't race this bulk status change.
             let existing = await t.query(
                 `SELECT * FROM ${API_METADATA_TABLE}
-                 WHERE org_uuid = ? AND type = ? AND ref_id IS NULL AND ${PROXY_ID_EXPR} = ? FOR UPDATE`,
+                 WHERE org_uuid = ? AND type = ? AND ref_id IS NULL AND ${PROXY_ID_EXPR} = ?${lockClause}`,
                 [orgId, constants.API_TYPE.MCP, serverIdentifier]
             );
             if (existing.length === 0) {
                 existing = await t.query(
                     `SELECT * FROM ${API_METADATA_TABLE}
-                     WHERE org_uuid = ? AND type = ? AND ref_id IS NULL AND name = ? FOR UPDATE`,
+                     WHERE org_uuid = ? AND type = ? AND ref_id IS NULL AND name = ?${lockClause}`,
                     [orgId, constants.API_TYPE.MCP, serverIdentifier]
                 );
             }

--- a/portals/developer-portal/src/utils/constants.js
+++ b/portals/developer-portal/src/utils/constants.js
@@ -131,6 +131,13 @@ module.exports = {
     SCOPES: {
         ADMIN: 'admin',
         DEVELOPER: 'dev',
+        // Same any-of scope groups the admin `/api/v0.9/mcp-servers*` OpenAPI security
+        // requirements declare per operation (docs/devportal-openapi-spec-v0.9.yaml) — reused
+        // here so the MCP registry protocol routes (mcpRegistryRoute.js) grant access to
+        // exactly the same principals as the equivalent admin CRUD operation.
+        MCP_CREATE: ['dp:mcp_create', 'dp:mcp_manage'],
+        MCP_UPDATE: ['dp:mcp_update', 'dp:mcp_manage'],
+        MCP_DELETE: ['dp:mcp_delete', 'dp:mcp_manage'],
     },
 
     FILE_EXTENSIONS: {


### PR DESCRIPTION
## Purpose
While manually testing the MCP registry endpoints against a running instance, several bugs surfaced that made the write side of the registry (publish, updateVersion, deleteVersion, status changes) effectively unusable, plus one SQLite-only crash on the read side.

**Bugs fixed:**

- **Unreachable write endpoints.** All write routes were gated by `enforceSecurity(constants.SCOPES.DEVELOPER)` — a flat `"dev"` scope that no configured account (including the local platform admin) ever carries; real tokens use granular `dp:mcp_*` scopes. Every write request failed authorization regardless of caller. Replaced with the same `dp:mcp_create` / `dp:mcp_update` / `dp:mcp_delete` (+ `dp:mcp_manage`) scope groups the admin `/api/v0.9/mcp-servers*` API already requires for the equivalent operation, so the registry grants access to exactly the same principals.
- **Bearer JWTs didn't validate in local-auth mode.** `validateAuthentication` only checked `config.auth.idp.certificate`/`jwksUrl`, so a bearer token had no way to authenticate when `auth.mode = "local"` (the default). It now delegates to `authMiddleware.js`'s `verifyBearerToken`, the same function `/api/v0.9`'s `authResolver` uses — verifies against the Platform API's RS256 public key in local mode, IDP cert/JWKS in idp mode.
- **Double-escaped route params broke any identifier containing `/`.** `enforceSecurity` and `validateAuthentication` each independently ran `param('*').escape()` over `req.params`. For a bearer-token request both ran in sequence, so `/` in a reverse-DNS MCP name (e.g. `io.github.user/weather-mcp`) got escaped twice (`&#x2F;` → `&amp;#x2F;`), which the existing `unescapeParam` reversal couldn't undo — every version-scoped write 404'd on any identifier with a slash. Removed the redundant second pass.
- **`ILIKE` crashes on SQLite.** `listServers`'s `search` query used Postgres-only `ILIKE` unconditionally, hard-failing with a `SqliteError: near "ILIKE": syntax error` on the default SQLite backend. Now branches on `db.getDialect()`.
- **`FOR UPDATE` crashes on SQLite.** Same class of bug in `updateAllVersionsStatus`'s row lock — SQLite rejects `FOR UPDATE` outright. Fixed the same way `eventDao.js` already handles it: the lock clause is conditional on `postgres` (SQLite already serializes writes through a single connection, so no lock is needed there).

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

