### PR TITLE
Add LLM security validation

### DIFF
--- a/platform-api/internal/service/llm.go
+++ b/platform-api/internal/service/llm.go
@@ -3328,7 +3328,7 @@ func mapSecurityAPIToModel(in *api.SecurityConfig) *model.SecurityConfig {
 	out := &model.SecurityConfig{Enabled: in.Enabled}
 	if in.ApiKey != nil {
 		key := utils.ValueOrEmpty(in.ApiKey.Key)
-		inLoc := ""
+		inLoc := "header"
 		if in.ApiKey.In != nil {
 			inLoc = string(*in.ApiKey.In)
 		}

--- a/platform-api/internal/service/llm.go
+++ b/platform-api/internal/service/llm.go
@@ -883,6 +883,9 @@ func (s *LLMProviderService) Create(orgUUID, createdBy string, req *api.LLMProvi
 	if err := validateLLMPolicyVersions(req.Policies); err != nil {
 		return nil, err
 	}
+	if err := validateSecurityConfig(req.Security); err != nil {
+		return nil, err
+	}
 	if err := validateModelProviders(req.Template, req.ModelProviders); err != nil {
 		return nil, err
 	}
@@ -1142,6 +1145,9 @@ func (s *LLMProviderService) Update(orgUUID, handle, updatedBy string, req *api.
 		return nil, err
 	}
 	if err := validateLLMPolicyVersions(req.Policies); err != nil {
+		return nil, err
+	}
+	if err := validateSecurityConfig(req.Security); err != nil {
 		return nil, err
 	}
 	if err := validateModelProviders(req.Template, req.ModelProviders); err != nil {
@@ -1445,6 +1451,9 @@ func (s *LLMProxyService) Create(orgUUID, createdBy string, req *api.LLMProxy) (
 		return nil, err
 	}
 	if err := validateLLMPolicyVersions(req.Policies); err != nil {
+		return nil, err
+	}
+	if err := validateSecurityConfig(req.Security); err != nil {
 		return nil, err
 	}
 	// req.ProjectId is the project handle; resolve it to the project UUID so the
@@ -1756,6 +1765,9 @@ func (s *LLMProxyService) Update(orgUUID, handle, updatedBy string, req *api.LLM
 	if err := validateLLMPolicyVersions(req.Policies); err != nil {
 		return nil, err
 	}
+	if err := validateSecurityConfig(req.Security); err != nil {
+		return nil, err
+	}
 
 	existing, err := s.repo.GetByID(handle, orgUUID)
 	if err != nil {
@@ -1972,6 +1984,27 @@ func validateUpstreamDefinition(name string, definition api.UpstreamDefinition) 
 	hasRef := strings.TrimSpace(utils.ValueOrEmpty(definition.Ref)) != ""
 	if hasUrl == hasRef {
 		return apperror.ValidationFailed.New(fmt.Sprintf("The upstream %s must specify either a url or a ref, not both.", name))
+	}
+	return nil
+}
+
+// validateSecurityConfig enforces that an enabled API-key security config carries a
+// non-empty header/query key name — mirrors the check generateLLM{Provider,Proxy}DeploymentYAML
+// performs at deploy time, run here so the request fails fast with a 400 instead of only
+// surfacing as an error at deploy.
+func validateSecurityConfig(sec *api.SecurityConfig) error {
+	if sec == nil || !isBoolTrue(sec.Enabled) || sec.ApiKey == nil || !isBoolTrue(sec.ApiKey.Enabled) {
+		return nil
+	}
+	if strings.TrimSpace(utils.ValueOrEmpty(sec.ApiKey.Key)) == "" {
+		return apperror.ValidationFailed.New("The security.apiKey.key field is required when API key security is enabled.")
+	}
+	in := ""
+	if sec.ApiKey.In != nil {
+		in = strings.ToLower(strings.TrimSpace(string(*sec.ApiKey.In)))
+	}
+	if in != "" && in != "header" && in != "query" {
+		return apperror.ValidationFailed.New("The security.apiKey.in field must be 'header' or 'query'.")
 	}
 	return nil
 }

--- a/platform-api/internal/service/llm.go
+++ b/platform-api/internal/service/llm.go
@@ -2003,7 +2003,7 @@ func validateSecurityConfig(sec *api.SecurityConfig) error {
 	if sec.ApiKey.In != nil {
 		in = strings.ToLower(strings.TrimSpace(string(*sec.ApiKey.In)))
 	}
-	if in != "" && in != "header" && in != "query" {
+	if in != "header" && in != "query" {
 		return apperror.ValidationFailed.New("The security.apiKey.in field must be 'header' or 'query'.")
 	}
 	return nil
@@ -3328,7 +3328,7 @@ func mapSecurityAPIToModel(in *api.SecurityConfig) *model.SecurityConfig {
 	out := &model.SecurityConfig{Enabled: in.Enabled}
 	if in.ApiKey != nil {
 		key := utils.ValueOrEmpty(in.ApiKey.Key)
-		inLoc := "header"
+		inLoc := ""
 		if in.ApiKey.In != nil {
 			inLoc = string(*in.ApiKey.In)
 		}

--- a/platform-api/internal/service/llm_deployment.go
+++ b/platform-api/internal/service/llm_deployment.go
@@ -674,12 +674,12 @@ func generateLLMProviderDeploymentYAML(provider *model.LLMProvider, templateHand
 		if security.APIKey != nil && isBoolTrue(security.APIKey.Enabled) {
 			key := strings.TrimSpace(security.APIKey.Key)
 			if key == "" {
-				return dto.LLMProviderDeploymentYAML{}, fmt.Errorf("invalid api key security configuration: key is required")
+				return dto.LLMProviderDeploymentYAML{}, apperror.LLMProviderDeploymentValidationFailed.New("invalid api key security configuration: key is required")
 			}
 
 			in := strings.ToLower(strings.TrimSpace(security.APIKey.In))
 			if in != "header" && in != "query" {
-				return dto.LLMProviderDeploymentYAML{}, fmt.Errorf("invalid api key security configuration: in must be 'header' or 'query', got %q", security.APIKey.In)
+				return dto.LLMProviderDeploymentYAML{}, apperror.LLMProviderDeploymentValidationFailed.New(fmt.Sprintf("invalid api key security configuration: in must be 'header' or 'query', got %q", security.APIKey.In))
 			}
 
 			params := map[string]interface{}{"key": key, "in": in}
@@ -1779,12 +1779,12 @@ func generateLLMProxyDeploymentYAML(proxy *model.LLMProxy) (dto.LLMProxyDeployme
 		if security.APIKey != nil && isBoolTrue(security.APIKey.Enabled) {
 			key := strings.TrimSpace(security.APIKey.Key)
 			if key == "" {
-				return dto.LLMProxyDeploymentYAML{}, fmt.Errorf("invalid api key security configuration: key is required")
+				return dto.LLMProxyDeploymentYAML{}, apperror.LLMProxyDeploymentValidationFailed.New("invalid api key security configuration: key is required")
 			}
 
 			in := strings.ToLower(strings.TrimSpace(security.APIKey.In))
 			if in != "header" && in != "query" {
-				return dto.LLMProxyDeploymentYAML{}, fmt.Errorf("invalid api key security configuration: in must be 'header' or 'query', got %q", security.APIKey.In)
+				return dto.LLMProxyDeploymentYAML{}, apperror.LLMProxyDeploymentValidationFailed.New(fmt.Sprintf("invalid api key security configuration: in must be 'header' or 'query', got %q", security.APIKey.In))
 			}
 
 			params := map[string]interface{}{"key": key, "in": in}

--- a/platform-api/resources/openapi.yaml
+++ b/platform-api/resources/openapi.yaml
@@ -5554,6 +5554,7 @@ components:
         key:
           type: string
           description: Name of the header or query parameter to be used for the API key
+          minLength: 1
           example: "X-API-Key"
         valuePrefix:
           type: string

--- a/platform-api/resources/openapi.yaml
+++ b/platform-api/resources/openapi.yaml
@@ -5554,7 +5554,6 @@ components:
         key:
           type: string
           description: Name of the header or query parameter to be used for the API key
-          minLength: 1
           example: "X-API-Key"
         valuePrefix:
           type: string

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyOverview.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxyOverview.tsx
@@ -273,6 +273,15 @@ function ProxyOverviewContent() {
     }
   }, [proxy, hasUnsavedChanges]);
 
+  const stagedSecurity = proxy?.security;
+  const isApiKeyEffectivelyEnabled =
+    stagedSecurity?.apiKey?.enabled ?? stagedSecurity?.enabled ?? true;
+  const isSecurityConfigValid =
+    !isApiKeyEffectivelyEnabled ||
+    (Boolean(stagedSecurity?.apiKey?.key?.trim()) &&
+      (stagedSecurity?.apiKey?.in === 'header' ||
+        stagedSecurity?.apiKey?.in === 'query'));
+
   const handleCancelChanges = () => {
     if (!savedProxy) return;
     setLocalProxy(savedProxy);
@@ -635,7 +644,7 @@ function ProxyOverviewContent() {
                 <Button
                   variant="contained"
                   disabled={
-                    !hasUnsavedChanges || isSavingChanges || !canUpdateProxy
+                    !hasUnsavedChanges || isSavingChanges || !canUpdateProxy || !isSecurityConfigValid
                   }
                   onClick={() => void handleSaveChanges()}
                 >

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxySecurityTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/proxies/LLMProxySecurityTab.tsx
@@ -55,6 +55,10 @@ export default function LLMProxySecurityTab() {
 
   const isFormDisabled =
     !apiKeyEnabled || isLoading || Boolean(error) || isReadOnlyProxy;
+  const isKeyValueInvalid =
+    authenticationType === 'apiKey' &&
+    apiKeyEnabled &&
+    keyName.trim().length === 0;
 
   useEffect(() => {
     if (!proxy) return;
@@ -191,6 +195,11 @@ export default function LLMProxySecurityTab() {
                   placeholder="X-API-Key"
                   value={keyName}
                   disabled={isFormDisabled}
+                  required={apiKeyEnabled}
+                  error={isKeyValueInvalid}
+                  helperText={
+                    isKeyValueInvalid ? 'API Key is required' : undefined
+                  }
                   onChange={handleKeyNameChange}
                 />
               </FormControl>

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverview.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverview.tsx
@@ -281,7 +281,6 @@ function ServiceProviderOverviewContent() {
   const draftProviderRef = useRef<LLMProvider | null>(null);
   const [hasDraftChanges, setHasDraftChanges] = useState(false);
   const [isRateLimitingDirty, setIsRateLimitingDirty] = useState(false);
-  const [isSecurityValid, setIsSecurityValid] = useState(true);
   const [isSavingChanges, setIsSavingChanges] = useState(false);
   const [rateLimitingActions, setRateLimitingActions] =
     useState<RateLimitingDraftActions | null>(null);
@@ -310,6 +309,12 @@ function ServiceProviderOverviewContent() {
   const [linkedProxyCount, setLinkedProxyCount] = useState<number | null>(null);
   const showSnackbar = useAIWorkspaceSnackbar();
   const hasUnsavedChanges = hasDraftChanges || isRateLimitingDirty;
+  const stagedSecurity = (draftProvider ?? provider)?.security;
+  const isSecurityConfigValid =
+    !(
+      stagedSecurity?.enabled === true &&
+      stagedSecurity?.apiKey?.enabled === true
+    ) || Boolean(stagedSecurity?.apiKey?.key?.trim());
   const selectedGateway = useMemo(
     () => gateways.find((gateway) => gateway.id === selectedGatewayId) ?? null,
     [gateways, selectedGatewayId]
@@ -406,7 +411,7 @@ function ServiceProviderOverviewContent() {
   const handleSaveChanges = async () => {
     if (!provider || isSavingChanges) return;
 
-    if (!isSecurityValid) {
+    if (!isSecurityConfigValid) {
       showSnackbar(
         'Enter a header or query parameter name for the API key before saving.',
         'error'
@@ -1719,9 +1724,7 @@ function ServiceProviderOverviewContent() {
                 {isReadOnlyProvider && (
                   <GatewayArtifactReadOnlyBanner message="Security settings are managed by the gateway that created this provider and are read-only here." />
                 )}
-                <ServiceProviderSecurityTab
-                  onValidityChange={setIsSecurityValid}
-                />
+                <ServiceProviderSecurityTab />
               </TabPanel>
 
               <TabPanel value={tabIndex} index={4}>
@@ -1780,7 +1783,7 @@ function ServiceProviderOverviewContent() {
                 </Button>
                 <Button
                   variant="contained"
-                  disabled={!hasUnsavedChanges || isSavingChanges || !isSecurityValid}
+                  disabled={!hasUnsavedChanges || isSavingChanges || !isSecurityConfigValid}
                   onClick={() => void handleSaveChanges()}
                 >
                   Save

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverview.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverview.tsx
@@ -310,11 +310,13 @@ function ServiceProviderOverviewContent() {
   const showSnackbar = useAIWorkspaceSnackbar();
   const hasUnsavedChanges = hasDraftChanges || isRateLimitingDirty;
   const stagedSecurity = (draftProvider ?? provider)?.security;
+  const isApiKeyEffectivelyEnabled =
+    stagedSecurity?.apiKey?.enabled ?? stagedSecurity?.enabled ?? true;
   const isSecurityConfigValid =
-    !(
-      stagedSecurity?.enabled === true &&
-      stagedSecurity?.apiKey?.enabled === true
-    ) || Boolean(stagedSecurity?.apiKey?.key?.trim());
+    !isApiKeyEffectivelyEnabled ||
+    (Boolean(stagedSecurity?.apiKey?.key?.trim()) &&
+      (stagedSecurity?.apiKey?.in === 'header' ||
+        stagedSecurity?.apiKey?.in === 'query'));
   const selectedGateway = useMemo(
     () => gateways.find((gateway) => gateway.id === selectedGatewayId) ?? null,
     [gateways, selectedGatewayId]
@@ -410,14 +412,6 @@ function ServiceProviderOverviewContent() {
 
   const handleSaveChanges = async () => {
     if (!provider || isSavingChanges) return;
-
-    if (!isSecurityConfigValid) {
-      showSnackbar(
-        'Enter a header or query parameter name for the API key before saving.',
-        'error'
-      );
-      return;
-    }
 
     let hasChangesToPersist = hasDraftChanges;
     if (isRateLimitingDirty) {

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverview.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverview.tsx
@@ -281,6 +281,7 @@ function ServiceProviderOverviewContent() {
   const draftProviderRef = useRef<LLMProvider | null>(null);
   const [hasDraftChanges, setHasDraftChanges] = useState(false);
   const [isRateLimitingDirty, setIsRateLimitingDirty] = useState(false);
+  const [isSecurityValid, setIsSecurityValid] = useState(true);
   const [isSavingChanges, setIsSavingChanges] = useState(false);
   const [rateLimitingActions, setRateLimitingActions] =
     useState<RateLimitingDraftActions | null>(null);
@@ -404,6 +405,14 @@ function ServiceProviderOverviewContent() {
 
   const handleSaveChanges = async () => {
     if (!provider || isSavingChanges) return;
+
+    if (!isSecurityValid) {
+      showSnackbar(
+        'Enter a header or query parameter name for the API key before saving.',
+        'error'
+      );
+      return;
+    }
 
     let hasChangesToPersist = hasDraftChanges;
     if (isRateLimitingDirty) {
@@ -1710,7 +1719,9 @@ function ServiceProviderOverviewContent() {
                 {isReadOnlyProvider && (
                   <GatewayArtifactReadOnlyBanner message="Security settings are managed by the gateway that created this provider and are read-only here." />
                 )}
-                <ServiceProviderSecurityTab />
+                <ServiceProviderSecurityTab
+                  onValidityChange={setIsSecurityValid}
+                />
               </TabPanel>
 
               <TabPanel value={tabIndex} index={4}>
@@ -1769,7 +1780,7 @@ function ServiceProviderOverviewContent() {
                 </Button>
                 <Button
                   variant="contained"
-                  disabled={!hasUnsavedChanges || isSavingChanges}
+                  disabled={!hasUnsavedChanges || isSavingChanges || !isSecurityValid}
                   onClick={() => void handleSaveChanges()}
                 >
                   Save

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderSecurityTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderSecurityTab.tsx
@@ -136,10 +136,9 @@ export default function ServiceProviderSecurityTab({
     setApiKeyEnabled(nextEnabled);
     if (nextEnabled && keyValue.trim().length === 0) {
       showSnackbar(
-        'Enter a header or query parameter name for the API key before enabling it.',
+        'Add an API key name before enabling API key authentication.',
         'error'
       );
-      return;
     }
     await updateSecurity(keyValue.trim(), keyIn, nextEnabled, valuePrefix.trim());
   };
@@ -147,16 +146,7 @@ export default function ServiceProviderSecurityTab({
   const handleKeyBlur = async () => {
     if (!provider || isLoading || error) return;
     const nextKey = keyValue.trim();
-    if (!nextKey) {
-      if (apiKeyEnabled) {
-        showSnackbar(
-          'Enter a header or query parameter name for the API key.',
-          'error'
-        );
-      }
-      return;
-    }
-    if (nextKey === (provider.security?.apiKey?.key || '')) {
+    if (!nextKey || nextKey === (provider.security?.apiKey?.key || '')) {
       return;
     }
     await updateSecurity(nextKey, keyIn, apiKeyEnabled, valuePrefix.trim());
@@ -253,13 +243,13 @@ export default function ServiceProviderSecurityTab({
                 error={isKeyValueInvalid}
                 helperText={
                   isKeyValueInvalid
-                    ? 'Enter a header or query parameter name for the API key.'
+                    ? 'API key name is required'
                     : undefined
                 }
                 onChange={(event) => {
                   const nextKey = event.target.value;
                   setKeyValue(nextKey);
-                  if (isDraftMode && nextKey.trim().length > 0) {
+                  if (isDraftMode) {
                     void updateSecurity(nextKey.trim(), keyIn, apiKeyEnabled, valuePrefix.trim());
                   }
                 }}

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderSecurityTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderSecurityTab.tsx
@@ -34,13 +34,7 @@ import { useLLMProvider } from '../../../../contexts/llmProvider';
 import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
 import { FormattedMessage } from 'react-intl';
 
-interface ServiceProviderSecurityTabProps {
-  onValidityChange?: (isValid: boolean) => void;
-}
-
-export default function ServiceProviderSecurityTab({
-  onValidityChange,
-}: ServiceProviderSecurityTabProps = {}) {
+export default function ServiceProviderSecurityTab() {
   const { provider, isLoading, error, updateProvider, isDraftMode } =
     useLLMProvider();
   const [authenticationType, setAuthenticationType] = useState('');
@@ -56,13 +50,6 @@ export default function ServiceProviderSecurityTab({
     authenticationType === 'apiKey' &&
     apiKeyEnabled &&
     keyValue.trim().length === 0;
-
-  useEffect(() => {
-    onValidityChange?.(!isKeyValueInvalid);
-    return () => {
-      onValidityChange?.(true);
-    };
-  }, [isKeyValueInvalid, onValidityChange]);
 
   useEffect(() => {
     if (!provider) return;
@@ -134,12 +121,6 @@ export default function ServiceProviderSecurityTab({
     const nextEnabled = event.target.checked;
     if (nextEnabled === apiKeyEnabled) return;
     setApiKeyEnabled(nextEnabled);
-    if (nextEnabled && keyValue.trim().length === 0) {
-      showSnackbar(
-        'Add an API key name before enabling API key authentication.',
-        'error'
-      );
-    }
     await updateSecurity(keyValue.trim(), keyIn, nextEnabled, valuePrefix.trim());
   };
 
@@ -243,7 +224,7 @@ export default function ServiceProviderSecurityTab({
                 error={isKeyValueInvalid}
                 helperText={
                   isKeyValueInvalid
-                    ? 'API key name is required'
+                    ? 'API Key is required'
                     : undefined
                 }
                 onChange={(event) => {

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderSecurityTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderSecurityTab.tsx
@@ -34,7 +34,13 @@ import { useLLMProvider } from '../../../../contexts/llmProvider';
 import useAIWorkspaceSnackbar from '../../../../hooks/aiWorkspaceSnackbar';
 import { FormattedMessage } from 'react-intl';
 
-export default function ServiceProviderSecurityTab() {
+interface ServiceProviderSecurityTabProps {
+  onValidityChange?: (isValid: boolean) => void;
+}
+
+export default function ServiceProviderSecurityTab({
+  onValidityChange,
+}: ServiceProviderSecurityTabProps = {}) {
   const { provider, isLoading, error, updateProvider, isDraftMode } =
     useLLMProvider();
   const [authenticationType, setAuthenticationType] = useState('');
@@ -46,6 +52,11 @@ export default function ServiceProviderSecurityTab() {
   const isReadOnlyProvider = Boolean(provider?.readOnly);
   const isSecurityFormDisabled =
     !apiKeyEnabled || isLoading || Boolean(error) || isReadOnlyProvider;
+  const isKeyValueInvalid = apiKeyEnabled && keyValue.trim().length === 0;
+
+  useEffect(() => {
+    onValidityChange?.(!isKeyValueInvalid);
+  }, [isKeyValueInvalid, onValidityChange]);
 
   useEffect(() => {
     if (!provider) return;
@@ -107,6 +118,7 @@ export default function ServiceProviderSecurityTab() {
     const nextType = String(event.target.value || '').trim();
     if (!nextType || nextType === authenticationType) return;
     setAuthenticationType(nextType);
+    if (keyValue.trim().length === 0) return;
     await updateSecurity(keyValue.trim(), keyIn, apiKeyEnabled, valuePrefix.trim());
   };
 
@@ -116,20 +128,36 @@ export default function ServiceProviderSecurityTab() {
     const nextEnabled = event.target.checked;
     if (nextEnabled === apiKeyEnabled) return;
     setApiKeyEnabled(nextEnabled);
+    if (nextEnabled && keyValue.trim().length === 0) {
+      showSnackbar(
+        'Enter a header or query parameter name for the API key before enabling it.',
+        'error'
+      );
+      return;
+    }
     await updateSecurity(keyValue.trim(), keyIn, nextEnabled, valuePrefix.trim());
   };
 
   const handleKeyBlur = async () => {
     if (!provider || isLoading || error) return;
     const nextKey = keyValue.trim();
-    if (!nextKey || nextKey === (provider.security?.apiKey?.key || '')) {
+    if (!nextKey) {
+      if (apiKeyEnabled) {
+        showSnackbar(
+          'Enter a header or query parameter name for the API key.',
+          'error'
+        );
+      }
+      return;
+    }
+    if (nextKey === (provider.security?.apiKey?.key || '')) {
       return;
     }
     await updateSecurity(nextKey, keyIn, apiKeyEnabled, valuePrefix.trim());
   };
 
   const handleValuePrefixBlur = async () => {
-    if (!provider || isLoading || error) return;
+    if (!provider || isLoading || error || isKeyValueInvalid) return;
     const nextValuePrefix = valuePrefix.trim();
     if (nextValuePrefix === (provider.security?.apiKey?.valuePrefix || '')) {
       return;
@@ -141,6 +169,7 @@ export default function ServiceProviderSecurityTab() {
     const nextIn = event.target.value as 'header' | 'query';
     if (nextIn === keyIn) return;
     setKeyIn(nextIn);
+    if (isKeyValueInvalid) return;
     await updateSecurity(keyValue.trim(), nextIn, apiKeyEnabled, valuePrefix.trim());
   };
 
@@ -214,10 +243,17 @@ export default function ServiceProviderSecurityTab() {
                 size="small"
                 value={keyValue}
                 disabled={isSecurityFormDisabled}
+                required={apiKeyEnabled}
+                error={isKeyValueInvalid}
+                helperText={
+                  isKeyValueInvalid
+                    ? 'Enter a header or query parameter name for the API key.'
+                    : undefined
+                }
                 onChange={(event) => {
                   const nextKey = event.target.value;
                   setKeyValue(nextKey);
-                  if (isDraftMode) {
+                  if (isDraftMode && nextKey.trim().length > 0) {
                     void updateSecurity(nextKey.trim(), keyIn, apiKeyEnabled, valuePrefix.trim());
                   }
                 }}
@@ -243,7 +279,7 @@ export default function ServiceProviderSecurityTab() {
                 onChange={(event) => {
                   const nextValuePrefix = event.target.value;
                   setValuePrefix(nextValuePrefix);
-                  if (isDraftMode) {
+                  if (isDraftMode && !isKeyValueInvalid) {
                     void updateSecurity(
                       keyValue.trim(),
                       keyIn,

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderSecurityTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderSecurityTab.tsx
@@ -52,10 +52,16 @@ export default function ServiceProviderSecurityTab({
   const isReadOnlyProvider = Boolean(provider?.readOnly);
   const isSecurityFormDisabled =
     !apiKeyEnabled || isLoading || Boolean(error) || isReadOnlyProvider;
-  const isKeyValueInvalid = apiKeyEnabled && keyValue.trim().length === 0;
+  const isKeyValueInvalid =
+    authenticationType === 'apiKey' &&
+    apiKeyEnabled &&
+    keyValue.trim().length === 0;
 
   useEffect(() => {
     onValidityChange?.(!isKeyValueInvalid);
+    return () => {
+      onValidityChange?.(true);
+    };
   }, [isKeyValueInvalid, onValidityChange]);
 
   useEffect(() => {


### PR DESCRIPTION
## Purpose
Implement comprehensive validation for LLM security configuration (API key) across both frontend and backend to ensure valid configuration at creation/update time rather than deployment time. This prevents incomplete or invalid security configurations from being persisted in the system.

Resolves 
- #3191

## Goals
1. Add backend validation for API key security configuration during LLM Provider and LLM Proxy Create/Update operations
2. Add frontend validation with real-time feedback to users when API key security is misconfigured
3. Align validation rules between frontend and backend to ensure consistency
4. Fail fast with clear error messages instead of allowing deployment failures later

## Approach
**Backend**: Added `validateSecurityConfig()` function in `platform-api/internal/service/llm.go` to validate API key security settings (required key field, valid 'header'/'query' location). Integrated into LLMProvider and LLMProxy Create/Update operations. Updated error handling to use proper error types and added `minLength: 1` constraint to OpenAPI spec.

**Frontend**: Added real-time validation in `ServiceProviderSecurityTab.tsx` that tracks security validity state and prevents enabling API key security without a key name. Parent component (`ServiceProviderOverview.tsx`) disables Save button when security config is invalid and shows error messages to users.

## User stories
N/A

## Documentation
N/A

## Automation tests
- Unit tests: Validate `validateSecurityConfig()` function with various input scenarios (enabled/disabled, valid/invalid key values, valid/invalid 'in' values)
- Integration tests: Test Create/Update endpoints with invalid security configurations to verify 400 response and proper error messages
- Frontend tests: Verify validation state tracking and UI behavior (enabled/disabled Save button, error messages)

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Test environment
- **Backend**: Go 1.21
- **Frontend**: Node.js 18+, React with TypeScript, tested on Chrome
