### PR TITLE
Fix Unauthorized mcp issue

### DIFF
--- a/platform-api/internal/apperror/catalog.go
+++ b/platform-api/internal/apperror/catalog.go
@@ -130,11 +130,17 @@ var (
 	DeploymentInvalidStatus   = def(CodeDeploymentInvalidStatus, http.StatusBadRequest, "The specified deployment status filter is invalid.")
 )
 
-// MCP proxy entries.
+// MCP proxy entries. MCPProxyUpstreamUnauthorized covers an upstream MCP
+// server rejecting the credentials we introspect it with. It must NOT reuse
+// Unauthorized: that entry means "the caller's own credentials are invalid",
+// and clients act on it by tearing down their session — which an upstream's
+// 401 must never trigger. A remote peer's status is data, not our status.
 var (
 	MCPProxyNotFound                   = def(CodeMCPProxyNotFound, http.StatusNotFound, "The specified MCP proxy could not be found.")
 	MCPProxyExists                     = def(CodeMCPProxyExists, http.StatusConflict, "An MCP proxy with this ID already exists.")
 	MCPProxyDeploymentValidationFailed = def(CodeMCPProxyDeploymentValidationFailed, http.StatusBadRequest, "%s")
+	MCPProxyUpstreamUnauthorized       = def(CodeMCPProxyUpstreamUnauthorized, http.StatusBadRequest,
+		"The MCP server rejected the supplied credentials.")
 )
 
 // Organization / project / application entries.

--- a/platform-api/internal/apperror/codes.go
+++ b/platform-api/internal/apperror/codes.go
@@ -102,11 +102,14 @@ const (
 	CodeRESTAPIAPIKeyForbidden            = "REST_API_API_KEY_FORBIDDEN"
 )
 
-// MCP proxy domain codes.
+// MCP proxy domain codes. MCP_PROXY_UPSTREAM_UNAUTHORIZED reports that the
+// *remote* MCP server rejected our credentials — deliberately not a 401, so a
+// client cannot confuse it with its own session expiring (see catalog.go).
 const (
 	CodeMCPProxyNotFound                   = "MCP_PROXY_NOT_FOUND"
 	CodeMCPProxyExists                     = "MCP_PROXY_EXISTS"
 	CodeMCPProxyDeploymentValidationFailed = "MCP_PROXY_DEPLOYMENT_VALIDATION_FAILED"
+	CodeMCPProxyUpstreamUnauthorized       = "MCP_PROXY_UPSTREAM_UNAUTHORIZED"
 )
 
 // Organization domain codes.

--- a/platform-api/internal/utils/mcp.go
+++ b/platform-api/internal/utils/mcp.go
@@ -293,8 +293,12 @@ func initializeMCPServer(url string, headerName string, headerValue string) (str
 	}
 
 	// Check HTTP status code
