### PR TITLE
Remove transitional status configuration from deployment settings and update deployment logic

### DIFF
--- a/kubernetes/helm/platform-api-helm-chart/templates/configmap.yaml
+++ b/kubernetes/helm/platform-api-helm-chart/templates/configmap.yaml
@@ -146,7 +146,6 @@ data:
 
     [platform_api.deployments]
     max_per_api_gateway = {{ $cfg.deployments.maxPerApiGateway | int }}
-    transitional_status_enabled = {{ $cfg.deployments.transitionalStatusEnabled }}
     timeout_enabled = {{ $cfg.deployments.timeoutEnabled }}
     timeout_interval = {{ $cfg.deployments.timeoutInterval | int }}
     timeout_duration = {{ $cfg.deployments.timeoutDuration | int }}

--- a/kubernetes/helm/platform-api-helm-chart/values.yaml
+++ b/kubernetes/helm/platform-api-helm-chart/values.yaml
@@ -245,7 +245,6 @@ config:
   # --- Deployments ---
   deployments:
     maxPerApiGateway: 20
-    transitionalStatusEnabled: false
     timeoutEnabled: true
     timeoutInterval: 20
     timeoutDuration: 60

--- a/platform-api/config/config-template.toml
+++ b/platform-api/config/config-template.toml
@@ -336,7 +336,6 @@ enable_functionality_type_verification = false
 # ---------------------------------------------------------------------------
 [platform_api.deployments]
 max_per_api_gateway         = 20      # maximum API deployments per gateway
-transitional_status_enabled = false   # expose "pending" deployment states in responses
 
 # Deployment timeout — mark stuck deployments as failed after timeout_duration seconds.
 timeout_enabled  = true

--- a/platform-api/config/config.go
+++ b/platform-api/config/config.go
@@ -395,11 +395,10 @@ type Database struct {
 
 // Deployments holds deployment-specific configuration.
 type Deployments struct {
-	MaxPerAPIGateway          int  `koanf:"max_per_api_gateway"`
-	TransitionalStatusEnabled bool `koanf:"transitional_status_enabled"`
-	TimeoutEnabled            bool `koanf:"timeout_enabled"`
-	TimeoutInterval           int  `koanf:"timeout_interval"`
-	TimeoutDuration           int  `koanf:"timeout_duration"`
+	MaxPerAPIGateway int  `koanf:"max_per_api_gateway"`
+	TimeoutEnabled   bool `koanf:"timeout_enabled"`
+	TimeoutInterval  int  `koanf:"timeout_interval"`
+	TimeoutDuration  int  `koanf:"timeout_duration"`
 }
 
 // APIKey holds API key-specific configuration.

--- a/platform-api/internal/model/deployment.go
+++ b/platform-api/internal/model/deployment.go
@@ -78,7 +78,12 @@ type DeploymentInfo struct {
 	Handle       string           `json:"handle" db:"handle"` // Artifact handle (apiId)
 	Type         string           `json:"type" db:"type"`     // Artifact type: RestAPI, LLMProvider, LLMProxy, MCPProxy
 	Status       DeploymentStatus `json:"status" db:"status"`
-	PerformedAt  time.Time        `json:"performedAt" db:"performed_at"` // When the deploy/undeploy action was initiated
+	// StatusDesired is the terminal state the operation is driving towards
+	// (DEPLOYED/UNDEPLOYED), which stays meaningful while Status is still
+	// transitional (DEPLOYING/UNDEPLOYING). Falls back to Status when the row
+	// predates the column.
+	StatusDesired DeploymentStatus `json:"statusDesired" db:"status_desired"`
+	PerformedAt   time.Time        `json:"performedAt" db:"performed_at"` // When the deploy/undeploy action was initiated
 }
 
 // DeploymentMetadata represents the metadata section of the API deployment YAML

--- a/platform-api/internal/model/deployment.go
+++ b/platform-api/internal/model/deployment.go
@@ -70,6 +70,15 @@ const (
 	DeploymentStatusArchived    DeploymentStatus = "ARCHIVED" // Derived state: exists in history but not in status table
 )
 
+// IsDeployedOrDeploying reports whether the status represents a deployment that is
+// live on the gateway or on its way there — i.e. one whose desired state is DEPLOYED.
+// A deploy is DEPLOYING until the gateway acknowledges it, so callers gating on
+// "is this deployment active?" must accept both: treating DEPLOYING as inactive makes
+// an in-flight deployment impossible to undeploy and, conversely, deletable mid-flight.
+func (s DeploymentStatus) IsDeployedOrDeploying() bool {
+	return s == DeploymentStatusDeployed || s == DeploymentStatusDeploying
+}
+
 // DeploymentInfo is a lightweight representation of a deployment
 // Contains only the essential fields needed for listing deployments
 type DeploymentInfo struct {

--- a/platform-api/internal/repository/api_deployments_test.go
+++ b/platform-api/internal/repository/api_deployments_test.go
@@ -611,6 +611,69 @@ func TestGetControlPlaneDeploymentsByGateway_ExcludesGatewayOrigin(t *testing.T)
 	}
 }
 
