### PR TITLE
[AM - GW] Add a separate release workflow for agent manager related releases (1.2.1)

### DIFF
--- a/.github/workflows/gateway-agent-manager-release.yml
+++ b/.github/workflows/gateway-agent-manager-release.yml
@@ -13,7 +13,7 @@ on:
         required: true
         type: string
       tag_name:
-        description: 'Git tag to create. Leave empty to use gateway/v<release_version>.'
+        description: 'Git tag to create, e.g. gateway/v1.2.1-rc. Leave empty to use gateway/v<release_version>.'
         required: false
         type: string
       next_dev_version:
@@ -27,7 +27,7 @@ on:
         type: boolean
 
 env:
-  DOCKER_REGISTRY: ghcr.io/wso2/api-platform
+  DOCKER_REGISTRY: ghcr.io/wso2
   RELEASE_BRANCH: gateway/1.2.0-agent-manager
 
 jobs:
@@ -71,6 +71,10 @@ jobs:
           TAG="$(echo "${TAG_NAME}" | tr -d '[:space:]')"
           if [ -z "${TAG}" ]; then
             TAG="gateway/v${VERSION}"
+          fi
+          if ! [[ "${TAG}" =~ ^[0-9A-Za-z._/+-]+$ ]]; then
+            echo "Error: tag_name contains unsupported characters" >&2
+            exit 1
           fi
           if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
             echo "Error: tag ${TAG} already exists" >&2

--- a/.github/workflows/gateway-agent-manager-release.yml
+++ b/.github/workflows/gateway-agent-manager-release.yml
@@ -1,0 +1,143 @@
+name: Gateway Agent Manager Release
+
+# Dedicated release pipeline for the gateway/1.2.0-agent-manager branch.
+# Unlike the main Gateway Release workflow, the version is supplied as an input
+# (not read from gateway/VERSION), so ad-hoc tags such as
+# 1.2.0-agent-manager-1 can be cut without touching main's version stream.
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'Version to release, without a leading v (e.g. 1.2.0-agent-manager-1). Used for the Docker image tags and the git tag.'
+        required: true
+        type: string
+      tag_name:
+        description: 'Git tag to create. Leave empty to use gateway/v<release_version>.'
+        required: false
+        type: string
+      next_dev_version:
+        description: 'Version to leave the branch on after the release (must end with -SNAPSHOT, e.g. 1.2.0-agent-manager-SNAPSHOT). Leave empty to skip the bump.'
+        required: false
+        type: string
+      run_tests:
+        description: 'Run unit tests before publishing'
+        required: false
+        default: true
+        type: boolean
+
+env:
+  DOCKER_REGISTRY: ghcr.io/wso2/api-platform
+  RELEASE_BRANCH: gateway/1.2.0-agent-manager
+
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Guard branch
+        run: |
+          if [ "${GITHUB_REF}" != "refs/heads/${RELEASE_BRANCH}" ]; then
+            echo "Error: this workflow may only be dispatched against ${RELEASE_BRANCH} (got ${GITHUB_REF})" >&2
+            exit 1
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+          token: ${{ secrets.API_PLATFORM_BOT_TOKEN }}
+
+      - name: Resolve version and tag
+        id: version
+        env:
+          RELEASE_VERSION: ${{ inputs.release_version }}
+          TAG_NAME: ${{ inputs.tag_name }}
+        run: |
+          VERSION="$(echo "${RELEASE_VERSION}" | tr -d '[:space:]')"
+          VERSION="${VERSION#v}"
+          if [ -z "${VERSION}" ]; then
+            echo "Error: release_version is required" >&2
+            exit 1
+          fi
+          if [[ "${VERSION}" == *-SNAPSHOT ]]; then
+            echo "Error: release_version must not end with -SNAPSHOT" >&2
+            exit 1
+          fi
+          if ! [[ "${VERSION}" =~ ^[0-9A-Za-z.+-]+$ ]]; then
+            echo "Error: release_version contains unsupported characters" >&2
+            exit 1
+          fi
+          TAG="$(echo "${TAG_NAME}" | tr -d '[:space:]')"
+          if [ -z "${TAG}" ]; then
+            TAG="gateway/v${VERSION}"
+          fi
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "Error: tag ${TAG} already exists" >&2
+            exit 1
+          fi
+          echo "Releasing gateway version ${VERSION} as tag ${TAG}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Set version
+        run: make -C gateway version-set VERSION=${{ steps.version.outputs.version }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26.5'
+          cache: false
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          install: true
+          driver: docker-container
+
+      - name: Run tests
+        if: ${{ inputs.run_tests }}
+        run: make test-gateway
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.API_PLATFORM_BOT_TOKEN }}
+
+      - name: Build and push multi arch Docker images
+        run: make build-and-push-gateway-multiarch
+
+      - name: Create and push tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+            git commit -am "Release gateway version ${{ steps.version.outputs.version }}"
+            git push origin HEAD:${RELEASE_BRANCH}
+          fi
+          git tag -a ${{ steps.version.outputs.tag }} -m "Gateway ${{ steps.version.outputs.version }}"
+          git push origin ${{ steps.version.outputs.tag }}
+
+      - name: Set next dev version
+        if: ${{ inputs.next_dev_version != '' }}
+        env:
+          NEXT_DEV_VERSION: ${{ inputs.next_dev_version }}
+        run: |
+          if [[ "${NEXT_DEV_VERSION}" != *-SNAPSHOT ]]; then
+            echo "Error: next_dev_version must end with -SNAPSHOT" >&2
+            exit 1
+          fi
+          make -C gateway version-set "VERSION=${NEXT_DEV_VERSION}"
+          if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+            git commit -am "Bump gateway to ${NEXT_DEV_VERSION}"
+            git push origin HEAD:${RELEASE_BRANCH}
+          else
+            echo "No changes to commit"
+          fi

--- a/.github/workflows/gateway-integration-test-postgres.yml
+++ b/.github/workflows/gateway-integration-test-postgres.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - main
+      - gateway/1.2.0-agent-manager
     paths:
       - 'gateway/**'
       - '.github/workflows/gateway-integration-test-postgres.yml'

--- a/.github/workflows/gateway-integration-test-sqlserver.yml
+++ b/.github/workflows/gateway-integration-test-sqlserver.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - main
+      - gateway/1.2.0-agent-manager
     paths:
       - 'gateway/**'
       - 'common/**'

--- a/.github/workflows/gateway-integration-test.yml
+++ b/.github/workflows/gateway-integration-test.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - main
+      - gateway/1.2.0-agent-manager
     paths:
       - 'gateway/**'
       - 'common/**'

--- a/.github/workflows/k8s-gateway-api-conformance.yml
+++ b/.github/workflows/k8s-gateway-api-conformance.yml
@@ -17,6 +17,7 @@ on:
   pull_request:
     branches:
       - main
+      - gateway/1.2.0-agent-manager
     paths:
       - 'kubernetes/**'
       - 'gateway/gateway-controller/**'

--- a/.github/workflows/operator-integration-test.yml
+++ b/.github/workflows/operator-integration-test.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - main
+      - gateway/1.2.0-agent-manager
     paths:
       - 'gateway/**'
       - 'kubernetes/**'

--- a/.github/workflows/platform-api-gateway-e2e.yml
+++ b/.github/workflows/platform-api-gateway-e2e.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     branches:
       - main
+      - gateway/1.2.0-agent-manager
 
 permissions:
   contents: read


### PR DESCRIPTION
## Purpose
- Add a separate release workflow for agent manager related releases
- The images should be pushed to wso2 ghcr