### PR TITLE
feat(sdk): add snapshot header writers for request/response contexts

### DIFF
--- a/sdk/core/policy/v1alpha2/context_header_writers.go
+++ b/sdk/core/policy/v1alpha2/context_header_writers.go
@@ -1,0 +1,226 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package policyv1alpha2
+
+import "strings"
+
+// This file provides the WRITE counterpart of the read accessors in
+// context_accessors.go. It lets an earlier policy influence what a LATER policy
+// in the same request observes when it reads the pre-mutation snapshot via
+// DownstreamHeaders() (request phase) or UpstreamHeaders() (response phase) —
+// for example, injecting a header that a downstream JWT/auth policy validates
+// against the client-request snapshot.
+//
+// These setters are deliberately IMPERATIVE and CHAIN-INTERNAL, mirroring how
+// policies mutate SharedContext.Metadata. A snapshot header set here is NEVER
+// translated into an Envoy header mutation:
+//
+//   - It does NOT change what the backend receives. To change the upstream
+//     request, return UpstreamRequestModifications.HeadersToSet/Append/Remove.
+//   - It does NOT change what the client receives. To change the downstream
+//     response, return DownstreamResponseModifications /
+//     DownstreamResponseHeaderModifications.
+//
+// Its only effect is on subsequent in-chain reads of the snapshot (the kernel
+// shares one snapshot object across every phase context of a request, so a
+// header-phase write is visible to the body/stream phases, and a request-phase
+// downstream write is visible to the response phase).
+//
+// SNAPSHOT-ONLY, never the live fallback: unlike the read accessors, these
+// setters do NOT fall back to the live working headers when the gateway does not
+// provide a snapshot. Mutating the live request headers would leak to the
+// backend, and mutating the live response headers would leak to the client —
+// precisely what a snapshot write must not do. On a gateway that does not
+// populate the snapshot, these setters are a no-op; a policy that requires the
+// write to take effect must run on a snapshot-capable gateway (see the
+// context_accessors.go header for the snapshot-presence guarantee).
+//
+// Header names are matched case-insensitively (lower-cased), consistent with the
+// read accessors and NewHeaders.
+
+// ─── Internal writable-target resolvers ──────────────────────────────────────
+
+// downstreamWritableHeaders returns the stored client-request snapshot's Headers
+// for mutation, lazily creating an empty Headers on the snapshot when it is
+// present but header-less. Returns nil when the gateway did not provide a
+// snapshot — in which case the caller must no-op rather than touch live headers.
+func downstreamWritableHeaders(ds *DownstreamContext) *Headers {
+	snap := downstreamSnapshot(ds)
+	if snap == nil {
+		return nil
+	}
+	if snap.Headers == nil {
+		snap.Headers = NewHeaders(nil)
+	}
+	return snap.Headers
+}
+
+// upstreamWritableHeaders returns the stored upstream-response snapshot's Headers
+// for mutation, lazily creating an empty Headers on the snapshot when it is
+// present but header-less. Returns nil when the gateway did not provide a
+// snapshot — in which case the caller must no-op rather than touch live headers.
+func upstreamWritableHeaders(us *UpstreamResponseContext) *Headers {
+	snap := upstreamSnapshot(us)
+	if snap == nil {
+		return nil
+	}
+	if snap.Headers == nil {
+		snap.Headers = NewHeaders(nil)
+	}
+	return snap.Headers
+}
+
+// setSnapshotHeader overwrites all values of name with a single value. No-op on a
+// nil target (absent snapshot).
+func setSnapshotHeader(h *Headers, name, value string) {
+	if h == nil {
+		return
+	}
+	h.UnsafeInternalValues()[strings.ToLower(name)] = []string{value}
+}
+
+// addSnapshotHeader appends value to the existing values of name, preserving any
+// already present. No-op on a nil target (absent snapshot).
+func addSnapshotHeader(h *Headers, name, value string) {
+	if h == nil {
+		return
+	}
+	lk := strings.ToLower(name)
+	m := h.UnsafeInternalValues()
+	m[lk] = append(m[lk], value)
+}
+
+// removeSnapshotHeader deletes name and all its values. No-op on a nil target
+// (absent snapshot).
+func removeSnapshotHeader(h *Headers, name string) {
+	if h == nil {
+		return
+	}
+	delete(h.UnsafeInternalValues(), strings.ToLower(name))
+}
+
+// ─── Request phase: client-request (downstream) snapshot writers ──────────────
+
+// SetDownstreamHeader overwrites a header in the client-request snapshot that
+// later policies read via DownstreamHeaders(). See this file's header for the
+// chain-internal, snapshot-only semantics.
+func (c *RequestHeaderContext) SetDownstreamHeader(name, value string) {
+	setSnapshotHeader(downstreamWritableHeaders(c.Downstream), name, value)
+}
+
+// AddDownstreamHeader appends a value to a header in the client-request snapshot.
+func (c *RequestHeaderContext) AddDownstreamHeader(name, value string) {
+	addSnapshotHeader(downstreamWritableHeaders(c.Downstream), name, value)
+}
+
+// RemoveDownstreamHeader removes a header from the client-request snapshot.
+func (c *RequestHeaderContext) RemoveDownstreamHeader(name string) {
+	removeSnapshotHeader(downstreamWritableHeaders(c.Downstream), name)
+}
+
+// SetDownstreamHeader overwrites a header in the client-request snapshot that
+// later policies read via DownstreamHeaders().
+func (c *RequestContext) SetDownstreamHeader(name, value string) {
+	setSnapshotHeader(downstreamWritableHeaders(c.Downstream), name, value)
+}
+
+// AddDownstreamHeader appends a value to a header in the client-request snapshot.
+func (c *RequestContext) AddDownstreamHeader(name, value string) {
+	addSnapshotHeader(downstreamWritableHeaders(c.Downstream), name, value)
+}
+
+// RemoveDownstreamHeader removes a header from the client-request snapshot.
+func (c *RequestContext) RemoveDownstreamHeader(name string) {
+	removeSnapshotHeader(downstreamWritableHeaders(c.Downstream), name)
+}
+
+// ─── Response phase: client-request (downstream) snapshot writers ─────────────
+//
+// The kernel carries the same client-request snapshot forward from the request
+// phase into the response phase, and response-phase policies read it via
+// DownstreamHeaders(). These writers let an earlier response-phase policy
+// influence what a later response-phase policy observes on that snapshot. They
+// mutate only the carried-forward request snapshot — never what the client
+// receives (use DownstreamResponseModifications for that).
+
+// SetDownstreamHeader overwrites a header in the client-request snapshot that
+// later response-phase policies read via DownstreamHeaders().
+func (c *ResponseHeaderContext) SetDownstreamHeader(name, value string) {
+	setSnapshotHeader(downstreamWritableHeaders(c.Downstream), name, value)
+}
+
+// AddDownstreamHeader appends a value to a header in the client-request snapshot.
+func (c *ResponseHeaderContext) AddDownstreamHeader(name, value string) {
+	addSnapshotHeader(downstreamWritableHeaders(c.Downstream), name, value)
+}
+
+// RemoveDownstreamHeader removes a header from the client-request snapshot.
+func (c *ResponseHeaderContext) RemoveDownstreamHeader(name string) {
+	removeSnapshotHeader(downstreamWritableHeaders(c.Downstream), name)
+}
+
+// SetDownstreamHeader overwrites a header in the client-request snapshot that
+// later response-phase policies read via DownstreamHeaders().
+func (c *ResponseContext) SetDownstreamHeader(name, value string) {
+	setSnapshotHeader(downstreamWritableHeaders(c.Downstream), name, value)
+}
+
+// AddDownstreamHeader appends a value to a header in the client-request snapshot.
+func (c *ResponseContext) AddDownstreamHeader(name, value string) {
+	addSnapshotHeader(downstreamWritableHeaders(c.Downstream), name, value)
+}
+
+// RemoveDownstreamHeader removes a header from the client-request snapshot.
+func (c *ResponseContext) RemoveDownstreamHeader(name string) {
+	removeSnapshotHeader(downstreamWritableHeaders(c.Downstream), name)
+}
+
+// ─── Response phase: upstream-response snapshot writers ───────────────────────
+
+// SetUpstreamHeader overwrites a header in the upstream-response snapshot that
+// later policies read via UpstreamHeaders(). See this file's header for the
+// chain-internal, snapshot-only semantics.
+func (c *ResponseHeaderContext) SetUpstreamHeader(name, value string) {
+	setSnapshotHeader(upstreamWritableHeaders(c.Upstream), name, value)
+}
+
+// AddUpstreamHeader appends a value to a header in the upstream-response snapshot.
+func (c *ResponseHeaderContext) AddUpstreamHeader(name, value string) {
+	addSnapshotHeader(upstreamWritableHeaders(c.Upstream), name, value)
+}
+
+// RemoveUpstreamHeader removes a header from the upstream-response snapshot.
+func (c *ResponseHeaderContext) RemoveUpstreamHeader(name string) {
+	removeSnapshotHeader(upstreamWritableHeaders(c.Upstream), name)
+}
+
+// SetUpstreamHeader overwrites a header in the upstream-response snapshot that
+// later policies read via UpstreamHeaders().
+func (c *ResponseContext) SetUpstreamHeader(name, value string) {
+	setSnapshotHeader(upstreamWritableHeaders(c.Upstream), name, value)
+}
+
+// AddUpstreamHeader appends a value to a header in the upstream-response snapshot.
+func (c *ResponseContext) AddUpstreamHeader(name, value string) {
+	addSnapshotHeader(upstreamWritableHeaders(c.Upstream), name, value)
+}
+
+// RemoveUpstreamHeader removes a header from the upstream-response snapshot.
+func (c *ResponseContext) RemoveUpstreamHeader(name string) {
+	removeSnapshotHeader(upstreamWritableHeaders(c.Upstream), name)
+}