+// TestGetControlPlaneDeploymentsByGateway_ReportsDesiredStatus verifies the sync feed
+// carries the desired terminal status alongside the current one. The gateway reconciles
+// against the desired status, so a deployment still awaiting the gateway's acknowledgement
+// (DEPLOYING/UNDEPLOYING) must advertise the DEPLOYED/UNDEPLOYED it is driving towards —
+// otherwise the controller's sync diff cannot parse it and skips the deployment entirely.
+func TestGetControlPlaneDeploymentsByGateway_ReportsDesiredStatus(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewDeploymentRepo(db, NewArtifactTableRegistry())
+
+	orgUUID := "org-001"
+	gatewayUUID := "gateway-001"
+
+	// createTestAPI seeds org + project, which the gateway row depends on.
+	deployingUUID := "api-deploying"
+	createTestAPI(t, db, deployingUUID, orgUUID)
+	createTestGateway(t, db, gatewayUUID, orgUUID)
+
+	insertDeployment(t, db, "deploy-transitional", "Transitional", deployingUUID, orgUUID, gatewayUUID, time.Now())
+	if _, err := repo.SetCurrentWithDetails(
+		deployingUUID, orgUUID, gatewayUUID, "deploy-transitional",
+		model.DeploymentStatusDeploying, string(model.DeploymentStatusDeployed), nil, "",
+	); err != nil {
+		t.Fatalf("SetCurrentWithDetails failed: %v", err)
+	}
+
+	// A row written before status_desired existed stores only status.
+	legacyUUID := "api-legacy"
+	createTestAPIWithOrigin(t, db, legacyUUID, "test-api-legacy", orgUUID, "control_plane")
+	insertDeployment(t, db, "deploy-legacy", "Legacy", legacyUUID, orgUUID, gatewayUUID, time.Now())
+	setDeploymentStatus(t, db, legacyUUID, orgUUID, gatewayUUID, "deploy-legacy", model.DeploymentStatusDeployed)
+
+	deployments, err := repo.GetControlPlaneDeploymentsByGateway(gatewayUUID, orgUUID, nil)
+	if err != nil {
+		t.Fatalf("GetControlPlaneDeploymentsByGateway failed: %v", err)
+	}
+
+	byArtifact := make(map[string]*model.DeploymentInfo, len(deployments))
+	for _, d := range deployments {
+		byArtifact[d.ArtifactID] = d
+	}
+
+	transitional, ok := byArtifact[deployingUUID]
+	if !ok {
+		t.Fatalf("transitional deployment %q missing from the gateway sync feed", deployingUUID)
+	}
+	if transitional.Status != model.DeploymentStatusDeploying {
+		t.Errorf("Status = %q, want %q", transitional.Status, model.DeploymentStatusDeploying)
+	}
+	if transitional.StatusDesired != model.DeploymentStatusDeployed {
+		t.Errorf("StatusDesired = %q, want %q", transitional.StatusDesired, model.DeploymentStatusDeployed)
+	}
+
+	legacy, ok := byArtifact[legacyUUID]
+	if !ok {
+		t.Fatalf("deployment %q missing from the gateway sync feed", legacyUUID)
+	}
+	if legacy.StatusDesired != model.DeploymentStatusDeployed {
+		t.Errorf("StatusDesired = %q, want fallback to Status %q", legacy.StatusDesired, model.DeploymentStatusDeployed)
+	}
+}
+
 func TestMain(m *testing.M) {
 	// APIP_CP_ENCRYPTION_KEY and APIP_CP_AUTH_JWT_SECRET_KEY are required.
 	os.Setenv("APIP_CP_ENCRYPTION_KEY", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")

--- a/platform-api/internal/repository/deployment.go
+++ b/platform-api/internal/repository/deployment.go
@@ -379,9 +379,14 @@ func (r *DeploymentRepo) SetCurrentWithDetails(artifactUUID, orgUUID, gatewayID,
 	}
 
 	// Maintain gateway-specific secret refs from the deployment snapshot.
-	// On DEPLOYED: derive handles from snapshot and insert; on UNDEPLOYED/ARCHIVED: clear only.
+	// Keyed on the desired status, not the current one: a deploy starts out
+	// DEPLOYING and is only acknowledged after the gateway has fetched the
+	// artifact's secrets, so gating on DEPLOYED here would leave the refs empty
+	// for exactly the window in which the gateway needs them.
+	// Desired DEPLOYED: derive handles from the snapshot and insert;
+	// UNDEPLOYED/FAILED/ARCHIVED: clear only.
 	var content []byte
-	if status == model.DeploymentStatusDeployed {
+	if statusDesired == string(model.DeploymentStatusDeployed) {
 		err = tx.QueryRow(r.db.Rebind(`SELECT content FROM deployments WHERE uuid = ?`), deploymentID).Scan(&content)
 		if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			return time.Time{}, fmt.Errorf("failed to fetch deployment content for secret refs: %w", err)
@@ -831,8 +836,10 @@ func (r *DeploymentRepo) GetDeployedGatewayIDs(artifactUUID, orgUUID string) ([]
 // specific gateway. Data-plane-originated (gateway_api) artifacts are excluded because they are
 // owned by the gateway and pushed up to the CP (DP->CP); syncing them back down would make the
 // gateway try to re-create artifacts it already has.
-// Returns lightweight DeploymentInfo for listing deployments
-// Only returns deployments that have an active status (DEPLOYED or UNDEPLOYED)
+// Returns lightweight DeploymentInfo for listing deployments, carrying both the
+// current status and the desired terminal status. The gateway reconciles against
+// the desired status, so an operation still awaiting the gateway's acknowledgement
+// (DEPLOYING/UNDEPLOYING) is synced as the DEPLOYED/UNDEPLOYED it is driving towards.
 // Results are ordered by kind (RestApi -> LlmProvider -> LlmProxy -> Mcp) to ensure
 // dependencies are processed in correct order (LLM Proxies depend on LLM Providers)
 // If since is provided, only returns deployments updated after that timestamp
@@ -844,6 +851,7 @@ func (r *DeploymentRepo) GetControlPlaneDeploymentsByGateway(gatewayID, orgUUID 
 			src.handle,
 			a.type,
 			s.status,
+			s.status_desired,
 			s.performed_at
 		FROM deployment_status s
 		INNER JOIN artifacts a ON s.artifact_uuid = a.uuid
@@ -880,6 +888,7 @@ func (r *DeploymentRepo) GetControlPlaneDeploymentsByGateway(gatewayID, orgUUID 
 	for rows.Next() {
 		dep := &model.DeploymentInfo{}
 		var statusStr string
+		var statusDesired sql.NullString
 
 		err := rows.Scan(
 			&dep.DeploymentID,
@@ -887,6 +896,7 @@ func (r *DeploymentRepo) GetControlPlaneDeploymentsByGateway(gatewayID, orgUUID 
 			&dep.Handle,
 			&dep.Type,
 			&statusStr,
+			&statusDesired,
 			&dep.PerformedAt,
 		)
 		if err != nil {
@@ -894,6 +904,12 @@ func (r *DeploymentRepo) GetControlPlaneDeploymentsByGateway(gatewayID, orgUUID 
 		}
 
 		dep.Status = model.DeploymentStatus(statusStr)
+		// Rows written before status_desired existed carry only status.
+		if statusDesired.Valid && statusDesired.String != "" {
+			dep.StatusDesired = model.DeploymentStatus(statusDesired.String)
+		} else {
+			dep.StatusDesired = dep.Status
+		}
 		deployments = append(deployments, dep)
 	}
 

--- a/platform-api/internal/service/deployment.go
+++ b/platform-api/internal/service/deployment.go
@@ -325,11 +325,8 @@ func (s *DeploymentService) DeployAPI(apiUUID string, req *api.DeployRequest, or
 		s.slogger.Warn("Failed to ensure API-gateway association", "error", err)
 	}
 
-	// Set initial status based on config; transitional (DEPLOYING) only when enabled
-	initialStatus := model.DeploymentStatusDeployed
-	if s.cfg.Deployments.TransitionalStatusEnabled {
-		initialStatus = model.DeploymentStatusDeploying
-	}
+	// Transitional until the gateway acknowledges the artifact.
+	initialStatus := model.DeploymentStatusDeploying
 	performedAt := time.Now().UTC().Truncate(time.Millisecond)
 	if _, err := s.deploymentRepo.SetCurrentWithDetails(
 		apiUUID, orgUUID, gatewayID, deploymentID,
@@ -411,11 +408,8 @@ func (s *DeploymentService) RestoreDeployment(apiUUID, deploymentID, gatewayID, 
 		return nil, apperror.GatewayNotFound.New()
 	}
 
-	// Set initial status based on config; transitional (DEPLOYING) only when enabled
-	initialStatus := model.DeploymentStatusDeployed
-	if s.cfg.Deployments.TransitionalStatusEnabled {
-		initialStatus = model.DeploymentStatusDeploying
-	}
+	// Transitional until the gateway acknowledges the artifact.
+	initialStatus := model.DeploymentStatusDeploying
 	performedAt := time.Now().UTC().Truncate(time.Millisecond)
 	updatedAt, err := s.deploymentRepo.SetCurrentWithDetails(
 		apiUUID, orgUUID, targetDeployment.GatewayID, deploymentID,
@@ -498,11 +492,8 @@ func (s *DeploymentService) UndeployDeployment(apiUUID, deploymentID, gatewayID,
 		return nil, apperror.GatewayNotFound.New()
 	}
 
-	// Set initial status based on config; transitional (UNDEPLOYING) only when enabled
-	initialStatus := model.DeploymentStatusUndeployed
-	if s.cfg.Deployments.TransitionalStatusEnabled {
-		initialStatus = model.DeploymentStatusUndeploying
-	}
+	// Transitional until the gateway acknowledges the artifact.
+	initialStatus := model.DeploymentStatusUndeploying
 	performedAt := time.Now().UTC().Truncate(time.Millisecond)
 	newUpdatedAt, err := s.deploymentRepo.SetCurrentWithDetails(
 		apiUUID, orgUUID, deployment.GatewayID, deploymentID,

--- a/platform-api/internal/service/deployment.go
+++ b/platform-api/internal/service/deployment.go
@@ -395,7 +395,7 @@ func (s *DeploymentService) RestoreDeployment(apiUUID, deploymentID, gatewayID, 
 	if err != nil {
 		return nil, fmt.Errorf("failed to get deployment status: %w", err)
 	}
-	if currentDeploymentID == deploymentID && status == model.DeploymentStatusDeployed {
+	if currentDeploymentID == deploymentID && status.IsDeployedOrDeploying() {
 		return nil, apperror.DeploymentRestoreConflict.New()
 	}
 
@@ -479,7 +479,7 @@ func (s *DeploymentService) UndeployDeployment(apiUUID, deploymentID, gatewayID,
 	}
 
 	// Verify deployment is currently DEPLOYED (status already populated by GetDeploymentWithState)
-	if deployment.Status == nil || *deployment.Status != model.DeploymentStatusDeployed {
+	if deployment.Status == nil || !deployment.Status.IsDeployedOrDeploying() {
 		return nil, apperror.DeploymentNotActive.New("API")
 	}
 
@@ -547,7 +547,7 @@ func (s *DeploymentService) DeleteDeployment(apiUUID, deploymentID, orgUUID, act
 	}
 
 	// Verify deployment is NOT currently DEPLOYED (status already populated by GetDeploymentWithState)
-	if deployment.Status != nil && *deployment.Status == model.DeploymentStatusDeployed {
+	if deployment.Status != nil && deployment.Status.IsDeployedOrDeploying() {
 		return apperror.DeploymentActive.New()
 	}
 

--- a/platform-api/internal/service/deployment_test.go
+++ b/platform-api/internal/service/deployment_test.go
@@ -592,8 +592,9 @@ func TestRestoreDeployment(t *testing.T) {
 				t.Errorf("RestoreDeployment() DeploymentID = %v, want %v", result.DeploymentId.String(), tt.deploymentID)
 			}
 
-			if string(result.Status) != string(model.DeploymentStatusDeployed) {
-				t.Errorf("RestoreDeployment() Status = %v, want %v", result.Status, model.DeploymentStatusDeployed)
+			// Restore is transitional until the gateway acknowledges the artifact.
+			if string(result.Status) != string(model.DeploymentStatusDeploying) {
+				t.Errorf("RestoreDeployment() Status = %v, want %v", result.Status, model.DeploymentStatusDeploying)
 			}
 
 			// Verify updatedAt is returned from SetCurrentDeployment
@@ -609,8 +610,8 @@ func TestRestoreDeployment(t *testing.T) {
 			if !mockDeploymentRepo.setCurrentCalled {
 				t.Error("SetCurrent was not called")
 			}
-			if mockDeploymentRepo.setCurrentStatus != model.DeploymentStatusDeployed {
-				t.Errorf("SetCurrent called with status %v, want %v", mockDeploymentRepo.setCurrentStatus, model.DeploymentStatusDeployed)
+			if mockDeploymentRepo.setCurrentStatus != model.DeploymentStatusDeploying {
+				t.Errorf("SetCurrent called with status %v, want %v", mockDeploymentRepo.setCurrentStatus, model.DeploymentStatusDeploying)
 			}
 		})
 	}
@@ -845,8 +846,9 @@ func TestUndeployDeployment(t *testing.T) {
 				t.Fatal("UndeployDeployment() result is nil, expected non-nil")
 			}
 
-			if string(result.Status) != string(model.DeploymentStatusUndeployed) {
-				t.Errorf("UndeployDeployment() Status = %v, want %v", result.Status, model.DeploymentStatusUndeployed)
+			// Undeploy is transitional until the gateway acknowledges the removal.
+			if string(result.Status) != string(model.DeploymentStatusUndeploying) {
+				t.Errorf("UndeployDeployment() Status = %v, want %v", result.Status, model.DeploymentStatusUndeploying)
 			}
 
 			// Verify updatedAt is returned from SetCurrentDeployment
@@ -858,12 +860,12 @@ func TestUndeployDeployment(t *testing.T) {
 				}
 			}
 
-			// Verify SetCurrentDeployment was called with UNDEPLOYED status
+			// Verify SetCurrentDeployment was called with UNDEPLOYING status
 			if !mockDeploymentRepo.setCurrentCalled {
 				t.Error("SetCurrentDeployment was not called")
 			}
-			if mockDeploymentRepo.setCurrentStatus != model.DeploymentStatusUndeployed {
-				t.Errorf("SetCurrentDeployment called with status %v, want %v", mockDeploymentRepo.setCurrentStatus, model.DeploymentStatusUndeployed)
+			if mockDeploymentRepo.setCurrentStatus != model.DeploymentStatusUndeploying {
+				t.Errorf("SetCurrentDeployment called with status %v, want %v", mockDeploymentRepo.setCurrentStatus, model.DeploymentStatusUndeploying)
 			}
 		})
 	}
@@ -1398,8 +1400,8 @@ func TestRollbackDeployment_WhenAllDeploymentsArchived(t *testing.T) {
 		t.Fatal("RestoreDeployment() result is nil, expected non-nil")
 	}
 
-	if string(result.Status) != string(model.DeploymentStatusDeployed) {
-		t.Errorf("Expected status DEPLOYED, got %s", result.Status)
+	if string(result.Status) != string(model.DeploymentStatusDeploying) {
+		t.Errorf("Expected status DEPLOYING, got %s", result.Status)
 	}
 
 	if !mockDeploymentRepo.setCurrentCalled {
@@ -1455,8 +1457,8 @@ func TestRollbackDeployment_ToArchivedWhenCurrentUndeployed(t *testing.T) {
 		t.Errorf("Expected deployment ID %s, got %s", testDeploymentID, result.DeploymentId.String())
 	}
 
-	if string(result.Status) != string(model.DeploymentStatusDeployed) {
-		t.Errorf("Expected status DEPLOYED, got %s", result.Status)
+	if string(result.Status) != string(model.DeploymentStatusDeploying) {
+		t.Errorf("Expected status DEPLOYING, got %s", result.Status)
 	}
 }
 
@@ -1639,11 +1641,11 @@ func TestUndeployDeployment_WhenOnlyOneDeploymentExists(t *testing.T) {
 		t.Fatalf("UndeployDeployment() unexpected error: %v", err)
 	}
 
-	if string(result.Status) != string(model.DeploymentStatusUndeployed) {
-		t.Errorf("Expected status UNDEPLOYED, got %s", result.Status)
+	if string(result.Status) != string(model.DeploymentStatusUndeploying) {
+		t.Errorf("Expected status UNDEPLOYING, got %s", result.Status)
 	}
 
-	// The deployment should transition to UNDEPLOYED, not be deleted
+	// The deployment should transition to UNDEPLOYING, not be deleted
 	if mockDeploymentRepo.deleteCalled {
 		t.Error("DeleteDeployment should not be called - undeploy should only change status")
 	}

--- a/platform-api/internal/service/gateway_internal.go
+++ b/platform-api/internal/service/gateway_internal.go
@@ -223,7 +223,15 @@ func (s *GatewayInternalAPIService) IsAPIDeployedOnGateway(apiID, gatewayID, org
 	if deploymentID == "" {
 		return apperror.DeploymentNotActive.New("API")
 	}
-	if status != model.DeploymentStatusDeployed && status != model.DeploymentStatusUndeployed {
+	// A transitional row (DEPLOYING/UNDEPLOYING) is still an association: the
+	// gateway fetches subscriptions while applying the artifact, before it has
+	// acknowledged the deploy, so rejecting it here would deny the gateway the
+	// data it needs to complete that very deployment. This matches the
+	// status_desired filter used by APIKeyRepo.ListByGatewayAndKind.
+	switch status {
+	case model.DeploymentStatusDeployed, model.DeploymentStatusUndeployed,
+		model.DeploymentStatusDeploying, model.DeploymentStatusUndeploying:
+	default:
 		return apperror.DeploymentNotActive.New("API")
 	}
 	return nil
@@ -422,9 +430,12 @@ func (s *GatewayInternalAPIService) GetDeploymentsByGateway(orgID, gatewayID str
 			ArtifactID:   dep.ArtifactID,
 			DeploymentID: dep.DeploymentID,
 			Kind:         dep.Type,
-			State:        string(dep.Status),
-			DeployedAt:   deployedAt,
-			Etag:         utils.GenerateDeterministicUUIDv7(dep.DeploymentID, deployedAt),
+			// The gateway reconciles towards the desired terminal state; sending a
+			// transitional DEPLOYING/UNDEPLOYING would not parse as a desired state
+			// and the deployment would be silently skipped by its sync diff.
+			State:      string(dep.StatusDesired),
+			DeployedAt: deployedAt,
+			Etag:       utils.GenerateDeterministicUUIDv7(dep.DeploymentID, deployedAt),
 		}
 	}
 

--- a/platform-api/internal/service/llm_deployment.go
+++ b/platform-api/internal/service/llm_deployment.go
@@ -260,11 +260,8 @@ func (s *LLMProviderDeploymentService) DeployLLMProvider(providerID string, req 
 		return nil, fmt.Errorf("failed to create deployment: %w", err)
 	}
 
-	// Set initial status based on config; transitional (DEPLOYING) only when enabled
-	initialStatus := model.DeploymentStatusDeployed
-	if s.cfg.Deployments.TransitionalStatusEnabled {
-		initialStatus = model.DeploymentStatusDeploying
-	}
+	// Transitional until the gateway acknowledges the artifact.
+	initialStatus := model.DeploymentStatusDeploying
 	performedAt := time.Now().UTC().Truncate(time.Millisecond)
 	if _, err := s.deploymentRepo.SetCurrentWithDetails(
 		provider.UUID, orgUUID, gatewayID, deploymentID,
@@ -356,11 +353,8 @@ func (s *LLMProviderDeploymentService) RestoreLLMProviderDeployment(providerID, 
 		return nil, apperror.GatewayNotFound.New()
 	}
 
-	// Set initial status based on config; transitional (DEPLOYING) only when enabled
-	initialStatus := model.DeploymentStatusDeployed
-	if s.cfg.Deployments.TransitionalStatusEnabled {
-		initialStatus = model.DeploymentStatusDeploying
-	}
+	// Transitional until the gateway acknowledges the artifact.
+	initialStatus := model.DeploymentStatusDeploying
 	performedAt := time.Now().UTC().Truncate(time.Millisecond)
 	updatedAt, err := s.deploymentRepo.SetCurrentWithDetails(
 		provider.UUID, orgUUID, targetDeployment.GatewayID, deploymentID,
@@ -448,11 +442,8 @@ func (s *LLMProviderDeploymentService) UndeployLLMProviderDeployment(providerID,
 		return nil, apperror.GatewayNotFound.New()
 	}
 
-	// Set initial status based on config; transitional (UNDEPLOYING) only when enabled
-	initialStatus := model.DeploymentStatusUndeployed
-	if s.cfg.Deployments.TransitionalStatusEnabled {
-		initialStatus = model.DeploymentStatusUndeploying
-	}
+	// Transitional until the gateway acknowledges the artifact.
+	initialStatus := model.DeploymentStatusUndeploying
 	performedAt := time.Now().UTC().Truncate(time.Millisecond)
 	newUpdatedAt, err := s.deploymentRepo.SetCurrentWithDetails(
 		provider.UUID, orgUUID, deployment.GatewayID, deploymentID,
@@ -1413,11 +1404,8 @@ func (s *LLMProxyDeploymentService) DeployLLMProxy(proxyID string, req *api.Depl
 		return nil, fmt.Errorf("failed to create deployment: %w", err)
 	}
 
-	// Set initial status based on config; transitional (DEPLOYING) only when enabled
-	initialStatus := model.DeploymentStatusDeployed
-	if s.cfg.Deployments.TransitionalStatusEnabled {
-		initialStatus = model.DeploymentStatusDeploying
-	}
+	// Transitional until the gateway acknowledges the artifact.
+	initialStatus := model.DeploymentStatusDeploying
 	performedAt := time.Now().UTC().Truncate(time.Millisecond)
 	if _, err := s.deploymentRepo.SetCurrentWithDetails(
 		proxy.UUID, orgUUID, gatewayID, deploymentID,
@@ -1507,11 +1495,8 @@ func (s *LLMProxyDeploymentService) RestoreLLMProxyDeployment(proxyID, deploymen
 		return nil, apperror.GatewayNotFound.New()
 	}
 
-	// Set initial status based on config; transitional (DEPLOYING) only when enabled
-	initialStatus := model.DeploymentStatusDeployed
-	if s.cfg.Deployments.TransitionalStatusEnabled {
-		initialStatus = model.DeploymentStatusDeploying
-	}
+	// Transitional until the gateway acknowledges the artifact.
+	initialStatus := model.DeploymentStatusDeploying
 	performedAt := time.Now().UTC().Truncate(time.Millisecond)
 	updatedAt, err := s.deploymentRepo.SetCurrentWithDetails(
 		proxy.UUID, orgUUID, targetDeployment.GatewayID, deploymentID,
@@ -1599,11 +1584,8 @@ func (s *LLMProxyDeploymentService) UndeployLLMProxyDeployment(proxyID, deployme
 		return nil, apperror.GatewayNotFound.New()
 	}
 
-	// Set initial status based on config; transitional (UNDEPLOYING) only when enabled
-	initialStatus := model.DeploymentStatusUndeployed
-	if s.cfg.Deployments.TransitionalStatusEnabled {
-		initialStatus = model.DeploymentStatusUndeploying
-	}
+	// Transitional until the gateway acknowledges the artifact.
+	initialStatus := model.DeploymentStatusUndeploying
 	performedAt := time.Now().UTC().Truncate(time.Millisecond)
 	newUpdatedAt, err := s.deploymentRepo.SetCurrentWithDetails(
 		proxy.UUID, orgUUID, deployment.GatewayID, deploymentID,

--- a/platform-api/internal/service/llm_deployment.go
+++ b/platform-api/internal/service/llm_deployment.go
@@ -341,7 +341,7 @@ func (s *LLMProviderDeploymentService) RestoreLLMProviderDeployment(providerID, 
 	if err != nil {
 		return nil, fmt.Errorf("failed to get deployment status: %w", err)
 	}
-	if currentDeploymentID == deploymentID && status == model.DeploymentStatusDeployed {
+	if currentDeploymentID == deploymentID && status.IsDeployedOrDeploying() {
 		return nil, apperror.DeploymentRestoreConflict.New()
 	}
 
@@ -430,7 +430,7 @@ func (s *LLMProviderDeploymentService) UndeployLLMProviderDeployment(providerID,
 	if deployment.GatewayID != resolvedGateway.ID {
 		return nil, apperror.DeploymentGatewayMismatch.New()
 	}
-	if deployment.Status == nil || *deployment.Status != model.DeploymentStatusDeployed {
+	if deployment.Status == nil || !deployment.Status.IsDeployedOrDeploying() {
 		return nil, apperror.DeploymentNotActive.New("LLM provider")
 	}
 
@@ -498,7 +498,7 @@ func (s *LLMProviderDeploymentService) DeleteLLMProviderDeployment(providerID, d
 	if deployment == nil {
 		return apperror.DeploymentNotFound.New()
 	}
-	if deployment.Status != nil && *deployment.Status == model.DeploymentStatusDeployed {
+	if deployment.Status != nil && deployment.Status.IsDeployedOrDeploying() {
 		return apperror.DeploymentActive.New()
 	}
 
@@ -1483,7 +1483,7 @@ func (s *LLMProxyDeploymentService) RestoreLLMProxyDeployment(proxyID, deploymen
 	if err != nil {
 		return nil, fmt.Errorf("failed to get deployment status: %w", err)
 	}
-	if currentDeploymentID == deploymentID && status == model.DeploymentStatusDeployed {
+	if currentDeploymentID == deploymentID && status.IsDeployedOrDeploying() {
 		return nil, apperror.DeploymentRestoreConflict.New()
 	}
 
@@ -1572,7 +1572,7 @@ func (s *LLMProxyDeploymentService) UndeployLLMProxyDeployment(proxyID, deployme
 	if deployment.GatewayID != resolvedGateway.ID {
 		return nil, apperror.DeploymentGatewayMismatch.New()
 	}
-	if deployment.Status == nil || *deployment.Status != model.DeploymentStatusDeployed {
+	if deployment.Status == nil || !deployment.Status.IsDeployedOrDeploying() {
 		return nil, apperror.DeploymentNotActive.New("LLM proxy")
 	}
 
@@ -1640,7 +1640,7 @@ func (s *LLMProxyDeploymentService) DeleteLLMProxyDeployment(proxyID, deployment
 	if deployment == nil {
 		return apperror.DeploymentNotFound.New()
 	}
-	if deployment.Status != nil && *deployment.Status == model.DeploymentStatusDeployed {
+	if deployment.Status != nil && deployment.Status.IsDeployedOrDeploying() {
 		return apperror.DeploymentActive.New()
 	}
 

--- a/platform-api/internal/service/mcp_deployment.go
+++ b/platform-api/internal/service/mcp_deployment.go
@@ -327,11 +327,8 @@ func (s *MCPDeploymentService) deployMCPProxy(proxyUUID string, req *api.DeployR
 		return nil, fmt.Errorf("failed to create deployment: %w", err)
 	}
 
-	// Set initial status based on config; transitional (DEPLOYING) only when enabled
-	initialStatus := model.DeploymentStatusDeployed
-	if s.cfg.Deployments.TransitionalStatusEnabled {
-		initialStatus = model.DeploymentStatusDeploying
-	}
+	// Transitional until the gateway acknowledges the artifact.
+	initialStatus := model.DeploymentStatusDeploying
 	performedAt := time.Now().UTC().Truncate(time.Millisecond)
 	if _, err := s.deploymentRepo.SetCurrentWithDetails(
 		proxyUUID, orgId, gatewayID, deploymentID,
@@ -456,11 +453,8 @@ func (s *MCPDeploymentService) undeployMCPProxyDeployment(proxyUUID string, depl
 		return nil, apperror.GatewayNotFound.New()
 	}
 
-	// Set initial status based on config; transitional (UNDEPLOYING) only when enabled
-	initialStatus := model.DeploymentStatusUndeployed
-	if s.cfg.Deployments.TransitionalStatusEnabled {
-		initialStatus = model.DeploymentStatusUndeploying
-	}
+	// Transitional until the gateway acknowledges the artifact.
+	initialStatus := model.DeploymentStatusUndeploying
 	performedAt := time.Now().UTC().Truncate(time.Millisecond)
 	newUpdatedAt, err := s.deploymentRepo.SetCurrentWithDetails(
 		proxyUUID, orgId, deployment.GatewayID, deployment.DeploymentID,
@@ -538,11 +532,8 @@ func (s *MCPDeploymentService) restoreMCPProxyDeployment(proxyUUID string, deplo
 		return nil, apperror.GatewayNotFound.New()
 	}
 
-	// Set initial status based on config; transitional (DEPLOYING) only when enabled
-	initialStatus := model.DeploymentStatusDeployed
-	if s.cfg.Deployments.TransitionalStatusEnabled {
-		initialStatus = model.DeploymentStatusDeploying
-	}
+	// Transitional until the gateway acknowledges the artifact.
+	initialStatus := model.DeploymentStatusDeploying
 	performedAt := time.Now().UTC().Truncate(time.Millisecond)
 	updatedAt, err := s.deploymentRepo.SetCurrentWithDetails(
 		proxyUUID, orgId, targetDeployment.GatewayID, *deploymentId,

--- a/platform-api/internal/service/mcp_deployment.go
+++ b/platform-api/internal/service/mcp_deployment.go
@@ -440,7 +440,7 @@ func (s *MCPDeploymentService) undeployMCPProxyDeployment(proxyUUID string, depl
 	}
 
 	// Verify deployment is currently DEPLOYED (status already populated by GetWithState)
-	if deployment.Status == nil || *deployment.Status != model.DeploymentStatusDeployed {
+	if deployment.Status == nil || !deployment.Status.IsDeployedOrDeploying() {
 		return nil, apperror.DeploymentNotActive.New("MCP proxy")
 	}
 
@@ -519,7 +519,7 @@ func (s *MCPDeploymentService) restoreMCPProxyDeployment(proxyUUID string, deplo
 	if err != nil {
 		return nil, fmt.Errorf("failed to get deployment status: %w", err)
 	}
-	if currentDeploymentID == *deploymentId && status == model.DeploymentStatusDeployed {
+	if currentDeploymentID == *deploymentId && status.IsDeployedOrDeploying() {
 		return nil, apperror.DeploymentRestoreConflict.New()
 	}
 
@@ -691,7 +691,7 @@ func (s *MCPDeploymentService) deleteMCPProxyDeployment(proxyUUID string, deploy
 	}
 
 	// Verify deployment is NOT currently DEPLOYED (status already populated by GetWithState)
-	if deployment.Status != nil && *deployment.Status == model.DeploymentStatusDeployed {
+	if deployment.Status != nil && deployment.Status.IsDeployedOrDeploying() {
 		return apperror.DeploymentActive.New()
 	}
 

--- a/platform-api/plugins/eventgateway/service/webbroker_api_deployment.go
+++ b/platform-api/plugins/eventgateway/service/webbroker_api_deployment.go
@@ -337,7 +337,7 @@ func (s *WebBrokerAPIDeploymentService) undeployWebBrokerAPIDeployment(apiUUID s
 		return nil, apperror.DeploymentGatewayMismatch.New()
 	}
 
-	if deployment.Status == nil || *deployment.Status != model.DeploymentStatusDeployed {
+	if deployment.Status == nil || !deployment.Status.IsDeployedOrDeploying() {
 		return nil, apperror.DeploymentNotActive.New("WebBroker API")
 	}
 
@@ -416,7 +416,7 @@ func (s *WebBrokerAPIDeploymentService) restoreWebBrokerAPIDeployment(apiUUID st
 	if err != nil {
 		return nil, fmt.Errorf("failed to get deployment status: %w", err)
 	}
-	if currentDeploymentID == *deploymentId && status == model.DeploymentStatusDeployed {
+	if currentDeploymentID == *deploymentId && status.IsDeployedOrDeploying() {
 		return nil, apperror.DeploymentRestoreConflict.New()
 	}
 
@@ -578,7 +578,7 @@ func (s *WebBrokerAPIDeploymentService) deleteWebBrokerAPIDeployment(apiUUID, de
 		return apperror.DeploymentNotFound.New()
 	}
 
-	if deployment.Status != nil && *deployment.Status == model.DeploymentStatusDeployed {
+	if deployment.Status != nil && deployment.Status.IsDeployedOrDeploying() {
 		return apperror.DeploymentActive.New()
 	}
 

--- a/platform-api/plugins/eventgateway/service/webbroker_api_deployment.go
+++ b/platform-api/plugins/eventgateway/service/webbroker_api_deployment.go
@@ -247,10 +247,8 @@ func (s *WebBrokerAPIDeploymentService) deployWebBrokerAPI(apiUUID string, req *
 		s.slogger.Warn("Failed to ensure API-gateway association", "error", err)
 	}
 
-	initialStatus := model.DeploymentStatusDeployed
-	if s.cfg.Deployments.TransitionalStatusEnabled {
-		initialStatus = model.DeploymentStatusDeploying
-	}
+	// Transitional until the gateway acknowledges the artifact.
+	initialStatus := model.DeploymentStatusDeploying
 	performedAt := time.Now().UTC().Truncate(time.Millisecond)
 	if _, err := s.deploymentRepo.SetCurrentWithDetails(
 		apiUUID, orgID, gatewayID, deploymentID,
@@ -351,10 +349,8 @@ func (s *WebBrokerAPIDeploymentService) undeployWebBrokerAPIDeployment(apiUUID s
 		return nil, apperror.GatewayNotFound.New()
 	}
 
-	initialStatus := model.DeploymentStatusUndeployed
-	if s.cfg.Deployments.TransitionalStatusEnabled {
-		initialStatus = model.DeploymentStatusUndeploying
-	}
+	// Transitional until the gateway acknowledges the artifact.
+	initialStatus := model.DeploymentStatusUndeploying
 	performedAt := time.Now().UTC().Truncate(time.Millisecond)
 	newUpdatedAt, err := s.deploymentRepo.SetCurrentWithDetails(
 		apiUUID, orgID, deployment.GatewayID, deployment.DeploymentID,
@@ -432,10 +428,8 @@ func (s *WebBrokerAPIDeploymentService) restoreWebBrokerAPIDeployment(apiUUID st
 		return nil, apperror.GatewayNotFound.New()
 	}
 
-	initialStatus := model.DeploymentStatusDeployed
-	if s.cfg.Deployments.TransitionalStatusEnabled {
-		initialStatus = model.DeploymentStatusDeploying
-	}
+	// Transitional until the gateway acknowledges the artifact.
+	initialStatus := model.DeploymentStatusDeploying
 	performedAt := time.Now().UTC().Truncate(time.Millisecond)
 	updatedAt, err := s.deploymentRepo.SetCurrentWithDetails(
 		apiUUID, orgID, targetDeployment.GatewayID, *deploymentId,

--- a/platform-api/plugins/eventgateway/service/websub_api_deployment.go
+++ b/platform-api/plugins/eventgateway/service/websub_api_deployment.go
@@ -337,7 +337,7 @@ func (s *WebSubAPIDeploymentService) undeployWebSubAPIDeployment(apiUUID string,
 		return nil, apperror.DeploymentGatewayMismatch.New()
 	}
 
-	if deployment.Status == nil || *deployment.Status != model.DeploymentStatusDeployed {
+	if deployment.Status == nil || !deployment.Status.IsDeployedOrDeploying() {
 		return nil, apperror.DeploymentNotActive.New("WebSub API")
 	}
 
@@ -415,7 +415,7 @@ func (s *WebSubAPIDeploymentService) restoreWebSubAPIDeployment(apiUUID string, 
 	if err != nil {
 		return nil, fmt.Errorf("failed to get deployment status: %w", err)
 	}
-	if currentDeploymentID == *deploymentId && status == model.DeploymentStatusDeployed {
+	if currentDeploymentID == *deploymentId && status.IsDeployedOrDeploying() {
 		return nil, apperror.DeploymentRestoreConflict.New()
 	}
 
@@ -576,7 +576,7 @@ func (s *WebSubAPIDeploymentService) deleteWebSubAPIDeployment(apiUUID, deployme
 		return apperror.DeploymentNotFound.New()
 	}
 
-	if deployment.Status != nil && *deployment.Status == model.DeploymentStatusDeployed {
+	if deployment.Status != nil && deployment.Status.IsDeployedOrDeploying() {
 		return apperror.DeploymentActive.New()
 	}
 

--- a/platform-api/plugins/eventgateway/service/websub_api_deployment.go
+++ b/platform-api/plugins/eventgateway/service/websub_api_deployment.go
@@ -247,10 +247,8 @@ func (s *WebSubAPIDeploymentService) deployWebSubAPI(apiUUID string, req *api.De
 		s.slogger.Warn("Failed to ensure API-gateway association", "error", err)
 	}
 
-	initialStatus := model.DeploymentStatusDeployed
-	if s.cfg.Deployments.TransitionalStatusEnabled {
-		initialStatus = model.DeploymentStatusDeploying
-	}
+	// Transitional until the gateway acknowledges the artifact.
+	initialStatus := model.DeploymentStatusDeploying
 	performedAt := time.Now().UTC().Truncate(time.Millisecond)
 	if _, err := s.deploymentRepo.SetCurrentWithDetails(
 		apiUUID, orgID, gatewayID, deploymentID,
@@ -351,10 +349,8 @@ func (s *WebSubAPIDeploymentService) undeployWebSubAPIDeployment(apiUUID string,
 		return nil, apperror.GatewayNotFound.New()
 	}
 
-	initialStatus := model.DeploymentStatusUndeployed
-	if s.cfg.Deployments.TransitionalStatusEnabled {
-		initialStatus = model.DeploymentStatusUndeploying
-	}
+	// Transitional until the gateway acknowledges the artifact.
+	initialStatus := model.DeploymentStatusUndeploying
 	performedAt := time.Now().UTC().Truncate(time.Millisecond)
 	newUpdatedAt, err := s.deploymentRepo.SetCurrentWithDetails(
 		apiUUID, orgID, deployment.GatewayID, deployment.DeploymentID,
@@ -431,10 +427,8 @@ func (s *WebSubAPIDeploymentService) restoreWebSubAPIDeployment(apiUUID string, 
 		return nil, apperror.GatewayNotFound.New()
 	}
 
-	initialStatus := model.DeploymentStatusDeployed
-	if s.cfg.Deployments.TransitionalStatusEnabled {
-		initialStatus = model.DeploymentStatusDeploying
-	}
+	// Transitional until the gateway acknowledges the artifact.
+	initialStatus := model.DeploymentStatusDeploying
 	performedAt := time.Now().UTC().Truncate(time.Millisecond)
 	updatedAt, err := s.deploymentRepo.SetCurrentWithDetails(
 		apiUUID, orgID, targetDeployment.GatewayID, *deploymentId,

--- a/portals/ai-workspace/configs/config-template.toml
+++ b/portals/ai-workspace/configs/config-template.toml
@@ -148,7 +148,7 @@ url = "https://platform-api:9243"
 tls_skip_verify = "false"
 
 # PEM bundle to trust for the upstream's TLS certificate, appended to system roots.
-ca_file = ""
+ca_file = "/etc/ai-workspace/tls/cert.pem"
 
 
 # ---------------------------------------------------------------------------

--- a/portals/ai-workspace/configs/config.toml
+++ b/portals/ai-workspace/configs/config.toml
@@ -4,30 +4,25 @@ default_org_region = "us"
 domain = '{{ env "APIP_AIW_DOMAIN" "localhost:9643" }}'
 
 [ai_workspace.server.https]
-
 port      = '{{ env "APIP_AIW_SERVER_HTTPS_PORT" "9643" }}'
 cert_file = "/etc/ai-workspace/tls/cert.pem"
 key_file  = "/etc/ai-workspace/tls/key.pem"
 
 
 [ai_workspace.logging]
-
 level = '{{ env "APIP_AIW_LOGGING_LEVEL" "info" }}'
 
 
 [ai_workspace.control_plane]
-
 url = '{{ env "APIP_AIW_CONTROL_PLANE_URL" "https://platform-api:9243" }}'
 tls_skip_verify = '{{ env "APIP_AIW_CONTROL_PLANE_TLS_SKIP_VERIFY" "false" }}'
 ca_file = "/etc/ai-workspace/tls/cert.pem"
 
 
 [ai_workspace.gateway]
-
 controlplane_host = '{{ env "APIP_AIW_GATEWAY_CONTROLPLANE_HOST" "host.docker.internal:9243" }}'
 platform_gateway_versions = "[{\"version\":\"1.2\",\"latestVersion\":\"v1.2.0-rc2\",\"distVersion\":\"1.2.0-rc2\",\"distFolderVersion\":\"1.2.0\",\"channel\":\"LTS\"}]"
 
 
 [ai_workspace.auth]
-
 mode = '{{ env "APIP_AIW_AUTH_MODE" "basic" }}'

--- a/portals/ai-workspace/src/Components/GatewayDeploy/GatewayDeployEnvCard.tsx
+++ b/portals/ai-workspace/src/Components/GatewayDeploy/GatewayDeployEnvCard.tsx
@@ -48,13 +48,11 @@ export default function GatewayDeployEnvCard({
     deployingGatewayId,
     isDeployingToGateway,
     isPollingGateway,
-    isVerifyingGateway,
     readOnly,
   } = useGatewayDeploy();
 
   const isThisGatewayDeploying = deployingGatewayId === gateway.id;
   const isPolling = isPollingGateway(gateway.id);
-  const isVerifying = isVerifyingGateway(gateway.id);
   const [selectorOpen, setSelectorOpen] = useState(false);
   const [activeColorScheme, setActiveColorScheme] = useState(
     getActiveColorScheme,
@@ -107,16 +105,6 @@ export default function GatewayDeployEnvCard({
   const isFailed = effectiveStatus === 'FAILED';
   const isNotActive = effectiveStatus === 'NOT_ACTIVE';
   const hasDeployment = currentDeployment !== null;
-
-  // The platform API can answer a deploy/undeploy optimistically, before the gateway
-  // has acknowledged the artifact. Until that acknowledgement lands the status is
-  // provisional, so report it as in-progress rather than claiming Active/Suspended.
-  const isAwaitingGatewayAck =
-    isVerifying &&
-    !isNotActive &&
-    !isFailed &&
-    !isDeploying &&
-    !isUndeploying;
 
   const handleUndeploy = async () => {
     if (!currentDeployment?.deploymentId) return;
@@ -187,7 +175,7 @@ export default function GatewayDeployEnvCard({
         {relativeTime && (
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
             <Typography variant="body2" sx={{ fontWeight: 500 }}>
-              {isDeployed && !isAwaitingGatewayAck ? 'Deployed' : 'Last deployed'}
+              {isDeployed ? 'Deployed' : 'Last deployed'}
             </Typography>
             <Typography variant="body2" color="text.secondary">
               ⏱ {relativeTime}
@@ -262,11 +250,6 @@ export default function GatewayDeployEnvCard({
           bgcolor: (theme) => {
             const isDarkMode = activeColorScheme === 'dark';
 
-            if (isAwaitingGatewayAck) {
-              return isDarkMode
-                ? 'rgba(237, 108, 2, 0.20)'
-                : 'rgba(237, 108, 2, 0.08)';
-            }
             if (isNotActive || isUndeployed) {
               return isDarkMode ? 'rgba(255, 255, 255, 0.12)' : theme.palette.grey[100];
             }
@@ -296,9 +279,7 @@ export default function GatewayDeployEnvCard({
           variant="body2"
           sx={{
             fontWeight: 600,
-            color: isAwaitingGatewayAck
-              ? 'warning.main'
-              : isNotActive
+            color: isNotActive
               ? 'text.secondary'
               : isDeployed
                 ? 'success.main'
@@ -311,7 +292,7 @@ export default function GatewayDeployEnvCard({
                       : 'text.secondary',
           }}
         >
-          {isAwaitingGatewayAck ? 'Deploying' : isNotActive ? 'Not Active' : isDeployed ? 'Active' : isUndeployed ? 'Suspended' : isDeploying ? 'Deploying' : isUndeploying ? 'Undeploying' : isFailed ? 'Failed' : deploymentStatus}
+          {isNotActive ? 'Not Active' : isDeployed ? 'Active' : isUndeployed ? 'Suspended' : isDeploying ? 'Deploying' : isUndeploying ? 'Undeploying' : isFailed ? 'Failed' : deploymentStatus}
         </Typography>
       </Box>
 

--- a/portals/ai-workspace/src/contexts/GatewayDeployContext.tsx
+++ b/portals/ai-workspace/src/contexts/GatewayDeployContext.tsx
@@ -69,23 +69,17 @@ type GatewayDeployResourceType = 'provider' | 'proxy' | 'mcp-server';
 const POLL_INTERVAL_MS = 3000;
 
 /**
- * How long a deployment keeps being polled after a deploy/redeploy/undeploy call
- * already answered with a terminal status.
+ * Upper bound on polling a transitional (DEPLOYING/UNDEPLOYING) deployment,
+ * mirroring platform-api's own deployment timeout: its sweeper marks a stuck
+ * deployment FAILED after `timeout_duration` (60s default) and runs every
+ * `timeout_interval` (20s default), so detection lands by 80s. Past that the
+ * record cannot still be transitional, and continuing to poll only keeps the tab
+ * busy — a lost acknowledgement would otherwise be polled forever.
  *
- * The platform API answers optimistically when transitional deployment statuses
- * are disabled (its default): the create call returns DEPLOYED before the gateway
- * has accepted the artifact, and a failure acknowledgement flips the record to
- * FAILED a moment later. Without this verification window the card would keep
- * claiming the deployment is active until the user reloads the page.
+ * Keep in step with [platform_api.deployments] in platform-api's config template;
+ * the values are not exposed over the API, so they cannot be read at runtime.
  */
-const ACK_VERIFY_WINDOW_MS = 20000;
-
-const TERMINAL_STATUSES: DeploymentStatus[] = [
-  'DEPLOYED',
-  'UNDEPLOYED',
-  'ARCHIVED',
-  'FAILED',
-];
+const TRANSITIONAL_POLL_TIMEOUT_MS = 80000;
 
 const isTransitionalStatus = (status: string): boolean =>
   status === 'DEPLOYING' || status === 'UNDEPLOYING';
@@ -93,13 +87,8 @@ const isTransitionalStatus = (status: string): boolean =>
 interface PollingEntry {
   deploymentId: string;
   gatewayId: string;
-  /** Last status observed for this deployment — a change is what polling waits for. */
-  lastStatus: string;
-  /**
-   * Epoch ms after which polling gives up. `null` means poll until a terminal
-   * status is reached (used for genuinely transitional deployments).
-   */
-  expiresAt: number | null;
+  /** Epoch ms after which polling gives up regardless of the status observed. */
+  expiresAt: number;
 }
 
 const normalizeGatewayNameForDeployment = (name: string): string =>
@@ -182,12 +171,6 @@ interface GatewayDeployContextValue {
   deployingGatewayId: string | null;
   isDeployingToGateway: boolean;
   isPollingGateway: (gatewayId: string) => boolean;
-  /**
-   * True while a gateway's latest deployment reports a terminal status that the
-   * gateway has not confirmed yet — the status shown is provisional and may still
-   * flip to FAILED.
-   */
-  isVerifyingGateway: (gatewayId: string) => boolean;
 
   /**
    * When true, the artifact is read-only (e.g. gateway-originated): its deployment
@@ -240,6 +223,16 @@ export function GatewayDeployProvider({
   const pollingDeploymentsRef = useRef(pollingDeployments);
   pollingDeploymentsRef.current = pollingDeployments;
 
+  /**
+   * Deployments whose poll window expired while still transitional — the gateway's
+   * acknowledgement never arrived, so they are surfaced as FAILED. The override only
+   * applies while platform-api still reports a transitional status, so a late
+   * acknowledgement replaces it with the real outcome on the next refetch.
+   */
+  const [timedOutDeployments, setTimedOutDeployments] = useState<Set<string>>(
+    new Set()
+  );
+
   const fetchSingleDeploymentStatus = useCallback(
     async (deploymentId: string): Promise<DeploymentResponse> => {
       if (resourceType === 'proxy') {
@@ -252,21 +245,23 @@ export function GatewayDeployProvider({
     [apiId, organizationId, resourceType]
   );
 
+  /**
+   * Watches a deployment whose status is still transitional (DEPLOYING/UNDEPLOYING)
+   * until platform-api reports a status that is no longer transitional, bounded by
+   * the server's own timeout (TRANSITIONAL_POLL_TIMEOUT_MS). A status that is
+   * already non-transitional is taken at face value — whatever platform-api
+   * reports is what the card shows.
+   */
   const startPolling = useCallback(
-    (
-      deploymentId: string,
-      gatewayId: string,
-      lastStatus: string,
-      verifyWindowMs: number | null
-    ) => {
+    (deploymentId: string, gatewayId: string, status: string) => {
+      if (!isTransitionalStatus(status)) return;
       setPollingDeployments((prev) => {
+        if (prev.has(deploymentId)) return prev;
         const next = new Map(prev);
         next.set(deploymentId, {
           deploymentId,
           gatewayId,
-          lastStatus,
-          expiresAt:
-            verifyWindowMs === null ? null : Date.now() + verifyWindowMs,
+          expiresAt: Date.now() + TRANSITIONAL_POLL_TIMEOUT_MS,
         });
         return next;
       });
@@ -274,40 +269,11 @@ export function GatewayDeployProvider({
     []
   );
 
-  /**
-   * Starts polling after a deploy/redeploy/undeploy call. A transitional response
-   * is polled until it settles; an already-terminal response is only provisional
-   * (see ACK_VERIFY_WINDOW_MS) and is polled for a bounded window so a late
-   * gateway failure acknowledgement surfaces without a page reload.
-   */
-  const startPostActionPolling = useCallback(
-    (deploymentId: string, gatewayId: string, status: string) => {
-      startPolling(
-        deploymentId,
-        gatewayId,
-        status,
-        isTransitionalStatus(status) ? null : ACK_VERIFY_WINDOW_MS
-      );
-    },
-    [startPolling]
-  );
-
+  /** True while a deployment on this gateway is still in a transitional status. */
   const isPollingGateway = useCallback(
     (gatewayId: string): boolean => {
       for (const entry of pollingDeployments.values()) {
         if (entry.gatewayId === gatewayId) return true;
-      }
-      return false;
-    },
-    [pollingDeployments]
-  );
-
-  const isVerifyingGateway = useCallback(
-    (gatewayId: string): boolean => {
-      for (const entry of pollingDeployments.values()) {
-        if (entry.gatewayId === gatewayId && entry.expiresAt !== null) {
-          return true;
-        }
       }
       return false;
     },
@@ -411,24 +377,48 @@ export function GatewayDeployProvider({
     }
   }, [apiId, refetchDeployments]);
 
+  /**
+   * Deployments as consumers see them: a record still reported as transitional after
+   * its poll window expired is shown as FAILED, since the status was never received.
+   */
+  const effectiveDeployments = useMemo<DeploymentListResponse | null>(() => {
+    if (!deployments?.list || timedOutDeployments.size === 0) return deployments;
+    return {
+      ...deployments,
+      list: deployments.list.map((d) =>
+        timedOutDeployments.has(d.deploymentId) && isTransitionalStatus(d.status)
+          ? { ...d, status: 'FAILED' as DeploymentStatus }
+          : d
+      ),
+    };
+  }, [deployments, timedOutDeployments]);
+
   // Auto-start polling for any deployments already in transitional state
   useEffect(() => {
-    if (!deployments?.list) return;
-    for (const d of deployments.list) {
+    if (!effectiveDeployments?.list) return;
+    for (const d of effectiveDeployments.list) {
       if (
         isTransitionalStatus(d.status) &&
         !pollingDeploymentsRef.current.has(d.deploymentId)
       ) {
-        startPolling(d.deploymentId, d.gatewayId, d.status, null);
+        startPolling(d.deploymentId, d.gatewayId, d.status);
       }
     }
-  }, [deployments, startPolling]);
+  }, [effectiveDeployments, startPolling]);
 
-  // Polling effect — 3s interval for each entry in pollingDeployments
+  /**
+   * Polling effect — one pass immediately when a deployment enters the watch set,
+   * then every POLL_INTERVAL_MS, so the first status read always lands well inside
+   * five seconds of the deploy/undeploy call rather than after an initial idle tick.
+   * An entry is dropped as soon as its status is no longer transitional, or once its
+   * poll window expires.
+   */
   useEffect(() => {
     if (pollingDeployments.size === 0) return;
 
-    const intervalId = setInterval(async () => {
+    let cancelled = false;
+
+    const poll = async () => {
       const current = pollingDeploymentsRef.current;
       if (current.size === 0) return;
 
@@ -438,41 +428,42 @@ export function GatewayDeployProvider({
           fetchSingleDeploymentStatus(deploymentId)
         )
       );
+      if (cancelled) return;
 
       const resolved: string[] = [];
-      const observed = new Map<string, string>();
+      const timedOut: string[] = [];
       results.forEach((result, idx) => {
         const [key, entry] = entries[idx];
         if (result.status !== 'fulfilled') {
+          // Give up on this deployment rather than retrying a failing read — the
+          // status could not be read, so report it as failed.
           resolved.push(key);
+          timedOut.push(key);
           return;
         }
 
-        const status = result.value.status;
-        const statusChanged = status !== entry.lastStatus;
-        if (statusChanged) {
-          observed.set(key, status);
-        }
-
-        if (statusChanged && TERMINAL_STATUSES.includes(status)) {
+        if (!isTransitionalStatus(result.value.status)) {
           // The gateway has reported the outcome — nothing further to wait for.
           resolved.push(key);
-        } else if (entry.expiresAt !== null && Date.now() >= entry.expiresAt) {
-          // Verification window elapsed with no contradicting acknowledgement:
-          // treat the status the API already reported as final.
+        } else if (Date.now() >= entry.expiresAt) {
+          // Still transitional past the server's own deployment timeout: the
+          // acknowledgement never arrived, so show it as failed.
           resolved.push(key);
+          timedOut.push(key);
         }
       });
 
-      if (resolved.length > 0 || observed.size > 0) {
+      if (timedOut.length > 0) {
+        setTimedOutDeployments((prev) => {
+          const next = new Set(prev);
+          for (const key of timedOut) next.add(key);
+          return next;
+        });
+      }
+
+      if (resolved.length > 0) {
         setPollingDeployments((prev) => {
           const next = new Map(prev);
-          for (const [key, status] of observed) {
-            const entry = next.get(key);
-            if (entry) {
-              next.set(key, { ...entry, lastStatus: status });
-            }
-          }
           for (const key of resolved) {
             next.delete(key);
           }
@@ -480,9 +471,15 @@ export function GatewayDeployProvider({
         });
         refetchDeployments();
       }
-    }, POLL_INTERVAL_MS);
+    };
 
-    return () => clearInterval(intervalId);
+    poll();
+    const intervalId = setInterval(poll, POLL_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      clearInterval(intervalId);
+    };
   }, [pollingDeployments, fetchSingleDeploymentStatus, refetchDeployments]);
 
   const deployToGateway = useCallback(
@@ -555,7 +552,7 @@ export function GatewayDeployProvider({
 
         // Keep watching the deployment: a terminal status here is still provisional
         // until the gateway acknowledges (or rejects) the artifact.
-        startPostActionPolling(result.deploymentId, gatewayId, result.status);
+        startPolling(result.deploymentId, gatewayId, result.status);
 
         await refetchDeployments();
 
@@ -573,7 +570,7 @@ export function GatewayDeployProvider({
       gateways,
       deployments,
       refetchDeployments,
-      startPostActionPolling,
+      startPolling,
       resourceType,
     ]
   );
@@ -622,7 +619,7 @@ export function GatewayDeployProvider({
         // the status read back here may still be overwritten with FAILED.
         try {
           const updated = await fetchSingleDeploymentStatus(deploymentId);
-          startPostActionPolling(deploymentId, gatewayId, updated.status);
+          startPolling(deploymentId, gatewayId, updated.status);
         } catch {
           // Ignore — the refetch below still reconciles the list.
         }
@@ -642,7 +639,7 @@ export function GatewayDeployProvider({
       organizationId,
       refetchDeployments,
       fetchSingleDeploymentStatus,
-      startPostActionPolling,
+      startPolling,
       resourceType,
     ]
   );
@@ -691,7 +688,7 @@ export function GatewayDeployProvider({
         });
 
         // A terminal status on the restore response is provisional as well.
-        startPostActionPolling(result.deploymentId, gatewayId, result.status);
+        startPolling(result.deploymentId, gatewayId, result.status);
 
         await refetchDeployments();
 
@@ -707,7 +704,7 @@ export function GatewayDeployProvider({
       apiId,
       organizationId,
       refetchDeployments,
-      startPostActionPolling,
+      startPolling,
       resourceType,
     ]
   );
@@ -773,7 +770,7 @@ export function GatewayDeployProvider({
       isLoading,
       error,
       refetchGateways: fetchGateways,
-      deployments,
+      deployments: effectiveDeployments,
       isLoadingDeployments,
       deploymentsError,
       refetchDeployments,
@@ -784,7 +781,6 @@ export function GatewayDeployProvider({
       deployingGatewayId,
       isDeployingToGateway,
       isPollingGateway,
-      isVerifyingGateway,
       readOnly,
     }),
     [
@@ -792,7 +788,7 @@ export function GatewayDeployProvider({
       isLoading,
       error,
       fetchGateways,
-      deployments,
+      effectiveDeployments,
       isLoadingDeployments,
       deploymentsError,
       refetchDeployments,
@@ -803,7 +799,6 @@ export function GatewayDeployProvider({
       deployingGatewayId,
       isDeployingToGateway,
       isPollingGateway,
-      isVerifyingGateway,
       readOnly,
     ]
   );

--- a/portals/ai-workspace/src/contexts/GatewayDeployContext.tsx
+++ b/portals/ai-workspace/src/contexts/GatewayDeployContext.tsx
@@ -66,7 +66,7 @@ export type { HybridGateway, GatewayDeployment };
 
 type GatewayDeployResourceType = 'provider' | 'proxy' | 'mcp-server';
 
-const POLL_INTERVAL_MS = 3000;
+const POLL_INTERVAL_MS = 2000;
 
 /**
  * Upper bound on polling a transitional (DEPLOYING/UNDEPLOYING) deployment,
@@ -255,6 +255,15 @@ export function GatewayDeployProvider({
   const startPolling = useCallback(
     (deploymentId: string, gatewayId: string, status: string) => {
       if (!isTransitionalStatus(status)) return;
+      // A new transitional phase gets a clean slate: drop any timed-out mark from
+      // an earlier phase of this same deploymentId, or the stale mark would paint
+      // it FAILED immediately and suppress the watch that resolves it.
+      setTimedOutDeployments((prev) => {
+        if (!prev.has(deploymentId)) return prev;
+        const next = new Set(prev);
+        next.delete(deploymentId);
+        return next;
+      });
       setPollingDeployments((prev) => {
         if (prev.has(deploymentId)) return prev;
         const next = new Map(prev);
@@ -435,10 +444,17 @@ export function GatewayDeployProvider({
       results.forEach((result, idx) => {
         const [key, entry] = entries[idx];
         if (result.status !== 'fulfilled') {
-          // Give up on this deployment rather than retrying a failing read — the
-          // status could not be read, so report it as failed.
-          resolved.push(key);
-          timedOut.push(key);
+          // A status read can fail transiently (network blip, brief 5xx). Keep the
+          // entry in the watch set and retry on the next tick; only give up once
+          // the poll window has expired.
+          logger.warn(
+            `Failed to read status for deployment ${entry.deploymentId}:`,
+            result.reason
+          );
+          if (Date.now() >= entry.expiresAt) {
+            resolved.push(key);
+            timedOut.push(key);
+          }
           return;
         }
 

--- a/tests/integration-e2e/docker-compose.sqlite.yaml
+++ b/tests/integration-e2e/docker-compose.sqlite.yaml
@@ -90,9 +90,9 @@ services:
       - APIP_GW_CONTROLLER_CONTROLPLANE_TOKEN=${GATEWAY_REGISTRATION_TOKEN:-}
       - APIP_GW_CONTROLLER_CONTROLPLANE_INSECURE_SKIP_VERIFY=true
     ports:
-      - "9090:9090"
-      - "9092:9092"
-      - "18000:18000"
+      - "${GW_REST_PORT:-9090}:9090"
+      - "${GW_ADMIN_PORT:-9092}:9092"
+      - "${GW_XDS_PORT:-18000}:18000"
     volumes:
       - ../../gateway/it/test-config.toml:/etc/gateway-controller/config.toml:ro
       - ../../gateway/it/it-aesgcm-keys/default-aesgcm256-v1.bin:/app/data/aesgcm-keys/default-aesgcm256-v1.bin:ro
@@ -112,7 +112,7 @@ services:
     ports:
       - "${GW_HTTP_PORT:-18080}:8080"
       - "${GW_HTTPS_PORT:-18443}:8443"
-      - "9002:9002"
+      - "${GW_POLICY_ADMIN_PORT:-9002}:9002"
     volumes:
       - ../../gateway/it/test-config.toml:/etc/policy-engine/config.toml:ro
     depends_on:
@@ -124,7 +124,7 @@ services:
     image: ghcr.io/wso2/api-platform/sample-service:latest
     command: ["-addr", ":9080", "-pretty"]
     ports:
-      - "9080:9080"
+      - "${SAMPLE_BACKEND_HOST_PORT:-9080}:9080"
     networks: [e2e]
 
 networks:

--- a/tests/integration-e2e/docker-compose.yaml
+++ b/tests/integration-e2e/docker-compose.yaml
@@ -151,9 +151,9 @@ services:
       - APIP_GW_CONTROLLER_CONTROLPLANE_TOKEN=${GATEWAY_REGISTRATION_TOKEN:-}
       - APIP_GW_CONTROLLER_CONTROLPLANE_INSECURE_SKIP_VERIFY=true
     ports:
-      - "9090:9090"   # REST API
-      - "9092:9092"   # Admin API
-      - "18000:18000" # xDS gRPC
+      - "${GW_REST_PORT:-9090}:9090"   # REST API
+      - "${GW_ADMIN_PORT:-9092}:9092"   # Admin API
+      - "${GW_XDS_PORT:-18000}:18000" # xDS gRPC
     volumes:
       - ../../gateway/it/test-config.toml:/etc/gateway-controller/config.toml:ro
       - ../../gateway/it/it-aesgcm-keys/default-aesgcm256-v1.bin:/app/data/aesgcm-keys/default-aesgcm256-v1.bin:ro
@@ -175,7 +175,7 @@ services:
     ports:
       - "${GW_HTTP_PORT:-18080}:8080"   # HTTP ingress (data plane)
       - "${GW_HTTPS_PORT:-18443}:8443"  # HTTPS ingress
-      - "9002:9002"                     # Policy engine admin
+      - "${GW_POLICY_ADMIN_PORT:-9002}:9002" # Policy engine admin
     volumes:
       - ../../gateway/it/test-config.toml:/etc/policy-engine/config.toml:ro
     depends_on:


### PR DESCRIPTION
Remove transitional status configuration from deployment settings and related code references. Update deployment logic to assume transitional status until gateway acknowledgment is received. Adjust polling behavior to handle timeout for transitional deployments, ensuring they are marked as FAILED if not acknowledged in time.

