### PR TITLE
Add gateway controller policies config

### DIFF
--- a/gateway/configs/config.toml
+++ b/gateway/configs/config.toml
@@ -34,6 +34,9 @@ gateway_name = '{{ env "APIP_GW_CONTROLLER_CONTROLPLANE_GATEWAY_NAME" "default" 
 apim_oauth2_client_id = '{{ env "APIP_GW_CONTROLLER_CONTROLPLANE_APIM_OAUTH2_CLIENT_ID" "" }}'
 apim_oauth2_client_secret = '{{ env "APIP_GW_CONTROLLER_CONTROLPLANE_APIM_OAUTH2_CLIENT_SECRET" "" }}'
 
+[controller.policies]
+definitions_path = '{{ env "APIP_GW_CONTROLLER_POLICIES_DEFINITIONS_PATH" "./default-policies" }}'
+
 [controller.auth.basic]
 enabled = true
 


### PR DESCRIPTION
This pull request introduces a configuration update to the gateway's TOML file, specifically adding a new section for policy definitions. This change allows the controller to specify the path where policy definitions are stored, making policy management more flexible and configurable.

Configuration enhancements:

* Added a new `[controller.policies]` section with a `definitions_path` setting to specify the directory for policy definitions in `config.toml`. The path can be configured via the `APIP_GW_CONTROLLER_POLICIES_DEFINITIONS_PATH` environment variable, defaulting to `./default-policies` if not set.