### PR TITLE
Fail fast for invalid additional LLM provider configurations

### DIFF
--- a/gateway/gateway-controller/pkg/utils/llm_transformer.go
+++ b/gateway/gateway-controller/pkg/utils/llm_transformer.go
@@ -184,9 +184,11 @@ func (t *LLMProviderTransformer) transformProxy(proxy *api.LLMProxyConfiguration
 			if err != nil {
 				return nil, fmt.Errorf("failed to get context for additional provider '%s': %w", ap.Id, err)
 			}
-			if addProviderConfig, ok := addCfg.SourceConfiguration.(api.LLMProviderConfiguration); ok {
-				additionalValuePrefixByID[ap.Id] = apiKeyAuthValuePrefix(addProviderConfig.Spec.GlobalPolicies)
+			addProviderConfig, ok := addCfg.SourceConfiguration.(api.LLMProviderConfiguration)
+			if !ok {
+				return nil, fmt.Errorf("additional provider '%s' source configuration is not LLMProviderConfiguration", ap.Id)
 			}
+			additionalValuePrefixByID[ap.Id] = apiKeyAuthValuePrefix(addProviderConfig.Spec.GlobalPolicies)
 			// UpstreamDefinition URLs are host[:port] only. Keep the provider's
 			// loopback context in BasePath so the router rewrites requests to the
 			// additional provider route instead of dropping the context.

--- a/gateway/gateway-controller/pkg/utils/llm_transformer_multiprovider_test.go
+++ b/gateway/gateway-controller/pkg/utils/llm_transformer_multiprovider_test.go
@@ -246,6 +246,84 @@ func TestLLMProviderTransformer_TransformProxy_AdditionalProviderTransformerIsCo
 	assert.Equal(t, "claude-sonnet-4-5-20250929", (*transformerPolicy.Params)["model"])
 }
 
+func TestLLMProviderTransformer_TransformProxy_RejectsInvalidAdditionalProviderSourceConfiguration(t *testing.T) {
+	store := storage.NewConfigStore()
+	db := newTestMockDB()
+
+	template := &models.StoredLLMProviderTemplate{
+		UUID: "0000-db-template-id-0000-000000000004",
+		Configuration: api.LLMProviderTemplate{
+			ApiVersion: api.LLMProviderTemplateApiVersionGatewayApiPlatformWso2Comv1,
+			Kind:       api.LLMProviderTemplateKindLlmProviderTemplate,
+			Metadata:   api.Metadata{Name: "openai"},
+			Spec:       api.LLMProviderTemplateData{DisplayName: "openai"},
+		},
+	}
+	require.NoError(t, db.SaveLLMProviderTemplate(template))
+
+	primaryProvider := api.LLMProviderConfiguration{
+		ApiVersion: api.LLMProviderConfigurationApiVersionGatewayApiPlatformWso2Comv1,
+		Kind:       api.LLMProviderConfigurationKindLlmProvider,
+		Metadata:   api.Metadata{Name: "openai-provider"},
+		Spec: api.LLMProviderConfigData{
+			DisplayName:   "openai-provider",
+			Version:       "v1.0",
+			Context:       stringPtr("/openai-provider"),
+			Template:      "openai",
+			Upstream:      api.LLMProviderConfigData_Upstream{Url: stringPtr("https://example.com")},
+			AccessControl: api.LLMAccessControl{Mode: api.AllowAll},
+		},
+	}
+	require.NoError(t, db.SaveConfig(&models.StoredConfig{
+		UUID:                "openai-provider-uuid",
+		Kind:                string(api.LLMProviderConfigurationKindLlmProvider),
+		Handle:              "openai-provider",
+		DisplayName:         "openai-provider",
+		Version:             "v1.0",
+		SourceConfiguration: primaryProvider,
+		DesiredState:        models.StateDeployed,
+	}))
+
+	require.NoError(t, db.SaveConfig(&models.StoredConfig{
+		UUID:        "invalid-provider-uuid",
+		Kind:        string(api.LLMProviderConfigurationKindLlmProvider),
+		Handle:      "invalid-provider",
+		DisplayName: "invalid-provider",
+		Version:     "v1.0",
+		SourceConfiguration: api.RestAPI{
+			ApiVersion: api.RestAPIApiVersionGatewayApiPlatformWso2Comv1,
+			Kind:       api.RestAPIKindRestApi,
+			Metadata:   api.Metadata{Name: "invalid-provider"},
+			Spec: api.APIConfigData{
+				DisplayName: "invalid-provider",
+				Version:     "v1.0",
+				Context:     "/invalid-provider",
+			},
+		},
+		DesiredState: models.StateDeployed,
+	}))
+
+	transformer := NewLLMProviderTransformer(store, db, &config.RouterConfig{ListenerPort: 8080}, newTestPolicyVersionResolver())
+	proxy := &api.LLMProxyConfiguration{
+		ApiVersion: api.LLMProxyConfigurationApiVersionGatewayApiPlatformWso2Comv1,
+		Kind:       api.LLMProxyConfigurationKindLlmProxy,
+		Metadata:   api.Metadata{Name: "openai-multi"},
+		Spec: api.LLMProxyConfigData{
+			DisplayName: "openai-multi",
+			Version:     "v1.0",
+			Provider:    api.LLMProxyProvider{Id: "openai-provider"},
+			AdditionalProviders: &[]api.LLMProxyAdditionalProvider{{
+				Id: "invalid-provider",
+			}},
+		},
+	}
+
+	result, err := transformer.Transform(proxy, &api.RestAPI{})
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Equal(t, "additional provider 'invalid-provider' source configuration is not LLMProviderConfiguration", err.Error())
+}
+
 // Test that a proxy that loops back into a provider with a downstream api-key-auth policy
 func TestLLMProviderTransformer_TransformProxy_LoopbackAuthCarriesProviderValuePrefix(t *testing.T) {
 	store := storage.NewConfigStore()


### PR DESCRIPTION
## Purpose

Additional LLM providers currently handle invalid `SourceConfiguration` values differently from the primary provider.

The primary provider rejects an invalid source configuration, while an additional provider silently continues processing. This can leave the API key value-prefix configuration incomplete and may generate incorrect routing or authentication configuration.

Resolves https://github.com/wso2/api-platform/issues/3007

## Goals

- Reject invalid additional LLM provider source configurations immediately.
- Return an error that identifies the affected additional provider.
- Prevent routing and authentication configuration from being generated for an invalid provider.
- Preserve the existing behavior for valid additional provider configurations.

## Approach

The additional-provider processing in `LLMProviderTransformer` now explicitly checks whether `SourceConfiguration` is an `LLMProviderConfiguration`.

If the type assertion fails, transformation stops and returns an error containing the additional provider ID.

A regression test was added with:

- A valid primary LLM provider.
- An additional provider containing an invalid source configuration type.
- Assertions that transformation returns the expected provider-specific error.
- An assertion that no transformed API configuration is returned.

Existing multi-provider tests continue to cover valid additional-provider authentication, transformers, and API key value-prefix handling.

## User stories

- As a gateway operator, I want invalid additional LLM provider configurations to be rejected immediately so that incomplete routing or authentication configuration is not deployed.
- As a developer, I want the validation error to identify the affected provider so that configuration problems can be diagnosed quickly.

## Documentation

N/A. This change only improves internal configuration validation and error handling. It does not introduce or modify any user-facing configuration fields or APIs.

## Automation tests

- Unit tests
  - Added `TestLLMProviderTransformer_TransformProxy_RejectsInvalidAdditionalProviderSourceConfiguration`.
  - Verified the invalid additional-provider configuration path.
  - Verified existing valid multi-provider transformer scenarios.
  - Ran the focused tests with Go race detection:

    ```bash
    go test -race -count=1 ./pkg/utils \
      -run 'TestLLMProviderTransformer_TransformProxy_'
    ```

  - Ran the complete gateway-controller test suite:

    ```bash
    go test -count=1 ./...
    ```

  - All tests passed.
  - The new failure branch is covered by the regression test. No new overall repository coverage percentage was collected.

- Integration tests
  - The complete gateway-controller test suite, including `gateway-controller/tests/integration`, passed.
  - The full Gateway BDD integration suite was not rerun specifically after rebasing this fix onto `bedrock-support`.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? no, not applicable because this is a Go-only change
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A. This validation fix does not introduce new configuration formats or features requiring samples.

## Related PRs

- https://github.com/wso2/api-platform/pull/2917

## Test environment

- Operating system: macOS
- Language/runtime: Go
- Database: SQLite-backed test storage and in-memory test storage
- JDK: N/A
- Browser: N/A