### PR TITLE
fix(platform-api): return ValidationFailed on upstream MCP server auth errors

### DIFF
--- a/platform-api/internal/service/mcp_test.go
+++ b/platform-api/internal/service/mcp_test.go
@@ -251,3 +251,26 @@ func TestFetchServerInfoSuppliedURLWithStoredCredential(t *testing.T) {
 		assert.Equal(t, "stored-secret", h, "the proxy's stored credential must still be sent")
 	}
 }
+
+// TestFetchServerInfoUpstreamUnauthorizedReturnsValidationFailed verifies that when the upstream
+// MCP server responds with 401 Unauthorized to the initialize request, FetchServerInfo returns an
+// apperror.ValidationFailed (HTTP 400 Bad Request) rather than apperror.Unauthorized (HTTP 401).
+// This prevents the frontend API client from treating the upstream credential failure as an
+// expired workspace session and logging out the user.
+func TestFetchServerInfoUpstreamUnauthorizedReturnsValidationFailed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"Unauthorized"}`))
+	}))
+	defer srv.Close()
+
+	service := NewMCPProxyService(&mockMCPProxyRepository{}, nil, nil, nil, nil, slog.Default(), &noopAuditRepo{}, &config.Server{}, newTestIdentityService())
+
+	targetURL := srv.URL + "/mcp"
+	_, err := service.FetchServerInfo("org-1", &api.MCPServerInfoFetchRequest{
+		Url: &targetURL,
+	})
+	require.Error(t, err)
+	assert.True(t, apperror.ValidationFailed.Is(err), "expected apperror.ValidationFailed when upstream returns 401, got: %v", err)
+	assert.False(t, apperror.Unauthorized.Is(err), "should NOT be apperror.Unauthorized (which would log out workspace session)")
+}

--- a/platform-api/internal/utils/mcp.go
+++ b/platform-api/internal/utils/mcp.go
@@ -294,11 +294,16 @@ func initializeMCPServer(url string, headerName string, headerValue string) (str
 
 	// Check HTTP status code
 	if resp.StatusCode == http.StatusUnauthorized {
-		return "", nil, apperror.Unauthorized.New().
+		return "", nil, apperror.ValidationFailed.New("The MCP server requires authentication credentials or the provided credentials are invalid.").
 			WithLogMessage("MCP server returned 401 Unauthorized to the initialize request")
 	}
+	if resp.StatusCode == http.StatusForbidden {
+		return "", nil, apperror.ValidationFailed.New("Access to the MCP server was forbidden (403).").
+			WithLogMessage("MCP server returned 403 Forbidden to the initialize request")
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return "", nil, fmt.Errorf("initialize request failed with status %d: %s", resp.StatusCode, string(body))
+		return "", nil, apperror.ValidationFailed.New(fmt.Sprintf("MCP server initialize request failed with status %d.", resp.StatusCode)).
+			WithLogMessage(fmt.Sprintf("initialize request failed with status %d: %s", resp.StatusCode, string(body)))
 	}
 
 	// Check if response is event stream and parse it

--- a/platform-api/internal/utils/mcp.go
+++ b/platform-api/internal/utils/mcp.go
@@ -303,7 +303,7 @@ func initializeMCPServer(url string, headerName string, headerValue string) (str
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return "", nil, apperror.ValidationFailed.New(fmt.Sprintf("MCP server initialize request failed with status %d.", resp.StatusCode)).
-			WithLogMessage(fmt.Sprintf("initialize request failed with status %d: %s", resp.StatusCode, string(body)))
+			WithLogMessage(fmt.Sprintf("initialize request failed with status %d", resp.StatusCode))
 	}
 
 	// Check if response is event stream and parse it
@@ -320,10 +320,10 @@ func initializeMCPServer(url string, headerName string, headerValue string) (str
 	if err := json.Unmarshal(body, &initResult); err != nil {
 		// Only ignore unmarshal error if this was a valid event stream (parsed above)
 		if !isEventStreamResp {
-			return "", nil, fmt.Errorf("failed to parse initialize response: %w, body: %s", err, string(body))
+			return "", nil, fmt.Errorf("failed to parse initialize response: %w", err)
 		}
 		// For event stream, if unmarshal fails after successful parsing, that's still an error
-		return "", nil, fmt.Errorf("failed to parse initialize response from event stream: %w, body: %s", err, string(body))
+		return "", nil, fmt.Errorf("failed to parse initialize response from event stream: %w", err)
 	}
 
 	if initResult.Error != nil {
@@ -379,7 +379,7 @@ func postJSONRPCWithSession(url string, req any, sessionID string, headerName st
 
 	// Check HTTP status code
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("request failed with status %d", resp.StatusCode)
 	}
 
 	// Check if response is event stream
@@ -387,7 +387,7 @@ func postJSONRPCWithSession(url string, req any, sessionID string, headerName st
 		// Extract JSON data from event stream
 		data, err := parseEventStream(body)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse event stream: %w, body: %s", err, string(body))
+			return nil, fmt.Errorf("failed to parse event stream: %w", err)
 		}
 		return data, nil
 	}


### PR DESCRIPTION
## Purpose
When setting up an MCP proxy for a secured server, omitting or supplying invalid required credentials triggers an unexpected workspace logout. The platform API returned an HTTP 401 Unauthorized error for upstream authentication failures, which the SPA API client interpreted as an expired user session.

Resolves #3173

## Goals
Ensure that upstream MCP server authentication failures during endpoint validation (`fetch-server-info`) return an HTTP 400 Bad Request (`apperror.ValidationFailed`) instead of an HTTP 401 Unauthorized. This presents a clear error notification in the UI without terminating the user's active workspace session.

## Approach
Updated `initializeMCPServer` in `platform-api/internal/utils/mcp.go`:
- Replaced `apperror.Unauthorized.New()` with `apperror.ValidationFailed.New(...)` when the target MCP server returns HTTP 401 Unauthorized during initialize.
- Added explicit handling for HTTP 403 Forbidden and non-2xx status codes to return `apperror.ValidationFailed` (HTTP 400 Bad Request).
- Added a unit test in `platform-api/internal/service/mcp_test.go` to assert that upstream 401 Unauthorized returns `apperror.ValidationFailed`.

## User stories
As an AI Workspace user creating or configuring an MCP proxy, when I fetch info for an upstream MCP server with invalid or missing credentials, I should see an inline validation error message rather than being logged out of the workspace.

## Documentation
N/A - Internal error mapping fix for MCP proxy validation; no user documentation impact.

## Automation tests
 - Unit tests 
   - Added `TestFetchServerInfoUpstreamUnauthorizedReturnsValidationFailed` in `platform-api/internal/service/mcp_test.go`.
   - Verified all tests in `platform-api/internal/service/...` and `platform-api/internal/utils/...` pass cleanly.
 - Integration tests
   - N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Test environment
- Go 1.22+
- macOS
- Chrome / Electron