### PR TITLE
docs(operator): add debug guide and per-gateway version sample

### DIFF
--- a/kubernetes/gateway-operator/DEBUG_GUIDE.md
+++ b/kubernetes/gateway-operator/DEBUG_GUIDE.md
@@ -1,0 +1,73 @@
+# Gateway Operator — Debug Guide
+
+Run the operator from your host (VS Code debugger) against a real cluster. All commands run from `kubernetes/gateway-operator/`.
+
+## Prerequisites
+
+1. Go toolchain + VS Code with the Go extension.
+2. `kubectl` pointing at the target cluster (the operator uses your current kubeconfig context).
+3. A reachable cluster (kind / k3s / colima / minikube / remote).
+
+## Steps
+
+1. **Confirm your cluster context:**
+   ```bash
+   kubectl config current-context && kubectl cluster-info
+   ```
+
+2. **Install the Gateway API standard CRDs** (the operator watches `Gateway`, `GatewayClass`, `HTTPRoute`, `ReferenceGrant`). Skip if already present:
+   ```bash
+   kubectl get crd gateways.gateway.networking.k8s.io >/dev/null 2>&1 || \
+     kubectl apply -f ../helm/operator-helm-chart/files/gateway-api-standard/standard-crds.yaml
+   ```
+   > Uses the in-repo bundle (v1.5.1) the operator compiles against.
+
+3. **Install the operator's own CRDs** (`gateway.api-platform.wso2.com`):
+   ```bash
+   make install
+   ```
+   > Regenerates the CRD manifests (controller-gen) and applies them via kustomize. Installs only this operator's CRDs — the Gateway API set in step 2 is separate.
+   > Fallback (no regeneration / avoids client-side apply limits): `kubectl apply --server-side -f config/crd/bases/`
+
+4. **Verify all CRDs are registered:**
+   ```bash
+   kubectl get crd | grep -E 'gateway.api-platform.wso2.com|gateway.networking.k8s.io'
+   ```
+
+5. **Launch the debugger:** VS Code → Run and Debug → **Gateway Operator**.
+   Already wired in `.vscode/launch.json`: `-config config/config.yaml`, `GATEWAY_HELM_CHART_PATH` (local `gateway-helm-chart`), `GATEWAY_HELM_VALUES_FILE_PATH` (`config/gateway_values.yaml`). Leader election is off and no webhooks are registered, so no certs/lease are needed.
+
+6. **Confirm a clean start:** you should see `Starting workers` for every controller and **no** `no matches for kind` / cache-sync-timeout errors. Health probe → `:8081`, metrics → `:8080` (keep these local ports free).
+
+7. **Provision the mandatory AES-256 encryption key Secret** — at-rest encryption is mandatory; the chart **refuses to render** and the controller won't start without it (no dev bypass). Create it in the namespace where the gateway deploys:
+   ```bash
+   NS=default   # the namespace your APIGateway deploys into
+   kubectl create namespace "$NS" --dry-run=client -o yaml | kubectl apply -f -
+   openssl rand 32 > default-aesgcm256-v1.bin
+   kubectl create secret generic gateway-encryption-keys \
+     --from-file=default-aesgcm256-v1.bin=default-aesgcm256-v1.bin -n "$NS"
+   rm -f default-aesgcm256-v1.bin
+   ```
+   Then **enable `encryptionKeys`** (disabled by default) so the chart renders — pick one:
+   - **Globally** (recommended for debug — every gateway inherits it): edit the operator default `config/gateway_values.yaml` (the `GATEWAY_HELM_VALUES_FILE_PATH` base) under `gateway.controller`:
+     ```yaml
+     encryptionKeys:
+       enabled: true
+       secretName: gateway-encryption-keys   # the Secret above; data key: default-aesgcm256-v1.bin
+     ```
+   - **Per gateway**: put the same block in that `APIGateway`'s `configRef` ConfigMap (overrides the default; lets each gateway use its own key).
+
+   Either way the Secret must exist **in each gateway namespace** — the operator doesn't create it.
+
+8. **Trigger a reconcile** (set breakpoints in `internal/controller/apigateway_controller.go` `Reconcile` first). Use the ready-made two-gateway example — it enables `encryptionKeys` and documents the per-namespace Secret in its header:
+   ```bash
+   # create the encryption Secret in gw-120 and gw-121 first (see the file header), then:
+   kubectl apply -f config/samples/api_v1_apigateway_multiversion.yaml
+   ```
+   > The shipped `config/samples/api_v1_apigateway.yaml` does **not** enable `encryptionKeys`, so it fails the at-rest-encryption check as-is — enable it (step 7) before applying, or use the multiversion sample above.
+
+## Notes
+
+- **`encryptionKeys must be enabled`** in operator logs (`Max retries exceeded ... at-rest encryption is mandatory`) = the Secret is missing in the gateway's namespace, or the values don't set `encryptionKeys.enabled=true` + `secretName`. It's per-namespace, so each gateway needs its own Secret. (Host-run gateway debug uses a file instead — see `gateway/DEBUG_GUIDE.md`.)
+- After changing API types (`api/**`): run `make manifests` to regenerate `config/crd/bases/`, then re-apply via step 3.
+- Cleanup: `kubectl delete -f config/samples/api_v1_apigateway_multiversion.yaml`; remove CRDs with `kubectl delete -f config/crd/bases/`.

