### PR TITLE
build(platform-api): add cloud image build with event-gateway plugin

### DIFF
--- a/.github/workflows/platform-api-cloud-pr-check.yml
+++ b/.github/workflows/platform-api-cloud-pr-check.yml
@@ -1,0 +1,55 @@
+name: Platform API Cloud PR Check
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'platform-api/**'
+      # common/ and httpkit/ are consumed by the experimental build via go.mod
+      # replace directives, so a change there can break `go build -tags
+      # experimental` — run this check for those too.
+      - 'common/**'
+      - 'httpkit/**'
+      - '.github/workflows/platform-api-cloud-pr-check.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # The cloud image is built with EXPERIMENTAL=true, which compiles in the
+  # event-gateway plugin (Dockerfile turns EXPERIMENTAL=true into `-tags
+  # experimental`). The default Platform API PR check only builds the OSS
+  # variant, so a change that breaks the experimental build — e.g. a plugin
+  # referencing an api type that no longer exists — would pass CI and only
+  # surface at cloud-release time. This check exercises that variant on every PR.
+  cloud-pr-check:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version: '1.26.5'
+          cache-dependency-path: '**/go.sum'
+
+      - name: Go build (experimental / cloud)
+        run: go build -tags experimental ./cmd/main.go
+        working-directory: platform-api
+
+      - name: Run tests (experimental / cloud)
+        run: go test -tags experimental -count=1 ./...
+        working-directory: platform-api
+
+      - name: Cross-database integration tests (SQLite, experimental / cloud)
+        run: IT_DB=sqlite go test -tags "integration experimental" -count=1 ./internal/integration/...
+        working-directory: platform-api

--- a/.github/workflows/platform-api-cloud-release.yml
+++ b/.github/workflows/platform-api-cloud-release.yml
@@ -47,4 +47,4 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push multi arch Docker images
-        run: make build-and-push-platform-api-multiarch PLATFORM_API_VERSION="${{ steps.version.outputs.IMAGE_VERSION }}" IMAGE_SUFFIX="platform-api-cloud" DOCKER_REGISTRY="ghcr.io/${{ github.repository_owner }}/api-platform"
+        run: make cloud-build-and-push-platform-api-multiarch PLATFORM_API_VERSION="${{ steps.version.outputs.IMAGE_VERSION }}" DOCKER_REGISTRY="ghcr.io/${{ github.repository_owner }}/api-platform"

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,8 @@ help: ## Show this help message
 	@echo '  make build-event-gateway              - Build all event gateway Docker images'
 	@echo '  make build-and-push-gateway-multiarch - Build and push all gateway images for multiple architectures'
 	@echo '  make build-and-push-event-gateway-multiarch - Build and push all event gateway images for multiple architectures'
-	@echo '  make build-and-push-platform-api-multiarch VERSION=X - Build and push platform-api images for multiple architectures'
+	@echo '  make build-and-push-platform-api-multiarch PLATFORM_API_VERSION=X - Build and push platform-api images for multiple architectures'
+	@echo '  make cloud-build-and-push-platform-api-multiarch PLATFORM_API_VERSION=X - Build and push platform-api cloud image (event-gateway plugin) for multiple architectures'
 	@echo '  make build-and-push-api-portal-multiarch - Build and push API Portal image for multiple architectures'
 	@echo '  make build-cli                        - Build CLI binaries for all platforms'
 	@echo '  make package-event-gateway            - Package event gateway as a self-contained zip'
@@ -112,6 +113,12 @@ build-and-push-platform-api-multiarch: ## Build and push platform-api Docker ima
 	@echo "Building and pushing multi-arch platform-api ($(PLATFORM_API_VERSION))..."
 	$(MAKE) -C platform-api build-and-push-multiarch VERSION=$(PLATFORM_API_VERSION)
 	@echo "Successfully built and pushed multi-arch platform-api"
+
+.PHONY: cloud-build-and-push-platform-api-multiarch
+cloud-build-and-push-platform-api-multiarch: ## Build and push multi-arch platform-api cloud image (event-gateway plugin, amd64, arm64)
+	@echo "Building and pushing multi-arch platform-api cloud image ($(PLATFORM_API_VERSION))..."
+	$(MAKE) -C platform-api cloud-build-and-push-multiarch VERSION=$(PLATFORM_API_VERSION)
+	@echo "Successfully built and pushed multi-arch platform-api cloud image"
 
 
 .PHONY: build-and-push-api-portal-multiarch

--- a/platform-api/Makefile
+++ b/platform-api/Makefile
@@ -27,6 +27,11 @@ BUILD_DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 DOCKER_REGISTRY ?= ghcr.io/wso2/api-platform
 IMAGE_SUFFIX ?= platform-api
 IMAGE_NAME := $(DOCKER_REGISTRY)/$(IMAGE_SUFFIX)
+# Cloud image — built with EXPERIMENTAL=true so the event-gateway plugin
+# (WebSub/WebBroker API management) is compiled in. Published under a distinct
+# image name so it never collides with the OSS platform-api image.
+CLOUD_IMAGE_SUFFIX ?= platform-api-cloud
+CLOUD_IMAGE_NAME := $(DOCKER_REGISTRY)/$(CLOUD_IMAGE_SUFFIX)
 PORT ?= 9243
 
 # Integration test configuration
