### PR TITLE
Expose a Projects capability on pdk.Deps for external plugins

### DIFF
--- a/platform-api/internal/server/server.go
+++ b/platform-api/internal/server/server.go
@@ -437,6 +437,7 @@ func StartPlatformAPIServer(cfg *config.Server, slogger *slog.Logger,
 	// signature drifts from the pdk interface, this stops building.
 	pdkDeps := &pdk.Deps{
 		Gateways: gatewayService,
+		Projects: projectService,
 		Config:   cfg,
 		Logger:   slogger,
 	}

--- a/platform-api/pdk/deps.go
+++ b/platform-api/pdk/deps.go
@@ -37,8 +37,9 @@ import (
 // signature drifts, the server stops building.
 type Deps struct {
 	Gateways Gateways
+	Projects Projects
 	// add more capability groups as external plugins need them
-	// (APIs, Subscriptions, Applications, Projects, Organizations, LLM, MCP, …)
+	// (APIs, Subscriptions, Applications, Organizations, LLM, MCP, …)
 
 	Config *config.Server
 	Logger *slog.Logger
@@ -61,4 +62,20 @@ type Gateways interface {
 
 	// DeleteGateway removes a gateway within an organization (Delete).
 	DeleteGateway(gatewayID, orgID, deletedBy string) error
+}
+
+// Projects exposes create/read/delete access to the platform's projects, scoped
+// by organization. Every method mirrors an existing ProjectService method verbatim
+// and takes the organization id explicitly — handlers MUST pass the org resolved
+// from the request context, never one from request input (GO-AUTH-005).
+type Projects interface {
+	// CreateProject creates a project in an organization (Create).
+	CreateProject(req *api.CreateProjectRequest, organizationID, actor string) (*api.Project, error)
+
+	// GetProjectByHandle returns a single project by its handle within an
+	// organization (Read).
+	GetProjectByHandle(handle, orgID string) (*api.Project, error)
+
+	// DeleteProject removes a project within an organization (Delete).
+	DeleteProject(handle, orgID, actor string) error
 }


### PR DESCRIPTION
## Purpose
`pdk.Deps` exposes the platform's capabilities to external plugins as public interfaces. It currently exposes a `Gateways` capability but no equivalent for projects, so an external plugin has no in-process way to create, read, or delete the platform's projects.

## Goals
Expose a `Projects` capability on `pdk.Deps`, mirroring the existing `Gateways` capability, so an external plugin can create, read, and delete projects in-process, scoped by organization.

## Approach
- `pdk/deps.go`: add a `Projects` interface (`CreateProject`, `GetProjectByHandle`, `DeleteProject`) and a `Projects` field on the `Deps` struct. The interface methods are exactly existing `ProjectService` methods that already speak public `api.*` types, so the interface is satisfied by shape — no adapter code.
- `internal/server/server.go`: assign `Projects: projectService` in the `pdk.Deps` literal. Following the established pattern, this assignment is the compile-time contract check — if a service method signature drifts from the interface, the server stops building.
- Only public `api.*` types cross the interface; no internal `model.*` / `repository.*` types leak. The organization id is passed explicitly on every method (GO-AUTH-005).

## User stories
N/A — additive plugin-SDK seam; no end-user-facing behavior change.

## Documentation
N/A — additive Go interface on the plugin SDK; no product documentation impact.

## Automation tests
 - Unit tests
   > No new tests. The `Projects: projectService` assignment is a compile-time interface-satisfaction check (the build fails if a signature drifts). `go build ./...`, `go vet ./pdk/... ./internal/server/...`, and `go test ./pdk/... ./internal/service/...` all pass.
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no — additive interface plus a single struct-field assignment, no security-relevant logic
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Test environment
Go 1.26; macOS. `go build` / `go vet` / `go test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