--- a/sdk/core/policy/v1alpha2/context_header_writers_test.go
+++ b/sdk/core/policy/v1alpha2/context_header_writers_test.go
@@ -1,0 +1,142 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package policyv1alpha2
+
+import (
+	"reflect"
+	"testing"
+)
+
+// ─── Request phase: downstream snapshot writers ──────────────────────────────
+
+func TestSetDownstreamHeader(t *testing.T) {
+	t.Run("overwrites in the snapshot and is read back via DownstreamHeaders", func(t *testing.T) {
+		c := &RequestHeaderContext{
+			Headers:    NewHeaders(map[string][]string{"authorization": {"live"}}),
+			Downstream: &DownstreamContext{Request: &DownstreamRequest{Headers: NewHeaders(map[string][]string{"authorization": {"original"}})}},
+		}
+		c.SetDownstreamHeader("Authorization", "injected") // mixed case normalizes
+		if got := firstValue(c.DownstreamHeaders(), "authorization"); got != "injected" {
+			t.Fatalf("DownstreamHeaders authorization = %q, want %q", got, "injected")
+		}
+	})
+
+	t.Run("does NOT leak into the live working headers", func(t *testing.T) {
+		live := NewHeaders(map[string][]string{"x-foo": {"live"}})
+		c := &RequestContext{
+			Headers:    live,
+			Downstream: &DownstreamContext{Request: &DownstreamRequest{Headers: NewHeaders(nil)}},
+		}
+		c.SetDownstreamHeader("x-foo", "snap")
+		// The working/upstream headers (what reaches the backend) must be untouched.
+		if got := firstValue(live, "x-foo"); got != "live" {
+			t.Fatalf("live working header x-foo = %q, want %q (snapshot write leaked to live)", got, "live")
+		}
+	})
+
+	t.Run("no-op when the gateway did not provide a snapshot", func(t *testing.T) {
+		live := NewHeaders(map[string][]string{"x-foo": {"live"}})
+		c := &RequestContext{Headers: live, Downstream: nil}
+		c.SetDownstreamHeader("x-foo", "snap")
+		// Must not fall back to mutating live headers.
+		if got := firstValue(live, "x-foo"); got != "live" {
+			t.Fatalf("live header x-foo = %q, want %q (setter touched live on absent snapshot)", got, "live")
+		}
+	})
+
+	t.Run("lazily creates Headers on a header-less snapshot", func(t *testing.T) {
+		c := &RequestContext{Downstream: &DownstreamContext{Request: &DownstreamRequest{Headers: nil}}}
+		c.SetDownstreamHeader("x-new", "v")
+		if got := firstValue(c.DownstreamHeaders(), "x-new"); got != "v" {
+			t.Fatalf("x-new = %q, want %q", got, "v")
+		}
+	})
+}
+
+func TestAddRemoveDownstreamHeader(t *testing.T) {
+	c := &RequestHeaderContext{
+		Downstream: &DownstreamContext{Request: &DownstreamRequest{Headers: NewHeaders(map[string][]string{"x-multi": {"a"}})}},
+	}
+	c.AddDownstreamHeader("X-Multi", "b")
+	if got := c.DownstreamHeaders().Get("x-multi"); !reflect.DeepEqual(got, []string{"a", "b"}) {
+		t.Fatalf("after Add, x-multi = %v, want [a b]", got)
+	}
+	c.RemoveDownstreamHeader("x-multi")
+	if c.DownstreamHeaders().Has("x-multi") {
+		t.Fatalf("x-multi should have been removed")
+	}
+}
+
+func TestResponseSetDownstreamHeader(t *testing.T) {
+	t.Run("mutates the carried-forward request snapshot, read via DownstreamHeaders", func(t *testing.T) {
+		c := &ResponseHeaderContext{
+			RequestHeaders: NewHeaders(map[string][]string{"x-trace": {"live-echo"}}),
+			Downstream:     &DownstreamContext{Request: &DownstreamRequest{Headers: NewHeaders(map[string][]string{"x-trace": {"original"}})}},
+		}
+		c.SetDownstreamHeader("X-Trace", "annotated")
+		if got := firstValue(c.DownstreamHeaders(), "x-trace"); got != "annotated" {
+			t.Fatalf("DownstreamHeaders x-trace = %q, want %q", got, "annotated")
+		}
+	})
+
+	t.Run("no-op when snapshot absent, does not touch live request echo", func(t *testing.T) {
+		echo := NewHeaders(map[string][]string{"x-trace": {"live-echo"}})
+		c := &ResponseContext{RequestHeaders: echo, Downstream: nil}
+		c.SetDownstreamHeader("x-trace", "annotated")
+		if got := firstValue(echo, "x-trace"); got != "live-echo" {
+			t.Fatalf("live request echo x-trace = %q, want %q (setter touched live on absent snapshot)", got, "live-echo")
+		}
+	})
+}
+
+// ─── Response phase: upstream-response snapshot writers ───────────────────────
+
+func TestSetUpstreamHeader(t *testing.T) {
+	t.Run("overwrites in the snapshot and is read back via UpstreamHeaders", func(t *testing.T) {
+		c := &ResponseHeaderContext{
+			ResponseHeaders: NewHeaders(map[string][]string{"x-cache": {"live"}}),
+			Upstream:        &UpstreamResponseContext{Response: &UpstreamResponse{Headers: NewHeaders(map[string][]string{"x-cache": {"HIT"}})}},
+		}
+		c.SetUpstreamHeader("X-Cache", "MISS")
+		if got := firstValue(c.UpstreamHeaders(), "x-cache"); got != "MISS" {
+			t.Fatalf("UpstreamHeaders x-cache = %q, want %q", got, "MISS")
+		}
+	})
+
+	t.Run("does NOT leak into the live response headers", func(t *testing.T) {
+		live := NewHeaders(map[string][]string{"x-cache": {"live"}})
+		c := &ResponseContext{
+			ResponseHeaders: live,
+			Upstream:        &UpstreamResponseContext{Response: &UpstreamResponse{Headers: NewHeaders(nil)}},
+		}
+		c.SetUpstreamHeader("x-cache", "snap")
+		// The working response headers (what reaches the client) must be untouched.
+		if got := firstValue(live, "x-cache"); got != "live" {
+			t.Fatalf("live response header x-cache = %q, want %q (snapshot write leaked to live)", got, "live")
+		}
+	})
+
+	t.Run("no-op when the gateway did not provide a snapshot", func(t *testing.T) {
+		live := NewHeaders(map[string][]string{"x-cache": {"live"}})
+		c := &ResponseContext{ResponseHeaders: live, Upstream: nil}
+		c.SetUpstreamHeader("x-cache", "snap")
+		if got := firstValue(live, "x-cache"); got != "live" {
+			t.Fatalf("live header x-cache = %q, want %q (setter touched live on absent snapshot)", got, "live")
+		}
+	})
+}


