### PR TITLE
feat(platform-api): cloud release pipeline and configurable JWT signature skip

### DIFF
--- a/.github/workflows/platform-api-cloud-release.yml
+++ b/.github/workflows/platform-api-cloud-release.yml
@@ -40,4 +40,4 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push multi arch Docker images
-        run: make build-and-push-platform-api-cloud-multiarch PLATFORM_API_VERSION="${{ steps.version.outputs.IMAGE_VERSION }}" IMAGE_SUFFIX="platform-api-cloud"
+        run: make build-and-push-platform-api-multiarch PLATFORM_API_VERSION="${{ steps.version.outputs.IMAGE_VERSION }}" IMAGE_SUFFIX="platform-api-cloud"

--- a/.github/workflows/platform-api-cloud-release.yml
+++ b/.github/workflows/platform-api-cloud-release.yml
@@ -3,19 +3,26 @@ name: Platform API Cloud Release
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Compute image version
         id: version
         run: |
-          BRANCH="${GITHUB_REF_NAME//\//-}"
+          BRANCH="${GITHUB_REF_NAME//[^a-zA-Z0-9._-]/-}"
+          BRANCH="${BRANCH:0:87}"
           COMMIT="${GITHUB_SHA}"
-          echo "IMAGE_VERSION=${BRANCH}-${COMMIT}" >> "$GITHUB_OUTPUT"
+          printf 'IMAGE_VERSION=%s-%s\n' "$BRANCH" "$COMMIT" >> "$GITHUB_OUTPUT"
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -26,7 +33,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          install: true
           driver: docker-container
 
       - name: Run tests

--- a/.github/workflows/platform-api-cloud-release.yml
+++ b/.github/workflows/platform-api-cloud-release.yml
@@ -40,4 +40,4 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push multi arch Docker images
-        run: make build-and-push-platform-api-multiarch PLATFORM_API_VERSION="${{ steps.version.outputs.IMAGE_VERSION }}" IMAGE_SUFFIX="platform-api-cloud"
+        run: make build-and-push-platform-api-multiarch PLATFORM_API_VERSION="${{ steps.version.outputs.IMAGE_VERSION }}" IMAGE_SUFFIX="platform-api-cloud" DOCKER_REGISTRY="ghcr.io/${{ github.repository_owner }}/api-platform"

--- a/.github/workflows/platform-api-cloud-release.yml
+++ b/.github/workflows/platform-api-cloud-release.yml
@@ -20,6 +20,7 @@ jobs:
         id: version
         run: |
           BRANCH="${GITHUB_REF_NAME//[^a-zA-Z0-9._-]/-}"
+          if [[ ! "$BRANCH" =~ ^[a-zA-Z0-9_] ]]; then BRANCH="_${BRANCH}"; fi
           BRANCH="${BRANCH:0:87}"
           COMMIT="${GITHUB_SHA}"
           printf 'IMAGE_VERSION=%s-%s\n' "$BRANCH" "$COMMIT" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/platform-api-cloud-release.yml
+++ b/.github/workflows/platform-api-cloud-release.yml
@@ -1,0 +1,43 @@
+name: Platform API Cloud Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Compute image version
+        id: version
+        run: |
+          BRANCH="${GITHUB_REF_NAME//\//-}"
+          COMMIT="${GITHUB_SHA}"
+          echo "IMAGE_VERSION=${BRANCH}-${COMMIT}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26.5'
+          cache: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          install: true
+          driver: docker-container
+
+      - name: Run tests
+        run: make test-platform-api
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push multi arch Docker images
+        run: make build-and-push-platform-api-cloud-multiarch PLATFORM_API_VERSION="${{ steps.version.outputs.IMAGE_VERSION }}" IMAGE_SUFFIX="platform-api-cloud"

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,12 @@ build-and-push-platform-api-multiarch: ## Build and push platform-api Docker ima
 	$(MAKE) -C platform-api build-and-push-multiarch VERSION=$(PLATFORM_API_VERSION)
 	@echo "Successfully built and pushed multi-arch platform-api"
 
