### PR TITLE
Fixes for helm charts along with db aliases support in platform api and api portal

### DIFF
--- a/kubernetes/helm/ai-workspace-helm-chart/generate-secrets.sh
+++ b/kubernetes/helm/ai-workspace-helm-chart/generate-secrets.sh
@@ -42,14 +42,14 @@
 #
 #   Platform API ([platform_api.*], APIP_CP_*)
 #     APIP_CP_ADMIN_USERNAME             File-mode admin username (default: admin).
-#     APIP_CP_DATABASE_PASSWORD          Postgres password.
+#     APIP_CP_DATABASE_PASSWORD          Database password (postgres/sqlserver).
 #     APIP_CP_WEBHOOK_SECRET             HMAC secret for the webhook receiver.
 #
 #   AI Workspace BFF ([ai_workspace.*], APIP_AIW_*)
 #     APIP_AIW_AUTH_OIDC_CLIENT_SECRET   OIDC client secret (OIDC mode only).
 #
 #   API Portal ([api_portal.*], APIP_AP_*) — needs API_PORTAL=true
-#     APIP_AP_DATABASE_PASSWORD          Postgres password.
+#     APIP_AP_DATABASE_PASSWORD          Database password (postgres/mssql).
 #     APIP_AP_AUTH_IDP_CLIENT_SECRET     OIDC/IDP client secret (idp mode only).
 # --------------------------------------------------------------------
 set -euo pipefail

--- a/kubernetes/helm/api-portal-helm-chart/generate-secrets.sh
+++ b/kubernetes/helm/api-portal-helm-chart/generate-secrets.sh
@@ -43,11 +43,11 @@
 #
 #   Platform API ([platform_api.*], APIP_CP_*)
 #     APIP_CP_ADMIN_USERNAME             File-mode admin username (default: admin).
-#     APIP_CP_DATABASE_PASSWORD          Postgres password.
+#     APIP_CP_DATABASE_PASSWORD          Database password (postgres/sqlserver).
 #     APIP_CP_WEBHOOK_SECRET             HMAC secret for the webhook receiver.
 #
 #   API Portal ([api_portal.*], APIP_AP_*)
-#     APIP_AP_DATABASE_PASSWORD          Postgres password.
+#     APIP_AP_DATABASE_PASSWORD          Database password (postgres/mssql).
 #     APIP_AP_AUTH_IDP_CLIENT_SECRET     OIDC/IDP client secret (idp mode only).
 #
 #   AI Workspace BFF ([ai_workspace.*], APIP_AIW_*) — extensibility case

--- a/kubernetes/helm/api-portal-ui-helm-chart/templates/_helpers.tpl
+++ b/kubernetes/helm/api-portal-ui-helm-chart/templates/_helpers.tpl
@@ -221,13 +221,13 @@ that component's secret. Fails the render when a required secret is unset.
 {{- end -}}
 
 {{/*
-Canonical database dialect for a configured config.database.type.
+Canonical database driver for a configured config.database.driver.
 
-Takes the raw type string, returns one of "sqlite" / "postgres" / "mssql", and
-fails the render on anything else — so a typo is an install-time error rather
+Takes the raw driver string, returns one of "sqlite" / "postgres" / "mssql", and 
+fails the render on anything else - so a typo is an install-time error rather
 than a crash-looping pod whose real cause is buried in container logs.
 */}}
-{{- define "apip.apiPortal.dbDialect" -}}
+{{- define "apip.apiPortal.dbDriver" -}}
 {{- $raw := . | toString | trim | lower -}}
 {{- $aliases := dict
       "sqlite" "sqlite" "sqlite3" "sqlite"
@@ -235,7 +235,7 @@ than a crash-looping pod whose real cause is buried in container logs.
       "mssql" "mssql" "sqlserver" "mssql" -}}
 {{- $canonical := get $aliases $raw -}}
 {{- if not $canonical -}}
-{{- fail (printf "config.database.type must be one of: sqlite, sqlite3, postgres, postgresql, pgx, mssql, sqlserver (got %q)" $raw) -}}
+{{- fail (printf "config.database.driver must be one of: sqlite, sqlite3, postgres, postgresql, pgx, mssql, sqlserver (got %q)" $raw) -}}
 {{- end -}}
 {{- $canonical -}}
 {{- end -}}

--- a/kubernetes/helm/api-portal-ui-helm-chart/templates/_helpers.tpl
+++ b/kubernetes/helm/api-portal-ui-helm-chart/templates/_helpers.tpl
@@ -219,3 +219,23 @@ that component's secret. Fails the render when a required secret is unset.
 {{- end -}}
 {{- $name -}}
 {{- end -}}
+
+{{/*
+Canonical database dialect for a configured config.database.type.
+
+Takes the raw type string, returns one of "sqlite" / "postgres" / "mssql", and
+fails the render on anything else — so a typo is an install-time error rather
+than a crash-looping pod whose real cause is buried in container logs.
+*/}}
+{{- define "apip.apiPortal.dbDialect" -}}
+{{- $raw := . | toString | trim | lower -}}
+{{- $aliases := dict
+      "sqlite" "sqlite" "sqlite3" "sqlite"
+      "postgres" "postgres" "postgresql" "postgres" "pgx" "postgres"
+      "mssql" "mssql" "sqlserver" "mssql" -}}
+{{- $canonical := get $aliases $raw -}}
+{{- if not $canonical -}}
+{{- fail (printf "config.database.type must be one of: sqlite, sqlite3, postgres, postgresql, pgx, mssql, sqlserver (got %q)" $raw) -}}
+{{- end -}}
+{{- $canonical -}}
+{{- end -}}

--- a/kubernetes/helm/api-portal-ui-helm-chart/templates/configmap.yaml
+++ b/kubernetes/helm/api-portal-ui-helm-chart/templates/configmap.yaml
@@ -1,7 +1,7 @@
 {{- $ap := .Values -}}
 {{- $cfg := $ap.config -}}
 {{- $db := $cfg.database -}}
-{{- $dbDialect := include "apip.apiPortal.dbDialect" $db.type -}}
+{{- $dbDriver := include "apip.apiPortal.dbDriver" $db.driver -}}
 {{- $auth := $cfg.auth -}}
 {{- $tls := $ap.tls -}}
 {{- $certDir := $tls.mountPath -}}
@@ -46,14 +46,14 @@ data:
     # Rendered as the canonical dialect rather than the raw values.yaml spelling,
     # so an alias (sqlserver, postgresql, pgx, sqlite3) also works against a
     # portal image predating the config-loader's own alias normalization.
-    driver = {{ $dbDialect | quote }}
-    {{- if eq $dbDialect "sqlite" }}
+    driver = {{ $dbDriver | quote }}
+    {{- if eq $dbDriver "sqlite" }}
     path = {{ $db.file | quote }}
     {{- else }}
     {{- if and (ne $db.sslmode "disable") (ne $db.sslmode "verify-full") }}
     {{- fail (printf "config.database.sslmode must be \"disable\" or \"verify-full\" (got %q). The portal supports no partial TLS mode: on postgres an unrecognised value aborts startup, and on mssql it silently connects unencrypted with certificate verification off." $db.sslmode) }}
     {{- end }}
-    host = {{ required (printf "config.database.host is required when database.type is %q" $db.type) $db.host | quote }}
+    host = {{ required (printf "config.database.host is required when database.driver is %q" $db.driver) $db.host | quote }}
     port = {{ $db.port | int }}
     name = {{ $db.database | quote }}
     user = {{ $db.user | quote }}

--- a/kubernetes/helm/api-portal-ui-helm-chart/templates/configmap.yaml
+++ b/kubernetes/helm/api-portal-ui-helm-chart/templates/configmap.yaml
@@ -1,6 +1,7 @@
 {{- $ap := .Values -}}
 {{- $cfg := $ap.config -}}
 {{- $db := $cfg.database -}}
