### PR TITLE
Refactor API Curl Snippet and Create Provider Template

### DIFF
--- a/portals/ai-workspace/src/Components/common/ApiTryOutCurlSnippet.tsx
+++ b/portals/ai-workspace/src/Components/common/ApiTryOutCurlSnippet.tsx
@@ -34,82 +34,110 @@ interface EndpointOption {
   extraHeaders?: Record<string, string>;
 }
 
-const TEMPLATE_ENDPOINTS: Record<string, EndpointOption> = {
+interface TemplateEndpoint {
+  /** Used only when the provider has no model configured yet. */
+  defaultModel: string;
+  build: (model: string) => EndpointOption;
+}
+
+const SAMPLE_PROMPT = 'Say hello!';
+
+/**
+ * Model ids appear in the request path for Gemini and AWS Bedrock. Percent-encode
+ * the segment but keep ':' literal — Bedrock model ids embed it
+ * (`us.meta.llama3-3-70b-instruct-v1:0`) and the gateway route matches it raw.
+ */
+const encodeModelPathSegment = (model: string): string =>
+  encodeURIComponent(model).replace(/%3A/gi, ':');
+
+/**
+ * Paths, query parameters and request bodies here must match the OpenAPI spec each
+ * default template ships with (`llm-provider-specs/<template>/openapi.yaml`), because
+ * the gateway only routes the operations present in that spec. Keys are the template
+ * ids from `platform-api/resources/default-llm-provider-templates`.
+ */
+const TEMPLATE_ENDPOINTS: Record<string, TemplateEndpoint> = {
   openai: {
-    path: '/chat/completions',
-    body: {
-      model: 'gpt-4o-mini',
-      messages: [{ role: 'user', content: 'Say hello!' }],
-    },
+    defaultModel: 'gpt-4o-mini',
+    build: (model) => ({
+      path: '/chat/completions',
+      body: {
+        model,
+        messages: [{ role: 'user', content: SAMPLE_PROMPT }],
+      },
+    }),
   },
   mistralai: {
-    path: '/v1/chat/completions',
-    body: {
-      model: 'mistral-large-latest',
-      messages: [{ role: 'user', content: 'Say hello!' }],
-    },
+    defaultModel: 'mistral-large-latest',
+    build: (model) => ({
+      path: '/v1/chat/completions',
+      body: {
+        model,
+        messages: [{ role: 'user', content: SAMPLE_PROMPT }],
+      },
+    }),
   },
   anthropic: {
-    path: '/v1/messages',
-    extraHeaders: { 'anthropic-version': '2023-06-01' },
-    body: {
-      model: 'claude-sonnet-4-6',
-      max_tokens: 1024,
-      messages: [{ role: 'user', content: 'Say hello!' }],
-    },
+    defaultModel: 'claude-sonnet-4-6',
+    build: (model) => ({
+      path: '/v1/messages',
+      extraHeaders: { 'anthropic-version': '2023-06-01' },
+      body: {
+        model,
+        max_tokens: 1024,
+        messages: [{ role: 'user', content: SAMPLE_PROMPT }],
+      },
+    }),
   },
   gemini: {
-    path: '/v1beta/models/gemini-2.5-flash:generateContent',
-    body: {
-      contents: [{ parts: [{ text: 'Say hello!' }] }],
-    },
+    defaultModel: 'gemini-2.5-flash',
+    build: (model) => ({
+      path: `/v1beta/models/${encodeModelPathSegment(model)}:generateContent`,
+      body: {
+        contents: [{ parts: [{ text: SAMPLE_PROMPT }] }],
+      },
+    }),
   },
   'azure-openai': {
-    path: '/chat/completions?api-version=2024-02-01',
-    body: {
-      messages: [{ role: 'user', content: 'Say hello!' }],
-    },
+    defaultModel: 'gpt-4o',
+    build: (model) => ({
+      path: '/openai/responses?api-version=2025-04-01-preview',
+      body: {
+        model,
+        input: SAMPLE_PROMPT,
+      },
+    }),
   },
   'azureai-foundry': {
-    path: '/chat/completions?api-version=2024-02-01',
-    body: {
-      messages: [{ role: 'user', content: 'Say hello!' }],
-    },
-  },
-  meta: {
-    path: '/chat/completions',
-    body: {
-      model: 'us.meta.llama3-3-70b-instruct-v1:0',
-      messages: [{ role: 'user', content: 'Say hello!' }],
-    },
+    defaultModel: 'gpt-4o',
+    build: (model) => ({
+      path: '/models/chat/completions?api-version=2024-05-01-preview',
+      body: {
+        model,
+        messages: [{ role: 'user', content: SAMPLE_PROMPT }],
+      },
+    }),
   },
   awsbedrock: {
-    path: '/model/amazon.titan-text-express-v1/invoke',
-    body: {
-      inputText: 'Say hello!',
-      textGenerationConfig: { maxTokenCount: 256, temperature: 0.7 },
-    },
-  },
-  'aws-bedrock': {
-    path: '/model/amazon.titan-text-express-v1/invoke',
-    body: {
-      inputText: 'Say hello!',
-      textGenerationConfig: { maxTokenCount: 256, temperature: 0.7 },
-    },
-  },
-  'google-vertex': {
-    path: '/projects/{project}/locations/us-central1/publishers/google/models/gemini-2.0-flash:generateContent',
-    body: {
-      contents: [{ parts: [{ text: 'Say hello!' }] }],
-    },
+    defaultModel: 'amazon.titan-text-express-v1',
+    build: (model) => ({
+      path: `/model/${encodeModelPathSegment(model)}/converse`,
+      body: {
+        messages: [{ role: 'user', content: [{ text: SAMPLE_PROMPT }] }],
+      },
+    }),
   },
 };
 
-const FALLBACK_ENDPOINT: EndpointOption = {
-  path: '/chat/completions',
-  body: {
-    messages: [{ role: 'user', content: 'Say hello!' }],
-  },
+const FALLBACK_ENDPOINT: TemplateEndpoint = {
+  defaultModel: '<model-id>',
+  build: (model) => ({
+    path: '/chat/completions',
+    body: {
+      model,
+      messages: [{ role: 'user', content: SAMPLE_PROMPT }],
+    },
+  }),
 };
 
 interface Props {
@@ -119,6 +147,8 @@ interface Props {
   apiKeyLocation: 'header' | 'query';
   apiKeyValuePrefix?: string;
   providerTemplate?: string | null;
+  /** Model ids configured on the provider; the first one is used in the sample. */
+  models?: string[];
 }
 
 function buildCurlCommand(
@@ -161,11 +191,16 @@ export default function ApiTryOutCurlSnippet({
   apiKeyLocation,
   apiKeyValuePrefix,
   providerTemplate,
+  models,
 }: Props) {
   const endpoint = useMemo(() => {
     const key = providerTemplate?.trim().toLowerCase() ?? '';
-    return TEMPLATE_ENDPOINTS[key] ?? FALLBACK_ENDPOINT;
-  }, [providerTemplate]);
+    const template = TEMPLATE_ENDPOINTS[key] ?? FALLBACK_ENDPOINT;
+    const configuredModel = models
+      ?.map((model) => model.trim())
+      .find((model) => model.length > 0);
+    return template.build(configuredModel || template.defaultModel);
+  }, [models, providerTemplate]);
 
   const [copied, setCopied] = useState(false);
 

--- a/portals/ai-workspace/src/Components/common/ApiTryOutCurlSnippet.tsx
+++ b/portals/ai-workspace/src/Components/common/ApiTryOutCurlSnippet.tsx
@@ -151,6 +151,14 @@ interface Props {
   models?: string[];
 }
 
+/**
+ * Close the single-quoted shell argument, emit an escaped quote, reopen it — the
+ * standard '\'' idiom. Model ids and header values reach the snippet from provider
+ * config, so a value containing a single quote would otherwise end the -d/-H argument
+ * early and hand the rest of the JSON to the shell.
+ */
+const escapeSingleQuoted = (value: string): string => value.replace(/'/g, `'\\''`);
+
 function buildCurlCommand(
   url: string,
   apiKeyHeaderName: string,
@@ -176,11 +184,11 @@ function buildCurlCommand(
 
   if (extraHeaders) {
     Object.entries(extraHeaders).forEach(([key, value]) => {
-      lines.push(`  -H '${key}: ${value}' \\`);
+      lines.push(`  -H '${escapeSingleQuoted(`${key}: ${value}`)}' \\`);
     });
   }
 
-  lines.push(`  -d '${bodyJson}'`);
+  lines.push(`  -d '${escapeSingleQuoted(bodyJson)}'`);
   return lines.join('\n');
 }
 

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/CreateProviderTemplate.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/CreateProviderTemplate.tsx
@@ -223,15 +223,15 @@ export default function CreateProviderTemplate() {
   // of those left the submit button disabled with nothing on screen explaining why. Seed
   // the field from the copied specification's server URL, the same value the
   // "Fetch specification" button would fill in, so the operator can edit it instead.
-  const endpointSeededRef = useRef(false);
   useEffect(() => {
-    if (endpointSeededRef.current) return;
     if (!copyFrom || endpointUrl.trim()) return;
-    endpointSeededRef.current = true;
 
+    // Seeding only ever fills an empty field: the functional update re-reads the
+    // current value, so anything the operator typed while the spec was in flight wins
+    // over the fetched server URL.
     const seedFrom = (text: string) => {
       const serverUrl = parseSpecServerUrl(text);
-      if (serverUrl) setEndpointUrl(serverUrl);
+      if (serverUrl) setEndpointUrl((current) => (current.trim() ? current : serverUrl));
     };
 
     if (copyFrom.openapi?.trim()) {
@@ -241,19 +241,20 @@ export default function CreateProviderTemplate() {
     const specUrl = copyFrom.metadata?.openapiSpecUrl?.trim();
     if (!specUrl || !isValidHttpUrl(specUrl)) return;
 
-    let cancelled = false;
+    const controller = new AbortController();
     void (async () => {
       try {
-        const res = await fetch(specUrl);
+        const res = await fetch(specUrl, { signal: controller.signal });
         if (!res.ok) return;
         const text = await res.text();
-        if (!cancelled && isParseableSpec(text)) seedFrom(text);
+        if (isParseableSpec(text)) seedFrom(text);
       } catch {
-        // Leave the field empty; the operator can fetch or type the endpoint manually.
+        // Aborted, or unreachable: leave the field empty; the operator can fetch or
+        // type the endpoint manually.
       }
     })();
     return () => {
-      cancelled = true;
+      controller.abort();
     };
   }, [copyFrom, endpointUrl]);
 

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/CreateProviderTemplate.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/CreateProviderTemplate.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useNavigate, useLocation, Link as RouterLink } from 'react-router-dom';
 import YAML from 'yaml';
 import {
@@ -216,6 +216,46 @@ export default function CreateProviderTemplate() {
       e.target.value = '';
     }
   };
+
+  // Some shipped templates deliberately omit metadata.endpointUrl because the host is
+  // per-deployment (AWS Bedrock is region-specific, Azure OpenAI / Azure AI Foundry are
+  // resource-specific). The endpoint URL is required to create a template, so a plain copy
+  // of those left the submit button disabled with nothing on screen explaining why. Seed
+  // the field from the copied specification's server URL, the same value the
+  // "Fetch specification" button would fill in, so the operator can edit it instead.
+  const endpointSeededRef = useRef(false);
+  useEffect(() => {
+    if (endpointSeededRef.current) return;
+    if (!copyFrom || endpointUrl.trim()) return;
+    endpointSeededRef.current = true;
+
+    const seedFrom = (text: string) => {
+      const serverUrl = parseSpecServerUrl(text);
+      if (serverUrl) setEndpointUrl(serverUrl);
+    };
+
+    if (copyFrom.openapi?.trim()) {
+      seedFrom(copyFrom.openapi);
+      return;
+    }
+    const specUrl = copyFrom.metadata?.openapiSpecUrl?.trim();
+    if (!specUrl || !isValidHttpUrl(specUrl)) return;
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch(specUrl);
+        if (!res.ok) return;
+        const text = await res.text();
+        if (!cancelled && isParseableSpec(text)) seedFrom(text);
+      } catch {
+        // Leave the field empty; the operator can fetch or type the endpoint manually.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [copyFrom, endpointUrl]);
 
   const toTemplateId = (value: string): string =>
     value
@@ -478,11 +518,13 @@ export default function CreateProviderTemplate() {
                   }}
                   onBlur={() => setEndpointUrlTouched(true)}
                   placeholder="https://api.openai.com"
-                  error={endpointUrlTouched && endpointUrl.trim().length > 0 && !isValidHttpUrl(endpointUrl)}
+                  error={endpointUrlTouched && !isEndpointValid}
                   helperText={
-                    endpointUrlTouched && endpointUrl.trim().length > 0 && !isValidHttpUrl(endpointUrl)
-                      ? 'Enter a valid URL.'
-                      : ''
+                    !endpointUrlTouched || isEndpointValid
+                      ? ''
+                      : endpointUrl.trim().length === 0
+                        ? 'Endpoint URL is required.'
+                        : 'Enter a valid URL.'
                   }
                 />
               </FormControl>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverviewTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverviewTab.tsx
@@ -203,6 +203,13 @@ export default function ServiceProviderOverviewTab({
       : '/';
     return `${normalizedBase}${normalizedContext}`;
   }, [provider?.context, selectedGateway?.endpoints, selectedGateway?.vhost]);
+  const providerModelIds = useMemo(
+    () =>
+      (provider?.modelProviders ?? []).flatMap((modelProvider) =>
+        (modelProvider.models ?? []).map((model) => model.id)
+      ),
+    [provider?.modelProviders]
+  );
   const swaggerSpecWithGatewayServer = useMemo<OpenApiSpec>(() => {
     const baseSpec = parsedOpenApiSpec;
     if (!baseSpec) return {};
@@ -1120,6 +1127,7 @@ export default function ServiceProviderOverviewTab({
                 apiKeyLocation={apiKeyLocation}
                 apiKeyValuePrefix={apiKeyValuePrefix}
                 providerTemplate={provider?.template}
+                models={providerModelIds}
               />
             </>
           ) : (


### PR DESCRIPTION
- https://github.com/wso2/api-platform/issues/3095

- Updated ApiTryOutCurlSnippet to use a more flexible template structure for endpoint definitions, allowing dynamic model selection.
- Enhanced CreateProviderTemplate to automatically seed the endpoint URL from the OpenAPI specification if not provided, improving user experience.
- Added validation for the endpoint URL input to ensure proper feedback for required and valid URL formats.
- Introduced a new useMemo hook in ServiceProviderOverviewTab to extract model IDs from the provider for better integration with the API snippet.


