### PR TITLE
Add Gateway API New Release Check to the Workflow and Minor Refactoring to Version Extraction in Conformance Tests

### DIFF
--- a/.github/workflows/k8s-gateway-api-conformance.yml
+++ b/.github/workflows/k8s-gateway-api-conformance.yml
@@ -303,7 +303,7 @@ jobs:
 
           # Create the final message payload
           MESSAGE="${HEADLINE}\n*Repository:* ${REPO}\n*Ref:* ${REF_NAME}\n*Trigger:* ${EVENT}\n*Run:* ${RUN_URL}${UPSTREAM_LINE}"
-          PAYLOAD="{\"text\": \"${MESSAGE}\"}"
+          PAYLOAD="$(jq -cn --arg text "${MESSAGE}" '{text: $text}')"
 
           echo "${PAYLOAD}" | curl --fail --silent --show-error \
             -X POST \

--- a/.github/workflows/k8s-gateway-api-conformance.yml
+++ b/.github/workflows/k8s-gateway-api-conformance.yml
@@ -199,9 +199,74 @@ jobs:
     if: always() && github.event_name == 'schedule'
     runs-on: ubuntu-24.04
     steps:
+      - name: Checkout conformance pin
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: kubernetes/conformance/runner/go.mod
+          sparse-checkout-cone-mode: false
+
+      # Compares the Gateway API version this suite is pinned to against the latest
+      # upstream release, so a new release is noticed by the weekly run instead of by
+      # someone remembering to check kubernetes-sigs/gateway-api by hand.
+      - name: Check for a newer Gateway API release
+        id: upstream
+        env:
+          # Raises the API rate limit from the shared-IP anonymous quota and needs no
+          # scope beyond the workflow's top-level `contents: read`.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+
+          GOMOD="kubernetes/conformance/runner/go.mod"
+
+          # The `require sigs.k8s.io/gateway-api/conformance vX.Y.Z` line is the single
+          # source of truth for what the suite actually runs (run-conformance.sh resolves
+          # the suite from the module cache, not from a checkout of the upstream repo).
+          PINNED=$(grep -oE 'sigs\.k8s\.io/gateway-api/conformance v[0-9]+\.[0-9]+\.[0-9]+' "${GOMOD}" \
+            | head -n1 | awk '{print $2}')
+          if [ -z "${PINNED:-}" ]; then
+            echo "::warning::Could not read the Gateway API conformance pin from ${GOMOD}; skipping the release check."
+            echo "latest=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "pinned=${PINNED}" >> "$GITHUB_OUTPUT"
+
+          # /releases/latest excludes drafts and pre-releases, so release candidates
+          # (v1.6.0-rc1 and friends) never raise a false alarm.
+          LATEST=$(curl --fail --silent --show-error --max-time 30 \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            https://api.github.com/repos/kubernetes-sigs/gateway-api/releases/latest \
+            | jq -r '.tag_name // empty') || LATEST=""
+
+          # Validate before the value is ever interpolated into the chat payload
+          if ! printf '%s' "${LATEST}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::warning::Could not resolve a usable latest Gateway API release tag (got '${LATEST}'); skipping the release check."
+            echo "latest=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Pinned Gateway API conformance version: ${PINNED}"
+          echo "Latest upstream Gateway API release:    ${LATEST}"
+
+          # sort -V orders semver correctly (Ex: 1.10.0 after 1.9.0)
+          NEWEST=$(printf '%s\n%s\n' "${PINNED#v}" "${LATEST#v}" | sort -V | tail -n1)
+          if [ "${NEWEST}" = "${PINNED#v}" ]; then
+            echo "Pin is up to date."
+            echo "latest=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "::notice::Gateway API ${LATEST} is available; the conformance suite is pinned to ${PINNED}."
+          echo "latest=${LATEST}" >> "$GITHUB_OUTPUT"
+
       - name: Send Google Chat notification
         env:
           WEBHOOK_URL: ${{ secrets.GOOGLE_CHATSPACE_WEBHOOK_URL }}
+          # UPSTREAM_LATEST is empty unless a strictly newer Gateway API release exists;
+          UPSTREAM_LATEST: ${{ steps.upstream.outputs.latest }}
+          UPSTREAM_PINNED: ${{ steps.upstream.outputs.pinned }}
           # needs.<job>.result is success/failure/cancelled; the status output adds
           # detail (passed/failed/error). Passed via env to keep untrusted-looking
           # context out of the inline shell.
@@ -230,10 +295,14 @@ jobs:
             HEADLINE="🔥 *Gateway API Conformance Errored*"
           fi
 
