### PR TITLE
build(platform-api): tag cloud image as <branch>-<commit>

### DIFF
--- a/platform-api/Makefile
+++ b/platform-api/Makefile
@@ -34,6 +34,26 @@ CLOUD_IMAGE_SUFFIX ?= platform-api-cloud
 CLOUD_IMAGE_NAME := $(DOCKER_REGISTRY)/$(CLOUD_IMAGE_SUFFIX)
 PORT ?= 9243
 
+# Cloud image tag: defaults to "<branch>-<commit>" computed IDENTICALLY to the
+# platform-api-cloud-release workflow's IMAGE_VERSION step — sanitize the branch
+# ([^a-zA-Z0-9._-] -> '-'), prefix '_' if it doesn't start with [a-zA-Z0-9_],
+# cap the branch at 87 chars, then append the FULL commit SHA. Prefer GitHub
+# Actions' GITHUB_REF_NAME/GITHUB_SHA when set (git rev-parse --abbrev-ref HEAD
+# returns "HEAD" after actions/checkout's detached checkout, which would yield a
+# "HEAD-<commit>" tag); fall back to git for local builds. An explicitly supplied
+# VERSION (CI passes PLATFORM_API_VERSION, or `make cloud-build VERSION=x`) takes
+# precedence over all of this.
+CLOUD_IMAGE_TAG := $(shell \
+	b="$${GITHUB_REF_NAME:-$$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)}"; \
+	b=$$(printf '%s' "$$b" | sed -e 's/[^a-zA-Z0-9._-]/-/g' -e 's/^[^a-zA-Z0-9_]/_&/' | cut -c1-87); \
+	printf '%s-%s' "$$b" "$${GITHUB_SHA:-$$(git rev-parse HEAD 2>/dev/null || echo unknown)}")
+ifeq ($(origin VERSION),command line)
+CLOUD_IMAGE_TAG := $(VERSION)
+endif
+ifeq ($(origin VERSION),environment)
+CLOUD_IMAGE_TAG := $(VERSION)
+endif
+
 # Integration test configuration
 IT_PROJECT ?= platform-api-it
 MSSQL_PASSWORD ?= Strong!Passw0rd
@@ -117,7 +137,8 @@ build: ## Build Docker image
 		--load \
 		.
 
-cloud-build: ## Build cloud Docker image with the event-gateway plugin (EXPERIMENTAL=true)
+cloud-build: VERSION := $(CLOUD_IMAGE_TAG)
+cloud-build: ## Build cloud Docker image with the event-gateway plugin (EXPERIMENTAL=true), tagged <branch>-<commit> (override with VERSION=x)
 	@echo "Building cloud Docker image ($(CLOUD_IMAGE_NAME):$(VERSION)) with event-gateway plugin..."
 	docker buildx build -f Dockerfile \
 		--build-context common=../common \
@@ -168,7 +189,8 @@ build-and-push-multiarch: ## Build and push multi-architecture Docker image (lin
 		--push \
 		.
 
-cloud-build-and-push-multiarch: ## Build and push multi-arch cloud image with the event-gateway plugin (linux/amd64, linux/arm64)
+cloud-build-and-push-multiarch: VERSION := $(CLOUD_IMAGE_TAG)
+cloud-build-and-push-multiarch: ## Build and push multi-arch cloud image with the event-gateway plugin (linux/amd64, linux/arm64), tagged <branch>-<commit> (override with VERSION=x)
 	@echo "Building and pushing multi-arch cloud image: $(CLOUD_IMAGE_NAME):$(VERSION) with event-gateway plugin"
 	docker buildx build -f Dockerfile \
 		--platform linux/amd64,linux/arm64 \


### PR DESCRIPTION
## Purpose

The `migration` branch's `cloud-build` and `cloud-build-and-push-multiarch` targets tagged the cloud image with the plain `VERSION` read from `platform-api/VERSION`. On a long-lived feature branch this meant every local cloud build reused the same tag (overwriting the previous image), and the tag carried no information about which branch or commit produced the image. The shared Platform API cloud release workflow (`.github/workflows/platform-api-cloud-release.yml`) computes its image version as `<branch>-<commit>`, so a locally built cloud image couldn't be correlated with a workflow-built one.

## Goals

- Give locally built cloud images a self-describing, unique `<branch>-<commit>` tag that matches the release workflow's computed `IMAGE_VERSION`.
- Preserve this branch's `EXPERIMENTAL=true` event-gateway plugin cloud build (unchanged image name and recipe).
- Keep an explicitly supplied `VERSION` authoritative so CI's `PLATFORM_API_VERSION` always wins.

## Approach

- Add a `CLOUD_IMAGE_TAG` variable in `platform-api/Makefile` derived as `<branch>-<commit>`, computed identically to the workflow's `IMAGE_VERSION` step (branch sanitized to `[a-zA-Z0-9._-]`, leading-character guard, 87-char cap, full commit SHA).
- Apply the derived tag to `cloud-build` and `cloud-build-and-push-multiarch` via a target-specific `VERSION := $(CLOUD_IMAGE_TAG)`, leaving the existing `EXPERIMENTAL` event-gateway build recipe and `platform-api-cloud` image name untouched.
- Keep an explicitly passed `VERSION` (command line or environment) authoritative via `ifeq ($(origin VERSION),...)` overrides, so both CI's `PLATFORM_API_VERSION` and `make cloud-build VERSION=x` take precedence over the derived tag.

## Related Issues

N/A

## User stories

N/A

## Documentation

N/A — build/release tooling change with no product documentation impact.

## Automation tests

 - Unit tests
   > N/A — Makefile/build-tooling change only, no application code modified.
 - Integration tests
   > N/A — verified via `make -n cloud-build` dry runs that the derived tag resolves to `<branch>-<commit>` (e.g. `platform-api-cloud:migration-a955ce8d3...`) and that an explicit `VERSION=` overrides it.

## Security checks

 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — FindSecurityBugs targets Java; this change is Makefile-only.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

Related #3269 — the equivalent cloud-build tagging change for the `platform-api/v0.10.x` maintenance branch.

## Test environment

Verified locally on macOS (darwin) with GNU Make and git.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)