### PR TITLE
Remove unsupported "query" option from key selection in security tab

### DIFF
--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxySecurityTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxySecurityTab.tsx
@@ -195,11 +195,11 @@ export default function LLMProxySecurityTab() {
                 />
               </FormControl>
 
+              {/* Only "header" is supported by the api-key-auth policy */}
               <FormControl fullWidth size="small">
                 <FormLabel>Sent in</FormLabel>
                 <Select value={keyLocation} disabled={isFormDisabled} onChange={handleKeyLocationChange}>
                   <MenuItem value="header">Header</MenuItem>
-                  <MenuItem value="query">Query parameter</MenuItem>
                 </Select>
               </FormControl>
 


### PR DESCRIPTION
## Purpose
The "Sent in" selector on the LLM proxy security tab offered a "Query parameter" option, but the api-key-auth policy only supports sending the API key in a header. Selecting "Query parameter" produced a configuration the gateway does not enforce. This removes the unsupported option so the UI only exposes what the policy actually supports.


## UI View
<img width="859" height="610" alt="image" src="https://github.com/user-attachments/assets/26d71df2-ed8c-4470-b3fb-53bba0f2e1b2" />

Resolves: https://github.com/wso2/api-platform/issues/2958