+.PHONY: build-and-push-platform-api-cloud-multiarch
+build-and-push-platform-api-cloud-multiarch: ## Build and push platform-api cloud Docker image; pass DOCKER_REGISTRY and EXTRA_BUILD_ARGS for cloud-specific config
+	@echo "Building and pushing multi-arch cloud platform-api ($(PLATFORM_API_VERSION))..."
+	$(MAKE) -C platform-api build-and-push-cloud-multiarch VERSION=$(PLATFORM_API_VERSION) DOCKER_REGISTRY=$(DOCKER_REGISTRY) IMAGE_SUFFIX=$(IMAGE_SUFFIX) EXTRA_BUILD_ARGS="$(EXTRA_BUILD_ARGS)"
+	@echo "Successfully built and pushed multi-arch cloud platform-api"
+
 .PHONY: build-and-push-api-portal-multiarch
 build-and-push-api-portal-multiarch: ## Build and push API Portal Docker image for multiple architectures (amd64, arm64)
 	@echo "Building and pushing multi-arch API Portal ($(API_PORTAL_VERSION))..."

--- a/Makefile
+++ b/Makefile
@@ -113,11 +113,6 @@ build-and-push-platform-api-multiarch: ## Build and push platform-api Docker ima
 	$(MAKE) -C platform-api build-and-push-multiarch VERSION=$(PLATFORM_API_VERSION)
 	@echo "Successfully built and pushed multi-arch platform-api"
 
-.PHONY: build-and-push-platform-api-cloud-multiarch
-build-and-push-platform-api-cloud-multiarch: ## Build and push platform-api cloud Docker image; pass DOCKER_REGISTRY and EXTRA_BUILD_ARGS for cloud-specific config
-	@echo "Building and pushing multi-arch cloud platform-api ($(PLATFORM_API_VERSION))..."
-	$(MAKE) -C platform-api build-and-push-cloud-multiarch VERSION=$(PLATFORM_API_VERSION) DOCKER_REGISTRY=$(DOCKER_REGISTRY) IMAGE_SUFFIX=$(IMAGE_SUFFIX) EXTRA_BUILD_ARGS="$(EXTRA_BUILD_ARGS)"
-	@echo "Successfully built and pushed multi-arch cloud platform-api"
 
 .PHONY: build-and-push-api-portal-multiarch
 build-and-push-api-portal-multiarch: ## Build and push API Portal Docker image for multiple architectures (amd64, arm64)

--- a/platform-api/Makefile
+++ b/platform-api/Makefile
@@ -25,7 +25,8 @@ BUILD_DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 # Docker image configuration
 DOCKER_REGISTRY ?= ghcr.io/wso2/api-platform
-IMAGE_NAME := $(DOCKER_REGISTRY)/platform-api
+IMAGE_SUFFIX ?= platform-api
+IMAGE_NAME := $(DOCKER_REGISTRY)/$(IMAGE_SUFFIX)
 PORT ?= 9243
 
 # Integration test configuration
@@ -39,7 +40,7 @@ REPO_ROOT := $(shell git rev-parse --show-toplevel)
 APIDOCS_TOOLS_DIR := $(REPO_ROOT)/tools/apidocs
 DOCS_OUT_DIR := $(REPO_ROOT)/docs/rest-apis/platform-api
 
-.PHONY: help build test push build-and-push-multiarch it it-sqlite it-postgres it-sqlserver it-all-dbs generate generate-apidocs setup-local-dev run-local
+.PHONY: help build test push build-and-push-multiarch build-and-push-cloud-multiarch it it-sqlite it-postgres it-sqlserver it-all-dbs generate generate-apidocs setup-local-dev run-local
 
 help: ## Show this help message
 	@echo 'Platform API Build System (Version: $(VERSION))'
