### PR TITLE
Fix: Gateway silently drops subscriptions and API keys for DP to CP synced APIs

### DIFF
--- a/gateway/gateway-controller/pkg/controlplane/api_deleted_test.go
+++ b/gateway/gateway-controller/pkg/controlplane/api_deleted_test.go
@@ -1317,3 +1317,89 @@ func TestClient_handleSubscriptionCreatedEvent_PublishesReplicaSyncEvent(t *test
 		t.Errorf("expected correlation ID corr-sub-created, got %s", hub.publishedEvents[0].event.EventID)
 	}
 }
+
+// A bottom-up (DP->CP) synced API is addressed by the control plane using the
+// UUID the control plane minted, which differs from the gateway's local UUID.
+// The subscription must be stored under the local one, since that is what the
+// routes, the policy config, and the subscription xDS snapshot are keyed by.
+func TestClient_handleSubscriptionCreatedEvent_MapsControlPlaneAPIIDToLocal(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	db := newMockStorageForDeletion()
+	db.configs["gw-uuid-1"] = &models.StoredConfig{
+		UUID:         "gw-uuid-1",
+		CPArtifactID: "cp-uuid-1",
+		Kind:         models.KindRestApi,
+	}
+	hub := &mockControlPlaneEventHub{}
+
+	client := &Client{
+		logger:    logger,
+		db:        db,
+		eventHub:  hub,
+		gatewayID: "test-gateway",
+	}
+
+	client.handleSubscriptionCreatedEvent(map[string]interface{}{
+		"type": "subscription.created",
+		"payload": map[string]interface{}{
+			"subscriptionId":    "sub-dpcp",
+			"apiId":             "cp-uuid-1",
+			"subscriptionToken": "token-dpcp",
+			"status":            "ACTIVE",
+			"applicationId":     "app-1",
+		},
+		"timestamp":     time.Now().Format(time.RFC3339),
+		"correlationId": "corr-sub-dpcp",
+	})
+
+	sub, err := db.GetSubscriptionByID("sub-dpcp", "")
+	if err != nil {
+		t.Fatalf("expected subscription to be stored, got %v", err)
+	}
+	if sub.APIID != "gw-uuid-1" {
+		t.Errorf("expected subscription stored under local api id gw-uuid-1, got %s", sub.APIID)
+	}
+}
+
+func TestClient_handleSubscriptionUpdatedEvent_MapsControlPlaneAPIIDToLocal(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	db := newMockStorageForDeletion()
+	db.configs["gw-uuid-1"] = &models.StoredConfig{
+		UUID:         "gw-uuid-1",
+		CPArtifactID: "cp-uuid-1",
+		Kind:         models.KindRestApi,
+	}
+	db.subscriptions["sub-dpcp"] = &models.Subscription{
+		ID:     "sub-dpcp",
+		APIID:  "gw-uuid-1",
+		Status: models.SubscriptionStatusActive,
+	}
+	hub := &mockControlPlaneEventHub{}
+
+	client := &Client{
+		logger:    logger,
+		db:        db,
+		eventHub:  hub,
+		gatewayID: "test-gateway",
+	}
+
+	client.handleSubscriptionUpdatedEvent(map[string]interface{}{
+		"type": "subscription.updated",
+		"payload": map[string]interface{}{
+			"subscriptionId":    "sub-dpcp",
+			"apiId":             "cp-uuid-1",
+			"subscriptionToken": "token-dpcp",
+			"status":            "ACTIVE",
+		},
+		"timestamp":     time.Now().Format(time.RFC3339),
+		"correlationId": "corr-sub-dpcp-update",
+	})
+
+	sub, err := db.GetSubscriptionByID("sub-dpcp", "")
+	if err != nil {
+		t.Fatalf("expected subscription to be present, got %v", err)
+	}
+	if sub.APIID != "gw-uuid-1" {
+		t.Errorf("expected api id to stay the local gw-uuid-1, got %s", sub.APIID)
+	}
+}

