### PR TITLE
Gate AI Workspace actions on scopes, and align scope matching with the API

### DIFF
--- a/platform-api/resources/role-to-scope-mapping.yaml
+++ b/platform-api/resources/role-to-scope-mapping.yaml
@@ -150,8 +150,9 @@ roles:
   # API publisher — owns the full REST API, MCP proxy and LLM proxy lifecycle and
   # the Developer Portal content for it. LLM providers are read-only: a publisher
   # points proxies at an existing provider, but creating, editing, deleting and
-  # deploying providers are all admin tasks. Reads applications, subscriptions
-  # and plans.
+  # deploying providers are all admin tasks. Manages secrets, which back the
+  # upstream auth values on the proxies it configures. Reads applications,
+  # subscriptions and plans.
   - name: ap_publisher
     scopes:
       # Platform API
@@ -168,7 +169,7 @@ roles:
       - ap:subscription_plan:read
       - ap:application:read
       - ap:subscription:read
-      - ap:secret:read
+      - ap:secret:manage
       - ap:api_key:read
       # - ap:websub_api:manage   # event-gateway build only
       # - ap:webbroker_api:manage   # event-gateway build only

--- a/portals/ai-workspace/src/auth/permissions.ts
+++ b/portals/ai-workspace/src/auth/permissions.ts
@@ -24,6 +24,28 @@ export function isPlatformRole(value: unknown): value is PlatformRole {
   return typeof value === 'string' && (PLATFORM_ROLES as readonly string[]).includes(value);
 }
 
