### PR TITLE
ci(platform-api): print published cloud image name on success

### DIFF
--- a/.github/workflows/platform-api-cloud-release.yml
+++ b/.github/workflows/platform-api-cloud-release.yml
@@ -48,3 +48,15 @@ jobs:
 
       - name: Build and push multi arch Docker images
         run: make cloud-build-and-push-platform-api-multiarch PLATFORM_API_VERSION="${{ steps.version.outputs.IMAGE_VERSION }}" DOCKER_REGISTRY="ghcr.io/${{ github.repository_owner }}/api-platform"
+
+      - name: Published image summary
+        run: |
+          IMAGE="ghcr.io/${{ github.repository_owner }}/api-platform/platform-api-cloud:${{ steps.version.outputs.IMAGE_VERSION }}"
+          echo "Pushed image: ${IMAGE}"
+          {
+            echo "### Platform API cloud image published :rocket:"
+            echo ""
+            echo '```'
+            echo "${IMAGE}"
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"


### PR DESCRIPTION
## Purpose

Follow-up to #3278. After the Platform API Cloud Release succeeds, the workflow does not surface where the image was published, so you have to read the build log to find the pushed reference. This adds a summary of the full image name on a successful run.

## Approach

- Add a `Published image summary` step after the build/push step that writes the full pushed reference to the log and to `$GITHUB_STEP_SUMMARY`:

  ```
  ghcr.io/wso2/api-platform/platform-api-cloud:<branch>-<sha>
  ```

- As an ordinary step placed after the push, it runs only when the build and push succeed (no `if: always()`), so the image name appears exactly when there is a published image.
- The registry owner is derived from `${{ github.repository_owner }}`, matching the `DOCKER_REGISTRY` passed to `make`, so it stays correct on forks.

## Related Issues

N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)