### PR TITLE
feat(helm): render config_toml above table sections for root keys

### DIFF
--- a/kubernetes/helm/gateway-helm-chart/README.md
+++ b/kubernetes/helm/gateway-helm-chart/README.md
@@ -201,6 +201,47 @@ ConfigMap:
 
 A plain `APIP_GW_*` env var with no matching token in `config.toml` is ignored.
 
+### Raw config passthrough (`gateway.config_toml`)
+
+For configuration the chart doesn't model as structured `gateway.config.*` values, use
+`gateway.config_toml` — a raw TOML string rendered into the generated `config.toml`. It is
+injected at the **top of the file, above every `[table]` section**, so it can carry two shapes:
+
+- **Bare root keys** — e.g. policy "system parameters" that policies read as `${config.<key>}`
+  (the Azure Content Safety, AWS Bedrock Guardrail, embedding-provider, Redis, and similar
+  policies). TOML requires bare keys to precede all `[table]` headers, which is why the block
+  leads the file.
+- **Whole `[table]` sections** — a custom section the chart doesn't render. Tables are
+  order-independent, so these work from the top too.
+
+Do **not** redefine a table the chart already emits (`[controller.server]`, `[router]`, etc.) —
+TOML rejects a duplicate table.
+
+`config.toml` is rendered into a **ConfigMap, not a Secret**, so it must not hold plaintext
+secrets. For any secret value, supply an `{{ env "NAME" }}` / `{{ file "/path" }}` interpolation
+token (resolved by the gateway at startup, same mechanism as the control-plane token and DB
+password above) instead of a literal, and inject the backing env var via
+`gateway.gatewayRuntime.deployment.extraEnv`. Allowed `{{ file }}` source dirs:
+`/etc/gateway-runtime`, `/secrets/gateway-runtime`.
+
+Example — the Azure Content Safety content-moderation policy (endpoint is non-secret, the
+subscription key is a secret):
+
+```yaml
+gateway:
+  config_toml: |
+    azurecontentsafety_endpoint = "https://your-resource.cognitiveservices.azure.com"
+    azurecontentsafety_key = '{{ env "APIP_GW_AZURE_CONTENT_SAFETY_KEY" }}'
+  gatewayRuntime:
+    deployment:
+      extraEnv:
+        - name: APIP_GW_AZURE_CONTENT_SAFETY_KEY
+          valueFrom:
+            secretKeyRef:
+              name: azure-content-safety   # kubectl create secret generic azure-content-safety --from-literal=subscription-key='<key>'
+              key: subscription-key
+```
+
 ### Storage backends and scaling
 
 `gateway.config.controller.storage.type` selects the controller's database:

--- a/kubernetes/helm/gateway-helm-chart/templates/gateway/gateway-config.yaml
+++ b/kubernetes/helm/gateway-helm-chart/templates/gateway/gateway-config.yaml
@@ -20,6 +20,24 @@ metadata:
   {{- end }}
 data:
   config.toml: |
+    {{- /*
+      config_toml is the raw TOML passthrough for configuration the chart doesn't
+      model as structured values. It leads the file (above [controller.server]) so
+      it can carry BARE ROOT keys — e.g. policy "system parameters" that policies
+      read as ${config.<key>} — which TOML requires to precede every [table]
+      section. Whole [table] sections work here too (tables are order-independent).
+      Do not redefine a table the chart already emits below (TOML duplicate-table
+      error).
+
+      config.toml renders into a ConfigMap, not a Secret. For any secret value,
+      supply an {{ env "VAR" }} / {{ file "/path" }} interpolation token (resolved
+      by the policy engine at load time via common/configinterpolate) instead of a
+      literal, and inject the backing env var via
+      gateway.gatewayRuntime.deployment.extraEnv.
+    */ -}}
+    {{- if .Values.gateway.config_toml }}
+{{ .Values.gateway.config_toml | indent 4 }}
+    {{- end }}
     [controller.server]
     api_port = {{ $gc.server.api_port }}
     xds_port = {{ $gc.server.xds_port }}
@@ -654,8 +672,4 @@ data:
     {{- if .Values.gateway.config.mcp }}
     [mcp]
     append_resource_path_to_backend = {{ .Values.gateway.config.mcp.append_resource_path_to_backend }}
-    {{- end }}
-
-    {{- if .Values.gateway.config_toml }}
-{{ .Values.gateway.config_toml | indent 4 }}
     {{- end }}

--- a/kubernetes/helm/gateway-helm-chart/values.yaml
+++ b/kubernetes/helm/gateway-helm-chart/values.yaml
@@ -577,12 +577,27 @@ gateway:
       # Default (false) forwards to exactly the configured upstream path.
       append_resource_path_to_backend: false
 
