### PR TITLE
Bypass JWT signature validation via a build-time flag instead of config

### DIFF
--- a/platform-api/config/config.go
+++ b/platform-api/config/config.go
@@ -330,6 +330,37 @@ type JWT struct {
 	TokenTTL       time.Duration `koanf:"token_ttl"`
 }
 
+// skipJWTValidation is stamped in at BUILD time via ldflags, exactly like the
+// binary's version (-X ...config.skipJWTValidation=true) — it is deliberately NOT
+// a config-file field. Disabling JWT signature validation is a property of a
+// specific build (the cloud build fronted by a trusted mediation layer on a
+// private network that has already authenticated the caller and forwards an
+// unsigned internal token carrying the org context), never a runtime toggle an
+// operator could flip on an internet-facing deployment. The empty default that
+// every normal build carries means strict validation.
+var skipJWTValidation string
+
+// skipJWTValidationEnabled is the parsed skipJWTValidation, evaluated once at
+// package initialization (the ldflags value is fixed at link time) so
+// SkipJWTValidation() is a plain field read on the hot authentication path.
+var skipJWTValidationEnabled = parseSkipJWTValidation(skipJWTValidation)
+
+// parseSkipJWTValidation reports whether the build-time flag value enables the
+// bypass: true only for the literal "true" (case-insensitive, surrounding space
+// trimmed); any other value keeps strict validation.
+func parseSkipJWTValidation(v string) bool {
+	return strings.EqualFold(strings.TrimSpace(v), "true")
+}
+
+// SkipJWTValidation reports whether this build disables JWT signature and issuer
+// verification in "internal_token" mode (see skipJWTValidation). DANGEROUS: it
+// makes unsigned ("none") tokens acceptable, so it must only be true in a build
+// deployed behind a trusted mediation layer on a private network. Ignored in
+// "file" and "idp" modes.
+func SkipJWTValidation() bool {
+	return skipJWTValidationEnabled
+}
+
 // LoadPublicKey reads and parses the PEM-encoded RSA public key from
 // PublicKeyFile. The file is read fresh on every call rather than cached,
 // so PublicKeyFile is a mounted-file path, never inlined PEM content.

--- a/platform-api/config/skip_jwt_validation_test.go
+++ b/platform-api/config/skip_jwt_validation_test.go
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package config
+
+import "testing"
+
+// parseSkipJWTValidation backs the ldflags-stamped build var. It is true only for
+// the literal "true" (case-insensitive, surrounding space trimmed) — the empty
+// value every normal build carries, and any other value, keep strict validation.
+func TestParseSkipJWTValidation(t *testing.T) {
+	cases := []struct {
+		name string
+		val  string
+		want bool
+	}{
+		{"empty default is strict", "", false},
+		{"explicit false", "false", false},
+		{"arbitrary value is strict", "1", false},
+		{"true enables bypass", "true", true},
+		{"uppercase TRUE", "TRUE", true},
+		{"padded true", "  true  ", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseSkipJWTValidation(tc.val); got != tc.want {
+				t.Errorf("parseSkipJWTValidation(%q) = %v, want %v", tc.val, got, tc.want)
+			}
+		})
+	}
+}

--- a/platform-api/internal/middleware/auth_skip_validation_test.go
+++ b/platform-api/internal/middleware/auth_skip_validation_test.go
@@ -1,0 +1,102 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// unsignedToken builds an alg:none JWT with the given claims, mirroring the
+// unsigned internal token a trusted mediation layer forwards.
+func unsignedToken(t *testing.T, claims jwt.MapClaims) string {
+	t.Helper()
+	tok := jwt.NewWithClaims(jwt.SigningMethodNone, claims)
+	s, err := tok.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	if err != nil {
+		t.Fatalf("sign unsigned token: %v", err)
+	}
+	return s
+}
+
+func serve(mw func(http.Handler) http.Handler, token string, next http.HandlerFunc) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, "/api/v0.9/environments", nil)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	rec := httptest.NewRecorder()
+	mw(next).ServeHTTP(rec, req)
+	return rec
+}
+
+// With SkipValidation, an unsigned token is accepted and its organization claim
+// is enriched into the request context for GetOrganizationFromRequest.
+func TestLocalJWTAuthMiddleware_SkipValidation_AcceptsUnsignedAndResolvesOrg(t *testing.T) {
+	mw := LocalJWTAuthMiddleware(AuthConfig{SkipValidation: true})
+	token := unsignedToken(t, jwt.MapClaims{"organization": "org-uuid-123", "sub": "system"})
+
+	var gotOrg string
+	var called bool
+	rec := serve(mw, token, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		gotOrg, _ = GetOrganizationFromRequest(r)
+	})
+
+	if !called {
+		t.Fatalf("next handler not called; status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if gotOrg != "org-uuid-123" {
+		t.Errorf("organization = %q, want org-uuid-123", gotOrg)
+	}
+}
+
+// Even with SkipValidation, a token missing the organization claim is rejected.
+func TestLocalJWTAuthMiddleware_SkipValidation_RejectsMissingOrgClaim(t *testing.T) {
+	mw := LocalJWTAuthMiddleware(AuthConfig{SkipValidation: true})
+	token := unsignedToken(t, jwt.MapClaims{"sub": "system"})
+
+	called := false
+	rec := serve(mw, token, func(http.ResponseWriter, *http.Request) { called = true })
+
+	if called {
+		t.Fatal("next handler should not be called when the org claim is absent")
+	}
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+}
+
+// Without SkipValidation, an unsigned (alg:none) token is rejected — signature
+// enforcement stays strict by default.
+func TestLocalJWTAuthMiddleware_StrictByDefault_RejectsUnsigned(t *testing.T) {
+	mw := LocalJWTAuthMiddleware(AuthConfig{SkipValidation: false})
+	token := unsignedToken(t, jwt.MapClaims{"organization": "org-uuid-123"})
+
+	called := false
+	rec := serve(mw, token, func(http.ResponseWriter, *http.Request) { called = true })
+
+	if called {
+		t.Fatal("next handler should not be called for an unsigned token under strict validation")
+	}
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+}