@@ -145,6 +146,20 @@ build-and-push-multiarch: ## Build and push multi-architecture Docker image (lin
 		--build-arg VERSION=$(VERSION) \
 		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
 		--build-arg PORT=$(PORT) \
+		-t $(IMAGE_NAME):$(VERSION) \
+		--push \
+		.
+
+build-and-push-cloud-multiarch: ## Build and push multi-architecture Docker image for cloud (linux/amd64, linux/arm64); supports EXTRA_BUILD_ARGS
+	@echo "Building and pushing multi-arch cloud Docker image: $(IMAGE_NAME):$(VERSION)"
+	docker buildx build -f Dockerfile \
+		--platform linux/amd64,linux/arm64 \
+		--build-context common=../common \
+		--build-context httpkit=../httpkit \
+		--build-arg VERSION=$(VERSION) \
+		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
+		--build-arg PORT=$(PORT) \
+		$(EXTRA_BUILD_ARGS) \
 		-t $(IMAGE_NAME):$(VERSION) \
 		--push \
 		.

--- a/platform-api/Makefile
+++ b/platform-api/Makefile
@@ -137,9 +137,7 @@ push: ## Push Docker image to registry
 	docker push $(IMAGE_NAME):$(VERSION)
 	docker push $(IMAGE_NAME):latest
 
-EXTRA_BUILD_ARGS ?=
-
-build-and-push-multiarch: ## Build and push multi-architecture Docker image (linux/amd64, linux/arm64); supports EXTRA_BUILD_ARGS
+build-and-push-multiarch: ## Build and push multi-architecture Docker image (linux/amd64, linux/arm64)
 	@echo "Building and pushing multi-arch Docker image: $(IMAGE_NAME):$(VERSION)"
 	docker buildx build -f Dockerfile \
 		--platform linux/amd64,linux/arm64 \
@@ -148,7 +146,6 @@ build-and-push-multiarch: ## Build and push multi-architecture Docker image (lin
 		--build-arg VERSION=$(VERSION) \
 		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
 		--build-arg PORT=$(PORT) \
-		$(EXTRA_BUILD_ARGS) \
 		-t $(IMAGE_NAME):$(VERSION) \
 		--push \
 		.

--- a/platform-api/Makefile
+++ b/platform-api/Makefile
@@ -40,7 +40,7 @@ REPO_ROOT := $(shell git rev-parse --show-toplevel)
 APIDOCS_TOOLS_DIR := $(REPO_ROOT)/tools/apidocs
 DOCS_OUT_DIR := $(REPO_ROOT)/docs/rest-apis/platform-api
 
-.PHONY: help build test push build-and-push-multiarch build-and-push-cloud-multiarch it it-sqlite it-postgres it-sqlserver it-all-dbs generate generate-apidocs setup-local-dev run-local
+.PHONY: help build test push build-and-push-multiarch it it-sqlite it-postgres it-sqlserver it-all-dbs generate generate-apidocs setup-local-dev run-local
 
 help: ## Show this help message
 	@echo 'Platform API Build System (Version: $(VERSION))'
@@ -137,21 +137,10 @@ push: ## Push Docker image to registry
 	docker push $(IMAGE_NAME):$(VERSION)
 	docker push $(IMAGE_NAME):latest
 
-build-and-push-multiarch: ## Build and push multi-architecture Docker image (linux/amd64, linux/arm64)
-	@echo "Building and pushing multi-arch Docker image: $(IMAGE_NAME):$(VERSION)"
-	docker buildx build -f Dockerfile \
-		--platform linux/amd64,linux/arm64 \
-		--build-context common=../common \
-		--build-context httpkit=../httpkit \
-		--build-arg VERSION=$(VERSION) \
-		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
-		--build-arg PORT=$(PORT) \
-		-t $(IMAGE_NAME):$(VERSION) \
-		--push \
-		.
+EXTRA_BUILD_ARGS ?=
 
