### PR TITLE
Add Pluggable Capability to the AI Workspace UI

### DIFF
--- a/portals/ai-workspace/package.json
+++ b/portals/ai-workspace/package.json
@@ -3,6 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
   "scripts": {
     "dev": "vite",
     "start": "vite",

--- a/portals/ai-workspace/src/AIWorkspace.tsx
+++ b/portals/ai-workspace/src/AIWorkspace.tsx
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ * Licensed under the Apache License, Version 2.0.
+ */
+
+import React, { useEffect } from "react";
+import { BrowserRouter } from "react-router-dom";
+import { IntlProvider } from "react-intl";
+import {
+  AcrylicOrangeTheme,
+  AcrylicPurpleTheme,
+  ClassicTheme,
+  HighContrastTheme,
+  OxygenUIThemeProvider,
+  Box,
+  LinearProgress,
+  Stack,
+  Typography,
+} from "@wso2/oxygen-ui";
+
+import App from "./App";
+import "./styles.css";
+import { AUTH_MODE } from "./config.env";
+import { BASE_PATH } from "./paths";
+import { BFFAuthProvider } from "./contexts/BFFAuthProvider";
+import { useAppAuth } from "./contexts/AppAuthContext";
+import BasicAuthLoginPage from "./pages/login/BasicAuthLoginPage";
+import type { AIWorkspaceExtension } from "./extensions";
+
+function LoadingScreen({ message }: { message?: string }) {
+  return (
+    <Box
+      sx={{
+        minHeight: "100vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        p: 4,
+      }}
+    >
+      <Stack
+        spacing={2}
+        alignItems="center"
+        sx={{ maxWidth: 480, textAlign: "center" }}
+      >
+        {message && <Typography color="text.secondary">{message}</Typography>}
+        <Box sx={{ width: 200 }}>
+          <LinearProgress color="primary" />
+        </Box>
+      </Stack>
+    </Box>
+  );
+}
+
+function OIDCRedirect() {
+  const { login } = useAppAuth();
+  useEffect(() => {
+    void login();
+  }, [login]);
+  return <LoadingScreen message="Redirecting to sign in…" />;
+}
+
+function AppGate({
+  extensions,
+}: {
+  extensions: readonly AIWorkspaceExtension[];
+}) {
+  const { isAuthenticated, isLoading } = useAppAuth();
+  if (isLoading) return <LoadingScreen />;
+  if (!isAuthenticated) {
+    if (AUTH_MODE === "basic") {
+      return (
+        <BasicAuthLoginPage
+          onSuccess={() => {
+            const { pathname, search, hash } = window.location;
+            const route = pathname.startsWith(BASE_PATH)
+              ? pathname.slice(BASE_PATH.length)
+              : pathname;
+            window.location.replace(
+              route === "/login" || route === "/signin"
+                ? `${BASE_PATH}/`
+                : pathname + search + hash,
+            );
+          }}
+        />
+      );
+    }
+    return <OIDCRedirect />;
+  }
+  return (
+    <IntlProvider locale="en" defaultLocale="en">
+      <App extensions={extensions} />
+    </IntlProvider>
+  );
+}
+
+export type AIWorkspaceProps = {
+  extensions?: readonly AIWorkspaceExtension[];
+};
+
+export default function AIWorkspace({ extensions = [] }: AIWorkspaceProps) {
+  return (
+    <OxygenUIThemeProvider
+      themes={[
+        {
+          key: "acrylicOrange",
+          label: "Acrylic Orange Theme",
+          theme: AcrylicOrangeTheme,
+        },
+        {
+          key: "acrylicPurple",
+          label: "Acrylic Purple Theme",
+          theme: AcrylicPurpleTheme,
+        },
+        {
+          key: "highContrast",
+          label: "High Contrast Theme",
+          theme: HighContrastTheme,
+        },
+        { key: "classic", label: "Classic Theme", theme: ClassicTheme },
+      ]}
+      initialTheme="acrylicOrange"
+    >
+      <BrowserRouter basename={BASE_PATH}>
+        <BFFAuthProvider>
+          <AppGate extensions={extensions} />
+        </BFFAuthProvider>
+      </BrowserRouter>
+    </OxygenUIThemeProvider>
+  );
+}

--- a/portals/ai-workspace/src/AIWorkspace.tsx
+++ b/portals/ai-workspace/src/AIWorkspace.tsx
@@ -1,6 +1,19 @@
 /*
  * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
- * Licensed under the Apache License, Version 2.0.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 import React, { useEffect } from "react";

--- a/portals/ai-workspace/src/App.tsx
+++ b/portals/ai-workspace/src/App.tsx
@@ -85,6 +85,10 @@ import { ChoreoUserProvider } from './contexts/ChoreoUserContext';
 import { useAppAuth } from './contexts/AppAuthContext';
 import { Box, Button, Stack, Typography } from '@wso2/oxygen-ui';
 import OoopsImage from './assets/images/Ooops.svg';
+import {
+  ExtensionsProvider,
+  type AIWorkspaceExtension,
+} from './extensions';
 
 /**
  * Only allow same-origin relative paths as return URLs to prevent open redirects.
@@ -275,7 +279,17 @@ function WithPageBoundary({ children }: { children: React.ReactNode }) {
   return <RoutePageBoundary>{children}</RoutePageBoundary>;
 }
 
-export default function App() {
+export type AppProps = {
+  extensions?: readonly AIWorkspaceExtension[];
+};
+
+function WorkspaceRoutes({ extensions = [] }: AppProps) {
+  const extensionRoutes = extensions.map((extension) => (
+    <Route key={extension.id} path={extension.path} element={
+      <WithPageBoundary>{extension.element}</WithPageBoundary>
+    } />
+  ));
+
   return (
     <ChoreoUserProvider>
       <Routes>
@@ -592,6 +606,7 @@ export default function App() {
                 />
               </Route>
             </Route>
+            {extensionRoutes}
             <Route path="projects/:projectSlug" element={<ProjectShell />}>
               <Route index element={<Navigate to="home" replace />} />
               <Route
@@ -803,6 +818,7 @@ export default function App() {
                   />
                 </Route>
               </Route>
+              {extensionRoutes}
             </Route>
           </Route>
         </Route>
@@ -810,5 +826,13 @@ export default function App() {
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </ChoreoUserProvider>
+  );
+}
+
+export default function App({ extensions = [] }: AppProps) {
+  return (
+    <ExtensionsProvider extensions={extensions}>
+      <WorkspaceRoutes extensions={extensions} />
+    </ExtensionsProvider>
   );
 }

--- a/portals/ai-workspace/src/extensions.tsx
+++ b/portals/ai-workspace/src/extensions.tsx
@@ -1,6 +1,19 @@
 /*
  * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
- * Licensed under the Apache License, Version 2.0.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 import React, { createContext, useContext } from 'react';

--- a/portals/ai-workspace/src/extensions.tsx
+++ b/portals/ai-workspace/src/extensions.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ * Licensed under the Apache License, Version 2.0.
+ */
+
+import React, { createContext, useContext } from 'react';
+
+export type AIWorkspaceExtension = {
+  id: string;
+  path: string;
+  label: string;
+  icon?: React.ReactNode;
+  element: React.ReactNode;
+};
+
+const ExtensionsContext = createContext<readonly AIWorkspaceExtension[]>([]);
+
+export function ExtensionsProvider({
+  extensions,
+  children,
+}: {
+  extensions: readonly AIWorkspaceExtension[];
+  children: React.ReactNode;
+}) {
+  return (
+    <ExtensionsContext.Provider value={extensions}>
+      {children}
+    </ExtensionsContext.Provider>
+  );
+}
+
+export function useAIWorkspaceExtensions(): readonly AIWorkspaceExtension[] {
+  return useContext(ExtensionsContext);
+}

--- a/portals/ai-workspace/src/index.ts
+++ b/portals/ai-workspace/src/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ * Licensed under the Apache License, Version 2.0.
+ */
+
+export { default as App } from './App';
+export type { AppProps } from './App';
+export { default as AIWorkspace } from './AIWorkspace';
+export type { AIWorkspaceProps } from './AIWorkspace';
+export type { AIWorkspaceExtension } from './extensions';
+export { BASE_PATH } from './paths';

--- a/portals/ai-workspace/src/main.tsx
+++ b/portals/ai-workspace/src/main.tsx
@@ -1,118 +1,14 @@
 /*
  * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
- *
- * WSO2 LLC. licenses this file to you under the Apache License,
- * Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Licensed under the Apache License, Version 2.0.
  */
 
-import React, { useEffect } from 'react';
-import { createRoot } from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
-import { IntlProvider } from 'react-intl';
-import {
-  AcrylicOrangeTheme, AcrylicPurpleTheme, ClassicTheme,
-  HighContrastTheme, OxygenUIThemeProvider,
-  Box, LinearProgress, Stack, Typography,
-} from '@wso2/oxygen-ui';
+import React from "react";
+import { createRoot } from "react-dom/client";
+import AIWorkspace from "./AIWorkspace";
 
-import App from './App.tsx';
-import './styles.css';
-import { AUTH_MODE } from './config.env';
-import { BASE_PATH } from './paths';
-import { BFFAuthProvider } from './contexts/BFFAuthProvider';
-import { useAppAuth } from './contexts/AppAuthContext';
-import BasicAuthLoginPage from './pages/login/BasicAuthLoginPage';
-
-// ── Loading screen ──────────────────────────────────────────────────────────
-
-function LoadingScreen({ message }: { message?: string }) {
-  return (
-    <Box sx={{ minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', p: 4 }}>
-      <Stack spacing={2} alignItems="center" sx={{ maxWidth: 480, textAlign: 'center' }}>
-        {message && <Typography color="text.secondary">{message}</Typography>}
-        <Box sx={{ width: 200 }}>
-          <LinearProgress color="primary" variant="indeterminate" />
-        </Box>
-      </Stack>
-    </Box>
-  );
-}
-
-// ── OIDC redirect — the BFF owns the handshake; we just navigate to it ─────────
-
-function OIDCRedirect() {
-  const { login } = useAppAuth();
-  useEffect(() => { void login(); }, [login]);
-  return <LoadingScreen message="Redirecting to sign in…" />;
-}
-
-// ── AppGate — decides login UX vs. the authenticated app ──────────────────────
-
-function AppGate() {
-  const { isAuthenticated, isLoading } = useAppAuth();
-
-  if (isLoading) {
-    return <LoadingScreen />;
-  }
-
-  if (!isAuthenticated) {
-    if (AUTH_MODE === 'basic') {
-      // On success the BFF has set the session cookie; reload to re-hydrate while
-      // preserving the path the user originally requested (matching OIDC return
-      // behaviour). Only avoid pinning to the login route itself.
-      return <BasicAuthLoginPage onSuccess={() => {
-        // window.location is outside the router, so these paths carry the base path
-        // (BrowserRouter's basename) and the fallback has to add it back.
-        const { pathname, search, hash } = window.location;
-        const route = pathname.startsWith(BASE_PATH) ? pathname.slice(BASE_PATH.length) : pathname;
-        const target = route === '/login' || route === '/signin'
-          ? `${BASE_PATH}/`
-          : pathname + search + hash;
-        window.location.replace(target);
-      }} />;
-    }
-    return <OIDCRedirect />;
-  }
-
-  return (
-    <IntlProvider locale="en" defaultLocale="en">
-      <App />
-    </IntlProvider>
-  );
-}
-
-// ── Entry point ───────────────────────────────────────────────────────────────
-
-const container = document.getElementById('root')!;
-const root = createRoot(container);
-
-root.render(
+createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <OxygenUIThemeProvider
-      themes={[
-        { key: 'acrylicOrange', label: 'Acrylic Orange Theme', theme: AcrylicOrangeTheme },
-        { key: 'acrylicPurple', label: 'Acrylic Purple Theme', theme: AcrylicPurpleTheme },
-        { key: 'highContrast', label: 'High Contrast Theme', theme: HighContrastTheme },
-        { key: 'classic', label: 'Classic Theme', theme: ClassicTheme },
-      ]}
-      initialTheme="acrylicOrange"
-    >
-      <BrowserRouter basename={BASE_PATH}>
-        <BFFAuthProvider>
-          <AppGate />
-        </BFFAuthProvider>
-      </BrowserRouter>
-    </OxygenUIThemeProvider>
-  </React.StrictMode>
+    <AIWorkspace />
+  </React.StrictMode>,
 );

--- a/portals/ai-workspace/src/main.tsx
+++ b/portals/ai-workspace/src/main.tsx
@@ -1,6 +1,19 @@
 /*
  * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
- * Licensed under the Apache License, Version 2.0.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 import React from "react";

--- a/portals/ai-workspace/src/pages/appShell/AppSidebar.tsx
+++ b/portals/ai-workspace/src/pages/appShell/AppSidebar.tsx
@@ -38,6 +38,7 @@ import { buildOrgPath, buildProjectPath } from '../../utils/projectRouting';
 import QuickStartIntroPopup, {
   QS_INTRO_STORAGE_KEY,
 } from './QuickStartIntroPopup';
+import { useAIWorkspaceExtensions } from '../../extensions';
 
 const navLinkStyle: React.CSSProperties = {
   textDecoration: 'none',
@@ -64,6 +65,7 @@ export default function AppSidebar({
   const [showIntro, setShowIntro] = useState(
     () => !localStorage.getItem(QS_INTRO_STORAGE_KEY)
   );
+  const extensions = useAIWorkspaceExtensions();
 
   const handleDismissIntro = () => {
     localStorage.setItem(QS_INTRO_STORAGE_KEY, '1');
@@ -127,6 +129,9 @@ export default function AppSidebar({
   const settingsPath = currentProject
     ? buildProjectPath(currentOrganization, currentProject, '/settings')
     : orgSettingsPath;
+  const extensionPath = (path: string) => currentProject
+    ? buildProjectPath(currentOrganization, currentProject, `/${path}`)
+    : buildOrgPath(currentOrganization, `/${path}`);
   return (
     <Sidebar
       collapsed={shellState.sidebarCollapsed}
@@ -300,6 +305,27 @@ export default function AppSidebar({
               </NavLink>
             )}
           </Sidebar.Category>
+          {extensions.length > 0 && (
+            <Sidebar.Category>
+              <Sidebar.CategoryLabel>
+                <span style={{ fontSize: '0.8rem' }}>Cloud</span>
+              </Sidebar.CategoryLabel>
+              {extensions.map((extension) => (
+                <NavLink
+                  key={extension.id}
+                  to={extensionPath(extension.path)}
+                  style={navLinkStyle}
+                >
+                  <Sidebar.Item id={extension.id}>
+                    <Sidebar.ItemIcon>
+                      {extension.icon ?? <Settings size={20} />}
+                    </Sidebar.ItemIcon>
+                    <Sidebar.ItemLabel>{extension.label}</Sidebar.ItemLabel>
+                  </Sidebar.Item>
+                </NavLink>
+              ))}
+            </Sidebar.Category>
+          )}
         </Box>
       </Sidebar.Nav>
 

--- a/portals/ai-workspace/src/pages/appShell/appShellMain.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellMain.tsx
@@ -48,6 +48,7 @@ import {
 import { logger } from '../../utils/logger';
 import { FormattedMessage } from 'react-intl';
 import OoopsImage from '../../assets/images/Ooops.svg';
+import { useAIWorkspaceExtensions } from '../../extensions';
 
 type SelectableOrg = {
   id: string;
@@ -64,6 +65,7 @@ type SelectableProject = {
 export default function AppLayout(): JSX.Element {
   const navigate = useNavigate();
   const location = useLocation();
+  const extensions = useAIWorkspaceExtensions();
   const { logout } = useAppAuth();
   // [standalone] const { signOut } = useAuthContext();
 
@@ -142,6 +144,16 @@ export default function AppLayout(): JSX.Element {
       ? segments[3] ?? ''
       : segments[1] ?? '';
     const tertiarySegment = isOrgScoped ? segments[4] ?? '' : segments[2] ?? '';
+    const extensionSegment = primarySegment === 'projects'
+      ? tertiarySegment
+      : primarySegment;
+    const activeExtension = extensions.find(
+      (extension) => extension.path.split('/')[0] === extensionSegment
+    );
+    if (activeExtension) {
+      shellActions.setActiveMenuItem(activeExtension.id);
+      return;
+    }
 
     if (!primarySegment || primarySegment === 'home') {
       shellActions.setActiveMenuItem('overview');
@@ -240,7 +252,7 @@ export default function AppLayout(): JSX.Element {
     if (primarySegment === 'settings') {
       shellActions.setActiveMenuItem('settings');
     }
-  }, [location.pathname, shellActions, currentProject, currentOrganization]);
+  }, [location.pathname, shellActions, currentProject, currentOrganization, extensions]);
 
   useEffect(() => {
     const legalLinks = [


### PR DESCRIPTION
This pull request introduces a new extension system for the AI Workspace, enabling the platform to support pluggable extensions that can add custom routes and navigation items. The changes include new context providers, updates to the main entry point, and modifications to the sidebar and app shell to surface extensions in the UI.

Issue: https://github.com/wso2-enterprise/apim-saas/issues/2882

**Extension system and context:**

* Introduced a new `AIWorkspaceExtension` type and an `ExtensionsProvider` context in `src/extensions.tsx` to manage and provide extension definitions throughout the app.
* Updated `App` and `AIWorkspace` components to accept an `extensions` prop, propagate it via context, and inject extension routes into the router. [[1]](diffhunk://#diff-4da7d52c0f032f6c555c67000c9107432507d795d0dd6a5d757e04a75c2d11d3R88-R91) [[2]](diffhunk://#diff-4da7d52c0f032f6c555c67000c9107432507d795d0dd6a5d757e04a75c2d11d3L278-R292) [[3]](diffhunk://#diff-4da7d52c0f032f6c555c67000c9107432507d795d0dd6a5d757e04a75c2d11d3R609) [[4]](diffhunk://#diff-4da7d52c0f032f6c555c67000c9107432507d795d0dd6a5d757e04a75c2d11d3R821) [[5]](diffhunk://#diff-4da7d52c0f032f6c555c67000c9107432507d795d0dd6a5d757e04a75c2d11d3R831-R838) [[6]](diffhunk://#diff-b46e7dc90f410fe94cb03d98e2b401c98eca8e0e05f244cbcaa1440948a3374eR1-R131)

**Sidebar and navigation integration:**

* Modified `AppSidebar` to consume extensions from context and render a new "Cloud" category with navigation links for each registered extension. [[1]](diffhunk://#diff-b66ed1a354b06c8db170f136461281126bd16f38b2f0a76d0fe8d80aa20956dfR41) [[2]](diffhunk://#diff-b66ed1a354b06c8db170f136461281126bd16f38b2f0a76d0fe8d80aa20956dfR68) [[3]](diffhunk://#diff-b66ed1a354b06c8db170f136461281126bd16f38b2f0a76d0fe8d80aa20956dfR132-R134) [[4]](diffhunk://#diff-b66ed1a354b06c8db170f136461281126bd16f38b2f0a76d0fe8d80aa20956dfR308-R328)
* Enhanced menu item selection logic in `appShellMain.tsx` to automatically highlight the correct sidebar item for extension routes. [[1]](diffhunk://#diff-7b7a33d1dac18ffc176bd79bc777f55eebdc79965799fc30dbbdc5afdb369cfbR51) [[2]](diffhunk://#diff-7b7a33d1dac18ffc176bd79bc777f55eebdc79965799fc30dbbdc5afdb369cfbR68) [[3]](diffhunk://#diff-7b7a33d1dac18ffc176bd79bc777f55eebdc79965799fc30dbbdc5afdb369cfbR147-R156) [[4]](diffhunk://#diff-7b7a33d1dac18ffc176bd79bc777f55eebdc79965799fc30dbbdc5afdb369cfbL243-R255)

**Entry point and exports:**

* Refactored `main.tsx` to use the new `AIWorkspace` entrypoint, simplifying the bootstrapping logic and centralizing theme and authentication handling. [[1]](diffhunk://#diff-132dd4bf3a5793e0c1276da922a570270f57d547ef2be5edaf60166978463e71L3-R13) [[2]](diffhunk://#diff-b46e7dc90f410fe94cb03d98e2b401c98eca8e0e05f244cbcaa1440948a3374eR1-R131)
* Updated `package.json` and `index.ts` to expose the new extension-related types and entrypoints for external consumption. [[1]](diffhunk://#diff-7d2e3382b59f682a1ace095428da5dde428acfe12e17aa3cf507cf2f2b4d719eR6-R7) [[2]](diffhunk://#diff-7a7fd3118ddd5eb92a9069c2b96f2c849da0159fd95f2638291fb1b5bc6c98a8R1-R11)

These changes collectively make the AI Workspace modular and extensible, allowing new features to be integrated as extensions with minimal changes to the core codebase.