### PR TITLE
fix(api-portal): make API workflow description optional

### DIFF
--- a/portals/api-portal/it/ui/cypress/e2e/settings/003-api-workflows.cy.js
+++ b/portals/api-portal/it/ui/cypress/e2e/settings/003-api-workflows.cy.js
@@ -80,11 +80,32 @@ describe('Settings — API Workflows', () => {
                 }
             });
 
+        // The readiness checklist tracks the name only, so an empty Description
+        // must not leave it flagged as unmet.
+        cy.get('#afReady1').should('have.class', 'is-ok').and('not.have.class', 'is-warn');
+
         cy.get('#saveApiWorkflowBtn').click();
 
         // A successful save reloads the page; the listing is rendered server-side.
         cy.get('#apiWorkflowList', { timeout: 20000 }).should('be.visible');
         cy.get(`.api-workflow-edit-btn[data-api-workflow-id="${WORKFLOW_HANDLE}"]`).should('exist');
         cy.get('#apiWorkflowList').should('contain', WORKFLOW_NAME);
+
+        // Reopen the saved workflow to confirm the empty Description round-tripped
+        // rather than being replaced on the save or read path. The edit button sits
+        // in the row's three-dots dropdown, so open that first.
+        cy.get(`.api-workflow-edit-btn[data-api-workflow-id="${WORKFLOW_HANDLE}"]`)
+            .closest('.cfg-cell-actions')
+            .find('.cfg-menu-trigger')
+            .click();
+        cy.get(`.api-workflow-edit-btn[data-api-workflow-id="${WORKFLOW_HANDLE}"]`)
+            .should('be.visible')
+            .click();
+
+        // The form is populated from the already-loaded listing data, so a settled
+        // name field is the signal that it finished opening.
+        cy.get('#apiWorkflowForm').should('be.visible');
+        cy.get('#apiWorkflowName').should('have.value', WORKFLOW_NAME);
+        cy.get('#apiWorkflowDescription').should('have.value', '');
     });
 });

