### PR TITLE
Fix startup xDS snapshot using legacy cluster names after controller restart

### DIFF
--- a/event-gateway/gateway-controller/cmd/controller/main.go
+++ b/event-gateway/gateway-controller/cmd/controller/main.go
@@ -389,6 +389,26 @@ func main() {
 		}
 	}
 
+	// Build the transformer registry and wire it into the Envoy translator BEFORE
+	// the initial xDS snapshot below, so the first snapshot already uses the
+	// transformer-path cluster/route names ("upstream_<name>_<host>_<port>") that the
+	// policy engine's resources reference. Wiring it later would leave the startup
+	// snapshot on the legacy naming path ("cluster_<scheme>_<host>"), breaking every
+	// previously deployed non-WebSub API with 503 cluster_not_found after a controller
+	// restart (issue #3197). WebSubApi is intentionally excluded so it keeps using the
+	// async-specific legacy translation path.
+	policyVersionResolver := utils.NewLoadedPolicyVersionResolver(policyDefinitions)
+	restTransformer := transform.NewRestAPITransformer(&cfg.Router, cfg, policyDefinitions)
+	llmTransformer := transform.NewLLMTransformer(configStore, db, &cfg.Router, cfg, policyDefinitions, policyVersionResolver)
+	transformerRegistry := transform.NewRegistry(restTransformer, llmTransformer)
+
+	xdsTranslator.SetTransformers(map[string]models.ConfigTransformer{
+		"RestApi":     transformerRegistry,
+		"Mcp":         transformerRegistry,
+		"LlmProvider": transformerRegistry,
+		"LlmProxy":    transformerRegistry,
+	})
+
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	if err := snapshotManager.UpdateSnapshot(ctx, ""); err != nil {
 		log.Warn("Failed to generate initial xDS snapshot", slog.Any("error", err))
@@ -427,18 +447,9 @@ func main() {
 	policyManager := policyxds.NewPolicyManager(policySnapshotManager, log)
 	policyManager.SetRuntimeStore(runtimeStore)
 
-	policyVersionResolver := utils.NewLoadedPolicyVersionResolver(policyDefinitions)
-	restTransformer := transform.NewRestAPITransformer(&cfg.Router, cfg, policyDefinitions)
-	llmTransformer := transform.NewLLMTransformer(configStore, db, &cfg.Router, cfg, policyDefinitions, policyVersionResolver)
-	transformerRegistry := transform.NewRegistry(restTransformer, llmTransformer)
+	// Share the transformer registry (built before the initial xDS snapshot above)
+	// with the policy manager so both snapshot paths key resources identically.
 	policyManager.SetTransformers(transformerRegistry)
-
-	xdsTranslator.SetTransformers(map[string]models.ConfigTransformer{
-		"RestApi":     transformerRegistry,
-		"Mcp":         transformerRegistry,
-		"LlmProvider": transformerRegistry,
-		"LlmProxy":    transformerRegistry,
-	})
 
 	loadedAPIs := configStore.GetAll()
 	if _, err := loadRuntimeConfigsFromExistingAPIConfigurations(loadedAPIs, runtimeStore, secretsService, transformerRegistry, log, cfg.Controller.Server.SkipInvalidDeploymentsOnStartup); err != nil {

--- a/gateway/gateway-controller/cmd/controller/main.go
+++ b/gateway/gateway-controller/cmd/controller/main.go
@@ -376,6 +376,33 @@ func main() {
 		}
 	}
 
+	// Build transformer registry for StoredConfig → RuntimeDeployConfig conversion.
+	// This MUST happen before the initial xDS snapshot below: the Envoy translator
+	// and the policy engine must agree on cluster names ("upstream_<name>_<host>_<port>"
+	// from the transformer path). With no transformers wired the translator silently
+	// falls back to the legacy path, which names clusters "cluster_<scheme>_<host>" —
+	// the policy engine then routes to upstream_* clusters that don't exist in Envoy,
+	// and every API returns 503 cluster_not_found until it is redeployed (issue #3197).
+	policyVersionResolver := utils.NewLoadedPolicyVersionResolver(policyDefinitions)
+	restTransformer := transform.NewRestAPITransformer(&cfg.Router, cfg, policyDefinitions)
+	llmTransformer := transform.NewLLMTransformer(configStore, db, &cfg.Router, cfg, policyDefinitions, policyVersionResolver)
+	transformerRegistry := transform.NewRegistry(restTransformer, llmTransformer)
+
+	// Wire the transformer into the Envoy xDS translator so Envoy routes are built from the
+	// RuntimeDeployConfig (RDC) path — identical to how the policy engine's RouteConfig/PolicyChain
+	// resources are keyed. Without this the Envoy translator falls back to the legacy per-operation
+	// path, which (a) does not render header matchers and (b) names routes "method|path|vhost"
+	// (3 segments), while the policy resources are keyed "method|path|vhost|<header-hash>". The
+	// policy engine resolves the chain by the Envoy route name, so the mismatch makes every
+	// header-matched route fail with 500 ("policy chain not found"). WebSubApi is intentionally
+	// excluded so it keeps using the async-specific legacy translation path.
+	translator.SetTransformers(map[string]models.ConfigTransformer{
+		"RestApi":     transformerRegistry,
+		"Mcp":         transformerRegistry,
+		"LlmProvider": transformerRegistry,
+		"LlmProxy":    transformerRegistry,
+	})
+
 	// Generate initial xDS snapshot
 	log.Info("Generating initial xDS snapshot")
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -426,27 +453,9 @@ func main() {
 	policyManager := policyxds.NewPolicyManager(policySnapshotManager, log)
 	policyManager.SetRuntimeStore(runtimeStore)
 
-	// Build transformer registry for StoredConfig → RuntimeDeployConfig conversion
-	policyVersionResolver := utils.NewLoadedPolicyVersionResolver(policyDefinitions)
-	restTransformer := transform.NewRestAPITransformer(&cfg.Router, cfg, policyDefinitions)
-	llmTransformer := transform.NewLLMTransformer(configStore, db, &cfg.Router, cfg, policyDefinitions, policyVersionResolver)
-	transformerRegistry := transform.NewRegistry(restTransformer, llmTransformer)
+	// Share the transformer registry (built before the initial xDS snapshot above)
+	// with the policy manager so both snapshot paths key resources identically.
 	policyManager.SetTransformers(transformerRegistry)
-
-	// Wire the same transformer into the Envoy xDS translator so Envoy routes are built from the
-	// RuntimeDeployConfig (RDC) path — identical to how the policy engine's RouteConfig/PolicyChain
-	// resources are keyed. Without this the Envoy translator falls back to the legacy per-operation
-	// path, which (a) does not render header matchers and (b) names routes "method|path|vhost"
-	// (3 segments), while the policy resources are keyed "method|path|vhost|<header-hash>". The
-	// policy engine resolves the chain by the Envoy route name, so the mismatch makes every
-	// header-matched route fail with 500 ("policy chain not found"). WebSubApi is intentionally
-	// excluded so it keeps using the async-specific legacy translation path.
-	translator.SetTransformers(map[string]models.ConfigTransformer{
-		"RestApi":     transformerRegistry,
-		"Mcp":         transformerRegistry,
-		"LlmProvider": transformerRegistry,
-		"LlmProxy":    transformerRegistry,
-	})
 
 	// Load runtime configs from existing API configurations on startup.
 	// We write directly to runtimeStore to avoid triggering N separate snapshot updates;

--- a/gateway/gateway-controller/pkg/xds/translator.go
+++ b/gateway/gateway-controller/pkg/xds/translator.go
@@ -719,7 +719,17 @@ func (t *Translator) TranslateConfigs(
 		var err error
 
 		// Try RuntimeDeployConfig transformer path first (produces minimal metadata routes)
-		if transformer, ok := t.transformers[cfg.Kind]; ok {
+		transformer, ok := t.transformers[cfg.Kind]
+		if !ok && cfg.Kind != "WebSubApi" {
+			// Transformers should be registered for every non-WebSub kind before the
+			// first snapshot is generated. Falling back here means Envoy cluster/route
+			// names will not match the policy engine's resources (503 cluster_not_found /
+			// 500 policy chain not found) — see issue #3197.
+			log.Warn("No transformer registered for config kind, using legacy translation path",
+				slog.String("id", cfg.UUID),
+				slog.String("kind", cfg.Kind))
+		}
+		if ok {
 			rdc, transformErr := transformer.Transform(cfg)
 			if transformErr != nil {
 				log.Error("Failed to transform config via RuntimeDeployConfig, falling back to legacy path",


### PR DESCRIPTION
## Purpose

Resolves wso2/api-platform#3197

Whenever the gateway controller restarts (a helm upgrade, a pod restart, anything), every API that was already deployed starts returning 503 with `cluster_not_found`. Auth still works (you get 401 without a token), so it looks like the backend is down, but it isn't. The only way to recover is to redeploy every API from the Publisher, and it breaks again on the next restart.

The root cause is an ordering problem in `cmd/controller/main.go`. The first Envoy xDS snapshot is built before the transformers are wired into the translator. At that point `t.transformers` is still nil, so the translator quietly falls back to the legacy path, which names clusters `cluster_<scheme>_<host>`. The policy engine builds its routes later through the transformer path, which names the same clusters `upstream_<name>_<host>_<port>`. The two sides never agree on a name, so Envoy can't find any cluster the policy engine routes to. Nothing ever rebuilds the snapshot either, because control plane reconciliation skips APIs whose `deployed_at` hasn't changed. So the broken state stays until someone redeploys by hand.

## Goals

1. The very first snapshot after a restart should use the same cluster and route names the policy engine uses, so already-deployed APIs keep working with no redeploy.
2. If the legacy path is ever taken unexpectedly again, it should show up in the logs instead of failing silently.

## Approach

Fix the order instead of building the snapshot twice. This PR moves the transformer registry construction (`policyVersionResolver`, `RestAPITransformer`, `LLMTransformer`, `transform.NewRegistry`) and the `translator.SetTransformers(...)` call up, so they run before the initial `snapshotManager.UpdateSnapshot(ctx, "")`. The constructors just assemble structs, and everything they need (`configStore`, `db`, `cfg`, `policyDefinitions`) already exists at that point. `policyManager.SetTransformers(transformerRegistry)` stays where the policy manager is created and reuses the same registry.

The issue thread suggested a different fix: keep the order as is, and add a second `UpdateSnapshot` call after the transformers are wired. I went with the reorder instead, for one reason. In a real deployment the gateway runtimes keep serving traffic while the controller restarts, and they reconnect the moment the xDS server starts (which happens before the transformers were wired). With the second-snapshot approach, Envoy would still get the broken legacy snapshot first, live traffic would 503 until the second snapshot arrives, and the routes would churn twice on every controller boot. With the reorder, the first snapshot is already correct, so there is no broken window and no extra rebuild.

The event-gateway controller (`event-gateway/gateway-controller/cmd/controller/main.go`) has the same startup order and shares the same translator package, so the same reorder is applied there too.

On top of that, the silent fall-through in `TranslateConfigs` now logs a warning when no transformer is registered for a kind (except `WebSubApi`, which intentionally uses the legacy path). `LlmProviderTemplate` objects live in a separate store map and never reach `TranslateConfigs`, so the warning can't fire for them.

Nothing else changes:
- If `Transform` fails for one config, it still falls back to the legacy path with an error log, same as before.
- WebSubApi translation is untouched.
- No other module imports `pkg/xds` or `pkg/transform`, so the change is contained to the two controller binaries.

Note: `event-gateway/gateway-controller/cmd/controller` currently fails to compile on `main` for an unrelated reason (its `adminserver.NewServer` call was not updated when that function gained a middleware parameter). That breakage exists before this PR and is not touched here. This PR's change to that file was typechecked separately (with that one call patched locally) and `go vet` passes.

## User stories

As an operator running the Platform Gateway against an APIM control plane, I can restart or upgrade the gateway controller without every deployed API breaking with 503 `cluster_not_found`, and without redeploying each API from the Publisher afterwards.

## Automation tests

- Unit tests: the full `gateway-controller` module suite passes (30 packages, including `pkg/xds`, `pkg/transform`, `cmd/controller`). The `event-gateway/gateway-controller` module has no unit tests outside the pre-broken `cmd/controller` package (see the note above).
- Integration tests: verified by hand using the steps from #3197. Deploy an API top-down from the Publisher (200), restart the controller with `kubectl rollout restart` (used to give 503 `cluster_not_found`, now gives 200), and check Envoy's `/clusters`, which shows the `upstream_<name>_<host>_<port>` names right after the restart.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (Go, `go vet` is clean)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

None

## Test environment

Go (toolchain go1.26.5), macOS (Apple Silicon). Reproduced and verified on: Gateway 1.2.0 Helm chart on k3s v1.35.0, WSO2 APIM 4.7.0 control plane, PostgreSQL 16.
