### PR TITLE
Refactor ApiTryOutCurlSnippet to improve endpoint resolution and conditional rendering

### DIFF
--- a/portals/ai-workspace/src/Components/common/ApiTryOutCurlSnippet.tsx
+++ b/portals/ai-workspace/src/Components/common/ApiTryOutCurlSnippet.tsx
@@ -105,12 +105,25 @@ const TEMPLATE_ENDPOINTS: Record<string, EndpointOption> = {
   },
 };
 
-const FALLBACK_ENDPOINT: EndpointOption = {
-  path: '/chat/completions',
-  body: {
-    messages: [{ role: 'user', content: 'Say hello!' }],
-  },
-};
+/**
+ * Look up the sample request by EXACT template key. A derived template
+ * (`mistral-copy`, `mistralai-v2-0`) deliberately resolves to nothing rather
+ * than borrowing the vendor's request shape: its upstream and request format
+ * are unknown to us, so a guessed curl would just fail.
+ */
+function resolveEndpoint(providerTemplate?: string | null): EndpointOption | undefined {
+  const key = providerTemplate?.trim().toLowerCase() ?? '';
+  if (!key) return undefined;
+  return TEMPLATE_ENDPOINTS[key];
+}
+
+/**
+ * True only when a known sample request exists for the provider template.
+ * Unknown templates get no curl snippet rather than a guessed one.
+ */
+export function hasTryOutCurlSnippet(providerTemplate?: string | null): boolean {
+  return resolveEndpoint(providerTemplate) !== undefined;
+}
 
 interface Props {
   apiKey: string;
@@ -162,14 +175,12 @@ export default function ApiTryOutCurlSnippet({
   apiKeyValuePrefix,
   providerTemplate,
 }: Props) {
-  const endpoint = useMemo(() => {
-    const key = providerTemplate?.trim().toLowerCase() ?? '';
-    return TEMPLATE_ENDPOINTS[key] ?? FALLBACK_ENDPOINT;
-  }, [providerTemplate]);
+  const endpoint = useMemo(() => resolveEndpoint(providerTemplate), [providerTemplate]);
 
   const [copied, setCopied] = useState(false);
 
   const curlCommand = useMemo(() => {
+    if (!endpoint) return '';
     const base = gatewayUrl ? gatewayUrl.replace(/\/+$/, '') : '<gateway-url>';
     const url = `${base}${endpoint.path}`;
     const keyValue = formatPrefixedKey(apiKeyValuePrefix ?? '', apiKey);
@@ -185,6 +196,10 @@ export default function ApiTryOutCurlSnippet({
       // clipboard not available
     }
   };
+
+  if (!endpoint) {
+    return null;
+  }
 
   return (
     <Stack spacing={1.5}>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverviewTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverviewTab.tsx
@@ -85,7 +85,7 @@ import {
   getProxyIdentifier,
 } from './ProviderMap/ProviderMapTab';
 import ResourceDrawerCards from './ResourceDrawerCards';
-import ApiTryOutCurlSnippet from '../../../../Components/common/ApiTryOutCurlSnippet';
+import ApiTryOutCurlSnippet, { hasTryOutCurlSnippet } from '../../../../Components/common/ApiTryOutCurlSnippet';
 
 type OpenApiSpec = Record<string, unknown>;
 
@@ -1112,15 +1112,19 @@ export default function ServiceProviderOverviewTab({
                   </Box>
                 </Stack>
               </Alert>
-              <Divider sx={{ my: 2 }} />
-              <ApiTryOutCurlSnippet
-                apiKey={generatedKey}
-                gatewayUrl={generatedGatewayUrl}
-                apiKeyHeaderName={apiKeyName}
-                apiKeyLocation={apiKeyLocation}
-                apiKeyValuePrefix={apiKeyValuePrefix}
-                providerTemplate={provider?.template}
-              />
+              {hasTryOutCurlSnippet(provider?.template) && (
+                <>
+                  <Divider sx={{ my: 2 }} />
+                  <ApiTryOutCurlSnippet
+                    apiKey={generatedKey}
+                    gatewayUrl={generatedGatewayUrl}
+                    apiKeyHeaderName={apiKeyName}
+                    apiKeyLocation={apiKeyLocation}
+                    apiKeyValuePrefix={apiKeyValuePrefix}
+                    providerTemplate={provider?.template}
+                  />
+                </>
+              )}
             </>
           ) : (
             <Stack spacing={1}>


### PR DESCRIPTION
- https://github.com/wso2/api-platform/issues/3095



- Introduced a new function `resolveEndpoint` to look up sample requests by template key, ensuring unknown templates do not return a guessed curl snippet.
- Added `hasTryOutCurlSnippet` to check for the existence of a sample request for a given provider template.
- Updated `ServiceProviderOverviewTab` to conditionally render `ApiTryOutCurlSnippet` based on the availability of a valid curl snippet, enhancing user experience.


<img width="1498" height="721" alt="image" src="https://github.com/user-attachments/assets/3b4c10ac-dc47-4d37-a086-87e0600de139" />