--- a/gateway/gateway-controller/pkg/controlplane/api_deleted_test.go
+++ b/gateway/gateway-controller/pkg/controlplane/api_deleted_test.go
@@ -19,9 +19,12 @@
 package controlplane
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
@@ -30,6 +33,7 @@ import (
 	api "github.com/wso2/api-platform/gateway/gateway-controller/pkg/api/management"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/models"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/storage"
+	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/utils"
 )
 
 // mockStorageForDeletion implements storage.Storage interface for deletion testing
@@ -39,6 +43,8 @@ type mockStorageForDeletion struct {
 	webhookSecrets               map[string]*models.WebhookSecret
 	subscriptions                map[string]*models.Subscription
 	apiKeysByUUID                map[string]*models.APIKey
+	upsertedAPIKeys              []models.APIKey
+	removedAPIKeysByArtifactName [][2]string
 	replacedMappings             []*models.ApplicationAPIKeyMapping
 	replacedAppID                string
 	replacedAppUUID              string
@@ -198,6 +204,7 @@ func (m *mockStorageForDeletion) SaveAPIKey(key *models.APIKey) error {
 }
 
 func (m *mockStorageForDeletion) UpsertAPIKey(key *models.APIKey) error {
+	m.upsertedAPIKeys = append(m.upsertedAPIKeys, *key)
 	return nil
 }
 
@@ -387,6 +394,7 @@ func (m *mockStorageForDeletion) GetAPIKeysByAPIAndName(apiID, name string) (*mo
 }
 
 func (m *mockStorageForDeletion) RemoveAPIKeyAPIAndName(apiID, name string) error {
+	m.removedAPIKeysByArtifactName = append(m.removedAPIKeysByArtifactName, [2]string{apiID, name})
 	return nil
 }
 
@@ -1358,6 +1366,128 @@ func TestClient_handleSubscriptionCreatedEvent_MapsControlPlaneAPIIDToLocal(t *t
 	}
 	if sub.APIID != "gw-uuid-1" {
 		t.Errorf("expected subscription stored under local api id gw-uuid-1, got %s", sub.APIID)
+	}
+}
+
+// The control plane reports API keys against the artifact UUID it minted. For a
+// bottom-up (DP->CP) synced artifact that is the cp_artifact_id, not the local
+// UUID the routes and the API-key xDS snapshot are keyed by, so startup backfill
+// must map it back before persisting — otherwise the key never authenticates.
+func TestClient_syncAPIKeysForExistingArtifacts_MapsControlPlaneArtifactIDToLocal(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/apis/api-keys" {
+			// Only RestApi keys are exercised here; every other kind returns none.
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[]`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{
+			"etag": "etag-1",
+			"uuid": "key-uuid-1",
+			"name": "prod-key",
+			"maskedApiKey": "abc***",
+			"apiKeyHashes": {"sha256": "hash-1"},
+			"artifactUuid": "cp-uuid-1",
+			"status": "active",
+			"source": "local"
+		}]`))
+	}))
+	defer srv.Close()
+
+	db := newMockStorageForDeletion()
+	db.configs["gw-uuid-1"] = &models.StoredConfig{
+		UUID:         "gw-uuid-1",
+		CPArtifactID: "cp-uuid-1",
+		Kind:         models.KindRestApi,
+	}
+	hub := &mockControlPlaneEventHub{}
+	configStore := storage.NewConfigStore()
+
+	client := &Client{
+		logger:          logger,
+		db:              db,
+		eventHub:        hub,
+		gatewayID:       "test-gateway",
+		ctx:             context.Background(),
+		state:           &ConnectionState{},
+		store:           configStore,
+		apiKeyStore:     storage.NewAPIKeyStore(logger),
+		apiKeyService:   utils.NewAPIKeyService(configStore, db, nil, nil, hub, "test-gateway"),
+		apiUtilsService: utils.NewAPIUtilsService(utils.PlatformAPIConfig{BaseURL: srv.URL, Token: "t"}, logger),
+	}
+
+	client.syncAPIKeysForExistingArtifacts("test-gateway")
+
+	if len(db.upsertedAPIKeys) != 1 {
+		t.Fatalf("expected exactly one API key upsert, got %d", len(db.upsertedAPIKeys))
+	}
+	if got := db.upsertedAPIKeys[0].ArtifactUUID; got != "gw-uuid-1" {
+		t.Errorf("expected key stored under local artifact uuid gw-uuid-1, got %s", got)
+	}
+	// A row filed under the CP UUID by an earlier version would collide with the
+	// correctly-keyed insert on UNIQUE (gateway_id, uuid), so it is dropped first.
+	if len(db.removedAPIKeysByArtifactName) != 1 ||
+		db.removedAPIKeysByArtifactName[0] != [2]string{"cp-uuid-1", "prod-key"} {
+		t.Errorf("expected the mis-keyed cp-uuid-1/prod-key row to be removed, got %v",
+			db.removedAPIKeysByArtifactName)
+	}
+}
+
+// A control-plane-originated API has no cp_artifact_id, so nothing is remapped
+// and no repair delete is issued.
+func TestClient_syncAPIKeysForExistingArtifacts_LeavesControlPlaneOriginatedKeysAlone(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/apis/api-keys" {
+			_, _ = w.Write([]byte(`[]`))
+			return
+		}
+		_, _ = w.Write([]byte(`[{
+			"etag": "etag-1",
+			"uuid": "key-uuid-1",
+			"name": "prod-key",
+			"maskedApiKey": "abc***",
+			"apiKeyHashes": {"sha256": "hash-1"},
+			"artifactUuid": "gw-uuid-1",
+			"status": "active",
+			"source": "local"
+		}]`))
+	}))
+	defer srv.Close()
+
+	db := newMockStorageForDeletion()
+	db.configs["gw-uuid-1"] = &models.StoredConfig{UUID: "gw-uuid-1", Kind: models.KindRestApi}
+	hub := &mockControlPlaneEventHub{}
+	configStore := storage.NewConfigStore()
+
+	client := &Client{
+		logger:          logger,
+		db:              db,
+		eventHub:        hub,
+		gatewayID:       "test-gateway",
+		ctx:             context.Background(),
+		state:           &ConnectionState{},
+		store:           configStore,
+		apiKeyStore:     storage.NewAPIKeyStore(logger),
+		apiKeyService:   utils.NewAPIKeyService(configStore, db, nil, nil, hub, "test-gateway"),
+		apiUtilsService: utils.NewAPIUtilsService(utils.PlatformAPIConfig{BaseURL: srv.URL, Token: "t"}, logger),
+	}
+
+	client.syncAPIKeysForExistingArtifacts("test-gateway")
+
+	if len(db.upsertedAPIKeys) != 1 {
+		t.Fatalf("expected exactly one API key upsert, got %d", len(db.upsertedAPIKeys))
+	}
+	if got := db.upsertedAPIKeys[0].ArtifactUUID; got != "gw-uuid-1" {
+		t.Errorf("expected artifact uuid gw-uuid-1, got %s", got)
+	}
+	if len(db.removedAPIKeysByArtifactName) != 0 {
+		t.Errorf("expected no repair deletes, got %v", db.removedAPIKeysByArtifactName)
 	}
 }
 