+	// The upstream's 401 is reported as MCP_PROXY_UPSTREAM_UNAUTHORIZED (400),
+	// never as our own Unauthorized: clients treat a 401 from this API as their
+	// session expiring and force a logout, so relaying a remote peer's 401
+	// verbatim would let any auth-requiring MCP server sign the user out.
 	if resp.StatusCode == http.StatusUnauthorized {
-		return "", nil, apperror.Unauthorized.New().
+		return "", nil, apperror.MCPProxyUpstreamUnauthorized.New().
 			WithLogMessage("MCP server returned 401 Unauthorized to the initialize request")
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {

--- a/platform-api/internal/utils/mcp_test.go
+++ b/platform-api/internal/utils/mcp_test.go
@@ -124,8 +124,7 @@ func TestFetchMCPServerInfoUpstream401IsNotOurUnauthorized(t *testing.T) {
 	if appErr.Code != apperror.CodeMCPProxyUpstreamUnauthorized {
 		t.Errorf("Code = %q, want %q", appErr.Code, apperror.CodeMCPProxyUpstreamUnauthorized)
 	}
-	if appErr.HTTPStatus == http.StatusUnauthorized {
-		t.Error("an upstream MCP server's 401 must not reach the caller as a 401 — " +
-			"clients treat that as their own session expiring")
+	if appErr.HTTPStatus != http.StatusBadRequest {
+		t.Errorf("HTTPStatus = %d, want %d", appErr.HTTPStatus, http.StatusBadRequest)
 	}
 }

--- a/platform-api/internal/utils/mcp_test.go
+++ b/platform-api/internal/utils/mcp_test.go
@@ -18,8 +18,12 @@
 package utils
 
 import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/wso2/api-platform/platform-api/internal/apperror"
 	"github.com/wso2/api-platform/platform-api/internal/constants"
 	"github.com/wso2/api-platform/platform-api/internal/model"
 
@@ -91,5 +95,37 @@ func TestBuildMCPDeploymentYAML(t *testing.T) {
 	}
 	if deploymentStruct.Spec.SpecVersion != "2025-06-18" {
 		t.Errorf("SpecVersion = %q", deploymentStruct.Spec.SpecVersion)
+	}
+}
+
+// TestFetchMCPServerInfoUpstream401IsNotOurUnauthorized pins the status-code
+// separation between "the remote MCP server rejected our credentials" and "the
+// caller's own session is invalid". Clients (the AI Workspace) react to a 401
+// from this API by tearing down the session and redirecting to /login, so
+// relaying an upstream's 401 verbatim let any auth-requiring MCP server sign
+// the user out. The condition must surface as MCP_PROXY_UPSTREAM_UNAUTHORIZED
+// with a non-401 status instead.
+func TestFetchMCPServerInfoUpstream401IsNotOurUnauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	_, err := FetchMCPServerInfo(srv.URL, "", "")
+	if err == nil {
+		t.Fatal("expected an error when the MCP server rejects the initialize request")
+	}
+
+	// errors.As, not a type assertion: FetchMCPServerInfo wraps the failure.
+	var appErr *apperror.Error
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected a catalog error, got %T: %v", err, err)
+	}
+	if appErr.Code != apperror.CodeMCPProxyUpstreamUnauthorized {
+		t.Errorf("Code = %q, want %q", appErr.Code, apperror.CodeMCPProxyUpstreamUnauthorized)
+	}
+	if appErr.HTTPStatus == http.StatusUnauthorized {
+		t.Error("an upstream MCP server's 401 must not reach the caller as a 401 — " +
+			"clients treat that as their own session expiring")
 	}
 }

