### PR TITLE
fix(policy-engine): extract trace context from request headers

### DIFF
--- a/gateway/gateway-runtime/policy-engine/internal/kernel/extproc.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/extproc.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	extprocconfigv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_proc/v3"
@@ -34,6 +35,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 	grpccodes "google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -97,6 +99,33 @@ func NewExternalProcessorServer(kernel *Kernel, chainExecutor *executor.ChainExe
 	}
 }
 
+// traceContextCarrier builds a W3C trace-context carrier from the downstream
+// HTTP request headers Envoy delivers in a RequestHeaders ProcessingRequest.
+// Only traceparent/tracestate are copied. Any non-header message (or one with
+// no headers) yields an empty carrier, so a new root trace is started. Header
+// keys arrive lowercased over HTTP/2, but ToLower keeps this robust regardless.
+func traceContextCarrier(req *extprocv3.ProcessingRequest) propagation.MapCarrier {
+	carrier := propagation.MapCarrier{}
+	rh, ok := req.Request.(*extprocv3.ProcessingRequest_RequestHeaders)
+	if !ok || rh.RequestHeaders.GetHeaders() == nil {
+		return carrier
+	}
+	for _, h := range rh.RequestHeaders.GetHeaders().GetHeaders() {
+		key := strings.ToLower(h.Key)
+		if key != "traceparent" && key != "tracestate" {
+			continue
+		}
+		// Newer Envoy carries the value in RawValue; fall back to the
+		// deprecated Value field for compatibility.
+		value := string(h.RawValue)
+		if value == "" {
+			value = h.Value
+		}
+		carrier[key] = value
+	}
+	return carrier
+}
+
 // Process implements the bidirectional streaming RPC handler
 // T060: Process(stream) bidirectional streaming RPC handler
 func (s *ExternalProcessorServer) Process(stream extprocv3.ExternalProcessor_ProcessServer) error {
@@ -104,12 +133,14 @@ func (s *ExternalProcessorServer) Process(stream extprocv3.ExternalProcessor_Pro
 	metrics.ActiveStreams.Inc()
 	defer metrics.ActiveStreams.Dec()
 
-	// Extract trace context and create span - NoOp if tracing disabled
-	traceCtx := tracing.ExtractTraceContext(stream.Context())
-	ctx, span := s.tracer.Start(traceCtx, constants.SpanExternalProcessingProcess,
-		trace.WithSpanKind(trace.SpanKindServer),
-	)
-	defer span.End()
+	// The root span and its context are created lazily on the first message.
+	// The downstream request's W3C trace context (traceparent/tracestate) is
+	// delivered by Envoy inside the RequestHeaders ProcessingRequest body — NOT
+	// as ext_proc gRPC stream metadata — so it cannot be extracted until the
+	// first message arrives. Until then, ctx is the raw stream context and span
+	// is nil. NoOp if tracing is disabled.
+	ctx := stream.Context()
+	var span trace.Span
 
 	// Execution context for this request-response lifecycle.
 	// Initialized lazily on first request headers phase via handleProcessingPhase.
@@ -117,13 +148,20 @@ func (s *ExternalProcessorServer) Process(stream extprocv3.ExternalProcessor_Pro
 	// Lives until response complete, then garbage collected when stream ends.
 	// One stream = one HTTP request, so this is allocated once per request.
 	var execCtx *PolicyExecutionContext
-	// Stamp the request's terminal HTTP status on the root span. Registered AFTER
-	// `defer span.End()` above, so LIFO ordering guarantees this runs while the
-	// span is still recording. execCtx.terminal holds the last outcome resolved
-	// by handleProcessingPhase: the upstream response status for a pass-through,
-	// or the denial/fault status for a short-circuit. Nothing is recorded when no
-	// phase ever resolved a status (execCtx nil, or the stream ended mid-request);
-	// paths that terminate without an execCtx stamp parentSpan inline instead.
+	// LIFO defer ordering (registered here, run at return): closeStreamDecompressors
+	// runs first, then the terminal-outcome stamp (while the span is still
+	// recording), then span.End() last — the outcome defer is registered AFTER
+	// span.End() precisely so it runs before it. execCtx.terminal holds the last
+	// outcome resolved by handleProcessingPhase: the upstream response status for
+	// a pass-through, or the denial/fault status for a short-circuit. Nothing is
+	// stamped when no phase ever resolved a status (execCtx nil, or the stream
+	// ended before the first message so span is nil); paths that terminate
+	// without an execCtx stamp parentSpan inline instead.
+	defer func() {
+		if span != nil {
+			span.End()
+		}
+	}()
 	defer func() {
 		if execCtx != nil {
 			tracing.RecordHTTPOutcome(span, execCtx.terminal)
@@ -142,6 +180,16 @@ func (s *ExternalProcessorServer) Process(stream extprocv3.ExternalProcessor_Pro
 			return nil
 		}
 		if err != nil {
+			// Ensure the root span exists even when the stream fails before the
+			// first message ever arrives: there is no request trace context to
+			// parent on yet, so this is the same new root we would otherwise
+			// start below — created here only so a stream-level failure is still
+			// observable.
+			if span == nil {
+				ctx, span = s.tracer.Start(ctx, constants.SpanExternalProcessingProcess,
+					trace.WithSpanKind(trace.SpanKindServer),
+				)
+			}
 			// Check if this is a normal stream closure due to context cancellation
 			// This happens when Envoy closes the stream after completing the request
 			if errors.Is(err, context.Canceled) || status.Code(err) == grpccodes.Canceled {
@@ -156,6 +204,16 @@ func (s *ExternalProcessorServer) Process(stream extprocv3.ExternalProcessor_Pro
 				span.SetStatus(codes.Error, "ext_proc stream receive failed")
 			}
 			return status.Errorf(grpccodes.Unknown, "failed to receive request: %v", err)
+		}
+
+		// Start the root span on the first message, parented on the request's
+		// trace context extracted from its HTTP headers (RequestHeaders phase).
+		// Subsequent messages on this stream reuse the same span and context.
+		if span == nil {
+			traceCtx := tracing.ExtractTraceContext(ctx, traceContextCarrier(req))
+			ctx, span = s.tracer.Start(traceCtx, constants.SpanExternalProcessingProcess,
+				trace.WithSpanKind(trace.SpanKindServer),
+			)
 		}
 
 		// Handle the request based on phase

--- a/gateway/gateway-runtime/policy-engine/internal/kernel/extproc.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/extproc.go
@@ -59,6 +59,11 @@ type ExternalProcessorServer struct {
 	executor *executor.ChainExecutor
 	tracer   trace.Tracer
 
+	// tracingEnabled gates the per-request trace-context extraction. When false,
+	// the tracer is a no-op anyway, so building the carrier and running the
+	// propagator would be wasted work on the request hot path — skip it.
+	tracingEnabled bool
+
 	// Per-direction caps on decompressed bytes buffered per body (buffered mode)
 	// or per chunk (streaming), from policy_engine.request_body/.response_body config.
 	// Always positive: the constructor falls back to
@@ -94,6 +99,7 @@ func NewExternalProcessorServer(kernel *Kernel, chainExecutor *executor.ChainExe
 		kernel:                       kernel,
 		executor:                     chainExecutor,
 		tracer:                       otel.Tracer(serviceName),
+		tracingEnabled:               tracingConfig.Enabled,
 		maxRequestDecompressedBytes:  maxRequestDecompressedBytes,
 		maxResponseDecompressedBytes: maxResponseDecompressedBytes,
 	}
@@ -138,6 +144,21 @@ func traceContextCarrier(req *extprocv3.ProcessingRequest) propagation.MapCarrie
 		carrier[key] = value
 	}
 	return carrier
+}
+
+// startRootSpan starts the ext_proc root span for a stream. When tracing is
+// enabled and a request is available, the span is parented on the downstream
+// request's W3C trace context (traceparent/tracestate from its HTTP headers);
+// otherwise it starts a new root. When tracing is disabled the returned span is
+// a no-op and the per-request header extraction is skipped entirely. req is nil
+// on the pre-first-message error path, which likewise starts a plain new root.
+func (s *ExternalProcessorServer) startRootSpan(ctx context.Context, req *extprocv3.ProcessingRequest) (context.Context, trace.Span) {
+	if s.tracingEnabled && req != nil {
+		ctx = tracing.ExtractTraceContext(ctx, traceContextCarrier(req))
+	}
+	return s.tracer.Start(ctx, constants.SpanExternalProcessingProcess,
+		trace.WithSpanKind(trace.SpanKindServer),
+	)
 }
 
 // Process implements the bidirectional streaming RPC handler
@@ -200,9 +221,7 @@ func (s *ExternalProcessorServer) Process(stream extprocv3.ExternalProcessor_Pro
 			// start below — created here only so a stream-level failure is still
 			// observable.
 			if span == nil {
-				ctx, span = s.tracer.Start(ctx, constants.SpanExternalProcessingProcess,
-					trace.WithSpanKind(trace.SpanKindServer),
-				)
+				ctx, span = s.startRootSpan(ctx, nil)
 			}
 			// Check if this is a normal stream closure due to context cancellation
 			// This happens when Envoy closes the stream after completing the request
@@ -224,10 +243,7 @@ func (s *ExternalProcessorServer) Process(stream extprocv3.ExternalProcessor_Pro
 		// trace context extracted from its HTTP headers (RequestHeaders phase).
 		// Subsequent messages on this stream reuse the same span and context.
 		if span == nil {
-			traceCtx := tracing.ExtractTraceContext(ctx, traceContextCarrier(req))
-			ctx, span = s.tracer.Start(traceCtx, constants.SpanExternalProcessingProcess,
-				trace.WithSpanKind(trace.SpanKindServer),
-			)
+			ctx, span = s.startRootSpan(ctx, req)
 		}
 
 		// Handle the request based on phase

--- a/gateway/gateway-runtime/policy-engine/internal/kernel/extproc.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/extproc.go
@@ -121,6 +121,20 @@ func traceContextCarrier(req *extprocv3.ProcessingRequest) propagation.MapCarrie
 		if value == "" {
 			value = h.Value
 		}
+		// W3C Trace Context permits tracestate to be split across multiple
+		// header fields; a receiver must combine them into one value in field
+		// order (comma-separated). traceparent must appear exactly once, so it
+		// stays last-wins — appending would yield a malformed value the
+		// propagator rejects.
+		if key == "tracestate" {
+			if prev := carrier[key]; prev != "" {
+				if value == "" {
+					value = prev
+				} else {
+					value = prev + "," + value
+				}
+			}
+		}
 		carrier[key] = value
 	}
 	return carrier

--- a/gateway/gateway-runtime/policy-engine/internal/kernel/extproc_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/extproc_test.go
@@ -269,6 +269,28 @@ func TestTraceContextCarrier(t *testing.T) {
 		assert.Empty(t, carrier.Get(":path"))
 	})
 
+	t.Run("combines repeated tracestate headers in field order", func(t *testing.T) {
+		req := &extprocv3.ProcessingRequest{
+			Request: &extprocv3.ProcessingRequest_RequestHeaders{
+				RequestHeaders: &extprocv3.HttpHeaders{
+					Headers: &corev3.HeaderMap{
+						Headers: []*corev3.HeaderValue{
+							{Key: "traceparent", RawValue: []byte(traceparent)},
+							{Key: "tracestate", RawValue: []byte("vendor1=value1")},
+							{Key: "tracestate", RawValue: []byte("vendor2=value2")},
+						},
+					},
+				},
+			},
+		}
+
+		carrier := traceContextCarrier(req)
+		// W3C requires repeated tracestate fields be combined in field order,
+		// not overwritten.
+		assert.Equal(t, "vendor1=value1,vendor2=value2", carrier.Get("tracestate"))
+		assert.Equal(t, traceparent, carrier.Get("traceparent"))
+	})
+
 	t.Run("falls back to deprecated Value field", func(t *testing.T) {
 		req := &extprocv3.ProcessingRequest{
 			Request: &extprocv3.ProcessingRequest_RequestHeaders{

--- a/gateway/gateway-runtime/policy-engine/internal/kernel/extproc_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/kernel/extproc_test.go
@@ -244,6 +244,69 @@ func TestProcess_RequestHeaders_NoPolicyChain(t *testing.T) {
 	assert.Contains(t, string(immResp.Body), "Internal Server Error")
 }
 
+func TestTraceContextCarrier(t *testing.T) {
+	const traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+	const tracestate = "vendor1=value1"
+
+	t.Run("extracts traceparent and tracestate from request headers", func(t *testing.T) {
+		req := &extprocv3.ProcessingRequest{
+			Request: &extprocv3.ProcessingRequest_RequestHeaders{
+				RequestHeaders: &extprocv3.HttpHeaders{
+					Headers: &corev3.HeaderMap{
+						Headers: []*corev3.HeaderValue{
+							{Key: ":path", RawValue: []byte("/api/v1/pets")},
+							{Key: "traceparent", RawValue: []byte(traceparent)},
+							{Key: "tracestate", RawValue: []byte(tracestate)},
+						},
+					},
+				},
+			},
+		}
+
+		carrier := traceContextCarrier(req)
+		assert.Equal(t, traceparent, carrier.Get("traceparent"))
+		assert.Equal(t, tracestate, carrier.Get("tracestate"))
+		assert.Empty(t, carrier.Get(":path"))
+	})
+
+	t.Run("falls back to deprecated Value field", func(t *testing.T) {
+		req := &extprocv3.ProcessingRequest{
+			Request: &extprocv3.ProcessingRequest_RequestHeaders{
+				RequestHeaders: &extprocv3.HttpHeaders{
+					Headers: &corev3.HeaderMap{
+						Headers: []*corev3.HeaderValue{
+							{Key: "TraceParent", Value: traceparent},
+						},
+					},
+				},
+			},
+		}
+
+		// Mixed-case key is lowercased; empty RawValue falls back to Value.
+		assert.Equal(t, traceparent, traceContextCarrier(req).Get("traceparent"))
+	})
+
+	t.Run("returns empty carrier for non-header messages", func(t *testing.T) {
+		req := &extprocv3.ProcessingRequest{
+			Request: &extprocv3.ProcessingRequest_RequestBody{
+				RequestBody: &extprocv3.HttpBody{Body: []byte("payload")},
+			},
+		}
+
+		assert.Empty(t, traceContextCarrier(req).Keys())
+	})
+
+	t.Run("returns empty carrier when no headers present", func(t *testing.T) {
+		req := &extprocv3.ProcessingRequest{
+			Request: &extprocv3.ProcessingRequest_RequestHeaders{
+				RequestHeaders: &extprocv3.HttpHeaders{},
+			},
+		}
+
+		assert.Empty(t, traceContextCarrier(req).Keys())
+	})
+}
+
 func TestProcess_UnknownRequestType(t *testing.T) {
 	kernel := NewKernel()
 	chainExecutor := executor.NewChainExecutor(nil, nil, nil)

--- a/gateway/gateway-runtime/policy-engine/internal/tracing/tracer.go
+++ b/gateway/gateway-runtime/policy-engine/internal/tracing/tracer.go
@@ -23,11 +23,8 @@ import (
 	"log/slog"
 	"time"
 
-	"strings"
-
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
-	"google.golang.org/grpc/metadata"
 
 	"github.com/wso2/api-platform/gateway/gateway-runtime/policy-engine/internal/config"
 
@@ -170,38 +167,29 @@ func InitTracer(cfg *config.Config) (func(), error) {
 	}, nil
 }
 
-// ExtractTraceContext extracts W3C Trace Context from gRPC metadata
-func ExtractTraceContext(ctx context.Context) context.Context {
-	md, ok := metadata.FromIncomingContext(ctx)
-	if !ok {
-		slog.DebugContext(ctx, "No gRPC metadata in context")
-		return ctx
-	}
-
-	// Create carrier from gRPC metadata
-	carrier := propagation.MapCarrier{}
-
-	for key, values := range md {
-		lowerKey := strings.ToLower(key)
-		// gRPC metadata is case-insensitive
-		if lowerKey == "traceparent" || lowerKey == "tracestate" {
-			if len(values) > 0 {
-				carrier.Set(lowerKey, values[0])
-				slog.DebugContext(ctx, "Extracted trace header", "header", lowerKey, "value", values[0])
-			}
-		}
-	}
-
-	// Extract using W3C Trace Context propagator
+// ExtractTraceContext extracts the W3C Trace Context (traceparent/tracestate)
+// from the given carrier and returns a context parented on the remote span.
+//
+// The carrier must be built from the downstream HTTP request headers that Envoy
+// delivers inside the RequestHeaders ProcessingRequest body — NOT from the
+// ext_proc gRPC stream metadata. The request's traceparent travels in the
+// message body, and the long-lived bidirectional ext_proc stream sets its gRPC
+// metadata only once at stream establishment, so it never carries a per-request
+// traceparent. Reading it from stream metadata always yielded an empty span
+// context, producing a new (unparented) root trace for every request.
+//
+// When the carrier holds no valid traceparent, the input context is returned
+// unchanged and the caller will start a fresh root trace — an ordinary,
+// non-error condition (e.g. Envoy tracing disabled), so it is logged at debug.
+func ExtractTraceContext(ctx context.Context, carrier propagation.TextMapCarrier) context.Context {
 	propagator := otel.GetTextMapPropagator()
 	newCtx := propagator.Extract(ctx, carrier)
 
-	// Verify extraction
 	span := trace.SpanContextFromContext(newCtx)
 	if span.IsValid() {
-		slog.DebugContext(ctx, "Successfully extracted trace", "trace_id", span.TraceID().String())
+		slog.DebugContext(ctx, "Extracted trace context from request headers", "trace_id", span.TraceID().String())
 	} else {
-		slog.InfoContext(ctx, "No valid trace context extracted")
+		slog.DebugContext(ctx, "No trace context in request headers; starting a new root trace")
 	}
 
 	return newCtx

--- a/gateway/gateway-runtime/policy-engine/internal/tracing/tracer_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/tracing/tracer_test.go
@@ -33,7 +33,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/metadata"
 )
 
 // =============================================================================
@@ -160,21 +159,20 @@ func TestInitTracer_DisabledWithEndpoint(t *testing.T) {
 // ExtractTraceContext Tests
 // =============================================================================
 
-func TestExtractTraceContext_NoMetadata(t *testing.T) {
+func TestExtractTraceContext_NilCarrier(t *testing.T) {
 	setupPropagator()
 	ctx := context.Background()
-	newCtx := ExtractTraceContext(ctx)
+	newCtx := ExtractTraceContext(ctx, propagation.MapCarrier(nil))
 
-	// Should return a valid context even without metadata
+	// Should return a valid context even without a carrier
 	assert.NotNil(t, newCtx)
+	span := trace.SpanContextFromContext(newCtx)
+	assert.False(t, span.IsValid())
 }
 
-func TestExtractTraceContext_EmptyMetadata(t *testing.T) {
+func TestExtractTraceContext_EmptyCarrier(t *testing.T) {
 	setupPropagator()
-	md := metadata.MD{}
-	ctx := metadata.NewIncomingContext(context.Background(), md)
-
-	newCtx := ExtractTraceContext(ctx)
+	newCtx := ExtractTraceContext(context.Background(), propagation.MapCarrier{})
 	assert.NotNil(t, newCtx)
 
 	// Should have no valid trace context
@@ -186,14 +184,11 @@ func TestExtractTraceContext_WithTraceparent(t *testing.T) {
 	setupPropagator()
 	// Valid W3C traceparent header
 	// Format: version-trace_id-parent_id-flags
-	traceparent := "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
-
-	md := metadata.MD{
-		"traceparent": []string{traceparent},
+	carrier := propagation.MapCarrier{
+		"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
 	}
-	ctx := metadata.NewIncomingContext(context.Background(), md)
 
-	newCtx := ExtractTraceContext(ctx)
+	newCtx := ExtractTraceContext(context.Background(), carrier)
 	assert.NotNil(t, newCtx)
 
 	span := trace.SpanContextFromContext(newCtx)
@@ -203,16 +198,12 @@ func TestExtractTraceContext_WithTraceparent(t *testing.T) {
 
 func TestExtractTraceContext_WithTracestate(t *testing.T) {
 	setupPropagator()
-	traceparent := "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
-	tracestate := "vendor1=value1,vendor2=value2"
-
-	md := metadata.MD{
-		"traceparent": []string{traceparent},
-		"tracestate":  []string{tracestate},
+	carrier := propagation.MapCarrier{
+		"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+		"tracestate":  "vendor1=value1,vendor2=value2",
 	}
-	ctx := metadata.NewIncomingContext(context.Background(), md)
 
-	newCtx := ExtractTraceContext(ctx)
+	newCtx := ExtractTraceContext(context.Background(), carrier)
 	assert.NotNil(t, newCtx)
 
 	span := trace.SpanContextFromContext(newCtx)
@@ -234,38 +225,15 @@ func TestExtractTraceContext_InvalidTraceparent(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			md := metadata.MD{
-				"traceparent": []string{tc.traceparent},
-			}
-			ctx := metadata.NewIncomingContext(context.Background(), md)
+			carrier := propagation.MapCarrier{"traceparent": tc.traceparent}
 
-			newCtx := ExtractTraceContext(ctx)
+			newCtx := ExtractTraceContext(context.Background(), carrier)
 			assert.NotNil(t, newCtx)
 
 			span := trace.SpanContextFromContext(newCtx)
 			assert.False(t, span.IsValid())
 		})
 	}
-}
-
-func TestExtractTraceContext_MultipleValues(t *testing.T) {
-	setupPropagator()
-	// When multiple values are present, only the first should be used
-	traceparent1 := "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
-	traceparent2 := "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01"
-
-	md := metadata.MD{
-		"traceparent": []string{traceparent1, traceparent2},
-	}
-	ctx := metadata.NewIncomingContext(context.Background(), md)
-
-	newCtx := ExtractTraceContext(ctx)
-	assert.NotNil(t, newCtx)
-
-	span := trace.SpanContextFromContext(newCtx)
-	assert.True(t, span.IsValid())
-	// Should use the first value
-	assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", span.TraceID().String())
 }
 
 func TestExtractTraceContext_SampledFlag(t *testing.T) {
@@ -289,12 +257,9 @@ func TestExtractTraceContext_SampledFlag(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			md := metadata.MD{
-				"traceparent": []string{tc.traceparent},
-			}
-			ctx := metadata.NewIncomingContext(context.Background(), md)
+			carrier := propagation.MapCarrier{"traceparent": tc.traceparent}
 
-			newCtx := ExtractTraceContext(ctx)
+			newCtx := ExtractTraceContext(context.Background(), carrier)
 			span := trace.SpanContextFromContext(newCtx)
 
 			assert.True(t, span.IsValid())
@@ -303,20 +268,16 @@ func TestExtractTraceContext_SampledFlag(t *testing.T) {
 	}
 }
 
-func TestExtractTraceContext_OtherMetadata(t *testing.T) {
+func TestExtractTraceContext_OtherHeaders(t *testing.T) {
 	setupPropagator()
-	traceparent := "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
-
-	md := metadata.MD{
-		"traceparent":   []string{traceparent},
-		"authorization": []string{"Bearer token123"},
-		"content-type":  []string{"application/json"},
-		"x-custom":      []string{"value"},
-		"grpc-timeout":  []string{"5s"},
+	carrier := propagation.MapCarrier{
+		"traceparent":   "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+		"authorization": "Bearer token123",
+		"content-type":  "application/json",
+		"x-custom":      "value",
 	}
-	ctx := metadata.NewIncomingContext(context.Background(), md)
 
-	newCtx := ExtractTraceContext(ctx)
+	newCtx := ExtractTraceContext(context.Background(), carrier)
 	span := trace.SpanContextFromContext(newCtx)
 
 	assert.True(t, span.IsValid())


### PR DESCRIPTION
## Purpose

The policy engine logged `No valid trace context extracted` on every request and never continued the router's distributed trace. The extraction read `traceparent`/`tracestate` from the ext_proc **gRPC stream metadata**, but the downstream request's W3C trace context is delivered by Envoy inside the `RequestHeaders` `ProcessingRequest` **body** — not as stream metadata. The long-lived bidirectional ext_proc stream also sets its gRPC metadata only once at establishment, so it can never carry a per-request `traceparent`. As a result the propagator always produced an empty (zero-ID) span context whose `IsValid()` is false, causing the noisy log and an unparented root trace for every request.

## Goals

Extract the trace context from the correct source (the HTTP request headers) so the policy engine's spans continue the incoming trace, and stop logging a benign condition at `Info` on the per-request path.

## Approach

- Build the W3C trace-context carrier from the HTTP request headers in the `RequestHeaders` phase (new `traceContextCarrier` helper), copying only `traceparent`/`tracestate`, lowercasing keys and preferring `RawValue` with a `Value` fallback.
- Change `tracing.ExtractTraceContext` to accept a `propagation.TextMapCarrier` instead of reading gRPC stream metadata, keeping the `tracing` package free of Envoy proto types.
- Create the root ext_proc span lazily on the first message, parented on the extracted context, so child spans correctly continue the router's trace.
- A stream that fails before the first message still starts a root span so stream-level errors remain observable.
- Demote the not-found log from `Info` to `Debug` — it is an ordinary condition (e.g. Envoy tracing disabled or no inbound `traceparent`).

## User stories

N/A

## Documentation

N/A — internal observability fix with no user-facing API or configuration change.

## Automation tests
 - Unit tests
   > Reworked `ExtractTraceContext` tests to drive `propagation.MapCarrier` instead of gRPC metadata. Added `TestTraceContextCarrier` covering header extraction, the deprecated `Value` fallback, non-header messages, and the no-headers case. Existing `Process` span-status tests (stream recv error, context canceled) still pass.
 - Integration tests
   > No new integration tests; the full `policy-engine` module test suite passes (`go test ./...`) and `go vet ./...` is clean.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no (Go module; not applicable)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

N/A

## Test environment

Go (policy-engine module), macOS (darwin/arm64). Verified via `go build ./...`, `go vet ./...`, and `go test ./...`.

## Related Issues

N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)