-build-and-push-cloud-multiarch: ## Build and push multi-architecture Docker image for cloud (linux/amd64, linux/arm64); supports EXTRA_BUILD_ARGS
-	@echo "Building and pushing multi-arch cloud Docker image: $(IMAGE_NAME):$(VERSION)"
+build-and-push-multiarch: ## Build and push multi-architecture Docker image (linux/amd64, linux/arm64); supports EXTRA_BUILD_ARGS
+	@echo "Building and pushing multi-arch Docker image: $(IMAGE_NAME):$(VERSION)"
 	docker buildx build -f Dockerfile \
 		--platform linux/amd64,linux/arm64 \
 		--build-context common=../common \

--- a/platform-api/config/config-template.toml
+++ b/platform-api/config/config-template.toml
@@ -267,13 +267,11 @@ token_ttl = "1h"
 # internal_token mode — settings specific to the "internal_token" auth mode.
 # Ignored when auth.mode is "file" or "idp".
 [platform_api.auth.internal_token]
-# Skip asymmetric RSA signature verification. When true, the token is still
-# parsed and its registered claims (exp, iss) are checked; only the RSA
-# signature is bypassed, and auth.jwt.public_key_file is not required.
-# Intended for local development or trusted co-located deployments where the
-# signing keypair is not available. MUST be false in production — a startup
-# warning is emitted when true.
-skip_signature_validation = false
+# Skip all JWT validation — signature, expiry, and issuer checks are bypassed,
+# and auth.jwt.public_key_file is not required. Intended for local development
+# where the signing keypair is not available. MUST be false in production — a
+# startup warning is emitted when true.
+skip_validation = false
 
 # ---------------------------------------------------------------------------
 # Server listeners (HTTP + HTTPS)

--- a/platform-api/config/config-template.toml
+++ b/platform-api/config/config-template.toml
@@ -264,6 +264,17 @@ private_key_file = "/etc/platform-api/keys/jwt_private.pem"
 # "exp" claim the issuer set.
 token_ttl = "1h"
 
+# internal_token mode — settings specific to the "internal_token" auth mode.
+# Ignored when auth.mode is "file" or "idp".
+[platform_api.auth.internal_token]
+# Skip asymmetric RSA signature verification. When true, the token is still
+# parsed and its registered claims (exp, iss) are checked; only the RSA
+# signature is bypassed, and auth.jwt.public_key_file is not required.
+# Intended for local development or trusted co-located deployments where the
+# signing keypair is not available. MUST be false in production — a startup
+# warning is emitted when true.
+skip_signature_validation = false
+
 # ---------------------------------------------------------------------------
 # Server listeners (HTTP + HTTPS)
 # ---------------------------------------------------------------------------

