### PR TITLE
Add llmusage, a template-driven LLM usage extraction library

### DIFF
--- a/sdk/ai/go.mod
+++ b/sdk/ai/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/milvus-io/milvus/client/v2 v2.6.2
 	github.com/milvus-io/milvus/pkg/v2 v2.6.8
 	github.com/redis/go-redis/v9 v9.17.3
+	github.com/wso2/api-platform/sdk/core v0.3.5
 )
 
 require (

--- a/sdk/ai/go.sum
+++ b/sdk/ai/go.sum
@@ -386,6 +386,8 @@ github.com/valyala/fasthttp v1.6.0/go.mod h1:FstJa9V+Pj9vQ7OJie2qMHdwemEDaDiSdBn
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
+github.com/wso2/api-platform/sdk/core v0.3.5 h1:EFeKx9bznEQSdZ7pmLB/06JFn0T3HUss0ZxzRPhhx6s=
+github.com/wso2/api-platform/sdk/core v0.3.5/go.mod h1:TgjpOk3QBPc7xEQC+NctWcNq5dSPBkn7wSKh+hULTj8=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/sdk/ai/llmusage/decode.go
+++ b/sdk/ai/llmusage/decode.go
@@ -1,0 +1,234 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package llmusage
+
+import (
+	"bytes"
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	"github.com/wso2/api-platform/sdk/core/utils"
+)
+
+// decodeBody turns a response body into a single JSON object suitable for
+// JSONPath extraction. Server-sent event streams are merged so values spread
+// across events — the model in an early event, usage in the last — end up in
+// one view. Anything else is returned unchanged.
+func decodeBody(body []byte, requestPath string) []byte {
+	if isSSE(body) {
+		if merged, ok := mergeSSEEvents(body); ok {
+			return merged
+		}
+	}
+	return body
+}
+
+// isSSE reports whether the body looks like a server-sent event stream.
+func isSSE(body []byte) bool {
+	trimmed := bytes.TrimLeft(body, " \t\r\n")
+	return bytes.HasPrefix(trimmed, []byte("data:")) ||
+		bytes.HasPrefix(trimmed, []byte("event:"))
+}
+
+// mergeSSEEvents shallow-merges every JSON event in a stream, later events
+// winning. Empty strings never displace a value already seen, so a trailing
+// event with an empty model cannot erase a real one.
+//
+// An event may spread its payload over several data fields, which the stream
+// format joins with a newline and dispatches on a blank line.
+func mergeSSEEvents(body []byte) ([]byte, bool) {
+	merged := make(map[string]interface{})
+	found := false
+
+	var fields [][]byte
+	dispatch := func() {
+		for _, payload := range eventPayloads(fields) {
+			var event map[string]interface{}
+			if err := json.Unmarshal(payload, &event); err != nil {
+				continue
+			}
+			found = true
+			for key, value := range event {
+				if str, ok := value.(string); ok && str == "" {
+					continue
+				}
+				merged[key] = value
+			}
+		}
+		fields = nil
+	}
+
+	for _, line := range bytes.Split(body, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			dispatch()
+			continue
+		}
+		if !bytes.HasPrefix(line, []byte("data:")) {
+			continue
+		}
+		payload := bytes.TrimSpace(bytes.TrimPrefix(line, []byte("data:")))
+		if len(payload) == 0 || bytes.Equal(payload, []byte("[DONE]")) {
+			continue
+		}
+		fields = append(fields, payload)
+	}
+	dispatch() // a stream may end without a trailing blank line
+
+	if !found {
+		return nil, false
+	}
+	out, err := json.Marshal(merged)
+	if err != nil {
+		return nil, false
+	}
+	return out, true
+}
+
+// eventPayloads returns the documents to read out of one event's data fields:
+// the newline-joined form the stream format defines, or each field alone when
+// the joined form is not valid JSON. The fallback keeps streams working that
+// pack a complete object into every data field without a blank line between.
+func eventPayloads(fields [][]byte) [][]byte {
+	if len(fields) < 2 {
+		return fields
+	}
+	if joined := bytes.Join(fields, []byte("\n")); json.Valid(joined) {
+		return [][]byte{joined}
+	}
+	return fields
+}
+
+// extractUsage reads every field the template declares out of the response and
+// normalizes the result. A field whose path is absent from the response
+// contributes zero; that is not an error, since providers omit fields routinely.
+func extractUsage(template map[string]interface{}, body, requestBody []byte, requestPath string) (Usage, error) {
+	fields, accounting := resolveFields(template, requestPath)
+	decoded := decodeBody(body, requestPath)
+
+	// Confirm the body is usable before reading fields, so a malformed
+	// response is reported rather than silently yielding zeros.
+	var probe interface{}
+	if err := json.Unmarshal(decoded, &probe); err != nil {
+		return Usage{}, err
+	}
+
+	raw := rawCounts{
+		InputTokens:        readInt(decoded, fields, "promptTokens", requestPath),
+		OutputTokens:       readInt(decoded, fields, "completionTokens", requestPath),
+		TotalTokens:        readInt(decoded, fields, "totalTokens", requestPath),
+		CachedTokens:       readInt(decoded, fields, "cachedTokens", requestPath),
+		CacheWriteTokens:   readInt(decoded, fields, "cacheWriteTokens", requestPath),
+		CacheWrite1hTokens: readInt(decoded, fields, "cacheWrite1hTokens", requestPath),
+		ReasoningTokens:    readInt(decoded, fields, "reasoningTokens", requestPath),
+		AudioInputTokens:   readInt(decoded, fields, "audioInputTokens", requestPath),
+		AudioOutputTokens:  readInt(decoded, fields, "audioOutputTokens", requestPath),
+		ServiceTier:        readString(decoded, fields, "serviceTier", requestPath),
+	}
+
+	raw.Model, raw.ModelCandidates = resolveModel(decoded, requestBody, fields, requestPath)
+
+	return normalize(raw, accounting), nil
+}
+
+// resolveModel prefers the model the response reports, falling back to the one
+// the request asked for. Both candidates are returned in the order tried.
+func resolveModel(body, requestBody []byte, fields map[string]fieldSpec, requestPath string) (string, []string) {
+	var candidates []string
+
+	if name := readString(body, fields, "responseModel", requestPath); name != "" {
+		candidates = append(candidates, name)
+	}
+	// Read unconditionally: a requestModel declared as a path param resolves
+	// from the request path, with no body involved. A payload identifier just
+	// yields an empty value when there is no body.
+	if name := readString(requestBody, fields, "requestModel", requestPath); name != "" {
+		candidates = append(candidates, name)
+	}
+
+	if len(candidates) == 0 {
+		return "", nil
+	}
+	return candidates[0], candidates
+}
+
+// readInt reads a declared field as an integer, returning zero when the field
+// is not declared or the path is absent from the payload.
+func readInt(payload []byte, fields map[string]fieldSpec, name, requestPath string) int64 {
+	value := readString(payload, fields, name, requestPath)
+	if value == "" {
+		return 0
+	}
+	parsed, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return 0
+	}
+	return int64(parsed)
+}
+
+// readString reads a declared field, trying its identifier and then each
+// fallback in order and returning the first that yields a non-empty value.
+// Payload fields are read from the given JSON document; pathParam fields are
+// matched against the request path.
+func readString(payload []byte, fields map[string]fieldSpec, name, requestPath string) string {
+	spec, ok := fields[name]
+	if !ok {
+		return ""
+	}
+
+	for _, identifier := range spec.Identifiers {
+		var value string
+		switch spec.Location {
+		case locationPayload:
+			extracted, err := utils.ExtractStringValueFromJsonpath(payload, identifier)
+			if err != nil {
+				continue
+			}
+			value = strings.TrimSpace(extracted)
+		case locationPathParam:
+			value = extractFromPath(requestPath, identifier)
+		default:
+			return ""
+		}
+		if value != "" {
+			return mapValue(spec, value)
+		}
+	}
+	return ""
+}
+
+// mapValue translates a value the provider reported into the vocabulary the
+// library reports. A value absent from the map is returned unchanged, so a
+// field with no valueMap behaves as though the map were not there.
+func mapValue(spec fieldSpec, raw string) string {
+	if spec.ValueMap == nil || raw == "" {
+		return raw
+	}
+	if mapped, ok := spec.ValueMap[raw]; ok {
+		return mapped
+	}
+	return raw
+}
+
+// locationPayload is the ExtractionIdentifier location for a response body.
+const locationPayload = "payload"
+
+// locationPathParam is the ExtractionIdentifier location for the request path.
+const locationPathParam = "pathParam"

