### PR TITLE
Add Logout logic and Remove Sample Curl in Proxy

### DIFF
--- a/portals/ai-workspace/src/apis/platformApis.ts
+++ b/portals/ai-workspace/src/apis/platformApis.ts
@@ -19,6 +19,7 @@
 import { PLATFORM_API_BASE_URL, CSRF_HEADER, CSRF_VALUE } from '../config.env';
 import { logger } from '../utils/logger';
 import { ApiError, buildApiError } from '../utils/apiError';
+import { handleUnauthorizedResponse } from '../auth/logout';
 
 // ============================================================================
 // Platform API Types
@@ -80,6 +81,7 @@ const mutatingHeaders = (): Record<string, string> => ({
  * instead of string-matching the message.
  */
 const parseApiError = async (res: Response): Promise<ApiError> => {
+  handleUnauthorizedResponse(res);
   let body: unknown;
   try {
     body = await res.json();

--- a/portals/ai-workspace/src/auth/logout.ts
+++ b/portals/ai-workspace/src/auth/logout.ts
@@ -16,7 +16,6 @@
  * under the License.
  */
 
-import { clearStoredToken } from '../clients/choreoApiClient';
 import { clearBasicAuthSession } from '../contexts/BasicAuthProvider';
 import { CSRF_HEADER, CSRF_VALUE } from '../config.env';
 import { logger } from '../utils/logger';
@@ -50,9 +49,25 @@ export const handleLogout = async (signoutRedirect: SignOutFunction): Promise<vo
  * Only removes known auth keys — does not wipe unrelated sessionStorage entries.
  */
 export const clearAuthData = (): void => {
-  clearStoredToken();
   clearBasicAuthSession();
   AUTH_SESSION_KEYS.forEach((key) => sessionStorage.removeItem(key));
+};
+
+let unauthorizedRedirectStarted = false;
+
+/**
+ * Start the session-expiry flow once when an authenticated API call returns
+ * 401. Several requests can fail together when a session expires, so the
+ * guard prevents duplicate logout calls and competing redirects.
+ */
+export const handleUnauthorizedResponse = (response: Response): boolean => {
+  if (response.status !== 401) return false;
+
+  if (!unauthorizedRedirectStarted) {
+    unauthorizedRedirectStarted = true;
+    void forceLogoutAndRedirect();
+  }
+  return true;
 };
 
 /**

--- a/portals/ai-workspace/src/clients/choreoApiClient.ts
+++ b/portals/ai-workspace/src/clients/choreoApiClient.ts
@@ -33,6 +33,7 @@ import { PLATFORM_API_BASE_URL, CSRF_HEADER, CSRF_VALUE } from '../config.env';
 import { logger } from '../utils/logger';
 import { HttpMethod, ApiRequestConfig, GQLResponse } from '../utils/types';
 import { buildApiError } from '../utils/apiError';
+import { handleUnauthorizedResponse } from '../auth/logout';
 
 export type { HttpMethod, ApiRequestConfig, GQLResponse };
 export type { ApiError, FieldError } from '../utils/apiError';
@@ -100,6 +101,7 @@ export const request = async <T>(config: ApiRequestConfig): Promise<T> => {
   });
 
   if (!res.ok) {
+    handleUnauthorizedResponse(res);
     let data: unknown;
     try {
       data = await res.json();
@@ -149,6 +151,7 @@ const sendForm = async <T>(
   const res = await fetch(url, { method, credentials: 'include', headers, body: form });
 
   if (!res.ok) {
+    handleUnauthorizedResponse(res);
     let data: unknown;
     try {
       data = await res.json();

--- a/portals/ai-workspace/src/contexts/ChoreoUserContext.tsx
+++ b/portals/ai-workspace/src/contexts/ChoreoUserContext.tsx
@@ -34,6 +34,7 @@ import React, {
 import { logger } from '../utils/logger';
 import type { Organization, ValidateUserResponse } from '../utils/types';
 import { PLATFORM_API_BASE_URL } from '../config.env';
+import { handleUnauthorizedResponse } from '../auth/logout';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -98,6 +99,7 @@ async function fetchPlatformOrganization(): Promise<Organization[]> {
     });
 
     if (!res.ok) {
+      handleUnauthorizedResponse(res);
       if (res.status === 404) {
         logger.warn('[ChoreoUserContext] No organization found — register one at /register-org');
         return [];

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyOverviewTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyOverviewTab.tsx
@@ -44,7 +44,6 @@ import { Copy, Trash2 } from '@wso2/oxygen-ui-icons-react';
 import YAML from 'yaml';
 import { useAppShell } from '../../../../contexts/AppShellContext';
 import { useProxy } from '../../../../contexts/proxy';
-import { useLLMProviders } from '../../../../contexts/llmProvider';
 import { getGateways } from '../../../../apis/gatewayApis';
 import { getLLMProxyDeployments } from '../../../../apis/llmProxiesApis';
 import { PLATFORM_API_BASE_URL } from '../../../../config.env';
@@ -60,7 +59,6 @@ import {
   DisabledActionTooltip,
   GATEWAY_MANAGED_ARTIFACT_TOOLTIP,
 } from '../../../../utils/readOnlyArtifacts';
-import ApiTryOutCurlSnippet from '../../../../Components/common/ApiTryOutCurlSnippet';
 import {
   formatPrefixedKey,
   resolveApiKeyAuthDisplay,
@@ -108,7 +106,6 @@ export default function LLMProxyOverviewTab() {
   const { currentOrganization } = useAppShell();
   const { proxy, getProxyAPIKeys, createProxyAPIKey, deleteProxyAPIKey } =
     useProxy();
-  const { getProviderById } = useLLMProviders();
   const showSnackbar = useAIWorkspaceSnackbar();
   const fetchedApiKeysProxyIdRef = useRef<string | null>(null);
   const fetchingApiKeysProxyIdRef = useRef<string | null>(null);
@@ -143,15 +140,6 @@ export default function LLMProxyOverviewTab() {
     () => resolveApiKeyAuthDisplay(proxy?.security, proxy?.globalPolicies),
     [proxy?.security, proxy?.globalPolicies]
   );
-  const providerTemplate = useMemo(() => {
-    const providerId =
-      typeof proxy?.provider === 'string'
-        ? proxy.provider
-        : proxy?.provider?.id ?? '';
-
-    return getProviderById(providerId)?.template ?? null;
-  }, [getProviderById, proxy?.provider]);
-
   const parsedOpenApiSpec = useMemo(
     () => parseOpenApiSpec(proxy?.openapi || ''),
     [proxy?.openapi]
@@ -947,15 +935,6 @@ export default function LLMProxyOverviewTab() {
                   </Box>
                 </Stack>
               </Alert>
-              <Divider sx={{ my: 2 }} />
-              <ApiTryOutCurlSnippet
-                apiKey={generatedKey}
-                gatewayUrl={generatedGatewayUrl}
-                apiKeyHeaderName={apiKeyName}
-                apiKeyLocation={apiKeyLocation}
-                apiKeyValuePrefix={apiKeyValuePrefix}
-                providerTemplate={providerTemplate}
-              />
             </>
           ) : (
             <Stack spacing={1}>


### PR DESCRIPTION
This pull request introduces a centralized and consistent mechanism for handling unauthorized API responses (HTTP 401) throughout the application. It adds a new `handleUnauthorizedResponse` utility to trigger a single logout and redirect flow when a session expires, and integrates this handler into all major API layers. Additionally, it removes unused code related to LLM providers from the `LLMProxyOverviewTab` component.

**Session Management and API Error Handling:**

* Added a new `handleUnauthorizedResponse` function in `logout.ts` that ensures only one forced logout/redirect occurs when multiple API calls return 401 due to session expiry. This prevents duplicate logout attempts and competing redirects.
* Integrated `handleUnauthorizedResponse` into all major API clients and context fetchers (`platformApis.ts`, `choreoApiClient.ts`, `ChoreoUserContext.tsx`) so that unauthorized responses consistently trigger the session-expiry flow. [[1]](diffhunk://#diff-2d8f9896e1f518086bf06f106f19ecff6d09533d08798675890f68e35bb89ca5R22) [[2]](diffhunk://#diff-2d8f9896e1f518086bf06f106f19ecff6d09533d08798675890f68e35bb89ca5R84) [[3]](diffhunk://#diff-47208a229241d6f799a35a1bafb0373ca416e36365964c79f510fc393d0a3e4cR36) [[4]](diffhunk://#diff-47208a229241d6f799a35a1bafb0373ca416e36365964c79f510fc393d0a3e4cR104) [[5]](diffhunk://#diff-47208a229241d6f799a35a1bafb0373ca416e36365964c79f510fc393d0a3e4cR154) [[6]](diffhunk://#diff-b8ecd237b012b721a4710e3c317468de4c71a4ed308bb172cc7594d70a339931R37) [[7]](diffhunk://#diff-b8ecd237b012b721a4710e3c317468de4c71a4ed308bb172cc7594d70a339931R102)

**Code Cleanup and Refactoring:**

* Removed the unused `clearStoredToken` call from `clearAuthData` in `logout.ts`, as it is no longer needed.
* Cleaned up the `LLMProxyOverviewTab` component by removing unused imports and logic related to LLM provider templates and the `ApiTryOutCurlSnippet` component, simplifying the component and reducing unnecessary dependencies. [[1]](diffhunk://#diff-714644b39bb5327a77a80f1e61ec062608d8a21868584c8bff8d47243f4dd137L47) [[2]](diffhunk://#diff-714644b39bb5327a77a80f1e61ec062608d8a21868584c8bff8d47243f4dd137L63) [[3]](diffhunk://#diff-714644b39bb5327a77a80f1e61ec062608d8a21868584c8bff8d47243f4dd137L111) [[4]](diffhunk://#diff-714644b39bb5327a77a80f1e61ec062608d8a21868584c8bff8d47243f4dd137L146-L154) [[5]](diffhunk://#diff-714644b39bb5327a77a80f1e61ec062608d8a21868584c8bff8d47243f4dd137L950-L958)