### PR TITLE
ci: trigger azure build for platform-api cloud image on merge

### DIFF
--- a/.github/workflows/platform-api-cloud-release.yml
+++ b/.github/workflows/platform-api-cloud-release.yml
@@ -71,7 +71,7 @@ jobs:
           # formatted as "sha1=<hex>".
           SIG="sha1=$(openssl dgst -sha1 -hmac "$AZURE_WEBHOOK_SECRET" payload.json | awk '{print $NF}')"
 
-          HTTP_CODE=$(curl -sS -o response.txt -w '%{http_code}' -X POST "$AZURE_WEBHOOK_URL" \
+          HTTP_CODE=$(curl -sS --connect-timeout 10 --max-time 60 -o response.txt -w '%{http_code}' -X POST "$AZURE_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
             -H "X-Hub-Signature: $SIG" \
             --data-binary @payload.json)

--- a/.github/workflows/platform-api-cloud-release.yml
+++ b/.github/workflows/platform-api-cloud-release.yml
@@ -1,62 +1,86 @@
 name: Platform API Cloud Release
 
+# The cloud image is built and pushed to ACR by an Azure DevOps pipeline. This
+# workflow no longer builds anything: on a merge into a release branch (main or
+# platform-api/v0.10.x) it just calls the Azure pipeline's incoming webhook,
+# passing the repo + branch to build. The payload is authenticated with an
+# HMAC-SHA1 signature.
+#
+# NOTE: pull_request runs the workflow from the PR's base branch, so this file
+# must be kept identical on every branch listed under `branches:` below.
+#
+# Required GitHub secrets:
+#   AZURE_WEBHOOK_URL    - https://dev.azure.com/<org>/_apis/public/distributedtask/webhooks/platform-api-cloud-release?api-version=6.0-preview
+#   AZURE_WEBHOOK_SECRET - the shared secret configured on the Incoming WebHook service connection
+
 on:
+  # Fire when a PR is merged into a release branch...
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+      - platform-api/v0.10.x
+    paths:
+      - 'platform-api/**'
+      - 'common/**'
+      - 'httpkit/**'
+      - '.github/workflows/platform-api-cloud-release.yml'
+  # ...and allow manual triggering against the current branch.
   workflow_dispatch:
 
 permissions:
   contents: read
-  packages: write
+
+concurrency:
+  group: platform-api-cloud-release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
-  release:
+  trigger-azure-build:
     runs-on: ubuntu-latest
+    # On pull_request only run for actual merges (not closed-without-merge).
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Compute image version
-        id: version
+      - name: Trigger Azure DevOps pipeline webhook
+        env:
+          AZURE_WEBHOOK_URL: ${{ secrets.AZURE_WEBHOOK_URL }}
+          AZURE_WEBHOOK_SECRET: ${{ secrets.AZURE_WEBHOOK_SECRET }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+          # base.ref/merge_commit_sha for merges; ref_name/sha for manual runs.
+          BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}
+          COMMIT: ${{ github.event_name == 'pull_request' && github.event.pull_request.merge_commit_sha || github.sha }}
         run: |
-          BRANCH="${GITHUB_REF_NAME//[^a-zA-Z0-9._-]/-}"
-          if [[ ! "$BRANCH" =~ ^[a-zA-Z0-9_] ]]; then BRANCH="_${BRANCH}"; fi
-          BRANCH="${BRANCH:0:87}"
-          COMMIT="${GITHUB_SHA}"
-          printf 'IMAGE_VERSION=%s-%s\n' "$BRANCH" "$COMMIT" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          if [ -z "${AZURE_WEBHOOK_URL:-}" ] || [ -z "${AZURE_WEBHOOK_SECRET:-}" ]; then
+            echo "::error::AZURE_WEBHOOK_URL and AZURE_WEBHOOK_SECRET secrets must be set."
+            exit 1
+          fi
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.26.2'
-          cache: false
+          # Build the payload as a file so the signed bytes are exactly what we send.
+          # Azure builds the branch HEAD; commit is included only for traceability.
+          jq -n \
+            --arg repositoryUrl "$REPO_URL" \
+            --arg branch "$BRANCH" \
+            --arg commit "$COMMIT" \
+            '{repositoryUrl: $repositoryUrl, branch: $branch, triggeredByCommit: $commit}' \
+            > payload.json
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        with:
-          driver: docker-container
+          echo "Payload:"; cat payload.json
 
-      - name: Run tests
-        run: make test-platform-api
+          # Azure verifies HMAC-SHA1(secret, body) against the X-Hub-Signature header,
+          # formatted as "sha1=<hex>".
+          SIG="sha1=$(openssl dgst -sha1 -hmac "$AZURE_WEBHOOK_SECRET" payload.json | awk '{print $NF}')"
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          HTTP_CODE=$(curl -sS -o response.txt -w '%{http_code}' -X POST "$AZURE_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -H "X-Hub-Signature: $SIG" \
+            --data-binary @payload.json)
 
-      - name: Build and push multi arch Docker images
-        run: make cloud-build-and-push-platform-api-multiarch PLATFORM_API_VERSION="${{ steps.version.outputs.IMAGE_VERSION }}" DOCKER_REGISTRY="ghcr.io/${{ github.repository_owner }}/api-platform"
-
-      - name: Published image summary
-        run: |
-          IMAGE="ghcr.io/${{ github.repository_owner }}/api-platform/platform-api-cloud:${{ steps.version.outputs.IMAGE_VERSION }}"
-          echo "Pushed image: ${IMAGE}"
-          {
-            echo "### Platform API cloud image published :rocket:"
-            echo ""
-            echo '```'
-            echo "${IMAGE}"
-            echo '```'
-          } >> "${GITHUB_STEP_SUMMARY}"
+          echo "Azure webhook responded with HTTP ${HTTP_CODE}"
+          cat response.txt || true
+          echo
+          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+            echo "::error::Failed to trigger Azure pipeline (HTTP ${HTTP_CODE})."
+            exit 1
+          fi
+          echo "Triggered Azure build for ${BRANCH}@${COMMIT}"


### PR DESCRIPTION
## Purpose

The `platform-api` cloud image is moving off GitHub Actions/GHCR. Building and pushing the image to the internal control-plane ACR is now owned by an Azure DevOps pipeline, so this workflow should stop building the image and instead trigger that pipeline on merge.

## Goals

- Stop building and pushing the cloud image to GHCR from GitHub Actions.
- Trigger the Azure DevOps pipeline (which builds via `make cloud-build` and pushes to the control-plane ACR) whenever a PR is merged into a release branch.

## Approach

- Replace the GHCR build-and-push job with a single job that POSTs an HMAC-SHA1-signed payload (`repositoryUrl`, `branch`) to an Azure DevOps incoming webhook.
- Fire on `pull_request` `closed` (merged only) into `main` and `platform-api/v0.10.x`, plus `workflow_dispatch`; path-filtered to `platform-api/**`, `common/**`, `httpkit/**`, and the workflow file itself.
- Keep the workflow file identical across release branches, since `pull_request` runs the workflow from the PR's base branch.
- Requires repository secrets `AZURE_WEBHOOK_URL` and `AZURE_WEBHOOK_SECRET`.

## User stories

N/A

## Documentation

N/A - CI-only change, no product documentation impact.

## Automation tests
 - Unit tests
   > N/A - GitHub Actions workflow change only.
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (no source changed; workflow YAML only)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes (uses the `AZURE_WEBHOOK_URL` / `AZURE_WEBHOOK_SECRET` GitHub secrets)

## Samples

On merge, the workflow signs and POSTs `{ "repositoryUrl": ..., "branch": ... }` to the Azure webhook; the pipeline clones the branch HEAD, runs `make cloud-build`, and pushes `choreocontrolplane.azurecr.io/choreoipaas/platform-api:<branch>-<commit>`.

## Related PRs

- Azure pipeline this workflow triggers: wso2-enterprise/apim-saas#2915
- Companion workflow change on `main`: wso2/api-platform#3282 (same workflow, kept identical).

## Test environment

N/A - GitHub Actions (ubuntu-latest).