--- a/portals/ai-workspace/src/apis/platformApis.ts
+++ b/portals/ai-workspace/src/apis/platformApis.ts
@@ -82,12 +82,14 @@ const mutatingHeaders = (): Record<string, string> => ({
  * instead of string-matching the message.
  */
 const parseApiError = async (res: Response): Promise<ApiError> => {
-  handleUnauthorizedResponse(res);
   let body: unknown;
   try {
     body = await res.json();
   } catch { /* body not JSON */ }
-  return buildApiError(res.status, body, `HTTP ${res.status}`);
+  const err = buildApiError(res.status, body, `HTTP ${res.status}`);
+  // Pass the code so only a genuine UNAUTHORIZED tears down the session.
+  handleUnauthorizedResponse(res, err.code);
+  return err;
 };
 
 // ============================================================================

--- a/portals/ai-workspace/src/auth/logout.ts
+++ b/portals/ai-workspace/src/auth/logout.ts
@@ -60,9 +60,17 @@ let unauthorizedRedirectStarted = false;
  * Start the session-expiry flow once when an authenticated API call returns
  * 401. Several requests can fail together when a session expires, so the
  * guard prevents duplicate logout calls and competing redirects.
+ *
+ * `errorCode` is the platform API's error `code` from the response body, when
+ * the caller has already parsed it. Only the unified `UNAUTHORIZED` code means
+ * *our* session is dead; any other code on a 401 describes something else the
+ * request touched (e.g. an upstream server rejecting credentials), and must not
+ * sign the user out. A 401 with no parseable code is treated as session expiry,
+ * which is the safe default.
  */
-export const handleUnauthorizedResponse = (response: Response): boolean => {
+export const handleUnauthorizedResponse = (response: Response, errorCode?: string): boolean => {
   if (response.status !== 401) return false;
+  if (errorCode !== undefined && errorCode !== 'UNAUTHORIZED') return false;
 
   if (!unauthorizedRedirectStarted) {
     unauthorizedRedirectStarted = true;

--- a/portals/ai-workspace/src/clients/choreoApiClient.ts
+++ b/portals/ai-workspace/src/clients/choreoApiClient.ts
@@ -102,12 +102,13 @@ export const request = async <T>(config: ApiRequestConfig): Promise<T> => {
   });
 
   if (!res.ok) {
-    handleUnauthorizedResponse(res);
     let data: unknown;
     try {
       data = await res.json();
     } catch { /* body not JSON */ }
     const err = buildApiError(res.status, data, `HTTP ${res.status}`);
+    // Pass the code so only a genuine UNAUTHORIZED tears down the session.
+    handleUnauthorizedResponse(res, err.code);
     logger.error(
       `[platformApiClient] ${method} ${url} → ${res.status} [${err.code ?? 'UNKNOWN'}]: ${err.message}`
       + (err.trackingId ? ` (trackingId: ${err.trackingId})` : ''),
@@ -152,12 +153,13 @@ const sendForm = async <T>(
   const res = await fetch(url, { method, credentials: 'include', headers, body: form });
 
   if (!res.ok) {
-    handleUnauthorizedResponse(res);
     let data: unknown;
     try {
       data = await res.json();
     } catch { /* body not JSON */ }
     const err = buildApiError(res.status, data, `HTTP ${res.status}`);
+    // Pass the code so only a genuine UNAUTHORIZED tears down the session.
+    handleUnauthorizedResponse(res, err.code);
     logger.error(
       `[platformApiClient] ${method} ${url} → ${res.status} [${err.code ?? 'UNKNOWN'}]: ${err.message}`
       + (err.trackingId ? ` (trackingId: ${err.trackingId})` : ''),

--- a/portals/ai-workspace/src/contexts/ChoreoUserContext.tsx
+++ b/portals/ai-workspace/src/contexts/ChoreoUserContext.tsx
@@ -99,12 +99,13 @@ async function fetchPlatformOrganization(): Promise<Organization[]> {
     });
 
     if (!res.ok) {
-      handleUnauthorizedResponse(res);
       if (res.status === 404) {
         logger.warn('[ChoreoUserContext] No organization found — register one at /register-org');
         return [];
       }
       const body = await res.json().catch(() => ({}));
+      // Pass the code so only a genuine UNAUTHORIZED tears down the session.
+      handleUnauthorizedResponse(res, body?.code);
       throw new Error(body?.message ?? `GET /organizations failed: HTTP ${res.status}`);
     }
 


### PR DESCRIPTION
This pull request addresses a subtle but important distinction in error handling for authentication failures when proxying to upstream MCP servers. It ensures that a 401 Unauthorized response from an upstream MCP server is not mistaken for the user's own session expiring, which previously could have caused clients to log users out unnecessarily. The change introduces a new error code and status for this scenario, updates backend and frontend logic to handle it, and adds tests to pin the correct behavior.

<img width="838" height="537" alt="Screenshot 2026-08-10 at 09 29 00" src="https://github.com/user-attachments/assets/53577bcd-e2a4-4974-9d53-55333ebd0575" />


**Backend changes:**

* Introduced a new error code `MCP_PROXY_UPSTREAM_UNAUTHORIZED` and corresponding error entry, ensuring that an upstream MCP server's 401 is surfaced as a 400 with a distinct code, not as a standard Unauthorized error. This prevents clients from logging out users when the error is not about their own session. [[1]](diffhunk://#diff-65dfcdef2c5297122d3f38b4ffd6fec0fd09d8c726e4f3ab0efd6722411ccab2L105-R112) [[2]](diffhunk://#diff-dae1667d851e8fd28b4dcb66c2cb00777327f873e3311997ff1b526ecf1da73eL133-R143) [[3]](diffhunk://#diff-720d17468868c1ccb6f825617ed9ddb56b18931ca6ae86b2679874cac3de4527R296-R301)
* Added a backend test (`TestFetchMCPServerInfoUpstream401IsNotOurUnauthorized`) to verify that an upstream 401 is mapped to the new error code and does not result in a 401 to the client.

**Frontend changes:**

* Updated the `handleUnauthorizedResponse` function and all its call sites to only trigger a logout if the error code is exactly `UNAUTHORIZED`. 401 responses with other codes (such as `MCP_PROXY_UPSTREAM_UNAUTHORIZED`) no longer cause the session to be torn down. [[1]](diffhunk://#diff-73993f8d4f99024289bf1c98bfe4e5b88738b9948e6619601786069ef93aa4d7R63-R73) [[2]](diffhunk://#diff-2d8f9896e1f518086bf06f106f19ecff6d09533d08798675890f68e35bb89ca5L85-R92) [[3]](diffhunk://#diff-47208a229241d6f799a35a1bafb0373ca416e36365964c79f510fc393d0a3e4cL105-R111) [[4]](diffhunk://#diff-47208a229241d6f799a35a1bafb0373ca416e36365964c79f510fc393d0a3e4cL155-R162) [[5]](diffhunk://#diff-b8ecd237b012b721a4710e3c317468de4c71a4ed308bb172cc7594d70a339931L102-R108)
* Improved inline documentation to clarify the distinction between user session expiry and upstream authentication failures.

These changes together ensure that only genuine user session expiry logs the user out, while upstream authentication issues are surfaced as errors without disrupting the user's session.