### PR TITLE
Add Pluggable architecture in ai workspace UI

### DIFF
--- a/portals/ai-workspace/src/App.tsx
+++ b/portals/ai-workspace/src/App.tsx
@@ -86,9 +86,11 @@ import { useAppAuth } from './contexts/AppAuthContext';
 import { Box, Button, Stack, Typography } from '@wso2/oxygen-ui';
 import OoopsImage from './assets/images/Ooops.svg';
 import {
+  AI_WORKSPACE_SIDEBAR_SLOT,
   ExtensionsProvider,
   type AIWorkspaceExtension,
 } from './extensions';
+import { usePort } from './hostPort';
 
 /**
  * Only allow same-origin relative paths as return URLs to prevent open redirects.
@@ -279,14 +281,25 @@ function WithPageBoundary({ children }: { children: React.ReactNode }) {
   return <RoutePageBoundary>{children}</RoutePageBoundary>;
 }
 
+// Resolves the real Port (built once in AppLayout from live hooks — see
+// appShellMain.tsx) and calls the extension's render(port), so the route
+// element itself never has to know where the Port comes from.
+function ExtensionRoute({ extension }: { extension: AIWorkspaceExtension }) {
+  const port = usePort();
+  return <>{extension.render(port)}</>;
+}
+
 export type AppProps = {
   extensions?: readonly AIWorkspaceExtension[];
 };
 
 function WorkspaceRoutes({ extensions = [] }: AppProps) {
-  const extensionRoutes = extensions.map((extension) => (
+  const sidebarExtensions = extensions.filter(
+    (extension) => extension.slot === AI_WORKSPACE_SIDEBAR_SLOT
+  );
+  const extensionRoutes = sidebarExtensions.map((extension) => (
     <Route key={extension.id} path={extension.path} element={
-      <WithPageBoundary>{extension.element}</WithPageBoundary>
+      <WithPageBoundary><ExtensionRoute extension={extension} /></WithPageBoundary>
     } />
   ));
 

--- a/portals/ai-workspace/src/cloud/index.ts
+++ b/portals/ai-workspace/src/cloud/index.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Injection seam for cloud-only extensions. `main.tsx` imports
+ * `cloudExtensions` from here unconditionally, so this file must always
+ * exist and export a valid (possibly empty) array — this is what lets a
+ * downstream build overlay just this one file/directory with real cloud
+ * features, without ever touching App.tsx/main.tsx/extensions.tsx. Mirrors
+ * `portals/api-control-plane/src/cloud/index.ts`.
+ */
+
+import type { AIWorkspaceExtension } from '../extensions';
+
+export const cloudExtensions: AIWorkspaceExtension[] = [];

--- a/portals/ai-workspace/src/extensions.tsx
+++ b/portals/ai-workspace/src/extensions.tsx
@@ -16,32 +16,49 @@
  * under the License.
  */
 
-import React, { createContext, useContext } from 'react';
+import type { ReactNode } from 'react';
 
