### PR TITLE
Enhance SyncCustomPolicy to include createdBy and updatedBy fields for tracking policy changes

### DIFF
--- a/platform-api/internal/handler/gateway.go
+++ b/platform-api/internal/handler/gateway.go
@@ -410,7 +410,12 @@ func (h *GatewayHandler) SyncCustomPolicy(w http.ResponseWriter, r *http.Request
 		return apperror.ValidationFailed.New("gatewayId, policyName and policyVersion are required")
 	}
 
-	policy, err := h.gatewayService.SyncCustomPolicy(gatewayHandle, orgId, policyName, version)
+	createdBy, err := resolveActorErr(r, h.identity, "sync custom policy")
+	if err != nil {
+		return err
+	}
+
+	policy, err := h.gatewayService.SyncCustomPolicy(gatewayHandle, orgId, policyName, version, createdBy)
 	if err != nil {
 		var appErr *apperror.Error
 		if errors.As(err, &appErr) {

--- a/platform-api/internal/service/custom_policy_test.go
+++ b/platform-api/internal/service/custom_policy_test.go
@@ -815,3 +815,112 @@ func TestSyncCustomPolicy_ActorRecordedAsCreator(t *testing.T) {
 		}
 	})
 }
+
+// mappingIdentityRepo maps internal platform UUIDs to external identities, so
+// tests can tell a resolved response apart from a raw UUID (unlike
+// passthroughIdentityRepo, which returns the input unchanged).
+type mappingIdentityRepo struct {
+	subs map[string]string
+}
+
+func (m mappingIdentityRepo) GetOrCreateUUID(identity string) (string, error) {
+	return identity, nil
+}
+
+func (m mappingIdentityRepo) GetSubByUUID(uuid string) (string, bool, error) {
+	sub, ok := m.subs[uuid]
+	return sub, ok, nil
+}
+
+func (m mappingIdentityRepo) GetSubsByUUIDs(uuids []string) (map[string]string, error) {
+	result := make(map[string]string, len(uuids))
+	for _, id := range uuids {
+		if sub, ok := m.subs[id]; ok {
+			result[id] = sub
+		}
+	}
+	return result, nil
+}
+
+// TestCustomPolicyResponses_ResolveIdentity verifies that sync, get, and list
+// responses expose the external identity behind created_by/updated_by rather
+// than the internal platform UUID stored in the column, and fall back to the
+// deleted-user placeholder when a UUID has no mapping.
+func TestCustomPolicyResponses_ResolveIdentity(t *testing.T) {
+	const (
+		orgID      = "org-uuid-0001"
+		gwID       = "gw-uuid-0001"
+		policyID   = "pol-uuid-0001"
+		unmappedID = "user-uuid-gone"
+	)
+
+	newSvc := func(gwRepo repository.GatewayRepository, cpRepo repository.CustomPolicyRepository) *GatewayService {
+		svc := newTestGatewayService(gwRepo, cpRepo)
+		svc.identity = NewIdentityService(mappingIdentityRepo{subs: map[string]string{testActorUUID: "alice"}})
+		return svc
+	}
+
+	t.Run("sync", func(t *testing.T) {
+		persisted := makeCustomPolicy(policyID, orgID, "my-policy", "1.0.0")
+		persisted.CreatedBy = testActorUUID
+		persisted.UpdatedBy = testActorUUID
+
+		svc := newSvc(&mockGatewayRepoForPolicy{
+			gateway:  &model.Gateway{ID: gwID, OrganizationID: orgID},
+			manifest: sampleManifest("my-policy", "1.0.0"),
+		}, &mockCustomPolicyRepo{getPolicyByNameVersion: persisted})
+
+		got, err := svc.SyncCustomPolicy(gwID, orgID, "my-policy", "1.0.0", testActorUUID)
+		if err != nil {
+			t.Fatalf("SyncCustomPolicy() unexpected error: %v", err)
+		}
+		if got.CreatedBy != "alice" || got.UpdatedBy != "alice" {
+			t.Errorf("SyncCustomPolicy() createdBy/updatedBy = %q/%q, want %q/%q", got.CreatedBy, got.UpdatedBy, "alice", "alice")
+		}
+	})
+
+	t.Run("get", func(t *testing.T) {
+		stored := makeCustomPolicy(policyID, orgID, "my-policy", "1.0.0")
+		stored.CreatedBy = testActorUUID
+		stored.UpdatedBy = unmappedID
+
+		svc := newSvc(&mockGatewayRepoForPolicy{}, &mockCustomPolicyRepo{getPolicyByUUID: stored})
+
+		got, err := svc.GetCustomPolicyByUUID(orgID, policyID, "1.0.0")
+		if err != nil {
+			t.Fatalf("GetCustomPolicyByUUID() unexpected error: %v", err)
+		}
+		if got.CreatedBy != "alice" {
+			t.Errorf("GetCustomPolicyByUUID() createdBy = %q, want %q", got.CreatedBy, "alice")
+		}
+		if got.UpdatedBy != constants.DeletedUser {
+			t.Errorf("GetCustomPolicyByUUID() updatedBy = %q, want %q for an unmapped UUID", got.UpdatedBy, constants.DeletedUser)
+		}
+	})
+
+	t.Run("list", func(t *testing.T) {
+		mapped := makeCustomPolicy(policyID, orgID, "my-policy", "1.0.0")
+		mapped.CreatedBy = testActorUUID
+		mapped.UpdatedBy = testActorUUID
+		unmapped := makeCustomPolicy("pol-uuid-0002", orgID, "other-policy", "1.0.0")
+		unmapped.CreatedBy = unmappedID
+
+		svc := newSvc(&mockGatewayRepoForPolicy{}, &mockCustomPolicyRepo{
+			listPolicies: []*model.CustomPolicy{mapped, unmapped},
+		})
+
+		got, _, err := svc.ListCustomPolicies(orgID, 10, 0)
+		if err != nil {
+			t.Fatalf("ListCustomPolicies() unexpected error: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("ListCustomPolicies() returned %d policies, want 2", len(got))
+		}
+		if got[0].CreatedBy != "alice" || got[0].UpdatedBy != "alice" {
+			t.Errorf("ListCustomPolicies() createdBy/updatedBy = %q/%q, want %q/%q", got[0].CreatedBy, got[0].UpdatedBy, "alice", "alice")
+		}
+		if got[1].CreatedBy != constants.DeletedUser {
+			t.Errorf("ListCustomPolicies() createdBy = %q, want %q for an unmapped UUID", got[1].CreatedBy, constants.DeletedUser)
+		}
+	})
+}

--- a/platform-api/internal/service/custom_policy_test.go
+++ b/platform-api/internal/service/custom_policy_test.go
@@ -103,18 +103,22 @@ type mockCustomPolicyRepo struct {
 	countUsages               int
 	countUsagesErr            error
 	insertCalled              bool
+	insertedPolicy            *model.CustomPolicy
 	updateCalled              bool
+	updatedPolicy             *model.CustomPolicy
 	updateOldVersion          string
 	deleteIfUnusedCalled      bool
 }
 
 func (m *mockCustomPolicyRepo) InsertCustomPolicy(policy *model.CustomPolicy) error {
 	m.insertCalled = true
+	m.insertedPolicy = policy
 	return m.insertErr
 }
 
 func (m *mockCustomPolicyRepo) UpdateCustomPolicy(policy *model.CustomPolicy, oldVersion string) error {
 	m.updateCalled = true
+	m.updatedPolicy = policy
 	m.updateOldVersion = oldVersion
 	return m.updateErr
 }
@@ -183,6 +187,9 @@ func sampleManifest(name, version string) []byte {
 		},
 	})
 }
