### PR TITLE
ci: add platform-api cloud release workflow

### DIFF
--- a/.github/workflows/platform-api-cloud-release.yml
+++ b/.github/workflows/platform-api-cloud-release.yml
@@ -1,0 +1,50 @@
+name: Platform API Cloud Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Compute image version
+        id: version
+        run: |
+          BRANCH="${GITHUB_REF_NAME//[^a-zA-Z0-9._-]/-}"
+          if [[ ! "$BRANCH" =~ ^[a-zA-Z0-9_] ]]; then BRANCH="_${BRANCH}"; fi
+          BRANCH="${BRANCH:0:87}"
+          COMMIT="${GITHUB_SHA}"
+          printf 'IMAGE_VERSION=%s-%s\n' "$BRANCH" "$COMMIT" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26.2'
+          cache: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+
+      - name: Run tests
+        run: make test-platform-api
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push multi arch Docker images
+        run: make cloud-build-and-push-platform-api-multiarch PLATFORM_API_VERSION="${{ steps.version.outputs.IMAGE_VERSION }}" DOCKER_REGISTRY="ghcr.io/${{ github.repository_owner }}/api-platform"

--- a/platform-api/Makefile
+++ b/platform-api/Makefile
@@ -31,13 +31,16 @@ PORT ?= 9243
 # Cloud image tag: defaults to "<branch>-<commit>" computed IDENTICALLY to the
 # platform-api-cloud-release workflow's IMAGE_VERSION step — sanitize the branch
 # ([^a-zA-Z0-9._-] -> '-'), prefix '_' if it doesn't start with [a-zA-Z0-9_],
-# cap the branch at 87 chars, then append the FULL commit SHA. An explicitly
-# supplied VERSION (CI passes PLATFORM_API_VERSION, or `make cloud-build VERSION=x`)
-# takes precedence.
+# cap the branch at 87 chars, then append the FULL commit SHA. Prefer GitHub
+# Actions' GITHUB_REF_NAME/GITHUB_SHA when set (git rev-parse --abbrev-ref HEAD
+# returns "HEAD" after actions/checkout's detached checkout, which would yield a
+# "HEAD-<commit>" tag); fall back to git for local builds. An explicitly supplied
+# VERSION (CI passes PLATFORM_API_VERSION, or `make cloud-build VERSION=x`) takes
+# precedence over all of this.
 CLOUD_IMAGE_TAG := $(shell \
-	b=$$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown); \
+	b="$${GITHUB_REF_NAME:-$$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)}"; \
 	b=$$(printf '%s' "$$b" | sed -e 's/[^a-zA-Z0-9._-]/-/g' -e 's/^[^a-zA-Z0-9_]/_&/' | cut -c1-87); \
-	printf '%s-%s' "$$b" "$$(git rev-parse HEAD 2>/dev/null || echo unknown)")
+	printf '%s-%s' "$$b" "$${GITHUB_SHA:-$$(git rev-parse HEAD 2>/dev/null || echo unknown)}")
 ifeq ($(origin VERSION),command line)
 CLOUD_IMAGE_TAG := $(VERSION)
 endif


### PR DESCRIPTION
## Purpose

The shared Platform API cloud release pipeline exists on other branches but is missing on `platform-api/v0.10.x`, so this branch cannot publish cloud images. This PR follows up the merged #3269 (which added the `cloud-build` make targets) by adding the workflow that drives them, so the Platform API can be released from this branch.

## Goals

- Enable the shared Platform API cloud release workflow on `platform-api/v0.10.x`.
- Ensure the cloud image tag is correct when the workflow runs under GitHub Actions.

## Approach

- Add `.github/workflows/platform-api-cloud-release.yml` (a `workflow_dispatch` job) that computes `IMAGE_VERSION` as `<branch>-<commit>`, runs `make test-platform-api`, and builds/pushes via `make cloud-build-and-push-platform-api-multiarch` to `ghcr.io/<owner>/api-platform` using `GITHUB_TOKEN` with `packages: write`.
- Pin `go-version` to `1.26.2` to match this branch's toolchain (`go.mod`/`go.work` and the other workflows on this branch).
- Prefer `GITHUB_REF_NAME`/`GITHUB_SHA` over `git rev-parse` when computing the Makefile's `CLOUD_IMAGE_TAG`, because `actions/checkout` leaves a detached HEAD (so `git rev-parse --abbrev-ref HEAD` returns `HEAD`, which would yield a `HEAD-<commit>` tag); fall back to git for local builds, and let an explicitly supplied `VERSION` take precedence.

## User stories

N/A

## Documentation

N/A — CI/build tooling change with no product documentation impact.

## Automation tests

 - Unit tests
   > N/A — CI/Makefile change only, no application code modified.
 - Integration tests
   > N/A — verified via `make -n` dry runs that the targets resolve and the computed tag matches the workflow's `IMAGE_VERSION` (branch sanitized, leading-char guard, 87-char cap, full commit SHA), including the detached-HEAD path via `GITHUB_REF_NAME`.

## Security checks

 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — FindSecurityBugs targets Java; this change is YAML + Makefile only.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes — GHCR login uses `secrets.GITHUB_TOKEN`, no hard-coded credentials.

## Samples

N/A

## Related PRs

- wso2/api-platform#3269 — added the `cloud-build` make targets this workflow invokes (merged).

## Test environment

Local macOS (darwin) with GNU Make and git; the workflow itself runs on GitHub Actions `ubuntu-latest`.