### PR TITLE
Fix key manager deletion blocked when linked to applications (#3164)

### DIFF
--- a/portals/api-portal/it/rest-api/key-managers/key-managers.spec.js
+++ b/portals/api-portal/it/rest-api/key-managers/key-managers.spec.js
@@ -75,6 +75,28 @@ describe('key managers', () => {
         expect(get.status).toBe(404);
     });
 
+    it('deletes a key manager linked to applications by client ID', async () => {
+        await client.login('developer');
+        const kmId = uniqueHandle('km');
+        await client.as('admin').post('/key-managers', {
+            id: kmId, displayName: 'Linked KM', tokenEndpoint: 'https://asgardeo.example.invalid/oauth2/token',
+        });
+
+        const appId = uniqueHandle('app');
+        await client.as('developer').post('/applications', { id: appId, displayName: 'Linked App', description: 'd' });
+        await client.as('developer').post(`/applications/${appId}/generate-keys`, {
+            keyManager: kmId,
+            type: 'PRODUCTION',
+            consumerKey: 'test-client-id',
+        });
+
+        const del = await client.as('admin').del(`/key-managers/${kmId}`);
+        expect(del.status).toBe(204);
+
+        const get = await client.as('admin').get(`/key-managers/${kmId}`);
+        expect(get.status).toBe(404);
+    });
+
     it('lists key managers for an org', async () => {
         const id = uniqueHandle('km');
         await client.as('admin').post('/key-managers', {

--- a/portals/api-portal/src/dao/keyManagerDao.js
+++ b/portals/api-portal/src/dao/keyManagerDao.js
@@ -170,9 +170,11 @@ const getIdByHandle = async (orgId, handle) => {
 /**
  * Delete a key manager.
  */
-const deleteKm = async (kmId) => {
+const deleteKm = async (kmId, t) => {
+    const exec = t || db;
     try {
-        const { rowCount: deleted } = await db.execute(`DELETE FROM ${TABLE} WHERE uuid = ?`, [kmId]);
+        await exec.execute('DELETE FROM app_key_mappings WHERE km_uuid = ?', [kmId]);
+        const { rowCount: deleted } = await exec.execute(`DELETE FROM ${TABLE} WHERE uuid = ?`, [kmId]);
         if (deleted < 1) {
             throw new NotFoundError('Key manager not found');
         }

--- a/portals/api-portal/src/dao/keyManagerDao.test.js
+++ b/portals/api-portal/src/dao/keyManagerDao.test.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+'use strict';
+
+if (!process.argv.includes('--config')) {
+    process.argv.push('--config', 'it/test-config.toml');
+}
+process.env.APIP_AP_SECURITY_ENCRYPTION_KEY = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+process.env.APIP_AP_SECURITY_SESSION_SECRET = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const kmDao = require('./keyManagerDao');
+
+test('deleteKm deletes linked app_key_mappings before deleting key_managers row', async (t) => {
+    const executedQueries = [];
+    const mockDbExec = {
+        execute: async (sql, params) => {
+            executedQueries.push({ sql, params });
+            if (sql.includes('DELETE FROM key_managers')) {
+                return { rowCount: 1 };
+            }
+            return { rowCount: 0 };
+        },
+    };
+
+    const deletedCount = await kmDao.delete('km-123', mockDbExec);
+    assert.equal(deletedCount, 1);
+    assert.equal(executedQueries.length, 2);
+    assert.equal(executedQueries[0].sql, 'DELETE FROM app_key_mappings WHERE km_uuid = ?');
+    assert.deepEqual(executedQueries[0].params, ['km-123']);
+    assert.equal(executedQueries[1].sql, 'DELETE FROM key_managers WHERE uuid = ?');
+    assert.deepEqual(executedQueries[1].params, ['km-123']);
+});

--- a/portals/api-portal/src/services/keyManagerService.js
+++ b/portals/api-portal/src/services/keyManagerService.js
@@ -267,7 +267,7 @@ const deleteKeyManager = async (req, res) => {
         if (!kmId) {
             return util.sendError(res, 404, constants.ERROR_MESSAGE.KEY_MANAGER_NOT_FOUND);
         }
-        await kmDao.delete(kmId);
+        await db.withTransaction((t) => kmDao.delete(kmId, t));
         logUserAction('KEY_MANAGER_DELETED', req, { orgId, kmId, resourceUuid: kmId, resourceType: 'key_manager' });
         return res.status(204).send();
     } catch (error) {


### PR DESCRIPTION
## Purpose
When attempting to delete a Key Manager that has linked application OAuth client ID mappings (`app_key_mappings`), the operation failed due to a database foreign key constraint error (`SQLITE_CONSTRAINT_FOREIGNKEY`). This PR ensures linked application key mappings are cleaned up before removing the key manager record.

Resolves #3164

## Goals
- Allow administrators to delete a Key Manager without being blocked by foreign key constraints from linked applications.
- Ensure key manager deletion and client mapping cleanup execute atomically within a single database transaction.

## Approach
- **DAO Layer (`keyManagerDao.js`)**: Updated `deleteKm` to accept a transaction handle and delete dependent rows from `app_key_mappings` (`WHERE km_uuid = ?`) before deleting the row from `key_managers`.
- **Service Layer (`keyManagerService.js`)**: Wrapped `kmDao.delete` inside `db.withTransaction` to guarantee atomicity.
- **Tests**:
  - Added unit test in `src/dao/keyManagerDao.test.js` to verify query execution order.
  - Added REST API integration test in `it/rest-api/key-managers/key-managers.spec.js` asserting successful deletion (HTTP 204) of a Key Manager linked to an application.

## User stories
As an API Portal administrator, I can delete a Key Manager even when applications have registered client IDs against it, without encountering database foreign key errors.

## Documentation
N/A - Bug fix addressing internal cascading delete logic. No changes to user documentation or public API contracts.

## Automation tests
 - Unit tests 
   > Added unit test in `src/dao/keyManagerDao.test.js` testing `deleteKm` query execution sequence (`app_key_mappings` cleanup followed by `key_managers` delete).
 - Integration tests
   > Added test case in `it/rest-api/key-managers/key-managers.spec.js` verifying end-to-end deletion of a Key Manager linked to consumer keys/applications.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Test environment
 - Node.js: 24.6.0
 - OS: macOS (ARM64)
 - Database: SQLite