### PR TITLE
Support shared HTTP client for policy engine (sdk/core)

### DIFF
--- a/event-gateway/gateway-controller/pkg/api/eventgateway/generated.go
+++ b/event-gateway/gateway-controller/pkg/api/eventgateway/generated.go
@@ -1840,8 +1840,8 @@ var swaggerSpec = []string{
 	"Ml5Zuf/hMdqIpfkCi6JiM8by66RagCmpeksf+WnbNZAauAe0J8FFlBZtj2p7gobd0wVfR/TXTDfqdKAv",
 	"+NYtLPODycKzw4yCMb8sKdxgIVkmRtRJN5167qCvDsyHSlGWfq/v8eorBJvebU6Baq8c4jbnsiXT+A0r",
 	"j45c470qkOFX9wvbknIldxWeoePkqmdobpvc6rUbJcp2DMp370nJedfsacn1Ltj7cKFY0kDdJtZvWIQT",
-	"ZEfTM/eCnCf2Ar7jwSBRL8yYkMdHw6PhAGdkkBZgDuZ7QVMWf2TRJfDBz/kYOAUJwjuroD581xV6nbNd",
-	"fP7fAAAA///JK4OH/sQAAA==",
+	"ZEfTM/eCnCf2Aj5xPBgk6o0ZE/L4aHg0HOCMDNICzsF8L2gK448sugQ++DkfA6cgQXiHFTTG77pEr3O6",
+	"i8//GwAA///4MCRIAMUAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/event-gateway/gateway-runtime/go.mod
+++ b/event-gateway/gateway-runtime/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/twmb/franz-go/pkg/kadm v1.14.0
 	github.com/wso2/api-platform/common v0.0.0
 	github.com/wso2/api-platform/gateway/gateway-runtime/policy-engine v0.0.0-00010101000000-000000000000
-	github.com/wso2/api-platform/sdk/core v0.2.18
+	github.com/wso2/api-platform/sdk/core v0.4.0
 	google.golang.org/grpc v1.82.1
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
@@ -46,6 +46,7 @@ require (
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/stoewer/go-strcase v1.3.1 // indirect
 	github.com/twmb/franz-go/pkg/kmsg v1.13.1 // indirect
+	github.com/wso2/go-httpkit v0.0.0-local // indirect
 	go.opentelemetry.io/otel v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
@@ -63,4 +64,5 @@ replace (
 	github.com/wso2/api-platform/common => ../../common
 	github.com/wso2/api-platform/gateway/gateway-runtime/policy-engine => ../../gateway/gateway-runtime/policy-engine
 	github.com/wso2/api-platform/sdk/core => ../../sdk/core
+	github.com/wso2/go-httpkit => ../../httpkit
 )

--- a/gateway/gateway-runtime/policy-engine/cmd/policy-engine/main.go
+++ b/gateway/gateway-runtime/policy-engine/cmd/policy-engine/main.go
@@ -32,7 +32,7 @@ import (
 	"time"
 
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
-	"github.com/wso2/api-platform/httpkit/httpclient"
+	"github.com/wso2/go-httpkit/httpclient"
 	"go.opentelemetry.io/otel"
 	"google.golang.org/grpc"
 

--- a/gateway/gateway-runtime/policy-engine/cmd/policy-engine/main.go
+++ b/gateway/gateway-runtime/policy-engine/cmd/policy-engine/main.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/wso2/api-platform/httpkit/httpclient"
 	"go.opentelemetry.io/otel"
 	"google.golang.org/grpc"
 
@@ -49,6 +50,7 @@ import (
 	"github.com/wso2/api-platform/gateway/gateway-runtime/policy-engine/internal/tracing"
 	"github.com/wso2/api-platform/gateway/gateway-runtime/policy-engine/internal/utils"
 	"github.com/wso2/api-platform/gateway/gateway-runtime/policy-engine/internal/xdsclient"
+	sdkutils "github.com/wso2/api-platform/sdk/core/utils"
 )
 
 // Version information (set via ldflags during build)
@@ -173,6 +175,25 @@ func main() {
 		os.Exit(1)
 	}
 	slog.InfoContext(ctx, "Config set in registry for ${config} CEL resolution")
+
+	// Build the single shared outbound *http.Client every policy retrieves via
+	// sdkutils.SharedHTTPClient() (see sdk/core/utils/httpclient.go). Built once,
+	// here, so every policy that makes an outbound call gets the same pooled
+	// connections, bounded timeouts/response size, and optional SSRF guard
+	// configured under [policy_engine.http_client], instead of each policy
+	// building (or forgetting to bound) its own *http.Client.
+	sharedHTTPClientCfg, err := config.BuildHTTPClientConfig(cfg.PolicyEngine.HTTPClient)
+	if err != nil {
+		slog.ErrorContext(ctx, "Invalid policy_engine.http_client configuration", "error", err)
+		os.Exit(1)
+	}
+	sharedHTTPClient, err := httpclient.New(sharedHTTPClientCfg)
+	if err != nil {
+		slog.ErrorContext(ctx, "Failed to build shared outbound HTTP client for policies", "error", err)
+		os.Exit(1)
+	}
+	sdkutils.SetSharedHTTPClient(sharedHTTPClient)
+	slog.InfoContext(ctx, "Shared outbound HTTP client built for policies")
 
 	// Initialize CEL evaluator
 	celEvaluator, err := cel.NewCELEvaluator()

--- a/gateway/gateway-runtime/policy-engine/go.mod
+++ b/gateway/gateway-runtime/policy-engine/go.mod
@@ -16,8 +16,8 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/stretchr/testify v1.11.1
 	github.com/wso2/api-platform/common v0.0.0-20260326194347-3d85c50eae71
-	github.com/wso2/api-platform/httpkit v0.0.0-local
 	github.com/wso2/api-platform/sdk/core v0.3.3
+	github.com/wso2/go-httpkit v0.0.0-local
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
@@ -67,6 +67,6 @@ require (
 
 replace github.com/wso2/api-platform/common => ../../../common
 
-replace github.com/wso2/api-platform/httpkit => ../../../httpkit
+replace github.com/wso2/go-httpkit => ../../../httpkit
 
 replace github.com/wso2/api-platform/sdk/core => ../../../sdk/core

--- a/gateway/gateway-runtime/policy-engine/go.mod
+++ b/gateway/gateway-runtime/policy-engine/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/stretchr/testify v1.11.1
 	github.com/wso2/api-platform/common v0.0.0-20260326194347-3d85c50eae71
+	github.com/wso2/api-platform/httpkit v0.0.0-local
 	github.com/wso2/api-platform/sdk/core v0.3.3
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0
@@ -65,3 +66,7 @@ require (
 )
 
 replace github.com/wso2/api-platform/common => ../../../common
+
+replace github.com/wso2/api-platform/httpkit => ../../../httpkit
+
+replace github.com/wso2/api-platform/sdk/core => ../../../sdk/core

--- a/gateway/gateway-runtime/policy-engine/go.mod
+++ b/gateway/gateway-runtime/policy-engine/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/stretchr/testify v1.11.1
 	github.com/wso2/api-platform/common v0.0.0-20260326194347-3d85c50eae71
-	github.com/wso2/api-platform/sdk/core v0.3.3
+	github.com/wso2/api-platform/sdk/core v0.4.0
 	github.com/wso2/go-httpkit v0.0.0-local
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0
@@ -68,5 +68,3 @@ require (
 replace github.com/wso2/api-platform/common => ../../../common
 
 replace github.com/wso2/go-httpkit => ../../../httpkit
-
-replace github.com/wso2/api-platform/sdk/core => ../../../sdk/core

--- a/gateway/gateway-runtime/policy-engine/go.sum
+++ b/gateway/gateway-runtime/policy-engine/go.sum
@@ -92,6 +92,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/wso2/api-platform/sdk/core v0.4.0 h1:6H2NWO/m+LCq0iXpPgr5KfOsyONfzEk54eAMzjAF/NE=
+github.com/wso2/api-platform/sdk/core v0.4.0/go.mod h1:TgjpOk3QBPc7xEQC+NctWcNq5dSPBkn7wSKh+hULTj8=
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/gateway/gateway-runtime/policy-engine/go.sum
+++ b/gateway/gateway-runtime/policy-engine/go.sum
@@ -92,8 +92,6 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/wso2/api-platform/sdk/core v0.3.3 h1:5bBapq9tWQf/kXZfYNnofJUTwZLyZ0PZpe7skbeZd/I=
-github.com/wso2/api-platform/sdk/core v0.3.3/go.mod h1:TgjpOk3QBPc7xEQC+NctWcNq5dSPBkn7wSKh+hULTj8=
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/gateway/gateway-runtime/policy-engine/internal/config/config.go
+++ b/gateway/gateway-runtime/policy-engine/internal/config/config.go
@@ -416,6 +416,11 @@ type PolicyEngine struct {
 	FileConfig     FileConfigConfig     `koanf:"file_config"`
 	Logging        LoggingConfig        `koanf:"logging"`
 	PythonExecutor PythonExecutorConfig `koanf:"python_executor"`
+	// HTTPClient configures the single shared outbound *http.Client built once at
+	// startup (see cmd/policy-engine/main.go) and injected into every policy
+	// instance via PolicyMetadata.SharedHTTPClient — see HTTPClientConfig's doc
+	// comment for the full rationale.
+	HTTPClient HTTPClientConfig `koanf:"http_client"`
 	// Tracing holds OpenTelemetry exporter configuration
 	TracingServiceName string `koanf:"tracing_service_name"`
 
@@ -437,6 +442,115 @@ type BodyConfig struct {
 	// or per chunk (streaming) — not cumulative, so long-lived streams such as SSE
 	// are unaffected. Defaults to DefaultMaxDecompressedBytes when unset.
 	MaxDecompressedBytes int64 `koanf:"max_decompressed_bytes"`
+}
+
+// HTTPClientConfig configures the single shared outbound *http.Client that the
+// policy-engine builds once at startup and injects into every policy instance
+// via PolicyMetadata.SharedHTTPClient (see internal/registry.PolicyRegistry).
+// It mirrors github.com/wso2/api-platform/httpkit/httpclient.Config field-for-field (see
+// that package's own doc comments for full semantics) so every knob the
+// library exposes that has a natural TOML shape is operator-configurable here
+// under [policy_engine.http_client], rather than left for each policy to
+// reinvent. The few fields httpclient.Config exposes that CANNOT be expressed
+// in TOML — Go callback hooks (GetClientCertificate, VerifyPeerCertificate,
+// VerifyConnection, ConnectHeader) and a pre-built *x509.CertPool — are not
+// represented here.
+//
+// Timeouts.Overall is only a generous safety-net budget: a policy issuing a
+// call with its own tighter per-operation deadline should use
+// context.WithTimeout, since http.Client.Do honors a request's context
+// deadline independent of the client-level Timeout.
+//
+// SSRF guarding is off by default (see HTTPClientSSRFConfig) since not every
+// policy dials a tenant/user-supplied URL. A policy whose outbound target
+// comes from request-derived or tenant-configured data — as opposed to a
+// fixed, operator-configured backend — should have its operator enable SSRF
+// guarding here; see ssrf-prevention.md.
+type HTTPClientConfig struct {
+	Pooling  HTTPClientPoolingConfig  `koanf:"pooling"`
+	Timeouts HTTPClientTimeoutsConfig `koanf:"timeouts"`
+	TLS      HTTPClientTLSConfig      `koanf:"tls"`
+	Proxy    HTTPClientProxyConfig    `koanf:"proxy"`
+	SSRF     HTTPClientSSRFConfig     `koanf:"ssrf"`
+}
+
+// HTTPClientPoolingConfig mirrors httpclient.PoolingConfig.
+type HTTPClientPoolingConfig struct {
+	MaxIdleConns        int           `koanf:"max_idle_conns"`
+	MaxIdleConnsPerHost int           `koanf:"max_idle_conns_per_host"`
+	MaxConnsPerHost     int           `koanf:"max_conns_per_host"`
+	IdleConnTimeout     time.Duration `koanf:"idle_conn_timeout"`
+	KeepAlive           time.Duration `koanf:"keep_alive"`
+	DisableKeepAlives   bool          `koanf:"disable_keep_alives"`
+	// EnableHTTP2 opts into HTTP/2. See httpclient.PoolingConfig.EnableHTTP2's doc comment
+	// on the HTTP/2 connection-coalescing caveat before enabling.
+	EnableHTTP2 bool `koanf:"enable_http2"`
+}
+
+// HTTPClientTimeoutsConfig mirrors httpclient.TimeoutsConfig.
+type HTTPClientTimeoutsConfig struct {
+	Overall          time.Duration `koanf:"overall"` // safety-net only; see HTTPClientConfig's doc comment
+	Dial             time.Duration `koanf:"dial"`
+	TLSHandshake     time.Duration `koanf:"tls_handshake"`
+	ResponseHeader   time.Duration `koanf:"response_header"`
+	ExpectContinue   time.Duration `koanf:"expect_continue"`
+	MaxResponseBytes int64         `koanf:"max_response_bytes"` // 0 = package default (10MiB); negative disables the bound
+}
+
+// HTTPClientTLSConfig mirrors the TOML-expressible subset of httpclient.TLSConfig.
+type HTTPClientTLSConfig struct {
+	MinVersion       string `koanf:"min_version"`       // one of "TLS1_0".."TLS1_3"
+	MaxVersion       string `koanf:"max_version"`       // one of "TLS1_0".."TLS1_3"
+	CipherSuites     string `koanf:"cipher_suites"`     // comma-separated Go crypto/tls cipher suite names; TLS 1.2 and below only
+	CurvePreferences string `koanf:"curve_preferences"` // comma-separated, e.g. "X25519MLKEM768,X25519,P-256"
+	RootCAFile       string `koanf:"root_ca_file"`      // PEM CA bundle; empty uses the system root pool
+	ClientCertFile   string `koanf:"client_cert_file"`  // mTLS to the origin; both cert and key must be set together
+	ClientKeyFile    string `koanf:"client_key_file"`
+}
+
+// HTTPClientProxyConfig mirrors the TOML-expressible subset of httpclient.ProxyConfig.
+type HTTPClientProxyConfig struct {
+	// Mode selects how the proxy is determined: "none" (default), "environment"
+	// (HTTP_PROXY/HTTPS_PROXY/NO_PROXY), or "url" (URL/Username/Password/NoProxy below).
+	Mode     string   `koanf:"mode"`
+	URL      string   `koanf:"url"`
+	Username string   `koanf:"username"`
+	Password string   `koanf:"password"`
+	NoProxy  []string `koanf:"no_proxy"` // exact host, ".suffix", or CIDR entries; only used when mode == "url"
+
+	TLS HTTPClientProxyTLSConfig `koanf:"tls"`
+
+	// Egress states how origin-destination SSRF risk is handled when a forward proxy is
+	// also configured: "delegated" (trust the proxy's own egress controls) or
+	// "manual_connect" (validate the origin locally before ever issuing CONNECT). Must be
+	// set explicitly whenever Mode != "none" and SSRF.Enabled — httpclient.New fails
+	// closed at startup otherwise rather than silently choosing one.
+	Egress string `koanf:"egress"`
+}
+
+// HTTPClientProxyTLSConfig mirrors httpclient.ProxyTLSConfig (the proxy's own TLS
+// handshake, fully decoupled from the origin TLS handshake in HTTPClientTLSConfig).
+type HTTPClientProxyTLSConfig struct {
+	RootCAFile         string `koanf:"root_ca_file"`
+	ClientCertFile     string `koanf:"client_cert_file"`
+	ClientKeyFile      string `koanf:"client_key_file"`
+	InsecureSkipVerify bool   `koanf:"insecure_skip_verify"`
+}
+
+// HTTPClientSSRFConfig mirrors the TOML-expressible subset of httpclient.SSRFConfig. Off by
+// default — see HTTPClientConfig's doc comment on when a policy's operator should enable it.
+type HTTPClientSSRFConfig struct {
+	Enabled bool `koanf:"enabled"`
+	// Preset selects a built-in netguard policy: "permit_private_block_metadata" (a
+	// backend that is normally private — a ClusterIP, a service-DNS name, localhost —
+	// stays reachable; only link-local/metadata/unspecified/multicast are refused) or
+	// "public_only" (stricter: every private/loopback/link-local/CGNAT address is
+	// refused, for a URL expected to point at the public internet). Required when Enabled
+	// is true. Custom CIDR allow/deny lists have no natural TOML shape and are not
+	// exposed here — use the httpclient/netguard packages directly in code for that.
+	Preset         string   `koanf:"preset"`
+	MaxRedirects   int      `koanf:"max_redirects"`
+	AllowedSchemes []string `koanf:"allowed_schemes"` // empty defaults to {"https"}
 }
 
 // MetricsConfig holds Prometheus metrics server configuration
@@ -898,6 +1012,33 @@ func defaultConfig() *Config {
 					Host: "localhost",
 				},
 				Timeout: 30 * time.Second,
+			},
+			HTTPClient: HTTPClientConfig{
+				Pooling: HTTPClientPoolingConfig{
+					MaxIdleConns:        100,
+					MaxIdleConnsPerHost: 10,
+					MaxConnsPerHost:     100,
+					IdleConnTimeout:     90 * time.Second,
+					KeepAlive:           30 * time.Second,
+				},
+				Timeouts: HTTPClientTimeoutsConfig{
+					Overall:        30 * time.Second, // safety-net only; see HTTPClientConfig's doc comment
+					Dial:           10 * time.Second,
+					TLSHandshake:   10 * time.Second,
+					ResponseHeader: 10 * time.Second,
+					ExpectContinue: 1 * time.Second,
+				},
+				TLS: HTTPClientTLSConfig{
+					MinVersion:       "TLS1_2",
+					MaxVersion:       "TLS1_3",
+					CurvePreferences: "",
+				},
+				Proxy: HTTPClientProxyConfig{
+					Mode: "none",
+				},
+				SSRF: HTTPClientSSRFConfig{
+					Enabled: false,
+				},
 			},
 			TracingServiceName: "policy-engine",
 			RequestBody: BodyConfig{

--- a/gateway/gateway-runtime/policy-engine/internal/config/config.go
+++ b/gateway/gateway-runtime/policy-engine/internal/config/config.go
@@ -447,7 +447,7 @@ type BodyConfig struct {
 // HTTPClientConfig configures the single shared outbound *http.Client that the
 // policy-engine builds once at startup and injects into every policy instance
 // via PolicyMetadata.SharedHTTPClient (see internal/registry.PolicyRegistry).
-// It mirrors github.com/wso2/api-platform/httpkit/httpclient.Config field-for-field (see
+// It mirrors github.com/wso2/go-httpkit/httpclient.Config field-for-field (see
 // that package's own doc comments for full semantics) so every knob the
 // library exposes that has a natural TOML shape is operator-configurable here
 // under [policy_engine.http_client], rather than left for each policy to

--- a/gateway/gateway-runtime/policy-engine/internal/config/httpclient.go
+++ b/gateway/gateway-runtime/policy-engine/internal/config/httpclient.go
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package config
+
+import (
+	"fmt"
+
+	"github.com/wso2/api-platform/httpkit/httpclient"
+	"github.com/wso2/api-platform/httpkit/netguard"
+)
+
+// BuildHTTPClientConfig translates an HTTPClientConfig (sourced from the
+// [policy_engine.http_client] section in config.toml) into an httpkit
+// httpclient.Config, mirroring every field the library exposes that has a
+// natural TOML shape. See HTTPClientConfig's doc comment for the full
+// rationale — this is the single translation used to build the shared
+// *http.Client that every policy receives via
+// PolicyMetadata.SharedHTTPClient.
+func BuildHTTPClientConfig(hc HTTPClientConfig) (httpclient.Config, error) {
+	cfg := httpclient.DefaultConfig()
+
+	cfg.Pooling.MaxIdleConns = hc.Pooling.MaxIdleConns
+	cfg.Pooling.MaxIdleConnsPerHost = hc.Pooling.MaxIdleConnsPerHost
+	cfg.Pooling.MaxConnsPerHost = hc.Pooling.MaxConnsPerHost
+	cfg.Pooling.IdleConnTimeout = hc.Pooling.IdleConnTimeout
+	cfg.Pooling.KeepAlive = hc.Pooling.KeepAlive
+	cfg.Pooling.DisableKeepAlives = hc.Pooling.DisableKeepAlives
+	cfg.Pooling.EnableHTTP2 = hc.Pooling.EnableHTTP2
+
+	cfg.Timeouts.Overall = hc.Timeouts.Overall
+	cfg.Timeouts.Dial = hc.Timeouts.Dial
+	cfg.Timeouts.TLSHandshake = hc.Timeouts.TLSHandshake
+	cfg.Timeouts.ResponseHeader = hc.Timeouts.ResponseHeader
+	cfg.Timeouts.ExpectContinue = hc.Timeouts.ExpectContinue
+	cfg.Timeouts.MaxResponseBytes = hc.Timeouts.MaxResponseBytes
+
+	cfg.TLS.MinVersion = hc.TLS.MinVersion
+	cfg.TLS.MaxVersion = hc.TLS.MaxVersion
+	cfg.TLS.CipherSuites = hc.TLS.CipherSuites
+	cfg.TLS.CurvePreferences = hc.TLS.CurvePreferences
+	cfg.TLS.RootCAFile = hc.TLS.RootCAFile
+	cfg.TLS.ClientCertFile = hc.TLS.ClientCertFile
+	cfg.TLS.ClientKeyFile = hc.TLS.ClientKeyFile
+	// InsecureSkipVerify is intentionally not exposed here: this shared client is
+	// used by arbitrary policies against arbitrary operator-configured (and
+	// potentially tenant/request-influenced) backends, so there is no single
+	// existing trust-boundary boolean to reuse the way gateway-controller reuses
+	// controller.controlplane.insecure_skip_verify. It stays at its safe default
+	// (verified).
+
+	switch hc.Proxy.Mode {
+	case "", "none":
+		// no proxy — cfg.Proxy stays at its zero value
+	case "environment":
+		cfg.Proxy.Mode = "environment"
+	case "url":
+		cfg.Proxy.Mode = "url"
+		cfg.Proxy.URL = hc.Proxy.URL
+		cfg.Proxy.Username = hc.Proxy.Username
+		cfg.Proxy.Password = hc.Proxy.Password
+		cfg.Proxy.NoProxy = hc.Proxy.NoProxy
+		if hc.Proxy.TLS != (HTTPClientProxyTLSConfig{}) {
+			cfg.Proxy.ProxyTLS = &httpclient.ProxyTLSConfig{
+				RootCAFile:                     hc.Proxy.TLS.RootCAFile,
+				ClientCertFile:                 hc.Proxy.TLS.ClientCertFile,
+				ClientKeyFile:                  hc.Proxy.TLS.ClientKeyFile,
+				InsecureSkipVerify:             hc.Proxy.TLS.InsecureSkipVerify,
+				InsecureSkipVerifyAcknowledged: hc.Proxy.TLS.InsecureSkipVerify,
+			}
+		}
+	default:
+		return httpclient.Config{}, fmt.Errorf("policy_engine.http_client.proxy.mode: unrecognized value %q (want \"none\", \"environment\", or \"url\")", hc.Proxy.Mode)
+	}
+
+	if hc.SSRF.Enabled {
+		cfg.SSRF.Enabled = true
+		switch hc.SSRF.Preset {
+		case "permit_private_block_metadata":
+			cfg.SSRF.Policy = netguard.PermitPrivateBlockMetadata()
+		case "public_only":
+			cfg.SSRF.Policy = netguard.PublicOnly()
+		default:
+			return httpclient.Config{}, fmt.Errorf("policy_engine.http_client.ssrf.preset: unrecognized value %q (want \"permit_private_block_metadata\" or \"public_only\")", hc.SSRF.Preset)
+		}
+		cfg.SSRF.Policy.AllowedSchemes = hc.SSRF.AllowedSchemes
+		cfg.SSRF.MaxRedirects = hc.SSRF.MaxRedirects
+
+		if cfg.Proxy.Mode != "" && cfg.Proxy.Mode != "none" {
+			switch hc.Proxy.Egress {
+			case "delegated":
+				cfg.Proxy.Egress = httpclient.ProxyEgressDelegated
+			case "manual_connect":
+				cfg.Proxy.Egress = httpclient.ProxyEgressManualCONNECT
+			default:
+				return httpclient.Config{}, fmt.Errorf("policy_engine.http_client.proxy.egress must be \"delegated\" or \"manual_connect\" when both proxy and SSRF are enabled, got %q", hc.Proxy.Egress)
+			}
+		}
+	}
+
+	return cfg, nil
+}

--- a/gateway/gateway-runtime/policy-engine/internal/config/httpclient.go
+++ b/gateway/gateway-runtime/policy-engine/internal/config/httpclient.go
@@ -21,8 +21,8 @@ package config
 import (
 	"fmt"
 
-	"github.com/wso2/api-platform/httpkit/httpclient"
-	"github.com/wso2/api-platform/httpkit/netguard"
+	"github.com/wso2/go-httpkit/httpclient"
+	"github.com/wso2/go-httpkit/netguard"
 )
 
 // BuildHTTPClientConfig translates an HTTPClientConfig (sourced from the

--- a/gateway/gateway-runtime/policy-engine/internal/config/httpclient_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/config/httpclient_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wso2/api-platform/httpkit/netguard"
+	"github.com/wso2/go-httpkit/netguard"
 )
 
 func defaultHTTPClientConfigForTest() HTTPClientConfig {

--- a/gateway/gateway-runtime/policy-engine/internal/config/httpclient_test.go
+++ b/gateway/gateway-runtime/policy-engine/internal/config/httpclient_test.go
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/wso2/api-platform/httpkit/netguard"
+)
+
+func defaultHTTPClientConfigForTest() HTTPClientConfig {
+	return defaultConfig().PolicyEngine.HTTPClient
+}
+
+func TestBuildHTTPClientConfigDefaultsSSRFDisabled(t *testing.T) {
+	cfg, err := BuildHTTPClientConfig(defaultHTTPClientConfigForTest())
+	if err != nil {
+		t.Fatalf("BuildHTTPClientConfig returned error: %v", err)
+	}
+
+	// Unlike the WebSub delivery/verifier clients (which always dial a
+	// tenant-supplied CallbackURL), this shared client is used by arbitrary
+	// policies — some targeting a fixed operator-configured backend, some
+	// potentially targeting a tenant/request-derived URL — so SSRF guarding is
+	// an explicit per-deployment opt-in rather than always-on.
+	if cfg.SSRF.Enabled {
+		t.Fatal("expected SSRF.Enabled to default to false, got true")
+	}
+	if cfg.Proxy.Mode != "" && cfg.Proxy.Mode != "none" {
+		t.Fatalf("expected no proxy mode by default, got %q", cfg.Proxy.Mode)
+	}
+}
+
+func TestBuildHTTPClientConfigCarriesPoolingTimeoutsAndTLS(t *testing.T) {
+	hc := defaultHTTPClientConfigForTest()
+	hc.Pooling.MaxIdleConns = 42
+	hc.Timeouts.Dial = 5 * time.Second
+	hc.TLS.MinVersion = "TLS1_3"
+
+	cfg, err := BuildHTTPClientConfig(hc)
+	if err != nil {
+		t.Fatalf("BuildHTTPClientConfig returned error: %v", err)
+	}
+
+	if cfg.Pooling.MaxIdleConns != 42 {
+		t.Errorf("expected Pooling.MaxIdleConns=42, got %d", cfg.Pooling.MaxIdleConns)
+	}
+	if cfg.Timeouts.Dial != 5*time.Second {
+		t.Errorf("expected Timeouts.Dial=5s, got %v", cfg.Timeouts.Dial)
+	}
+	if cfg.TLS.MinVersion != "TLS1_3" {
+		t.Errorf("expected TLS.MinVersion=TLS1_3, got %q", cfg.TLS.MinVersion)
+	}
+}
+
+func TestBuildHTTPClientConfigSSRFEnabledRequiresValidPreset(t *testing.T) {
+	hc := defaultHTTPClientConfigForTest()
+	hc.SSRF.Enabled = true
+	hc.SSRF.Preset = "not-a-real-preset"
+
+	if _, err := BuildHTTPClientConfig(hc); err == nil {
+		t.Fatal("expected error for unrecognized ssrf.preset, got nil")
+	}
+
+	hc.SSRF.Preset = "public_only"
+	hc.SSRF.MaxRedirects = 3
+	hc.SSRF.AllowedSchemes = []string{"https"}
+	cfg, err := BuildHTTPClientConfig(hc)
+	if err != nil {
+		t.Fatalf("BuildHTTPClientConfig returned error with valid preset: %v", err)
+	}
+	if !cfg.SSRF.Enabled {
+		t.Fatal("expected SSRF.Enabled to be true")
+	}
+	if cfg.SSRF.Policy.BlockLoopback != netguard.PublicOnly().BlockLoopback {
+		t.Errorf("expected SSRF.Policy to be derived from the public_only preset, got %+v", cfg.SSRF.Policy)
+	}
+	if cfg.SSRF.Policy.AllowedSchemes[0] != "https" || cfg.SSRF.MaxRedirects != 3 {
+		t.Errorf("expected SSRF policy/redirects carried through, got %+v maxRedirects=%d", cfg.SSRF.Policy, cfg.SSRF.MaxRedirects)
+	}
+}
+
+func TestBuildHTTPClientConfigRejectsUnknownProxyMode(t *testing.T) {
+	hc := defaultHTTPClientConfigForTest()
+	hc.Proxy.Mode = "socks5"
+
+	if _, err := BuildHTTPClientConfig(hc); err == nil {
+		t.Fatal("expected error for unrecognized proxy.mode, got nil")
+	}
+}
+
+func TestBuildHTTPClientConfigRequiresEgressWhenProxyAndSSRFConfigured(t *testing.T) {
+	hc := defaultHTTPClientConfigForTest()
+	hc.Proxy.Mode = "url"
+	hc.Proxy.URL = "https://proxy.example.com:3128"
+	hc.Proxy.Egress = ""
+	hc.SSRF.Enabled = true
+	hc.SSRF.Preset = "permit_private_block_metadata"
+
+	if _, err := BuildHTTPClientConfig(hc); err == nil {
+		t.Fatal("expected error when proxy+SSRF are configured without an explicit egress policy, got nil")
+	}
+
+	hc.Proxy.Egress = "delegated"
+	cfg, err := BuildHTTPClientConfig(hc)
+	if err != nil {
+		t.Fatalf("BuildHTTPClientConfig returned error with valid egress: %v", err)
+	}
+	if cfg.Proxy.Mode != "url" || cfg.Proxy.URL != hc.Proxy.URL {
+		t.Errorf("expected proxy url mode carried through, got %+v", cfg.Proxy)
+	}
+}
+
+func TestBuildHTTPClientConfigEnvironmentProxyMode(t *testing.T) {
+	hc := defaultHTTPClientConfigForTest()
+	hc.Proxy.Mode = "environment"
+
+	cfg, err := BuildHTTPClientConfig(hc)
+	if err != nil {
+		t.Fatalf("BuildHTTPClientConfig returned error: %v", err)
+	}
+	if cfg.Proxy.Mode != "environment" {
+		t.Errorf("expected proxy mode environment, got %q", cfg.Proxy.Mode)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `SharedHTTPClient`/`SetSharedHTTPClient` to `sdk/core/utils` — a single process-wide `*http.Client`, built once at policy-engine startup from `[policy_engine.http_client]` config (pooling, timeouts, TLS, forward-proxy, SSRF-guard), that any policy retrieves instead of constructing/caching its own.
- Wires this into the policy engine: `policy-engine` config parsing/validation for the new `http_client` section, `BuildHTTPClientConfig` translation into `go-httpkit`'s `httpclient.Config`, and startup wiring in `cmd/policy-engine/main.go` that builds the client and installs it via `sdk/core/utils.SetSharedHTTPClient`.
- Adds a `go-httpkit` dependency + local `replace` to `policy-engine/go.mod`.

## Test plan
- [x] `go build ./...` and `go test ./...` pass in `sdk/core`
- [x] `go build ./...` and `go test ./...` pass in `gateway/gateway-runtime/policy-engine`
- [x] `go mod tidy` clean for `policy-engine`