### PR TITLE
Show outbound header value in UI

### DIFF
--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderConnectionTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderConnectionTab.tsx
@@ -53,6 +53,9 @@ export default function ServiceProviderConnectionTab() {
     authHeader: string;
   } | null>(null);
   const [providerEndpoint, setProviderEndpoint] = useState('');
+  const [connectionProviderId, setConnectionProviderId] = useState<
+    string | null
+  >(null);
   const [authenticationType, setAuthenticationType] = useState('');
   const [authenticationHeader, setAuthenticationHeader] = useState('');
   const [credentialValue, setCredentialValue] = useState('');
@@ -137,6 +140,7 @@ export default function ServiceProviderConnectionTab() {
         ? nextConnection.authHeader
         : currentValue
     );
+    setConnectionProviderId(provider.id);
     lastProviderConnectionRef.current = nextConnection;
 
     if (initializedProviderIdRef.current === provider.id) {
@@ -341,6 +345,11 @@ export default function ServiceProviderConnectionTab() {
 
   useEffect(() => {
     const templateAuthHeader = providerTemplate?.metadata?.auth?.header || '';
+    const isCurrentProviderState = connectionProviderId === provider?.id;
+    const isCurrentProviderTemplate =
+      providerTemplate?.id === provider?.template;
+    if (!isCurrentProviderState || !isCurrentProviderTemplate) return;
+
     if (authenticationType !== 'api-key') {
       appliedTemplateAuthHeaderRef.current = null;
       return;
@@ -364,8 +373,10 @@ export default function ServiceProviderConnectionTab() {
   }, [
     authenticationHeader,
     authenticationType,
+    connectionProviderId,
     isDraftMode,
     provider?.id,
+    provider?.template,
     providerTemplate,
   ]);
 

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderConnectionTab.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderConnectionTab.tsx
@@ -45,6 +45,13 @@ export default function ServiceProviderConnectionTab() {
     useLLMProvider();
   const { currentOrganization } = useAppShell();
   const initializedProviderIdRef = useRef<string | null>(null);
+  const appliedTemplateAuthHeaderRef = useRef<string | null>(null);
+  const lastProviderConnectionRef = useRef<{
+    id: string;
+    url: string;
+    authType: string;
+    authHeader: string;
+  } | null>(null);
   const [providerEndpoint, setProviderEndpoint] = useState('');
   const [authenticationType, setAuthenticationType] = useState('');
   const [authenticationHeader, setAuthenticationHeader] = useState('');
@@ -60,6 +67,8 @@ export default function ServiceProviderConnectionTab() {
   const effectiveAuthType = authenticationType || 'none';
   const isOtherAuthType = effectiveAuthType === 'other';
   const isNoCredentialsAuthType = effectiveAuthType === 'other' || effectiveAuthType === 'none';
+  const isAuthenticationHeaderInvalid =
+    !isNoCredentialsAuthType && authenticationHeader.trim().length === 0;
   const isProviderEndpointInvalid =
     providerEndpoint.trim().length > 0 && !isValidHttpUrl(providerEndpoint);
 
@@ -102,9 +111,33 @@ export default function ServiceProviderConnectionTab() {
 
   useEffect(() => {
     if (!provider) return;
-    setProviderEndpoint(provider.upstream?.main?.url || '');
-    setAuthenticationType(provider.upstream?.main?.auth?.type || 'none');
-    setAuthenticationHeader(provider.upstream?.main?.auth?.header || '');
+    const nextConnection = {
+      id: provider.id,
+      url: provider.upstream?.main?.url || '',
+      authType: provider.upstream?.main?.auth?.type || 'none',
+      authHeader: provider.upstream?.main?.auth?.header || '',
+    };
+    const previousConnection = lastProviderConnectionRef.current;
+
+    setProviderEndpoint((currentValue) =>
+      !previousConnection || previousConnection.id !== provider.id ||
+      currentValue === previousConnection.url
+        ? nextConnection.url
+        : currentValue
+    );
+    setAuthenticationType((currentValue) =>
+      !previousConnection || previousConnection.id !== provider.id ||
+      currentValue === previousConnection.authType
+        ? nextConnection.authType
+        : currentValue
+    );
+    setAuthenticationHeader((currentValue) =>
+      !previousConnection || previousConnection.id !== provider.id ||
+      currentValue === previousConnection.authHeader
+        ? nextConnection.authHeader
+        : currentValue
+    );
+    lastProviderConnectionRef.current = nextConnection;
 
     if (initializedProviderIdRef.current === provider.id) {
       return;
@@ -163,12 +196,24 @@ export default function ServiceProviderConnectionTab() {
     }
   };
 
-  const handleUpdateAuthentication = async (value = authenticationType) => {
+  const handleUpdateAuthentication = async (
+    value = authenticationType,
+    header = authenticationHeader
+  ) => {
     if (!provider || isLoading || error || isReadOnlyProvider) return;
     const nextType = value.trim();
-    if (!nextType || nextType === (provider.upstream?.main?.auth?.type || ''))
-      return;
     const isNoCredentials = nextType === 'other' || nextType === 'none';
+    const nextHeader = isNoCredentials ? '' : header.trim();
+    if (!isNoCredentials && !nextHeader && !isDraftMode) {
+      showSnackbar('Authentication Header is required.', 'error');
+      return;
+    }
+    if (
+      !nextType ||
+      (nextType === (provider.upstream?.main?.auth?.type || '') &&
+        nextHeader === (provider.upstream?.main?.auth?.header || ''))
+    )
+      return;
     try {
       const {
         status,
@@ -186,9 +231,7 @@ export default function ServiceProviderConnectionTab() {
             url: provider.upstream?.main?.url || '',
             auth: {
               type: nextType,
-              header: isNoCredentials
-                ? ''
-                : provider.upstream?.main?.auth?.header || '',
+              header: nextHeader,
               value: isNoCredentials
                 ? ''
                 : provider.upstream?.main?.auth?.value || '',
@@ -211,6 +254,10 @@ export default function ServiceProviderConnectionTab() {
   ) => {
     if (!provider || isLoading || error || isReadOnlyProvider) return;
     const nextHeader = value.trim();
+    if (!nextHeader && !isDraftMode) {
+      showSnackbar('Authentication Header is required.', 'error');
+      return;
+    }
     if (nextHeader === (provider.upstream?.main?.auth?.header || '')) return;
 
     try {
@@ -292,6 +339,36 @@ export default function ServiceProviderConnectionTab() {
     }
   };
 
+  useEffect(() => {
+    const templateAuthHeader = providerTemplate?.metadata?.auth?.header || '';
+    if (authenticationType !== 'api-key') {
+      appliedTemplateAuthHeaderRef.current = null;
+      return;
+    }
+
+    const templateHeaderKey = `${provider?.id || ''}:${providerTemplate?.id || ''}`;
+    if (
+      !templateAuthHeader ||
+      appliedTemplateAuthHeaderRef.current === templateHeaderKey
+    ) {
+      return;
+    }
+    appliedTemplateAuthHeaderRef.current = templateHeaderKey;
+
+    if (authenticationHeader) return;
+
+    setAuthenticationHeader(templateAuthHeader);
+    if (isDraftMode) {
+      void handleUpdateAuthentication('api-key', templateAuthHeader);
+    }
+  }, [
+    authenticationHeader,
+    authenticationType,
+    isDraftMode,
+    provider?.id,
+    providerTemplate,
+  ]);
+
   return (
     <>
       <Stack spacing={2} sx={{ maxWidth: { xs: '100%', md: 720 } }}>
@@ -330,13 +407,20 @@ export default function ServiceProviderConnectionTab() {
             disabled={isFormDisabled}
             onChange={(e) => {
               const nextValue = String(e.target.value);
+              const nextHeader =
+                nextValue === 'api-key'
+                  ? providerTemplate?.metadata?.auth?.header || ''
+                  : nextValue === 'other' || nextValue === 'none'
+                    ? ''
+                    : authenticationHeader;
+
               setAuthenticationType(nextValue);
+              setAuthenticationHeader(nextHeader);
               if (nextValue === 'other' || nextValue === 'none') {
-                setAuthenticationHeader('');
                 setCredentialValue('');
               }
               if (isDraftMode) {
-                void handleUpdateAuthentication(nextValue);
+                void handleUpdateAuthentication(nextValue, nextHeader);
               }
             }}
             onBlur={() => {
@@ -365,6 +449,13 @@ export default function ServiceProviderConnectionTab() {
                 size="small"
                 value={authenticationHeader}
                 disabled={isFormDisabled}
+                required
+                error={isAuthenticationHeaderInvalid}
+                helperText={
+                  isAuthenticationHeaderInvalid
+                    ? 'Authentication Header is required.'
+                    : undefined
+                }
                 onChange={(e) => {
                   const nextValue = e.target.value;
                   setAuthenticationHeader(nextValue);

--- a/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverview.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellPages/serviceProvider/ServiceProviderOverview.tsx
@@ -309,6 +309,13 @@ function ServiceProviderOverviewContent() {
   const [linkedProxyCount, setLinkedProxyCount] = useState<number | null>(null);
   const showSnackbar = useAIWorkspaceSnackbar();
   const hasUnsavedChanges = hasDraftChanges || isRateLimitingDirty;
+  const stagedAuthentication = (draftProvider ?? provider)?.upstream?.main?.auth;
+  const stagedAuthenticationType = stagedAuthentication?.type || 'none';
+  const isAuthenticationHeaderRequired =
+    stagedAuthenticationType !== 'none' && stagedAuthenticationType !== 'other';
+  const isAuthenticationHeaderInvalid =
+    isAuthenticationHeaderRequired &&
+    !(stagedAuthentication?.header || '').trim();
   const selectedGateway = useMemo(
     () => gateways.find((gateway) => gateway.id === selectedGatewayId) ?? null,
     [gateways, selectedGatewayId]
@@ -404,6 +411,10 @@ function ServiceProviderOverviewContent() {
 
   const handleSaveChanges = async () => {
     if (!provider || isSavingChanges) return;
+    if (isAuthenticationHeaderInvalid) {
+      showSnackbar('Authentication Header is required.', 'error');
+      return;
+    }
 
     let hasChangesToPersist = hasDraftChanges;
     if (isRateLimitingDirty) {
@@ -1769,7 +1780,11 @@ function ServiceProviderOverviewContent() {
                 </Button>
                 <Button
                   variant="contained"
-                  disabled={!hasUnsavedChanges || isSavingChanges}
+                  disabled={
+                    !hasUnsavedChanges ||
+                    isSavingChanges ||
+                    isAuthenticationHeaderInvalid
+                  }
                   onClick={() => void handleSaveChanges()}
                 >
                   Save


### PR DESCRIPTION
This pull request enhances the robustness and user experience of the Service Provider connection and overview forms by improving how authentication headers are handled and validated. The changes ensure that authentication headers are required and validated when appropriate, synchronize form state more reliably, and provide clearer feedback to users.

Issue: https://github.com/wso2/api-platform/issues/3246

**Authentication Header Validation and Enforcement:**

- Added validation logic to require an authentication header when the authentication type is not 'none' or 'other', both in the connection tab and overview page. Error messages are now shown if this field is missing, and the "Save" button is disabled until it is provided. [[1]](diffhunk://#diff-001ea464189d9c7880ec96f181795e7a992ca7ded7463ac0ff92068f597f140aR70-R71) [[2]](diffhunk://#diff-efd312aa5753c561eb31097151c2aeae08fb9be9e263231e841214bbfb366e2aR312-R318) [[3]](diffhunk://#diff-efd312aa5753c561eb31097151c2aeae08fb9be9e263231e841214bbfb366e2aR414-R417) [[4]](diffhunk://#diff-efd312aa5753c561eb31097151c2aeae08fb9be9e263231e841214bbfb366e2aL1772-R1787) [[5]](diffhunk://#diff-001ea464189d9c7880ec96f181795e7a992ca7ded7463ac0ff92068f597f140aL166-R216) [[6]](diffhunk://#diff-001ea464189d9c7880ec96f181795e7a992ca7ded7463ac0ff92068f597f140aR257-R260) [[7]](diffhunk://#diff-001ea464189d9c7880ec96f181795e7a992ca7ded7463ac0ff92068f597f140aR452-R458)

**Form State Synchronization and Initialization:**

- Improved synchronization of the form state with the provider's current connection details by using refs to track the last provider connection, ensuring that form fields are not unintentionally overwritten when switching providers. [[1]](diffhunk://#diff-001ea464189d9c7880ec96f181795e7a992ca7ded7463ac0ff92068f597f140aR48-R54) [[2]](diffhunk://#diff-001ea464189d9c7880ec96f181795e7a992ca7ded7463ac0ff92068f597f140aL105-R140)

**Provider Template Integration:**

- Automatically applies the authentication header from the provider template when the authentication type is set to 'api-key', and updates the form and backend accordingly in draft mode. [[1]](diffhunk://#diff-001ea464189d9c7880ec96f181795e7a992ca7ded7463ac0ff92068f597f140aR342-R371) [[2]](diffhunk://#diff-001ea464189d9c7880ec96f181795e7a992ca7ded7463ac0ff92068f597f140aR410-R423)

These updates help prevent invalid configurations, reduce user error, and make the authentication process more intuitive and reliable.