--- a/sdk/ai/llmusage/decode_test.go
+++ b/sdk/ai/llmusage/decode_test.go
@@ -1,0 +1,443 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package llmusage
+
+import "testing"
+
+func openAITemplate() map[string]interface{} {
+	return map[string]interface{}{
+		"promptTokens": map[string]interface{}{
+			"location": "payload", "identifier": "$.usage.prompt_tokens",
+		},
+		"completionTokens": map[string]interface{}{
+			"location": "payload", "identifier": "$.usage.completion_tokens",
+		},
+		"totalTokens": map[string]interface{}{
+			"location": "payload", "identifier": "$.usage.total_tokens",
+		},
+		"cachedTokens": map[string]interface{}{
+			"location": "payload", "identifier": "$.usage.prompt_tokens_details.cached_tokens",
+		},
+		"serviceTier": map[string]interface{}{
+			"location": "payload", "identifier": "$.service_tier",
+		},
+		"responseModel": map[string]interface{}{
+			"location": "payload", "identifier": "$.model",
+		},
+	}
+}
+
+func TestExtractUsage_BufferedResponse(t *testing.T) {
+	body := []byte(`{
+		"model": "gpt-4o-mini-2024-07-18",
+		"service_tier": "default",
+		"usage": {
+			"prompt_tokens": 1000,
+			"completion_tokens": 200,
+			"total_tokens": 1200,
+			"prompt_tokens_details": {"cached_tokens": 800}
+		}
+	}`)
+
+	got, err := extractUsage(openAITemplate(), body, nil, "/chat/completions")
+	if err != nil {
+		t.Fatalf("extractUsage returned error: %v", err)
+	}
+
+	if got.TotalInputTokens != 1000 {
+		t.Errorf("TotalInputTokens = %d, want 1000", got.TotalInputTokens)
+	}
+	if got.CachedReadTokens != 800 {
+		t.Errorf("CachedReadTokens = %d, want 800", got.CachedReadTokens)
+	}
+	if got.UncachedInputTokens != 200 {
+		t.Errorf("UncachedInputTokens = %d, want 200", got.UncachedInputTokens)
+	}
+	if got.OutputTokens != 200 {
+		t.Errorf("OutputTokens = %d, want 200", got.OutputTokens)
+	}
+	if got.TotalTokens != 1200 {
+		t.Errorf("TotalTokens = %d, want 1200", got.TotalTokens)
+	}
+	if got.Model != "gpt-4o-mini-2024-07-18" {
+		t.Errorf("Model = %q, want the response model", got.Model)
+	}
+	if got.IsPriority {
+		t.Error("IsPriority = true, want false for service_tier=default")
+	}
+}
+
+func TestExtractUsage_ModelFallsBackToRequestBody(t *testing.T) {
+	tmpl := openAITemplate()
+	tmpl["requestModel"] = map[string]interface{}{
+		"location": "payload", "identifier": "$.model",
+	}
+
+	// The responses API echoes no model, so the request body supplies it.
+	body := []byte(`{"usage":{"prompt_tokens":10,"completion_tokens":5}}`)
+	requestBody := []byte(`{"model":"my-deployment"}`)
+
+	got, err := extractUsage(tmpl, body, requestBody, "/responses")
+	if err != nil {
+		t.Fatalf("extractUsage returned error: %v", err)
+	}
+
+	if got.Model != "my-deployment" {
+		t.Errorf("Model = %q, want my-deployment from the request body", got.Model)
+	}
+	if len(got.ModelCandidates) == 0 {
+		t.Error("ModelCandidates is empty, want the tried names recorded")
+	}
+}
+
+func TestExtractUsage_SSEStreamMergesEvents(t *testing.T) {
+	// The model arrives in the first event and usage only in the last, so the
+	// merged view must carry both.
+	body := []byte(`data: {"model":"gpt-4o-mini","choices":[{"delta":{"content":"hi"}}]}
+
+data: {"usage":{"prompt_tokens":50,"completion_tokens":10,"total_tokens":60}}
+
+data: [DONE]
+`)
+
+	got, err := extractUsage(openAITemplate(), body, nil, "/chat/completions")
+	if err != nil {
+		t.Fatalf("extractUsage returned error: %v", err)
+	}
+
+	if got.TotalInputTokens != 50 {
+		t.Errorf("TotalInputTokens = %d, want 50", got.TotalInputTokens)
+	}
+	if got.Model != "gpt-4o-mini" {
+		t.Errorf("Model = %q, want the model from the first event", got.Model)
+	}
+}
+
+func TestExtractUsage_SSEEmptyStringDoesNotOverwrite(t *testing.T) {
+	// A later event carrying an empty model must not erase an earlier real one.
+	body := []byte(`data: {"model":"gpt-4o-mini"}
+
+data: {"model":"","usage":{"prompt_tokens":5,"completion_tokens":1}}
+`)
+
+	got, err := extractUsage(openAITemplate(), body, nil, "/chat/completions")
+	if err != nil {
+		t.Fatalf("extractUsage returned error: %v", err)
+	}
+
+	if got.Model != "gpt-4o-mini" {
+		t.Errorf("Model = %q, want the non-empty earlier value preserved", got.Model)
+	}
+}
+
+func TestExtractUsage_NoUsageObject(t *testing.T) {
+	body := []byte(`{"model":"gpt-4o-mini","choices":[]}`)
+
+	got, err := extractUsage(openAITemplate(), body, nil, "/chat/completions")
+	if err != nil {
+		t.Fatalf("extractUsage returned error: %v", err)
+	}
+
+	if got.TotalInputTokens != 0 || got.OutputTokens != 0 {
+		t.Errorf("expected zero counts, got in=%d out=%d", got.TotalInputTokens, got.OutputTokens)
+	}
+}
+
+func TestExtractUsage_UnparseableBody(t *testing.T) {
+	if _, err := extractUsage(openAITemplate(), []byte(`not json at all`), nil, "/x"); err == nil {
+		t.Error("expected an error for an unparseable body")
+	}
+}
+
+func TestExtractUsage_AnthropicAdditiveAccounting(t *testing.T) {
+	tmpl := map[string]interface{}{
+		"cacheAccounting": "additive",
+		"promptTokens": map[string]interface{}{
+			"location": "payload", "identifier": "$.usage.input_tokens",
+		},
+		"completionTokens": map[string]interface{}{
+			"location": "payload", "identifier": "$.usage.output_tokens",
+		},
+		"cachedTokens": map[string]interface{}{
+			"location": "payload", "identifier": "$.usage.cache_read_input_tokens",
+		},
+		"cacheWriteTokens": map[string]interface{}{
+			"location": "payload", "identifier": "$.usage.cache_creation.ephemeral_5m_input_tokens",
+		},
+		"serviceTier": map[string]interface{}{
+			"location": "payload", "identifier": "$.usage.service_tier",
+		},
+	}
+	body := []byte(`{
+		"usage": {
+			"input_tokens": 1000,
+			"output_tokens": 200,
+			"cache_read_input_tokens": 500,
+			"cache_creation": {"ephemeral_5m_input_tokens": 300},
+			"service_tier": "priority"
+		}
+	}`)
+
+	got, err := extractUsage(tmpl, body, nil, "/v1/messages")
+	if err != nil {
+		t.Fatalf("extractUsage returned error: %v", err)
+	}
+
+	if got.TotalInputTokens != 1800 {
+		t.Errorf("TotalInputTokens = %d, want 1800 (1000+500+300)", got.TotalInputTokens)
+	}
+	if got.UncachedInputTokens != 1000 {
+		t.Errorf("UncachedInputTokens = %d, want 1000", got.UncachedInputTokens)
+	}
+	if !got.IsPriority {
+		t.Error("IsPriority = false, want true")
+	}
+}
+
+func TestExtractUsage_FallbackIdentifiersTryInOrder(t *testing.T) {
+	// One template covering three Bedrock response shapes.
+	ident := func(primary string, fallbacks ...string) map[string]interface{} {
+		spec := map[string]interface{}{"location": "payload", "identifier": primary}
+		if len(fallbacks) > 0 {
+			list := make([]interface{}, 0, len(fallbacks))
+			for _, f := range fallbacks {
+				list = append(list, f)
+			}
+			spec["fallbackIdentifiers"] = list
+		}
+		return spec
+	}
+	tmpl := map[string]interface{}{
+		"promptTokens":     ident("$.usage.inputTokens", "$.usage.input_tokens", "$.usage.prompt_tokens", "$.inputTextTokenCount"),
+		"completionTokens": ident("$.usage.outputTokens", "$.usage.output_tokens", "$.usage.completion_tokens", "$.results[0].tokenCount"),
+	}
+
+	tests := []struct {
+		name    string
+		body    string
+		wantIn  int64
+		wantOut int64
+	}{
+		{"converse shape", `{"usage":{"inputTokens":100,"outputTokens":50}}`, 100, 50},
+		{"anthropic invokemodel shape", `{"usage":{"input_tokens":200,"output_tokens":60}}`, 200, 60},
+		{"openai transformed shape", `{"usage":{"prompt_tokens":300,"completion_tokens":70}}`, 300, 70},
+		{"titan shape", `{"inputTextTokenCount":400,"results":[{"tokenCount":80}]}`, 400, 80},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := extractUsage(tmpl, []byte(tt.body), nil, "/model/x/invoke")
+			if err != nil {
+				t.Fatalf("extractUsage returned error: %v", err)
+			}
+			if got.TotalInputTokens != tt.wantIn {
+				t.Errorf("TotalInputTokens = %d, want %d", got.TotalInputTokens, tt.wantIn)
+			}
+			if got.OutputTokens != tt.wantOut {
+				t.Errorf("OutputTokens = %d, want %d", got.OutputTokens, tt.wantOut)
+			}
+		})
+	}
+}
+
+func TestExtractUsage_PrimaryIdentifierWinsOverFallback(t *testing.T) {
+	tmpl := map[string]interface{}{
+		"promptTokens": map[string]interface{}{
+			"location":            "payload",
+			"identifier":          "$.usage.inputTokens",
+			"fallbackIdentifiers": []interface{}{"$.usage.prompt_tokens"},
+		},
+	}
+	// Both present: the primary must win.
+	body := []byte(`{"usage":{"inputTokens":100,"prompt_tokens":999}}`)
+
+	got, err := extractUsage(tmpl, body, nil, "/x")
+	if err != nil {
+		t.Fatalf("extractUsage returned error: %v", err)
+	}
+	if got.TotalInputTokens != 100 {
+		t.Errorf("TotalInputTokens = %d, want 100 from the primary identifier", got.TotalInputTokens)
+	}
+}
+
+func TestExtractUsage_ValueMapTranslatesServiceTier(t *testing.T) {
+	template := map[string]interface{}{
+		"promptTokens": map[string]interface{}{
+			"location": "payload", "identifier": "$.usageMetadata.promptTokenCount",
+		},
+		"completionTokens": map[string]interface{}{
+			"location": "payload", "identifier": "$.usageMetadata.candidatesTokenCount",
+		},
+		"responseModel": map[string]interface{}{
+			"location": "payload", "identifier": "$.modelVersion",
+		},
+		"serviceTier": map[string]interface{}{
+			"location":   "payload",
+			"identifier": "$.usageMetadata.trafficType",
+			"valueMap": map[string]interface{}{
+				"ON_DEMAND_PRIORITY": "priority",
+				"ON_DEMAND_FLEX":     "flex",
+			},
+		},
+	}
+
+	body := []byte(`{
+		"modelVersion": "gemini-2.0-flash",
+		"usageMetadata": {
+			"promptTokenCount": 100,
+			"candidatesTokenCount": 20,
+			"trafficType": "ON_DEMAND_PRIORITY"
+		}
+	}`)
+
+	usage, err := extractUsage(template, body, nil, "/v1/models/gemini-2.0-flash:generateContent")
+	if err != nil {
+		t.Fatalf("extractUsage: %v", err)
+	}
+	if usage.ServiceTier != "priority" {
+		t.Errorf("ServiceTier = %q, want priority", usage.ServiceTier)
+	}
+	if !usage.IsPriority {
+		t.Error("IsPriority = false, want true")
+	}
+}
+
+func TestExtractUsage_UnmappedTierFallsThroughToStandard(t *testing.T) {
+	template := map[string]interface{}{
+		"promptTokens": map[string]interface{}{
+			"location": "payload", "identifier": "$.usageMetadata.promptTokenCount",
+		},
+		"serviceTier": map[string]interface{}{
+			"location":   "payload",
+			"identifier": "$.usageMetadata.trafficType",
+			"valueMap": map[string]interface{}{
+				"ON_DEMAND_PRIORITY": "priority",
+			},
+		},
+	}
+
+	body := []byte(`{"usageMetadata":{"promptTokenCount":100,"trafficType":"PROVISIONED_THROUGHPUT"}}`)
+
+	usage, err := extractUsage(template, body, nil, "/v1/models/x:generateContent")
+	if err != nil {
+		t.Fatalf("extractUsage: %v", err)
+	}
+	if usage.ServiceTier != "" {
+		t.Errorf("ServiceTier = %q, want empty", usage.ServiceTier)
+	}
+}
+
+func TestExtractUsage_NoValueMapKeepsExistingBehaviour(t *testing.T) {
+	template := map[string]interface{}{
+		"promptTokens": map[string]interface{}{
+			"location": "payload", "identifier": "$.usage.prompt_tokens",
+		},
+		"serviceTier": map[string]interface{}{
+			"location": "payload", "identifier": "$.service_tier",
+		},
+	}
+
+	body := []byte(`{"service_tier":"flex","usage":{"prompt_tokens":100}}`)
+
+	usage, err := extractUsage(template, body, nil, "/v1/chat/completions")
+	if err != nil {
+		t.Fatalf("extractUsage: %v", err)
+	}
+	if usage.ServiceTier != "flex" {
+		t.Errorf("ServiceTier = %q, want flex", usage.ServiceTier)
+	}
+}
+
+func TestExtractUsage_SSEEventSplitAcrossDataFields(t *testing.T) {
+	// The stream format lets one event spread its payload over several data
+	// fields, joined by a newline. Read individually each fragment is invalid
+	// JSON, so the fields have to be joined before decoding.
+	body := []byte(`data: {"model":"gpt-4o-mini",
+data: "usage":{"prompt_tokens":50,
+data: "completion_tokens":10,"total_tokens":60}}
+
+data: [DONE]
+`)
+
+	got, err := extractUsage(openAITemplate(), body, nil, "/chat/completions")
+	if err != nil {
+		t.Fatalf("extractUsage returned error: %v", err)
+	}
+
+	if got.TotalInputTokens != 50 {
+		t.Errorf("TotalInputTokens = %d, want 50", got.TotalInputTokens)
+	}
+	if got.OutputTokens != 10 {
+		t.Errorf("OutputTokens = %d, want 10", got.OutputTokens)
+	}
+	if got.Model != "gpt-4o-mini" {
+		t.Errorf("Model = %q, want gpt-4o-mini", got.Model)
+	}
+}
+
+func TestExtractUsage_SSECompleteObjectPerDataFieldWithoutBlankLine(t *testing.T) {
+	// Joining these fields would produce two top-level objects, which is not
+	// valid JSON. Each field is a complete document on its own, so both must
+	// still be read rather than the event being discarded.
+	body := []byte(`data: {"model":"gpt-4o-mini"}
+data: {"usage":{"prompt_tokens":7,"completion_tokens":2,"total_tokens":9}}
+`)
+
+	got, err := extractUsage(openAITemplate(), body, nil, "/chat/completions")
+	if err != nil {
+		t.Fatalf("extractUsage returned error: %v", err)
+	}
+
+	if got.TotalInputTokens != 7 {
+		t.Errorf("TotalInputTokens = %d, want 7", got.TotalInputTokens)
+	}
+	if got.Model != "gpt-4o-mini" {
+		t.Errorf("Model = %q, want gpt-4o-mini", got.Model)
+	}
+}
+
+func TestResolveModel_PathParamRequestModelWithoutRequestBody(t *testing.T) {
+	// AWS Bedrock and Gemini declare requestModel as a path param, so it must
+	// resolve from the request path even when no request body is available.
+	// A response that carries no model of its own relies on this fallback.
+	template := map[string]interface{}{
+		"promptTokens": map[string]interface{}{
+			"location": "payload", "identifier": "$.usage.inputTokens",
+		},
+		"responseModel": map[string]interface{}{
+			"location": "payload", "identifier": "$.model",
+		},
+		"requestModel": map[string]interface{}{
+			"location": "pathParam", "identifier": `model/([A-Za-z0-9.:%-]+)/`,
+		},
+	}
+	body := []byte(`{"usage":{"inputTokens":10}}`) // no model in the response
+
+	got, err := extractUsage(template, body, nil, "/model/anthropic.claude-3-7-sonnet-20250219-v1:0/converse")
+	if err != nil {
+		t.Fatalf("extractUsage returned error: %v", err)
+	}
+
+	want := "anthropic.claude-3-7-sonnet-20250219-v1:0"
+	if got.Model != want {
+		t.Errorf("Model = %q, want it resolved from the request path (%q)", got.Model, want)
+	}
+	if len(got.ModelCandidates) != 1 || got.ModelCandidates[0] != want {
+		t.Errorf("ModelCandidates = %v, want [%s]", got.ModelCandidates, want)
+	}
+}

