### PR TITLE
[API Portal] Display key manager name instead of uuid

### DIFF
--- a/portals/api-portal/it/ui/cypress/e2e/applications/application-flows.cy.js
+++ b/portals/api-portal/it/ui/cypress/e2e/applications/application-flows.cy.js
@@ -96,6 +96,7 @@ describe('Applications', () => {
         // The Manage Keys card labels each key manager by its handle (kmName =
         // km.handle), so seed a known id and assert on that.
         const KM_ID = 'it-key-manager';
+        const KM_DISPLAY_NAME = 'IT Key Manager';
         // Populated from the on-demand mock token server (started in before()).
         let mockToken;
 
@@ -109,7 +110,7 @@ describe('Applications', () => {
                 mockToken = mock;
                 cy.seedKeyManager({
                     id: KM_ID,
-                    displayName: 'IT Key Manager',
+                    displayName: KM_DISPLAY_NAME,
                     tokenEndpoint: mock.endpoint,
                 });
             });
@@ -128,7 +129,7 @@ describe('Applications', () => {
             // The unavailable message is gone; a key-manager card renders instead.
             cy.get('.mk-unavailable').should('not.exist');
             cy.get('.mk-km-card').should('exist');
-            cy.get('.mk-km-name').should('contain', KM_ID);
+            cy.get('.mk-km-name').should('contain', KM_DISPLAY_NAME);
             // With no credentials yet, the card exposes the "add client ID" control
             // (OAuth apps are created in the key manager itself, then linked here).
             cy.get('[id^="addClientIdBtn-"]').should('exist');

--- a/portals/api-portal/src/controllers/applicationsContentController.js
+++ b/portals/api-portal/src/controllers/applicationsContentController.js
@@ -109,6 +109,7 @@ const loadApplicationData = async (req, orgName, applicationHandle, viewName) =>
         for (const km of dbKeyManagers) {
             kMmetaData.push({
                 id: km.handle,
+                name: km.display_name,
                 enabled: true,
                 tokenEndpoint: km.token_endpoint,
             });

--- a/portals/api-portal/src/pages/application/partials/manage-keys.hbs
+++ b/portals/api-portal/src/pages/application/partials/manage-keys.hbs
@@ -45,7 +45,7 @@
             {{#if enabled}}
             {{#let "keys" productionKeys}}
             {{> manage-keys-km-card
-                kmName=../id
+                kmName=../name
                 kmId=../id
                 keyType="PRODUCTION"
                 keys=keys
@@ -81,7 +81,7 @@
             {{#if enabled}}
             {{#let "keys" sandboxKeys}}
             {{> manage-keys-km-card
-                kmName=../id
+                kmName=../name
                 kmId=../id
                 keyType="SANDBOX"
                 keys=keys

--- a/portals/api-portal/src/scripts/oauth2-key-generation.js
+++ b/portals/api-portal/src/scripts/oauth2-key-generation.js
@@ -28,7 +28,7 @@ async function addClientId(kmId, keyType, appId, orgId, keyManager) {
         const response = await fetch(apiPortalApi.root(`/applications/${appId}/generate-keys`), {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ keyManager, type: keyType, consumerKey }),
+            body: JSON.stringify({ keyManager: kmId, type: keyType, consumerKey }),
         });
         const data = await response.json();
         if (response.ok) {


### PR DESCRIPTION
## Purpose
$subject

## Summary
Previously the key manager UI was showing the id of keymanager instead of the display name. Fixed the issue with this PR.

## Samples
<img width="712" height="342" alt="image" src="https://github.com/user-attachments/assets/300f8c37-ac1a-4af8-aa65-37ffef20be64" />
