### PR TITLE
Fix dependency validation for pull requests from forks

### DIFF
--- a/.github/workflows/dependency-validation.yml
+++ b/.github/workflows/dependency-validation.yml
@@ -21,17 +21,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Fetch PR head as data
+        run: |
+          git fetch --no-tags origin \
+            "pull/${{ github.event.pull_request.number }}/head:pr-head"
 
       - name: Detect modified go.mod files
         id: detect-changes
         run: |
           # Get the base branch SHA
           BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          # Pin to the event SHA and verify the fetched ref matches, so detection
+          # and validation use the same commit even if the PR head moved.
           HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          FETCHED_SHA="$(git rev-parse pr-head)"
+          if [ "$HEAD_SHA" != "$FETCHED_SHA" ]; then
+            echo "::error::PR head moved after the workflow was triggered (event: $HEAD_SHA, fetched: $FETCHED_SHA). Re-run the workflow."
+            exit 1
+          fi
 
           echo "Comparing $BASE_SHA...$HEAD_SHA"
 
@@ -51,7 +62,7 @@ jobs:
 
       - name: Checkout engineering-governance repository
         if: steps.detect-changes.outputs.has_changes == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: wso2/engineering-governance
           path: engineering-governance
@@ -72,7 +83,7 @@ jobs:
 
       - name: Comment on PR - Validation Failed
         if: steps.validate.outcome == 'failure'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
@@ -139,7 +150,7 @@ jobs:
 
       - name: Comment on PR - Validation Passed
         if: steps.validate.outcome == 'success' && steps.detect-changes.outputs.has_changes == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
## Problem
`Validate Go Dependencies` fails for every pull request whose head is a fork. It aborts at the checkout step in a few seconds, before reading any `go.mod`, so the result says nothing about the change:

Error: Refusing to check out fork pull request code from a 'pull_request_target' workflow.

The job runs on `pull_request_target`, which carries the base repository's token and secrets, and then checks out the fork's head SHA. `actions/checkout` blocks that combination because running untrusted code in a trusted context is the "pwn request" vulnerability.

## Fix
Check out the base repository and fetch the pull request head as **data only**. `git fetch` executes nothing from the fork; it just makes the commits available so `git diff` can compare them.

Nothing downstream needed the fork's working tree in the first place. The validation step passes only the base and head SHAs to `validate-go-dependencies.sh`, which reads the `go.mod` content out of git.

Also included:
- verify the fetched head matches the SHA the event carried, so detection and validation use the same commit if the head moves after the trigger
- `actions/checkout` v4 → v6, `actions/github-script` v7 → v8

## Precedent
This makes the file match the version already running in another WSO2-governed repository:
https://github.com/thunder-id/thunderid/blob/main/.github/workflows/dependency-validation.yml

The only intentional difference is `DEPENDENCY_SCOPE: api-platform`.

## Effect
External contributors get a check that actually validates their dependencies instead of failing at checkout. This PR changes no `go.mod`, so the workflow's `paths` filter means it does not trigger on itself.