--- a/sdk/ai/llmusage/extract.go
+++ b/sdk/ai/llmusage/extract.go
@@ -1,0 +1,164 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+// Package llmusage extracts normalized LLM token usage from a provider
+// response, using the field locations declared in the route's
+// LlmProviderTemplate rather than per-provider Go code. Results are memoized
+// in SharedContext so several policies on one route extract once.
+package llmusage
+
+import (
+	"errors"
+
+	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
+)
+
+// Metadata keys the library reads from and writes to SharedContext.
+const (
+	// MetadataTemplateHandle is set by the kernel and names the route's template.
+	MetadataTemplateHandle = "template_handle"
+
+	// UsageKey holds the extracted Usage. The version suffix allows the shape
+	// to change without breaking existing readers.
+	UsageKey = "llm:usage:v1"
+
+	// StatusKey reports whether extraction succeeded, so a consumer can tell
+	// a genuinely free request from a failed extraction.
+	StatusKey = "llm:usage:status"
+)
+
+// Status values written to StatusKey.
+const (
+	StatusExtracted       = "extracted"
+	StatusTemplateMissing = "template_missing"
+	StatusNoUsage         = "no_usage"
+)
+
+// ResourceTypeLLMProviderTemplate is the lazy-resource type holding templates.
+const ResourceTypeLLMProviderTemplate = "LlmProviderTemplate"
+
+// streamAccumKey and streamIndexKey hold per-request streaming state. Both are
+// removed by Accumulate at end of stream.
+const (
+	streamAccumKey = "llm:usage:stream-accum"
+	streamIndexKey = "llm:usage:stream-index"
+)
+
+// ErrNoTemplate reports that the route carries no resolvable template, so
+// there are no field locations to extract from.
+var ErrNoTemplate = errors.New("llmusage: no template for route")
+
+// Get returns normalized usage for this request. The first call extracts and
+// stores the result; later calls return the stored value, so several policies
+// on one route pay for extraction once.
+func Get(sc *policy.SharedContext, body, requestBody []byte, requestPath string) (Usage, error) {
+	if sc == nil {
+		return Usage{}, ErrNoTemplate
+	}
+	if sc.Metadata == nil {
+		sc.Metadata = make(map[string]interface{})
+	}
+
+	if cached, ok := sc.Metadata[UsageKey].(Usage); ok {
+		return cached, nil
+	}
+
+	template, err := templateForRoute(sc)
+	if err != nil {
+		sc.Metadata[StatusKey] = StatusTemplateMissing
+		return Usage{}, err
+	}
+
+	usage, err := extractUsage(template, body, requestBody, requestPath)
+	if err != nil {
+		sc.Metadata[StatusKey] = StatusNoUsage
+		return Usage{}, err
+	}
+
+	Publish(sc, usage)
+	return usage, nil
+}
+
+// Publish stores usage and its status in SharedContext for other policies.
+func Publish(sc *policy.SharedContext, u Usage) {
+	if sc == nil {
+		return
+	}
+	if sc.Metadata == nil {
+		sc.Metadata = make(map[string]interface{})
+	}
+
+	sc.Metadata[UsageKey] = u
+	if u.TotalInputTokens == 0 && u.OutputTokens == 0 {
+		sc.Metadata[StatusKey] = StatusNoUsage
+		return
+	}
+	sc.Metadata[StatusKey] = StatusExtracted
+}
+
+// Accumulate appends a stream chunk to the shared buffer and returns the buffer
+// so far. Chunks are deduped by index, so several policies accumulating the
+// same stream produce one buffer rather than one each. At end of stream the
+// buffer is returned and the state removed.
+func Accumulate(sc *policy.SharedContext, chunk *policy.StreamBody) []byte {
+	if sc == nil || chunk == nil {
+		return nil
+	}
+	if sc.Metadata == nil {
+		sc.Metadata = make(map[string]interface{})
+	}
+
+	buffered, _ := sc.Metadata[streamAccumKey].([]byte)
+	lastIndex, seen := sc.Metadata[streamIndexKey].(uint64)
+
+	isNew := !seen || chunk.Index > lastIndex
+	if isNew && len(chunk.Chunk) > 0 {
+		buffered = append(buffered, chunk.Chunk...)
+		sc.Metadata[streamAccumKey] = buffered
+	}
+	if isNew {
+		sc.Metadata[streamIndexKey] = chunk.Index
+	}
+
+	// The buffer is deliberately kept after the final chunk. Every policy on the
+	// route is handed the same chunk in turn, so clearing it here would leave the
+	// next policy with only the last chunk. SharedContext is per request, so the
+	// buffer is released when the request ends.
+	return buffered
+}
+
+// templateForRoute resolves the route's template from the lazy-resource store
+// using the handle the kernel placed in SharedContext.
+func templateForRoute(sc *policy.SharedContext) (map[string]interface{}, error) {
+	handle, ok := sc.Metadata[MetadataTemplateHandle].(string)
+	if !ok || handle == "" {
+		return nil, ErrNoTemplate
+	}
+
+	resource, err := policy.GetLazyResourceStoreInstance().
+		GetResourceByIDAndType(handle, ResourceTypeLLMProviderTemplate)
+	if err != nil || resource == nil {
+		return nil, ErrNoTemplate
+	}
+
+	spec, ok := resource.Resource["spec"].(map[string]interface{})
+	if ok {
+		return spec, nil
+	}
+	return resource.Resource, nil
+}