--- a/kubernetes/gateway-operator/DEBUG_GUIDE.md
+++ b/kubernetes/gateway-operator/DEBUG_GUIDE.md
@@ -42,11 +42,13 @@ Run the operator from your host (VS Code debugger) against a real cluster. All c
    ```bash
    NS=default   # the namespace your APIGateway deploys into
    kubectl create namespace "$NS" --dry-run=client -o yaml | kubectl apply -f -
-   ( umask 077   # keep the temp key file owner-only, regardless of your umask
-     openssl rand 32 > default-aesgcm256-v1.bin
-     kubectl create secret generic gateway-encryption-keys \
-       --from-file=default-aesgcm256-v1.bin=default-aesgcm256-v1.bin -n "$NS"
-     rm -f default-aesgcm256-v1.bin )
+   # mktemp gives a unique owner-only (mode 600) key file; the secret's data
+   # key stays default-aesgcm256-v1.bin (the filename the chart mounts).
+   keyfile="$(mktemp)"; trap 'rm -f "$keyfile"' EXIT
+   openssl rand 32 > "$keyfile"
+   kubectl create secret generic gateway-encryption-keys \
+     --from-file=default-aesgcm256-v1.bin="$keyfile" -n "$NS"
+   rm -f "$keyfile"; trap - EXIT
    ```
    Then **enable `encryptionKeys`** (disabled by default) so the chart renders — pick one:
    - **Globally** (recommended for debug — every gateway inherits it): edit the operator default `config/gateway_values.yaml` (the `GATEWAY_HELM_VALUES_FILE_PATH` base) under `gateway.controller`:

--- a/kubernetes/gateway-operator/DEBUG_GUIDE.md
+++ b/kubernetes/gateway-operator/DEBUG_GUIDE.md
@@ -15,10 +15,9 @@ Run the operator from your host (VS Code debugger) against a real cluster. All c
    kubectl config current-context && kubectl cluster-info
    ```
 
-2. **Install the Gateway API standard CRDs** (the operator watches `Gateway`, `GatewayClass`, `HTTPRoute`, `ReferenceGrant`). Skip if already present:
+2. **Install the Gateway API standard CRDs** (the operator watches `Gateway`, `GatewayClass`, `HTTPRoute`, `ReferenceGrant`). `kubectl apply` is idempotent, so run it unconditionally — this also fills in any missing CRD when only part of the set is already present:
    ```bash