+{{- $dbDialect := include "apip.apiPortal.dbDialect" $db.type -}}
 {{- $auth := $cfg.auth -}}
 {{- $tls := $ap.tls -}}
 {{- $certDir := $tls.mountPath -}}
@@ -42,11 +43,17 @@ data:
     console_only = {{ $cfg.logging.consoleOnly }}
 
     [api_portal.database]
-    driver = {{ $db.type | quote }}
-    {{- if eq $db.type "sqlite" }}
+    # Rendered as the canonical dialect rather than the raw values.yaml spelling,
+    # so an alias (sqlserver, postgresql, pgx, sqlite3) also works against a
+    # portal image predating the config-loader's own alias normalization.
+    driver = {{ $dbDialect | quote }}
+    {{- if eq $dbDialect "sqlite" }}
     path = {{ $db.file | quote }}
     {{- else }}
-    host = {{ required "config.database.host is required when database.type is \"postgres\"" $db.host | quote }}
+    {{- if and (ne $db.sslmode "disable") (ne $db.sslmode "verify-full") }}
+    {{- fail (printf "config.database.sslmode must be \"disable\" or \"verify-full\" (got %q). The portal supports no partial TLS mode: on postgres an unrecognised value aborts startup, and on mssql it silently connects unencrypted with certificate verification off." $db.sslmode) }}
+    {{- end }}
+    host = {{ required (printf "config.database.host is required when database.type is %q" $db.type) $db.host | quote }}
     port = {{ $db.port | int }}
     name = {{ $db.database | quote }}
     user = {{ $db.user | quote }}

--- a/kubernetes/helm/api-portal-ui-helm-chart/templates/deployment.yaml
+++ b/kubernetes/helm/api-portal-ui-helm-chart/templates/deployment.yaml
@@ -9,6 +9,9 @@
 {{- if and $ap.deployment.enabled (not (or $tlsFromSecret (eq $tls.certificateProvider "none"))) }}
 {{- fail "api-portal-ui: tls.certificateProvider must be \"cert-manager\", \"secret\", or \"none\" (plain HTTP) — there is no self-signed fallback (the image does not generate a certificate at startup). Provide a TLS Secret (certificateProvider=secret), use cert-manager, or set certificateProvider=none to serve plain HTTP behind a TLS-terminating proxy." }}
 {{- end }}
+{{- if and $ap.deployment.enabled (gt (int $deployment.replicaCount) 1) (eq (include "apip.apiPortal.dbDriver" $cfg.database.driver) "sqlite") }}
+{{- fail "api-portal-ui: deployment.replicaCount > 1 requires an external database (config.database.driver=postgres or mssql) — SQLite is a per-pod file and cannot be shared across replicas. Set replicaCount: 1 or switch to an external database." }}
+{{- end }}
 {{- $secretName := include "apip.apiPortal.secretName" . -}}
 {{- $imageTag := default .Chart.AppVersion $ap.image.tag -}}
 {{- $certDir := $tls.mountPath -}}

--- a/kubernetes/helm/api-portal-ui-helm-chart/templates/deployment.yaml
+++ b/kubernetes/helm/api-portal-ui-helm-chart/templates/deployment.yaml
@@ -108,7 +108,7 @@ spec:
                 secretKeyRef:
                   name: {{ $secretName }}
                   key: {{ $secrets.keys.sessionSecret }}
-            {{- if ne (include "apip.apiPortal.dbDialect" $cfg.database.type) "sqlite" }}
+            {{- if ne (include "apip.apiPortal.dbDriver" $cfg.database.driver) "sqlite" }}
             - name: APIP_AP_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/kubernetes/helm/api-portal-ui-helm-chart/templates/deployment.yaml
+++ b/kubernetes/helm/api-portal-ui-helm-chart/templates/deployment.yaml
@@ -108,7 +108,7 @@ spec:
                 secretKeyRef:
                   name: {{ $secretName }}
                   key: {{ $secrets.keys.sessionSecret }}
-            {{- if eq $cfg.database.type "postgres" }}
+            {{- if ne (include "apip.apiPortal.dbDialect" $cfg.database.type) "sqlite" }}
             - name: APIP_AP_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/kubernetes/helm/api-portal-ui-helm-chart/templates/hpa.yaml
+++ b/kubernetes/helm/api-portal-ui-helm-chart/templates/hpa.yaml
@@ -1,8 +1,8 @@
 {{- $ap := .Values -}}
 {{- $hpa := $ap.hpa -}}
 {{- if and $ap.deployment.enabled $hpa.enabled }}