--- a/sdk/ai/llmusage/extract_test.go
+++ b/sdk/ai/llmusage/extract_test.go
@@ -1,0 +1,189 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package llmusage
+
+import (
+	"bytes"
+	"testing"
+
+	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
+)
+
+func newSharedContext() *policy.SharedContext {
+	return &policy.SharedContext{Metadata: map[string]interface{}{}}
+}
+
+func TestAccumulate_DedupesByChunkIndex(t *testing.T) {
+	sc := newSharedContext()
+
+	// Two policies see the same chunk, so it must be appended once.
+	first := &policy.StreamBody{Chunk: []byte("abc"), Index: 0}
+	Accumulate(sc, first)
+	Accumulate(sc, first)
+
+	got := Accumulate(sc, &policy.StreamBody{Chunk: []byte("def"), Index: 1})
+
+	if string(got) != "abcdef" {
+		t.Errorf("accumulated = %q, want %q", got, "abcdef")
+	}
+}
+
+func TestAccumulate_OutOfOrderIndexIgnored(t *testing.T) {
+	sc := newSharedContext()
+
+	Accumulate(sc, &policy.StreamBody{Chunk: []byte("abc"), Index: 0})
+	Accumulate(sc, &policy.StreamBody{Chunk: []byte("def"), Index: 1})
+	got := Accumulate(sc, &policy.StreamBody{Chunk: []byte("STALE"), Index: 0})
+
+	if string(got) != "abcdef" {
+		t.Errorf("accumulated = %q, want the stale chunk ignored", got)
+	}
+}
+
+func TestAccumulate_NilContextDoesNotPanic(t *testing.T) {
+	if got := Accumulate(nil, &policy.StreamBody{Chunk: []byte("abc")}); got != nil {
+		t.Errorf("got %q, want nil for a nil context", got)
+	}
+}
+
+func TestGet_MemoizesAcrossCalls(t *testing.T) {
+	sc := newSharedContext()
+	sc.Metadata[MetadataTemplateHandle] = "openai"
+	storeTestTemplate(t, "openai", openAITemplate())
+
+	body := []byte(`{"model":"gpt-4o-mini","usage":{"prompt_tokens":10,"completion_tokens":5}}`)
+
+	first, err := Get(sc, body, nil, "/chat/completions")
+	if err != nil {
+		t.Fatalf("first Get returned error: %v", err)
+	}
+
+	// A second call with a different body must return the memoized value,
+	// proving extraction happened once for the request.
+	second, err := Get(sc, []byte(`{"usage":{"prompt_tokens":999}}`), nil, "/chat/completions")
+	if err != nil {
+		t.Fatalf("second Get returned error: %v", err)
+	}
+
+	if second.TotalInputTokens != first.TotalInputTokens {
+		t.Errorf("second call re-extracted: got %d, want the memoized %d",
+			second.TotalInputTokens, first.TotalInputTokens)
+	}
+	if first.TotalInputTokens != 10 {
+		t.Errorf("TotalInputTokens = %d, want 10", first.TotalInputTokens)
+	}
+}
+
+func TestGet_NoTemplateHandleReportsStatus(t *testing.T) {
+	sc := newSharedContext()
+
+	_, err := Get(sc, []byte(`{"usage":{"prompt_tokens":10}}`), nil, "/chat/completions")
+
+	if err == nil {
+		t.Fatal("expected an error when the route carries no template handle")
+	}
+	if sc.Metadata[StatusKey] != StatusTemplateMissing {
+		t.Errorf("status = %v, want %q", sc.Metadata[StatusKey], StatusTemplateMissing)
+	}
+}
+
+func TestPublish_WritesUsageAndStatus(t *testing.T) {
+	sc := newSharedContext()
+
+	Publish(sc, Usage{TotalInputTokens: 100, OutputTokens: 20, TotalTokens: 120, Model: "m"})
+
+	if sc.Metadata[StatusKey] != StatusExtracted {
+		t.Errorf("status = %v, want %q", sc.Metadata[StatusKey], StatusExtracted)
+	}
+	published, ok := sc.Metadata[UsageKey].(Usage)
+	if !ok {
+		t.Fatalf("usage under %q is %T, want Usage", UsageKey, sc.Metadata[UsageKey])
+	}
+	if published.TotalInputTokens != 100 {
+		t.Errorf("published TotalInputTokens = %d, want 100", published.TotalInputTokens)
+	}
+}
+
+func TestPublish_NilContextDoesNotPanic(t *testing.T) {
+	Publish(nil, Usage{TotalInputTokens: 1})
+}
+
+// storeTestTemplate puts a template into the shared lazy-resource store and
+// removes it when the test ends, so tests do not leak state into each other.
+func storeTestTemplate(t *testing.T, handle string, spec map[string]interface{}) {
+	t.Helper()
+
+	store := policy.GetLazyResourceStoreInstance()
+	if err := store.StoreResource(&policy.LazyResource{
+		ID:           handle,
+		ResourceType: ResourceTypeLLMProviderTemplate,
+		Resource:     spec,
+	}); err != nil {
+		t.Fatalf("failed to store test template: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = store.RemoveResourceByIDAndType(handle, ResourceTypeLLMProviderTemplate)
+	})
+}
+
+// The kernel hands each chunk to every policy on the route in turn, so
+// Accumulate is called once per policy per chunk. Each caller must come away
+// with the whole stream, which means the buffer cannot be cleared when the
+// first caller reaches the final chunk.
+func TestAccumulate_EveryPolicySeesTheWholeStream(t *testing.T) {
+	sc := &policy.SharedContext{Metadata: map[string]interface{}{}}
+	chunks := []struct {
+		data string
+		eos  bool
+	}{
+		{"data: {\"model\":\"m\"}\n\n", false},
+		{"data: {\"choices\":[]}\n\n", false},
+		{"data: {\"usage\":{\"prompt_tokens\":6}}\n\n", true},
+	}
+
+	var first, second []byte
+	for i, c := range chunks {
+		chunk := &policy.StreamBody{Chunk: []byte(c.data), Index: uint64(i + 1), EndOfStream: c.eos}
+		first = Accumulate(sc, chunk)  // first policy in the chain
+		second = Accumulate(sc, chunk) // second policy, same chunk
+	}
+
+	if string(second) != string(first) {
+		t.Errorf("second policy saw %d bytes, first saw %d; both must see the whole stream",
+			len(second), len(first))
+	}
+	for _, want := range []string{`"model":"m"`, `"prompt_tokens":6`} {
+		if !bytes.Contains(second, []byte(want)) {
+			t.Errorf("second policy's buffer is missing %s", want)
+		}
+	}
+}
+
+// A redelivered final chunk must not restart the buffer either.
+func TestAccumulate_RedeliveredFinalChunkKeepsBuffer(t *testing.T) {
+	sc := &policy.SharedContext{Metadata: map[string]interface{}{}}
+
+	Accumulate(sc, &policy.StreamBody{Chunk: []byte("aaaa"), Index: 1})
+	first := Accumulate(sc, &policy.StreamBody{Chunk: []byte("bbbb"), Index: 2, EndOfStream: true})
+	again := Accumulate(sc, &policy.StreamBody{Chunk: []byte("bbbb"), Index: 2, EndOfStream: true})
+
+	if string(again) != string(first) {
+		t.Errorf("redelivered final chunk gave %q, want %q", again, first)
+	}
+}

--- a/sdk/ai/llmusage/pathmatch.go
+++ b/sdk/ai/llmusage/pathmatch.go
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package llmusage
+
+import "strings"
+
+// pathsMatch reports whether a request path is covered by a resource pattern.
+// A pattern may end in a wildcard to cover everything beneath a prefix. A
+// specific pattern never matches a wildcard request path, so catch-all routes
+// do not pick up resource-specific configuration.
+func pathsMatch(requestPath, pattern string) bool {
+	if pattern == "/*" {
+		return true
+	}
+	if requestPath == pattern {
+		return true
+	}
+	if strings.Contains(pattern, "*") {
+		// Only a single trailing wildcard is supported. An embedded one such as
+		// "/v1/*/usage" would otherwise reduce to the prefix "/v1/" and cover
+		// every route beneath it, applying this resource's field locations to
+		// requests it was never meant to describe.
+		if !strings.HasSuffix(pattern, "*") || strings.Count(pattern, "*") != 1 {
+			return false
+		}
+		prefix := pattern[:strings.LastIndex(pattern, "*")]
+		return strings.HasPrefix(requestPath, prefix)
+	}
+	return false
+}
+
+// preferMoreSpecificPath reports whether candidate is a better match than
+// current: a pattern without a wildcard beats one with a wildcard, and a longer
+// pattern beats a shorter one.
+func preferMoreSpecificPath(candidate, current string) bool {
+	candidateHasWildcard := strings.Contains(candidate, "*")
+	currentHasWildcard := strings.Contains(current, "*")
+
+	if !candidateHasWildcard && currentHasWildcard {
+		return true
+	}
+	if candidateHasWildcard && !currentHasWildcard {
+		return false
+	}
+
+	return len(candidate) > len(current)
+}