-          # Google Chat webhook expects {"text": "..."}; \n renders as a line break and
-          # *text* as bold. The message is fully controlled (no quotes/backslashes other
-          # than the intended \n), so a plain JSON string is safe here.
-          MESSAGE="${HEADLINE}\n*Repository:* ${REPO}\n*Ref:* ${REF_NAME}\n*Trigger:* ${EVENT}\n*Run:* ${RUN_URL}"
+          # Appended only when the release check found a newer upstream version. 
+          UPSTREAM_LINE=""
+          if [ -n "${UPSTREAM_LATEST}" ]; then
+            UPSTREAM_LINE="\n🔔 *(Alert):* Gateway-API ${UPSTREAM_LATEST} is now available — this suite is pinned to ${UPSTREAM_PINNED}."
+          fi
+
+          # Create the final message payload
+          MESSAGE="${HEADLINE}\n*Repository:* ${REPO}\n*Ref:* ${REF_NAME}\n*Trigger:* ${EVENT}\n*Run:* ${RUN_URL}${UPSTREAM_LINE}"
           PAYLOAD="{\"text\": \"${MESSAGE}\"}"
 
           echo "${PAYLOAD}" | curl --fail --silent --show-error \

--- a/kubernetes/conformance/install-wso2-gateway.sh
+++ b/kubernetes/conformance/install-wso2-gateway.sh
@@ -28,8 +28,9 @@
 # -----------------------------------------------------------------------------
 set -euo pipefail
 
-# This script lives at kubernetes/conformance/, so the repo root is two levels up.
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# Sets REPO_ROOT, REGISTRY, GW_VERSION and OPERATOR_VERSION.
+# shellcheck source=versions.sh
+source "$(dirname "${BASH_SOURCE[0]}")/versions.sh"
 
 OPERATOR_CHART="${OPERATOR_CHART:-${REPO_ROOT}/kubernetes/helm/operator-helm-chart}"
 OPERATOR_NS="${OPERATOR_NS:-gateway-system}"
@@ -156,19 +157,8 @@ kubectl wait --namespace cert-manager \
   --for=condition=available deployment --all --timeout=180s
 
 # --- 2. Gateway operator (installs the bundled Gateway API CRDs too) --------
-# Derive the image tags from the same sources the build and load-images.sh use, so helm
-# deploys exactly the images that were built and loaded (imagePullPolicy=IfNotPresent).
-# Hardcoding these caused the loaded (freshly built) images to be ignored. Overridable
-# via env to stay in lock-step with load-images.sh.
-REGISTRY="${REGISTRY:-ghcr.io/wso2/api-platform}"
-GW_VERSION="${GW_VERSION:-$(cat "${REPO_ROOT}/gateway/VERSION")}"
-OPERATOR_VERSION="${OPERATOR_VERSION:-$(sed -nE 's/^VERSION[[:space:]]*\?=[[:space:]]*([^[:space:]]+).*/\1/p' \
-  "${REPO_ROOT}/kubernetes/gateway-operator/Makefile" | head -1)}"
-
-if [ -z "${GW_VERSION}" ] || [ -z "${OPERATOR_VERSION}" ]; then
-  echo "error: could not determine image versions (GW_VERSION='${GW_VERSION}', OPERATOR_VERSION='${OPERATOR_VERSION}')." >&2
-  exit 1
-fi
+# Tags come from versions.sh so helm deploys exactly the images load-images.sh loaded
+# (imagePullPolicy=IfNotPresent); hardcoding them made the freshly built images be ignored.
 
 # Provision the mandatory at-rest encryption key before the gateway is reconciled.
 provision_encryption_key

--- a/kubernetes/conformance/load-images.sh
+++ b/kubernetes/conformance/load-images.sh
@@ -24,21 +24,11 @@
 # -----------------------------------------------------------------------------
 set -euo pipefail
 
-# This script lives at kubernetes/conformance/, so the repo root is two levels up.
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# Sets REPO_ROOT, REGISTRY, GW_VERSION and OPERATOR_VERSION.
+# shellcheck source=versions.sh
+source "$(dirname "${BASH_SOURCE[0]}")/versions.sh"
 
 CLUSTER_NAME="${CLUSTER_NAME:-wso2-conformance}"