--- a/gateway/gateway-controller/pkg/controlplane/client.go
+++ b/gateway/gateway-controller/pkg/controlplane/client.go
@@ -1061,6 +1061,8 @@ func (c *Client) syncAPIKeysForExistingArtifacts(gatewayID string) {
 		return
 	}
 	artifactUUIDsByKind := make(map[string][]string)
+	// The control plane reports each key against the artifact UUID. For a bottom-up synced artifact that is the cp_artifact_id
+	localArtifactIDs := make(map[string]string)
 	for _, cfg := range configs {
 		if cfg == nil {
 			continue
@@ -1070,6 +1072,19 @@ func (c *Client) syncAPIKeysForExistingArtifacts(gatewayID string) {
 			continue
 		}
 		artifactUUIDsByKind[cfg.Kind] = append(artifactUUIDsByKind[cfg.Kind], cfg.UUID)
+		localArtifactIDs[cfg.UUID] = cfg.UUID
+	}
+	for _, cfg := range configs {
+		if cfg == nil || cfg.CPArtifactID == "" {
+			continue
+		}
+		if _, taken := localArtifactIDs[cfg.CPArtifactID]; taken {
+			continue
+		}
+		if _, known := localArtifactIDs[cfg.UUID]; !known {
+			continue // kind not covered by API-key sync
+		}
+		localArtifactIDs[cfg.CPArtifactID] = cfg.UUID
 	}
 
 	for _, kind := range []string{models.KindRestApi, models.KindWebSubApi, models.KindWebBrokerApi, models.KindLlmProvider, models.KindLlmProxy} {
@@ -1115,6 +1130,17 @@ func (c *Client) syncAPIKeysForExistingArtifacts(gatewayID string) {
 			key := keys[i]
 			if key.UUID == "" {
 				continue
+			}
+
+			if local, mapped := localArtifactIDs[key.ArtifactUUID]; mapped && local != key.ArtifactUUID {
+				if err := c.db.RemoveAPIKeyAPIAndName(key.ArtifactUUID, key.Name); err != nil &&
+					!storage.IsNotFoundError(err) {
+					c.logger.Warn("Failed to remove API key mis-keyed by control-plane artifact UUID",
+						slog.String("key_uuid", key.UUID),
+						slog.String("cp_artifact_uuid", key.ArtifactUUID),
+						slog.Any("error", err))
+				}
+				key.ArtifactUUID = local
 			}
 
 			if err := c.db.UpsertAPIKey(&key); err != nil {

--- a/gateway/gateway-controller/pkg/controlplane/client.go
+++ b/gateway/gateway-controller/pkg/controlplane/client.go
@@ -958,11 +958,17 @@ func (c *Client) syncSubscriptionsForExistingAPIs(gatewayID string) {
 		}
 
 		apiID := cfg.UUID
+		// The control plane knows a bottom-up (DP->CP) synced API by the CP UUID
+		remoteAPIID := apiID
+		if cfg.CPArtifactID != "" {
+			remoteAPIID = cfg.CPArtifactID
+		}
 
-		subs, err := c.apiUtilsService.FetchSubscriptionsForAPI(apiID)
+		subs, err := c.apiUtilsService.FetchSubscriptionsForAPI(remoteAPIID)
 		if err != nil {
 			c.logger.Warn("Failed to bulk-sync subscriptions for API",
 				slog.String("api_id", apiID),
+				slog.String("cp_api_id", remoteAPIID),
 				slog.Any("error", err),
 			)
 			continue
@@ -3480,16 +3486,18 @@ func (c *Client) handleSubscriptionCreatedEvent(event map[string]interface{}) {
 			slog.Bool("hasToken", payload.SubscriptionToken != ""))
 		return
 	}
+	localAPIID := c.resolveLocalArtifactID(payload.APIID)
 	logger := baseLogger.With(
 		slog.String("correlation_id", createdEvent.CorrelationID),
 		slog.String("subscription_id", payload.SubscriptionID),
-		slog.String("api_id", payload.APIID),
+		slog.String("api_id", localAPIID),
+		slog.String("cp_api_id", payload.APIID),
 	)
 
 	status := models.SubscriptionStatus(payload.Status)
 	sub := &models.Subscription{
 		ID:                payload.SubscriptionID,
-		APIID:             payload.APIID,
+		APIID:             localAPIID,
 		SubscriptionToken: payload.SubscriptionToken,
 		Status:            status,
 		CreatedAt:         time.Now(),
@@ -3558,8 +3566,9 @@ func (c *Client) handleSubscriptionUpdatedEvent(event map[string]interface{}) {
 	}
 
 	// Copy all mutable fields from payload into existing before update.
+	// As in the created path, the control-plane UUID is mapped to the local one.
 	if payload.APIID != "" {
-		existing.APIID = payload.APIID
+		existing.APIID = c.resolveLocalArtifactID(payload.APIID)
 	}
 	if payload.ApplicationID != "" {
 		existing.ApplicationID = &payload.ApplicationID

--- a/gateway/gateway-controller/pkg/subscriptionxds/subscription_snapshot.go
+++ b/gateway/gateway-controller/pkg/subscriptionxds/subscription_snapshot.go
@@ -112,18 +112,33 @@ func (sm *SnapshotManager) UpdateSnapshot(ctx context.Context) error {
 		subsByAPI[s.APIID] = append(subsByAPI[s.APIID], s)
 	}
 
-	// Build set of API IDs that exist in configs (RestApi kind only).
-	apiIDs := make(map[string]bool)
+	// Map every identifier a subscription may be keyed by to the local (gateway) API
+	// UUID, for RestApi configs only. A bottom-up (DP->CP) synced API keeps its
+	// locally generated UUID and records the control-plane UUID as cp_artifact_id
+	localAPIIDs := make(map[string]string)
 	for _, cfg := range configs {
-		if cfg != nil && cfg.Kind == "RestApi" {
-			apiIDs[cfg.UUID] = true
+		if cfg == nil || cfg.Kind != models.KindRestApi {
+			continue
+		}
+		localAPIIDs[cfg.UUID] = cfg.UUID
+	}
+	for _, cfg := range configs {
+		if cfg == nil || cfg.Kind != models.KindRestApi || cfg.CPArtifactID == "" {
+			continue
+		}
+		if _, taken := localAPIIDs[cfg.CPArtifactID]; !taken {
+			localAPIIDs[cfg.CPArtifactID] = cfg.UUID
 		}
 	}
 
 	// Assemble SubscriptionData only for APIs that exist in configs.
 	var subs []policyenginev1.SubscriptionData
 	for apiID, list := range subsByAPI {
-		if !apiIDs[apiID] {
+		localAPIID, known := localAPIIDs[apiID]
+		if !known {
+			sm.logger.Warn("Skipping subscriptions for an API with no matching RestApi config",
+				slog.String("api_id", apiID),
+				slog.Int("skipped_subscription_count", len(list)))
 			continue
 		}
 		for _, s := range list {
@@ -131,7 +146,7 @@ func (sm *SnapshotManager) UpdateSnapshot(ctx context.Context) error {
 				continue
 			}
 			entry := policyenginev1.SubscriptionData{
-				APIId:             s.APIID,
+				APIId:             localAPIID,
 				SubscriptionToken: s.SubscriptionTokenHash,
 				Status:            string(s.Status),
 			}

--- a/gateway/gateway-controller/pkg/subscriptionxds/subscription_snapshot_test.go
+++ b/gateway/gateway-controller/pkg/subscriptionxds/subscription_snapshot_test.go
@@ -21,6 +21,7 @@ package subscriptionxds
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"testing"
@@ -28,6 +29,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wso2/api-platform/gateway/gateway-controller/pkg/models"
+	policyenginev1 "github.com/wso2/api-platform/sdk/core/policyengine"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 // MockStorage implements the storage.Storage interface for testing.
@@ -533,6 +538,132 @@ func TestSnapshotManager_UpdateSnapshot(t *testing.T) {
 
 		err := sm.UpdateSnapshot(ctx)
 		assert.NoError(t, err)
+	})
+}
+
+// snapshotSubscriptions decodes the subscriptions currently published in the
+// manager's xDS cache, so tests can assert on what the policy engine actually
+// receives rather than only that UpdateSnapshot returned no error.
+func snapshotSubscriptions(t *testing.T, sm *SnapshotManager) []policyenginev1.SubscriptionData {
+	t.Helper()
+
+	resource, ok := sm.cache.GetResources()["subscription-state"]
+	require.True(t, ok, "subscription-state resource missing from cache")
+
+	anyMsg, ok := resource.(*anypb.Any)
+	require.True(t, ok, "cached resource is not an *anypb.Any")
+
+	// anypb.New stamped a struct payload before the TypeUrl was overwritten with
+	// the custom SubscriptionStateTypeURL, so unmarshal the struct directly.
+	st := &structpb.Struct{}
+	require.NoError(t, proto.Unmarshal(anyMsg.Value, st))
+
+	jsonBytes, err := st.MarshalJSON()
+	require.NoError(t, err)
+
+	var state policyenginev1.SubscriptionStateResource
+	require.NoError(t, json.Unmarshal(jsonBytes, &state))
+	return state.Subscriptions
+}
+
+// A bottom-up (DP->CP) synced API is stored on the gateway under its locally
+// generated UUID with the control-plane UUID recorded as cp_artifact_id, so
+// subscriptions broadcast by the control plane arrive keyed by the CP UUID.
+// They must still reach the policy engine, keyed by the local UUID that the
+// Envoy route metadata uses.
+func TestSnapshotManager_UpdateSnapshot_DPToCPSyncedAPI(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("accepts a subscription keyed by the control-plane UUID", func(t *testing.T) {
+		store := &MockStorage{
+			configs: []*models.StoredConfig{
+				{UUID: "gw-uuid-1", CPArtifactID: "cp-uuid-1", Kind: models.KindRestApi},
+			},
+			subscriptionPlans: []*models.SubscriptionPlan{},
+			subscriptions: []*models.Subscription{
+				{
+					ID:                    "sub-1",
+					APIID:                 "cp-uuid-1",
+					SubscriptionTokenHash: "token-hash-1",
+					Status:                models.SubscriptionStatusActive,
+				},
+			},
+		}
+		sm := NewSnapshotManager(store, nil)
+
+		require.NoError(t, sm.UpdateSnapshot(ctx))
+
+		subs := snapshotSubscriptions(t, sm)
+		require.Len(t, subs, 1)
+		// Emitted under the local UUID — the policy engine matches on that, not the CP one.
+		assert.Equal(t, "gw-uuid-1", subs[0].APIId)
+		assert.Equal(t, "token-hash-1", subs[0].SubscriptionToken)
+	})
+
+	t.Run("still accepts a subscription keyed by the local UUID", func(t *testing.T) {
+		store := &MockStorage{
+			configs: []*models.StoredConfig{
+				{UUID: "gw-uuid-1", CPArtifactID: "cp-uuid-1", Kind: models.KindRestApi},
+			},
+			subscriptionPlans: []*models.SubscriptionPlan{},
+			subscriptions: []*models.Subscription{
+				{
+					ID:                    "sub-1",
+					APIID:                 "gw-uuid-1",
+					SubscriptionTokenHash: "token-hash-1",
+					Status:                models.SubscriptionStatusActive,
+				},
+			},
+		}
+		sm := NewSnapshotManager(store, nil)
+
+		require.NoError(t, sm.UpdateSnapshot(ctx))
+
+		subs := snapshotSubscriptions(t, sm)
+		require.Len(t, subs, 1)
+		assert.Equal(t, "gw-uuid-1", subs[0].APIId)
+	})
+
+	t.Run("a CP UUID belonging to another API is still rejected", func(t *testing.T) {
+		store := &MockStorage{
+			configs: []*models.StoredConfig{
+				{UUID: "gw-uuid-1", CPArtifactID: "cp-uuid-1", Kind: models.KindRestApi},
+			},
+			subscriptionPlans: []*models.SubscriptionPlan{},
+			subscriptions: []*models.Subscription{
+				{
+					ID:                    "sub-1",
+					APIID:                 "cp-uuid-other",
+					SubscriptionTokenHash: "token-hash-1",
+					Status:                models.SubscriptionStatusActive,
+				},
+			},
+		}
+		sm := NewSnapshotManager(store, nil)
+
+		require.NoError(t, sm.UpdateSnapshot(ctx))
+		assert.Empty(t, snapshotSubscriptions(t, sm))
+	})
+
+	t.Run("a cp_artifact_id on a non-RestApi config is not accepted", func(t *testing.T) {
+		store := &MockStorage{
+			configs: []*models.StoredConfig{
+				{UUID: "gw-uuid-1", CPArtifactID: "cp-uuid-1", Kind: models.KindMcp},
+			},
+			subscriptionPlans: []*models.SubscriptionPlan{},
+			subscriptions: []*models.Subscription{
+				{
+					ID:                    "sub-1",
+					APIID:                 "cp-uuid-1",
+					SubscriptionTokenHash: "token-hash-1",
+					Status:                models.SubscriptionStatusActive,
+				},
+			},
+		}
+		sm := NewSnapshotManager(store, nil)
+
+		require.NoError(t, sm.UpdateSnapshot(ctx))
+		assert.Empty(t, snapshotSubscriptions(t, sm))
 	})
 }
 


### PR DESCRIPTION
This pull request ensures that bottom-up (DP→CP) synced APIs and their related resources (subscriptions and API keys) are consistently mapped from the control-plane-minted UUIDs to the gateway's local UUIDs. This mapping is critical for correct routing, policy enforcement, and preventing data inconsistencies during bulk syncs and event handling.

Related to: 
- https://github.com/wso2/api-platform/issues/3247

Key changes include:

**Correct mapping of API and artifact IDs between control plane and gateway:**

* Updated `syncSubscriptionsForExistingAPIs`, `handleSubscriptionCreatedEvent`, and `handleSubscriptionUpdatedEvent` in `client.go` to map control-plane API IDs to the local gateway UUID when handling subscriptions, ensuring subscriptions are correctly keyed for route and policy lookups. [[1]](diffhunk://#diff-6d4056ca8ee663cd79b1fb4f4fb0f41b23b0c5f78d723bb820de3bd618cb5904R961-R971) [[2]](diffhunk://#diff-6d4056ca8ee663cd79b1fb4f4fb0f41b23b0c5f78d723bb820de3bd618cb5904R3515-R3526) [[3]](diffhunk://#diff-6d4056ca8ee663cd79b1fb4f4fb0f41b23b0c5f78d723bb820de3bd618cb5904R3595-R3597)
* Enhanced `syncAPIKeysForExistingArtifacts` in `client.go` to remap API key artifact UUIDs from the control-plane UUID to the local gateway UUID during bulk sync, and to remove any API key rows mis-keyed by the CP UUID, preventing duplicate or mismatched entries. [[1]](diffhunk://#diff-6d4056ca8ee663cd79b1fb4f4fb0f41b23b0c5f78d723bb820de3bd618cb5904R1064-R1065) [[2]](diffhunk://#diff-6d4056ca8ee663cd79b1fb4f4fb0f41b23b0c5f78d723bb820de3bd618cb5904R1075-R1087) [[3]](diffhunk://#diff-6d4056ca8ee663cd79b1fb4f4fb0f41b23b0c5f78d723bb820de3bd618cb5904R1135-R1145)

**Subscription xDS snapshot improvements:**

* Modified `UpdateSnapshot` in `subscription_snapshot.go` to map all possible subscription API IDs (both local and CP UUIDs) to the local UUID for RestApi configs, ensuring that the policy engine receives subscriptions keyed by the correct identifier.