-export type AIWorkspaceExtension = {
-  id: string;
+import type { AIWorkspaceHostPort } from './hostPort';
+import { SlotEntriesProvider, useSlotEntries, type SlotEntry } from './slots';
+
+/**
+ * The only slot this host currently exposes: a top-level sidebar item (plus
+ * a matching route mounted at both the org- and project-scoped URL, mirroring
+ * wherever the sidebar link currently points). New slot names — e.g. a
+ * Settings sub-nav tab — can be introduced later without changing this type.
+ */
+export const AI_WORKSPACE_SIDEBAR_SLOT = 'sidebar.main';
+
+/**
+ * A host-injected feature: a sidebar item plus its route. `path` is relative
+ * to the same route group the built-in pages live in (e.g. `"billing"`, not
+ * `/organizations/:orgSlug/billing`) — resolved against the org or project
+ * currently in view, the same way the built-in sidebar links are.
+ *
+ * `render` receives the small, portable `AIWorkspaceHostPort` (org/project
+ * handle, navigate, notify) instead of a pre-built element, so the same
+ * feature component can be reused by another host app without depending on
+ * this portal's own hooks — see `hostPort.tsx`.
+ */
+export type AIWorkspaceExtension = SlotEntry & {
   path: string;
   label: string;
-  icon?: React.ReactNode;
-  element: React.ReactNode;
+  icon?: ReactNode;
+  render: (port: AIWorkspaceHostPort) => ReactNode;
 };
-
-const ExtensionsContext = createContext<readonly AIWorkspaceExtension[]>([]);
 
 export function ExtensionsProvider({
   extensions,
   children,
 }: {
   extensions: readonly AIWorkspaceExtension[];
-  children: React.ReactNode;
+  children: ReactNode;
 }) {
   return (
-    <ExtensionsContext.Provider value={extensions}>
-      {children}
-    </ExtensionsContext.Provider>
+    <SlotEntriesProvider entries={extensions}>{children}</SlotEntriesProvider>
   );
 }
 
 export function useAIWorkspaceExtensions(): readonly AIWorkspaceExtension[] {
-  return useContext(ExtensionsContext);
+  return useSlotEntries<AIWorkspaceExtension>();
 }

--- a/portals/ai-workspace/src/hostPort.tsx
+++ b/portals/ai-workspace/src/hostPort.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * The "Port": the small set of host capabilities an extension's `render`
+ * function receives, so a feature component never imports this portal's
+ * own hooks (`useAppShell`, `useAIWorkspaceSnackbar`) directly — that's what
+ * would make it impossible to reuse the same component in another host.
+ *
+ * This is a real React context, but — unlike `slots/index.tsx` — it is NOT
+ * meant to be imported across the api-platform/apim-saas repo boundary.
+ * apim-saas's host file (e.g. `hosts/ai-workspace.tsx`) hand-mirrors this
+ * exact `AIWorkspaceHostPort` type (same convention as `AIWorkspaceExtension`)
+ * and receives a value of that shape as a plain function argument via
+ * `extension.render(port)` — never by importing `PortContext`/`usePort`
+ * itself. `PortProvider` is built and mounted once, here in core, from real
+ * hooks; only the small type crosses the boundary, never the context object.
+ */
+
+import { createContext, useContext, type ReactNode } from 'react';
+
+export type NotifySeverity = 'success' | 'info' | 'warning' | 'error';
+
+export type AIWorkspaceHostPort = {
+  orgHandle: string;
+  projectHandle?: string;
+  navigate: (path: string) => void;
+  notify: (message: string, severity?: NotifySeverity) => void;
+};
+
+const PortContext = createContext<AIWorkspaceHostPort | null>(null);
+
+export function PortProvider({
+  value,
+  children,
+}: {
+  value: AIWorkspaceHostPort;
+  children: ReactNode;
+}) {
+  return <PortContext.Provider value={value}>{children}</PortContext.Provider>;
+}
+
+export function usePort(): AIWorkspaceHostPort {
+  const port = useContext(PortContext);
+  if (!port) {
+    throw new Error('usePort must be used within a PortProvider');
+  }
+  return port;
+}

--- a/portals/ai-workspace/src/index.ts
+++ b/portals/ai-workspace/src/index.ts
@@ -8,4 +8,6 @@ export type { AppProps } from './App';
 export { default as AIWorkspace } from './AIWorkspace';
 export type { AIWorkspaceProps } from './AIWorkspace';
 export type { AIWorkspaceExtension } from './extensions';
+export { AI_WORKSPACE_SIDEBAR_SLOT } from './extensions';
+export type { AIWorkspaceHostPort, NotifySeverity } from './hostPort';
 export { BASE_PATH } from './paths';

--- a/portals/ai-workspace/src/index.ts
+++ b/portals/ai-workspace/src/index.ts
@@ -10,4 +10,13 @@ export type { AIWorkspaceProps } from './AIWorkspace';
 export type { AIWorkspaceExtension } from './extensions';
 export { AI_WORKSPACE_SIDEBAR_SLOT } from './extensions';
 export type { AIWorkspaceHostPort, NotifySeverity } from './hostPort';
+export type { SlotEntry } from './slots';
+export {
+  SlotEntriesProvider,
+  useSlotEntries,
+  useSlot,
+  HiddenRegionsProvider,
+  useIsHidden,
+  Hideable,
+} from './slots';
 export { BASE_PATH } from './paths';

--- a/portals/ai-workspace/src/main.tsx
+++ b/portals/ai-workspace/src/main.tsx
@@ -19,9 +19,25 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import AIWorkspace from "./AIWorkspace";
+import type { AIWorkspaceExtension } from "./extensions";
 
-createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
-    <AIWorkspace />
-  </React.StrictMode>,
-);
+// Loads cloud-only extensions from the `./cloud` injection seam (see
+// `cloud/index.ts`) before the first render, mirroring
+// `portals/api-control-plane/src/main.tsx`. Wrapped in an async function
+// rather than a top-level `await` for broader build-target compatibility.
+async function bootstrap() {
+  const cloudExtensions: AIWorkspaceExtension[] = await import("./cloud")
+    .then((module) => module.cloudExtensions)
+    .catch((error) => {
+      console.warn("Cloud extensions could not be loaded.", error);
+      return [];
+    });
+
+  createRoot(document.getElementById("root")!).render(
+    <React.StrictMode>
+      <AIWorkspace extensions={cloudExtensions} />
+    </React.StrictMode>,
+  );
+}
+
+void bootstrap();