+/**
+ * Tooltip shown on a control disabled purely because the signed-in user lacks
+ * the required scope. Deliberately does not name the missing scope — that would
+ * let a caller probe the authorization model.
+ */
+export const NO_PERMISSION_TOOLTIP =
+  'You do not have permission to perform this action. Please contact your admin.';
+
+/**
+ * `sx` for a permission-disabled action that renders as a link
+ * (`component={RouterLink}`), i.e. an `<a>` rather than a `<button>`.
+ *
+ * A disabled `<a>` still blocks the click, but it does not pick up the
+ * theme's disabled colouring the way a native disabled `<button>` does, so the
+ * control looks fully enabled while doing nothing — which reads as a broken
+ * button rather than a permission boundary. Dimming it makes the disabled state
+ * visible. Not needed for plain `<Button onClick=...>`.
+ */
+export const DISABLED_ACTION_SX = {
+  '&.Mui-disabled': { opacity: 0.55 },
+} as const;
+
 /** All platform API OAuth2 scopes derived from openapi.yaml x-required-scopes (ap: prefix). */
 export const SCOPES = {
   // Organization
@@ -179,19 +201,57 @@ export const SCOPES = {
 } as const;
 
 /**
+ * Scopes that must be held explicitly and are never derived from a broader
+ * `:manage`. `ap:api_key:all:manage` is an ownership override (it widens which
+ * users' keys are reachable, not which actions), so holding `ap:api_key:manage`
+ * must not confer it — matching the service-layer rule in
+ * `platform-api/internal/service` and `/me/api-keys` in openapi.yaml, the one
+ * operation whose accepted-scope list omits its parent `:manage`.
+ */
+const NON_DERIVABLE_SCOPE_SUFFIX = ':all:manage';
+
+/**
  * Check whether a set of scopes grants a requested scope.
  *
- * Rules:
+ * Mirrors how platform-api actually authorizes a request: each operation in
+ * openapi.yaml declares a list of accepted scopes, and
+ * `scopeSatisfies` (`platform-api/internal/middleware/authorization.go`) admits
+ * the caller if any held scope matches any entry in that list. Rules:
+ *
  *  1. Exact match — the scope is directly present.
- *  2. Parent :manage — `ap:<resource>:manage` covers all CRUD and sub-resource
- *     scopes under that resource (e.g. ap:gateway:manage covers ap:gateway:token:read).
+ *  2. Own-level `:manage` — an operation accepting `<level>:<action>` also
+ *     accepts `<level>:manage` (`ap:llm_provider:api_key:read` is satisfied by
+ *     `ap:llm_provider:api_key:manage`).
+ *  3. Ancestor `:manage` — a resource-level `:manage` also covers its
+ *     sub-resources' operations, because those operations list it explicitly.
+ *     `ap:llm_provider:manage` appears in the accepted list of every
+ *     `/llm-providers/{id}/api-keys` and `/deployments` operation, so it grants
+ *     `ap:llm_provider:api_key:create`, `ap:llm_provider:deployment:read`, etc.
+ *     This holds for 47 of the 48 sub-resource operations in the spec; the sole
+ *     exception is the override scope excluded above.
+ *  4. Own-level `:*` wildcard — as on the backend, a wildcard covers only the
+ *     actions directly at its level and never descends into a sub-resource
+ *     (`ap:gateway:*` grants `ap:gateway:create`, not `ap:gateway:token:create`).
  */
 export function checkPermission(userScopes: string[], scope: string): boolean {
   if (userScopes.includes(scope)) return true;
+
   const parts = scope.split(':');
-  if (parts.length >= 3) {
-    const parentManage = `${parts[0]}:${parts[1]}:manage`;
-    if (parentManage !== scope && userScopes.includes(parentManage)) return true;
+  if (parts.length < 2) return false;
+
+  // Own-level wildcard: `ap:gateway:*` covers `ap:gateway:create` only.
+  const ownLevel = parts.slice(0, -1).join(':');
+  if (userScopes.includes(`${ownLevel}:*`)) return true;
+
+  if (scope.endsWith(NON_DERIVABLE_SCOPE_SUFFIX)) return false;
+
+  // Own-level `:manage`, then each broader ancestor's `:manage`. For
+  // `ap:llm_provider:api_key:read` that is `ap:llm_provider:api_key:manage`
+  // followed by `ap:llm_provider:manage`.
+  for (let depth = parts.length - 1; depth >= 2; depth -= 1) {
+    const candidate = `${parts.slice(0, depth).join(':')}:manage`;
+    if (candidate !== scope && userScopes.includes(candidate)) return true;
   }
+
   return false;
 }

--- a/portals/ai-workspace/src/contexts/GatewayPoliciesContext.tsx
+++ b/portals/ai-workspace/src/contexts/GatewayPoliciesContext.tsx
@@ -16,6 +16,8 @@ import type {
 } from '../apis/gatewayPolicyApis';
 import { getPolicies } from '../apis/policyHubApis';
 import type { PolicyHubPolicy } from '../utils/types';
+import { useAppAuth } from './AppAuthContext';
+import { SCOPES } from '../auth/permissions';
 
 export type GatewayPolicyRow = {
   key: string;
@@ -35,6 +37,10 @@ type GatewayPoliciesContextValue = {
   refresh: () => Promise<void>;
   syncPolicy: (policyName: string, version: string) => Promise<GatewayCustomPolicy>;
   syncingPolicyKey: string | null;
+  /** False when the caller lacks the scopes the policy view reads. */
+  canViewPolicies: boolean;
+  /** False when the caller may view policies but not sync them into the org. */
+  canSyncPolicies: boolean;
 };
 
 const GatewayPoliciesContext = createContext<GatewayPoliciesContextValue | null>(null);
@@ -89,8 +95,22 @@ export function GatewayPoliciesProvider({ gatewayId, children }: { gatewayId: st
   const [error, setError] = useState<Error | null>(null);
   const [syncingPolicyKey, setSyncingPolicyKey] = useState<string | null>(null);
 
+  // This view reads the gateway manifest and the org's custom policies. Without
+  // both scopes the platform API returns 403, so skip the request entirely and
+  // let the consumer render a permission notice instead of a load failure.
+  const { hasPermission } = useAppAuth();
+  const canViewPolicies =
+    hasPermission(SCOPES.GATEWAY_MANIFEST_READ) &&
+    hasPermission(SCOPES.GATEWAY_CUSTOM_POLICY_READ);
+  const canSyncPolicies = hasPermission(SCOPES.GATEWAY_CUSTOM_POLICY_CREATE);
+
   const refresh = useCallback(async () => {
     if (!gatewayId) return;
+    if (!canViewPolicies) {
+      setPolicies([]);
+      setIsLoading(false);
+      return;
+    }
     setIsLoading(true);
     setError(null);
     try {
@@ -111,7 +131,7 @@ export function GatewayPoliciesProvider({ gatewayId, children }: { gatewayId: st
     } finally {
       setIsLoading(false);
     }
-  }, [gatewayId]);
+  }, [gatewayId, canViewPolicies]);
 
   useEffect(() => { void refresh(); }, [refresh]);
 
@@ -136,8 +156,26 @@ export function GatewayPoliciesProvider({ gatewayId, children }: { gatewayId: st
   }, [gatewayId, refresh]);
 
   const value = useMemo(
-    () => ({ policies, isLoading, error, refresh, syncPolicy, syncingPolicyKey }),
-    [policies, isLoading, error, refresh, syncPolicy, syncingPolicyKey],
+    () => ({
+      policies,
+      isLoading,
+      error,
+      refresh,
+      syncPolicy,
+      syncingPolicyKey,
+      canViewPolicies,
+      canSyncPolicies,
+    }),
+    [
+      policies,
+      isLoading,
+      error,
+      refresh,
+      syncPolicy,
+      syncingPolicyKey,
+      canViewPolicies,
+      canSyncPolicies,
+    ],
   );
   return <GatewayPoliciesContext.Provider value={value}>{children}</GatewayPoliciesContext.Provider>;
 }

--- a/portals/ai-workspace/src/contexts/OIDCAppAuthProvider.tsx
+++ b/portals/ai-workspace/src/contexts/OIDCAppAuthProvider.tsx
@@ -131,7 +131,15 @@ export function OIDCAppAuthProvider({ children }: { children: React.ReactNode })
       login,
       logout,
     }),
-    [auth.isAuthenticated, auth.isLoading, user, getAccessToken, hasPermission, login, logout]
+    [
+      auth.isAuthenticated,
+      auth.isLoading,
+      user,
+      getAccessToken,
+      hasPermission,
+      login,
+      logout,
+    ]
   );
 
   return <AppAuthContext.Provider value={value}>{children}</AppAuthContext.Provider>;

--- a/portals/ai-workspace/src/pages/appShell/QuickStartIntroPopup.tsx
+++ b/portals/ai-workspace/src/pages/appShell/QuickStartIntroPopup.tsx
@@ -215,7 +215,7 @@ export default function QuickStartIntroPopup({
               variant="text"
               size="small"
               component="a"
-              href="https://wso2.com/bijira/docs/ai-workspace/getting-started/"
+              href="https://wso2.com/api-platform/docs/next/ai-workspace/getting-started/"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/applications/ApplicationNew.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/applications/ApplicationNew.tsx
@@ -29,8 +29,10 @@ import {
   PageTitle,
   Stack,
   TextField,
+  Typography,
 } from '@wso2/oxygen-ui';
 import { ChevronLeft } from '@wso2/oxygen-ui-icons-react';
+import { FormattedMessage } from 'react-intl';
 import { useApplications } from '../../../../contexts/ApplicationsContext';
 import { useAppShell } from '../../../../contexts/AppShellContext';
 import {
@@ -39,6 +41,8 @@ import {
 } from '../../../../utils/projectRouting';
 import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
 import { getErrorMessage, getFieldErrors } from '../../../../utils/apiError';
+import { useAppAuth } from '../../../../contexts/AppAuthContext';
+import { SCOPES } from '../../../../auth/permissions';
 
 type FormState = {
   name: string;
@@ -75,6 +79,7 @@ export default function ApplicationNew() {
   const navigate = useNavigate();
   const { applications, createApplication } = useApplications();
   const { currentProject, currentOrganization } = useAppShell();
+  const { hasPermission } = useAppAuth();
   const showSnackbar = useAIWorkspaceSnackbar();
   const isProjectLevel = Boolean(currentProject?.id);
   const applicationsPath = isProjectLevel
@@ -148,6 +153,29 @@ export default function ApplicationNew() {
       setIsSubmitting(false);
     }
   };
+
+  if (!hasPermission(SCOPES.APPLICATION_CREATE)) {
+    return (
+      <PageContent fullWidth>
+        <Stack spacing={1}>
+          <Typography variant="h6">
+            <FormattedMessage
+              id="aiWorkspace.pages.appShell.appShellPages.applications.ApplicationNew.creation.unavailable"
+              defaultMessage={'GenAI Application creation is unavailable.'}
+            />
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            <FormattedMessage
+              id="aiWorkspace.pages.appShell.appShellPages.applications.ApplicationNew.creation.unavailable.description"
+              defaultMessage={
+                'You do not have permission to create GenAI Applications. Please contact your admin.'
+              }
+            />
+          </Typography>
+        </Stack>
+      </PageContent>
+    );
+  }
 
   return (
     <PageContent fullWidth>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/applications/ApplicationsList.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/applications/ApplicationsList.tsx
@@ -40,6 +40,7 @@ import {
   Select,
   Stack,
   TextField,
+  Tooltip,
   Typography,
 } from '@wso2/oxygen-ui';
 import { Clock, Plus, Search, Trash2 } from '@wso2/oxygen-ui-icons-react';
@@ -59,6 +60,8 @@ import ErrorAlert from '../../../../Components/common/ErrorAlert';
 import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
 import NoApplications from '../../../../assets/images/NoApplications.svg';
 import { getErrorCode } from '../../../../utils/apiError';
+import { useAppAuth } from '../../../../contexts/AppAuthContext';
+import { DISABLED_ACTION_SX, NO_PERMISSION_TOOLTIP, SCOPES } from '../../../../auth/permissions';
 
 function getInitials(name: string): string {
   const words = name.trim().split(/\s+/);
@@ -74,6 +77,7 @@ function truncateText(text: string, maxLength: number): string {
 
 export default function ApplicationsList() {
   const navigate = useNavigate();
+  const { hasPermission } = useAppAuth();
   const { projectSlug } = useParams<{ projectSlug: string }>();
   const {
     currentProject,
@@ -175,6 +179,12 @@ export default function ApplicationsList() {
         '/applications/create'
       )
     : buildOrgPath(currentOrganization, '/applications/create');
+
+  const canCreateApplication = hasPermission(SCOPES.APPLICATION_CREATE);
+  const canDeleteApplication = hasPermission(SCOPES.APPLICATION_DELETE);
+  const createApplicationTooltip = canCreateApplication
+    ? ''
+    : NO_PERMISSION_TOOLTIP;
 
   const renderOrgLevelContent = () => (
     <Grid size={{ xs: 12, sm: 12, md: 7 }}>
@@ -288,18 +298,23 @@ export default function ApplicationsList() {
         </PageTitle>
 
         {filteredApplications.length > 0 ? (
-          <Button
-            variant="contained"
-            component={RouterLink}
-            to={newApplicationPath}
-            startIcon={<Plus size={20} />}
-            sx={{ ml: 'auto', flexShrink: 0 }}
-          >
-            <FormattedMessage
-              id="aiWorkspace.pages.appShell.appShellPages.applications.ApplicationsList.add.new.application"
-              defaultMessage="Add New Application"
-            />
-          </Button>
+          <Tooltip title={createApplicationTooltip}>
+            <Box component="span" sx={{ ml: 'auto', flexShrink: 0 }}>
+              <Button
+                variant="contained"
+                component={RouterLink}
+                to={newApplicationPath}
+                startIcon={<Plus size={20} />}
+                disabled={!canCreateApplication}
+                sx={DISABLED_ACTION_SX}
+              >
+                <FormattedMessage
+                  id="aiWorkspace.pages.appShell.appShellPages.applications.ApplicationsList.add.new.application"
+                  defaultMessage="Add New Application"
+                />
+              </Button>
+            </Box>
+          </Tooltip>
         ) : null}
       </Box>
     </Grid>
@@ -358,17 +373,23 @@ export default function ApplicationsList() {
                     defaultMessage="Set up a GenAI application to securely consume AI services through your workspace."
                   />
                 </Typography>
-                <Button
-                  variant="contained"
-                  component={RouterLink}
-                  to={newApplicationPath}
-                  startIcon={<Plus size={20} />}
-                >
-                  <FormattedMessage
-                    id="aiWorkspace.pages.appShell.appShellPages.applications.ApplicationsList.create.application"
-                    defaultMessage="Create Application"
-                  />
-                </Button>
+                <Tooltip title={createApplicationTooltip}>
+                  <Box component="span">
+                    <Button
+                      variant="contained"
+                      component={RouterLink}
+                      to={newApplicationPath}
+                      startIcon={<Plus size={20} />}
+                      disabled={!canCreateApplication}
+                      sx={DISABLED_ACTION_SX}
+                    >
+                      <FormattedMessage
+                        id="aiWorkspace.pages.appShell.appShellPages.applications.ApplicationsList.create.application"
+                        defaultMessage="Create Application"
+                      />
+                    </Button>
+                  </Box>
+                </Tooltip>
               </Stack>
             </Box>
           </Grid>
@@ -444,17 +465,23 @@ export default function ApplicationsList() {
                         defaultMessage="Set up a GenAI application to securely consume AI services through your workspace."
                       />
                     </Typography>
-                    <Button
-                      variant="contained"
-                      component={RouterLink}
-                      to={newApplicationPath}
-                      startIcon={<Plus size={20} />}
-                    >
-                      <FormattedMessage
-                        id="aiWorkspace.pages.appShell.appShellPages.applications.ApplicationsList.create.application"
-                        defaultMessage="Create Application"
-                      />
-                    </Button>
+                    <Tooltip title={createApplicationTooltip}>
+                      <Box component="span">
+                        <Button
+                          variant="contained"
+                          component={RouterLink}
+                          to={newApplicationPath}
+                          startIcon={<Plus size={20} />}
+                          disabled={!canCreateApplication}
+                          sx={DISABLED_ACTION_SX}
+                        >
+                          <FormattedMessage
+                            id="aiWorkspace.pages.appShell.appShellPages.applications.ApplicationsList.create.application"
+                            defaultMessage="Create Application"
+                          />
+                        </Button>
+                      </Box>
+                    </Tooltip>
                   </Stack>
                 </Box>
               </Grid>
@@ -555,17 +582,26 @@ export default function ApplicationsList() {
                             </Typography>
                           </Stack>
 
-                          <IconButton
-                            size="small"
-                            color="error"
-                            onClick={(event) => {
-                              event.stopPropagation();
-                              setDeleteTarget(app);
-                            }}
-                            aria-label={`Delete ${app.displayName}`}
+                          <Tooltip
+                            title={
+                              canDeleteApplication ? '' : NO_PERMISSION_TOOLTIP
+                            }
                           >
-                            <Trash2 size={16} />
-                          </IconButton>
+                            <Box component="span">
+                              <IconButton
+                                size="small"
+                                color="error"
+                                disabled={!canDeleteApplication}
+                                onClick={(event) => {
+                                  event.stopPropagation();
+                                  setDeleteTarget(app);
+                                }}
+                                aria-label={`Delete ${app.displayName}`}
+                              >
+                                <Trash2 size={16} />
+                              </IconButton>
+                            </Box>
+                          </Tooltip>
                         </Box>
                       </Box>
                     </Card>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/applications/GenAIApplicationsSummaryCardSection.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/applications/GenAIApplicationsSummaryCardSection.tsx
@@ -28,6 +28,7 @@ import {
   ParticleBackground,
   Skeleton,
   Stack,
+  Tooltip,
   Typography,
 } from '@wso2/oxygen-ui';
 import { Clock, Plus } from '@wso2/oxygen-ui-icons-react';
@@ -38,6 +39,8 @@ import {
 } from '../../../../contexts/ApplicationsContext';
 import NoApplications from '../../../../assets/images/NoApplications.svg';
 import ErrorAlert from '../../../../Components/common/ErrorAlert';
+import { useAppAuth } from '../../../../contexts/AppAuthContext';
+import { DISABLED_ACTION_SX, NO_PERMISSION_TOOLTIP, SCOPES } from '../../../../auth/permissions';
 
 function getInitials(name: string): string {
   const words = name.trim().split(/\s+/);
@@ -75,6 +78,8 @@ export default function GenAIApplicationsSummaryCardSection({
   newApplicationPath,
   onApplicationClick,
 }: GenAIApplicationsSummaryCardSectionProps) {
+  const { hasPermission } = useAppAuth();
+  const canCreateApplication = hasPermission(SCOPES.APPLICATION_CREATE);
   const {
     applicationsResponse,
     isLoading,
@@ -129,9 +134,21 @@ export default function GenAIApplicationsSummaryCardSection({
                 See more
               </Button>
             ) : (
-              <Button component={RouterLink} to={newApplicationPath} size="small">
-                + Add New
-              </Button>
+              <Tooltip
+                title={canCreateApplication ? '' : NO_PERMISSION_TOOLTIP}
+              >
+                <Box component="span">
+                  <Button
+                    component={RouterLink}
+                    to={newApplicationPath}
+                    size="small"
+                    disabled={!canCreateApplication}
+                    sx={DISABLED_ACTION_SX}
+                  >
+                    + Add New
+                  </Button>
+                </Box>
+              </Tooltip>
             )
           }
         />
@@ -217,17 +234,23 @@ export default function GenAIApplicationsSummaryCardSection({
                 defaultMessage="Set up a GenAI application to securely consume AI services through your workspace."
               />
             </Typography>
-            <Button
-              variant="contained"
-              component={RouterLink}
-              to={newApplicationPath}
-              startIcon={<Plus size={20} />}
-            >
-              <FormattedMessage
-                id="aiWorkspace.pages.appShell.appShellPages.applications.ApplicationsList.create.application"
-                defaultMessage="Create Application"
-              />
-            </Button>
+            <Tooltip title={canCreateApplication ? '' : NO_PERMISSION_TOOLTIP}>
+              <Box component="span">
+                <Button
+                  variant="contained"
+                  component={RouterLink}
+                  to={newApplicationPath}
+                  startIcon={<Plus size={20} />}
+                  disabled={!canCreateApplication}
+                  sx={DISABLED_ACTION_SX}
+                >
+                  <FormattedMessage
+                    id="aiWorkspace.pages.appShell.appShellPages.applications.ApplicationsList.create.application"
+                    defaultMessage="Create Application"
+                  />
+                </Button>
+              </Box>
+            </Tooltip>
           </Stack>
         ) : (
           <Stack divider={<Divider />} spacing={1.5}>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/applications/OverviewTabs/APIKeyTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/applications/OverviewTabs/APIKeyTab.tsx
@@ -43,6 +43,8 @@ import { Inbox, Plus, Search, Trash2, X } from '@wso2/oxygen-ui-icons-react';
 import { useApplications } from '../../../../../contexts/ApplicationsContext';
 import { useAppShell } from '../../../../../contexts/AppShellContext';
 import useAIWorkspaceSnackbar from '../../../../../hooks/aiWorkspaceSnackbar';
+import { useAppAuth } from '../../../../../contexts/AppAuthContext';
+import { NO_PERMISSION_TOOLTIP, SCOPES } from '../../../../../auth/permissions';
 import { PLATFORM_API_BASE_URL } from '../../../../../paths';
 import { keyManagementApis } from '../../../../../apis/keyManagementApis';
 import type { MappedAPIKey, UserAPIKey } from '../../../../../utils/types';
@@ -110,6 +112,9 @@ export default function APIKeyTab({ applicationId }: APIKeyTabProps) {
     useApplications();
   const { currentOrganization } = useAppShell();
   const showSnackbar = useAIWorkspaceSnackbar();
+  const { hasPermission } = useAppAuth();
+  const canCreateApiKey = hasPermission(SCOPES.APPLICATION_API_KEY_CREATE);
+  const canDeleteApiKey = hasPermission(SCOPES.APPLICATION_API_KEY_DELETE);
   const apimBaseUrl = PLATFORM_API_BASE_URL;
 
   const [searchValue, setSearchValue] = useState('');
@@ -306,14 +311,19 @@ export default function APIKeyTab({ applicationId }: APIKeyTabProps) {
           searchPlaceholder="Search mapped API keys..."
           actions={
             hasApiKeys ? (
-              <Button
-                variant="contained"
-                size="small"
-                startIcon={<Plus size={16} />}
-                onClick={handleOpenAddDrawer}
-              >
-                Add API Key
-              </Button>
+              <Tooltip title={canCreateApiKey ? '' : NO_PERMISSION_TOOLTIP}>
+                <Box component="span">
+                  <Button
+                    variant="contained"
+                    size="small"
+                    startIcon={<Plus size={16} />}
+                    disabled={!canCreateApiKey}
+                    onClick={handleOpenAddDrawer}
+                  >
+                    Add API Key
+                  </Button>
+                </Box>
+              </Tooltip>
             ) : null
           }
         />
@@ -393,14 +403,21 @@ export default function APIKeyTab({ applicationId }: APIKeyTabProps) {
                         </Tooltip>
                       </ListingTable.Cell>
                       <ListingTable.Cell align="right">
-                        <IconButton
-                          size="small"
-                          color="error"
-                          onClick={() => setDeleteTarget(key)}
-                          aria-label={`Delete ${key.keyId}`}
+                        <Tooltip
+                          title={canDeleteApiKey ? '' : NO_PERMISSION_TOOLTIP}
                         >
-                          <Trash2 size={16} />
-                        </IconButton>
+                          <Box component="span">
+                            <IconButton
+                              size="small"
+                              color="error"
+                              disabled={!canDeleteApiKey}
+                              onClick={() => setDeleteTarget(key)}
+                              aria-label={`Delete ${key.keyId}`}
+                            >
+                              <Trash2 size={16} />
+                            </IconButton>
+                          </Box>
+                        </Tooltip>
                       </ListingTable.Cell>
                     </ListingTable.Row>
                   ))}
@@ -425,13 +442,18 @@ export default function APIKeyTab({ applicationId }: APIKeyTabProps) {
                   Clear search
                 </Button>
               ) : (
-                <Button
-                  variant="contained"
-                  startIcon={<Plus size={16} />}
-                  onClick={handleOpenAddDrawer}
-                >
-                  Add API Key
-                </Button>
+                <Tooltip title={canCreateApiKey ? '' : NO_PERMISSION_TOOLTIP}>
+                  <Box component="span">
+                    <Button
+                      variant="contained"
+                      startIcon={<Plus size={16} />}
+                      disabled={!canCreateApiKey}
+                      onClick={handleOpenAddDrawer}
+                    >
+                      Add API Key
+                    </Button>
+                  </Box>
+                </Tooltip>
               )
             }
           />

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/applications/OverviewTabs/AssociationsTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/applications/OverviewTabs/AssociationsTab.tsx
@@ -55,6 +55,8 @@ import OpenAILogo from '../../../../../assets/brands/openAI.png';
 import { PLATFORM_API_BASE_URL } from '../../../../../paths';
 import { useApplicationAssociations } from '../../../../../contexts/ApplicationAssociationsContext';
 import { useAppShell } from '../../../../../contexts/AppShellContext';
+import { useAppAuth } from '../../../../../contexts/AppAuthContext';
+import { NO_PERMISSION_TOOLTIP, SCOPES } from '../../../../../auth/permissions';
 import useAIWorkspaceSnackbar from '../../../../../hooks/aiWorkspaceSnackbar';
 import { getProviderTemplateDisplayName } from '../../../../../utils/providerTemplateDisplay';
 import type {
@@ -395,6 +397,11 @@ export default function AssociationsTab() {
   const { currentOrganization, currentProject } = useAppShell();
   const showSnackbar = useAIWorkspaceSnackbar();
   const apimBaseUrl = PLATFORM_API_BASE_URL;
+  const { hasPermission } = useAppAuth();
+  // Mapping a key to an association posts to /applications/{id}/api-keys — the
+  // same endpoint APIKeyTab guards — so the association scopes are not enough.
+  const canCreateApiKey = hasPermission(SCOPES.APPLICATION_API_KEY_CREATE);
+  const canDeleteApiKey = hasPermission(SCOPES.APPLICATION_API_KEY_DELETE);
 
   const [reservedKeyOwners, setReservedKeyOwners] = useState<
     Map<string, Set<string>>
@@ -505,7 +512,11 @@ export default function AssociationsTab() {
     () => new Set(reservedKeyOwners.keys()),
     [reservedKeyOwners]
   );
-  const selectionBlockedMessage = isReservedKeysLoading
+  // Also gates key selection in the provider/proxy association drawers, which
+  // attach the selected keys via the same addAPIKeys call.
+  const selectionBlockedMessage = !canCreateApiKey
+    ? NO_PERMISSION_TOOLTIP
+    : isReservedKeysLoading
     ? 'Checking whether these API keys are already used in another application.'
     : reservedKeysLoadError;
 
@@ -906,7 +917,7 @@ export default function AssociationsTab() {
         ...linkedProviderKeyPayload,
       ];
 
-      if (keyPayload.length > 0) {
+      if (canCreateApiKey && keyPayload.length > 0) {
         await addAPIKeys({ apiKeys: keyPayload });
       }
 
@@ -1055,7 +1066,7 @@ export default function AssociationsTab() {
         ...linkedProxyKeyPayload,
       ];
 
-      if (keyPayload.length > 0) {
+      if (canCreateApiKey && keyPayload.length > 0) {
         await addAPIKeys({ apiKeys: keyPayload });
       }
 
@@ -1134,7 +1145,7 @@ export default function AssociationsTab() {
   };
 
   const handleOpenManageKeysDrawer = async (association: ApplicationAssociation) => {
-    if (!currentOrganization?.uuid) return;
+    if (!currentOrganization?.uuid || !canCreateApiKey) return;
 
     setManageKeysDrawerTarget(association);
     setSelectedManageKeyNames(new Set());
@@ -1169,7 +1180,13 @@ export default function AssociationsTab() {
   };
 
   const handleAddManagedKeys = async () => {
-    if (!manageKeysDrawerTarget || selectedManageKeyNames.size === 0) return;
+    if (
+      !manageKeysDrawerTarget ||
+      selectedManageKeyNames.size === 0 ||
+      !canCreateApiKey
+    ) {
+      return;
+    }
 
     setIsAddingManagedKeys(true);
 
@@ -1221,6 +1238,7 @@ export default function AssociationsTab() {
   };
 
   const handleRemoveKey = async (associationId: string, key: MappedAPIKey) => {
+    if (!canDeleteApiKey) return;
     const mappedKeyId = resolveMappedKeyId(key);
     if (removingKeyIds.has(mappedKeyId)) return;
     const entityID = resolveEntityId(key);

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/applications/OverviewTabs/AssociationsTable.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/applications/OverviewTabs/AssociationsTable.tsx
@@ -52,6 +52,8 @@ import {
   getKeyStatusColor,
   resolveMappedKeyId,
 } from './associationsTabUtils';
+import { useAppAuth } from '../../../../../contexts/AppAuthContext';
+import { NO_PERMISSION_TOOLTIP, SCOPES } from '../../../../../auth/permissions';
 
 type AssociationsTableProps = {
   isLoading: boolean;
@@ -91,26 +93,38 @@ type AssociationsTableProps = {
 
 function renderPrimaryActions(
   onOpenProviderDrawer: () => Promise<void> | void,
-  onOpenProxyDrawer: () => Promise<void> | void
+  onOpenProxyDrawer: () => Promise<void> | void,
+  canAssociate: boolean
 ) {
+  const tooltip = canAssociate ? '' : NO_PERMISSION_TOOLTIP;
   return (
     <Stack direction="row" spacing={1}>
-      <Button
-        variant="contained"
-        size="small"
-        startIcon={<Plus size={16} />}
-        onClick={() => void onOpenProviderDrawer()}
-      >
-        Add LLM Provider
-      </Button>
-      <Button
-        variant="contained"
-        size="small"
-        startIcon={<Plus size={16} />}
-        onClick={() => void onOpenProxyDrawer()}
-      >
-        Add LLM Proxy
-      </Button>
+      <Tooltip title={tooltip}>
+        <Box component="span">
+          <Button
+            variant="contained"
+            size="small"
+            startIcon={<Plus size={16} />}
+            disabled={!canAssociate}
+            onClick={() => void onOpenProviderDrawer()}
+          >
+            Add LLM Provider
+          </Button>
+        </Box>
+      </Tooltip>
+      <Tooltip title={tooltip}>
+        <Box component="span">
+          <Button
+            variant="contained"
+            size="small"
+            startIcon={<Plus size={16} />}
+            disabled={!canAssociate}
+            onClick={() => void onOpenProxyDrawer()}
+          >
+            Add LLM Proxy
+          </Button>
+        </Box>
+      </Tooltip>
     </Stack>
   );
 }
@@ -145,6 +159,11 @@ export default function AssociationsTable({
   onDeleteAssociation,
   onRemoveKey,
 }: AssociationsTableProps) {
+  const { hasPermission } = useAppAuth();
+  const canAssociate = hasPermission(SCOPES.APPLICATION_ASSOCIATIONS_CREATE);
+  const canRemoveAssociation = hasPermission(
+    SCOPES.APPLICATION_ASSOCIATIONS_DELETE
+  );
   return (
     <ListingTable.Container sx={{ minWidth: 600 }}>
       <ListingTable.Toolbar
@@ -154,7 +173,11 @@ export default function AssociationsTable({
         searchPlaceholder="Search associations..."
         actions={
           hasAssociations
-            ? renderPrimaryActions(onOpenProviderDrawer, onOpenProxyDrawer)
+            ? renderPrimaryActions(
+                onOpenProviderDrawer,
+                onOpenProxyDrawer,
+                canAssociate
+              )
             : null
         }
       />
@@ -310,16 +333,27 @@ export default function AssociationsTable({
                               </IconButton>
                             </span>
                           </Tooltip>
-                          <IconButton
-                            size="small"
-                            color="error"
-                            onClick={() => onDeleteAssociation(association)}
-                            aria-label={`Remove ${
-                              association.displayName || association.id
-                            }`}
+                          <Tooltip
+                            title={
+                              canRemoveAssociation
+                                ? ''
+                                : NO_PERMISSION_TOOLTIP
+                            }
                           >
-                            <Trash2 size={16} />
-                          </IconButton>
+                            <Box component="span">
+                              <IconButton
+                                size="small"
+                                color="error"
+                                disabled={!canRemoveAssociation}
+                                onClick={() => onDeleteAssociation(association)}
+                                aria-label={`Remove ${
+                                  association.displayName || association.id
+                                }`}
+                              >
+                                <Trash2 size={16} />
+                              </IconButton>
+                            </Box>
+                          </Tooltip>
                         </Box>
                       </ListingTable.Cell>
                     </ListingTable.Row>
@@ -474,7 +508,11 @@ export default function AssociationsTable({
                 Clear search
               </Button>
             ) : (
-              renderPrimaryActions(onOpenProviderDrawer, onOpenProxyDrawer)
+              renderPrimaryActions(
+                onOpenProviderDrawer,
+                onOpenProxyDrawer,
+                canAssociate
+              )
             )
           }
         />

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/applications/OverviewTabs/AssociationsTable.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/applications/OverviewTabs/AssociationsTable.tsx
@@ -164,6 +164,11 @@ export default function AssociationsTable({
   const canRemoveAssociation = hasPermission(
     SCOPES.APPLICATION_ASSOCIATIONS_DELETE
   );
+  // Mapping/unmapping a key here hits the same POST/DELETE
+  // /applications/{id}/api-keys endpoints as APIKeyTab, so it needs the same
+  // scopes — the association scopes alone don't cover it.
+  const canCreateApiKey = hasPermission(SCOPES.APPLICATION_API_KEY_CREATE);
+  const canDeleteApiKey = hasPermission(SCOPES.APPLICATION_API_KEY_DELETE);
   return (
     <ListingTable.Container sx={{ minWidth: 600 }}>
       <ListingTable.Toolbar
@@ -250,7 +255,9 @@ export default function AssociationsTable({
                       !unavailableKeyNames.has(key.id)
                   );
                   const entityLabel = isProvider ? 'provider' : 'proxy';
-                  const addApiKeyTooltip = selectionBlockedMessage
+                  const addApiKeyTooltip = !canCreateApiKey
+                    ? NO_PERMISSION_TOOLTIP
+                    : selectionBlockedMessage
                     ? selectionBlockedMessage
                     : !canDetermineAddableKeys ||
                       isLoadingEntityKeys ||
@@ -262,6 +269,7 @@ export default function AssociationsTable({
                     ? `No unused API keys are available for this ${entityLabel}.`
                     : 'Add API Key';
                   const isAddApiKeyDisabled =
+                    !canCreateApiKey ||
                     Boolean(selectionBlockedMessage) ||
                     !canDetermineAddableKeys ||
                     isLoadingEntityKeys ||
@@ -462,14 +470,21 @@ export default function AssociationsTable({
                             </Typography>
                           </ListingTable.Cell>
                           <ListingTable.Cell>
-                            <Tooltip title="Remove API key">
+                            <Tooltip
+                              title={
+                                canDeleteApiKey
+                                  ? 'Remove API key'
+                                  : NO_PERMISSION_TOOLTIP
+                              }
+                            >
                               <span>
                                 <IconButton
                                   size="small"
                                   color="error"
-                                  disabled={removingKeyIds.has(
-                                    resolveMappedKeyId(key)
-                                  )}
+                                  disabled={
+                                    !canDeleteApiKey ||
+                                    removingKeyIds.has(resolveMappedKeyId(key))
+                                  }
                                   onClick={() =>
                                     void onRemoveKey(association.id, key)
                                   }

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/ExternalServersList.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/ExternalServersList.tsx
@@ -46,6 +46,7 @@ import {
   TableHead,
   TableRow,
   TextField,
+  Tooltip,
   Typography,
 } from '@wso2/oxygen-ui';
 import { Plus, Search, Trash2 } from '@wso2/oxygen-ui-icons-react';
@@ -62,6 +63,8 @@ import { mcpProxiesApis } from '../../../../apis/MCP/mcpProxiesApis';
 import type { MCPServer } from '../../../../utils/types';
 import NoMCPServers from '../../../../assets/images/NoMCPServers.svg';
 import { getErrorMessage } from '../../../../utils/apiError';
+import { useAppAuth } from '../../../../contexts/AppAuthContext';
+import { DISABLED_ACTION_SX, NO_PERMISSION_TOOLTIP, SCOPES } from '../../../../auth/permissions';
 
 function getErrorDescription(error: unknown, fallbackMessage: string): string {
   return getErrorMessage(error, fallbackMessage);
@@ -78,6 +81,10 @@ export default function ExternalServersList(): React.JSX.Element {
     isProjectsLoading,
   } = useAppShell();
   const showSnackbar = useAIWorkspaceSnackbar();
+  const { hasPermission } = useAppAuth();
+  const canCreateMcpProxy = hasPermission(SCOPES.MCP_PROXY_CREATE);
+  const canDeleteMcpProxy = hasPermission(SCOPES.MCP_PROXY_DELETE);
+  const createMcpProxyTooltip = canCreateMcpProxy ? '' : NO_PERMISSION_TOOLTIP;
   const routeProject = useMemo(
     () =>
       projectsForCurrentOrganization.find(
@@ -299,22 +306,27 @@ export default function ExternalServersList(): React.JSX.Element {
           </PageTitle>
 
           {servers.length > 0 ? (
-            <Button
-              variant="contained"
-              component={RouterLink}
-              to={buildProjectPath(
-                currentOrganization,
-                effectiveProject,
-                '/mcp-proxy/create'
-              )}
-              startIcon={<Plus size={20} />}
-              sx={{ ml: 'auto', flexShrink: 0 }}
-            >
-              <FormattedMessage
-                id="aiWorkspace.pages.appShell.appShellPages.externalServers.Main.create.external.server"
-                defaultMessage="Create MCP Proxy"
-              />
-            </Button>
+            <Tooltip title={createMcpProxyTooltip}>
+              <Box component="span" sx={{ ml: 'auto', flexShrink: 0 }}>
+                <Button
+                  variant="contained"
+                  component={RouterLink}
+                  to={buildProjectPath(
+                    currentOrganization,
+                    effectiveProject,
+                    '/mcp-proxy/create'
+                  )}
+                  startIcon={<Plus size={20} />}
+                  disabled={!canCreateMcpProxy}
+                  sx={DISABLED_ACTION_SX}
+                >
+                  <FormattedMessage
+                    id="aiWorkspace.pages.appShell.appShellPages.externalServers.Main.create.external.server"
+                    defaultMessage="Create MCP Proxy"
+                  />
+                </Button>
+              </Box>
+            </Tooltip>
           ) : null}
         </Box>
       </Grid>
@@ -405,21 +417,27 @@ export default function ExternalServersList(): React.JSX.Element {
                   defaultMessage="Set up an MCP Proxy to expose tools, prompts, and resources through your AI gateway workflows."
                 />
               </Typography>
-              <Button
-                variant="contained"
-                component={RouterLink}
-                to={buildProjectPath(
-                  currentOrganization,
-                  effectiveProject,
-                  '/mcp-proxy/create'
-                )}
-                startIcon={<Plus size={20} />}
-              >
-                <FormattedMessage
-                  id="aiWorkspace.pages.appShell.appShellPages.externalServers.Main.create.external.server"
-                  defaultMessage="Create MCP Proxy"
-                />
-              </Button>
+              <Tooltip title={createMcpProxyTooltip}>
+                <Box component="span">
+                  <Button
+                    variant="contained"
+                    component={RouterLink}
+                    to={buildProjectPath(
+                      currentOrganization,
+                      effectiveProject,
+                      '/mcp-proxy/create'
+                    )}
+                    startIcon={<Plus size={20} />}
+                    disabled={!canCreateMcpProxy}
+                    sx={DISABLED_ACTION_SX}
+                  >
+                    <FormattedMessage
+                      id="aiWorkspace.pages.appShell.appShellPages.externalServers.Main.create.external.server"
+                      defaultMessage="Create MCP Proxy"
+                    />
+                  </Button>
+                </Box>
+              </Tooltip>
             </Stack>
           </Box>
         </Grid>
@@ -530,17 +548,26 @@ export default function ExternalServersList(): React.JSX.Element {
                             {formatRelativeTime(server.updatedAt)}
                           </TableCell>
                           <TableCell align="right">
-                            <IconButton
-                              size="small"
-                              color="error"
-                              onClick={(event) => {
-                                event.stopPropagation();
-                                setDeleteTarget(server);
-                              }}
-                              aria-label={`Delete ${server.displayName}`}
+                            <Tooltip
+                              title={
+                                canDeleteMcpProxy ? '' : NO_PERMISSION_TOOLTIP
+                              }
                             >
-                              <Trash2 size={16} />
-                            </IconButton>
+                              <Box component="span">
+                                <IconButton
+                                  size="small"
+                                  color="error"
+                                  disabled={!canDeleteMcpProxy}
+                                  onClick={(event) => {
+                                    event.stopPropagation();
+                                    setDeleteTarget(server);
+                                  }}
+                                  aria-label={`Delete ${server.displayName}`}
+                                >
+                                  <Trash2 size={16} />
+                                </IconButton>
+                              </Box>
+                            </Tooltip>
                           </TableCell>
                         </TableRow>
                       ))

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/ExternalServersNew.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/ExternalServersNew.tsx
@@ -53,6 +53,8 @@ import {
 } from '../../../../utils/projectRouting';
 import { useMCPServerValidation } from '../../../../contexts/MCP';
 import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
+import { useAppAuth } from '../../../../contexts/AppAuthContext';
+import { SCOPES } from '../../../../auth/permissions';
 import { PLATFORM_API_BASE_URL } from '../../../../paths';
 import { mcpProxiesApis } from '../../../../apis/MCP/mcpProxiesApis';
 import {
@@ -118,6 +120,8 @@ export default function ExternalServersNew(): JSX.Element {
     reset: resetValidation,
   } = useMCPServerValidation();
   const showSnackbar = useAIWorkspaceSnackbar();
+  const { hasPermission } = useAppAuth();
+  const canCreateMcpProxy = hasPermission(SCOPES.MCP_PROXY_CREATE);
   const [isCreating, setIsCreating] = useState(false);
   const [createFieldErrors, setCreateFieldErrors] = useState<Record<string, string>>({});
   const routeProject = useMemo(
@@ -339,9 +343,33 @@ export default function ExternalServersNew(): JSX.Element {
 
   const isCreateDisabled =
     isCreating ||
+    !canCreateMcpProxy ||
     !serverName.trim() ||
     !serverVersion.trim() ||
     !serverTarget.trim();
+
+  if (!canCreateMcpProxy) {
+    return (
+      <PageContent fullWidth>
+        <Stack spacing={1}>
+          <Typography variant="h6">
+            <FormattedMessage
+              id="aiWorkspace.pages.appShell.appShellPages.externalServers.Main.creation.unavailable"
+              defaultMessage={'MCP Proxy creation is unavailable.'}
+            />
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            <FormattedMessage
+              id="aiWorkspace.pages.appShell.appShellPages.externalServers.Main.creation.unavailable.description"
+              defaultMessage={
+                'You do not have permission to create MCP Proxies. Please contact your admin.'
+              }
+            />
+          </Typography>
+        </Stack>
+      </PageContent>
+    );
+  }
 
   return (
     <PageContent fullWidth>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/MCPProxiesSummaryCardSection.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/externalServers/MCPProxiesSummaryCardSection.tsx
@@ -29,6 +29,7 @@ import {
   ParticleBackground,
   Skeleton,
   Stack,
+  Tooltip,
   Typography,
 } from '@wso2/oxygen-ui';
 import { Clock, Layers, Plus } from '@wso2/oxygen-ui-icons-react';
@@ -37,6 +38,8 @@ import { useMCPServers } from '../../../../contexts/MCP';
 import { formatRelativeTime } from '../../../../contexts/ApplicationsContext';
 import NoMCPServers from '../../../../assets/images/NoMCPServers.svg';
 import ErrorAlert from '../../../../Components/common/ErrorAlert';
+import { useAppAuth } from '../../../../contexts/AppAuthContext';
+import { DISABLED_ACTION_SX, NO_PERMISSION_TOOLTIP, SCOPES } from '../../../../auth/permissions';
 
 function truncateWords(text: string, maxWords: number): string {
   const words = text.trim().split(/\s+/);
@@ -67,6 +70,8 @@ export default function MCPProxiesSummaryCardSection({
   newMCPProxyPath,
   onMCPProxyClick,
 }: MCPProxiesSummaryCardSectionProps) {
+  const { hasPermission } = useAppAuth();
+  const canCreateMcpProxy = hasPermission(SCOPES.MCP_PROXY_CREATE);
   const { mcpServersResponse, isLoading, error, refreshMCPServers } =
     useMCPServers();
   const servers = mcpServersResponse.list;
@@ -115,9 +120,19 @@ export default function MCPProxiesSummaryCardSection({
                 See more
               </Button>
             ) : (
-              <Button component={RouterLink} to={newMCPProxyPath} size="small">
-                + Add New
-              </Button>
+              <Tooltip title={canCreateMcpProxy ? '' : NO_PERMISSION_TOOLTIP}>
+                <Box component="span">
+                  <Button
+                    component={RouterLink}
+                    to={newMCPProxyPath}
+                    size="small"
+                    disabled={!canCreateMcpProxy}
+                    sx={DISABLED_ACTION_SX}
+                  >
+                    + Add New
+                  </Button>
+                </Box>
+              </Tooltip>
             )
           }
         />
@@ -203,17 +218,23 @@ export default function MCPProxiesSummaryCardSection({
                 defaultMessage="Set up an MCP Proxy to expose tools, prompts, and resources through your AI gateway workflows."
               />
             </Typography>
-            <Button
-              variant="contained"
-              component={RouterLink}
-              to={newMCPProxyPath}
-              startIcon={<Plus size={20} />}
-            >
-              <FormattedMessage
-                id="aiWorkspace.pages.appShell.appShellPages.externalServers.Main.create.external.server"
-                defaultMessage="Create MCP Proxy"
-              />
-            </Button>
+            <Tooltip title={canCreateMcpProxy ? '' : NO_PERMISSION_TOOLTIP}>
+              <Box component="span">
+                <Button
+                  variant="contained"
+                  component={RouterLink}
+                  to={newMCPProxyPath}
+                  startIcon={<Plus size={20} />}
+                  disabled={!canCreateMcpProxy}
+                  sx={DISABLED_ACTION_SX}
+                >
+                  <FormattedMessage
+                    id="aiWorkspace.pages.appShell.appShellPages.externalServers.Main.create.external.server"
+                    defaultMessage="Create MCP Proxy"
+                  />
+                </Button>
+              </Box>
+            </Tooltip>
           </Stack>
         ) : (
           <Stack divider={<Divider />} spacing={1.5}>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/gateways/GatewayPolicies.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/gateways/GatewayPolicies.tsx
@@ -20,10 +20,19 @@ import {
 } from "@wso2/oxygen-ui";
 import { useGatewayPolicies } from "../../../../contexts/GatewayPoliciesContext";
 import useAIWorkspaceSnackbar from "../../../../hooks/aiWorkspaceSnackbar";
+import { NO_PERMISSION_TOOLTIP } from "../../../../auth/permissions";
 
 export default function GatewayPolicies() {
-  const { policies, isLoading, error, refresh, syncPolicy, syncingPolicyKey } =
-    useGatewayPolicies();
+  const {
+    policies,
+    isLoading,
+    error,
+    refresh,
+    syncPolicy,
+    syncingPolicyKey,
+    canViewPolicies,
+    canSyncPolicies,
+  } = useGatewayPolicies();
   const showSnackbar = useAIWorkspaceSnackbar();
 
   const handleSync = async (policyName: string, version: string) => {
@@ -41,6 +50,17 @@ export default function GatewayPolicies() {
       showSnackbar(message, "error");
     }
   };
+
+  // The provider skips the fetch without the read scopes, so there is nothing to
+  // show here — say why rather than rendering an empty table.
+  if (!canViewPolicies) {
+    return (
+      <Alert severity="info">
+        You do not have permission to view gateway policies. Please contact your
+        admin.
+      </Alert>
+    );
+  }
 
   if (isLoading) {
     return (
@@ -149,12 +169,18 @@ export default function GatewayPolicies() {
                     variant="outlined"
                   />
                 ) : (
-                  <Tooltip title="Click to sync the policy">
+                  <Tooltip
+                    title={
+                      canSyncPolicies
+                        ? "Click to sync the policy"
+                        : NO_PERMISSION_TOOLTIP
+                    }
+                  >
                     <span>
                       <Button
                         size="small"
                         variant="contained"
-                        disabled={syncingPolicyKey !== null}
+                        disabled={syncingPolicyKey !== null || !canSyncPolicies}
                         onClick={() =>
                           void handleSync(policy.policyName, policy.version)
                         }

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/gateways/GatewaysTable.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/gateways/GatewaysTable.tsx
@@ -35,8 +35,11 @@ import {
   DialogContentText,
   DialogActions,
   Button,
+  Tooltip,
 } from '@wso2/oxygen-ui';
 import { Edit, Trash2 } from '@wso2/oxygen-ui-icons-react';
+import { useAppAuth } from '../../../../contexts/AppAuthContext';
+import { NO_PERMISSION_TOOLTIP, SCOPES } from '../../../../auth/permissions';
 
 interface GatewayWithType {
   id: string;
@@ -67,6 +70,9 @@ export default function GatewaysTable({
   onDelete,
   isDeleting,
 }: GatewaysTableProps) {
+  const { hasPermission } = useAppAuth();
+  const canUpdateGateway = hasPermission(SCOPES.GATEWAY_UPDATE);
+  const canDeleteGateway = hasPermission(SCOPES.GATEWAY_DELETE);
   const [deletingId, setDeletingId] = useState<string | null>(null);
 
   const handleDeleteConfirm = () => {
@@ -165,25 +171,39 @@ export default function GatewaysTable({
                         gap: 1,
                       }}
                     >
-                      <IconButton
-                        size="small"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onEdit?.(gateway.name);
-                        }}
+                      <Tooltip
+                        title={canUpdateGateway ? '' : NO_PERMISSION_TOOLTIP}
                       >
-                        <Edit size={18} />
-                      </IconButton>
-                      <IconButton
-                        size="small"
-                        color="error"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setDeletingId(gateway.id);
-                        }}
+                        <Box component="span">
+                          <IconButton
+                            size="small"
+                            disabled={!canUpdateGateway}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              onEdit?.(gateway.name);
+                            }}
+                          >
+                            <Edit size={18} />
+                          </IconButton>
+                        </Box>
+                      </Tooltip>
+                      <Tooltip
+                        title={canDeleteGateway ? '' : NO_PERMISSION_TOOLTIP}
                       >
-                        <Trash2 size={18} />
-                      </IconButton>
+                        <Box component="span">
+                          <IconButton
+                            size="small"
+                            color="error"
+                            disabled={!canDeleteGateway}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setDeletingId(gateway.id);
+                            }}
+                          >
+                            <Trash2 size={18} />
+                          </IconButton>
+                        </Box>
+                      </Tooltip>
                     </Box>
                   )}
                 </TableCell>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/gateways/ViewGateway.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/gateways/ViewGateway.tsx
@@ -96,7 +96,11 @@ import AIGatewayStepBanner from "../quickStart/AIGatewayStepBanner";
 import ErrorAlert from "../../../../Components/common/ErrorAlert";
 import { GatewayPoliciesProvider } from "../../../../contexts/GatewayPoliciesContext";
 import { useAppAuth } from "../../../../contexts/AppAuthContext";
-import { NO_PERMISSION_TOOLTIP, SCOPES } from "../../../../auth/permissions";
+import {
+  DISABLED_ACTION_SX,
+  NO_PERMISSION_TOOLTIP,
+  SCOPES,
+} from "../../../../auth/permissions";
 import GatewayPolicies from "./GatewayPolicies";
 
 const resolveGatewayVersion = (gatewayVersion?: string): string => {
@@ -231,6 +235,7 @@ export default function ViewGateway() {
   const { currentOrganization } = useAppShell();
   const showSnackbar = useAIWorkspaceSnackbar();
   const { hasPermission } = useAppAuth();
+  const canUpdateGateway = hasPermission(SCOPES.GATEWAY_UPDATE);
   // Reconfigure runs three token operations in sequence — list the existing
   // tokens, revoke each, then rotate. All three scopes are required, or the
   // flow fails part-way through with some tokens already revoked. A caller with
@@ -722,17 +727,25 @@ export default function ViewGateway() {
                   size="small"
                   color={gateway?.isActive ? "success" : "default"}
                 />
-                <Tooltip title="Edit Gateway">
-                  <IconButton
-                    component={RouterLink}
-                    to={buildOrgPath(
-                      currentOrganization,
-                      `/gateways/edit/${gatewayName}`,
-                    )}
-                    size="small"
-                  >
-                    <Edit size={16} />
-                  </IconButton>
+                <Tooltip
+                  title={
+                    canUpdateGateway ? "Edit Gateway" : NO_PERMISSION_TOOLTIP
+                  }
+                >
+                  <Box component="span">
+                    <IconButton
+                      component={RouterLink}
+                      to={buildOrgPath(
+                        currentOrganization,
+                        `/gateways/edit/${gatewayName}`,
+                      )}
+                      size="small"
+                      disabled={!canUpdateGateway}
+                      sx={DISABLED_ACTION_SX}
+                    >
+                      <Edit size={16} />
+                    </IconButton>
+                  </Box>
                 </Tooltip>
               </Stack>
               <Typography variant="body2" color="text.secondary">

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/gateways/ViewGateway.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/gateways/ViewGateway.tsx
@@ -95,6 +95,8 @@ import type { ColorScheme } from "../../../../utils/colorScheme";
 import AIGatewayStepBanner from "../quickStart/AIGatewayStepBanner";
 import ErrorAlert from "../../../../Components/common/ErrorAlert";
 import { GatewayPoliciesProvider } from "../../../../contexts/GatewayPoliciesContext";
+import { useAppAuth } from "../../../../contexts/AppAuthContext";
+import { NO_PERMISSION_TOOLTIP, SCOPES } from "../../../../auth/permissions";
 import GatewayPolicies from "./GatewayPolicies";
 
 const resolveGatewayVersion = (gatewayVersion?: string): string => {
@@ -228,6 +230,15 @@ export default function ViewGateway() {
   const { gatewayName } = useParams<{ gatewayName: string }>();
   const { currentOrganization } = useAppShell();
   const showSnackbar = useAIWorkspaceSnackbar();
+  const { hasPermission } = useAppAuth();
+  // Reconfigure runs three token operations in sequence — list the existing
+  // tokens, revoke each, then rotate. All three scopes are required, or the
+  // flow fails part-way through with some tokens already revoked. A caller with
+  // ap:gateway:token:manage (or ap:gateway:manage) satisfies all three.
+  const canRotateToken =
+    hasPermission(SCOPES.GATEWAY_TOKEN_READ) &&
+    hasPermission(SCOPES.GATEWAY_TOKEN_DELETE) &&
+    hasPermission(SCOPES.GATEWAY_TOKEN_CREATE);
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -1125,14 +1136,20 @@ export default function ViewGateway() {
                       updated Helm command, click Reconfigure. This will revoke
                       the previous token.
                     </Typography>
-                    <Button
-                      variant="outlined"
-                      color="primary"
-                      onClick={handleRegenerateToken}
-                      disabled={isRegeneratingToken}
+                    <Tooltip
+                      title={canRotateToken ? '' : NO_PERMISSION_TOOLTIP}
                     >
-                      Reconfigure
-                    </Button>
+                      <Box component="span">
+                        <Button
+                          variant="outlined"
+                          color="primary"
+                          onClick={handleRegenerateToken}
+                          disabled={isRegeneratingToken || !canRotateToken}
+                        >
+                          Reconfigure
+                        </Button>
+                      </Box>
+                    </Tooltip>
                   </>
                 )}
               </Box>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/projects/AddNewProject.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/projects/AddNewProject.tsx
@@ -29,6 +29,7 @@ import {
   PageTitle,
   Stack,
   TextField,
+  Tooltip,
 } from '@wso2/oxygen-ui';
 import { ChevronLeft } from '@wso2/oxygen-ui-icons-react';
 import { ProjectsProvider, useProjects } from '../../../../contexts/ProjectsContext';
@@ -36,6 +37,8 @@ import { useAppShell } from '../../../../contexts/AppShellContext';
 import { buildOrgPath } from '../../../../utils/projectRouting';
 import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
 import { getErrorMessage, getFieldErrors, fieldErrorsToMap } from '../../../../utils/apiError';
+import { useAppAuth } from '../../../../contexts/AppAuthContext';
+import { NO_PERMISSION_TOOLTIP, SCOPES } from '../../../../auth/permissions';
 
 // Backend field names (from CreateProjectRequest) mapped onto this form's state keys.
 const FIELD_NAME_MAP: Record<string, 'name' | 'description'> = {
@@ -48,6 +51,8 @@ function AddNewProjectForm() {
   const { currentOrganization } = useAppShell();
   const { createProject } = useProjects();
   const showSnackbar = useAIWorkspaceSnackbar();
+  const { hasPermission } = useAppAuth();
+  const canCreateProject = hasPermission(SCOPES.PROJECT_CREATE);
 
   const projectsListPath = buildOrgPath(currentOrganization, '/projects/list');
 
@@ -161,17 +166,24 @@ function AddNewProjectForm() {
           >
             Cancel
           </Button>
-          <Button
-            variant="contained"
-            onClick={handleCreate}
-            disabled={!name.trim() || isSubmitting}
-            data-cyid="create-project-button"
-          >
-            {isSubmitting ? (
-              <CircularProgress size={18} sx={{ color: 'inherit', mr: 1 }} />
-            ) : null}
-            Create
-          </Button>
+          <Tooltip title={canCreateProject ? '' : NO_PERMISSION_TOOLTIP}>
+            <Box component="span">
+              <Button
+                variant="contained"
+                onClick={handleCreate}
+                disabled={!name.trim() || isSubmitting || !canCreateProject}
+                data-cyid="create-project-button"
+              >
+                {isSubmitting ? (
+                  <CircularProgress
+                    size={18}
+                    sx={{ color: 'inherit', mr: 1 }}
+                  />
+                ) : null}
+                Create
+              </Button>
+            </Box>
+          </Tooltip>
         </Box>
       </Box>
     </PageContent>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/projects/ExploreMoreCard.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/projects/ExploreMoreCard.tsx
@@ -42,11 +42,11 @@ export default function ExploreMoreCard() {
       links: [
         {
           label: 'AI Workspace Getting Started Guide',
-          href: 'https://wso2.com/bijira/docs/ai-workspace/getting-started/',
+          href: 'https://wso2.com/api-platform/docs/next/ai-workspace/getting-started/',
         },
         {
           label: 'Set Up and Configure an AI Gateway',
-          href: 'https://wso2.com/bijira/docs/ai-workspace/ai-gateways/setting-up/',
+          href: 'https://wso2.com/api-platform/docs/next/ai-workspace/ai-gateways/setting-up/',
         },
       ],
     },
@@ -58,15 +58,15 @@ export default function ExploreMoreCard() {
       links: [
         {
           label: 'LLM Providers Overview',
-          href: 'https://wso2.com/bijira/docs/ai-workspace/llm-providers/overview/',
+          href: 'https://wso2.com/api-platform/docs/next/ai-workspace/llm-providers/overview/',
         },
         {
           label: 'Configure a New LLM Provider',
-          href: 'https://wso2.com/bijira/docs/ai-workspace/llm-providers/configure-provider/',
+          href: 'https://wso2.com/api-platform/docs/next/ai-workspace/llm-providers/configure-provider/',
         },
         {
           label: 'Manage Existing LLM Providers',
-          href: 'https://wso2.com/bijira/docs/ai-workspace/llm-providers/manage-provider/',
+          href: 'https://wso2.com/api-platform/docs/next/ai-workspace/llm-providers/manage-provider/',
         },
       ],
     },
@@ -77,15 +77,15 @@ export default function ExploreMoreCard() {
       links: [
         {
           label: 'App LLM Proxies Overview',
-          href: 'https://wso2.com/bijira/docs/ai-workspace/llm-proxies/overview/',
+          href: 'https://wso2.com/api-platform/docs/next/ai-workspace/llm-proxies/overview/',
         },
         {
           label: 'Create a New App LLM Proxy',
-          href: 'https://wso2.com/api-platform/docs/ai-workspace/llm-proxies/configure-proxy/',
+          href: 'https://wso2.com/api-platform/docs/next/ai-workspace/llm-proxies/configure-proxy/',
         },
         {
           label: 'Manage Existing App LLM Proxies',
-          href: 'https://wso2.com/bijira/docs/ai-workspace/llm-proxies/manage-proxy/',
+          href: 'https://wso2.com/api-platform/docs/next/ai-workspace/llm-proxies/manage-proxy/',
         },
       ],
     },

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/projects/ProjectListView.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/projects/ProjectListView.tsx
@@ -62,6 +62,8 @@ import { useAIWorkspaceSnackbar } from '../../../../hooks/aiWorkspaceSnackbar';
 import { FormattedMessage } from 'react-intl';
 import NoProjects from '../../../../assets/images/NoProjects.svg';
 import { getErrorMessage } from '../../../../utils/apiError';
+import { useAppAuth } from '../../../../contexts/AppAuthContext';
+import { DISABLED_ACTION_SX, NO_PERMISSION_TOOLTIP, SCOPES } from '../../../../auth/permissions';
 
 
 function ProjectListViewInner() {
@@ -76,6 +78,10 @@ function ProjectListViewInner() {
   } = useAppShell();
   const { deleteProject } = useProjects();
   const showSnackbar = useAIWorkspaceSnackbar();
+  const { hasPermission } = useAppAuth();
+  const canCreateProject = hasPermission(SCOPES.PROJECT_CREATE);
+  const canUpdateProject = hasPermission(SCOPES.PROJECT_UPDATE);
+  const canDeleteProject = hasPermission(SCOPES.PROJECT_DELETE);
   const [searchQuery, setSearchQuery] = useState('');
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(10);
@@ -178,18 +184,24 @@ function ProjectListViewInner() {
           </PageTitle.SubHeader>
           {hasProjects && newProjectPath ? (
             <PageTitle.Actions>
-              <Button
-                variant="contained"
-                size="small"
-                startIcon={<Plus size={16} />}
-                component={RouterLink}
-                to={newProjectPath}
-              >
-                <FormattedMessage
-                  id="aiWorkspace.pages.appShell.appShellPages.projects.ProjectListView.new.project"
-                  defaultMessage="Add New Project"
-                />
-              </Button>
+              <Tooltip title={canCreateProject ? '' : NO_PERMISSION_TOOLTIP}>
+                <Box component="span">
+                  <Button
+                    variant="contained"
+                    size="small"
+                    startIcon={<Plus size={16} />}
+                    component={RouterLink}
+                    to={newProjectPath}
+                    disabled={!canCreateProject}
+                    sx={DISABLED_ACTION_SX}
+                  >
+                    <FormattedMessage
+                      id="aiWorkspace.pages.appShell.appShellPages.projects.ProjectListView.new.project"
+                      defaultMessage="Add New Project"
+                    />
+                  </Button>
+                </Box>
+              </Tooltip>
             </PageTitle.Actions>
           ) : null}
         </PageTitle>
@@ -266,17 +278,25 @@ function ProjectListViewInner() {
                     />
                   </Typography>
                   {newProjectPath ? (
-                    <Button
-                      variant="contained"
-                      component={RouterLink}
-                      to={newProjectPath}
-                      startIcon={<Plus size={20} />}
+                    <Tooltip
+                      title={canCreateProject ? '' : NO_PERMISSION_TOOLTIP}
                     >
-                      <FormattedMessage
-                        id="aiWorkspace.pages.appShell.appShellPages.projects.ProjectListView.create.project"
-                        defaultMessage="Create Project"
-                      />
-                    </Button>
+                      <Box component="span">
+                        <Button
+                          variant="contained"
+                          component={RouterLink}
+                          to={newProjectPath}
+                          startIcon={<Plus size={20} />}
+                          disabled={!canCreateProject}
+                          sx={DISABLED_ACTION_SX}
+                        >
+                          <FormattedMessage
+                            id="aiWorkspace.pages.appShell.appShellPages.projects.ProjectListView.create.project"
+                            defaultMessage="Create Project"
+                          />
+                        </Button>
+                      </Box>
+                    </Tooltip>
                   ) : null}
                 </Stack>
               </Box>
@@ -386,9 +406,17 @@ function ProjectListViewInner() {
                         </Stack>
 
                         <Stack direction="row" spacing={0.5}>
-                          <Tooltip title="Edit project">
+                          <Tooltip
+                            title={
+                              canUpdateProject
+                                ? 'Edit project'
+                                : NO_PERMISSION_TOOLTIP
+                            }
+                          >
+                           <Box component="span">
                             <IconButton
                               size="small"
+                              disabled={!canUpdateProject}
                               onClick={(e) => {
                                 e.stopPropagation();
                                 const path = buildOrgPath(
@@ -401,19 +429,29 @@ function ProjectListViewInner() {
                             >
                               <Pencil size={15} />
                             </IconButton>
+                           </Box>
                           </Tooltip>
-                          <Tooltip title="Delete project">
-                            <IconButton
-                              size="small"
-                              color="error"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                setDeleteTargetId(project.id);
-                              }}
-                              aria-label="Delete project"
-                            >
-                              <Trash2 size={15} />
-                            </IconButton>
+                          <Tooltip
+                            title={
+                              canDeleteProject
+                                ? 'Delete project'
+                                : NO_PERMISSION_TOOLTIP
+                            }
+                          >
+                            <Box component="span">
+                              <IconButton
+                                size="small"
+                                color="error"
+                                disabled={!canDeleteProject}
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  setDeleteTargetId(project.id);
+                                }}
+                                aria-label="Delete project"
+                              >
+                                <Trash2 size={15} />
+                              </IconButton>
+                            </Box>
                           </Tooltip>
                         </Stack>
                       </Stack>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/CreateProviderTemplate.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/CreateProviderTemplate.tsx
@@ -35,6 +35,7 @@ import {
   Select,
   Stack,
   TextField,
+  Tooltip,
   Typography,
 } from '@wso2/oxygen-ui';
 import { ChevronDown, ChevronLeft } from '@wso2/oxygen-ui-icons-react';
@@ -43,6 +44,8 @@ import { useProviderTemplates } from '../../../../contexts/llmProvider/providerT
 import { useAppShell } from '../../../../contexts/AppShellContext';
 import { buildOrgPath } from '../../../../utils/projectRouting';
 import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
+import { useAppAuth } from '../../../../contexts/AppAuthContext';
+import { NO_PERMISSION_TOOLTIP, SCOPES } from '../../../../auth/permissions';
 import type {
   CreateProviderTemplateRequest,
   ProviderTemplate,
@@ -107,6 +110,7 @@ export default function CreateProviderTemplate() {
   const { currentOrganization } = useAppShell();
   const { createTemplate } = useProviderTemplates();
   const showSnackbar = useAIWorkspaceSnackbar();
+  const { hasPermission } = useAppAuth();
 
   const copyFrom = (location.state as { copyFrom?: ProviderTemplate } | null)
     ?.copyFrom;
@@ -232,7 +236,9 @@ export default function CreateProviderTemplate() {
   const specUrlEntered = openapiSpecUrl.trim().length > 0;
   const isSpecUrlValid = isValidHttpUrl(openapiSpecUrl);
   const isSpecReady = !specUrlEntered || (isSpecUrlValid && specFetched);
+  const canCreateTemplate = hasPermission(SCOPES.LLM_TEMPLATE_CREATE);
   const isFormValid =
+    canCreateTemplate &&
     isNameValid &&
     Boolean(normalizedTemplateId) &&
     isDescriptionValid &&
@@ -556,24 +562,28 @@ export default function CreateProviderTemplate() {
                 defaultMessage={'Cancel'}
               />
             </Button>
-            <Button
-              variant="contained"
-              type="submit"
-              disabled={isSubmitting || !isFormValid}
-              data-cyid="create-provider-template-submit"
-            >
-              {isSubmitting ? (
-                <FormattedMessage
-                  id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.CreateProviderTemplate.creating"
-                  defaultMessage={'Creating...'}
-                />
-              ) : (
-                <FormattedMessage
-                  id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.CreateProviderTemplate.create"
-                  defaultMessage={'Create Template'}
-                />
-              )}
-            </Button>
+            <Tooltip title={canCreateTemplate ? '' : NO_PERMISSION_TOOLTIP}>
+              <Box component="span">
+                <Button
+                  variant="contained"
+                  type="submit"
+                  disabled={isSubmitting || !isFormValid}
+                  data-cyid="create-provider-template-submit"
+                >
+                  {isSubmitting ? (
+                    <FormattedMessage
+                      id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.CreateProviderTemplate.creating"
+                      defaultMessage={'Creating...'}
+                    />
+                  ) : (
+                    <FormattedMessage
+                      id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.CreateProviderTemplate.create"
+                      defaultMessage={'Create Template'}
+                    />
+                  )}
+                </Button>
+              </Box>
+            </Tooltip>
           </Box>
         </Box>
       </Box>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/CreateProviderTemplateVersion.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/CreateProviderTemplateVersion.tsx
@@ -36,6 +36,7 @@ import {
   Select,
   Stack,
   TextField,
+  Tooltip,
   Typography,
 } from '@wso2/oxygen-ui';
 import { ChevronDown, ChevronLeft } from '@wso2/oxygen-ui-icons-react';
@@ -43,6 +44,8 @@ import { FormattedMessage } from 'react-intl';
 import { useProviderTemplates } from '../../../../contexts/llmProvider/providerTemplate';
 import { useAppShell } from '../../../../contexts/AppShellContext';
 import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
+import { useAppAuth } from '../../../../contexts/AppAuthContext';
+import { NO_PERMISSION_TOOLTIP, SCOPES } from '../../../../auth/permissions';
 import * as providerTemplateApis from '../../../../apis/providerTemplateApis';
 import { PLATFORM_API_BASE_URL } from '../../../../paths';
 import { buildOrgPath } from '../../../../utils/projectRouting';
@@ -119,6 +122,7 @@ function CreateProviderTemplateVersionForm({
   const { currentOrganization } = useAppShell();
   const { refreshTemplates } = useProviderTemplates();
   const showSnackbar = useAIWorkspaceSnackbar();
+  const { hasPermission } = useAppAuth();
 
   const overviewPath = `${buildOrgPath(
     currentOrganization,
@@ -223,7 +227,9 @@ function CreateProviderTemplateVersionForm({
   const specUrlEntered = openapiSpecUrl.trim().length > 0;
   const isSpecUrlValid = isValidHttpUrl(openapiSpecUrl);
   const isVersionValid = VERSION_PATTERN.test(version.trim());
+  const canCreateTemplateVersion = hasPermission(SCOPES.LLM_TEMPLATE_CREATE);
   const isFormValid =
+    canCreateTemplateVersion &&
     isDescriptionValid &&
     isEndpointValid &&
     isVersionValid &&
@@ -545,24 +551,30 @@ function CreateProviderTemplateVersionForm({
                 defaultMessage={'Cancel'}
               />
             </Button>
-            <Button
-              variant="contained"
-              type="submit"
-              disabled={isSubmitting || !isFormValid}
-              data-cyid="create-provider-template-version-submit"
+            <Tooltip
+              title={canCreateTemplateVersion ? '' : NO_PERMISSION_TOOLTIP}
             >
-              {isSubmitting ? (
-                <FormattedMessage
-                  id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.CreateProviderTemplateVersion.creating"
-                  defaultMessage={'Creating...'}
-                />
-              ) : (
-                <FormattedMessage
-                  id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.CreateProviderTemplateVersion.create"
-                  defaultMessage={'Create Version'}
-                />
-              )}
-            </Button>
+              <Box component="span">
+                <Button
+                  variant="contained"
+                  type="submit"
+                  disabled={isSubmitting || !isFormValid}
+                  data-cyid="create-provider-template-version-submit"
+                >
+                  {isSubmitting ? (
+                    <FormattedMessage
+                      id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.CreateProviderTemplateVersion.creating"
+                      defaultMessage={'Creating...'}
+                    />
+                  ) : (
+                    <FormattedMessage
+                      id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.CreateProviderTemplateVersion.create"
+                      defaultMessage={'Create Version'}
+                    />
+                  )}
+                </Button>
+              </Box>
+            </Tooltip>
           </Box>
         </Box>
       </Box>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/ProviderTemplateOverview.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/ProviderTemplateOverview.tsx
@@ -51,6 +51,8 @@ import { formatRelativeTime } from '../../../../contexts/llmProvider';
 import { useProviderTemplates } from '../../../../contexts/llmProvider/providerTemplate';
 import { useAppShell } from '../../../../contexts/AppShellContext';
 import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
+import { useAppAuth } from '../../../../contexts/AppAuthContext';
+import { NO_PERMISSION_TOOLTIP, SCOPES } from '../../../../auth/permissions';
 import * as providerTemplateApis from '../../../../apis/providerTemplateApis';
 import { getLLMProviders } from '../../../../apis/llmProviderApis';
 import { PLATFORM_API_BASE_URL } from '../../../../paths';
@@ -140,6 +142,7 @@ export default function ProviderTemplateOverview() {
   const { currentOrganization } = useAppShell();
   const { updateTemplate, refreshTemplates } = useProviderTemplates();
   const showSnackbar = useAIWorkspaceSnackbar();
+  const { hasPermission } = useAppAuth();
   const [tabIndex, setTabIndex] = useState(0);
 
   const [template, setTemplate] = useState<ProviderTemplate | undefined>();
@@ -543,8 +546,12 @@ export default function ProviderTemplateOverview() {
     })();
   const isBuiltIn = activeProvider === 'wso2';
   const isReadOnly = isBuiltIn;
-  const canEdit = !isReadOnly;
-  const canDelete = !isReadOnly;
+  // Read-only is a property of the template itself; the scope check is a
+  // property of the caller. Both must hold for an action to be offered.
+  const canEdit = !isReadOnly && hasPermission(SCOPES.LLM_TEMPLATE_UPDATE);
+  const canDelete = !isReadOnly && hasPermission(SCOPES.LLM_TEMPLATE_DELETE);
+  const canCreateTemplate = hasPermission(SCOPES.LLM_TEMPLATE_CREATE);
+  const canUpdateTemplate = hasPermission(SCOPES.LLM_TEMPLATE_UPDATE);
   // Data-plane-originated (gateway-pushed) template: the gateway owns the runtime
   // configuration, so the Connection (endpoint/auth) and Token Mapping (extraction +
   // resource mappings) sections are read-only in the control plane. Name/description/
@@ -831,16 +838,25 @@ export default function ProviderTemplateOverview() {
 
             <Stack direction="column" spacing={1.5} alignItems="flex-end">
               {isBuiltIn && (
-                <Button
-                  variant="outlined"
-                  startIcon={<Copy size={16} />}
-                  onClick={() =>
-                    navigate(`${listPath}/new`, { state: { copyFrom: template } })
-                  }
-                  data-cyid="provider-template-create-copy-button"
+                <Tooltip
+                  title={canCreateTemplate ? '' : NO_PERMISSION_TOOLTIP}
                 >
-                  Create a copy
-                </Button>
+                  <Box component="span">
+                    <Button
+                      variant="outlined"
+                      startIcon={<Copy size={16} />}
+                      disabled={!canCreateTemplate}
+                      onClick={() =>
+                        navigate(`${listPath}/new`, {
+                          state: { copyFrom: template },
+                        })
+                      }
+                      data-cyid="provider-template-create-copy-button"
+                    >
+                      Create a copy
+                    </Button>
+                  </Box>
+                </Tooltip>
               )}
               {!isBuiltIn && (
                 <Button
@@ -863,12 +879,22 @@ export default function ProviderTemplateOverview() {
                 <Typography variant="body2" color="text.primary">
                   {isEnabled ? 'Enabled' : 'Disabled'}
                 </Typography>
-                <Switch
-                  checked={isEnabled}
-                  disabled={isTogglingEnabled}
-                  onChange={(e) => void handleToggleEnabled(e.target.checked)}
-                  inputProps={{ 'aria-label': 'Enable or disable this version' }}
-                />
+                <Tooltip
+                  title={canUpdateTemplate ? '' : NO_PERMISSION_TOOLTIP}
+                >
+                  <Box component="span">
+                    <Switch
+                      checked={isEnabled}
+                      disabled={isTogglingEnabled || !canUpdateTemplate}
+                      onChange={(e) =>
+                        void handleToggleEnabled(e.target.checked)
+                      }
+                      inputProps={{
+                        'aria-label': 'Enable or disable this version',
+                      }}
+                    />
+                  </Box>
+                </Tooltip>
               </Stack>
               {/* Custom templates can be deleted entirely (all versions). */}
               {canDelete && (

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/ProviderTemplatesList.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/providerTemplate/ProviderTemplatesList.tsx
@@ -32,6 +32,7 @@ import {
   Skeleton,
   Stack,
   TextField,
+  Tooltip,
   Typography,
 } from '@wso2/oxygen-ui';
 import { ChevronLeft, ChevronRight, Clock, Cpu, Plus, Search } from '@wso2/oxygen-ui-icons-react';
@@ -49,6 +50,8 @@ import type { ProviderTemplate } from '../../../../utils/types';
 import * as providerTemplateApis from '../../../../apis/providerTemplateApis';
 import { PLATFORM_API_BASE_URL } from '../../../../paths';
 import { logger } from '../../../../utils/logger';
+import { useAppAuth } from '../../../../contexts/AppAuthContext';
+import { NO_PERMISSION_TOOLTIP, SCOPES } from '../../../../auth/permissions';
 import AnthropicLogo from '../../../../assets/brands/Anthropic.jpg';
 import AWSBedrockLogo from '../../../../assets/brands/AWSBedrock.webp';
 import AzureLogo from '../../../../assets/brands/Azure.png';
@@ -95,6 +98,9 @@ export default function ProviderTemplatesList({
 } = {}) {
   const navigate = useNavigate();
   const { currentOrganization } = useAppShell();
+  const { hasPermission } = useAppAuth();
+  const canCreateTemplate = hasPermission(SCOPES.LLM_TEMPLATE_CREATE);
+  const createTemplateTooltip = canCreateTemplate ? '' : NO_PERMISSION_TOOLTIP;
 
   const { templatesResponse, isLoading, error, refreshTemplates } =
     useProviderTemplates();
@@ -365,18 +371,23 @@ export default function ProviderTemplatesList({
         </PageTitle>
 
         {templates.length > 0 && (
-          <Button
-            variant="contained"
-            color="primary"
-            onClick={() => navigate(newTemplatePath)}
-            startIcon={<Plus size={20} />}
-            data-cyid="add-provider-template-button"
-          >
-            <FormattedMessage
-              id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.ProviderTemplatesList.create"
-              defaultMessage={'Create'}
-            />
-          </Button>
+          <Tooltip title={createTemplateTooltip}>
+            <Box component="span">
+              <Button
+                variant="contained"
+                color="primary"
+                onClick={() => navigate(newTemplatePath)}
+                startIcon={<Plus size={20} />}
+                disabled={!canCreateTemplate}
+                data-cyid="add-provider-template-button"
+              >
+                <FormattedMessage
+                  id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.ProviderTemplatesList.create"
+                  defaultMessage={'Create'}
+                />
+              </Button>
+            </Box>
+          </Tooltip>
         )}
       </Box>
 
@@ -432,17 +443,22 @@ export default function ProviderTemplatesList({
                   }
                 />
               </Typography>
-              <Button
-                variant="contained"
-                onClick={() => navigate(newTemplatePath)}
-                startIcon={<Plus size={18} />}
-                data-cyid="add-provider-template-button"
-              >
-                <FormattedMessage
-                  id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.ProviderTemplatesList.create"
-                  defaultMessage={'Create'}
-                />
-              </Button>
+              <Tooltip title={createTemplateTooltip}>
+                <Box component="span">
+                  <Button
+                    variant="contained"
+                    onClick={() => navigate(newTemplatePath)}
+                    startIcon={<Plus size={18} />}
+                    disabled={!canCreateTemplate}
+                    data-cyid="add-provider-template-button"
+                  >
+                    <FormattedMessage
+                      id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.ProviderTemplatesList.create"
+                      defaultMessage={'Create'}
+                    />
+                  </Button>
+                </Box>
+              </Tooltip>
             </Stack>
           </Box>
         )}
@@ -579,17 +595,22 @@ export default function ProviderTemplatesList({
                       }
                     />
                   </Typography>
-                  <Button
-                    variant="contained"
-                    onClick={() => navigate(newTemplatePath)}
-                    startIcon={<Plus size={18} />}
-                    data-cyid="add-provider-template-button"
-                  >
-                    <FormattedMessage
-                      id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.ProviderTemplatesList.create"
-                      defaultMessage={'Create'}
-                    />
-                  </Button>
+                  <Tooltip title={createTemplateTooltip}>
+                    <Box component="span">
+                      <Button
+                        variant="contained"
+                        onClick={() => navigate(newTemplatePath)}
+                        startIcon={<Plus size={18} />}
+                        disabled={!canCreateTemplate}
+                        data-cyid="add-provider-template-button"
+                      >
+                        <FormattedMessage
+                          id="aiWorkspace.pages.appShell.appShellPages.providerTemplate.ProviderTemplatesList.create"
+                          defaultMessage={'Create'}
+                        />
+                      </Button>
+                    </Box>
+                  </Tooltip>
                 </Stack>
               </Box>
             ) : (

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxiesList.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxiesList.tsx
@@ -64,6 +64,8 @@ import NoProxies from '../../../../assets/images/NoProxies.svg';
 import ErrorAlert from '../../../../Components/common/ErrorAlert';
 import { useAIWorkspaceSnackbar } from '../../../../hooks/aiWorkspaceSnackbar';
 import { getErrorMessage } from '../../../../utils/apiError';
+import { useAppAuth } from '../../../../contexts/AppAuthContext';
+import { NO_PERMISSION_TOOLTIP, SCOPES } from '../../../../auth/permissions';
 
 function getHttpStatusCode(error?: Error | null): number | null {
   if (!error) return null;
@@ -89,6 +91,7 @@ export default function LLMProxiesList() {
   const navigate = useNavigate();
   const location = useLocation();
   const showSnackbar = useAIWorkspaceSnackbar();
+  const { hasPermission } = useAppAuth();
   const {
     proxiesResponse,
     isLoading: isProxiesLoading,
@@ -212,10 +215,18 @@ export default function LLMProxiesList() {
   const isProxyQuotaReached = false;
   const proxyQuotaTooltip =
     'You cannot create more App LLM Proxies because your organization has reached the maximum limit of 5 proxies.';
+  const canCreateProxy = hasPermission(SCOPES.LLM_PROXY_CREATE);
+  const canDeleteProxy = hasPermission(SCOPES.LLM_PROXY_DELETE);
+  const createProxyDisabled = !canCreateProxy || isProxyQuotaReached;
+  const createProxyTooltip = !canCreateProxy
+    ? NO_PERMISSION_TOOLTIP
+    : isProxyQuotaReached
+      ? proxyQuotaTooltip
+      : '';
   const createProxyButtonSx = {
-    opacity: isProxyQuotaReached ? 0.55 : 1,
+    opacity: createProxyDisabled ? 0.55 : 1,
     '&.Mui-disabled': {
-      opacity: isProxyQuotaReached ? 0.55 : 1,
+      opacity: 0.55,
     },
   };
   const proxyErrorStatusCode = getHttpStatusCode(proxiesError);
@@ -248,14 +259,14 @@ export default function LLMProxiesList() {
                 sx={{ ml: 'auto', flexShrink: 0 }}
               >
                 {proxies.length > 0 ? (
-                  <Tooltip title={isProxyQuotaReached ? proxyQuotaTooltip : ''}>
+                  <Tooltip title={createProxyTooltip}>
                     <Box component="span">
                       <Button
                         variant="contained"
                         component={RouterLink}
                         to={newProxyPath}
                         startIcon={<Plus size={20} />}
-                        disabled={isProxyQuotaReached}
+                        disabled={createProxyDisabled}
                         sx={createProxyButtonSx}
                       >
                         Create App LLM Proxy
@@ -393,14 +404,14 @@ export default function LLMProxiesList() {
                     }
                   />
                 </Typography>
-                <Tooltip title={isProxyQuotaReached ? proxyQuotaTooltip : ''}>
+                <Tooltip title={createProxyTooltip}>
                   <Box component="span">
                     <Button
                       variant="contained"
                       component={RouterLink}
                       to={newProxyPath}
                       startIcon={<Plus size={20} />}
-                      disabled={isProxyQuotaReached}
+                      disabled={createProxyDisabled}
                       sx={createProxyButtonSx}
                     >
                       Create App LLM Proxy
@@ -516,20 +527,29 @@ export default function LLMProxiesList() {
                               {formatRelativeTime(proxy.updatedAt)}
                             </TableCell>
                             <TableCell align="right">
-                              <IconButton
-                                size="small"
-                                color="error"
-                                onClick={(event) => {
-                                  event.stopPropagation();
-                                  setDeleteTarget({
-                                    id: proxy.id,
-                                    name: proxy.displayName,
-                                  });
-                                }}
-                                aria-label={`Delete ${proxy.displayName}`}
+                              <Tooltip
+                                title={
+                                  canDeleteProxy ? '' : NO_PERMISSION_TOOLTIP
+                                }
                               >
-                                <Trash2 size={16} />
-                              </IconButton>
+                                <Box component="span">
+                                  <IconButton
+                                    size="small"
+                                    color="error"
+                                    disabled={!canDeleteProxy}
+                                    onClick={(event) => {
+                                      event.stopPropagation();
+                                      setDeleteTarget({
+                                        id: proxy.id,
+                                        name: proxy.displayName,
+                                      });
+                                    }}
+                                    aria-label={`Delete ${proxy.displayName}`}
+                                  >
+                                    <Trash2 size={16} />
+                                  </IconButton>
+                                </Box>
+                              </Tooltip>
                             </TableCell>
                           </TableRow>
                         ))

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxiesSummaryCardSection.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxiesSummaryCardSection.tsx
@@ -29,6 +29,7 @@ import {
   ParticleBackground,
   Skeleton,
   Stack,
+  Tooltip,
   Typography,
 } from '@wso2/oxygen-ui';
 import { Clock, Layers, Plus } from '@wso2/oxygen-ui-icons-react';
@@ -37,6 +38,8 @@ import { useProxies } from '../../../../contexts/proxy';
 import { formatRelativeTime } from '../../../../contexts/ApplicationsContext';
 import NoProxies from '../../../../assets/images/NoProxies.svg';
 import ErrorAlert from '../../../../Components/common/ErrorAlert';
+import { useAppAuth } from '../../../../contexts/AppAuthContext';
+import { DISABLED_ACTION_SX, NO_PERMISSION_TOOLTIP, SCOPES } from '../../../../auth/permissions';
 
 function truncateWords(text: string, maxWords: number): string {
   const words = text.trim().split(/\s+/);
@@ -68,6 +71,8 @@ export default function LLMProxiesSummaryCardSection({
   onProxyClick,
 }: LLMProxiesSummaryCardSectionProps) {
   const { proxiesResponse, isLoading, error, refreshProxies } = useProxies();
+  const { hasPermission } = useAppAuth();
+  const canCreateProxy = hasPermission(SCOPES.LLM_PROXY_CREATE);
   const proxies = proxiesResponse.list;
 
   const proxyErrorStatusCode = getHttpStatusCode(error);
@@ -114,9 +119,19 @@ export default function LLMProxiesSummaryCardSection({
                 See more
               </Button>
             ) : (
-              <Button component={RouterLink} to={newProxyPath} size="small">
-                + Add New
-              </Button>
+              <Tooltip title={canCreateProxy ? '' : NO_PERMISSION_TOOLTIP}>
+                <Box component="span">
+                  <Button
+                    component={RouterLink}
+                    to={newProxyPath}
+                    size="small"
+                    disabled={!canCreateProxy}
+                    sx={DISABLED_ACTION_SX}
+                  >
+                    + Add New
+                  </Button>
+                </Box>
+              </Tooltip>
             )
           }
         />
@@ -204,17 +219,23 @@ export default function LLMProxiesSummaryCardSection({
                 }
               />
             </Typography>
-            <Button
-              variant="contained"
-              component={RouterLink}
-              to={newProxyPath}
-              startIcon={<Plus size={20} />}
-            >
-              <FormattedMessage
-                id="aiWorkspace.pages.appShell.appShellPages.overview.Overview.create.llm.proxy"
-                defaultMessage={'Create App LLM Proxy'}
-              />
-            </Button>
+            <Tooltip title={canCreateProxy ? '' : NO_PERMISSION_TOOLTIP}>
+              <Box component="span">
+                <Button
+                  variant="contained"
+                  component={RouterLink}
+                  to={newProxyPath}
+                  startIcon={<Plus size={20} />}
+                  disabled={!canCreateProxy}
+                  sx={DISABLED_ACTION_SX}
+                >
+                  <FormattedMessage
+                    id="aiWorkspace.pages.appShell.appShellPages.overview.Overview.create.llm.proxy"
+                    defaultMessage={'Create App LLM Proxy'}
+                  />
+                </Button>
+              </Box>
+            </Tooltip>
           </Stack>
         ) : (
           <Stack divider={<Divider />} spacing={1.5}>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyGuardrailsTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyGuardrailsTab.tsx
@@ -70,6 +70,8 @@ import { parsePolicyYaml } from '../../PolicyParameterEditor/yamlParser';
 import { FormattedMessage } from 'react-intl';
 import ErrorAlert from '../../../../Components/common/ErrorAlert';
 import { DisabledActionTooltip } from '../../../../utils/readOnlyArtifacts';
+import { useAppAuth } from '../../../../contexts/AppAuthContext';
+import { NO_PERMISSION_TOOLTIP, SCOPES } from '../../../../auth/permissions';
 
 // ─── Shared helpers ──────────────────────────────────────────────────────────
 
@@ -202,7 +204,12 @@ const buildPolicyDefinitionFromCustomPolicy = (item: {
  */
 export default function LLMProxyGuardrailsTab() {
   const { proxy, setLocalProxy } = useProxy();
-  const isReadOnlyProxy = Boolean(proxy?.readOnly);
+  // An action is locked either because the artifact is gateway-managed or
+  // because the caller lacks the update scope; both disable the same controls.
+  const { hasPermission } = useAppAuth();
+  const canEditProxy = hasPermission(SCOPES.LLM_PROXY_UPDATE);
+  const isReadOnlyProxy = Boolean(proxy?.readOnly) || !canEditProxy;
+  const lockedActionTooltip = canEditProxy ? undefined : NO_PERMISSION_TOOLTIP;
   const {
     guardrails: availableGuardrails = [],
     isLoading: isLoadingGuardrails,
@@ -752,7 +759,7 @@ export default function LLMProxyGuardrailsTab() {
             </Grid>
 
             <Grid size={{ xs: 12, sm: 'auto' }}>
-              <DisabledActionTooltip disabled={isReadOnlyProxy}>
+              <DisabledActionTooltip disabled={isReadOnlyProxy} title={lockedActionTooltip}>
                 <span>
                   <Button
                     size="small"

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyGuardrailsTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyGuardrailsTab.tsx
@@ -1071,6 +1071,7 @@ export default function LLMProxyGuardrailsTab() {
                                 <Grid size={{ xs: 12, sm: 'auto' }}>
                                   <DisabledActionTooltip
                                     disabled={isReadOnlyProxy}
+                                    title={lockedActionTooltip}
                                   >
                                     <span>
                                       <Button

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyNew.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyNew.tsx
@@ -70,6 +70,8 @@ import type { CreateProxyRequest, LLMProvider } from '../../../../utils/types';
 import { useAIWorkspaceSnackbar } from '../../../../hooks/aiWorkspaceSnackbar';
 import { logger } from '../../../../utils/logger';
 import { getErrorMessage, getFieldErrors } from '../../../../utils/apiError';
+import { useAppAuth } from '../../../../contexts/AppAuthContext';
+import { NO_PERMISSION_TOOLTIP, SCOPES } from '../../../../auth/permissions';
 
 type FormState = {
   name: string;
@@ -128,6 +130,15 @@ function LLMProxyNewContent({
   const navigate = useNavigate();
   const { createProxy } = useProxies();
   const showSnackbar = useAIWorkspaceSnackbar();
+  const { hasPermission } = useAppAuth();
+  const canCreateProxy = hasPermission(SCOPES.LLM_PROXY_CREATE);
+  // Generating a provider key is a distinct grant from creating a proxy: the
+  // API-key operations accept only ap:llm_provider:api_key:{create,manage}, so
+  // a user who may create proxies can still be unable to mint the key. They can
+  // always paste one into the manual field instead.
+  const canGenerateProviderApiKey = hasPermission(
+    SCOPES.LLM_PROVIDER_API_KEY_CREATE
+  );
   const { providersResponse, isLoading: isProvidersLoading } =
     useLLMProviders();
   const { provider: selectedProvider, isLoading: isSelectedProviderLoading } =
@@ -298,6 +309,31 @@ function LLMProxyNewContent({
   const isManualKeyReady = Boolean(manualApiKeyValue.trim());
   const isSelectedProviderApiKeyReady =
     !selectedProviderRequiresApiKey || isGeneratedKeyReady || isManualKeyReady;
+
+  const isCreateProxyDisabled =
+    !formState.name.trim() ||
+    !formState.providerId ||
+    !effectiveProject?.id ||
+    !providerDetail ||
+    !isSelectedProviderApiKeyReady ||
+    isCreating;
+
+  // The submit button used to disable itself with no explanation, which reads as
+  // a permission problem even when it is only a missing field. Name the actual
+  // blocker instead.
+  const createProxyBlockedReason = (() => {
+    if (!isCreateProxyDisabled || isCreating) return '';
+    if (!formState.name.trim()) return 'Enter a name for the proxy.';
+    if (!formState.providerId) return 'Select an LLM provider.';
+    if (!effectiveProject?.id) return 'Select a project.';
+    if (!providerDetail) return 'Loading the selected provider details.';
+    if (!isSelectedProviderApiKeyReady) {
+      return canGenerateProviderApiKey
+        ? 'This provider requires an API key. Generate one or enter it manually.'
+        : 'This provider requires an API key. Enter it manually, or ask your admin to generate one.';
+    }
+    return '';
+  })();
 
   useEffect(() => {
     setApiKeyError(null);
@@ -552,6 +588,29 @@ function LLMProxyNewContent({
       document.body.removeChild(textarea);
     }
   };
+
+  if (!canCreateProxy) {
+    return (
+      <PageContent fullWidth>
+        <Stack spacing={1}>
+          <Typography variant="h6">
+            <FormattedMessage
+              id="aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxyNew.creation.unavailable"
+              defaultMessage={'App LLM Proxy creation is unavailable.'}
+            />
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            <FormattedMessage
+              id="aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxyNew.creation.unavailable.description"
+              defaultMessage={
+                'You do not have permission to create App LLM Proxies. Please contact your admin.'
+              }
+            />
+          </Typography>
+        </Stack>
+      </PageContent>
+    );
+  }
 
   return (
     <PageContent fullWidth>
@@ -822,9 +881,11 @@ function LLMProxyNewContent({
                         </Box>
                         <Tooltip
                           title={
-                            isSelectedProviderLoading
-                              ? 'Loading selected provider details.'
-                              : ''
+                            !canGenerateProviderApiKey
+                              ? NO_PERMISSION_TOOLTIP
+                              : isSelectedProviderLoading
+                                ? 'Loading selected provider details.'
+                                : ''
                           }
                           placement="top"
                         >
@@ -833,7 +894,10 @@ function LLMProxyNewContent({
                               variant="contained"
                               size="medium"
                               onClick={handleOpenApiKeyModal}
-                              disabled={isSelectedProviderLoading}
+                              disabled={
+                                isSelectedProviderLoading ||
+                                !canGenerateProviderApiKey
+                              }
                             >
                               <FormattedMessage
                                 id="aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxyNew.generate.api.key"
@@ -889,28 +953,25 @@ function LLMProxyNewContent({
               defaultMessage="Cancel"
             />
           </Button>
-          <Button
-            variant="contained"
-            onClick={handleCreate}
-            disabled={
-              !formState.name.trim() ||
-              !formState.providerId ||
-              !effectiveProject?.id ||
-              !providerDetail ||
-              !isSelectedProviderApiKeyReady ||
-              isCreating
-            }
-            data-cyid="create-proxy-button"
-          >
-            {isCreating ? (
-              <CircularProgress size={20} />
-            ) : (
-              <FormattedMessage
-                id="aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxyNew.create.proxy"
-                defaultMessage="Create Proxy"
-              />
-            )}
-          </Button>
+          <Tooltip title={createProxyBlockedReason} placement="top">
+            <span>
+              <Button
+                variant="contained"
+                onClick={handleCreate}
+                disabled={isCreateProxyDisabled}
+                data-cyid="create-proxy-button"
+              >
+                {isCreating ? (
+                  <CircularProgress size={20} />
+                ) : (
+                  <FormattedMessage
+                    id="aiWorkspace.pages.appShell.appShellPages.proxies.LLMProxyNew.create.proxy"
+                    defaultMessage="Create Proxy"
+                  />
+                )}
+              </Button>
+            </span>
+          </Tooltip>
         </Box>
       </Box>
 

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyOverview.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyOverview.tsx
@@ -63,6 +63,8 @@ import {
   buildProjectPath,
 } from '../../../../utils/projectRouting';
 import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
+import { useAppAuth } from '../../../../contexts/AppAuthContext';
+import { NO_PERMISSION_TOOLTIP, SCOPES } from '../../../../auth/permissions';
 import { truncateProviderDisplayName } from '../../../../utils/providerTemplateDisplay';
 import { FormattedMessage } from 'react-intl';
 import type {
@@ -150,6 +152,8 @@ function ProxyOverviewContent() {
   const { refreshProxies } = useProxies();
   const { providersResponse } = useLLMProviders();
   const showSnackbar = useAIWorkspaceSnackbar();
+  const { hasPermission } = useAppAuth();
+  const canDeleteProxy = hasPermission(SCOPES.LLM_PROXY_DELETE);
   const navigate = useNavigate();
   const location = useLocation();
   const { currentProject, currentOrganization } = useAppShell();
@@ -458,13 +462,20 @@ function ProxyOverviewContent() {
                 >
                   {isReadOnlyProxy ? 'View Deployments' : 'Deploy to Gateway'}
                 </Button>
-                <IconButton
-                  color="error"
-                  onClick={() => setDeleteDialogOpen(true)}
-                  aria-label="Delete proxy"
+                <Tooltip
+                  title={canDeleteProxy ? '' : NO_PERMISSION_TOOLTIP}
                 >
-                  <Trash2 size={16} />
-                </IconButton>
+                  <Box component="span">
+                    <IconButton
+                      color="error"
+                      disabled={!canDeleteProxy}
+                      onClick={() => setDeleteDialogOpen(true)}
+                      aria-label="Delete proxy"
+                    >
+                      <Trash2 size={16} />
+                    </IconButton>
+                  </Box>
+                </Tooltip>
               </Stack>
             </Box>
           </Box>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyOverview.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyOverview.tsx
@@ -64,7 +64,11 @@ import {
 } from '../../../../utils/projectRouting';
 import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
 import { useAppAuth } from '../../../../contexts/AppAuthContext';
-import { NO_PERMISSION_TOOLTIP, SCOPES } from '../../../../auth/permissions';
+import {
+  DISABLED_ACTION_SX,
+  NO_PERMISSION_TOOLTIP,
+  SCOPES,
+} from '../../../../auth/permissions';
 import { truncateProviderDisplayName } from '../../../../utils/providerTemplateDisplay';
 import { FormattedMessage } from 'react-intl';
 import type {
@@ -154,6 +158,7 @@ function ProxyOverviewContent() {
   const showSnackbar = useAIWorkspaceSnackbar();
   const { hasPermission } = useAppAuth();
   const canDeleteProxy = hasPermission(SCOPES.LLM_PROXY_DELETE);
+  const canUpdateProxy = hasPermission(SCOPES.LLM_PROXY_UPDATE);
   const navigate = useNavigate();
   const location = useLocation();
   const { currentProject, currentOrganization } = useAppShell();
@@ -229,7 +234,7 @@ function ProxyOverviewContent() {
     // Runtime tabs (provider/security/guardrails & policies) are locked, so a save
     // from a gateway-created proxy only carries non-runtime edits (definition), which
     // the control plane accepts without altering the gateway runtime artifact.
-    if (!proxy || !hasUnsavedChanges || isSavingChanges) {
+    if (!proxy || !hasUnsavedChanges || isSavingChanges || !canUpdateProxy) {
       return;
     }
     try {
@@ -385,14 +390,22 @@ function ProxyOverviewContent() {
                     {/* Edit page (name/version/context/description). Enabled even
                         for gateway-created proxies — the page keeps the runtime
                         fields read-only and allows only the description. */}
-                    <Tooltip title="Edit Proxy">
-                      <IconButton
-                        component={RouterLink}
-                        to={`${proxiesPath}/${proxy.id}/edit`}
-                        size="small"
-                      >
-                        <Edit size={16} />
-                      </IconButton>
+                    <Tooltip
+                      title={
+                        canUpdateProxy ? 'Edit Proxy' : NO_PERMISSION_TOOLTIP
+                      }
+                    >
+                      <Box component="span">
+                        <IconButton
+                          component={RouterLink}
+                          to={`${proxiesPath}/${proxy.id}/edit`}
+                          size="small"
+                          disabled={!canUpdateProxy}
+                          sx={DISABLED_ACTION_SX}
+                        >
+                          <Edit size={16} />
+                        </IconButton>
+                      </Box>
                     </Tooltip>
                   </Stack>
                   <Stack spacing={0.1} sx={{ mt: 1 }}>
@@ -564,7 +577,9 @@ function ProxyOverviewContent() {
                 </Button>
                 <Button
                   variant="contained"
-                  disabled={!hasUnsavedChanges || isSavingChanges}
+                  disabled={
+                    !hasUnsavedChanges || isSavingChanges || !canUpdateProxy
+                  }
                   onClick={() => void handleSaveChanges()}
                 >
                   {isSavingChanges ? <CircularProgress size={20} /> : 'Save'}

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyResourcesTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyResourcesTab.tsx
@@ -17,7 +17,7 @@
  */
 
 import React, { useMemo, useRef } from 'react';
-import { Box, Button, Stack, Typography } from '@wso2/oxygen-ui';
+import { Box, Button, Stack, Tooltip, Typography } from '@wso2/oxygen-ui';
 import { Upload } from '@wso2/oxygen-ui-icons-react';
 import YAML from 'yaml';
 import { useProxy } from '../../../../contexts/proxy';
@@ -25,6 +25,8 @@ import { logger } from '../../../../utils/logger';
 import NoData from '../../../../assets/images/NoData.svg';
 import { FormattedMessage } from 'react-intl';
 import SwaggerSpecViewer from '../../../../Components/SwaggerSpecViewer';
+import { useAppAuth } from '../../../../contexts/AppAuthContext';
+import { NO_PERMISSION_TOOLTIP, SCOPES } from '../../../../auth/permissions';
 
 // ─── Shared helpers ──────────────────────────────────────────────────────────
 
@@ -99,6 +101,8 @@ function parseOpenApiSpec(text: string): OpenApiSpec | null {
  */
 export default function LLMProxyResourcesTab() {
   const { proxy, setLocalProxy } = useProxy();
+  const { hasPermission } = useAppAuth();
+  const canEditProxy = hasPermission(SCOPES.LLM_PROXY_UPDATE);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const openApiSpecText = proxy?.openapi || '';
   const parsedOpenApiSpec = useMemo(
@@ -163,14 +167,19 @@ export default function LLMProxyResourcesTab() {
           </Typography>
 
           <Stack direction="row" spacing={1}>
-            <Button
-              variant="outlined"
-              size="small"
-              startIcon={<Upload size={16} />}
-              onClick={() => fileInputRef.current?.click()}
-            >
-              Import from file
-            </Button>
+            <Tooltip title={canEditProxy ? '' : NO_PERMISSION_TOOLTIP}>
+              <Box component="span">
+                <Button
+                  variant="outlined"
+                  size="small"
+                  startIcon={<Upload size={16} />}
+                  disabled={!canEditProxy}
+                  onClick={() => fileInputRef.current?.click()}
+                >
+                  Import from file
+                </Button>
+              </Box>
+            </Tooltip>
             <input
               ref={fileInputRef}
               type="file"

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ProvidersList.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ProvidersList.tsx
@@ -348,8 +348,26 @@ export default function ServiceProviders() {
           display="flex"
           justifyContent="flex-end"
         >
-          {!isDeveloper && !isProjectLevel && providers.length > 0 && (
-            <Tooltip title={isProviderQuotaReached ? providerQuotaTooltip : ''}>
+          {!isProjectLevel && providers.length > 0 && (
+            <Tooltip
+              title={
+                canCreateProvider ? (
+                  ''
+                ) : isDeveloper ? (
+                  <FormattedMessage
+                    id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProvidersSummaryCard.contact.admin.tooltip"
+                    defaultMessage={
+                      'This is an admin task. Please contact your admin.'
+                    }
+                  />
+                ) : (
+                  providerQuotaTooltip
+                )
+              }
+              disableHoverListener={canCreateProvider}
+              disableFocusListener={canCreateProvider}
+              disableTouchListener={canCreateProvider}
+            >
               <Box component="span">
                 <Button
                   variant="contained"
@@ -357,12 +375,12 @@ export default function ServiceProviders() {
                   component={RouterLink}
                   to={newProviderPath}
                   startIcon={<Plus size={20} />}
-                  disabled={isProviderQuotaReached}
+                  disabled={!canCreateProvider}
                   data-cyid="add-new-provider-button"
                   sx={{
-                    opacity: isProviderQuotaReached ? 0.55 : 1,
+                    opacity: canCreateProvider ? 1 : 0.55,
                     '&.Mui-disabled': {
-                      opacity: isProviderQuotaReached ? 0.55 : 1,
+                      opacity: 0.55,
                     },
                   }}
                 >

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderDeploymentsCard.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderDeploymentsCard.tsx
@@ -564,7 +564,9 @@ export default function ServiceProviderDeploymentsCard({
                           <ListingTable.Cell align="right">
                             <Tooltip
                               title={
-                                key.id
+                                !canDeleteProviderApiKey
+                                  ? NO_PERMISSION_TOOLTIP
+                                  : key.id
                                   ? 'Delete API key'
                                   : 'Unable to delete key without an identifier'
                               }

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderDeploymentsCard.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderDeploymentsCard.tsx
@@ -52,6 +52,8 @@ import { useAppShell } from '../../../../contexts/AppShellContext';
 import { useGatewayDeploy } from '../../../../contexts/GatewayDeployContext';
 import { useLLMProvider } from '../../../../contexts/llmProvider';
 import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
+import { useAppAuth } from '../../../../contexts/AppAuthContext';
+import { NO_PERMISSION_TOOLTIP, SCOPES } from '../../../../auth/permissions';
 import type { UserAPIKey } from '../../../../utils/types';
 import { logger } from '../../../../utils/logger';
 import { getErrorMessage } from '../../../../utils/apiError';
@@ -106,6 +108,13 @@ export default function ServiceProviderDeploymentsCard({
     deployments,
   } = useGatewayDeploy();
   const showSnackbar = useAIWorkspaceSnackbar();
+  const { hasPermission } = useAppAuth();
+  const canCreateProviderApiKey = hasPermission(
+    SCOPES.LLM_PROVIDER_API_KEY_CREATE
+  );
+  const canDeleteProviderApiKey = hasPermission(
+    SCOPES.LLM_PROVIDER_API_KEY_DELETE
+  );
 
   const fetchedApiKeysProviderIdRef = useRef<string | null>(null);
   const fetchingApiKeysProviderIdRef = useRef<string | null>(null);
@@ -464,12 +473,17 @@ export default function ServiceProviderDeploymentsCard({
                     />
                   </Typography>
                 </Box>
-                <DisabledActionTooltip disabled={false}>
+                <DisabledActionTooltip
+                  disabled={!canCreateProviderApiKey}
+                  title={NO_PERMISSION_TOOLTIP}
+                >
                   <Button
                     variant="contained"
                     size="medium"
                     onClick={handleOpenApiKeyModal}
-                    disabled={gateways.length === 0}
+                    disabled={
+                      gateways.length === 0 || !canCreateProviderApiKey
+                    }
                   >
                     Generate API Key
                   </Button>
@@ -564,7 +578,11 @@ export default function ServiceProviderDeploymentsCard({
                                       key.id?.trim() || null
                                     )
                                   }
-                                  disabled={!key.id || isDeletingKey}
+                                  disabled={
+                                    !key.id ||
+                                    isDeletingKey ||
+                                    !canDeleteProviderApiKey
+                                  }
                                 >
                                   <Trash2 size={16} />
                                 </IconButton>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderGuardrailsTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderGuardrailsTab.tsx
@@ -1090,6 +1090,7 @@ export default function ServiceProviderGuardrailsTab() {
                               <Grid size={{ xs: 12, sm: 'auto' }}>
                                 <DisabledActionTooltip
                                   disabled={isReadOnlyProvider}
+                                  title={lockedActionTooltip}
                                 >
                                   <Button
                                     size="small"

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderGuardrailsTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderGuardrailsTab.tsx
@@ -71,6 +71,8 @@ import type { AccessControl, PolicyHubPolicy } from '../../../../utils/types';
 import { parsePolicyYaml } from '../../PolicyParameterEditor/yamlParser';
 import { FormattedMessage } from 'react-intl';
 import ErrorAlert from '../../../../Components/common/ErrorAlert';
+import { useAppAuth } from '../../../../contexts/AppAuthContext';
+import { NO_PERMISSION_TOOLTIP, SCOPES } from '../../../../auth/permissions';
 import {
   DisabledActionTooltip,
 } from '../../../../utils/readOnlyArtifacts';
@@ -217,7 +219,12 @@ const buildPolicyDefinitionFromCustomPolicy = (item: {
 export default function ServiceProviderGuardrailsTab() {
   const { provider, isLoading, error, updateProvider, isDraftMode } =
     useLLMProvider();
-  const isReadOnlyProvider = Boolean(provider?.readOnly);
+  // An action is locked either because the artifact is gateway-managed or
+  // because the caller lacks the update scope; both disable the same controls.
+  const { hasPermission } = useAppAuth();
+  const canEditProvider = hasPermission(SCOPES.LLM_PROVIDER_UPDATE);
+  const isReadOnlyProvider = Boolean(provider?.readOnly) || !canEditProvider;
+  const lockedActionTooltip = canEditProvider ? undefined : NO_PERMISSION_TOOLTIP;
   const {
     guardrails: availableGuardrails = [],
     isLoading: isLoadingGuardrails,
@@ -800,7 +807,7 @@ export default function ServiceProviderGuardrailsTab() {
             </Grid>
 
             <Grid size={{ xs: 12, sm: 'auto' }}>
-              <DisabledActionTooltip disabled={isReadOnlyProvider}>
+              <DisabledActionTooltip disabled={isReadOnlyProvider} title={lockedActionTooltip}>
                 <Button
                   size="small"
                   variant="outlined"

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderModelsTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderModelsTab.tsx
@@ -36,6 +36,8 @@ import {
 import { Plus, X } from '@wso2/oxygen-ui-icons-react';
 import { useLLMProvider } from '../../../../contexts/llmProvider';
 import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
+import { useAppAuth } from '../../../../contexts/AppAuthContext';
+import { NO_PERMISSION_TOOLTIP, SCOPES } from '../../../../auth/permissions';
 import { FormattedMessage } from 'react-intl';
 import NoModelsImage from '../../../../assets/images/NoModels.svg';
 import { DisabledActionTooltip } from '../../../../utils/readOnlyArtifacts';
@@ -157,8 +159,12 @@ export default function ServiceProviderModelsTab() {
     useLLMProvider();
   // The model catalog is control-plane-only metadata: it is NOT part of the gateway
   // runtime artifact (the deployment spec carries no model list), so it stays editable
-  // even for gateway-created (read-only) providers.
-  const isReadOnlyProvider = false;
+  // even for gateway-created (read-only) providers. Editing it still writes to the
+  // provider, so it requires the provider update scope.
+  const { hasPermission } = useAppAuth();
+  const canEditProvider = hasPermission(SCOPES.LLM_PROVIDER_UPDATE);
+  const isReadOnlyProvider = !canEditProvider;
+  const lockedActionTooltip = canEditProvider ? undefined : NO_PERMISSION_TOOLTIP;
   const modelCatalog = useMemo<Record<string, string[]>>(
     () => ({
       meta: [
@@ -484,7 +490,7 @@ export default function ServiceProviderModelsTab() {
                     ))}
                   </Stack>
 
-                  <DisabledActionTooltip disabled={isReadOnlyProvider}>
+                  <DisabledActionTooltip disabled={isReadOnlyProvider} title={lockedActionTooltip}>
                     <Tooltip
                       placement="top"
                       title={
@@ -572,7 +578,7 @@ export default function ServiceProviderModelsTab() {
                         inputProps={{ 'aria-label': 'Model provider name' }}
                       />
                     ) : (
-                      <DisabledActionTooltip disabled={isReadOnlyProvider}>
+                      <DisabledActionTooltip disabled={isReadOnlyProvider} title={lockedActionTooltip}>
                         <Button
                           size="small"
                           variant="outlined"

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderModelsTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderModelsTab.tsx
@@ -490,38 +490,41 @@ export default function ServiceProviderModelsTab() {
                     ))}
                   </Stack>
 
-                  <DisabledActionTooltip disabled={isReadOnlyProvider} title={lockedActionTooltip}>
-                    <Tooltip
-                      placement="top"
-                      title={
-                        disableAddProviderButton ? (
-                          <FormattedMessage
-                            id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderModelsTab.single.provider.support.tooltip"
-                            defaultMessage={
-                              'Only one model provider is supported for this service provider.'
-                            }
-                          />
-                        ) : (
-                          ''
-                        )
-                      }
-                    >
-                      <Box component="span">
-                        <Button
-                          size="small"
-                          variant="outlined"
-                          startIcon={<Plus size={16} />}
-                          disabled={disableAddProviderButton || isReadOnlyProvider}
-                          onClick={() => setDrawerOpen(true)}
-                        >
-                          <FormattedMessage
-                            id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderModelsTab.add.model.provider.2"
-                            defaultMessage={'Add Model Provider'}
-                          />
-                        </Button>
-                      </Box>
-                    </Tooltip>
-                  </DisabledActionTooltip>
+                  {/* One tooltip only — nesting two meant a missing-permission
+                      message and the single-provider-limit message could both
+                      render. Permission takes precedence. */}
+                  <Tooltip
+                    placement="top"
+                    title={
+                      isReadOnlyProvider ? (
+                        lockedActionTooltip
+                      ) : disableAddProviderButton ? (
+                        <FormattedMessage
+                          id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderModelsTab.single.provider.support.tooltip"
+                          defaultMessage={
+                            'Only one model provider is supported for this service provider.'
+                          }
+                        />
+                      ) : (
+                        ''
+                      )
+                    }
+                  >
+                    <Box component="span">
+                      <Button
+                        size="small"
+                        variant="outlined"
+                        startIcon={<Plus size={16} />}
+                        disabled={disableAddProviderButton || isReadOnlyProvider}
+                        onClick={() => setDrawerOpen(true)}
+                      >
+                        <FormattedMessage
+                          id="aiWorkspace.pages.appShell.appShellPages.serviceProvider.ServiceProviderModelsTab.add.model.provider.2"
+                          defaultMessage={'Add Model Provider'}
+                        />
+                      </Button>
+                    </Box>
+                  </Tooltip>
                 </Stack>
               ) : (
                 <Box

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverview.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverview.tsx
@@ -95,7 +95,7 @@ import {
 } from '../../../../utils/providerTemplateDisplay';
 import { useProviderTemplates } from '../../../../contexts/llmProvider/providerTemplate';
 import { useAppAuth } from '../../../../contexts/AppAuthContext';
-import { SCOPES } from '../../../../auth/permissions';
+import { NO_PERMISSION_TOOLTIP, SCOPES } from '../../../../auth/permissions';
 import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
 import {
   AIEntityProvider,
@@ -490,10 +490,17 @@ function ServiceProviderOverviewContent() {
   const proxyQuotaTooltip =
     'You cannot create more App LLM Proxies because your organization has reached the maximum limit of 5 proxies.';
   const isReadOnlyProvider = Boolean(provider?.readOnly);
-  const createProxyTooltip = isProxyQuotaReached ? proxyQuotaTooltip : '';
+  const canCreateProxy = hasPermission(SCOPES.LLM_PROXY_CREATE);
+  const isCreateProxyDisabled =
+    !provider?.id || isProxyQuotaReached || !canCreateProxy;
+  const createProxyTooltip = !canCreateProxy
+    ? NO_PERMISSION_TOOLTIP
+    : isProxyQuotaReached
+      ? proxyQuotaTooltip
+      : '';
 
   const handleCreateProxyClick = () => {
-    if (!provider?.id || isProxyQuotaReached) {
+    if (!provider?.id || isProxyQuotaReached || !canCreateProxy) {
       return;
     }
 
@@ -1233,12 +1240,12 @@ function ServiceProviderOverviewContent() {
                 p={2}
                 sx={{ width: { xs: '100%', sm: 200 }, alignItems: 'stretch' }}
               >
-                <Tooltip title={isProxyQuotaReached ? proxyQuotaTooltip : ''}>
+                <Tooltip title={createProxyTooltip}>
                   <Box component="span">
                     <Button
                       variant="outlined"
                       onClick={handleCreateProxyClick}
-                      disabled={!provider.id || isProxyQuotaReached}
+                      disabled={isCreateProxyDisabled}
                       data-cyid="create-app-llm-proxy-button"
                     >
                       <FormattedMessage
@@ -1545,14 +1552,14 @@ function ServiceProviderOverviewContent() {
                   )}
                 </Button>
                 <DisabledActionTooltip
-                  disabled={isProxyQuotaReached}
+                  disabled={isProxyQuotaReached || !canCreateProxy}
                   title={createProxyTooltip}
                   fullWidth
                 >
                   <Button
                     variant="outlined"
                     onClick={handleCreateProxyClick}
-                    disabled={!provider.id || isProxyQuotaReached}
+                    disabled={isCreateProxyDisabled}
                     fullWidth
                   >
                     <FormattedMessage


### PR DESCRIPTION
$subject

- https://github.com/wso2/api-platform/issues/3122

## Problem

A user holding `ap:llm_proxy:manage` found the **Create Proxy** button disabled, while **Add Provider** stayed enabled for a role not meant to administer providers. Investigating both turned up four separate defects.

**1. Most action buttons had no permission check at all.** The LLM-proxy create buttons, all application create/delete affordances, provider templates, MCP proxies, projects, gateway row actions, guardrail and model-catalog editors, and API-key actions rendered fully enabled regardless of scope. The disabled Create Proxy button was not a permission decision — `LLMProxyNew.tsx` had no scope logic at all, and the button was blocked by unmet form state (an unfulfilled provider API key) with no explanation shown.

**2. Two buttons that looked gated were not.** `ProvidersList` and `LLMProxiesList` computed `disabled` from a quota flag hardcoded to `false`, so the scope check only controlled *rendering*. Whenever those buttons appeared they were clickable.

**3. Frontend scope matching disagreed with the API.** `checkPermission` derived a parent `:manage` from only the first two segments of the requested scope, so `ap:llm_provider:api_key:manage` failed to satisfy `ap:llm_provider:api_key:read` — a holder of the sub-resource grant was wrongly denied in the UI.

**4. Disabled link-buttons did not look disabled.** A `Button` rendered as `component={RouterLink}` is an `<a>`, not a `<button>`. The click is blocked, but the anchor does not pick up the theme's disabled colouring, so the control appeared fully enabled while doing nothing — reading as a broken button rather than a permission boundary. `ProvidersList` and `LLMProxiesList` already hand-rolled an opacity override for exactly this reason.

## Changes

### Scope matching (`src/auth/permissions.ts`)

`checkPermission` now resolves in the same order the API authorizes a request — exact match → own-level `:*` wildcard → own-level `:manage` → each broader ancestor's `:manage`. The ancestor rule is correct because sub-resource operations list the parent explicitly in their own `security` block: `ap:llm_provider:manage` appears in the accepted set of every `/llm-providers/{id}/api-keys` and `/deployments` operation.

Scopes ending `:all:manage` are excluded from derivation. `ap:api_key:all:manage` is an ownership override — it widens *whose* rows are reachable, not which actions — so `ap:api_key:manage` must not confer it, matching `canManageAPIKey` in `platform-api/internal/service` and the one operation (`/me/api-keys`) whose accepted list omits a parent `:manage`.

Two shared constants were added: `NO_PERMISSION_TOOLTIP`, which deliberately does not name the missing scope so the tooltip cannot be used to probe the authorization model, and `DISABLED_ACTION_SX`, which supplies the disabled styling anchors don't inherit.

### UI gating

Create, update and delete affordances across LLM proxies, providers, applications, MCP proxies, projects, provider templates, gateways, guardrails, the model catalog and API keys are now `disabled` with an explanatory tooltip, rather than hidden or silently inert. Create pages for LLM proxies, applications and MCP proxies gained route-level guards mirroring the existing one in `ServiceProviderNew.tsx`.

Where a tab already had a gateway-managed read-only gate (guardrails, models), the permission was folded into that existing flag rather than added as a parallel mechanism, so one definition change covers every control it already guarded — and the tooltip switches to the permission message when that is the cause rather than mislabelling it "gateway-managed".

The Create Proxy submit button now names its actual blocker ("Select an LLM provider", "This provider requires an API key…") instead of disabling itself with no signal — the behaviour that made a form-state problem look like a permissions problem.

Detail-page header actions are gated alongside their list-table equivalents. `ViewGateway` and `LLMProxyOverview` each carried an Edit control that the corresponding row action in `GatewaysTable`/`ProxiesList` already gated, so the same operation was reachable or not depending on which screen you opened it from. `LLMProxyOverview`'s sticky **Save** is gated on `ap:llm_proxy:update` as well, with `handleSaveChanges` returning before `updateProxy` — the button is not the only entry point to it.

Where two tooltips could fire on one control, the permission message takes precedence. The resource-level Add buttons on both guardrails tabs were wrapped in a `DisabledActionTooltip` that fell through to its "gateway-managed" default, so a permission block was mislabelled; the provider models tab nested a `DisabledActionTooltip` inside a `Tooltip`, letting the missing-permission and single-provider-limit messages render together. Both now resolve to one title, permission first.

### Reads that would 403 are no longer attempted

Gating write actions is not sufficient on its own: a surface whose *read* is denied fails just as visibly. The gateway Policies tab loaded the gateway manifest and the org's custom policies on mount, so a caller without `ap:gateway:manifest:read` and `ap:gateway_custom_policy:read` got a 403 and a "Failed to load gateway policies" error that looked like an outage rather than a permission boundary. `GatewayPoliciesProvider` now skips the request entirely when either scope is missing, and the tab renders a permission notice instead. The per-row **Sync** action is separately gated on `ap:gateway_custom_policy:create`, since viewing the manifest and syncing a policy into the organization are different grants.

### Role-to-scope mapping (committed separately)

With ancestor matching in place, sub-resource scopes listed alongside a parent `:manage` became redundant. 25 such entries were removed across the five roles, and the convention block now documents that a resource `:manage` covers its sub-resources and that `:all:manage` is neither implied by nor implies the plain `:manage`. The Helm chart's inlined `ap_admin` is now identical to the canonical role's `ap:` scopes.

### Documentation links

Nine AI Workspace doc links pointed at the retired `wso2.com/bijira/docs/` base (one was on `api-platform` but missing the `/next/` segment). All now point at `https://wso2.com/api-platform/docs/next/ai-workspace/…`, verified against the live site — the section exists and its structure matches ours one-for-one.

## Behaviour changes

Every role's effective access is **unchanged** except `ap_publisher`, which was deliberately narrowed:

| Role | Change |
|---|---|
| `ap_admin`, `ap_operator`, `ap_subscriber`, `ap_viewer` | Redundant scopes removed; reachable operations identical |
| `ap_publisher` | `ap:llm_provider:manage` → `ap:llm_provider:read`; `ap:llm_provider:deployment:manage` removed |

Publishers can no longer create, edit, delete or deploy LLM providers — provider administration is now an admin task. They retain `ap:llm_proxy:manage` (which covers proxy API keys and deployments), so pointing a proxy at an existing provider and deploying it still works.

Three consequences to be aware of:

- Publishers lose **read** access to provider deployments as well, not just write — six operations in total. `ap:llm_provider:read` does not reach the sub-resource, because those operations accept the parent `:manage`, never the parent `:read`. Add `ap:llm_provider:deployment:read` if read-only visibility is wanted.
- Publishers cannot generate a provider API key (`ap:llm_provider:api_key:create` is admin-only). The Generate API Key button shows disabled with a tooltip; the manual key field on the proxy form remains available.
- A gateway read-only holder (`ap:gateway:read`) can list gateways, open one and see live status — the row click and both read endpoints are unaffected — while Edit, Delete and Reconfigure are disabled, and the Policies tab shows a permission notice instead of erroring.

This is a live authorization narrowing — any `ap_publisher` currently managing LLM providers will receive `403`s after a restart, which the mapping file requires to take effect.

## Validation

- **Typecheck and build clean.** `tsc --noEmit` reports zero errors in every touched file and `npm run build` succeeds; the remaining ~30 errors are pre-existing on this branch (missing `JSX` namespace, absent `@types` for `js-yaml`/`swagger-ui-react`, and unrelated context type errors). No lint run — `portals/ai-workspace` has no `eslint.config.js`.
- **Scope matching verified against the spec, not by inspection.** The UI's decision was compared against a reimplementation of the API's `scopeSatisfies` looping over each operation's declared accepted scopes, for all 5 roles × 114 operations: **0 mismatches** — no false enables, no false disables.
- **Compaction proven behaviour-preserving.** Each role's full reachable operation set was computed before and after and diffed: identical. Redundancy was determined greedily per role — a scope was dropped only if reachability was unchanged given everything still remaining — so no ordering artifact where two scopes each look redundant because of the other.
- **Gating coverage audited mechanically.** Every `NO_PERMISSION_TOOLTIP` site was checked for a paired disabled control, and separately for the subtler case where the tooltip condition and the `disabled` expression use different flags. Zero unpaired sites; a brace-aware JSX scan confirms no gated link-button is left without disabled styling. Review follow-up caught the inverse of that case — a control correctly `disabled` but carrying a tooltip that named the wrong reason — which the scan did not look for; those are fixed above.
- **The one action still not scope-checked was verified to be inert.** `ModelPill`'s remove icon takes `removeDisabled={isSaving || isReadOnlyProvider}` and re-checks the flag inside `onRemove`, so the missing `ap:llm_provider:update` check is a tooltip gap, not a reachable path.
- 47 of 48 sub-resource operations in `openapi.yaml` accept the parent `:manage`, confirming the ancestor rule models the API correctly.

## Notable fixes found while verifying

- **Gateway token rotation was gated too narrowly.** Reconfigure runs three operations in sequence (list tokens → revoke each → rotate), but the gate checked only `ap:gateway:token:create`. A holder of `:read` + `:create` without `:delete` would have minted a new token while revoking nothing, leaving stale tokens live. It now requires all three; `ap:gateway:token:manage` and `ap:gateway:manage` satisfy them via the ancestor rule.
- **`ServiceProviderModelsTab` had `isReadOnlyProvider` hardcoded `false`**, deliberately, because the model catalog is not part of the runtime artifact. That reasoning holds for read-only artifacts but not for permissions — editing it still writes to the provider — so it is now driven by `ap:llm_provider:update`, with the original comment preserved and extended.
- **Association-mapped API keys bypassed the API-key scopes entirely.** `AssociationsTab` mapped and unmapped keys through `POST`/`DELETE /applications/{id}/api-keys` — the same two endpoints `APIKeyTab` gates on `ap:application:api_key:create`/`:delete` — but the file had no `hasPermission` call at all, so the association scopes were the only thing standing in front of them. The two grants are distinct: associating a provider with an application is not the same as minting a key against it. Both handlers now return before touching drawer state or the API, the permission is folded into the existing `selectionBlockedMessage` (which already gates key selection inside both association drawers), and the key payload is dropped from the add-association flows so associating still works without the key grant.
- **The gateway Policies tab fired a guaranteed-403 read** for anyone without the manifest and custom-policy read scopes, surfacing as a load error. Found by tracing what a `ap:gateway:read`-only role can actually reach, rather than by testing the button gating alone.

## Not covered

**No unit tests for the changed matching logic.** The portal has only Cypress e2e configured; adding a unit runner is a dependency decision under `js-dependency-management.md`. This logic is security-relevant and should get tests — worth resolving before or shortly after merge. The spec-driven equivalence checks above were run manually and are not committed as regression tests.

**Eight files still lack scope checks**, all deliberately: sub-components of an already-gated form (`PolicyParameterEditor/*`, `GuardrailsSection`, `TemplateVersionDialog`, `ProviderTemplateFormFields`, `PolicyMapper`), a display-only tab (`LLMProxyOverviewTab`), and pre-auth onboarding (`OrgProvisioningPage`, which runs before a user has scopes). `AssociationsTab` was on this list as "dialog confirm buttons whose trigger is gated" — that turned out to be wrong for its API-key actions, see above.

**`dp:` scope redundancy not addressed.** Three entries look redundant by the mapping file's documented convention (`dp:key_manager:read` under `dp:key_manager:manage`; `dp:application_key:revoke` under `dp:application_key:manage`). `platform-api` only shape-checks `dp:` scopes — the API Portal enforces them against a spec not verified here, and `revoke` being separately named suggests it may be an override like `:all:manage`. Removing them needs the portal's accepted-scope lists checked first.

**Four scopes are referenced but declared nowhere** — `ap:gateway:artifact:read` and `ap:organization:subscription:read` (in both OIDC scope-request strings) and `ap:rest_api:api_key:read`, `ap:rest_api:publication:read` (in `permissions.ts`). No role grants them and no UI check uses them, but they were left in place: the mapping file notes that scopes may also be declared by compiled-in plugins, exactly as the `websub`/`webbroker` entries are.

**Five non-docs `wso2.com/bijira/*` links remain** (`terms-of-use`, `privacy-policy` in `appShellMain.tsx` and `BasicAuthLoginPage.tsx`). These are legal pages, not documentation, and the api-platform equivalents were not verified.

## Reviewer notes

- The branch also carries earlier, unrelated `/ai-workspace` path-prefix commits. Confirm the intended PR scope before opening.
- Worth a second opinion on the `ap_publisher` narrowing, since it changes production authorization.


<img width="1498" height="820" alt="image" src="https://github.com/user-attachments/assets/b5dc6b3e-8d57-4e3c-912e-2018c4506fe5" />

<img width="1498" height="820" alt="image" src="https://github.com/user-attachments/assets/add33d86-3f22-4f37-88cf-714b33496427" />