### PR DESCRIPTION
## Purpose

Policies can read the pre-mutation client-request snapshot via `DownstreamHeaders()` and the upstream-response snapshot via `UpstreamHeaders()`, but there was no sanctioned way to *write* those snapshots. The only option was the kernel-only `UnsafeInternalValues()` escape hatch, which policies must never call. This blocked legitimate inter-policy coordination — for example, an earlier policy injecting a header that a later JWT/auth policy validates against the client-request snapshot.

## Goals

Give policies a safe, first-class API to mutate the request/response snapshots that later policies in the same request read, without exposing the unsafe internal map and without changing what is sent to the backend or the client.

## Approach

- Add imperative, chain-internal setters that mirror the existing read accessors:
  - `SetDownstreamHeader` / `AddDownstreamHeader` / `RemoveDownstreamHeader` on `RequestHeaderContext` and `RequestContext` (client-request snapshot).
  - `SetUpstreamHeader` / `AddUpstreamHeader` / `RemoveUpstreamHeader` on `ResponseHeaderContext` and `ResponseContext` (upstream-response snapshot).
- These follow the same imperative, chain-internal pattern already used for `SharedContext.Metadata`. The kernel shares one snapshot object across every phase context of a request, so a header-phase write is visible to the body/stream phases, and a request-phase downstream write is visible to the response phase.
- They are never translated into an Envoy header mutation: to change what the backend receives, return `UpstreamRequestModifications.HeadersToSet`; to change what the client receives, return `DownstreamResponseModifications`.
- Snapshot-only, never the live fallback: unlike the read accessors, the setters do not fall back to the live working headers when the gateway provides no snapshot, since mutating live request headers would leak to the backend and mutating live response headers would leak to the client. They no-op instead.
- `Headers` stays read-only for policies; `UnsafeInternalValues()` remains confined to these SDK-internal helpers. This is a pure SDK change — no policy-engine code is touched, because the engine already builds a stable, shared, mutable snapshot across all phase contexts.