-   kubectl get crd gateways.gateway.networking.k8s.io >/dev/null 2>&1 || \
-     kubectl apply -f ../helm/operator-helm-chart/files/gateway-api-standard/standard-crds.yaml
+   kubectl apply -f ../helm/operator-helm-chart/files/gateway-api-standard/standard-crds.yaml
    ```
    > Uses the in-repo bundle (v1.5.1) the operator compiles against.
 
@@ -43,10 +42,11 @@ Run the operator from your host (VS Code debugger) against a real cluster. All c
    ```bash
    NS=default   # the namespace your APIGateway deploys into
    kubectl create namespace "$NS" --dry-run=client -o yaml | kubectl apply -f -
-   openssl rand 32 > default-aesgcm256-v1.bin
-   kubectl create secret generic gateway-encryption-keys \
-     --from-file=default-aesgcm256-v1.bin=default-aesgcm256-v1.bin -n "$NS"
-   rm -f default-aesgcm256-v1.bin
+   ( umask 077   # keep the temp key file owner-only, regardless of your umask
+     openssl rand 32 > default-aesgcm256-v1.bin
+     kubectl create secret generic gateway-encryption-keys \
+       --from-file=default-aesgcm256-v1.bin=default-aesgcm256-v1.bin -n "$NS"
+     rm -f default-aesgcm256-v1.bin )
    ```
    Then **enable `encryptionKeys`** (disabled by default) so the chart renders — pick one:
    - **Globally** (recommended for debug — every gateway inherits it): edit the operator default `config/gateway_values.yaml` (the `GATEWAY_HELM_VALUES_FILE_PATH` base) under `gateway.controller`:
@@ -61,7 +61,7 @@ Run the operator from your host (VS Code debugger) against a real cluster. All c
 
 8. **Trigger a reconcile** (set breakpoints in `internal/controller/apigateway_controller.go` `Reconcile` first). Use the ready-made two-gateway example — it enables `encryptionKeys` and documents the per-namespace Secret in its header:
    ```bash