@@ -40,7 +45,7 @@ REPO_ROOT := $(shell git rev-parse --show-toplevel)
 APIDOCS_TOOLS_DIR := $(REPO_ROOT)/tools/apidocs
 DOCS_OUT_DIR := $(REPO_ROOT)/docs/rest-apis/platform-api
 
-.PHONY: help build test push build-and-push-multiarch it it-sqlite it-postgres it-sqlserver it-all-dbs generate generate-apidocs setup-local-dev run-local
+.PHONY: help build cloud-build test push build-and-push-multiarch cloud-build-and-push-multiarch it it-sqlite it-postgres it-sqlserver it-all-dbs generate generate-apidocs setup-local-dev run-local
 
 help: ## Show this help message
 	@echo 'Platform API Build System (Version: $(VERSION))'
@@ -112,6 +117,19 @@ build: ## Build Docker image
 		--load \
 		.
 
+cloud-build: ## Build cloud Docker image with the event-gateway plugin (EXPERIMENTAL=true)
+	@echo "Building cloud Docker image ($(CLOUD_IMAGE_NAME):$(VERSION)) with event-gateway plugin..."
+	docker buildx build -f Dockerfile \
+		--build-context common=../common \
+		--build-context httpkit=../httpkit \
+		--build-arg VERSION=$(VERSION) \
+		--build-arg PORT=$(PORT) \
+		--build-arg EXPERIMENTAL=true \
+		-t $(CLOUD_IMAGE_NAME):$(VERSION) \
+		-t $(CLOUD_IMAGE_NAME):latest \
+		--load \
+		.
+
 generate: ## Generate API server code from OpenAPI spec
 	@echo "Adding bindings to OpenAPI spec..."
 	@command -v yq >/dev/null 2>&1 || { echo "Error: yq is not installed. Install it via 'brew install yq' or 'go install github.com/mikefarah/yq/v4@latest'"; exit 1; }
@@ -147,6 +165,20 @@ build-and-push-multiarch: ## Build and push multi-architecture Docker image (lin
 		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
 		--build-arg PORT=$(PORT) \
 		-t $(IMAGE_NAME):$(VERSION) \
+		--push \
+		.
+
+cloud-build-and-push-multiarch: ## Build and push multi-arch cloud image with the event-gateway plugin (linux/amd64, linux/arm64)
+	@echo "Building and pushing multi-arch cloud image: $(CLOUD_IMAGE_NAME):$(VERSION) with event-gateway plugin"
+	docker buildx build -f Dockerfile \
+		--platform linux/amd64,linux/arm64 \
+		--build-context common=../common \
+		--build-context httpkit=../httpkit \
+		--build-arg VERSION=$(VERSION) \
+		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
+		--build-arg PORT=$(PORT) \
+		--build-arg EXPERIMENTAL=true \
+		-t $(CLOUD_IMAGE_NAME):$(VERSION) \
 		--push \
 		.
 

--- a/platform-api/plugins/eventgateway/plugin.go
+++ b/platform-api/plugins/eventgateway/plugin.go
@@ -31,7 +31,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/wso2/api-platform/platform-api/api"
 	"github.com/wso2/api-platform/platform-api/config"
 	"github.com/wso2/api-platform/platform-api/internal/apperror"
 	"github.com/wso2/api-platform/platform-api/internal/constants"
@@ -268,17 +267,6 @@ func (p *EventGatewayPlugin) CheckProjectDeletion(orgID, projectID string) error
 	if webbrokerCount > 0 {
 		return apperror.ValidationFailed.New("Project has associated WebBroker APIs")
 	}
-	return nil
-}
-
-// EnrichSubscription implements service.OrgSubscriptionEnricher.
-// It adds the WebSub API quota to the organization subscription response.
-func (p *EventGatewayPlugin) EnrichSubscription(orgID string, sub *api.OrganizationSubscription) error {
-	count, err := p.websubAPIRepo.Count(orgID)
-	if err != nil {
-		return err
-	}
-	sub.Quotas.WebsubApis = &api.OrganizationQuota{Used: count}
 	return nil
 }
 


### PR DESCRIPTION
## Purpose

The `platform-api` cloud image is the experimental build (`EXPERIMENTAL=true` → `-tags experimental`) that compiles in the event-gateway plugin (WebSub/WebBroker API management).
There was no first-class way to build it — the image had to be produced with a long hand-written `docker buildx` command — and the default Platform API PR check only built the OSS variant.
As a result a change that broke the experimental build (as recently happened, when a plugin method referenced an `api` type that no longer exists) would pass CI and only surface at cloud-release time.

## Approach

- Add `cloud-build` and `cloud-build-and-push-multiarch` targets to `platform-api/Makefile` that build with `EXPERIMENTAL=true` and publish under a distinct `platform-api-cloud` image name.
- Add a root `cloud-build-and-push-platform-api-multiarch` delegating target and point the `platform-api-cloud-release` workflow at it, so the released cloud image now actually includes the event-gateway plugin.
- Add `platform-api-cloud-pr-check.yml`, which on every Platform API PR builds, unit-tests, and runs SQLite integration tests for the experimental variant, closing the gap where the default PR check only exercised the OSS build.
- Remove the unused `EnrichSubscription` method from the event-gateway plugin, which referenced `api` types that no longer exist and broke the experimental build.

## Related Issues

https://github.com/wso2-enterprise/apim-saas/issues/2908

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)