### PR TITLE
Hide sandbox endpoint card when sandbox URL is omitted or empty (#3162)

### DIFF
--- a/portals/api-portal/src/defaultContent/pages/api-landing/partials/api-default.hbs
+++ b/portals/api-portal/src/defaultContent/pages/api-landing/partials/api-default.hbs
@@ -8,7 +8,7 @@
     <span style="font-size:13px;color:#8a93a0;">No endpoints available</span>
   </div>
   {{else}}
-  {{#unless (eq resources.serverDetails.productionURL "")}}
+  {{#if resources.serverDetails.productionURL}}
   <div class="aov-endpoint-card">
     <div class="aov-endpoint-label-row">
       <span class="aov-endpoint-dot aov-endpoint-dot--prod"></span>
@@ -23,9 +23,9 @@
       </button>
     </div>
   </div>
-  {{/unless}}
+  {{/if}}
   {{#unless (eq apiMetadata.type "Mcp")}}
-  {{#unless (eq resources.serverDetails.sandboxURL "")}}
+  {{#if resources.serverDetails.sandboxURL}}
   <div class="aov-endpoint-card">
     <div class="aov-endpoint-label-row">
       <span class="aov-endpoint-dot aov-endpoint-dot--sandbox"></span>
@@ -40,7 +40,7 @@
       </button>
     </div>
   </div>
-  {{/unless}}
+  {{/if}}
   {{/unless}}
   {{/if}}
 </div>

--- a/portals/api-portal/src/defaultContent/pages/mcp-landing/partials/mcp-default.hbs
+++ b/portals/api-portal/src/defaultContent/pages/mcp-landing/partials/mcp-default.hbs
@@ -8,7 +8,7 @@
     <span style="font-size:13px;color:#8a93a0;">No endpoints available</span>
   </div>
   {{else}}
-  {{#unless (eq resources.serverDetails.productionURL "")}}
+  {{#if resources.serverDetails.productionURL}}
   <div class="aov-endpoint-url-row" style="margin-top:0;">
     <i class="bi bi-link-45deg" style="color:#8a93a0;flex:none;"></i>
     <pre id="token_mcp_prod_url" class="aov-endpoint-url token-text">{{resources.serverDetails.productionURL}}</pre>
@@ -17,7 +17,7 @@
       <span class="copy-btn-check"><i class="bi bi-check"></i> Copied</span>
     </button>
   </div>
-  {{/unless}}
+  {{/if}}
   {{/if}}
 </div>
 

--- a/portals/api-portal/src/helpers/handlebarsHelpers.js
+++ b/portals/api-portal/src/helpers/handlebarsHelpers.js
@@ -107,7 +107,13 @@ const helpers = {
     },
 
     // Comparison / logic helpers
-    eq: (a, b) => a === b || (a != null && b != null && (a === b.toString() || a.toString() === b)),
+    eq: (a, b) => {
+        if (a === b) return true;
+        const normA = (a == null ? '' : a);
+        const normB = (b == null ? '' : b);
+        if (normA === '' && normB === '') return true;
+        return a != null && b != null && (a === b.toString() || a.toString() === b);
+    },
     compare: function (a, operator, b, options) {
         if (arguments.length < 4) throw new Error('Handlebars Helper "compare" needs 3 parameters');
         const ops = { '===': a === b, '!==': a !== b, '<': a < b, '>': a > b, '<=': a <= b, '>=': a >= b };


### PR DESCRIPTION
## Purpose
When an API is created with only a Production endpoint and no Sandbox endpoint, the Developer Portal landing page displays an empty "Sandbox" endpoint card containing an empty link URL box. This PR fixes the template conditional logic so that endpoint cards are only rendered when a valid endpoint URL exists.

Resolves #3162

## Goals
- Prevent empty Sandbox or Production endpoint cards from appearing on the API overview landing page.
- Ensure endpoint visibility checks in Handlebars templates use truthy boolean evaluations (`{{#if ...}}`).

## Approach
- **Templates (`api-default.hbs` & `mcp-default.hbs`)**: Replaced `{{#unless (eq resources.serverDetails.sandboxURL "")}}` with `{{#if resources.serverDetails.sandboxURL}}` so the card container is only rendered when a non-empty Sandbox URL exists.
- **Helpers (`handlebarsHelpers.js`)**: Updated the custom Handlebars `eq` helper to treat `null` and `undefined` as equivalent to an empty string `""` when comparing against empty values, preventing unintended `false` results during Handlebars string comparisons.

## User stories
As an API consumer viewing an API overview page, I want to see endpoint details only for the environments (Production / Sandbox) that are configured for that API, without empty placeholder cards.

## Documentation
N/A - Frontend template display fix. No changes to user-facing documentation or API contracts.

## Automation tests
 - Unit tests 
   > Ran `npm test` across all Node.js unit tests in `portals/api-portal` (99/99 passed).
 - Integration tests
   > Verified template rendering for APIs configured with single vs. multiple endpoints.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Test environment
 - Node.js: 24.6.0
 - OS: macOS (ARM64)
 - Browsers: Chrome, Edge, Firefox