-   # create the encryption Secret in gw-120 and gw-121 first (see the file header), then:
+   # create the encryption Secret in gw-default and gw-121 first (see the file header), then:
    kubectl apply -f config/samples/api_v1_apigateway_multiversion.yaml
    ```
    > The shipped `config/samples/api_v1_apigateway.yaml` does **not** enable `encryptionKeys`, so it fails the at-rest-encryption check as-is — enable it (step 7) before applying, or use the multiversion sample above.
@@ -70,4 +70,5 @@ Run the operator from your host (VS Code debugger) against a real cluster. All c
 
 - **`encryptionKeys must be enabled`** in operator logs (`Max retries exceeded ... at-rest encryption is mandatory`) = the Secret is missing in the gateway's namespace, or the values don't set `encryptionKeys.enabled=true` + `secretName`. It's per-namespace, so each gateway needs its own Secret. (Host-run gateway debug uses a file instead — see `gateway/DEBUG_GUIDE.md`.)
 - After changing API types (`api/**`): run `make manifests` to regenerate `config/crd/bases/`, then re-apply via step 3.
-- Cleanup: `kubectl delete -f config/samples/api_v1_apigateway_multiversion.yaml`; remove CRDs with `kubectl delete -f config/crd/bases/`.
+- Cleanup: `kubectl delete -f config/samples/api_v1_apigateway_multiversion.yaml`.
+- ⚠️ `kubectl delete -f config/crd/bases/` deletes the **cluster-scoped CRDs**, which cascades to **every** custom resource of those kinds in **all** namespaces (not just the sample). Use it only on a disposable cluster — it causes data loss otherwise.

--- a/kubernetes/gateway-operator/README.md
+++ b/kubernetes/gateway-operator/README.md
@@ -138,4 +138,47 @@ curl -X POST http://localhost:9090/api/management/v0.9/certificates \
 curl https://localhost:8444/ssa/info -vk
 ```
 
+---
+
+## Per-gateway gateway version (image tag)
+
+One operator can run multiple API Gateways, each on a **different gateway version**. The version is not a typed CR field — set it via the gateway's own `spec.configRef` ConfigMap, which the operator deep-merges as the highest-priority overlay on top of its default gateway values:
+
+```
+configRef ConfigMap  >  spec.infrastructure labels/annotations  >  operator default (/config/gateway_values.yaml)  >  chart built-in values
+```
+
+A configRef ConfigMap that contains only the image blocks overrides just the version and inherits everything else:
+
+```yaml
+# values.yaml key inside the configRef ConfigMap
+gateway:
+  controller:
+    image: { repository: ghcr.io/wso2/api-platform/gateway-controller, tag: "1.2.0", pullPolicy: IfNotPresent }
+  gatewayRuntime:
+    image: { repository: ghcr.io/wso2/api-platform/gateway-runtime,   tag: "1.2.0", pullPolicy: IfNotPresent }
+```
+
+A full example — one gateway (`gw-default`) that tracks the operator default version and one (`gw-121`) pinned to 1.2.1, each with its own configRef ConfigMap — is in [`config/samples/api_v1_apigateway_multiversion.yaml`](config/samples/api_v1_apigateway_multiversion.yaml):
+
+```sh
+kubectl apply -f config/samples/api_v1_apigateway_multiversion.yaml
+
+# confirm the versions running
+kubectl get pods -n gw-default -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.containers[*].image}{"\n"}{end}'
+kubectl get pods -n gw-121     -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.containers[*].image}{"\n"}{end}'
+```
+
+**Notes:**
+
+- **Create the ConfigMap before the APIGateway.** The operator ignores ConfigMap *create* events, so an APIGateway created before its configRef ConfigMap won't be re-triggered by the later ConfigMap creation. (The sample orders Namespaces + ConfigMaps ahead of the APIGateways.)
+- **`spec.infrastructure.image` / `routerImage` are not wired** — use the configRef `gateway.controller.image.*` / `gateway.gatewayRuntime.image.*` keys instead.
+- **Updating an existing gateway:** edit its configRef ConfigMap. If the rollout doesn't trigger, restart the operator or bump the CR generation — the annotation must go under **`spec.infrastructure.annotations`** (a `.spec` change bumps `metadata.generation`); a `metadata.annotations` change does **not** bump generation and won't force a redeploy:
+  ```sh
+  kubectl patch apigateway gw-default -n gw-default --type merge \
+    -p '{"spec":{"infrastructure":{"annotations":{"redeploy":"'"$(date +%s)"'"}}}}'
+  ```
+- **Changing the operator default (`GATEWAY_HELM_VALUES_FILE_PATH`) only auto-applies to *new* gateways.** It isn't watched or hashed, so restarting the operator won't roll it onto existing gateways — bump each existing CR's generation (above) to pick up a default change.
+- Keep `gateway-controller` and `gateway-runtime` on the **same** version — they share the xDS/policy-definition contract.
+
 

--- a/kubernetes/gateway-operator/config/crd/kustomization.yaml
+++ b/kubernetes/gateway-operator/config/crd/kustomization.yaml
@@ -2,8 +2,18 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
-- bases/gateway.api-platform.wso2.com_gateways.yaml
+- bases/gateway.api-platform.wso2.com_apigateways.yaml
+- bases/gateway.api-platform.wso2.com_apikeys.yaml
+- bases/gateway.api-platform.wso2.com_apipolicies.yaml
+- bases/gateway.api-platform.wso2.com_certificates.yaml
+- bases/gateway.api-platform.wso2.com_llmproviders.yaml
+- bases/gateway.api-platform.wso2.com_llmprovidertemplates.yaml
+- bases/gateway.api-platform.wso2.com_llmproxies.yaml
+- bases/gateway.api-platform.wso2.com_managedsecrets.yaml
+- bases/gateway.api-platform.wso2.com_mcps.yaml
 - bases/gateway.api-platform.wso2.com_restapis.yaml
+- bases/gateway.api-platform.wso2.com_subscriptionplans.yaml
+- bases/gateway.api-platform.wso2.com_subscriptions.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
 patches:

--- a/kubernetes/gateway-operator/config/samples/api_v1_apigateway_multiversion.yaml
+++ b/kubernetes/gateway-operator/config/samples/api_v1_apigateway_multiversion.yaml
@@ -39,16 +39,16 @@
 #   kubectl create namespace gw-default
 #   kubectl create namespace gw-121
 #
-#   # 2. Mandatory AES-256 encryption key Secret, one per namespace
-#   #    (umask 077 keeps the temp key file owner-only, regardless of your umask)
+#   # 2. Mandatory AES-256 encryption key Secret, one per namespace.
+#   #    mktemp gives a unique owner-only (mode 600) file; the secret's data key
+#   #    stays default-aesgcm256-v1.bin (the filename the chart mounts).
+#   keyfile="$(mktemp)"; trap 'rm -f "$keyfile"' EXIT
 #   for ns in gw-default gw-121; do
-#     ( umask 077
-#       openssl rand 32 > default-aesgcm256-v1.bin
-#       kubectl create secret generic gateway-encryption-keys \
-#         --from-file=default-aesgcm256-v1.bin=default-aesgcm256-v1.bin -n "$ns"
-#       rm -f default-aesgcm256-v1.bin
-#     )
+#     openssl rand 32 > "$keyfile"
+#     kubectl create secret generic gateway-encryption-keys \
+#       --from-file=default-aesgcm256-v1.bin="$keyfile" -n "$ns"
 #   done
+#   rm -f "$keyfile"; trap - EXIT
 #
 #   # 3. ConfigMaps + APIGateways (this file — namespaces already created in step 1)
 #   kubectl apply -f api_v1_apigateway_multiversion.yaml

--- a/kubernetes/gateway-operator/config/samples/api_v1_apigateway_multiversion.yaml
+++ b/kubernetes/gateway-operator/config/samples/api_v1_apigateway_multiversion.yaml
@@ -1,0 +1,126 @@
+# API Gateway version example — default-tracking vs pinned.
+#
+# Two API Gateways managed by ONE operator:
+#   - gw-default  -> no image tag pinned; tracks whatever version the operator
+#                    default (GATEWAY_HELM_VALUES_FILE_PATH) currently sets, so
+#                    it moves when that default changes.
+#   - gw-121      -> pins gateway-controller/gateway-runtime 1.2.1 via its own
+#                    configRef, independent of the operator default.
+#
+# How it works: the operator deep-merges each gateway's configRef ConfigMap
+# (`values.yaml`) as the HIGHEST-priority overlay on top of its default
+# gateway values, so a ConfigMap containing only a few keys overrides just
+# those and inherits everything else. Value precedence (highest wins):
+#   configRef ConfigMap  >  spec.infrastructure labels/annotations  >
+#   operator default (/config/gateway_values.yaml)  >  chart built-in values
+# gw-default omits image.repository/tag -> inherits the default version;
+# gw-121 sets them -> stays on 1.2.1 regardless of the default.
+#
+# NOTE: The typed spec.infrastructure.image / routerImage fields are NOT wired
+#       into the deployment yet (tracked in wso2/api-platform#3287) — set the
+#       version via the configRef ConfigMap keys below
+#       (gateway.controller.image.* / gateway.gatewayRuntime.image.*).
+#
+# MANDATORY at-rest encryption: the gateway-controller requires an AES-256 key
+# and the chart REFUSES TO RENDER without it (there is no dev bypass). This
+# sample sets encryptionKeys.enabled=true per gateway; the SECRET NAME is
+# inherited from the operator default (GATEWAY_HELM_VALUES_FILE_PATH), which
+# must set gateway.controller.encryptionKeys.secretName — enable it globally
+# per the operator DEBUG_GUIDE. Each gateway still needs that Secret IN ITS
+# OWN NAMESPACE (see APPLY step 2 below; the Secret name must match the global
+# secretName, gateway-encryption-keys here).
+#
+# ---------------------------------------------------------------------------
+# APPLY (order matters — create namespaces + Secrets BEFORE the APIGateways;
+# the operator ignores ConfigMap/Secret *create* events):
+#
+#   # 1. Namespaces
+#   kubectl create namespace gw-default
+#   kubectl create namespace gw-121
+#
+#   # 2. Mandatory AES-256 encryption key Secret, one per namespace
+#   for ns in gw-default gw-121; do
+#     openssl rand 32 > default-aesgcm256-v1.bin
+#     kubectl create secret generic gateway-encryption-keys \
+#       --from-file=default-aesgcm256-v1.bin=default-aesgcm256-v1.bin -n "$ns"
+#     rm -f default-aesgcm256-v1.bin
+#   done
+#
+#   # 3. ConfigMaps + APIGateways (this file — namespaces already created in step 1)
+#   kubectl apply -f api_v1_apigateway_multiversion.yaml
+#
+# Verify the versions running:
+#   kubectl get pods -n gw-default -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.containers[*].image}{"\n"}{end}'
+#   kubectl get pods -n gw-121     -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.containers[*].image}{"\n"}{end}'
+#
+# Replace 1.2.1 with a tag actually published to ghcr.io/wso2/api-platform/*.
+# ---------------------------------------------------------------------------
+---
+# gw-default: no version pinned -> tracks the operator default gateway version.
+# Only cross-cutting overrides are set (pullPolicy, encryption); the image
+# repository/tag are intentionally omitted so this gateway follows the default.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gw-default-values
+  namespace: gw-default        # MUST be the same namespace as its APIGateway
+data:
+  values.yaml: |               # the key MUST be "values.yaml"
+    gateway:
+      controller:
+        image:
+          # no repository/tag -> inherits the operator default version
+          pullPolicy: IfNotPresent
+        encryptionKeys:                       # secretName inherited from the operator default (see header)
+          enabled: true
+      gatewayRuntime:
+        image:
+          pullPolicy: IfNotPresent
+---
+# gw-121: pins 1.2.1 regardless of the operator default.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gw-121-values
+  namespace: gw-121
+data:
+  values.yaml: |
+    gateway:
+      controller:
+        image:
+          repository: ghcr.io/wso2/api-platform/gateway-controller
+          tag: "1.2.1"
+          pullPolicy: IfNotPresent
+        encryptionKeys:
+          enabled: true
+      gatewayRuntime:
+        image:
+          repository: ghcr.io/wso2/api-platform/gateway-runtime
+          tag: "1.2.1"
+          pullPolicy: IfNotPresent
+---
+apiVersion: gateway.api-platform.wso2.com/v1
+kind: APIGateway
+metadata:
+  name: gw-default
+  namespace: gw-default
+spec:
+  apiSelector:
+    scope: Namespaced          # serves RestApis in its own namespace (isolates the gateways)
+  storage:
+    type: sqlite
+  configRef:
+    name: gw-default-values    # -> tracks the operator default version
+---
+apiVersion: gateway.api-platform.wso2.com/v1
+kind: APIGateway
+metadata:
+  name: gw-121
+  namespace: gw-121
+spec:
+  apiSelector:
+    scope: Namespaced
+  storage:
+    type: sqlite
+  configRef:
+    name: gw-121-values        # -> pinned to 1.2.1

--- a/kubernetes/gateway-operator/config/samples/api_v1_apigateway_multiversion.yaml
+++ b/kubernetes/gateway-operator/config/samples/api_v1_apigateway_multiversion.yaml
@@ -1,9 +1,10 @@
 # API Gateway version example — default-tracking vs pinned.
 #
 # Two API Gateways managed by ONE operator:
-#   - gw-default  -> no image tag pinned; tracks whatever version the operator
-#                    default (GATEWAY_HELM_VALUES_FILE_PATH) currently sets, so
-#                    it moves when that default changes.
+#   - gw-default  -> no image tag pinned; inherits the operator default version
+#                    (GATEWAY_HELM_VALUES_FILE_PATH) at (re)deploy time. An
+#                    EXISTING gateway does NOT auto-move when the default changes
+#                    — bump its APIGateway generation to pick up a new default.
 #   - gw-121      -> pins gateway-controller/gateway-runtime 1.2.1 via its own
 #                    configRef, independent of the operator default.
 #
@@ -39,11 +40,14 @@
 #   kubectl create namespace gw-121
 #
 #   # 2. Mandatory AES-256 encryption key Secret, one per namespace
+#   #    (umask 077 keeps the temp key file owner-only, regardless of your umask)
 #   for ns in gw-default gw-121; do
-#     openssl rand 32 > default-aesgcm256-v1.bin
-#     kubectl create secret generic gateway-encryption-keys \
-#       --from-file=default-aesgcm256-v1.bin=default-aesgcm256-v1.bin -n "$ns"
-#     rm -f default-aesgcm256-v1.bin
+#     ( umask 077
+#       openssl rand 32 > default-aesgcm256-v1.bin
+#       kubectl create secret generic gateway-encryption-keys \
+#         --from-file=default-aesgcm256-v1.bin=default-aesgcm256-v1.bin -n "$ns"
+#       rm -f default-aesgcm256-v1.bin
+#     )
 #   done
 #
 #   # 3. ConfigMaps + APIGateways (this file — namespaces already created in step 1)


### PR DESCRIPTION
## Purpose

The gateway operator had no debug guide and no sample for running different gateway versions per `APIGateway`, and `make install` was broken because its CRD kustomization still referenced the pre-rename `_gateways.yaml` and omitted most CRDs. This PR adds the missing docs and sample and fixes the CRD kustomization. It also documents that the typed `spec.infrastructure.image`/`routerImage` fields are not wired yet (tracked in #3287) and that the gateway version is set via the `configRef` ConfigMap.

Related #3287

## Goals

- Give contributors a working host-run (VS Code) debug workflow for the operator.
- Show how to run different gateway (data-plane) versions per `APIGateway` from a single operator.
- Make `make install` work again by listing the current CRDs.

## Approach

- Add `kubernetes/gateway-operator/DEBUG_GUIDE.md` for running the operator from VS Code against a cluster: install the operator's own CRDs plus the Gateway API standard CRDs, provision the mandatory AES-256 at-rest encryption key Secret per namespace, launch the debugger, and trigger a reconcile.
- Add `config/samples/api_v1_apigateway_multiversion.yaml` showing one gateway that tracks the operator default version and one pinned to a specific version via its own `configRef`, i.e. per-gateway image/tag overrides from a single operator.
- Document per-gateway versioning in the operator README: value precedence (configRef > CR labels/annotations > operator default > chart defaults), using `spec.infrastructure.annotations` rather than `metadata.annotations` to force a redeploy, and the caveat that operator-default changes only auto-apply to new gateways.
- Fix `config/crd/kustomization.yaml`, which referenced the pre-rename `_gateways.yaml` and listed only 2 of 12 CRDs (breaking `make install`); it now lists all 12 current CRD bases.

## User stories

- As a contributor, I want to run and debug the gateway operator locally against a real cluster.
- As an operator user, I want one gateway to track the operator default version and another pinned to a specific version, from a single operator.

## Documentation

This PR is itself operator documentation (`DEBUG_GUIDE.md` and a new README section). No separate product-documentation impact.

## Automation tests

- Unit tests: N/A — this PR only changes docs, a sample manifest, and the CRD kustomization resource list; no Go code is changed.
- Integration tests: N/A. The `make install` fix was verified manually via `kubectl kustomize config/crd`, which now renders all 12 CRDs.

## Security checks

- Followed secure coding standards: yes.
- Ran FindSecurityBugs plugin and verified report: N/A — no Java/compiled code changed.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets: yes. The sample and debug guide instruct generating an AES-256 key locally via `openssl` (created owner-only with `umask 077`) and never commit key material.

## Samples

- `kubernetes/gateway-operator/config/samples/api_v1_apigateway_multiversion.yaml` — `gw-default` (inherits the operator default version) and `gw-121` (pins both gateway images to `1.2.1`).

## Related PRs

N/A

## Test environment

N/A — documentation and sample manifests. The debug workflow steps were validated manually with `kubectl` against a local cluster.
