### PR TITLE
Add deprecated chip and fix plolicy loading issue

### DIFF
--- a/portals/ai-workspace/src/Components/GuardrailPill/PolicyCategorySelector.tsx
+++ b/portals/ai-workspace/src/Components/GuardrailPill/PolicyCategorySelector.tsx
@@ -101,7 +101,7 @@ export default function PolicyCategorySelector({
       >
         {value.length === 0 ? (
           <Typography variant="body2" color="text.secondary" sx={{ flex: 1 }}>
-            Select categories to filter
+            All categories
           </Typography>
         ) : (
           value.map((cat) => (

--- a/portals/ai-workspace/src/pages/appShell/PolicyParameterEditor/SchemaTree.tsx
+++ b/portals/ai-workspace/src/pages/appShell/PolicyParameterEditor/SchemaTree.tsx
@@ -18,7 +18,14 @@ import React, {
   useRef,
   useEffect,
 } from 'react';
-import { Box, Typography, Collapse, IconButton, Button } from '@wso2/oxygen-ui';
+import {
+  Box,
+  Typography,
+  Collapse,
+  IconButton,
+  Button,
+  Chip,
+} from '@wso2/oxygen-ui';
 import {
   ChevronRight,
   ChevronDown,
@@ -312,6 +319,15 @@ const SchemaTreeNodeComponent: React.FC<SchemaTreeNodeProps> = ({
                   defaultMessage={'(Optional)'}
                 />
               </Typography>
+            )}
+            {node.schema['x-wso2-policy-deprecated-param'] === true && (
+              <Chip
+                label="Deprecated"
+                size="small"
+                variant="outlined"
+                color="warning"
+                sx={classes.deprecatedBadge}
+              />
             )}
             {/* Delete button for array items */}
             {node.isArrayItem && node.parentArrayPath !== undefined && (

--- a/portals/ai-workspace/src/pages/appShell/PolicyParameterEditor/styles.ts
+++ b/portals/ai-workspace/src/pages/appShell/PolicyParameterEditor/styles.ts
@@ -129,6 +129,10 @@ export const useStyles = () => {
         color: theme.palette.error.main,
         fontSize: '0.75rem',
       },
+      deprecatedBadge: {
+        height: theme.spacing(2.5),
+        fontSize: '0.7rem',
+      },
       typeBadge: {
         fontSize: '0.7rem',
         padding: theme.spacing(0.25, 0.75),

--- a/portals/ai-workspace/src/pages/appShell/PolicyParameterEditor/types.ts
+++ b/portals/ai-workspace/src/pages/appShell/PolicyParameterEditor/types.ts
@@ -31,6 +31,7 @@ export interface ParameterSchema {
   minimum?: number;
   maximum?: number;
   'x-wso2-policy-advanced-param'?: boolean;
+  'x-wso2-policy-deprecated-param'?: boolean;
   anyOf?: Array<{
     required?: string[];
     properties?: Record<string, { const?: unknown }>;

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyGuardrailsTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyGuardrailsTab.tsx
@@ -46,14 +46,18 @@ import {
   X,
 } from '@wso2/oxygen-ui-icons-react';
 import YAML from 'yaml';
-import { getGuardrails } from '../../../../apis/policyHubApis';
+import { getGuardrails, getPolicies } from '../../../../apis/policyHubApis';
 import { getGatewayCustomPolicies } from '../../../../apis/gatewayPolicyApis';
 import type { GatewayCustomPolicy } from '../../../../apis/gatewayPolicyApis';
 import { useProxy } from '../../../../contexts/proxy';
 import { useGuardrails } from '../../../../contexts/GuardrailsContext';
 import { logger } from '../../../../utils/logger';
 import NoData from '../../../../assets/images/NoData.svg';
-import { GuardrailPill, PolicyCategorySelector } from '../../../../Components/GuardrailPill';
+import {
+  GuardrailPill,
+  POLICY_CATEGORIES,
+  PolicyCategorySelector,
+} from '../../../../Components/GuardrailPill';
 import { ResourceRow } from '../../../../Components/ResourceView';
 import PolicyParameterEditor from '../../PolicyParameterEditor/PolicyParameterEditor';
 import type {
@@ -238,13 +242,14 @@ export default function LLMProxyGuardrailsTab() {
   const [customPoliciesLoading, setCustomPoliciesLoading] = useState(false);
 
   const fetchDrawerGuardrails = useCallback(async (categories: string[]) => {
-    if (categories.length === 0) {
-      setDrawerGuardrails([]);
-      return;
-    }
     setDrawerGuardrailsLoading(true);
     try {
-      const response = await getGuardrails(categories.join(','));
+      const showAll =
+        categories.length === 0 ||
+        categories.length === POLICY_CATEGORIES.length;
+      const response = showAll
+        ? await getPolicies()
+        : await getGuardrails(categories.join(','));
       setDrawerGuardrails(response.data);
     } catch {
       setDrawerGuardrails([]);

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/AddNewProvider/GuardrailsSection.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/AddNewProvider/GuardrailsSection.tsx
@@ -36,10 +36,14 @@ import {
 } from '@wso2/oxygen-ui';
 import { Plus, Search, X } from '@wso2/oxygen-ui-icons-react';
 import { useGuardrails } from '../../../../../contexts/GuardrailsContext';
-import { getGuardrails } from '../../../../../apis/policyHubApis';
+import { getGuardrails, getPolicies } from '../../../../../apis/policyHubApis';
 import { getGatewayCustomPolicies } from '../../../../../apis/gatewayPolicyApis';
 import type { GatewayCustomPolicy } from '../../../../../apis/gatewayPolicyApis';
-import { GuardrailPill, PolicyCategorySelector } from '../../../../../Components/GuardrailPill';
+import {
+  GuardrailPill,
+  POLICY_CATEGORIES,
+  PolicyCategorySelector,
+} from '../../../../../Components/GuardrailPill';
 import PolicyParameterEditor from '../../../PolicyParameterEditor/PolicyParameterEditor';
 import type {
   ParameterSchema,
@@ -179,11 +183,6 @@ export default function GuardrailsSection({
 
   const fetchDrawerGuardrails = useCallback(
     async (categories: string[], offset: number, append: boolean) => {
-      if (categories.length === 0) {
-        setDrawerGuardrails([]);
-        setHasMoreGuardrails(false);
-        return;
-      }
       if (append) {
         setIsLoadingMoreGuardrails(true);
       } else {
@@ -191,11 +190,16 @@ export default function GuardrailsSection({
       }
       setDrawerGuardrailsError(null);
       try {
-        const response = await getGuardrails(
-          categories.join(','),
-          GUARDRAILS_PAGE_SIZE,
-          offset
-        );
+        const showAll =
+          categories.length === 0 ||
+          categories.length === POLICY_CATEGORIES.length;
+        const response = showAll
+          ? await getPolicies(offset, GUARDRAILS_PAGE_SIZE)
+          : await getGuardrails(
+              categories.join(','),
+              GUARDRAILS_PAGE_SIZE,
+              offset
+            );
         setDrawerGuardrails((prev) =>
           append ? [...prev, ...response.data] : response.data
         );

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderGuardrailsTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderGuardrailsTab.tsx
@@ -47,7 +47,7 @@ import {
   ChevronUp,
 } from '@wso2/oxygen-ui-icons-react';
 import YAML from 'yaml';
-import { getGuardrails } from '../../../../apis/policyHubApis';
+import { getGuardrails, getPolicies } from '../../../../apis/policyHubApis';
 import { getGatewayCustomPolicies } from '../../../../apis/gatewayPolicyApis';
 import type { GatewayCustomPolicy } from '../../../../apis/gatewayPolicyApis';
 import { useLLMProvider } from '../../../../contexts/llmProvider';
@@ -55,7 +55,11 @@ import { useGuardrails } from '../../../../contexts/GuardrailsContext';
 import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
 import { logger } from '../../../../utils/logger';
 import { filterOpenApiSpecByAccessControl } from '../../../../utils/openApiAccessControl';
-import { GuardrailPill, PolicyCategorySelector } from '../../../../Components/GuardrailPill';
+import {
+  GuardrailPill,
+  POLICY_CATEGORIES,
+  PolicyCategorySelector,
+} from '../../../../Components/GuardrailPill';
 import { ResourceRow } from '../../../../Components/ResourceView';
 import PolicyParameterEditor from '../../PolicyParameterEditor/PolicyParameterEditor';
 import type {
@@ -254,13 +258,14 @@ export default function ServiceProviderGuardrailsTab() {
   const showSnackbar = useAIWorkspaceSnackbar();
 
   const fetchDrawerGuardrails = useCallback(async (categories: string[]) => {
-    if (categories.length === 0) {
-      setDrawerGuardrails([]);
-      return;
-    }
     setDrawerGuardrailsLoading(true);
     try {
-      const response = await getGuardrails(categories.join(','));
+      const showAll =
+        categories.length === 0 ||
+        categories.length === POLICY_CATEGORIES.length;
+      const response = showAll
+        ? await getPolicies()
+        : await getGuardrails(categories.join(','));
       setDrawerGuardrails(response.data);
     } catch {
       setDrawerGuardrails([]);


### PR DESCRIPTION
This pull request updates the policy guardrails UI to improve category filtering and deprecated parameter visibility. The main changes ensure that selecting "All categories" fetches all policies instead of none, and that deprecated parameters are clearly indicated in the schema editor.

Issue: https://github.com/wso2/api-platform/issues/2912
<img width="526" height="433" alt="Screenshot 2026-07-30 at 19 21 02" src="https://github.com/user-attachments/assets/7f38365d-027c-4d8f-8d58-068324a49a7c" />


**Category filtering improvements:**
* Updated category selection logic in `LLMProxyGuardrailsTab.tsx`, `ServiceProviderGuardrailsTab.tsx`, and `AddNewProvider/GuardrailsSection.tsx` to fetch all policies when "All categories" are selected or no categories are chosen, using the new `getPolicies` API instead of returning an empty list. [[1]](diffhunk://#diff-1a40d994232962a2dbf8f2953f66aee1743e082634d106dcd6b4549d4b23529eL241-R252) [[2]](diffhunk://#diff-649184b21f9d9e48869f8e19f383dc659cb78588f66e433cf50480905390e26cL257-R268) [[3]](diffhunk://#diff-fbacc66a012bcb6c1b944239f0bc57da459c1bb961e9fba10111665ecaa2704cL182-R198)
* Changed the placeholder text in `PolicyCategorySelector.tsx` to display "All categories" instead of "Select categories to filter" when no categories are selected.
* Added `POLICY_CATEGORIES` import to relevant files to support the new filtering logic. [[1]](diffhunk://#diff-1a40d994232962a2dbf8f2953f66aee1743e082634d106dcd6b4549d4b23529eL49-R60) [[2]](diffhunk://#diff-fbacc66a012bcb6c1b944239f0bc57da459c1bb961e9fba10111665ecaa2704cL39-R46) [[3]](diffhunk://#diff-649184b21f9d9e48869f8e19f383dc659cb78588f66e433cf50480905390e26cL50-R62)

**Deprecated parameter indication:**
* Added support for displaying a "Deprecated" badge using a `Chip` in the schema tree node if a parameter is marked as deprecated (`x-wso2-policy-deprecated-param`).
* Updated the `ParameterSchema` type and styles to support the deprecated parameter badge. [[1]](diffhunk://#diff-c8e0f2aa085efb705172c0bc22fa3539240b52d38a2d4f5d65fd6aeeb00cdf6fR34) [[2]](diffhunk://#diff-8287b893088dc4ab41cfe04d9d624614be476141bd76c6e42d14bf11a5b331aeR132-R135)

These changes enhance the user experience by making category filtering more intuitive and by clearly marking deprecated parameters in the policy parameter editor.