### PR TITLE
feat(platform-api): include user-agent in access logs

### DIFF
--- a/platform-api/src/internal/server/server.go
+++ b/platform-api/src/internal/server/server.go
@@ -328,8 +328,11 @@ func StartPlatformAPIServer(cfg *config.Server, slogger *slog.Logger) (*Server, 
 		gin.SetMode(gin.ReleaseMode)
 	}
 
-	// Setup router
-	router := gin.Default()
+	// Setup router. Use gin.New() with explicit middleware (instead of gin.Default())
+	// so the access log can include the request User-Agent.
+	router := gin.New()
+	router.Use(gin.LoggerWithFormatter(accessLogFormatter))
+	router.Use(gin.Recovery())
 
 	// Configure and apply CORS middleware first (before auth middleware)
 	corsConfig := cors.DefaultConfig()
@@ -443,6 +446,26 @@ func StartPlatformAPIServer(cfg *config.Server, slogger *slog.Logger) (*Server, 
 		eventHub:       eventHub,
 		logger:         slogger,
 	}, nil
+}
+
+// accessLogFormatter mirrors gin's default access-log format (without color)
+// and appends the request's User-Agent so the client is identified in the logs.
+func accessLogFormatter(param gin.LogFormatterParams) string {
+	latency := param.Latency
+	if latency > time.Minute {
+		latency = latency.Truncate(time.Second)
+	}
+
+	return fmt.Sprintf("[GIN] %v | %3d | %13v | %15s | %-7s %#v | %q\n%s",
+		param.TimeStamp.Format("2006/01/02 - 15:04:05"),
+		param.StatusCode,
+		latency,
+		param.ClientIP,
+		param.Method,
+		param.Path,
+		param.Request.UserAgent(),
+		param.ErrorMessage,
+	)
 }
 
 // demoMode reports whether APIP_DEMO_MODE is enabled.


### PR DESCRIPTION
## Purpose

The platform-api access log is produced by gin's built-in logger, whose format is fixed and does not capture the client User-Agent, making it hard to identify which clients are calling the API.
This PR extends the access log to include the request User-Agent.

## Approach

- Replace `gin.Default()` with `gin.New()` plus explicit logger and recovery middleware so the access-log format can be customized.
- Add a custom log formatter that mirrors gin's default access-log format and appends the request User-Agent.

## Related Issues

N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)