## User stories

As a policy author, I want to inject or modify a header on the client-request snapshot so that a later policy (e.g. JWT validation) reads the value I set, without resorting to unsafe internal APIs.

## Documentation

N/A — SDK-level API addition; policy authoring docs can reference the new setters alongside the existing `DownstreamHeaders()`/`UpstreamHeaders()` accessors in a follow-up.

## Automation tests

 - Unit tests
   > Added `context_header_writers_test.go` covering: read-back through `DownstreamHeaders()`/`UpstreamHeaders()`, the guarantee that a snapshot write does not leak into the live working headers (backend/client), no-op behavior when the gateway provides no snapshot, lazy `Headers` creation on a header-less snapshot, and Add/Remove semantics.
 - Integration tests
   > N/A for this change — no policy-engine or wire behavior changes. Existing SDK package tests pass (`go test ./core/policy/v1alpha2/`), `go vet` clean.

## Security checks

 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no — Go SDK change; FindSecurityBugs is a Java tool and not applicable.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A — no sample changes in this PR. A follow-up can wire a JWT/sample policy to demonstrate `SetDownstreamHeader` usage.

## Related PRs

N/A

## Test environment

Go (SDK module `sdk/core/policy/v1alpha2`); macOS (darwin). Verified via `go build`, `go vet`, and `go test`.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)