+
+// testActorUUID is the internal platform UUID of the user triggering a sync in tests.
+const testActorUUID = "user-uuid-0001"
 
 // newTestGatewayService provides a GatewayService with given mock repos.
 func newTestGatewayService(gwRepo repository.GatewayRepository, cpRepo repository.CustomPolicyRepository) *GatewayService {
@@ -421,7 +428,7 @@ func TestSyncCustomPolicy(t *testing.T) {
 			}
 
 			svc := newTestGatewayService(gwRepo, cpRepo)
-			policy, err := svc.SyncCustomPolicy(gwID, orgID, tt.policyName, tt.version)
+			policy, err := svc.SyncCustomPolicy(gwID, orgID, tt.policyName, tt.version, testActorUUID)
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("SyncCustomPolicy() error = %v, wantErr %v", err, tt.wantErr)
@@ -471,7 +478,7 @@ func TestSyncCustomPolicy_MinorUpdatePreservesUUID(t *testing.T) {
 	}
 
 	svc := newTestGatewayService(gwRepo, cpRepo)
-	result, err := svc.SyncCustomPolicy(gwID, orgID, "my-policy", "1.2.0")
+	result, err := svc.SyncCustomPolicy(gwID, orgID, "my-policy", "1.2.0", testActorUUID)
 	if err != nil {
 		t.Fatalf("SyncCustomPolicy() unexpected error: %v", err)
 	}
@@ -748,4 +755,63 @@ func TestReceiveGatewayManifest_LegacyCustomerNormalized(t *testing.T) {
 	if p := byName["built-in"]; p.ManagedBy != constants.PolicyManagedByWSO2 {
 		t.Errorf("built-in policy stored with managedBy %q, want %q", p.ManagedBy, constants.PolicyManagedByWSO2)
 	}
+}
+
+// TestSyncCustomPolicy_ActorRecordedAsCreator verifies that created_by/updated_by
+// carry the triggering user's internal UUID, not the gateway's ID, and that an
+// existing policy's original creator survives a minor-version update.
+func TestSyncCustomPolicy_ActorRecordedAsCreator(t *testing.T) {
+	const (
+		orgID      = "org-uuid-0001"
+		gwID       = "gw-uuid-0001"
+		existingID = "stable-policy-uuid"
+	)
+
+	t.Run("insert", func(t *testing.T) {
+		gwRepo := &mockGatewayRepoForPolicy{
+			gateway:  &model.Gateway{ID: gwID, OrganizationID: orgID},
+			manifest: sampleManifest("my-policy", "1.0.0"),
+		}
+		cpRepo := &mockCustomPolicyRepo{}
+
+		svc := newTestGatewayService(gwRepo, cpRepo)
+		if _, err := svc.SyncCustomPolicy(gwID, orgID, "my-policy", "1.0.0", testActorUUID); err != nil {
+			t.Fatalf("SyncCustomPolicy() unexpected error: %v", err)
+		}
+		if cpRepo.insertedPolicy == nil {
+			t.Fatal("InsertCustomPolicy() was not called")
+		}
+		if got := cpRepo.insertedPolicy.CreatedBy; got != testActorUUID {
+			t.Errorf("CreatedBy = %q, want %q (the triggering user, not the gateway)", got, testActorUUID)
+		}
+		if got := cpRepo.insertedPolicy.UpdatedBy; got != testActorUUID {
+			t.Errorf("UpdatedBy = %q, want %q", got, testActorUUID)
+		}
+	})
+
+	t.Run("minor version update", func(t *testing.T) {
+		const originalCreator = "user-uuid-0002"
+		existing := makeCustomPolicy(existingID, orgID, "my-policy", "1.1.0")
+		existing.CreatedBy = originalCreator
+
+		gwRepo := &mockGatewayRepoForPolicy{
+			gateway:  &model.Gateway{ID: gwID, OrganizationID: orgID},
+			manifest: sampleManifest("my-policy", "1.2.0"),
+		}
+		cpRepo := &mockCustomPolicyRepo{getPoliciesByName: []*model.CustomPolicy{existing}}
+
+		svc := newTestGatewayService(gwRepo, cpRepo)
+		if _, err := svc.SyncCustomPolicy(gwID, orgID, "my-policy", "1.2.0", testActorUUID); err != nil {
+			t.Fatalf("SyncCustomPolicy() unexpected error: %v", err)
+		}
+		if cpRepo.updatedPolicy == nil {
+			t.Fatal("UpdateCustomPolicy() was not called")
+		}
+		if got := cpRepo.updatedPolicy.UpdatedBy; got != testActorUUID {
+			t.Errorf("UpdatedBy = %q, want %q (the triggering user)", got, testActorUUID)
+		}
+		if got := cpRepo.updatedPolicy.CreatedBy; got != originalCreator {
+			t.Errorf("CreatedBy = %q, want %q (original creator preserved)", got, originalCreator)
+		}
+	})
 }

--- a/platform-api/internal/service/gateway.go
+++ b/platform-api/internal/service/gateway.go
@@ -326,8 +326,10 @@ func parseVersion(v string) (parsedVersion, error) {
 
 // SyncCustomPolicy upserts a custom policy from the gateway manifest into the gateway_custom_policies table.
 // The gateway is identified by its handle and must belong to the caller's organization. The policy must
-// exist in the manifest and it should be a custom policy.
-func (s *GatewayService) SyncCustomPolicy(gatewayHandle, orgID, policyName, version string) (*model.CustomPolicy, error) {
+// exist in the manifest and it should be a custom policy. createdBy is the internal platform UUID of the
+// user who triggered the sync (resolved from the token), and is what lands in created_by/updated_by —
+// never the gateway's own ID.
+func (s *GatewayService) SyncCustomPolicy(gatewayHandle, orgID, policyName, version, createdBy string) (*model.CustomPolicy, error) {
 	policyName = strings.ToLower(policyName)
 
 	gateway, err := s.gatewayRepo.GetByHandleAndOrgID(gatewayHandle, orgID)
@@ -413,8 +415,8 @@ func (s *GatewayService) SyncCustomPolicy(gatewayHandle, orgID, policyName, vers
 		Version:          version,
 		Description:      found.Description,
 		PolicyDefinition: policyDefJSON,
-		CreatedBy:        gateway.ID,
-		UpdatedBy:        gateway.ID,
+		CreatedBy:        createdBy,
+		UpdatedBy:        createdBy,
 	}
 
 	if sameMajorVersionedPolicy != nil {
@@ -438,8 +440,11 @@ func (s *GatewayService) SyncCustomPolicy(gatewayHandle, orgID, policyName, vers
 				WithLogMessage(fmt.Sprintf("cannot downgrade policy '%s' from '%s' to '%s'",
 					policyName, sameMajorVersionedPolicy.Version, version))
 		}
-		// New minor version — update the existing record.
+		// New minor version — update the existing record. created_by stays with the
+		// original creator (the UPDATE only touches updated_by); mirror that here so
+		// the returned model matches the persisted row.
 		policy.UUID = sameMajorVersionedPolicy.UUID
+		policy.CreatedBy = sameMajorVersionedPolicy.CreatedBy
 		if err := s.customPolicyRepo.UpdateCustomPolicy(policy, sameMajorVersionedPolicy.Version); err != nil {
 			s.slogger.Error("failed to update custom policy", slog.String("org_id", orgID), slog.String("policy_name", policyName), slog.String("old_version", sameMajorVersionedPolicy.Version), slog.String("new_version", version))
 			return nil, fmt.Errorf("failed to update custom policy: %w", err)
@@ -472,12 +477,12 @@ func (s *GatewayService) SyncCustomPolicy(gatewayHandle, orgID, policyName, vers
 	persisted, err := s.customPolicyRepo.GetCustomPolicyByNameAndVersion(orgID, policyName, version)
 	if err != nil || persisted == nil {
 		if s.auditRepo != nil {
-			_ = s.auditRepo.Record("CREATE", policy.UUID, "custom_policy", orgID, "")
+			_ = s.auditRepo.Record("CREATE", policy.UUID, "custom_policy", orgID, createdBy)
 		}
 		return policy, nil
 	}
 	if s.auditRepo != nil {
-		_ = s.auditRepo.Record("CREATE", persisted.UUID, "custom_policy", orgID, "")
+		_ = s.auditRepo.Record("CREATE", persisted.UUID, "custom_policy", orgID, createdBy)
 	}
 	return persisted, nil
 }

--- a/platform-api/internal/service/gateway.go
+++ b/platform-api/internal/service/gateway.go
@@ -479,12 +479,73 @@ func (s *GatewayService) SyncCustomPolicy(gatewayHandle, orgID, policyName, vers
 		if s.auditRepo != nil {
 			_ = s.auditRepo.Record("CREATE", policy.UUID, "custom_policy", orgID, createdBy)
 		}
+		if err := s.resolveCustomPolicyIdentity(policy); err != nil {
+			return nil, err
+		}
 		return policy, nil
 	}
 	if s.auditRepo != nil {
 		_ = s.auditRepo.Record("CREATE", persisted.UUID, "custom_policy", orgID, createdBy)
 	}
+	if err := s.resolveCustomPolicyIdentity(persisted); err != nil {
+		return nil, err
+	}
 	return persisted, nil
+}
+
+// resolveCustomPolicyIdentity replaces the internal platform UUIDs held in a
+// custom policy's CreatedBy/UpdatedBy with the raw external identity, so a
+// response never exposes an internal UUID — the same unwrapping every other
+// resource does via IdentityService before returning a detail response.
+func (s *GatewayService) resolveCustomPolicyIdentity(policy *model.CustomPolicy) error {
+	if policy == nil {
+		return nil
+	}
+	createdBy, err := s.identity.SubForUUID(policy.CreatedBy)
+	if err != nil {
+		return err
+	}
+	updatedBy, err := s.identity.SubForUUID(policy.UpdatedBy)
+	if err != nil {
+		return err
+	}
+	policy.CreatedBy = createdBy
+	policy.UpdatedBy = updatedBy
+	return nil
+}
+
+// resolveCustomPolicyIdentities is the list equivalent of
+// resolveCustomPolicyIdentity, batching every lookup into one query to avoid
+// an N+1 against the identity mapping table.
+func (s *GatewayService) resolveCustomPolicyIdentities(policies []*model.CustomPolicy) error {
+	uuids := make([]string, 0, len(policies)*2)
+	for _, p := range policies {
+		if p == nil {
+			continue
+		}
+		uuids = append(uuids, p.CreatedBy, p.UpdatedBy)
+	}
+	resolved, err := s.identity.SubsForUUIDs(uuids)
+	if err != nil {
+		return err
+	}
+	for _, p := range policies {
+		if p == nil {
+			continue
+		}
+		// An empty UUID is absent from the map; SubForUUID's contract maps it
+		// to the deleted-user placeholder, so mirror that here.
+		p.CreatedBy = resolvedIdentityOrDeleted(resolved, p.CreatedBy)
+		p.UpdatedBy = resolvedIdentityOrDeleted(resolved, p.UpdatedBy)
+	}
+	return nil
+}
+
+func resolvedIdentityOrDeleted(resolved map[string]string, uuid string) string {
+	if identity, ok := resolved[uuid]; ok && identity != "" {
+		return identity
+	}
+	return constants.DeletedUser
 }
 
 // ListCustomPolicies returns all custom policies synced for the given organization.
@@ -498,7 +559,11 @@ func (s *GatewayService) ListCustomPolicies(orgID string, limit, offset int) ([]
 	// Custom policies for one organization are a small, bounded set, so the total
 	// is the full count and the requested window is applied in memory.
 	total := len(policies)
-	return paginateSlice(policies, limit, offset), total, nil
+	page := paginateSlice(policies, limit, offset)
+	if err := s.resolveCustomPolicyIdentities(page); err != nil {
+		return nil, 0, err
+	}
+	return page, total, nil
 }
 
 // GetCustomPolicyByUUID returns a custom policy by UUID, verifying org ownership and version.
@@ -512,6 +577,9 @@ func (s *GatewayService) GetCustomPolicyByUUID(orgID, policyUUID, version string
 	}
 	if policy.Version != version {
 		return nil, apperror.CustomPolicyVersionNotFnd.New()
+	}
+	if err := s.resolveCustomPolicyIdentity(policy); err != nil {
+		return nil, err
 	}
 	return policy, nil
 }


### PR DESCRIPTION
Enhance SyncCustomPolicy to include createdBy and updatedBy fields for better tracking of policy changes. Update related tests to verify correct user attribution during policy sync operations.

https://github.com/wso2/api-platform/issues/3039