### PR TITLE
fix(controller): rebuild Envoy xDS snapshot after wiring transformers

### DIFF
--- a/gateway/gateway-controller/cmd/controller/main.go
+++ b/gateway/gateway-controller/cmd/controller/main.go
@@ -469,6 +469,22 @@ func main() {
 		slog.Int("total_apis", len(loadedAPIs)),
 		slog.Int("configs_loaded", loadedCount))
 
+	// Regenerate the Envoy xDS snapshot now that the transformers are wired (above)
+	// and runtime configs are loaded. The initial snapshot generated earlier ran
+	// before SetTransformers, so it fell back to the legacy translation path — naming
+	// clusters "cluster_<scheme>_<host>" and routes without the header-hash
+	// discriminator. The policy engine's resources are keyed off the transformer path
+	// ("upstream_<name>_<host>_<port>" clusters, header-hashed route names), so without
+	// this rebuild Envoy and the policy engine disagree: cluster-header APIs fail with
+	// cluster_not_found and header-matched routes 500 with "policy chain not found"
+	// until the first redeploy happens to re-run the transformer path.
+	log.Info("Regenerating xDS snapshot via transformer path after wiring transformers")
+	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
+	if err := snapshotManager.UpdateSnapshot(ctx, ""); err != nil {
+		log.Warn("Failed to regenerate xDS snapshot after transformer init", slog.Any("error", err))
+	}
+	cancel()
+
 	// Generate initial policy snapshot
 	log.Info("Generating initial policy xDS snapshot")
 	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)

--- a/gateway/gateway-controller/pkg/xds/translator.go
+++ b/gateway/gateway-controller/pkg/xds/translator.go
@@ -747,6 +747,17 @@ func (t *Translator) TranslateConfigs(
 					routesList, clusterList, err = t.eventGatewayHooks.TranslateWebSubAPI(t, cfg, configs)
 				}
 			} else {
+				// No transformer produced routes for a non-WebSub kind. If the kind has
+				// no transformer registered at all, we silently fell back here — a nil or
+				// unwired transformer map returns ok=false at the check above, with no
+				// error. Surface it, because the resulting Envoy snapshot uses legacy
+				// cluster/route naming that the policy engine's transformer-path resources
+				// don't match. (A transformer that errored is already logged above.)
+				if _, ok := t.transformers[cfg.Kind]; !ok {
+					log.Warn("No transformer registered for API kind; using legacy translation path",
+						slog.String("kind", cfg.Kind),
+						slog.String("id", cfg.UUID))
+				}
 				routesList, clusterList, err = t.translateAPIConfig(cfg, configs)
 			}
 			if err != nil {


### PR DESCRIPTION
## Purpose

On controller startup the initial Envoy xDS snapshot is generated before `translator.SetTransformers(...)` runs, so it falls back to the legacy translation path.
The legacy path names clusters `cluster_<scheme>_<host>` and names routes without the header-hash discriminator, while the policy engine's resources are built from the transformer path (`upstream_<name>_<host>_<port>` clusters and header-hashed route names).
The two subsystems therefore disagree until the first redeploy happens to re-run the transformer path: cluster-header APIs (those with named upstream definitions or a sandbox) fail with `cluster_not_found`, and header-matched routes return `500` with "policy chain not found".
A restart silently reintroduces the broken state, and it persists until the next deploy/event rebuilds the snapshot.

## Goals

- Make the Envoy snapshot consistent with the policy engine snapshot from the moment the controller finishes startup, without waiting for a redeploy.
- Make the silent legacy-path fallback observable so this class of regression is visible in logs.

## Approach

- Regenerate the Envoy xDS snapshot in `cmd/controller/main.go` after the transformers are wired and the runtime configs are loaded, immediately before the initial policy snapshot is built. The earlier snapshot ran before `SetTransformers`, so this second `snapshotManager.UpdateSnapshot(ctx, "")` rebuilds Envoy resources through the transformer path, matching the cluster and route names the policy engine references.
- Emit a warning in `TranslateConfigs` (`pkg/xds/translator.go`) when a non-WebSub kind falls back to the legacy path because no transformer is registered. A nil or unwired transformer map returns `ok=false` with no error, so this previously happened silently; a transformer that errored is already logged separately.

## User stories

As a gateway operator, after the controller restarts I expect existing APIs to keep routing correctly without having to redeploy them.

## Documentation

N/A — internal control-plane startup-ordering fix with no user-facing API or configuration change.

## Automation tests
 - Unit tests
   > No new unit test was added for this fix specifically. Existing `pkg/xds` tests pass (`go test ./pkg/xds/...`), and `go build ./cmd/controller/...` and `go vet ./cmd/controller/... ./pkg/xds/...` are clean. A regression test asserting that transformer-path Envoy cluster names match the policy snapshot's `upstream_...` keys is a recommended follow-up.
 - Integration tests
   > None added. Recommended manual/IT validation: deploy one plain direct-URL API and one API with named upstream definitions, restart the controller, and confirm both route successfully without a redeploy (the upstream-definition API previously returned `cluster_not_found`).

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — FindSecurityBugs targets Java; this change is Go.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

N/A

## Test environment

Go toolchain build/vet/test on macOS (darwin/arm64).

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)