### PR TITLE
build(platform-api): push cloud release to platform-api-cloud image

### DIFF
--- a/platform-api/Makefile
+++ b/platform-api/Makefile
@@ -25,7 +25,14 @@ BUILD_DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 # Docker image configuration
 DOCKER_REGISTRY ?= ghcr.io/wso2/api-platform
-IMAGE_NAME := $(DOCKER_REGISTRY)/platform-api
+IMAGE_SUFFIX ?= platform-api
+IMAGE_NAME := $(DOCKER_REGISTRY)/$(IMAGE_SUFFIX)
+# Cloud image is published under a distinct package (platform-api-cloud): the
+# release token has write access to that package, not to platform-api. On this
+# branch the cloud image is the SAME build as IMAGE_NAME (no event-gateway
+# plugin) — only the published name/tag differ.
+CLOUD_IMAGE_SUFFIX ?= platform-api-cloud
+CLOUD_IMAGE_NAME := $(DOCKER_REGISTRY)/$(CLOUD_IMAGE_SUFFIX)
 PORT ?= 9243
 
 # Cloud image tag: defaults to "<branch>-<commit>" computed IDENTICALLY to the
@@ -72,6 +79,7 @@ build: ## Build Docker image
 		.
 
 cloud-build: VERSION := $(CLOUD_IMAGE_TAG)
+cloud-build: IMAGE_NAME := $(CLOUD_IMAGE_NAME)
 cloud-build: build ## Build cloud Docker image tagged <branch>-<commit> (override with VERSION=x; no event-gateway plugin on this branch)
 
 generate: ## Generate API server code from OpenAPI spec
@@ -99,6 +107,7 @@ build-and-push-multiarch: ## Build and push multi-architecture Docker image (lin
 		.
 
 cloud-build-and-push-multiarch: VERSION := $(CLOUD_IMAGE_TAG)
+cloud-build-and-push-multiarch: IMAGE_NAME := $(CLOUD_IMAGE_NAME)
 cloud-build-and-push-multiarch: build-and-push-multiarch ## Build and push multi-arch cloud image tagged <branch>-<commit> (override with VERSION=x)
 
 # Version Management Targets


### PR DESCRIPTION
## Purpose

The Platform API Cloud Release workflow on `platform-api/v0.10.x` fails when building and pushing the multi-arch image ([failing run](https://github.com/wso2/api-platform/actions/runs/32352915027/job/96375795513)):

```
ERROR: failed to push ghcr.io/wso2/api-platform/platform-api:platform-api-v0.10.x-<sha>: denied: permission_denied: write_package
```

Two problems, one root cause — the cloud targets pushed to the wrong image name:

- The image name is wrong: it should be `ghcr.io/wso2/api-platform/platform-api-cloud`, not `.../platform-api`.
- The push is denied (`write_package`): the release `GITHUB_TOKEN` has write access to the `platform-api-cloud` package, not to `platform-api`.

The equivalent workflow on `main` ([successful run](https://github.com/wso2/api-platform/actions/runs/32009868462)) succeeds precisely because it publishes to `platform-api-cloud`.

## Approach

- Parameterize the image name in `platform-api/Makefile` with `IMAGE_SUFFIX`/`IMAGE_NAME` and add `CLOUD_IMAGE_SUFFIX ?= platform-api-cloud` → `CLOUD_IMAGE_NAME`, matching the convention on `main`.
- Override `IMAGE_NAME := $(CLOUD_IMAGE_NAME)` on the `cloud-build` and `cloud-build-and-push-multiarch` targets so the cloud build publishes under `platform-api-cloud`. The target-specific override propagates to the reused `build` / `build-and-push-multiarch` prerequisites (the same mechanism the existing `VERSION := $(CLOUD_IMAGE_TAG)` overrides already rely on), so there is no recipe duplication.
- No workflow change needed — `platform-api-cloud-release.yml` already invokes `cloud-build-and-push-platform-api-multiarch`, which now resolves to the correct name.
- On this branch the cloud image is the same build as the regular image (no event-gateway plugin); only the published package name/tag differ. Verified via `make -n` that the cloud target now tags `.../platform-api-cloud:<branch>-<sha>` while the regular target stays `.../platform-api`.

## Related Issues

N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)