-{{- if ne $ap.config.database.type "postgres" }}
-{{- fail "api-portal.hpa requires api-portal.config.database.type=postgres — SQLite does not support multiple replicas." }}
+{{- if eq (include "apip.apiPortal.dbDialect" $ap.config.database.type) "sqlite" }}
+{{- fail "api-portal.hpa requires an external database (config.database.type=postgres or mssql) — SQLite is a per-pod file and does not support multiple replicas." }}
 {{- end }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler

--- a/kubernetes/helm/api-portal-ui-helm-chart/templates/hpa.yaml
+++ b/kubernetes/helm/api-portal-ui-helm-chart/templates/hpa.yaml
@@ -1,8 +1,8 @@
 {{- $ap := .Values -}}
 {{- $hpa := $ap.hpa -}}
 {{- if and $ap.deployment.enabled $hpa.enabled }}
-{{- if eq (include "apip.apiPortal.dbDialect" $ap.config.database.type) "sqlite" }}
-{{- fail "api-portal.hpa requires an external database (config.database.type=postgres or mssql) — SQLite is a per-pod file and does not support multiple replicas." }}
+{{- if eq (include "apip.apiPortal.dbDriver" $ap.config.database.driver) "sqlite" }}
+{{- fail "api-portal.hpa requires an external database (config.database.driver=postgres or mssql) — SQLite is a per-pod file and does not support multiple replicas." }}
 {{- end }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler

--- a/kubernetes/helm/api-portal-ui-helm-chart/values.yaml
+++ b/kubernetes/helm/api-portal-ui-helm-chart/values.yaml
@@ -73,8 +73,8 @@ config:
     # Aliases are accepted and normalized by the portal at startup, so you can use
     # the same spelling here as in the platform-api values block:
     #   sqlite3 → sqlite,  postgresql/pgx → postgres,  sqlserver → mssql
-    type: sqlite
-    # SQLite file (type=sqlite). Must sit under the mounted data volume.
+    driver: sqlite
+    # SQLite file (driver=sqlite). Must sit under the mounted data volume.
     file: /app/data/devportal.db
     # Server connection — used by BOTH postgres and mssql. The password is NOT
     # here; it comes from the Secret key secrets.keys.databasePassword. Leave host
@@ -311,7 +311,7 @@ tls:
 # persistence — the PVC backing SQLite
 # ----------------------------------------------------------------------------
 persistence:
-  enabled: true                 # required for database.type=sqlite
+  enabled: true                 # required for database.driver=sqlite
   existingClaim: ""             # reuse a PVC you created yourself instead
   accessModes:
     - ReadWriteOnce
@@ -332,7 +332,7 @@ persistence:
 # ----------------------------------------------------------------------------
 deployment:
   enabled: true
-  replicaCount: 1               # >1 requires database.type=postgres
+  replicaCount: 1               # >1 requires an external DB (postgres/mssql)
   volumeMountPath: /app/data
   extraEnv: []
   extraEnvFrom: []
@@ -371,9 +371,10 @@ deployment:
 # ----------------------------------------------------------------------------
 # Autoscaling & disruption budget
 # ----------------------------------------------------------------------------
-# HorizontalPodAutoscaler. REQUIRES config.database.type=postgres — on sqlite the
-# chart refuses to render it (SQLite is single-replica). Enable only after
-# switching to postgres, and set deployment.resources.requests.cpu.
+# HorizontalPodAutoscaler. REQUIRES an external database — config.database.driver
+# of postgres or mssql. On sqlite the chart refuses to render it (SQLite is a
+# per-pod file, so it is single-replica). Enable only after switching to an
+# external database, and set deployment.resources.requests.cpu.
 hpa:
   enabled: false
   minReplicas: 2

--- a/kubernetes/helm/api-portal-ui-helm-chart/values.yaml
+++ b/kubernetes/helm/api-portal-ui-helm-chart/values.yaml
@@ -248,7 +248,7 @@ secrets:
   keys:
     encryptionKey: APIP_AP_SECURITY_ENCRYPTION_KEY
     sessionSecret: APIP_AP_SECURITY_SESSION_SECRET
-    databasePassword: APIP_AP_DATABASE_PASSWORD        # postgres only
+    databasePassword: APIP_AP_DATABASE_PASSWORD        # any non-sqlite driver (postgres/mssql)
     idpClientSecret: APIP_AP_AUTH_IDP_CLIENT_SECRET    # idp mode only
     publicKey: jwt_public.pem                          # mounted file → config.auth.publicKeyPath
   # Flip to true ONLY if the referenced Secret actually carries that optional key,

--- a/kubernetes/helm/api-portal-ui-helm-chart/values.yaml
+++ b/kubernetes/helm/api-portal-ui-helm-chart/values.yaml
@@ -67,20 +67,30 @@ config:
   # --- Database (the portal's OWN store, separate from the Platform API's) ---
   database:
     # sqlite   → file on the PVC; single replica; HPA unavailable.
-    # postgres → external server (configured below); enables multi-replica + HPA.
+    # postgres → external PostgreSQL (configured below); enables multi-replica + HPA.
+    # mssql    → external SQL Server (configured below); enables multi-replica + HPA.
+    #
+    # Aliases are accepted and normalized by the portal at startup, so you can use
+    # the same spelling here as in the platform-api values block:
+    #   sqlite3 → sqlite,  postgresql/pgx → postgres,  sqlserver → mssql
     type: sqlite
     # SQLite file (type=sqlite). Must sit under the mounted data volume.
     file: /app/data/devportal.db
-    # PostgreSQL connection (type=postgres only). The password is NOT here — it
-    # comes from the Secret key secrets.keys.databasePassword. Leave host empty
-    # for sqlite.
+    # Server connection — used by BOTH postgres and mssql. The password is NOT
+    # here; it comes from the Secret key secrets.keys.databasePassword. Leave host
+    # empty for sqlite.
     host: ""
-    port: 5432
+    port: 5432                   # 1433 for SQL Server
     database: devportal          # database (schema) name → rendered as `name`
     user: postgres               # login role; password from the Secret
-    sslmode: disable             # disable | require | verify-ca | verify-full
-    sslRootCert: ""              # CA cert — used by verify-ca / verify-full
-    # Connection-pool tuning (postgres only).
+    # TLS to the database. Only these two values are supported:
+    #   disable      → no TLS
+    #   verify-full  → encrypt AND verify the certificate chain + hostname
+    # On SQL Server, anything other than verify-full connects UNENCRYPTED with
+    # certificate verification off, so there is no partial mode — use verify-full.
+    sslmode: disable             # disable | verify-full
+    sslRootCert: ""              # CA cert — used by verify-full
+    # Connection-pool tuning (postgres / mssql only).
     maxOpenConns: 50
     minOpenConns: 2
     poolIdleTimeoutMs: 10000

--- a/kubernetes/helm/platform-api-helm-chart/templates/_helpers.tpl
+++ b/kubernetes/helm/platform-api-helm-chart/templates/_helpers.tpl
@@ -219,3 +219,24 @@ that component's secret. Fails the render when a required secret is unset.
 {{- end -}}
 {{- $name -}}
 {{- end -}}
+
+{{/*
+Canonical database driver for a configured config.database.driver.
+
+Takes the raw driver string, returns one of "sqlite3" / "postgres" /
+"sqlserver" — the three names platform-api's own code canonicalizes to 
+and fails the render on anything else, so a typo is an install-time error 
+instead of a crash-looping pod.
+*/}}
+{{- define "apip.platformApi.dbDriver" -}}
+{{- $raw := . | toString | trim | lower -}}
+{{- $aliases := dict
+      "sqlite" "sqlite3" "sqlite3" "sqlite3"
+      "postgres" "postgres" "postgresql" "postgres" "pgx" "postgres"
+      "mssql" "sqlserver" "sqlserver" "sqlserver" -}}
+{{- $canonical := get $aliases $raw -}}
+{{- if not $canonical -}}
+{{- fail (printf "config.database.driver must be one of: sqlite, sqlite3, postgres, postgresql, pgx, mssql, sqlserver (got %q)" $raw) -}}
+{{- end -}}
+{{- $canonical -}}
+{{- end -}}

--- a/kubernetes/helm/platform-api-helm-chart/templates/configmap.yaml
+++ b/kubernetes/helm/platform-api-helm-chart/templates/configmap.yaml
@@ -1,6 +1,7 @@
 {{- $pa := .Values -}}
 {{- $cfg := $pa.config -}}
 {{- $db := $cfg.database -}}
+{{- $dbDriver := include "apip.platformApi.dbDriver" $db.driver -}}
 {{- $auth := $cfg.auth -}}
 {{- $srv := $cfg.server -}}
 {{- $https := $srv.https -}}
@@ -39,8 +40,11 @@ data:
     hashing_algorithms = {{ $cfg.security.apiKey.hashingAlgorithms | quote }}
 
     [platform_api.database]
-    driver = {{ $db.driver | quote }}
-    {{- if eq $db.driver "sqlite3" }}
+    # Rendered as the canonical driver rather than the raw values.yaml spelling,
+    # so an alias resolves to the one name this component's config validator
+    # expects regardless of which spelling the shared values file used.
+    driver = {{ $dbDriver | quote }}
+    {{- if eq $dbDriver "sqlite3" }}
     path = {{ $db.path | quote }}
     {{- else }}
     host = {{ required "config.database.postgres.host is required when database.driver is not sqlite3" $db.postgres.host | quote }}

--- a/kubernetes/helm/platform-api-helm-chart/templates/configmap.yaml
+++ b/kubernetes/helm/platform-api-helm-chart/templates/configmap.yaml
@@ -96,11 +96,15 @@ data:
     roles = {{ $auth.claimMappings.roles | quote }}
     {{- end }}
 
+    {{- if ne $auth.mode "idp" }}
     [platform_api.auth.jwt]
     issuer = {{ $auth.jwt.issuer | quote }}
-    public_key_file = {{ $auth.jwt.publicKeyFile | quote }}
-    private_key_file = {{ $auth.jwt.privateKeyFile | quote }}
+    public_key_file = {{ required "config.auth.jwt.publicKeyFile is required when auth.mode is \"internal_token\" or \"file\"" $auth.jwt.publicKeyFile | quote }}
+    {{- if eq $auth.mode "file" }}
+    private_key_file = {{ required "config.auth.jwt.privateKeyFile is required when auth.mode is \"file\"" $auth.jwt.privateKeyFile | quote }}
+    {{- end }}
     token_ttl = {{ $auth.jwt.tokenTtl | quote }}
+    {{- end }}
 
     {{- if eq $auth.mode "idp" }}
 

--- a/kubernetes/helm/platform-api-helm-chart/templates/deployment.yaml
+++ b/kubernetes/helm/platform-api-helm-chart/templates/deployment.yaml
@@ -7,11 +7,27 @@
 {{- $jwtKeysMounted := has $pa.config.auth.mode (list "internal_token" "file") -}}
 {{- $jwtKeyDir := "" -}}
 {{- if $jwtKeysMounted -}}
-{{- $jwtKeyDir = regexReplaceAll "/[^/]+$" (required "platform-api: config.auth.jwt.publicKeyFile is required when config.auth.mode is \"internal_token\" or \"file\" — it is the mount path of the PEM that verifies token signatures." $jwt.publicKeyFile) "" -}}
+{{- $jwtPublicKeyFile := required "platform-api: config.auth.jwt.publicKeyFile is required when config.auth.mode is \"internal_token\" or \"file\" — it is the mount path of the PEM that verifies token signatures." $jwt.publicKeyFile -}}
+{{- if not (hasPrefix "/" $jwtPublicKeyFile) -}}
+{{- fail (printf "platform-api: config.auth.jwt.publicKeyFile must be an absolute path (got %q) — the chart derives the jwt-keys volume mountPath from its parent directory." $jwtPublicKeyFile) -}}
+{{- end -}}
+{{- $jwtKeyDir = regexReplaceAll "/[^/]+$" $jwtPublicKeyFile "" -}}
+{{- if or (eq $jwtKeyDir "") (eq $jwtKeyDir "/") -}}
+{{- fail (printf "platform-api: config.auth.jwt.publicKeyFile must sit in a subdirectory, not directly at the filesystem root (got %q) — the chart mounts its parent directory as the jwt-keys volume and cannot mount \"/\". Use e.g. /etc/platform-api/keys/jwt_public.pem." $jwtPublicKeyFile) -}}
+{{- end -}}
+{{- if eq $pa.config.auth.mode "file" -}}
+{{- $jwtPrivateKeyFile := required "platform-api: config.auth.jwt.privateKeyFile is required when config.auth.mode is \"file\" — it is the mount path of the PEM that signs login tokens." $jwt.privateKeyFile -}}
+{{- if ne (regexReplaceAll "/[^/]+$" $jwtPrivateKeyFile "") $jwtKeyDir -}}
+{{- fail (printf "platform-api: config.auth.jwt.privateKeyFile must be in the same directory as publicKeyFile (public %q, private %q) — both PEMs come from one Secret mounted as a single jwt-keys volume at %q, so a private key elsewhere would be written into that directory while the config kept reading it from its own." $jwtPublicKeyFile $jwtPrivateKeyFile $jwtKeyDir) -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 {{- $tlsMounted := and $https.enabled (or (eq $tls.certificateProvider "cert-manager") (eq $tls.certificateProvider "secret")) -}}
 {{- if and $deployment.enabled $https.enabled (not (or (eq $tls.certificateProvider "cert-manager") (eq $tls.certificateProvider "secret"))) }}
 {{- fail "platform-api: config.server.https.enabled=true requires tls.certificateProvider to be \"cert-manager\" or \"secret\" — the Platform API has no self-signed fallback." }}
+{{- end }}
+{{- if and $deployment.enabled (gt (int $deployment.replicaCount) 1) (eq (include "apip.platformApi.dbDriver" $pa.config.database.driver) "sqlite3") }}
+{{- fail "platform-api: deployment.replicaCount > 1 requires an external database (config.database.driver=postgres or sqlserver) — SQLite is a per-pod file and cannot be shared across replicas. Set replicaCount: 1 or switch to an external database." }}
 {{- end }}
 {{- $secretName := include "apip.platformApi.secretName" . -}}
 {{- if $deployment.enabled }}

--- a/kubernetes/helm/platform-api-helm-chart/templates/deployment.yaml
+++ b/kubernetes/helm/platform-api-helm-chart/templates/deployment.yaml
@@ -4,7 +4,11 @@
 {{- $tls := $pa.tls -}}
 {{- $https := $pa.config.server.https -}}
 {{- $jwt := $pa.config.auth.jwt -}}
-{{- $jwtKeyDir := regexReplaceAll "/[^/]+$" $jwt.publicKeyFile "" -}}
+{{- $jwtKeysMounted := has $pa.config.auth.mode (list "internal_token" "file") -}}
+{{- $jwtKeyDir := "" -}}
+{{- if $jwtKeysMounted -}}
+{{- $jwtKeyDir = regexReplaceAll "/[^/]+$" (required "platform-api: config.auth.jwt.publicKeyFile is required when config.auth.mode is \"internal_token\" or \"file\" — it is the mount path of the PEM that verifies token signatures." $jwt.publicKeyFile) "" -}}
+{{- end -}}
 {{- $tlsMounted := and $https.enabled (or (eq $tls.certificateProvider "cert-manager") (eq $tls.certificateProvider "secret")) -}}
 {{- if and $deployment.enabled $https.enabled (not (or (eq $tls.certificateProvider "cert-manager") (eq $tls.certificateProvider "secret"))) }}
 {{- fail "platform-api: config.server.https.enabled=true requires tls.certificateProvider to be \"cert-manager\" or \"secret\" — the Platform API has no self-signed fallback." }}
@@ -164,9 +168,11 @@ spec:
               mountPath: {{ $pa.config.auth.authorization.roleToScopeMapping }}
               subPath: role-to-scope-mapping.yaml
             {{- end }}
+            {{- if $jwtKeysMounted }}
             - name: jwt-keys
               mountPath: {{ $jwtKeyDir }}
               readOnly: true
+            {{- end }}
             {{- if $tlsMounted }}
             - name: tls-certs
               mountPath: {{ $https.certDir }}
@@ -193,9 +199,10 @@ spec:
               - key: role-to-scope-mapping.yaml
                 path: role-to-scope-mapping.yaml
               {{- end }}
+        {{- if $jwtKeysMounted }}
         # RS256 JWT keys mounted as PEM files from the external Secret. The
-        # public key verifies tokens (every mode); the private key signs
-        # file-mode login tokens (mounted only in file mode).
+        # public key verifies tokens in internal_token and file modes; the
+        # private key signs file-mode login tokens (mounted only in file mode).
         - name: jwt-keys
           secret:
             secretName: {{ $secretName }}
@@ -204,8 +211,9 @@ spec:
                 path: {{ base $jwt.publicKeyFile }}
               {{- if eq $pa.config.auth.mode "file" }}
               - key: {{ $secrets.keys.jwtPrivateKey }}
-                path: {{ base $jwt.privateKeyFile }}
+                path: {{ base (required "platform-api: config.auth.jwt.privateKeyFile is required when config.auth.mode is \"file\" — it is the mount path of the PEM that signs login tokens." $jwt.privateKeyFile) }}
               {{- end }}
+        {{- end }}
         {{- if $tlsMounted }}
         - name: tls-certs
           secret:

--- a/kubernetes/helm/platform-api-helm-chart/templates/deployment.yaml
+++ b/kubernetes/helm/platform-api-helm-chart/templates/deployment.yaml
@@ -108,7 +108,7 @@ spec:
                 secretKeyRef:
                   name: {{ $secretName }}
                   key: {{ $secrets.keys.encryptionKey }}
-            {{- if ne $pa.config.database.driver "sqlite3" }}
+            {{- if ne (include "apip.platformApi.dbDriver" $pa.config.database.driver) "sqlite3" }}
             - name: APIP_CP_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/kubernetes/helm/platform-api-helm-chart/templates/hpa.yaml
+++ b/kubernetes/helm/platform-api-helm-chart/templates/hpa.yaml
@@ -1,8 +1,8 @@
 {{- $pa := .Values -}}
 {{- $hpa := $pa.hpa -}}
 {{- if and $pa.deployment.enabled $hpa.enabled }}
-{{- if ne $pa.config.database.driver "postgres" }}
-{{- fail "platformApi.hpa requires platformApi.config.database.driver=postgres — SQLite does not support multiple replicas." }}
+{{- if eq (include "apip.platformApi.dbDriver" $pa.config.database.driver) "sqlite3" }}
+{{- fail "platformApi.hpa requires an external database (config.database.driver=postgres or sqlserver) — SQLite is a per-pod file and does not support multiple replicas." }}
 {{- end }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler

--- a/kubernetes/helm/platform-api-helm-chart/values.yaml
+++ b/kubernetes/helm/platform-api-helm-chart/values.yaml
@@ -110,7 +110,9 @@ config:
     #                    component, using the public key.
     #   file           — internal_token + local username/password login (issues
     #                    RS256 tokens signed with the private key).
-    #   idp            — validate tokens against an external IDP's JWKS.
+    #   idp            — validate tokens against an external IDP's JWKS. No local
+    #                    RS256 keys are read or mounted in this mode, so the
+    #                    Secret needn't carry jwt_public.pem / jwt_private.pem.
     mode: file
     # --- Authorization --- applies in every auth mode above: an enterprise-IDP
     # token carries the same roles claim whether it is verified against a JWKS
@@ -167,9 +169,14 @@ config:
       # Claim carrying the user's roles — read in role authorization mode, and the
       # claim the file-mode login endpoint signs auth.file.admin.roles into.
       roles: roles               # Keycloak nests it: "realm_access.roles"
-    # Local RS256 JWT keys. public_key_file verifies tokens (every mode);
-    # private_key_file signs login tokens (file mode only). Both are mounted as
-    # PEM files from the Secret (secrets.keys.jwtPublicKey / jwtPrivateKey).
+    # Local RS256 JWT keys, mounted as PEM files from the Secret
+    # (secrets.keys.jwtPublicKey / jwtPrivateKey). Which of them the chart mounts
+    # follows the mode, because only the mode's own code path opens them:
+    #   internal_token — public_key_file only (verifies tokens minted elsewhere)
+    #   file           — both (also signs its login tokens)
+    #   idp            — neither; validation goes to the IDP's JWKS instead, so
+    #                    these paths are not rendered into config either
+    # The paths below are container mount points, not host paths.
     jwt:
       issuer: platform-api
       publicKeyFile: /etc/platform-api/keys/jwt_public.pem
@@ -275,10 +282,20 @@ configToml: ""
 # ----------------------------------------------------------------------------
 # The chart never creates or embeds secret values. Point existingSecret at a
 # Secret made by ./generate-secrets.sh. Render FAILS if it's unset. The Secret
-# must hold APIP_CP_ENCRYPTION_KEY and the RS256 JWT key files jwt_public.pem /
-# jwt_private.pem (mounted into config.auth.jwt.*File), plus APIP_CP_DATABASE_PASSWORD
-# when driver=postgres and APIP_CP_WEBHOOK_SECRET when config.webhook.enabled. `keys`
-# maps each logical name to the key inside that Secret.
+# must always hold APIP_CP_ENCRYPTION_KEY; the rest are conditional, and a key
+# the chart doesn't reference for your settings can simply be absent:
+#   APIP_CP_DATABASE_PASSWORD  — driver=postgres only
+#   APIP_CP_WEBHOOK_SECRET     — config.webhook.enabled only
+#   jwt_public.pem             — auth.mode internal_token or file only
+#   jwt_private.pem            — auth.mode file only
+# The PEMs are mounted as files into config.auth.jwt.*File. In auth.mode=idp
+# neither is mounted or referenced, so an idp-mode Secret needs no PEMs at all.
+# `keys` maps each logical name to the key inside that Secret.
+#
+# Note the asymmetry between a missing Secret KEY and a missing Secret: only the
+# keys the chart actually references matter, but a referenced-and-absent key
+# leaves the pod in ContainerCreating ("references non-existent secret key")
+# rather than surfacing a config error — which is why the mounts follow the mode.
 #
 # Upgrading from a chart version predating the APIP_CP_* rename: an existing
 # Secret still has the old generic key names (ENCRYPTION_KEY, DATABASE_PASSWORD,
@@ -302,7 +319,7 @@ secrets:
     encryptionKey: APIP_CP_ENCRYPTION_KEY
     databasePassword: APIP_CP_DATABASE_PASSWORD      # postgres only
     webhookSecret: APIP_CP_WEBHOOK_SECRET            # config.webhook.enabled only
-    jwtPublicKey: jwt_public.pem                     # mounted file → config.auth.jwt.publicKeyFile
+    jwtPublicKey: jwt_public.pem                     # mounted file → config.auth.jwt.publicKeyFile (internal_token/file modes)
     jwtPrivateKey: jwt_private.pem                   # mounted file → config.auth.jwt.privateKeyFile (file mode)
     adminUsername: APIP_CP_ADMIN_USERNAME            # auth.mode=file only
     adminPasswordHash: APIP_CP_ADMIN_PASSWORD_HASH   # auth.mode=file only

--- a/kubernetes/helm/platform-api-helm-chart/values.yaml
+++ b/kubernetes/helm/platform-api-helm-chart/values.yaml
@@ -81,15 +81,22 @@ config:
 
   # --- Database ---
   database:
-    # sqlite3  — no external DB; the file lives on the PVC (see persistence).
-    #            Single replica only → the HPA cannot be used.
-    # postgres — external PostgreSQL (configured below); enables multi-replica + HPA.
+    # sqlite3   — no external DB; the file lives on the PVC (see persistence).
+    #             Single replica only → the HPA cannot be used.
+    # postgres  — external PostgreSQL (configured below); enables multi-replica + HPA.
+    # sqlserver — external SQL Server (configured below); enables multi-replica + HPA.
+    #
+    # Aliases are accepted and normalized by the chart, so the same spelling works
+    # here and in the api-portal values block:
+    #   sqlite → sqlite3,  postgresql/pgx → postgres,  mssql → sqlserver
     driver: sqlite3
     # SQLite database file (driver=sqlite3 only). Must sit under the mounted data
     # volume (deployment.volumeMountPath), so it persists on the PVC.
     path: /app/data/api_platform.db
-    # PostgreSQL connection (driver=postgres only). The password is NOT set here —
-    # it comes from the Secret key secrets.keys.databasePassword.
+    # Server connection — used by BOTH postgres and sqlserver (the block keeps its
+    # `postgres` name for values compatibility; renaming it would break existing
+    # overrides). Set port: 1433 for SQL Server. The password is NOT set here — it
+    # comes from the Secret key secrets.keys.databasePassword.
     postgres:
       host: ""                   # in-cluster Service or external endpoint
       port: 5432
@@ -401,7 +408,7 @@ persistence:
 # ----------------------------------------------------------------------------
 deployment:
   enabled: true
-  replicaCount: 1                # >1 requires driver=postgres
+  replicaCount: 1                # >1 requires an external DB (postgres/sqlserver)
   # Where the data volume mounts. Must contain config.database.path and
   # config.tls.certDir.
   volumeMountPath: /app/data
@@ -465,10 +472,11 @@ deployment:
 # ----------------------------------------------------------------------------
 # Autoscaling & disruption budget
 # ----------------------------------------------------------------------------
-# HorizontalPodAutoscaler. REQUIRES config.database.driver=postgres — on sqlite3
-# the chart refuses to render it (SQLite is single-replica). Enable only after
-# switching to postgres, and set deployment.resources.requests.cpu so the HPA has
-# a baseline to measure against.
+# HorizontalPodAutoscaler. REQUIRES an external database — config.database.driver
+# of postgres or sqlserver. On sqlite3 the chart refuses to render it (SQLite is a
+# per-pod file, so it is single-replica). Enable only after switching to an
+# external database, and set deployment.resources.requests.cpu so the HPA has a
+# baseline to measure against.
 hpa:
   enabled: false
   minReplicas: 2

--- a/kubernetes/helm/platform-api-helm-chart/values.yaml
+++ b/kubernetes/helm/platform-api-helm-chart/values.yaml
@@ -291,29 +291,13 @@ configToml: ""
 # Secret made by ./generate-secrets.sh. Render FAILS if it's unset. The Secret
 # must always hold APIP_CP_ENCRYPTION_KEY; the rest are conditional, and a key
 # the chart doesn't reference for your settings can simply be absent:
-#   APIP_CP_DATABASE_PASSWORD  — driver=postgres only
+#   APIP_CP_DATABASE_PASSWORD  — every non-sqlite3 driver (postgres/sqlserver)
 #   APIP_CP_WEBHOOK_SECRET     — config.webhook.enabled only
 #   jwt_public.pem             — auth.mode internal_token or file only
 #   jwt_private.pem            — auth.mode file only
 # The PEMs are mounted as files into config.auth.jwt.*File. In auth.mode=idp
 # neither is mounted or referenced, so an idp-mode Secret needs no PEMs at all.
 # `keys` maps each logical name to the key inside that Secret.
-#
-# Note the asymmetry between a missing Secret KEY and a missing Secret: only the
-# keys the chart actually references matter, but a referenced-and-absent key
-# leaves the pod in ContainerCreating ("references non-existent secret key")
-# rather than surfacing a config error — which is why the mounts follow the mode.
-#
-# Upgrading from a chart version predating the APIP_CP_* rename: an existing
-# Secret still has the old generic key names (ENCRYPTION_KEY, DATABASE_PASSWORD,
-# WEBHOOK_SECRET, ADMIN_USERNAME, ADMIN_PASSWORD_HASH — the PEM entries were
-# never renamed). generate-secrets.sh never rewrites an existing Secret, so
-# `helm upgrade` alone will not migrate it and the deployment will look for keys
-# that aren't there. Either add the new-named keys to the existing Secret
-# (`kubectl patch secret <name> -p '{"data":{"APIP_CP_ENCRYPTION_KEY":"<same
-# base64 value as the old ENCRYPTION_KEY key>", ...}}'`), or override the `keys`
-# below back to your Secret's actual (old) key names until you're ready to
-# migrate it.
 secrets:
   existingSecret: ""
   # Each key inside the Secret is named EXACTLY like the env var the container
@@ -324,7 +308,7 @@ secrets:
   # their path, not an env var.
   keys:
     encryptionKey: APIP_CP_ENCRYPTION_KEY
-    databasePassword: APIP_CP_DATABASE_PASSWORD      # postgres only
+    databasePassword: APIP_CP_DATABASE_PASSWORD      # any non-sqlite3 driver (postgres/sqlserver)
     webhookSecret: APIP_CP_WEBHOOK_SECRET            # config.webhook.enabled only
     jwtPublicKey: jwt_public.pem                     # mounted file → config.auth.jwt.publicKeyFile (internal_token/file modes)
     jwtPrivateKey: jwt_private.pem                   # mounted file → config.auth.jwt.privateKeyFile (file mode)

--- a/platform-api/config/config-template.toml
+++ b/platform-api/config/config-template.toml
@@ -247,11 +247,13 @@ roles         = []
 # keys at these paths, or point elsewhere by editing the path directly.
 [platform_api.auth.jwt]
 issuer = "platform-api"
-# public_key_file is REQUIRED in every mode (verifies token signatures);
-# private_key_file is REQUIRED only in "file" mode (signs login tokens) and
-# must be the matching half of the pair. Neither is generated — a missing
-# path, unreadable file, or malformed key fails config load. Both files must
-# contain a PEM-encoded RSA key.
+# public_key_file is REQUIRED in "internal_token" and "file" modes (it verifies
+# token signatures); private_key_file is REQUIRED only in "file" mode (signs
+# login tokens) and must be the matching half of the pair. This whole table is
+# unused in "idp" mode — validation goes to the IDP's JWKS there and neither
+# file is ever opened, so neither is required. Neither key is generated — in the
+# modes that need it, a missing path, unreadable file, or malformed key fails
+# config load. Both files must contain a PEM-encoded RSA key.
 public_key_file  = "/etc/platform-api/keys/jwt_public.pem"
 private_key_file = "/etc/platform-api/keys/jwt_private.pem"
 # Lifetime of tokens issued by the file-mode login endpoint (Go duration

--- a/platform-api/config/config-template.toml
+++ b/platform-api/config/config-template.toml
@@ -253,7 +253,10 @@ issuer = "platform-api"
 # unused in "idp" mode — validation goes to the IDP's JWKS there and neither
 # file is ever opened, so neither is required. Neither key is generated — in the
 # modes that need it, a missing path, unreadable file, or malformed key fails
-# config load. Both files must contain a PEM-encoded RSA key.
+# config load. Whichever key a mode requires must be a PEM-encoded RSA key; in
+# "file" mode the two must be the matching halves of one pair. When deploying via
+# the Helm chart, both paths must also be absolute and share the same parent
+# directory — the chart mounts that one directory as a single jwt-keys volume.
 public_key_file  = "/etc/platform-api/keys/jwt_public.pem"
 private_key_file = "/etc/platform-api/keys/jwt_private.pem"
 # Lifetime of tokens issued by the file-mode login endpoint (Go duration

--- a/portals/api-portal/src/config/configDefaults.js
+++ b/portals/api-portal/src/config/configDefaults.js
@@ -52,16 +52,22 @@ const DEFAULTS = {
         format: 'text',  // text | json
         consoleOnly: true,
     },
-    // driver uses Sequelize's dialect values (sqlite | postgres).
+    // driver selects the dialect adapter in db/driver.js. Aliases are accepted
+    // and normalized at startup (see db/rebind.js DRIVER_ALIASES), so any spelling
+    // platform-api takes works here too: sqlite3 -> sqlite, postgresql/pgx ->
+    // postgres, sqlserver -> mssql.
     database: {
-        driver: 'sqlite',        // sqlite | postgres
+        driver: 'sqlite',        // sqlite | postgres | mssql
         path: './api-portal.db', // SQLite only
-        host: 'localhost',       // PostgreSQL only
-        port: 5432,              // PostgreSQL only
-        name: 'api_portal',      // PostgreSQL only
-        user: '',                // PostgreSQL / MSSQL only
-        password: '',            // PostgreSQL only
-        // PostgreSQL TLS: disable | verify-full.
+        // Connection settings below apply to both server-backed dialects
+        // (PostgreSQL and SQL Server); SQLite uses `path` instead.
+        host: 'localhost',
+        port: 5432,              // 1433 for SQL Server
+        name: 'api_portal',
+        user: '',
+        password: '',
+        // TLS: disable | verify-full. On SQL Server, verify-full maps to
+        // encrypt + server-certificate verification (see db/adapters/mssqlAdapter.js).
         sslMode: 'disable',
         sslRootCert: './resources/security/ca.pem',  // CA cert — used by verify-full
         // Connection pool — PostgreSQL / MSSQL only. Same defaults both adapters

--- a/portals/api-portal/src/config/configLoader.js
+++ b/portals/api-portal/src/config/configLoader.js
@@ -31,6 +31,9 @@ const roleScopeMap = require('./roleScopeMap');
 // utils/constants.js has no imports of its own, so pulling the route constants in here
 // cannot create a cycle back through the config loader.
 const routeConstants = require('../utils/constants');
+// db/rebind.js is a pure helper module with no requires of its own (db/driver.js is
+// what requires *this* module), so taking the dialect name table from it cannot cycle.
+const { DIALECTS, DRIVER_ALIASES, normalizeDriver } = require('../db/rebind');
 
 // Load api-platform.env if present (silently ignored if absent)
 try {
@@ -391,6 +394,37 @@ if (config.designMode?.enabled) {
     requireHexSecret(config.security.encryptionKey, 'encryptionKey');
     requireHexSecret(config.security.sessionSecret, 'sessionSecret');
 }
+
+/**
+ * Fail-closed startup check: database.driver must be a recognised spelling, and
+ * is rewritten in place to its canonical dialect before anything reads it.
+ *
+ * This runs BEFORE validateDatabasePoolConfig below, and that ordering is
+ * load-bearing: the pool check applies only to the server-backed dialects, so
+ * against an un-normalized `sqlserver` it would take its early return and skip
+ * validation entirely — an invalid pool setting would then reach
+ * mssql.ConnectionPool() unchecked, which is exactly what that check exists to
+ * prevent.
+ *
+ * An unrecognised driver aborts startup here rather than at the first query.
+ * db/driver.js does throw on an unknown dialect, but only when the adapter is
+ * first loaded — late enough to look like a runtime fault (and, in Kubernetes,
+ * a crash-loop with the real cause buried) instead of a plain config error.
+ */
+function normalizeDatabaseDriver(database) {
+    const canonical = normalizeDriver(database.driver);
+    if (!canonical) {
+        fatalConfig(
+            `database.driver must be one of: ${Object.keys(DRIVER_ALIASES).join(', ')} ` +
+            `(got ${JSON.stringify(database.driver)}). Aliases are accepted and normalized — ` +
+            `sqlite3 -> ${DIALECTS.SQLITE}, postgresql/pgx -> ${DIALECTS.POSTGRES}, ` +
+            `sqlserver -> ${DIALECTS.MSSQL} — so the same spelling works here and in platform-api.`
+        );
+    }
+    database.driver = canonical;
+}
+
+normalizeDatabaseDriver(config.database);
 
 /**
  * Fail-closed startup check: database connection-pool settings must resolve to

--- a/portals/api-portal/src/db/rebind.js
+++ b/portals/api-portal/src/db/rebind.js
@@ -54,7 +54,8 @@ const DIALECTS = Object.freeze({
  * Normalization happens once at startup (config/configLoader.js), so nothing
  * downstream of that ever sees an alias.
  */
-const DRIVER_ALIASES = Object.freeze({
+
+const DRIVER_ALIASES = Object.freeze(Object.assign(Object.create(null), {
     sqlite: DIALECTS.SQLITE,
     sqlite3: DIALECTS.SQLITE,
     postgres: DIALECTS.POSTGRES,
@@ -62,7 +63,7 @@ const DRIVER_ALIASES = Object.freeze({
     pgx: DIALECTS.POSTGRES,
     mssql: DIALECTS.MSSQL,
     sqlserver: DIALECTS.MSSQL,
-});
+}));
 
 /**
  * Resolves an operator-supplied database.driver to its canonical dialect, or
@@ -77,7 +78,11 @@ function normalizeDriver(rawDriver) {
     if (typeof rawDriver !== 'string') {
         return null;
     }
-    return DRIVER_ALIASES[rawDriver.trim().toLowerCase()] || null;
+    const key = rawDriver.trim().toLowerCase();
+    if (!Object.prototype.hasOwnProperty.call(DRIVER_ALIASES, key)) {
+        return null;
+    }
+    return DRIVER_ALIASES[key] || null;
 }
 
 /**

--- a/portals/api-portal/src/db/rebind.js
+++ b/portals/api-portal/src/db/rebind.js
@@ -37,6 +37,50 @@ const DIALECTS = Object.freeze({
 });
 
 /**
+ * Every spelling of a driver an operator may write in config.toml, mapped to
+ * the canonical dialect the adapters and DAOs switch on.
+ *
+ * The alias set is deliberately identical to platform-api's
+ * (internal/database/connection.go: pgx/postgresql -> postgres, mssql ->
+ * sqlserver), because both components are installed by the same umbrella chart
+ * (kubernetes/helm/api-portal-helm-chart) and an operator configures one
+ * database for both. Without this, the same SQL Server deployment had to be
+ * spelled `sqlserver` in the platform-api values block and `mssql` in the
+ * portal's — a difference with no meaning behind it.
+ *
+ * Canonical names stay this component's own (`sqlite`, not `sqlite3`;
+ * `mssql`, not `sqlserver`): they are what `mssql`/`better-sqlite3` call
+ * themselves, and every DAO dialect branch already compares against them.
+ * Normalization happens once at startup (config/configLoader.js), so nothing
+ * downstream of that ever sees an alias.
+ */
+const DRIVER_ALIASES = Object.freeze({
+    sqlite: DIALECTS.SQLITE,
+    sqlite3: DIALECTS.SQLITE,
+    postgres: DIALECTS.POSTGRES,
+    postgresql: DIALECTS.POSTGRES,
+    pgx: DIALECTS.POSTGRES,
+    mssql: DIALECTS.MSSQL,
+    sqlserver: DIALECTS.MSSQL,
+});
+
+/**
+ * Resolves an operator-supplied database.driver to its canonical dialect, or
+ * null when it is not a recognised spelling. Case- and whitespace-insensitive,
+ * matching platform-api's strings.ToLower() handling of the same field.
+ *
+ * Returning null rather than falling back to a default is deliberate: the
+ * caller fails closed on it. A driver that silently defaulted to sqlite would
+ * hand a multi-replica deployment its own private, empty database file per pod.
+ */
+function normalizeDriver(rawDriver) {
+    if (typeof rawDriver !== 'string') {
+        return null;
+    }
+    return DRIVER_ALIASES[rawDriver.trim().toLowerCase()] || null;
+}
+
+/**
  * Converts a SQL string written with positional `?` placeholders into the
  * placeholder syntax the active dialect's driver expects.
  *
@@ -232,6 +276,8 @@ function isDuplicateKeyError(dialect, err) {
 
 module.exports = {
     DIALECTS,
+    DRIVER_ALIASES,
+    normalizeDriver,
     rebind,
     paginationClause,
     buildUpsert,

--- a/portals/api-portal/src/db/rebind.test.js
+++ b/portals/api-portal/src/db/rebind.test.js
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { DIALECTS, DRIVER_ALIASES, normalizeDriver } = require('./rebind');
+
+test('normalizeDriver accepts every platform-api driver spelling', () => {
+    // The point of the alias table: one database.driver value configured once in
+    // the umbrella chart has to be valid for platform-api and this portal alike.
+    // These are exactly the six platform-api's validateDatabaseConfig accepts
+    // (platform-api/config/config.go), plus this component's own 'sqlite'.
+    assert.equal(normalizeDriver('sqlite'), DIALECTS.SQLITE);
+    assert.equal(normalizeDriver('sqlite3'), DIALECTS.SQLITE);
+    assert.equal(normalizeDriver('postgres'), DIALECTS.POSTGRES);
+    assert.equal(normalizeDriver('postgresql'), DIALECTS.POSTGRES);
+    assert.equal(normalizeDriver('pgx'), DIALECTS.POSTGRES);
+    assert.equal(normalizeDriver('mssql'), DIALECTS.MSSQL);
+    assert.equal(normalizeDriver('sqlserver'), DIALECTS.MSSQL);
+});
+
+test('normalizeDriver is case- and whitespace-insensitive', () => {
+    // platform-api lowercases the same field (strings.ToLower in
+    // internal/database/connection.go), so a value that boots one component
+    // must not be rejected by the other purely on casing.
+    assert.equal(normalizeDriver('SQLServer'), DIALECTS.MSSQL);
+    assert.equal(normalizeDriver('POSTGRES'), DIALECTS.POSTGRES);
+    assert.equal(normalizeDriver('  mssql  '), DIALECTS.MSSQL);
+});
+
+test('normalizeDriver returns null for anything unrecognised', () => {
+    // Null, never a default — configLoader fails startup on it. A silent
+    // fallback to sqlite would give each replica its own empty database file.
+    for (const bogus of ['', '   ', 'mysql', 'postgres-sql', 'sqlite2', 'MSSQL_', 'oracle']) {
+        assert.equal(normalizeDriver(bogus), null, `expected null for ${JSON.stringify(bogus)}`);
+    }
+});
+
+test('normalizeDriver returns null for non-string input', () => {
+    // A TOML table or number reaching this field must fail closed, not throw
+    // a TypeError out of startup validation.
+    for (const bogus of [undefined, null, 42, {}, [], true]) {
+        assert.equal(normalizeDriver(bogus), null, `expected null for ${JSON.stringify(bogus)}`);
+    }
+});
+
+test('every alias resolves to a declared dialect', () => {
+    const canonical = new Set(Object.values(DIALECTS));
+    for (const [alias, target] of Object.entries(DRIVER_ALIASES)) {
+        assert.ok(canonical.has(target), `alias ${alias} maps to unknown dialect ${target}`);
+        assert.equal(alias, alias.toLowerCase(), `alias ${alias} must be lowercase to be reachable`);
+    }
+});
+
+test('every canonical dialect is itself an accepted alias', () => {
+    // Guards the case where a new dialect is added to DIALECTS but never listed
+    // in DRIVER_ALIASES — its own name would then be rejected at startup.
+    for (const dialect of Object.values(DIALECTS)) {
+        assert.equal(normalizeDriver(dialect), dialect);
+    }
+});

--- a/portals/api-portal/src/db/rebind.test.js
+++ b/portals/api-portal/src/db/rebind.test.js
@@ -53,6 +53,25 @@ test('normalizeDriver returns null for anything unrecognised', () => {
     }
 });
 
+test('normalizeDriver rejects inherited Object.prototype members', () => {
+    // A plain object literal would resolve these to inherited functions —
+    // truthy values normalizeDatabaseDriver would accept as a real driver,
+    // letting startup validation pass on a database that does not exist.
+    for (const inherited of [
+        'constructor', 'toString', '__proto__', 'hasOwnProperty', 'valueOf',
+        'isPrototypeOf', 'propertyIsEnumerable', 'toLocaleString',
+    ]) {
+        assert.equal(
+            normalizeDriver(inherited), null,
+            `expected null for inherited member ${JSON.stringify(inherited)}`,
+        );
+    }
+});
+
+test('DRIVER_ALIASES has no prototype chain to inherit from', () => {
+    assert.equal(Object.getPrototypeOf(DRIVER_ALIASES), null);
+});
+
 test('normalizeDriver returns null for non-string input', () => {
     // A TOML table or number reaching this field must fail closed, not throw
     // a TypeError out of startup validation.


### PR DESCRIPTION
This pull request introduces improved database driver handling and configuration validation for both the API Portal UI and Platform API Helm charts. It adds canonicalization and alias support for database drivers, enhances install-time error checking, and refines configuration and documentation for clarity and usability. Additionally, it improves JWT key mounting logic and validation based on authentication mode.

**Database driver handling and validation**
* Added helper templates (`apip.apiPortal.dbDriver` and `apip.platformApi.dbDriver`) to canonicalize and validate `config.database.driver`, supporting common aliases (e.g., `sqlite3`, `postgresql`, `pgx`, `sqlserver`, `mssql`) and failing the render on invalid values for both charts. [[1]](diffhunk://#diff-2ed793a85bef988718789cf5f8a1598706feb92d26550b6a7156476f900923e6R222-R241) [[2]](diffhunk://#diff-c6bfa3aabcd2217f0d866bce146f4c61bac0de23b0cd422468e2a415f51af504R222-R242)
* Updated all chart templates and values files to use the new canonical driver variable, ensuring consistent driver handling and improved error messages for misconfiguration. [[1]](diffhunk://#diff-d3757f09da5674733bd142e32944195f3252819abcc9b95335f90e83910afbccR4) [[2]](diffhunk://#diff-d3757f09da5674733bd142e32944195f3252819abcc9b95335f90e83910afbccL45-R56) [[3]](diffhunk://#diff-3a64339a926da2be288e8c5cb8c842c5e95c842976f561895e545e3e995dec6cL111-R111) [[4]](diffhunk://#diff-e8cc4f1f49c238a5e7f21498e933f3bc8cfb13f07623564721a7faa497705e0fL4-R5) [[5]](diffhunk://#diff-9a4a07b2962f44e8d1755cf2c2175f8acfb197f0167d2a5d8d27e98f17adebafR4) [[6]](diffhunk://#diff-9a4a07b2962f44e8d1755cf2c2175f8acfb197f0167d2a5d8d27e98f17adebafL42-R47) [[7]](diffhunk://#diff-aeb349434df48b656803f09e13c4b9933a88f1489cfe6c398d6cb597f5c113ccL107-R111) [[8]](diffhunk://#diff-1f130a8a75510de98688ad8f425829bf52f2577bb16cf5cc1cd24d2f3b665ea9L4-R5)

**Configuration and documentation improvements**
* Enhanced `values.yaml` documentation for both charts to clearly explain driver aliases, supported databases, and replica/HPA requirements, reducing confusion and improving user experience. [[1]](diffhunk://#diff-feb04e262d2b03446ae39fa5b6d395eb7fd66120a5bd392ffb0a90052c6b7249L70-R93) [[2]](diffhunk://#diff-feb04e262d2b03446ae39fa5b6d395eb7fd66120a5bd392ffb0a90052c6b7249L304-R314) [[3]](diffhunk://#diff-feb04e262d2b03446ae39fa5b6d395eb7fd66120a5bd392ffb0a90052c6b7249L325-R335) [[4]](diffhunk://#diff-feb04e262d2b03446ae39fa5b6d395eb7fd66120a5bd392ffb0a90052c6b7249L364-R377) [[5]](diffhunk://#diff-0a2883220e773de6ad988c5745dd5b8792a27278ec246e76ff925fa8460badf5R87-R99) [[6]](diffhunk://#diff-0a2883220e773de6ad988c5745dd5b8792a27278ec246e76ff925fa8460badf5L113-R122)

**TLS and connection settings**
* Enforced stricter validation of `sslmode` for database connections, ensuring only supported values are accepted and providing clear error messages for misconfiguration.

**JWT key mounting and authentication validation**
* Refined JWT key mounting logic in Platform API: keys are only mounted when required by the selected `auth.mode`, and config validation ensures required key paths are set, preventing silent misconfigurations. [[1]](diffhunk://#diff-9a4a07b2962f44e8d1755cf2c2175f8acfb197f0167d2a5d8d27e98f17adebafR103-R111) [[2]](diffhunk://#diff-aeb349434df48b656803f09e13c4b9933a88f1489cfe6c398d6cb597f5c113ccL7-R11) [[3]](diffhunk://#diff-aeb349434df48b656803f09e13c4b9933a88f1489cfe6c398d6cb597f5c113ccR171-R175) [[4]](diffhunk://#diff-aeb349434df48b656803f09e13c4b9933a88f1489cfe6c398d6cb597f5c113ccR202-R205) [[5]](diffhunk://#diff-aeb349434df48b656803f09e13c4b9933a88f1489cfe6c398d6cb597f5c113ccL207-R215) [[6]](diffhunk://#diff-0a2883220e773de6ad988c5745dd5b8792a27278ec246e76ff925fa8460badf5L170-R186)

**HPA (Horizontal Pod Autoscaler) logic**
* Updated HPA templates to require an external database (Postgres or SQL Server) for multi-replica support, with improved error messages and checks based on the canonicalized driver. [[1]](diffhunk://#diff-e8cc4f1f49c238a5e7f21498e933f3bc8cfb13f07623564721a7faa497705e0fL4-R5) [[2]](diffhunk://#diff-1f130a8a75510de98688ad8f425829bf52f2577bb16cf5cc1cd24d2f3b665ea9L4-R5)

These changes make the charts more robust, user-friendly, and less error-prone during installation and upgrades.