-REGISTRY="${REGISTRY:-ghcr.io/wso2/api-platform}"
-
-# Derive tags from the build's own sources so they match install-wso2-gateway.sh.
-GW_VERSION="${GW_VERSION:-$(cat "${REPO_ROOT}/gateway/VERSION")}"
-OPERATOR_VERSION="${OPERATOR_VERSION:-$(sed -nE 's/^VERSION[[:space:]]*\?=[[:space:]]*([^[:space:]]+).*/\1/p' \
-  "${REPO_ROOT}/kubernetes/gateway-operator/Makefile" | head -1)}"
-
-if [ -z "${GW_VERSION}" ] || [ -z "${OPERATOR_VERSION}" ]; then
-  echo "error: could not determine image versions (GW_VERSION='${GW_VERSION}', OPERATOR_VERSION='${OPERATOR_VERSION}')." >&2
-  exit 1
-fi
 
 IMAGES=(
   "${REGISTRY}/gateway-controller:${GW_VERSION}"

--- a/kubernetes/conformance/run-conformance.sh
+++ b/kubernetes/conformance/run-conformance.sh
@@ -16,7 +16,7 @@
 #   GATEWAY_CLASS        GatewayClass name              (default: wso2-api-platform)
 #   PROFILE              conformance profile            (default: GATEWAY-HTTP)
 #   SUPPORTED_FEATURES   comma-separated features       (default: Gateway,HTTPRoute)
-#   IMPL_VERSION         implementation version string  (default: 1.1.0)
+#   IMPL_VERSION         implementation version string  (default: gateway/VERSION)
 #   REPORT_OUT           report output path
 # -----------------------------------------------------------------------------
 set -euo pipefail
@@ -24,13 +24,19 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RUNNER_DIR="${SCRIPT_DIR}/runner"
 
+# Sets GW_VERSION (among others) from gateway/VERSION.
+# shellcheck source=versions.sh
+source "${SCRIPT_DIR}/versions.sh"
+
 GATEWAY_CLASS="${GATEWAY_CLASS:-wso2-api-platform}"
 PROFILE="${PROFILE:-GATEWAY-HTTP}"
 # Keep this on ONE line: a line break (even with a trailing backslash) leaves the
 # continuation's leading whitespace inside the value, corrupting the feature name
 # right after each break so that feature silently fails to register.
 SUPPORTED_FEATURES="${SUPPORTED_FEATURES:-Gateway,HTTPRoute,HTTPRouteSchemeRedirect,HTTPRoutePortRedirect,HTTPRoute303RedirectStatusCode,HTTPRoute307RedirectStatusCode,HTTPRoute308RedirectStatusCode}"
-IMPL_VERSION="${IMPL_VERSION:-1.2.0-milestone}"
+# Report the gateway actually under test; lowercased since gateway/VERSION uses the
+# Maven-style "1.2.0-SNAPSHOT" spelling and SemVer pre-releases are conventionally lowercase.
+IMPL_VERSION="${IMPL_VERSION:-$(printf '%s' "${GW_VERSION}" | tr '[:upper:]' '[:lower:]')}"
 REPORT_OUT="${REPORT_OUT:-${SCRIPT_DIR}/wso2-api-platform-${IMPL_VERSION}-report.yaml}"
 # Resolve a relative REPORT_OUT against the caller's directory NOW, before we cd into
 # the runner module. Otherwise `go test` would write it relative to runner/ while the

--- a/kubernetes/conformance/versions.sh
+++ b/kubernetes/conformance/versions.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# Shared version/registry resolution for the conformance scripts. Source it, don't
+# run it — keeping this in one place is what guarantees the images that get built,
+# loaded, deployed and reported on all carry the same tag.
+#
+# Sets (each overridable via env):
+#   REPO_ROOT, REGISTRY, GW_VERSION, OPERATOR_VERSION
+# -----------------------------------------------------------------------------
+
+# This file lives at kubernetes/conformance/, so the repo root is two levels up.
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
+REGISTRY="${REGISTRY:-ghcr.io/wso2/api-platform}"
+GW_VERSION="${GW_VERSION:-$(cat "${REPO_ROOT}/gateway/VERSION")}"
+OPERATOR_VERSION="${OPERATOR_VERSION:-$(sed -nE 's/^VERSION[[:space:]]*\?=[[:space:]]*([^[:space:]]+).*/\1/p' \
+  "${REPO_ROOT}/kubernetes/gateway-operator/Makefile" | head -1)}"
+
+if [ -z "${GW_VERSION}" ] || [ -z "${OPERATOR_VERSION}" ]; then
+  echo "error: could not determine image versions (GW_VERSION='${GW_VERSION}', OPERATOR_VERSION='${OPERATOR_VERSION}')." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Purpose
- Currently a manual effort is required for tracking the new gateway api version releases. Instead, during the weekly runs, the workflow itself will check for latest releases and alert via the chat notification. 