--- a/platform-api/internal/server/server.go
+++ b/platform-api/internal/server/server.go
@@ -673,6 +673,22 @@ func buildClaimMappings(cm config.ClaimMappings, roleScopeMap map[string][]strin
 // its own local-JWT middleware).
 func buildAuthenticator(cfg *config.Server, slogger *slog.Logger, roleScopeMap map[string][]string) (middleware.Authenticator, error) {
 	if cfg.Auth.Mode != config.AuthModeIDP {
+		// Signature-validation bypass: only for builds fronted by a trusted
+		// mediation layer on a private network that has already authenticated the
+		// caller and forwards an unsigned internal token carrying the org context
+		// (see config.SkipJWTValidation — a build-time flag, not a config field).
+		// No public key is loaded; claims are still read.
+		if config.SkipJWTValidation() {
+			slogger.Warn("Auth mode: internal_token with signature validation DISABLED (build-time config.skipJWTValidation=true) — accepting unsigned tokens; use ONLY behind a trusted mediation layer on a private network")
+			return middleware.NewJWTAuthenticator(
+				middleware.LocalJWTAuthMiddleware(middleware.AuthConfig{
+					TokenIssuer:    cfg.Auth.JWT.Issuer,
+					SkipPaths:      cfg.Auth.SkipPaths,
+					SkipValidation: true,
+					ClaimMappings:  buildClaimMappings(cfg.Auth.ClaimMappings, roleScopeMap),
+				}),
+			), nil
+		}
 		slogger.Info("Auth mode: jwt (asymmetric RS256 signature validation enabled)")
 		publicKey, err := cfg.Auth.JWT.LoadPublicKey()
 		if err != nil {


### PR DESCRIPTION
## Purpose

Some deployments front `platform-api` (in `internal_token` mode) with a **trusted mediation layer on a private network** that has already authenticated the caller and forwards an unsigned internal token carrying only the org context. Those deployments need `platform-api` to read the token's claims without verifying its signature.

The concern is how that bypass is *exposed*. A `config.toml` field (`auth.jwt.skip_validation`) is a runtime toggle any operator could flip — including on an internet-facing listener, where it would let anyone forge claims. Signature-bypass should not be an operator-flippable setting at all.

## Goals

Make the signature-validation bypass a **property of a specific build**, not a runtime configuration option — so no configuration change on a normally-built binary can ever disable signature validation.

## Approach

The bypass is now a **build-time variable stamped in via ldflags**, mirroring how the binary's version is injected:

```
-X github.com/wso2/api-platform/platform-api/config.skipJWTValidation=true
```

- `config.skipJWTValidation` is an unexported package-scope string var; `config.SkipJWTValidation()` reports whether the build set it to `true` (case-insensitive, trimmed).
- The empty default that every normal build carries keeps strict RS256 validation. There is no `config.toml` key — the field was removed from the `JWT` config struct and the config template.
- `buildAuthenticator` reads `config.SkipJWTValidation()` in `internal_token` mode; when true it logs a prominent warning and wires the local-JWT middleware to accept unsigned tokens (claims still read; org claim still required). When false it loads the public key and validates as before. File mode is unaffected — it is handled by a separate branch that always loads the public key and validates strictly.

This replaces the earlier `auth.jwt.skip_validation` config field from this PR's first revision.

## Documentation

N/A — the removed config key was documented inline in `config-template.toml`; that block is replaced with a note pointing to the build-time flag.

## Automation tests

- Unit tests
  > `config`: `TestSkipJWTValidation` covers the accessor's parsing (empty/false/arbitrary → strict; `true`/`TRUE`/padded → bypass). `middleware`: existing `auth_skip_validation_test.go` covers the middleware behavior (unsigned token accepted + org resolved with bypass; missing org claim still 401; unsigned rejected under strict). `go build ./...`, `go test ./config/... ./internal/middleware/...` pass; symbol verified linkable under the ldflag.
- Integration tests
  > N/A — covered by unit tests at the config and middleware layers.

## Security checks

- Followed secure coding standards? **yes** — the bypass is no longer runtime-configurable; a normal build cannot disable signature validation, and the default is strict RS256. When bypass is compiled in, the org claim is still required and a loud warning is logged at startup.
- Ran FindSecurityBugs plugin and verified report? **N/A** (Go module; not a Java/FindSecurityBugs target).
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**.

## Related PRs

N/A — the consuming build passes the ldflag from its own build tooling.

## Test environment

Go (module build); linux/amd64 + linux/arm64 build targets.

- Resolves https://github.com/wso2/api-platform/issues/3211