--- a/portals/ai-workspace/src/pages/appShell/AppSidebar.tsx
+++ b/portals/ai-workspace/src/pages/appShell/AppSidebar.tsx
@@ -38,7 +38,11 @@ import { buildOrgPath, buildProjectPath } from '../../utils/projectRouting';
 import QuickStartIntroPopup, {
   QS_INTRO_STORAGE_KEY,
 } from './QuickStartIntroPopup';
-import { useAIWorkspaceExtensions } from '../../extensions';
+import {
+  AI_WORKSPACE_SIDEBAR_SLOT,
+  type AIWorkspaceExtension,
+} from '../../extensions';
+import { useSlot } from '../../slots';
 
 const navLinkStyle: React.CSSProperties = {
   textDecoration: 'none',
@@ -65,7 +69,7 @@ export default function AppSidebar({
   const [showIntro, setShowIntro] = useState(
     () => !localStorage.getItem(QS_INTRO_STORAGE_KEY)
   );
-  const extensions = useAIWorkspaceExtensions();
+  const extensions = useSlot<AIWorkspaceExtension>(AI_WORKSPACE_SIDEBAR_SLOT);
 
   const handleDismissIntro = () => {
     localStorage.setItem(QS_INTRO_STORAGE_KEY, '1');

--- a/portals/ai-workspace/src/pages/appShell/appShellMain.tsx
+++ b/portals/ai-workspace/src/pages/appShell/appShellMain.tsx
@@ -48,7 +48,10 @@ import {
 import { logger } from '../../utils/logger';
 import { FormattedMessage } from 'react-intl';
 import OoopsImage from '../../assets/images/Ooops.svg';
-import { useAIWorkspaceExtensions } from '../../extensions';
+import { AI_WORKSPACE_SIDEBAR_SLOT, type AIWorkspaceExtension } from '../../extensions';
+import { useSlot } from '../../slots';
+import { PortProvider, type AIWorkspaceHostPort, type NotifySeverity } from '../../hostPort';
+import useAIWorkspaceSnackbar from '../../hooks/aiWorkspaceSnackbar';
 
 type SelectableOrg = {
   id: string;
@@ -65,7 +68,7 @@ type SelectableProject = {
 export default function AppLayout(): JSX.Element {
   const navigate = useNavigate();
   const location = useLocation();
-  const extensions = useAIWorkspaceExtensions();
+  const extensions = useSlot<AIWorkspaceExtension>(AI_WORKSPACE_SIDEBAR_SLOT);
   const { logout } = useAppAuth();
   // [standalone] const { signOut } = useAuthContext();
 
@@ -87,6 +90,26 @@ export default function AppLayout(): JSX.Element {
   } = useWorkspaceAppShell();
 
   const onLogout = useCallback(() => { void logout(); }, [logout]);
+
+  // Built once per render from real hooks, then handed down as a plain value
+  // via PortProvider — extension `render(port)` calls never import this
+  // portal's own hooks directly. See hostPort.tsx.
+  const showSnackbar = useAIWorkspaceSnackbar();
+  const notify = useCallback(
+    (message: string, severity?: NotifySeverity) => {
+      showSnackbar(message, severity ?? 'success');
+    },
+    [showSnackbar]
+  );
+  const port: AIWorkspaceHostPort = useMemo(
+    () => ({
+      orgHandle: getOrgSlug(currentOrganization),
+      projectHandle: currentProject ? getProjectSlug(currentProject) : undefined,
+      navigate,
+      notify,
+    }),
+    [currentOrganization, currentProject, navigate, notify]
+  );
 
   const { state: shellState, actions: shellActions } = useOxygenAppShell({
     initialCollapsed: false,
@@ -410,7 +433,9 @@ export default function AppLayout(): JSX.Element {
       </AppShell.Sidebar>
 
       <AppShell.Main>
-        <Outlet />
+        <PortProvider value={port}>
+          <Outlet />
+        </PortProvider>
       </AppShell.Main>
 
       <AppShell.Footer>

--- a/portals/ai-workspace/src/slots/index.tsx
+++ b/portals/ai-workspace/src/slots/index.tsx
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Slot & Hideable — the two primitives every host-injected extension point
+ * in this app is built from. Deliberately generic: no dependency on this
+ * portal's own scope/auth/routing types, so this file is meant to be copied
+ * verbatim into any other host app that wants the same seam (see the
+ * `apip-cloud-extensions` skill, and `api-control-plane/src/slots/index.tsx`
+ * for the sibling copy this was ported from).
+ *
+ * - Slot: a named, additive extension point. A host exposes a slot name
+ *   (e.g. "sidebar.main"); anything can register an entry against that name
+ *   without the host knowing what it is. New slot names cost nothing to
+ *   introduce later — no enum to extend.
+ * - Hideable: a named, suppressible region wrapping *built-in* UI, so an
+ *   extension can eventually replace (not just add to) something the host
+ *   ships by default. Orthogonal to Slot: Slot adds, Hideable suppresses;
+ *   using both at the same conceptual position is how you override.
+ */
+
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
+
+/** The minimum shape any slot-registered entry must have. */
+export type SlotEntry = {
+  id: string;
+  /** Which named extension point this entry attaches to. */
+  slot: string;
+  /** Merge-sort key among other entries in the same slot. */
+  order: number;
+};
+
+const SlotEntriesContext = createContext<readonly SlotEntry[]>([]);
+
+export function SlotEntriesProvider({
+  entries,
+  children,
+}: {
+  entries: readonly SlotEntry[];
+  children: ReactNode;
+}) {
+  return (
+    <SlotEntriesContext.Provider value={entries}>
+      {children}
+    </SlotEntriesContext.Provider>
+  );
+}
+
+/** Every registered entry, unfiltered — for consumers that group by more than one slot name (e.g. a prefix match). */
+export function useSlotEntries<T extends SlotEntry>(): readonly T[] {
+  return useContext(SlotEntriesContext) as readonly T[];
+}
+
+/** Entries registered for exactly `slotName`, sorted by `order`. */
+export function useSlot<T extends SlotEntry>(slotName: string): T[] {
+  const entries = useSlotEntries<T>();
+  return useMemo(
+    () =>
+      entries
+        .filter((entry) => entry.slot === slotName)
+        .sort((a, b) => a.order - b.order),
+    [entries, slotName]
+  );
+}
+
+const HiddenRegionsContext = createContext<ReadonlySet<string>>(new Set());
+
+export function HiddenRegionsProvider({
+  hidden,
+  children,
+}: {
+  hidden: ReadonlySet<string> | readonly string[];
+  children: ReactNode;
+}) {
+  const set = useMemo(
+    () => (hidden instanceof Set ? hidden : new Set(hidden)),
+    [hidden]
+  );
+  return (
+    <HiddenRegionsContext.Provider value={set}>
+      {children}
+    </HiddenRegionsContext.Provider>
+  );
+}
+
+/** Whether `name` has been suppressed by a `HiddenRegionsProvider` up the tree. */
+export function useIsHidden(name: string): boolean {
+  return useContext(HiddenRegionsContext).has(name);
+}
+
+/** Renders `children` unless `name` is currently hidden. */
+export function Hideable({
+  name,
+  children,
+}: {
+  name: string;
+  children: ReactNode;
+}) {
+  return useIsHidden(name) ? null : <>{children}</>;
+}


### PR DESCRIPTION
This pull request introduces a new, flexible extension system for the AI Workspace portal, centered around the concepts of "slots" and a "host port." It allows host-injected features (like sidebar items and routes) to be registered and rendered in a decoupled way, making it easier to add, override, or reuse features across different host apps. The changes include new primitives for slot-based extension points, a portable host port interface, and refactoring of sidebar and route rendering to use these mechanisms.

The most important changes are:

**Extension System & Slot Infrastructure:**
- Introduced a generic slot-based extension system in `slots/index.tsx`, allowing features to be registered to named extension points (slots) and providing utilities like `SlotEntriesProvider`, `useSlotEntries`, and `useSlot`. Also added support for suppressible (hideable) regions.
- Refactored `extensions.tsx` to define the `AIWorkspaceExtension` type as a slot entry with a `render(port)` function (instead of a static React element), and switched extension context management to use the new slot infrastructure.

**Host Port Abstraction:**
- Added `hostPort.tsx`, defining the `AIWorkspaceHostPort` type (org/project handles, navigation, notifications) and a context/provider for passing this port to extensions, ensuring extensions are decoupled from the portal's internal hooks.
- Updated `appShellMain.tsx` to build the `port` value from live hooks and provide it via `PortProvider`, so all extensions receive the correct host context. [[1]](diffhunk://#diff-7b7a33d1dac18ffc176bd79bc777f55eebdc79965799fc30dbbdc5afdb369cfbL51-R54) [[2]](diffhunk://#diff-7b7a33d1dac18ffc176bd79bc777f55eebdc79965799fc30dbbdc5afdb369cfbR94-R113) [[3]](diffhunk://#diff-7b7a33d1dac18ffc176bd79bc777f55eebdc79965799fc30dbbdc5afdb369cfbR436-R438)

**Sidebar and Routing Refactor:**
- Changed sidebar rendering in `AppSidebar.tsx` to use the slot-based extension system (`useSlot` for `AI_WORKSPACE_SIDEBAR_SLOT`) instead of the old context. [[1]](diffhunk://#diff-b66ed1a354b06c8db170f136461281126bd16f38b2f0a76d0fe8d80aa20956dfL41-R45) [[2]](diffhunk://#diff-b66ed1a354b06c8db170f136461281126bd16f38b2f0a76d0fe8d80aa20956dfL68-R72)
- Updated route rendering in `App.tsx` to filter and render only sidebar slot extensions, and to call their `render(port)` function via a new `ExtensionRoute` component.

**Cloud Extension Injection Seam:**
- Added `cloud/index.ts` as an injection seam for cloud-only extensions, always exporting a valid array, and updated `main.tsx` to dynamically import and pass these extensions to the app. [[1]](diffhunk://#diff-4883d644abbf55d4c2e6a9ca394abf413c6b99888028180bb7b988a4761ff5bfR1-R28) [[2]](diffhunk://#diff-132dd4bf3a5793e0c1276da922a570270f57d547ef2be5edaf60166978463e71R22-R43)

**Exports and API Surface:**
- Updated `index.ts` to export the new slot and host port types, making them available to downstream consumers.

These changes collectively make the portal more modular and extensible, enabling easier integration of new features and customization by downstream builds.