--- a/sdk/ai/llmusage/pathmatch_test.go
+++ b/sdk/ai/llmusage/pathmatch_test.go
@@ -1,0 +1,101 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package llmusage
+
+import "testing"
+
+func TestPathsMatch(t *testing.T) {
+	tests := []struct {
+		name        string
+		requestPath string
+		pattern     string
+		want        bool
+	}{
+		{"root wildcard matches anything", "/chat/completions", "/*", true},
+		{"exact match", "/responses", "/responses", true},
+		{"prefix wildcard matches", "/chat/completions", "/chat/*", true},
+		{"prefix wildcard matches deeper", "/chat/completions/stream", "/chat/*", true},
+		{"different path does not match", "/responses", "/chat/completions", false},
+		{"specific pattern does not match wildcard request", "/chat/*", "/chat/completions", false},
+		{"empty pattern does not match", "/responses", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pathsMatch(tt.requestPath, tt.pattern); got != tt.want {
+				t.Errorf("pathsMatch(%q, %q) = %v, want %v", tt.requestPath, tt.pattern, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPreferMoreSpecificPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		candidate string
+		current   string
+		want      bool
+	}{
+		{"exact beats wildcard", "/v1/exact", "/v1/*", true},
+		{"wildcard loses to exact", "/v1/*", "/v1/exact", false},
+		{"longer exact wins", "/v1/chat/completions", "/v1/chat", true},
+		{"shorter exact loses", "/v1/chat", "/v1/chat/completions", false},
+		{"longer wildcard wins over shorter wildcard", "/v1/chat/*", "/v1/*", true},
+		{"equal length does not displace", "/v1/aaa", "/v1/bbb", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := preferMoreSpecificPath(tt.candidate, tt.current); got != tt.want {
+				t.Errorf("preferMoreSpecificPath(%q, %q) = %v, want %v",
+					tt.candidate, tt.current, got, tt.want)
+			}
+		})
+	}
+}
+
+// Only a trailing wildcard is supported. An embedded one used to reduce to the
+// prefix before it, so "/v1/*/usage" covered every route under "/v1/" and this
+// resource's field locations were applied to unrelated requests.
+func TestPathsMatch_OnlyTrailingWildcardIsHonoured(t *testing.T) {
+	cases := []struct {
+		pattern, requestPath string
+		want                 bool
+		why                  string
+	}{
+		{"/v1/*/usage", "/v1/chat/completions", false, "embedded wildcard must not cover unrelated routes"},
+		{"/v1/*/usage", "/v1/embeddings", false, "embedded wildcard must not cover unrelated routes"},
+		{"/v1/*/usage", "/v1/foo/usage", false, "embedded wildcards are not supported at all"},
+		{"/v1/**", "/v1/anything", false, "repeated wildcards are rejected"},
+		{"/v1/*/*", "/v1/a/b", false, "repeated wildcards are rejected"},
+
+		// The supported forms keep working.
+		{"/v1/*", "/v1/chat/completions", true, "trailing wildcard covers the prefix"},
+		{"/*", "/anything", true, "catch-all"},
+		{"/responses", "/responses", true, "exact match, as the shipped templates use"},
+		{"/responses", "/responses/create", false, "exact pattern must not prefix-match"},
+	}
+
+	for _, c := range cases {
+		if got := pathsMatch(c.requestPath, c.pattern); got != c.want {
+			t.Errorf("pathsMatch(%q, %q) = %v, want %v — %s",
+				c.requestPath, c.pattern, got, c.want, c.why)
+		}
+	}
+}

--- a/sdk/ai/llmusage/pathparam.go
+++ b/sdk/ai/llmusage/pathparam.go
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package llmusage
+
+import (
+	"net/url"
+	"regexp"
+	"sync"
+)
+
+// pathPatternCache holds compiled patterns so a template's regex is compiled
+// once rather than on every request.
+var pathPatternCache sync.Map
+
+// extractFromPath returns the first capture group of pattern applied to the
+// request path, percent-decoded. An unparseable pattern, a pattern with no
+// capture group, or no match yields an empty string, which callers treat the
+// same as an absent field.
+func extractFromPath(requestPath, pattern string) string {
+	re := compilePathPattern(pattern)
+	if re == nil {
+		return ""
+	}
+
+	match := re.FindStringSubmatch(requestPath)
+	if len(match) < 2 {
+		return ""
+	}
+
+	// Values taken from a URL may be percent-encoded; AWS encodes ARN model
+	// identifiers because their resource component can contain a slash.
+	if decoded, err := url.PathUnescape(match[1]); err == nil {
+		return decoded
+	}
+	return match[1]
+}
+
+// compilePathPattern compiles and caches a pattern, returning nil when it is
+// not valid so a malformed template cannot break request handling.
+func compilePathPattern(pattern string) *regexp.Regexp {
+	if cached, ok := pathPatternCache.Load(pattern); ok {
+		re, _ := cached.(*regexp.Regexp)
+		return re
+	}
+
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		pathPatternCache.Store(pattern, (*regexp.Regexp)(nil))
+		return nil
+	}
+	pathPatternCache.Store(pattern, re)
+	return re
+}

--- a/sdk/ai/llmusage/pathparam_test.go
+++ b/sdk/ai/llmusage/pathparam_test.go
@@ -1,0 +1,111 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package llmusage
+
+import "testing"
+
+func TestExtractFromPath(t *testing.T) {
+	const bedrockPattern = `model/([A-Za-z0-9.:%-]+)/`
+
+	tests := []struct {
+		name        string
+		requestPath string
+		pattern     string
+		want        string
+	}{
+		{
+			name:        "plain bedrock model id",
+			requestPath: "/model/anthropic.claude-3-sonnet-20240229-v1:0/converse",
+			pattern:     bedrockPattern,
+			want:        "anthropic.claude-3-sonnet-20240229-v1:0",
+		},
+		{
+			name:        "cross-region inference profile",
+			requestPath: "/model/us.anthropic.claude-3-5-sonnet-20240620-v1:0/converse-stream",
+			pattern:     bedrockPattern,
+			want:        "us.anthropic.claude-3-5-sonnet-20240620-v1:0",
+		},
+		{
+			name:        "percent-encoded arn is decoded",
+			requestPath: "/model/arn%3Aaws%3Abedrock%3Aus-east-1%3A123%3Ainference-profile%2Fus.anthropic.claude-3-5-sonnet-20240620-v1%3A0/converse",
+			pattern:     bedrockPattern,
+			want:        "arn:aws:bedrock:us-east-1:123:inference-profile/us.anthropic.claude-3-5-sonnet-20240620-v1:0",
+		},
+		{
+			name:        "gemini lookbehind pattern",
+			requestPath: "/v1beta/models/gemini-2.5-flash:streamGenerateContent",
+			pattern:     `models/([a-zA-Z0-9.\-]+)`,
+			want:        "gemini-2.5-flash",
+		},
+		{
+			name:        "no match returns empty",
+			requestPath: "/chat/completions",
+			pattern:     bedrockPattern,
+			want:        "",
+		},
+		{
+			name:        "unparseable pattern returns empty rather than panicking",
+			requestPath: "/model/x/converse",
+			pattern:     `model/([A-Za-z`,
+			want:        "",
+		},
+		{
+			name:        "pattern with no capture group returns empty",
+			requestPath: "/model/x/converse",
+			pattern:     `model/`,
+			want:        "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractFromPath(tt.requestPath, tt.pattern); got != tt.want {
+				t.Errorf("extractFromPath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractUsage_ModelFromPathParam(t *testing.T) {
+	tmpl := map[string]interface{}{
+		"promptTokens": map[string]interface{}{
+			"location": "payload", "identifier": "$.usage.inputTokens",
+		},
+		"completionTokens": map[string]interface{}{
+			"location": "payload", "identifier": "$.usage.outputTokens",
+		},
+		"responseModel": map[string]interface{}{
+			"location": "pathParam", "identifier": `model/([A-Za-z0-9.:%-]+)/`,
+		},
+	}
+	// A Bedrock Converse response carries no model field at all.
+	body := []byte(`{"usage":{"inputTokens":100,"outputTokens":50}}`)
+
+	got, err := extractUsage(tmpl, body, nil, "/model/anthropic.claude-3-sonnet-20240229-v1:0/converse")
+	if err != nil {
+		t.Fatalf("extractUsage returned error: %v", err)
+	}
+
+	if got.Model != "anthropic.claude-3-sonnet-20240229-v1:0" {
+		t.Errorf("Model = %q, want the id from the request path", got.Model)
+	}
+	if got.TotalInputTokens != 100 {
+		t.Errorf("TotalInputTokens = %d, want 100", got.TotalInputTokens)
+	}
+}

--- a/sdk/ai/llmusage/providerfield.go
+++ b/sdk/ai/llmusage/providerfield.go
@@ -1,0 +1,115 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package llmusage
+
+import (
+	"encoding/json"
+
+	"github.com/wso2/api-platform/sdk/core/utils"
+
+	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
+)
+
+// decodedBodyKey holds the response decoded once per request, so a consumer
+// reading several provider fields does not re-parse the body for each.
+const (
+	decodedBodyKey    = "llm:usage:decoded-body"
+	decodedRequestKey = "llm:usage:decoded-request"
+)
+
+// ProviderField returns the value at the location the route's template declares
+// for name under providerFields. The value is returned as decoded JSON — a
+// string, a number, a list or an object — so a caller can walk a list or a map
+// without knowing where the provider puts it. Reports false when the route has
+// no template, the name is not declared, or the location holds nothing.
+//
+// This is the escape hatch for values the closed vocabulary does not cover: the
+// template still owns where the data is, and the caller owns what to do with it.
+func ProviderField(sc *policy.SharedContext, body []byte, requestPath, name string) (interface{}, bool) {
+	return providerFieldFrom(sc, body, requestPath, name, decodedBodyKey)
+}
+
+// ProviderFieldFromRequest is ProviderField against the request body, for the
+// values a provider reports only on the way in — a requested search depth, for
+// instance, that the response never echoes.
+func ProviderFieldFromRequest(sc *policy.SharedContext, requestBody []byte, requestPath, name string) (interface{}, bool) {
+	return providerFieldFrom(sc, requestBody, requestPath, name, decodedRequestKey)
+}
+
+func providerFieldFrom(sc *policy.SharedContext, body []byte, requestPath, name, cacheKey string) (interface{}, bool) {
+	if sc == nil || name == "" {
+		return nil, false
+	}
+
+	template, err := templateForRoute(sc)
+	if err != nil {
+		return nil, false
+	}
+
+	spec, ok := providerFieldSpec(template, name)
+	if !ok || spec.Location != locationPayload {
+		return nil, false
+	}
+
+	document, ok := decodedDocument(sc, body, requestPath, cacheKey)
+	if !ok {
+		return nil, false
+	}
+
+	for _, identifier := range spec.Identifiers {
+		value, err := utils.ExtractValueFromJsonpath(document, identifier)
+		if err != nil || value == nil {
+			continue
+		}
+		return value, true
+	}
+	return nil, false
+}
+
+// providerFieldSpec reads one entry from the template's providerFields map.
+func providerFieldSpec(template map[string]interface{}, name string) (fieldSpec, bool) {
+	fields, ok := template["providerFields"].(map[string]interface{})
+	if !ok {
+		return fieldSpec{}, false
+	}
+	return readFieldSpec(fields, name)
+}
+
+// decodedDocument decodes the response once and keeps it for the rest of the
+// request, since a provider needing several fields would otherwise pay for a
+// parse per field.
+func decodedDocument(sc *policy.SharedContext, body []byte, requestPath, cacheKey string) (map[string]interface{}, bool) {
+	if sc.Metadata == nil {
+		sc.Metadata = make(map[string]interface{})
+	}
+	if cached, ok := sc.Metadata[cacheKey].(map[string]interface{}); ok {
+		return cached, true
+	}
+
+	if len(body) == 0 {
+		return nil, false
+	}
+	var document map[string]interface{}
+	if err := json.Unmarshal(decodeBody(body, requestPath), &document); err != nil {
+		return nil, false
+	}
+
+	sc.Metadata[cacheKey] = document
+	return document, true
+}

--- a/sdk/ai/llmusage/providerfield_test.go
+++ b/sdk/ai/llmusage/providerfield_test.go
@@ -1,0 +1,109 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package llmusage
+
+import (
+	"testing"
+
+	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
+)
+
+func templateWithProviderFields() map[string]interface{} {
+	return map[string]interface{}{
+		"promptTokens": map[string]interface{}{
+			"location": "payload", "identifier": "$.usage.inputTokens",
+		},
+		"providerFields": map[string]interface{}{
+			"cacheDetails": map[string]interface{}{
+				"location": "payload", "identifier": "$.usage.cacheDetails",
+			},
+			"tier": map[string]interface{}{
+				"location": "payload", "identifier": "$.serviceTier.type",
+			},
+		},
+	}
+}
+
+const bodyWithList = `{
+  "usage": {"inputTokens": 100,
+            "cacheDetails": [{"ttl":"5m","inputTokens":300},{"ttl":"1h","inputTokens":200}]},
+  "serviceTier": {"type": "priority"}
+}`
+
+func TestProviderField_ReturnsListAsDecodedJSON(t *testing.T) {
+	storeTestTemplate(t, "pf", templateWithProviderFields())
+	sc := &policy.SharedContext{Metadata: map[string]interface{}{MetadataTemplateHandle: "pf"}}
+
+	raw, ok := ProviderField(sc, []byte(bodyWithList), "/converse", "cacheDetails")
+	if !ok {
+		t.Fatal("cacheDetails not found")
+	}
+	list, ok := raw.([]interface{})
+	if !ok {
+		t.Fatalf("got %T, want []interface{}", raw)
+	}
+	if len(list) != 2 {
+		t.Fatalf("got %d entries, want 2", len(list))
+	}
+	first, _ := list[0].(map[string]interface{})
+	if first["ttl"] != "5m" {
+		t.Errorf("first ttl = %v, want 5m", first["ttl"])
+	}
+}
+
+func TestProviderField_ReturnsScalar(t *testing.T) {
+	storeTestTemplate(t, "pf2", templateWithProviderFields())
+	sc := &policy.SharedContext{Metadata: map[string]interface{}{MetadataTemplateHandle: "pf2"}}
+
+	raw, ok := ProviderField(sc, []byte(bodyWithList), "/converse", "tier")
+	if !ok {
+		t.Fatal("tier not found")
+	}
+	if raw != "priority" {
+		t.Errorf("tier = %v, want priority", raw)
+	}
+}
+
+func TestProviderField_UndeclaredNameReportsMissing(t *testing.T) {
+	storeTestTemplate(t, "pf3", templateWithProviderFields())
+	sc := &policy.SharedContext{Metadata: map[string]interface{}{MetadataTemplateHandle: "pf3"}}
+
+	if _, ok := ProviderField(sc, []byte(bodyWithList), "/converse", "nope"); ok {
+		t.Error("an undeclared name must report missing")
+	}
+}
+
+func TestProviderField_NoTemplateReportsMissing(t *testing.T) {
+	sc := &policy.SharedContext{Metadata: map[string]interface{}{}}
+	if _, ok := ProviderField(sc, []byte(bodyWithList), "/converse", "cacheDetails"); ok {
+		t.Error("no template must report missing")
+	}
+	if _, ok := ProviderField(nil, []byte(bodyWithList), "/converse", "cacheDetails"); ok {
+		t.Error("nil context must report missing")
+	}
+}
+
+func TestProviderField_AbsentInBodyReportsMissing(t *testing.T) {
+	storeTestTemplate(t, "pf4", templateWithProviderFields())
+	sc := &policy.SharedContext{Metadata: map[string]interface{}{MetadataTemplateHandle: "pf4"}}
+
+	if _, ok := ProviderField(sc, []byte(`{"usage":{"inputTokens":1}}`), "/converse", "cacheDetails"); ok {
+		t.Error("a declared location absent from the body must report missing")
+	}
+}

--- a/sdk/ai/llmusage/template.go
+++ b/sdk/ai/llmusage/template.go
@@ -1,0 +1,190 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package llmusage
+
+import (
+	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
+)
+
+// fieldSpec is one extraction identifier from a template, with any fallback
+// locations to try after it.
+type fieldSpec struct {
+	Location    string
+	Identifier  string
+	Identifiers []string
+
+	// ValueMap translates values the provider reports into the vocabulary the
+	// gateway works in. A value that is not a key is used as reported.
+	ValueMap map[string]string
+}
+
+// extractionFields are the template keys this library reads. Names match the
+// LlmProviderTemplate schema exactly.
+var extractionFields = []string{
+	"promptTokens",
+	"completionTokens",
+	"totalTokens",
+	"cachedTokens",
+	"cacheWriteTokens",
+	"cacheWrite1hTokens",
+	"reasoningTokens",
+	"audioInputTokens",
+	"audioOutputTokens",
+	"serviceTier",
+	"requestModel",
+	"responseModel",
+}
+
+// resolveFields returns the effective extraction fields for a request path and
+// the effective cache accounting mode. A resourceMappings entry matching the
+// path overrides individual fields; every field it does not set falls back to
+// the template root on its own.
+func resolveFields(template map[string]interface{}, requestPath string) (map[string]fieldSpec, string) {
+	fields := make(map[string]fieldSpec, len(extractionFields))
+	if template == nil {
+		return fields, ""
+	}
+
+	for _, name := range extractionFields {
+		if spec, ok := readFieldSpec(template, name); ok {
+			fields[name] = spec
+		}
+	}
+	accounting, _ := template["cacheAccounting"].(string)
+
+	mapping := selectMapping(template, requestPath)
+	if mapping == nil {
+		return fields, accounting
+	}
+
+	for _, name := range extractionFields {
+		if spec, ok := readFieldSpec(mapping, name); ok {
+			fields[name] = spec
+		}
+	}
+	if override, ok := mapping["cacheAccounting"].(string); ok && override != "" {
+		accounting = override
+	}
+
+	return fields, accounting
+}
+
+// readFieldSpec reads one extraction identifier. A field that is absent,
+// malformed, or missing its identifier is treated as not set. Identifiers
+// holds the primary identifier followed by any fallbackIdentifiers, in order.
+func readFieldSpec(source map[string]interface{}, name string) (fieldSpec, bool) {
+	raw, ok := source[name].(map[string]interface{})
+	if !ok {
+		return fieldSpec{}, false
+	}
+	identifier, ok := raw["identifier"].(string)
+	if !ok || identifier == "" {
+		return fieldSpec{}, false
+	}
+	location, _ := raw["location"].(string)
+
+	identifiers := []string{identifier}
+	if fallbacks, ok := raw["fallbackIdentifiers"].([]interface{}); ok {
+		for _, f := range fallbacks {
+			fallback, ok := f.(string)
+			if !ok || fallback == "" {
+				continue
+			}
+			identifiers = append(identifiers, fallback)
+		}
+	}
+
+	var valueMap map[string]string
+	if entries, ok := raw["valueMap"].(map[string]interface{}); ok {
+		for key, value := range entries {
+			mapped, ok := value.(string)
+			if !ok || key == "" {
+				continue
+			}
+			if valueMap == nil {
+				valueMap = make(map[string]string, len(entries))
+			}
+			valueMap[key] = mapped
+		}
+	}
+
+	return fieldSpec{
+		Location:    location,
+		Identifier:  identifier,
+		Identifiers: identifiers,
+		ValueMap:    valueMap,
+	}, true
+}
+
+// selectMapping returns the resourceMappings entry that best matches the
+// request path, preferring an exact match over a wildcard and a longer pattern
+// over a shorter one.
+func selectMapping(template map[string]interface{}, requestPath string) map[string]interface{} {
+	mappings, ok := template["resourceMappings"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	resources, ok := mappings["resources"].([]interface{})
+	if !ok {
+		return nil
+	}
+
+	var selected map[string]interface{}
+	var selectedPath string
+	for _, entry := range resources {
+		candidate, ok := entry.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		candidatePath, ok := candidate["resource"].(string)
+		if !ok || !pathsMatch(requestPath, candidatePath) {
+			continue
+		}
+		if selected == nil || preferMoreSpecificPath(candidatePath, selectedPath) {
+			selected, selectedPath = candidate, candidatePath
+		}
+	}
+
+	return selected
+}
+
+// FieldPaths returns the response path each usage field is declared at for this
+// route, so a consumer can label per-field output with the provider's own field
+// names. Only payload fields are returned; header and path-parameter
+// identifiers do not name a location in the response body. The result reflects
+// any resourceMappings override that applies to requestPath.
+func FieldPaths(sc *policy.SharedContext, requestPath string) map[string]string {
+	if sc == nil {
+		return map[string]string{}
+	}
+
+	template, err := templateForRoute(sc)
+	if err != nil {
+		return map[string]string{}
+	}
+
+	fields, _ := resolveFields(template, requestPath)
+	paths := make(map[string]string, len(fields))
+	for name, spec := range fields {
+		if spec.Location == locationPayload && spec.Identifier != "" {
+			paths[name] = spec.Identifier
+		}
+	}
+	return paths
+}

--- a/sdk/ai/llmusage/template_test.go
+++ b/sdk/ai/llmusage/template_test.go
@@ -1,0 +1,256 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package llmusage
+
+import (
+	"testing"
+
+	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
+)
+
+// buildTemplate mirrors the shape the lazy-resource store holds: the template
+// spec decoded into a generic map.
+func buildTemplate() map[string]interface{} {
+	return map[string]interface{}{
+		"cacheAccounting": "additive",
+		"promptTokens": map[string]interface{}{
+			"location": "payload", "identifier": "$.usage.input_tokens",
+		},
+		"completionTokens": map[string]interface{}{
+			"location": "payload", "identifier": "$.usage.output_tokens",
+		},
+		"serviceTier": map[string]interface{}{
+			"location": "payload", "identifier": "$.usage.service_tier",
+		},
+		"resourceMappings": map[string]interface{}{
+			"resources": []interface{}{
+				map[string]interface{}{
+					"resource": "/responses",
+					"promptTokens": map[string]interface{}{
+						"location": "payload", "identifier": "$.usage.prompt_tokens",
+					},
+					"cacheAccounting": "inclusive",
+				},
+				map[string]interface{}{
+					"resource": "/v1/*",
+					"completionTokens": map[string]interface{}{
+						"location": "payload", "identifier": "$.usage.wildcard_tokens",
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestResolveFields_NoMappingUsesTemplateRoot(t *testing.T) {
+	fields, accounting := resolveFields(buildTemplate(), "/chat/completions")
+
+	if got := fields["promptTokens"].Identifier; got != "$.usage.input_tokens" {
+		t.Errorf("promptTokens = %q, want the template root value", got)
+	}
+	if accounting != "additive" {
+		t.Errorf("cacheAccounting = %q, want additive", accounting)
+	}
+}
+
+func TestResolveFields_MappingOverridesOnlyItsOwnFields(t *testing.T) {
+	fields, accounting := resolveFields(buildTemplate(), "/responses")
+
+	if got := fields["promptTokens"].Identifier; got != "$.usage.prompt_tokens" {
+		t.Errorf("promptTokens = %q, want the mapping override", got)
+	}
+	// completionTokens is not set on this mapping, so it must fall back
+	// individually rather than being lost with the rest of the object.
+	if got := fields["completionTokens"].Identifier; got != "$.usage.output_tokens" {
+		t.Errorf("completionTokens = %q, want the inherited root value", got)
+	}
+	if got := fields["serviceTier"].Identifier; got != "$.usage.service_tier" {
+		t.Errorf("serviceTier = %q, want the inherited root value", got)
+	}
+	if accounting != "inclusive" {
+		t.Errorf("cacheAccounting = %q, want the mapping override", accounting)
+	}
+}
+
+func TestResolveFields_MappingWithoutAccountingInheritsIt(t *testing.T) {
+	// The /v1/* mapping sets no cacheAccounting, so the template-level value
+	// must be inherited rather than defaulting to inclusive.
+	_, accounting := resolveFields(buildTemplate(), "/v1/anything")
+
+	if accounting != "additive" {
+		t.Errorf("cacheAccounting = %q, want the inherited additive", accounting)
+	}
+}
+
+func TestResolveFields_ExactMappingBeatsWildcard(t *testing.T) {
+	tmpl := map[string]interface{}{
+		"resourceMappings": map[string]interface{}{
+			"resources": []interface{}{
+				map[string]interface{}{
+					"resource": "/v1/*",
+					"promptTokens": map[string]interface{}{
+						"location": "payload", "identifier": "$.wildcard",
+					},
+				},
+				map[string]interface{}{
+					"resource": "/v1/exact",
+					"promptTokens": map[string]interface{}{
+						"location": "payload", "identifier": "$.exact",
+					},
+				},
+			},
+		},
+	}
+
+	fields, _ := resolveFields(tmpl, "/v1/exact")
+
+	if got := fields["promptTokens"].Identifier; got != "$.exact" {
+		t.Errorf("promptTokens = %q, want the exact mapping to win over the wildcard", got)
+	}
+}
+
+func TestResolveFields_MalformedEntriesIgnored(t *testing.T) {
+	tmpl := map[string]interface{}{
+		"promptTokens":     "not-an-object",
+		"completionTokens": map[string]interface{}{"location": "payload"},
+		"resourceMappings": "not-an-object",
+	}
+
+	fields, accounting := resolveFields(tmpl, "/chat/completions")
+
+	if _, ok := fields["promptTokens"]; ok {
+		t.Error("promptTokens should be absent when it is not an object")
+	}
+	if _, ok := fields["completionTokens"]; ok {
+		t.Error("completionTokens should be absent when it has no identifier")
+	}
+	if accounting != "" {
+		t.Errorf("cacheAccounting = %q, want empty", accounting)
+	}
+}
+
+func TestResolveFields_NilTemplate(t *testing.T) {
+	fields, accounting := resolveFields(nil, "/chat/completions")
+
+	if len(fields) != 0 {
+		t.Errorf("fields = %v, want empty", fields)
+	}
+	if accounting != "" {
+		t.Errorf("cacheAccounting = %q, want empty", accounting)
+	}
+}
+
+func TestReadFieldSpec_ReadsValueMap(t *testing.T) {
+	source := map[string]interface{}{
+		"serviceTier": map[string]interface{}{
+			"location":   "payload",
+			"identifier": "$.usageMetadata.trafficType",
+			"valueMap": map[string]interface{}{
+				"ON_DEMAND_PRIORITY": "priority",
+				"ON_DEMAND_FLEX":     "flex",
+			},
+		},
+	}
+
+	spec, ok := readFieldSpec(source, "serviceTier")
+	if !ok {
+		t.Fatal("readFieldSpec reported no spec")
+	}
+	if spec.ValueMap["ON_DEMAND_PRIORITY"] != "priority" {
+		t.Errorf("ON_DEMAND_PRIORITY = %q, want priority", spec.ValueMap["ON_DEMAND_PRIORITY"])
+	}
+	if spec.ValueMap["ON_DEMAND_FLEX"] != "flex" {
+		t.Errorf("ON_DEMAND_FLEX = %q, want flex", spec.ValueMap["ON_DEMAND_FLEX"])
+	}
+}
+
+func TestReadFieldSpec_AbsentValueMapIsNil(t *testing.T) {
+	spec, ok := readFieldSpec(buildTemplate(), "serviceTier")
+	if !ok {
+		t.Fatal("readFieldSpec reported no spec")
+	}
+	if spec.ValueMap != nil {
+		t.Errorf("ValueMap = %v, want nil", spec.ValueMap)
+	}
+}
+
+func TestReadFieldSpec_MalformedValueMapEntriesIgnored(t *testing.T) {
+	source := map[string]interface{}{
+		"serviceTier": map[string]interface{}{
+			"location":   "payload",
+			"identifier": "$.service_tier",
+			"valueMap": map[string]interface{}{
+				"fast":  "priority",
+				"bogus": 42,
+			},
+		},
+	}
+
+	spec, _ := readFieldSpec(source, "serviceTier")
+	if spec.ValueMap["fast"] != "priority" {
+		t.Errorf("fast = %q, want priority", spec.ValueMap["fast"])
+	}
+	if _, present := spec.ValueMap["bogus"]; present {
+		t.Error("non-string value should be skipped")
+	}
+}
+
+func TestFieldPaths_ReturnsPayloadIdentifiers(t *testing.T) {
+	storeTestTemplate(t, "fp-basic", buildTemplate())
+	sc := &policy.SharedContext{Metadata: map[string]interface{}{
+		MetadataTemplateHandle: "fp-basic",
+	}}
+
+	paths := FieldPaths(sc, "/chat/completions")
+
+	if paths["promptTokens"] != "$.usage.input_tokens" {
+		t.Errorf("promptTokens = %q, want $.usage.input_tokens", paths["promptTokens"])
+	}
+	if paths["completionTokens"] != "$.usage.output_tokens" {
+		t.Errorf("completionTokens = %q, want $.usage.output_tokens", paths["completionTokens"])
+	}
+}
+
+func TestFieldPaths_HonoursResourceMappings(t *testing.T) {
+	storeTestTemplate(t, "fp-mapped", buildTemplate())
+	sc := &policy.SharedContext{Metadata: map[string]interface{}{
+		MetadataTemplateHandle: "fp-mapped",
+	}}
+
+	paths := FieldPaths(sc, "/responses")
+
+	if paths["promptTokens"] != "$.usage.prompt_tokens" {
+		t.Errorf("promptTokens = %q, want the /responses override $.usage.prompt_tokens",
+			paths["promptTokens"])
+	}
+}
+
+func TestFieldPaths_NoTemplateReturnsEmpty(t *testing.T) {
+	sc := &policy.SharedContext{Metadata: map[string]interface{}{}}
+
+	if got := FieldPaths(sc, "/chat/completions"); len(got) != 0 {
+		t.Errorf("FieldPaths = %v, want empty", got)
+	}
+}
+
+func TestFieldPaths_NilContextReturnsEmpty(t *testing.T) {
+	if got := FieldPaths(nil, "/chat/completions"); len(got) != 0 {
+		t.Errorf("FieldPaths = %v, want empty", got)
+	}
+}

--- a/sdk/ai/llmusage/usage.go
+++ b/sdk/ai/llmusage/usage.go
@@ -1,0 +1,148 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package llmusage
+
+// Usage holds token counts normalized from a provider response, with the
+// provider's cache accounting already resolved.
+type Usage struct {
+	// TotalInputTokens is every input token the request consumed, including
+	// cached and cache-write tokens.
+	TotalInputTokens int64
+
+	// UncachedInputTokens is the subset of TotalInputTokens billed at the
+	// standard input rate.
+	UncachedInputTokens int64
+
+	// CachedReadTokens is the subset billed at the cache-read rate.
+	CachedReadTokens int64
+
+	// CacheWriteTokens and CacheWrite1hTokens are the subsets billed at the
+	// cache-creation rates. CacheWrite1hTokens covers the extended TTL.
+	CacheWriteTokens   int64
+	CacheWrite1hTokens int64
+
+	OutputTokens    int64
+	ReasoningTokens int64
+
+	AudioInputTokens  int64
+	AudioOutputTokens int64
+
+	// TotalTokens is the provider's reported total when it gives one, and
+	// input + output otherwise. Providers do not always agree with the sum.
+	TotalTokens int64
+
+	// ServiceTier is the billing tier the provider served the request on, when
+	// it is one that carries its own rates: "priority", "flex" or "batch". The
+	// standard tier is reported as an empty string, whichever word the provider
+	// happens to use for it.
+	ServiceTier string
+
+	// IsPriority reports the priority tier specifically, for consumers that only
+	// need that distinction.
+	IsPriority bool
+
+	// Model is the model name resolved from the response or request.
+	Model string
+
+	// ModelCandidates lists the names considered, in the order they were
+	// tried, so a consumer needing the fallback chain can see it.
+	ModelCandidates []string
+}
+
+// rawCounts holds the values read straight out of a response, before cache
+// accounting is applied.
+type rawCounts struct {
+	InputTokens        int64
+	OutputTokens       int64
+	TotalTokens        int64
+	CachedTokens       int64
+	CacheWriteTokens   int64
+	CacheWrite1hTokens int64
+	ReasoningTokens    int64
+	AudioInputTokens   int64
+	AudioOutputTokens  int64
+	ServiceTier        string
+	Model              string
+	ModelCandidates    []string
+}
+
+// accountingAdditive is the cacheAccounting value meaning the cached and
+// cache-write counts sit outside the reported input total.
+const accountingAdditive = "additive"
+
+// Service tiers that carry their own rates. Providers spell the standard tier
+// variously ("default", "standard", absent), and all of those normalize to an
+// empty string.
+const (
+	tierPriority = "priority"
+	tierFlex     = "flex"
+	tierBatch    = "batch"
+)
+
+// normalizeServiceTier keeps only the tiers that select different rates. Any
+// other value, including the several spellings of the standard tier, becomes
+// empty so a consumer applies standard pricing.
+func normalizeServiceTier(reported string) string {
+	switch reported {
+	case tierPriority, tierFlex, tierBatch:
+		return reported
+	default:
+		return ""
+	}
+}
+
+// normalize resolves cache accounting into a Usage. With "additive" the cache
+// counts are added to the reported input total; otherwise they are already
+// inside it and only the uncached remainder is derived.
+func normalize(raw rawCounts, accounting string) Usage {
+	u := Usage{
+		OutputTokens:      raw.OutputTokens,
+		CachedReadTokens:  raw.CachedTokens,
+		ReasoningTokens:   raw.ReasoningTokens,
+		AudioInputTokens:  raw.AudioInputTokens,
+		AudioOutputTokens: raw.AudioOutputTokens,
+		ServiceTier:       normalizeServiceTier(raw.ServiceTier),
+		IsPriority:        raw.ServiceTier == tierPriority,
+		Model:             raw.Model,
+		ModelCandidates:   raw.ModelCandidates,
+	}
+
+	u.CacheWriteTokens = raw.CacheWriteTokens
+	u.CacheWrite1hTokens = raw.CacheWrite1hTokens
+
+	if accounting == accountingAdditive {
+		u.TotalInputTokens = raw.InputTokens + raw.CachedTokens +
+			raw.CacheWriteTokens + raw.CacheWrite1hTokens
+		u.UncachedInputTokens = raw.InputTokens
+	} else {
+		u.TotalInputTokens = raw.InputTokens
+		u.UncachedInputTokens = raw.InputTokens - raw.CachedTokens -
+			raw.CacheWriteTokens - raw.CacheWrite1hTokens
+		if u.UncachedInputTokens < 0 {
+			u.UncachedInputTokens = 0
+		}
+	}
+
+	u.TotalTokens = raw.TotalTokens
+	if u.TotalTokens == 0 {
+		u.TotalTokens = u.TotalInputTokens + u.OutputTokens
+	}
+
+	return u
+}

--- a/sdk/ai/llmusage/usage_test.go
+++ b/sdk/ai/llmusage/usage_test.go
@@ -1,0 +1,146 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package llmusage
+
+import "testing"
+
+func TestNormalize_InclusiveKeepsInputTotal(t *testing.T) {
+	// OpenAI style: cached_tokens is already inside prompt_tokens.
+	raw := rawCounts{InputTokens: 1000, OutputTokens: 200, CachedTokens: 800}
+
+	got := normalize(raw, "inclusive")
+
+	if got.TotalInputTokens != 1000 {
+		t.Errorf("TotalInputTokens = %d, want 1000", got.TotalInputTokens)
+	}
+	if got.CachedReadTokens != 800 {
+		t.Errorf("CachedReadTokens = %d, want 800", got.CachedReadTokens)
+	}
+	if got.UncachedInputTokens != 200 {
+		t.Errorf("UncachedInputTokens = %d, want 200", got.UncachedInputTokens)
+	}
+}
+
+func TestNormalize_AdditiveSumsIntoInputTotal(t *testing.T) {
+	// Anthropic style: total input is input + cache_creation + cache_read.
+	raw := rawCounts{
+		InputTokens:        1000,
+		OutputTokens:       200,
+		CachedTokens:       500,
+		CacheWriteTokens:   300,
+		CacheWrite1hTokens: 100,
+	}
+
+	got := normalize(raw, "additive")
+
+	if got.TotalInputTokens != 1900 {
+		t.Errorf("TotalInputTokens = %d, want 1900", got.TotalInputTokens)
+	}
+	if got.UncachedInputTokens != 1000 {
+		t.Errorf("UncachedInputTokens = %d, want 1000", got.UncachedInputTokens)
+	}
+}
+
+func TestNormalize_AbsentAccountingIsInclusive(t *testing.T) {
+	raw := rawCounts{InputTokens: 500, CachedTokens: 200}
+
+	got := normalize(raw, "")
+
+	if got.TotalInputTokens != 500 {
+		t.Errorf("TotalInputTokens = %d, want 500", got.TotalInputTokens)
+	}
+}
+
+func TestNormalize_UncachedNeverNegative(t *testing.T) {
+	// A provider reporting more cached tokens than input must not produce a
+	// negative billable count.
+	raw := rawCounts{InputTokens: 100, CachedTokens: 500}
+
+	got := normalize(raw, "inclusive")
+
+	if got.UncachedInputTokens != 0 {
+		t.Errorf("UncachedInputTokens = %d, want 0", got.UncachedInputTokens)
+	}
+}
+
+func TestNormalize_TotalTokensPreferredWhenReported(t *testing.T) {
+	raw := rawCounts{InputTokens: 100, OutputTokens: 50, TotalTokens: 175}
+
+	got := normalize(raw, "inclusive")
+
+	if got.TotalTokens != 175 {
+		t.Errorf("TotalTokens = %d, want 175 (reported value, not the sum)", got.TotalTokens)
+	}
+}
+
+func TestNormalize_TotalTokensDerivedWhenAbsent(t *testing.T) {
+	raw := rawCounts{InputTokens: 100, OutputTokens: 50}
+
+	got := normalize(raw, "inclusive")
+
+	if got.TotalTokens != 150 {
+		t.Errorf("TotalTokens = %d, want 150", got.TotalTokens)
+	}
+}
+
+func TestNormalize_PriorityTierDetected(t *testing.T) {
+	raw := rawCounts{InputTokens: 10, ServiceTier: "priority"}
+
+	if got := normalize(raw, ""); !got.IsPriority {
+		t.Error("IsPriority = false, want true for service_tier=priority")
+	}
+	if got := normalize(rawCounts{ServiceTier: "standard"}, ""); got.IsPriority {
+		t.Error("IsPriority = true, want false for service_tier=standard")
+	}
+}
+
+func TestNormalize_ServiceTierKeepsRateBearingTiers(t *testing.T) {
+	// Only tiers with their own rates survive; every spelling of standard
+	// becomes empty so the consumer applies standard pricing.
+	tests := []struct {
+		reported string
+		want     string
+	}{
+		{"priority", "priority"},
+		{"flex", "flex"},
+		{"batch", "batch"},
+		{"default", ""},
+		{"standard", ""},
+		{"", ""},
+		{"scale", ""},
+	}
+
+	for _, tt := range tests {
+		got := normalize(rawCounts{InputTokens: 10, ServiceTier: tt.reported}, "")
+		if got.ServiceTier != tt.want {
+			t.Errorf("ServiceTier for %q = %q, want %q", tt.reported, got.ServiceTier, tt.want)
+		}
+	}
+}
+
+func TestNormalize_IsPriorityOnlyForPriority(t *testing.T) {
+	for _, tier := range []string{"flex", "batch", "default", ""} {
+		if normalize(rawCounts{ServiceTier: tier}, "").IsPriority {
+			t.Errorf("IsPriority = true for tier %q, want false", tier)
+		}
+	}
+	if !normalize(rawCounts{ServiceTier: "priority"}, "").IsPriority {
+		t.Error("IsPriority = false for priority, want true")
+	}
+}


### PR DESCRIPTION
## Purpose
Adds `sdk/ai/llmusage`, which extracts LLM token usage from a provider response using the locations declared in that provider's `LlmProviderTemplate`, instead of hardcoding each provider's response shape in Go.

## What it does
- Reads every usage field a template declares: tokens, cache counts, model, service tier
- Merges server-sent events into a single JSON view, so streamed and buffered responses read alike
- Reads values from the request URL as well as the body, which is how Bedrock model IDs, ARNs and Gemini model names resolve
- Translates provider-specific vocabularies, such as service-tier names, through the template's `valueMap`
- Caches the extracted result in `SharedContext`, so a response body is parsed once per request regardless of how many policies need it

## Usage of the Library in Downstream Policies
<img width="3651" height="3278" alt="Template-Driven LLM Metering with Shared Context drawio (8) (1)" src="https://github.com/user-attachments/assets/b102b3af-a474-4fb3-a62b-9a9fa8964db4" />

## Shape of the change
It is a package inside the `sdk/ai` module rather than a module of its own, so it releases under the existing `sdk/ai` tags and needs no `go.work` entry. `sdk/ai` gains a direct dependency on `sdk/core v0.3.5`; it had no dependency on `sdk/core` before. Nothing currently imports `sdk/ai`, so no existing consumer is affected.

## Testing
56 test functions, 90.7% statement coverage. They cover template resolution, JSONPath extraction, event-stream merging including payloads split across multiple data fields, URL path parameters, provider fields, value maps and cross-policy stream accumulation. Verified with `GOWORK=off` so `sdk/core` resolves from the module proxy rather than the workspace.

## Consumers
None in this PR. The library lands first so a consuming policy can depend on a released version. The LLM cost policy that uses it follows separately.