### PR TITLE
fix(ai-workspace): scroll API Keys into view from the Consume LLM Provider step

### DIFF
--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderDeploy.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderDeploy.tsx
@@ -74,7 +74,13 @@ function ServiceProviderDeployLayout({ providerId }: ServiceProviderDeployLayout
         )
       : buildOrgPath(currentOrganization, `/service-provider/${providerId}`);
 
-    navigate(overviewPath);
+    // The API Keys section lives on the overview page, so the consume step
+    // carries a one-time focus intent that the overview page consumes and
+    // clears on arrival.
+    navigate(
+      overviewPath,
+      stepId === 'consume' ? { state: { focusApiKeys: true } } : undefined
+    );
   };
   const stepBannerRefreshTrigger = useMemo(() => {
     if (isLoadingDeployments) return 'loading';

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderDeploy.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderDeploy.tsx
@@ -38,7 +38,7 @@ import {
   useGatewayDeploy,
 } from '../../../../contexts/GatewayDeployContext';
 import { GatewayDeployMainSection } from '../../../../Components/GatewayDeploy';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import LLLMStepBanner, {
   type LLLMStepBannerStepId,
 } from '../quickStart/lllmStepBanner';
@@ -47,6 +47,9 @@ import {
   buildProjectPath,
 } from '../../../../utils/projectRouting';
 import { useAppShell } from '../../../../contexts/AppShellContext';
+import { useAppAuth } from '../../../../contexts/AppAuthContext';
+import { SCOPES } from '../../../../auth/permissions';
+import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
 import { AIEntityProvider } from '../../../../contexts/AIEntitiesContext';
 
 type ServiceProviderDeployLayoutProps = {
@@ -58,11 +61,34 @@ function ServiceProviderDeployLayout({ providerId }: ServiceProviderDeployLayout
   const { provider } = useLLMProvider();
   const { deployments, isLoadingDeployments } = useGatewayDeploy();
   const { currentOrganization, currentProject } = useAppShell();
+  const { hasPermission } = useAppAuth();
+  const showSnackbar = useAIWorkspaceSnackbar();
+  const intl = useIntl();
   const isProjectLevel = Boolean(currentProject?.id);
+  // Mirrors `isAdminOrgLevel` on the overview page: it only renders the tabbed
+  // layout containing the API Keys section for org-level callers holding
+  // provider management permission.
+  const canManageApiKeys =
+    hasPermission(SCOPES.LLM_PROVIDER_MANAGE) && !isProjectLevel;
   const handleLLLMStepBannerClick = (stepId: LLLMStepBannerStepId) => {
     if (!providerId) return;
 
     if (stepId === 'deploy-to-gateway') {
+      return;
+    }
+
+    if (stepId === 'consume' && !canManageApiKeys) {
+      // The overview page renders no API Keys section in this context, so
+      // navigating there would look like a dead button. Explain instead, and
+      // don't create a focus intent that nothing can honour.
+      showSnackbar(
+        intl.formatMessage({
+          id: 'aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderDeploy.api.key.management.unavailable',
+          defaultMessage:
+            'API key management is available only at the organization level with LLM provider management permission.',
+        }),
+        'info'
+      );
       return;
     }
 

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverview.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverview.tsx
@@ -186,6 +186,9 @@ function parseOpenApiSpec(text: string): OpenApiSpec | null {
 
 type LocationState = {
   providerAdded?: boolean;
+  // One-time intent set by the "Consume LLM Provider" step on the deploy page.
+  // Consumed and cleared on arrival so a refresh doesn't re-trigger the scroll.
+  focusApiKeys?: boolean;
 };
 
 type ProxyCreationNavigationState = {
@@ -217,6 +220,8 @@ const tabs = [
   'Guardrails & Policies',
   'Models',
 ];
+
+const API_KEY_HIGHLIGHT_DURATION_MS = 3000;
 
 type RateLimitingDraftActions = {
   saveDraftChanges: () => Promise<boolean>;
@@ -539,6 +544,57 @@ function ServiceProviderOverviewContent() {
   };
 
   const [highlightApiKeySection, setHighlightApiKeySection] = useState(false);
+  const apiKeysSectionNodeRef = useRef<HTMLDivElement | null>(null);
+  // Set when a focus is requested before the section is mounted. The section is
+  // behind both the Overview tab panel (which unmounts inactive tabs) and an
+  // async `gateways.length > 0` guard, so on a tab switch or a fresh navigation
+  // the node doesn't exist yet. The callback ref below drains this flag as soon
+  // as it mounts, so no timeout or polling is needed.
+  const pendingApiKeysFocusRef = useRef(false);
+  // Last history entry whose navigation state was consumed, so an effect replay
+  // (React Strict Mode) can't re-run the snackbar or the scroll for that entry.
+  const processedNavigationStateKeyRef = useRef<string | null>(null);
+
+  // Scrolls to the section if it is mounted; otherwise the intent stays pending
+  // for `registerApiKeysSection` to pick up once it does mount.
+  const focusApiKeysNode = useCallback(() => {
+    const node = apiKeysSectionNodeRef.current;
+    if (!node) return;
+    // Cleared before scrolling so a single intent can never scroll twice
+    // (relevant under React Strict Mode's double effect/ref invocation).
+    pendingApiKeysFocusRef.current = false;
+    setHighlightApiKeySection(true);
+    node.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  }, []);
+
+  // Stable callback ref: React invokes it exactly when the section mounts or
+  // unmounts, making this render-aware rather than time-based.
+  const registerApiKeysSection = useCallback(
+    (node: HTMLDivElement | null) => {
+      apiKeysSectionNodeRef.current = node;
+      if (node && pendingApiKeysFocusRef.current) {
+        focusApiKeysNode();
+      }
+    },
+    [focusApiKeysNode]
+  );
+
+  const focusApiKeysSection = useCallback(() => {
+    setTabIndex(0); // API Keys live on the Overview tab.
+    pendingApiKeysFocusRef.current = true;
+    focusApiKeysNode();
+  }, [focusApiKeysNode]);
+
+  // Auto-clears the highlight and owns its own timer cleanup, so an unmount or
+  // a Strict Mode remount can't leave a stray timeout behind.
+  useEffect(() => {
+    if (!highlightApiKeySection) return;
+    const timer = setTimeout(
+      () => setHighlightApiKeySection(false),
+      API_KEY_HIGHLIGHT_DURATION_MS
+    );
+    return () => clearTimeout(timer);
+  }, [highlightApiKeySection]);
 
   const handleDeleteConfirm = async () => {
     if (!deleteTarget || isDeletingProvider) return;
@@ -618,9 +674,7 @@ function ServiceProviderOverviewContent() {
           );
       navigate(deployPath);
     } else if (stepId === 'consume') {
-      setTabIndex(0);
-      setHighlightApiKeySection(true);
-      setTimeout(() => setHighlightApiKeySection(false), 3000);
+      focusApiKeysSection();
     }
   };
 
@@ -653,11 +707,44 @@ function ServiceProviderOverviewContent() {
 
   useEffect(() => {
     const state = location.state as LocationState | null;
-    if (state?.providerAdded) {
+    if (!state?.providerAdded && !state?.focusApiKeys) return;
+    // The replace navigation below is async, so a replayed effect still sees this
+    // state. Claim the entry first — both runs then resolve to a single pass.
+    if (processedNavigationStateKeyRef.current === location.key) return;
+    processedNavigationStateKeyRef.current = location.key;
+
+    if (state.providerAdded) {
       showSnackbar('Successfully added new service provider.', 'success');
-      navigate(location.pathname, { replace: true, state: null });
     }
-  }, [location.pathname, location.state, navigate]);
+    if (state.focusApiKeys) {
+      focusApiKeysSection();
+    }
+
+    // Drop only the consumed flags so unrelated router state survives, and keep
+    // search/hash so replacing the entry doesn't discard query parameters.
+    const remainingState: Record<string, unknown> = { ...state };
+    delete remainingState.providerAdded;
+    delete remainingState.focusApiKeys;
+    navigate(
+      {
+        pathname: location.pathname,
+        search: location.search,
+        hash: location.hash,
+      },
+      {
+        replace: true,
+        state: Object.keys(remainingState).length > 0 ? remainingState : null,
+      }
+    );
+  }, [
+    location.key,
+    location.pathname,
+    location.search,
+    location.hash,
+    location.state,
+    navigate,
+    focusApiKeysSection,
+  ]);
 
   useEffect(() => {
     if (hasUnsavedChanges) return;
@@ -1586,6 +1673,7 @@ function ServiceProviderOverviewContent() {
                     setStepBannerRefreshTrigger((prev) => prev + 1)
                   }
                   highlightApiKeySection={highlightApiKeySection}
+                  apiKeysSectionRef={registerApiKeysSection}
                   onCreateProxy={handleCreateProxyClick}
                   onBlockedNavigation={handleDeployNavigation}
                 />

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverviewTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverviewTab.tsx
@@ -16,7 +16,14 @@
  * under the License.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type Ref,
+} from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   Alert,
@@ -128,6 +135,7 @@ function buildApiKeyResourceName(displayName: string): string {
 type ServiceProviderOverviewTabProps = {
   onApiKeyCreated?: () => void;
   highlightApiKeySection?: boolean;
+  apiKeysSectionRef?: Ref<HTMLDivElement>;
   onCreateProxy?: () => void;
   onBlockedNavigation?: () => void;
 };
@@ -135,6 +143,7 @@ type ServiceProviderOverviewTabProps = {
 export default function ServiceProviderOverviewTab({
   onApiKeyCreated,
   highlightApiKeySection,
+  apiKeysSectionRef,
   onCreateProxy,
   onBlockedNavigation,
 }: ServiceProviderOverviewTabProps) {
@@ -852,7 +861,7 @@ export default function ServiceProviderOverviewTab({
                   </Grid>
                 </Stack>
                 <Divider />
-                <Box>
+                <Box ref={apiKeysSectionRef}>
                   <Typography variant="h6" sx={{ mb: 1.5, fontWeight: 600 }}>
                     <FormattedMessage
                       id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderDeploymentsCard.api.keys"


### PR DESCRIPTION
## Purpose
The "Consume LLM Provider" step in the LLM provider quick-start banner gave no
visible feedback, so it read as a dead button. Two causes, one per entry point:

- **Overview page** — the handler called `setTabIndex(0)` when tab 0 is already
  the default (a no-op), then set `highlightApiKeySection`, which only changes a
  `borderColor`/`boxShadow` on the API Keys section. That section sits below the
  fold and nothing ever scrolled it into view.
- **Deploy page** — the step navigated to the overview route carrying no state,
  so the highlight intent was dropped across the navigation.

Related to #3099

Scoped to the first defect reported in that issue only. The second (LLM proxy
deployment failing when provider security is switched off) is already covered by
#2955, so the issue is intentionally left open.

## Goals
Select the Overview tab, smoothly scroll the API Keys section into view, and
briefly highlight it — from both entry points.

## Approach
- Added an optional `apiKeysSectionRef` prop to `ServiceProviderOverviewTab`,
  attached to the `Box` already wrapping the API Keys heading and panel.
- `ServiceProviderOverview` scrolls it with
  `scrollIntoView({ behavior: 'smooth', block: 'center' })` and enables the
  existing temporary highlight.
- The target isn't always mounted when the intent arrives: `TabPanel` unmounts
  inactive tabs, and the section sits inside an async `gateways.length > 0`
  branch owned by the child. So a pending-intent flag is drained by a stable
  callback ref the moment the node mounts — no timeout or polling in the focus
  path.
- The overview page consumes `focusApiKeys` in the effect that already handles
  `providerAdded`, guarded on `location.key` so a single history entry is
  consumed exactly once. This matters because the clearing navigation is async:
  without the guard a replayed effect sees the same state and would fire the
  snackbar and the scroll twice. It then drops only the consumed flags, keeping
  unrelated state as well as `search`/`hash`, so a refresh or back-navigation
  cannot replay the scroll.
- The pre-existing inline `setTimeout(..., 3000)` moved into an effect with
  `clearTimeout` cleanup, fixing an uncancelled timer on unmount.
- The deploy page applies the same availability condition as the destination
  (`hasPermission(SCOPES.LLM_PROVIDER_MANAGE) && !isProjectLevel`, matching
  `isAdminOrgLevel` on the overview page). When API Keys are unavailable it shows
  an informational snackbar without navigating and without creating a
  `focusApiKeys` intent, so the step never lands on a page with no target.

No changes to the deployment or security path, no new dependencies, no unrelated
refactoring.

## User stories
As a user who has created and deployed an LLM provider, clicking "Consume LLM
Provider" takes me to the API Keys section and highlights it — from either the
overview or the deploy page.

## Documentation
N/A — no documented behaviour changes; this restores the interaction the existing
quick-start banner already implies.

## Automation tests
- Unit tests
  > Automated UI tests were not added because this package has no unit-test
  > runner.
- Integration tests
  > The existing Cypress suite requires a live platform stack, so no spec was
  > added.

Verification performed:
- `npm run build` — passed.
- `npx tsc --noEmit` — currently fails with the same 20 pre-existing errors on
  unchanged `main`; this change introduces no additional TypeScript errors.
- Browser and Cypress verification were not performed.

Manual verification steps:
1. Create an LLM provider and deploy it to a gateway.
2. On the provider Overview page, scroll so API Keys is off screen, then click
   **Consume LLM Provider** — the page should scroll to API Keys and highlight it.
3. Switch to **Guardrails & Policies** and click the step again — should return to
   Overview and scroll to API Keys.
4. From the provider's **Deploy to Gateway** page, click the step — should
   navigate to Overview and scroll to API Keys.
5. Refresh that page; it must not scroll again. Back/forward likewise.
6. As a project-level user (or one without LLM provider management permission),
   click the step on the Deploy page — you should stay on the Deploy page, see the
   informational message, and no navigation state should be created.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React UI change; FindSecurityBugs is a Java tool. No new dependencies, no network calls, no user-controlled data rendered or persisted.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
- #2955 covers the second defect in #3099; intentionally not touched here.
- #2648 also edits `ServiceProviderOverview.tsx` (LLM → AI terminology sweep);
  whichever merges second needs a small mechanical rebase.

## Test environment
- Node.js v24.9.0, npm 11.6.0, Windows 11
- Verified via `npm run build` and `npx tsc --noEmit` only.