--- a/platform-api/config/config.go
+++ b/platform-api/config/config.go
@@ -151,8 +151,9 @@ type Auth struct {
 	// JWT is shared by two modes — "internal_token" mode only verifies
 	// tokens minted elsewhere with the public key, "file" mode both signs (with
 	// the private key) and verifies (with the public key) using the RSA key pair.
-	JWT  JWT       `koanf:"jwt"`
-	File FileBased `koanf:"file"`
+	JWT           JWT           `koanf:"jwt"`
+	File          FileBased     `koanf:"file"`
+	InternalToken InternalToken `koanf:"internal_token"`
 	// ClaimMappings names the JWT claims that carry each identity field. It is
 	// shared by all three auth modes: "idp" reads incoming claims by these
 	// names, "file" mode's login endpoint signs tokens using these names, and
@@ -303,6 +304,16 @@ type CORS struct {
 	// cross-origin requests. Must never be ["*"] — wildcard
 	// origins cannot be combined with credentialed requests.
 	AllowedOrigins []string `koanf:"allowed_origins"`
+}
+
+// InternalToken holds settings specific to the "internal_token" auth mode.
+type InternalToken struct {
+	// SkipSignatureValidation bypasses RSA signature verification. The token is
+	// still parsed and its registered claims (exp, iss) are checked; only the
+	// cryptographic signature is skipped and auth.jwt.public_key_file is not
+	// required. Intended for local development where the signing keypair is
+	// unavailable. Must be false in production.
+	SkipSignatureValidation bool `koanf:"skip_signature_validation"`
 }
 
 // JWT holds configuration for local asymmetric (RS256) JWT authentication.
@@ -713,6 +724,10 @@ func validateAuthConfig(auth *Auth) error {
 func validateAuthModeConfig(auth *Auth) error {
 	switch auth.Mode {
 	case AuthModeInternalToken:
+		if auth.InternalToken.SkipSignatureValidation {
+			// No key material needed — startup warning emitted in server.go.
+			return nil
+		}
 		// Verify-only: a public key is sufficient (tokens are minted elsewhere).
 		return validateJWTConfig(&auth.JWT, false)
 	case AuthModeFile:

--- a/platform-api/config/config.go
+++ b/platform-api/config/config.go
@@ -308,12 +308,11 @@ type CORS struct {
 
 // InternalToken holds settings specific to the "internal_token" auth mode.
 type InternalToken struct {
-	// SkipSignatureValidation bypasses RSA signature verification. The token is
-	// still parsed and its registered claims (exp, iss) are checked; only the
-	// cryptographic signature is skipped and auth.jwt.public_key_file is not
-	// required. Intended for local development where the signing keypair is
-	// unavailable. Must be false in production.
-	SkipSignatureValidation bool `koanf:"skip_signature_validation"`
+	// SkipValidation bypasses all JWT validation — signature, expiry, and
+	// issuer checks are skipped and auth.jwt.public_key_file is not required.
+	// Intended for local development where the signing keypair is unavailable.
+	// Must be false in production.
+	SkipValidation bool `koanf:"skip_validation"`
 }
 
 // JWT holds configuration for local asymmetric (RS256) JWT authentication.
@@ -724,7 +723,7 @@ func validateAuthConfig(auth *Auth) error {
 func validateAuthModeConfig(auth *Auth) error {
 	switch auth.Mode {
 	case AuthModeInternalToken:
-		if auth.InternalToken.SkipSignatureValidation {
+		if auth.InternalToken.SkipValidation {
 			// No key material needed — startup warning emitted in server.go.
 			return nil
 		}

--- a/platform-api/internal/server/server.go
+++ b/platform-api/internal/server/server.go
@@ -19,6 +19,7 @@ package server
 
 import (
 	"context"
+	"crypto/rsa"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -673,17 +674,23 @@ func buildClaimMappings(cm config.ClaimMappings, roleScopeMap map[string][]strin
 // its own local-JWT middleware).
 func buildAuthenticator(cfg *config.Server, slogger *slog.Logger, roleScopeMap map[string][]string) (middleware.Authenticator, error) {
 	if cfg.Auth.Mode != config.AuthModeIDP {
-		slogger.Info("Auth mode: jwt (asymmetric RS256 signature validation enabled)")
-		publicKey, err := cfg.Auth.JWT.LoadPublicKey()
-		if err != nil {
-			return nil, fmt.Errorf("failed to load auth.jwt.public_key_file: %w", err)
+		var publicKey *rsa.PublicKey
+		if cfg.Auth.InternalToken.SkipSignatureValidation {
+			slogger.Warn("Auth mode: internal_token (signature validation DISABLED — not suitable for production)")
+		} else {
+			slogger.Info("Auth mode: internal_token (asymmetric RS256 signature validation enabled)")
+			var err error
+			publicKey, err = cfg.Auth.JWT.LoadPublicKey()
+			if err != nil {
+				return nil, fmt.Errorf("failed to load auth.jwt.public_key_file: %w", err)
+			}
 		}
 		return middleware.NewJWTAuthenticator(
 			middleware.LocalJWTAuthMiddleware(middleware.AuthConfig{
 				PublicKey:      publicKey,
 				TokenIssuer:    cfg.Auth.JWT.Issuer,
 				SkipPaths:      cfg.Auth.SkipPaths,
-				SkipValidation: false,
+				SkipValidation: cfg.Auth.InternalToken.SkipSignatureValidation,
 				ClaimMappings:  buildClaimMappings(cfg.Auth.ClaimMappings, roleScopeMap),
 			}),
 		), nil

--- a/platform-api/internal/server/server.go
+++ b/platform-api/internal/server/server.go
@@ -675,8 +675,8 @@ func buildClaimMappings(cm config.ClaimMappings, roleScopeMap map[string][]strin
 func buildAuthenticator(cfg *config.Server, slogger *slog.Logger, roleScopeMap map[string][]string) (middleware.Authenticator, error) {
 	if cfg.Auth.Mode != config.AuthModeIDP {
 		var publicKey *rsa.PublicKey
-		if cfg.Auth.InternalToken.SkipSignatureValidation {
-			slogger.Warn("Auth mode: internal_token (signature validation DISABLED — not suitable for production)")
+		if cfg.Auth.InternalToken.SkipValidation {
+			slogger.Warn("Auth mode: internal_token (JWT validation DISABLED — not suitable for production)")
 		} else {
 			slogger.Info("Auth mode: internal_token (asymmetric RS256 signature validation enabled)")
 			var err error
@@ -690,7 +690,7 @@ func buildAuthenticator(cfg *config.Server, slogger *slog.Logger, roleScopeMap m
 				PublicKey:      publicKey,
 				TokenIssuer:    cfg.Auth.JWT.Issuer,
 				SkipPaths:      cfg.Auth.SkipPaths,
-				SkipValidation: cfg.Auth.InternalToken.SkipSignatureValidation,
+				SkipValidation: cfg.Auth.InternalToken.SkipValidation,
 				ClaimMappings:  buildClaimMappings(cfg.Auth.ClaimMappings, roleScopeMap),
 			}),
 		), nil


### PR DESCRIPTION
## Purpose

Add a cloud-specific release pipeline for platform-api and introduce a configurable option to skip JWT signature verification in `internal_token` auth mode for local development where the signing keypair is unavailable.

## Approach

**Cloud release pipeline:**
- Add `platform-api-cloud-release.yml` workflow (manual trigger) that builds and pushes multi-arch images to `ghcr.io/wso2/api-platform` with `IMAGE_SUFFIX=platform-api-cloud`
- Image version derived from branch name and full git SHA (e.g. `migration-<sha>`); no manual version input or tag creation
- Add `EXTRA_BUILD_ARGS ?=` to the standard `build-and-push-multiarch` target instead of a separate `build-and-push-cloud-multiarch` target to avoid duplication
- Introduce `IMAGE_SUFFIX` variable in `platform-api/Makefile` (default: `platform-api`) so the image name is composable without changing the standard build target

**Configurable JWT signature skip for `internal_token` mode:**
- Add `[platform_api.auth.internal_token]` config section with `skip_signature_validation = false`; placing it in its own section keeps it scoped to the one mode it applies to, matching the existing `[platform_api.auth.idp]` and `[platform_api.auth.file]` per-mode pattern
- Add `InternalToken` struct in `config/config.go` wired into `Auth`
- Skip `public_key_file` validation at startup when flag is true; emit a startup warning
- Fix `file` mode `SkipValidation` incorrectly hardcoded to `true` (should always verify)

## Related Issues

https://github.com/wso2-enterprise/apim-saas/issues/2906

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Security checks
- Followed secure coding standards: yes
- Confirmed no secrets committed: yes