-  # Raw TOML string to append to the generated config.toml
-  # Use this for additional configuration not covered by the structured values above
-  # Example:
+  # Raw TOML injected at the TOP of the generated config.toml, above every [table]
+  # section. Use it for configuration the chart doesn't model as structured values.
+  # Because it leads the file, it can carry BARE ROOT keys — e.g. policy "system
+  # parameters" that policies read as ${config.<key>} — which TOML requires to
+  # appear before any [table] header. Whole [table] sections work here too. Do NOT
+  # redefine a table the chart already emits (that's a TOML duplicate-table error).
+  #
+  # config.toml renders into a ConfigMap, not a Secret. For any secret value, supply
+  # an `{{ env "VAR" }}` / `{{ file "/path" }}` interpolation token (the policy
+  # engine resolves it at load time) instead of a literal, and inject the backing
+  # env var via gateway.gatewayRuntime.deployment.extraEnv.
+  #
+  # Example — a [custom_section] table:
   #   config_toml: |
   #     [custom_section]
   #     key = "value"
+  #
+  # Example — bare root keys (Azure Content Safety policy; endpoint literal, key a token):
+  #   config_toml: |
+  #     azurecontentsafety_endpoint = "https://your-resource.cognitiveservices.azure.com"
+  #     azurecontentsafety_key = '{{ env "APIP_GW_AZURE_CONTENT_SAFETY_KEY" }}'
   config_toml: ""
 
   # metadata for the generated shared ConfigMap (annotations / labels)


### PR DESCRIPTION
## Purpose

The gateway Helm chart's `gateway.config_toml` raw TOML passthrough was appended at the bottom of the generated `config.toml`, after all `[table]` sections. TOML requires bare (un-tabled) keys to precede every table header, so any bare root-level key set via `config_toml` was silently absorbed into the last-emitted table (e.g. `[mcp]`) instead of landing at the root. This made it impossible to configure root-level policy "system parameters" — which policies read as `${config.<key>}` (e.g. Azure Content Safety, AWS Bedrock Guardrail, embedding-provider) — through the chart.

Resolves N/A

## Goals

Let `gateway.config_toml` carry bare root-level keys in addition to `[table]` sections, so policy system parameters can be set through the chart without hand-editing the rendered ConfigMap.

## Approach

- Move the `gateway.config_toml` render block from the bottom to the top of `config.toml` (above `[controller.server]`), the only position where bare keys are valid TOML.
- `[table]` sections continue to work unchanged, since TOML tables are order-independent.
- Document both usage shapes (bare root keys and whole `[table]` sections) and the duplicate-table caveat in `values.yaml` and the chart README.
- Document the secret-handling guidance: `config.toml` renders into a ConfigMap (not a Secret), so secrets must be supplied as `{{ env }}`/`{{ file }}` interpolation tokens with the backing value injected via `gateway.gatewayRuntime.deployment.extraEnv`, consistent with how the control-plane token and DB password are already handled.

## User stories

As a gateway operator, I want to set root-level policy system parameters (e.g. the Azure Content Safety endpoint and key) via the Helm chart so I can configure AI guardrail policies without editing the generated ConfigMap by hand.

## Documentation

Chart README updated in this PR (`kubernetes/helm/gateway-helm-chart/README.md`) with a new "Raw config passthrough (`gateway.config_toml`)" section covering both usage shapes, the duplicate-table caveat, and the secret-token guidance.

## Automation tests

- Unit tests
  > N/A — this is a Helm template/documentation change with no Go or application code touched.
- Integration tests
  > N/A — validated manually with `helm lint` and `helm template` across three cases (empty `config_toml`, bare root keys, and a `[custom_section]` table), then parsed the rendered `config.toml` with a real TOML parser to confirm bare keys land at the root (not absorbed into a table), the generated sections stay intact, and an `{{ env }}` token round-trips to a clean interpolation form.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — no Java/compiled code changed; this is a Helm chart change.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes — the only credential-shaped strings are documentation placeholders and `{{ env }}` interpolation tokens.

## Samples

The README includes a copy-pasteable example configuring the Azure Content Safety content-moderation policy via `config_toml` (non-secret endpoint as a literal, subscription key as an `{{ env }}` token) paired with a `secretKeyRef` under `gateway.gatewayRuntime.deployment.extraEnv`.

## Related PRs

N/A

## Test environment

Helm v3.18.3; chart rendered and validated locally on macOS. No JDK, database, or browser dependencies apply to this chart-template change.