--- a/portals/api-portal/it/ui/cypress/e2e/settings/003-api-workflows.cy.js
+++ b/portals/api-portal/it/ui/cypress/e2e/settings/003-api-workflows.cy.js
@@ -1,0 +1,90 @@
+// --------------------------------------------------------------------
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// --------------------------------------------------------------------
+
+// A workflow Description is optional. This walks the create wizard leaving it
+// empty, which previously failed twice: the step 1 -> 2 advance and the final
+// save both treated an empty Description as invalid.
+
+describe('Settings — API Workflows', () => {
+    // Not crypto.randomUUID(): Cypress runs specs against http://api-portal:9543, an
+    // insecure context where the WebCrypto API is unavailable. Date.now() + a random
+    // suffix is unique across (serial) runs and stays slug-safe ([0-9a-z-]).
+    const uid = `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+    const WORKFLOW_NAME = `IT Workflow ${uid}`;
+    const WORKFLOW_HANDLE = `it-workflow-${uid}`; // slugify(WORKFLOW_NAME)
+
+    const settingsUrl = () => `/${Cypress.env('ORG_HANDLE')}/settings`;
+    const workflowUrl = () =>
+        `/api/v0.9/views/${Cypress.env('VIEW_NAME')}/api-workflows/${WORKFLOW_HANDLE}`;
+
+    after(() => {
+        // Idempotent API cleanup (404 if the create step never persisted).
+        cy.login();
+        cy.apiRequest('DELETE', workflowUrl(), { failOnStatusCode: false });
+    });
+
+    it('creates a workflow without a description', () => {
+        cy.login();
+        cy.visit(settingsUrl());
+
+        cy.get('.cfg-nav-item[data-panel="cfg-workflows"]').click();
+        cy.get('#createApiWorkflowBtn').click();
+
+        // Step 1 — name only. The handle auto-generates; Description stays empty.
+        cy.get('#afStep1').should('be.visible');
+        cy.get('#apiWorkflowName').type(WORKFLOW_NAME);
+        cy.get('#apiWorkflowHandle').should('have.value', WORKFLOW_HANDLE);
+        cy.get('#apiWorkflowDescription').should('have.value', '');
+
+        cy.get('#afContinueBtn').click();
+
+        // Step 2 — supply the workflow content, which is genuinely required.
+        // Uploading a .md file sets the content type to MD and fills the editor.
+        cy.get('#afStep2').should('be.visible');
+        cy.get('#arazoFileInput').selectFile(
+            {
+                contents: Cypress.Buffer.from('# IT Workflow\n\nCreated by an integration test.\n'),
+                fileName: 'workflow.md',
+                mimeType: 'text/markdown',
+            },
+            // The input sits behind a drop zone and is display:none.
+            { force: true }
+        );
+        cy.get('#uploadFileName').should('contain', 'workflow.md');
+
+        cy.get('#afContinueBtn').click();
+
+        // Step 3 — an agent prompt is required while agent visibility is VISIBLE.
+        // It is normally auto-generated, so only type one if it came back empty.
+        cy.get('#afStep3').should('be.visible');
+        cy.get('#agentPromptField')
+            .invoke('val')
+            .then((prompt) => {
+                if (!String(prompt || '').trim()) {
+                    cy.get('#agentPromptField').type('Use this workflow in an integration test.');
+                }
+            });
+
+        cy.get('#saveApiWorkflowBtn').click();
+
+        // A successful save reloads the page; the listing is rendered server-side.
+        cy.get('#apiWorkflowList', { timeout: 20000 }).should('be.visible');
+        cy.get(`.api-workflow-edit-btn[data-api-workflow-id="${WORKFLOW_HANDLE}"]`).should('exist');
+        cy.get('#apiWorkflowList').should('contain', WORKFLOW_NAME);
+    });
+});

--- a/portals/api-portal/src/pages/settings/partials/create-api-workflow.hbs
+++ b/portals/api-portal/src/pages/settings/partials/create-api-workflow.hbs
@@ -483,7 +483,7 @@
                 <div class="af-rp-section-card">
                     <div class="af-rp-section-card-title">Workflow File Preview</div>
                     <pre class="af-workflow-md-preview"
-                        id="afWorkflowMdPreview">Fill in name and description to see a preview.</pre>
+                        id="afWorkflowMdPreview">Enter a name to see a preview.</pre>
                 </div>
 
                 {{!-- Not visible for agents notice --}}
@@ -501,7 +501,7 @@
                 <div class="af-rp-section-card">
                     <div class="af-rp-header">Readiness</div>
                     <ul class="af-checklist">
-                        <li class="af-checklist-item is-warn" id="afReady1">Name and description set</li>
+                        <li class="af-checklist-item is-warn" id="afReady1">Name set</li>
                         <li class="af-checklist-item is-warn" id="afReady2">API workflow defined</li>
                         <li class="af-checklist-item is-warn" id="afReady3">Agent prompt generated</li>
                     </ul>

--- a/portals/api-portal/src/pages/settings/partials/create-api-workflow.hbs
+++ b/portals/api-portal/src/pages/settings/partials/create-api-workflow.hbs
@@ -72,7 +72,7 @@
 
                 <div class="mb-4">
                     <label for="apiWorkflowDescription" class="form-label fw-semibold d-flex align-items-center gap-2">
-                        <span>Description <span class="text-danger">*</span></span>
+                        <span>Description</span>
                         <span class="af-field-status d-none" id="afDescStatus"
                             data-bs-toggle="tooltip" data-bs-placement="right" data-bs-trigger="hover focus"
                             data-bs-title="">
@@ -81,7 +81,6 @@
                     </label>
                     <textarea class="form-control" id="apiWorkflowDescription" rows="4"
                         placeholder="e.g. Orchestrates a multi-step patient booking workflow across appointment scheduling and healthcare provider systems…"></textarea>
-                    <div class="invalid-feedback">Description is required.</div>
                 </div>
 
                 {{!-- Agent visibility --}}

--- a/portals/api-portal/src/scripts/manage-api-workflows.js
+++ b/portals/api-portal/src/scripts/manage-api-workflows.js
@@ -1214,7 +1214,7 @@ function updateWorkflowMdPreview() {
     const isMarkdown = createPathFormat === 'markdown';
 
     if (!name && !desc) {
-        el.textContent = 'Fill in name and description to see a preview.';
+        el.textContent = 'Enter a name to see a preview.';
         return;
     }
 
@@ -2078,7 +2078,7 @@ function updateStep3Readiness() {
     const hasSpec = hasArazzo || hasMd;
     const hasPrompt = document.getElementById('agentPromptField')?.value?.trim().length > 0;
 
-    setChecklistItem('afReady1', (name && desc) ? 'ok' : 'warn');
+    setChecklistItem('afReady1', name ? 'ok' : 'warn');
     setChecklistItem('afReady2', hasSpec ? 'ok' : 'warn');
     setChecklistItem('afReady3', hasPrompt ? 'ok' : 'warn');
 

--- a/portals/api-portal/src/scripts/manage-api-workflows.js
+++ b/portals/api-portal/src/scripts/manage-api-workflows.js
@@ -1304,7 +1304,6 @@ async function saveApiWorkflow(orgId, viewName, status) {
     let valid = true;
     const fieldsToValidate = [
         ['apiWorkflowName', name],
-        ['apiWorkflowDescription', description],
     ];
     if (agentVisibility !== 'HIDDEN') fieldsToValidate.push(['agentPromptField', agentPrompt]);
     if (contentType === 'ARAZZO') fieldsToValidate.push(['apiWorkflowDefinition', apiWorkflowDefinition]);
@@ -1945,10 +1944,8 @@ function goToStep(n) {
 function validateWizardStep(step) {
     if (step === 1) {
         const name = document.getElementById('apiWorkflowName');
-        const desc = document.getElementById('apiWorkflowDescription');
         let valid = true;
         if (!name?.value.trim()) { name?.classList.add('is-invalid'); valid = false; } else name?.classList.remove('is-invalid');
-        if (!desc?.value.trim()) { desc?.classList.add('is-invalid'); valid = false; } else desc?.classList.remove('is-invalid');
         return valid;
     }
     if (step === 2) {


### PR DESCRIPTION
## Purpose

The API Workflow wizard treated Description as mandatory even though workflow
descriptions should be optional. It blocked users in two places:

- Step-one validation prevented advancing through the wizard.
- Final-save validation rejected an empty description.

The field was also displayed with a required indicator.

Fixes #3082

## Goals

Allow an API Workflow to be created or updated without a description, consistent
with the existing optional API-description behavior.

## Approach

- Removed the required indicator and obsolete required-field feedback from the
  Description field.
- Removed Description from both blocking wizard validation paths.
- Kept Name, agent prompt, workflow content, and advisory description guidance
  unchanged.
- Added a Cypress regression test that creates and lists a workflow with an empty
  description.
- Updated the preview guidance and readiness state to depend on Name only, so an
  omitted optional Description is no longer presented as incomplete.

The client continues sending `description: ""`. The existing OpenAPI request
schema accepts it because the property has no `minLength`, and the existing
`NOT NULL` database column stores an empty string. No API contract, service, or
schema change is required.

## User stories

As a portal administrator, I can create an API Workflow without providing a
description.

## Documentation

N/A — this corrects form validation and does not change a documented API or
configuration surface.

## Automation tests

- Unit tests
  > No new unit test was added because this behavior is exercised through the
  > browser workflow.
- Integration tests
  > Added `003-api-workflows.cy.js`, covering creation with an empty description.
  > The test fails before the fix because the wizard cannot leave step one and
  > passes afterward. The test also verifies the readiness state and reopens the
  > saved workflow to confirm the empty description persisted.

Verification performed:

- New Cypress spec: fails before the fix and passes after it.
- Full settings Cypress suite: 4/4 tests passed.
- Scoped ESLint: passed with no findings.
- API Portal and Platform API Docker builds: passed.
- Existing Node tests: 83 passed and 6 pre-existing failures, identical to the
  unchanged baseline.

The REST API suite was not run because this change does not modify the workflow
API contract or service.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — JavaScript/Handlebars UI change; FindSecurityBugs is a Java tool.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

N/A. Commit `cc8d6b584` made API descriptions optional; this change applies the
same behavior to API Workflows.

## Test environment

- Node.js v24.9.0
- npm 11.6.0
- Docker 28.4.0 / Compose 2.39.2
- Cypress 13.17.0, headless Electron, SQLite integration fixture

