### PR TITLE
Add Pipeline UI in APIPC

### DIFF
--- a/portals/ai-workspace/src/pages/appShell/AppSidebar.tsx
+++ b/portals/ai-workspace/src/pages/appShell/AppSidebar.tsx
@@ -310,25 +310,25 @@ export default function AppSidebar({
             )}
           </Sidebar.Category>
           {extensions.length > 0 && (
-            <Sidebar.Category>
-              <Sidebar.CategoryLabel>
-                <span style={{ fontSize: '0.8rem' }}>Cloud</span>
-              </Sidebar.CategoryLabel>
-              {extensions.map((extension) => (
-                <NavLink
-                  key={extension.id}
-                  to={extensionPath(extension.path)}
-                  style={navLinkStyle}
-                >
-                  <Sidebar.Item id={extension.id}>
-                    <Sidebar.ItemIcon>
-                      {extension.icon ?? <Settings size={20} />}
-                    </Sidebar.ItemIcon>
-                    <Sidebar.ItemLabel>{extension.label}</Sidebar.ItemLabel>
-                  </Sidebar.Item>
-                </NavLink>
-              ))}
-            </Sidebar.Category>
+            <>
+              <Box sx={{ borderTop: '1px solid', borderColor: 'divider', mx: 1.5, my: 0.5 }} />
+              <Sidebar.Category>
+                {extensions.map((extension) => (
+                  <NavLink
+                    key={extension.id}
+                    to={extensionPath(extension.path)}
+                    style={navLinkStyle}
+                  >
+                    <Sidebar.Item id={extension.id}>
+                      <Sidebar.ItemIcon>
+                        {extension.icon ?? <Settings size={20} />}
+                      </Sidebar.ItemIcon>
+                      <Sidebar.ItemLabel>{extension.label}</Sidebar.ItemLabel>
+                    </Sidebar.Item>
+                  </NavLink>
+                ))}
+              </Sidebar.Category>
+            </>
           )}
         </Box>
       </Sidebar.Nav>

--- a/portals/cloud-plugins/apip-cloud-ui-pipelines/package.json
+++ b/portals/cloud-plugins/apip-cloud-ui-pipelines/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@wso2-enterprise/apip-cloud-ui-pipelines",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "_phase:build": "tsc --noEmit",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@wso2/oxygen-ui": "0.5.0",
+    "@wso2/oxygen-ui-icons-react": "0.5.0",
+    "react": "19.2.3"
+  },
+  "devDependencies": {
+    "@types/react": "19.2.17",
+    "typescript": "5.9.3"
+  }
+}

--- a/portals/cloud-plugins/apip-cloud-ui-pipelines/src/PipelineCreatePage.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-pipelines/src/PipelineCreatePage.tsx
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+import { useRef, useState, type FC } from 'react';
+import {
+  Box,
+  Button,
+  IconButton,
+  PageContent,
+  PageTitle,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@wso2/oxygen-ui';
+import { ArrowRight, ChevronLeft, Plus } from '@wso2/oxygen-ui-icons-react';
+import EnvironmentGatewayPicker from './components/EnvironmentGatewayPicker';
+import PipelineStageCard from './components/PipelineStageCard';
+import type { CreatePipelineInput, Environment, Pipeline, PipelineStage } from './types';
+
+export type PipelineCreatePageProps = {
+  environments: Environment[];
+  /** Editing an existing pipeline pre-fills name/stages and changes the page's labels. Omit (or 'create') for a blank pipeline. */
+  mode?: 'create' | 'edit';
+  initialPipeline?: Pipeline;
+  onBack: () => void;
+  /** `pipelineId` is set only in edit mode, so the caller can route to createPipeline vs updatePipeline without this page knowing which store function to call. */
+  onSubmit: (input: CreatePipelineInput, pipelineId?: string) => void;
+};
+
+const findEnvironment = (environments: Environment[], environmentId: string) =>
+  environments.find((environment) => environment.id === environmentId);
+
+const findGateway = (environment: Environment | undefined, gatewayId: string) =>
+  environment?.gateways.find((gateway) => gateway.id === gatewayId);
+
+const PipelineCreatePage: FC<PipelineCreatePageProps> = ({
+  environments,
+  mode = 'create',
+  initialPipeline,
+  onBack,
+  onSubmit,
+}) => {
+  const isEdit = mode === 'edit' && !!initialPipeline;
+  const [name, setName] = useState(initialPipeline?.name ?? '');
+  const isDefault = initialPipeline?.isDefault ?? false;
+  const [stages, setStages] = useState<PipelineStage[]>(initialPipeline?.stages ?? []);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [pickerAnchor, setPickerAnchor] = useState<HTMLElement | null>(null);
+  // Position a new stage is inserted at; null means append to the end. A ref
+  // (not state) because it's only ever read once, synchronously, inside
+  // handleAddStage — no re-render should depend on it.
+  const insertIndexRef = useRef<number | null>(null);
+
+  const openPickerAt = (anchor: HTMLElement, insertIndex: number | null) => {
+    insertIndexRef.current = insertIndex;
+    setPickerAnchor(anchor);
+    setPickerOpen(true);
+  };
+
+  const handleAddStage = (environmentId: string, defaultGatewayId: string) => {
+    const newStage: PipelineStage = { id: crypto.randomUUID(), environmentId, defaultGatewayId };
+    setStages((prev) => {
+      const index = insertIndexRef.current;
+      if (index === null || index >= prev.length) return [...prev, newStage];
+      return [...prev.slice(0, index), newStage, ...prev.slice(index)];
+    });
+  };
+
+  const handleRemoveStage = (stageId: string) => {
+    setStages((prev) => prev.filter((stage) => stage.id !== stageId));
+  };
+
+  const canSubmit = name.trim().length > 0 && stages.length > 0;
+
+  return (
+    <PageContent fullWidth>
+      <Button size="small" startIcon={<ChevronLeft size={18} />} onClick={onBack}>
+        Back to Deployment Pipelines
+      </Button>
+
+      <Stack spacing={2} mt={2}>
+        <PageTitle>
+          <PageTitle.Header>{isEdit ? 'Edit Pipeline' : 'Create a New Pipeline'}</PageTitle.Header>
+        </PageTitle>
+      </Stack>
+
+      <Box sx={{ mt: 2, maxWidth: 880 }}>
+        <Box sx={{ maxWidth: 420, mb: 2 }}>
+          <Typography variant="body2" sx={{ mb: 0.5 }}>
+            Name
+          </Typography>
+          <TextField
+            fullWidth
+            placeholder="Enter pipeline name"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            autoFocus
+          />
+        </Box>
+
+        <Box
+          sx={{
+            bgcolor: 'action.hover',
+            border: '1px solid',
+            borderColor: 'divider',
+            borderRadius: 1.5,
+            p: 3,
+            minHeight: 160,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: stages.length === 0 ? 'center' : 'flex-start',
+            flexWrap: 'wrap',
+            gap: 1.5,
+          }}
+        >
+          {stages.length === 0 ? (
+            <Button
+              variant="contained"
+              startIcon={<Plus size={16} />}
+              onClick={(event) => openPickerAt(event.currentTarget, null)}
+            >
+              Add Environment
+            </Button>
+          ) : (
+            <>
+              {stages.map((stage, index) => {
+                const environment = findEnvironment(environments, stage.environmentId);
+                const gateway = findGateway(environment, stage.defaultGatewayId);
+                return (
+                  <Box key={stage.id} sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+                    {index > 0 ? (
+                      <Tooltip title="Insert environment here">
+                        <IconButton
+                          size="small"
+                          aria-label="Insert environment here"
+                          onClick={(event) => openPickerAt(event.currentTarget, index)}
+                          sx={{ color: 'text.secondary' }}
+                        >
+                          <ArrowRight size={18} />
+                        </IconButton>
+                      </Tooltip>
+                    ) : null}
+                    <PipelineStageCard
+                      environmentName={environment?.name ?? stage.environmentId}
+                      gatewayName={gateway?.name ?? stage.defaultGatewayId}
+                      critical={environment?.critical}
+                      onRemove={() => handleRemoveStage(stage.id)}
+                    />
+                  </Box>
+                );
+              })}
+              <Tooltip title="Add next environment">
+                <IconButton
+                  color="primary"
+                  onClick={(event) => openPickerAt(event.currentTarget, null)}
+                  sx={{
+                    bgcolor: 'primary.main',
+                    color: 'primary.contrastText',
+                    '&:hover': { bgcolor: 'primary.dark' },
+                  }}
+                >
+                  <Plus size={20} />
+                </IconButton>
+              </Tooltip>
+            </>
+          )}
+
+          <EnvironmentGatewayPicker
+            open={pickerOpen}
+            anchorEl={pickerAnchor}
+            environments={environments}
+            usedStages={stages}
+            onClose={() => setPickerOpen(false)}
+            onAdd={handleAddStage}
+          />
+        </Box>
+
+        <Box sx={{ mt: 3, display: 'flex', gap: 1 }}>
+          <Button variant="outlined" color="secondary" onClick={onBack}>
+            Cancel
+          </Button>
+          <Tooltip
+            title={!canSubmit
+              ? name.trim().length === 0
+                ? 'Enter a pipeline name to continue.'
+                : 'Add at least one environment to the pipeline.'
+              : ''}
+          >
+            <span>
+              <Button
+                variant="contained"
+                disabled={!canSubmit}
+                onClick={() => onSubmit({ name: name.trim(), isDefault, stages }, initialPipeline?.id)}
+              >
+                {isEdit ? 'Save Changes' : 'Create'}
+              </Button>
+            </span>
+          </Tooltip>
+        </Box>
+      </Box>
+    </PageContent>
+  );
+};
+
+export default PipelineCreatePage;

--- a/portals/cloud-plugins/apip-cloud-ui-pipelines/src/PipelinesFeature.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-pipelines/src/PipelinesFeature.tsx
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+import { useEffect, useState, type FC } from 'react';
+import PipelineCreatePage from './PipelineCreatePage';
+import PipelinesListPage from './PipelinesListPage';
+import ProjectPipelinesPage from './ProjectPipelinesPage';
+import {
+  associateProjectPipelines,
+  createPipeline,
+  deletePipeline,
+  listEnvironments,
+  listPipelines,
+  listProjectPipelines,
+  removeProjectPipeline,
+  updatePipeline,
+} from './mocks/pipelinesStore';
+import type { AIWorkspaceHostPort } from './hostPort';
+import type { CreatePipelineInput } from './types';
+
+export type PipelinesFeatureProps = {
+  port: AIWorkspaceHostPort;
+};
+
+/**
+ * The extension's `render(port)` result: a self-contained list/create/edit
+ * flow backed by the mock store, switching view with local state rather than
+ * a nested route — `AIWorkspaceExtension` only carries one `path` per sidebar
+ * entry today, so a sub-router isn't available to this extension yet.
+ */
+const PipelinesFeature: FC<PipelinesFeatureProps> = ({ port }) => {
+  const [view, setView] = useState<'list' | 'create' | 'edit'>('list');
+  const [editingPipelineId, setEditingPipelineId] = useState<string | null>(null);
+  const [pipelines, setPipelines] = useState(() => listPipelines());
+  const [environments] = useState(() => listEnvironments());
+  const [projectPipelines, setProjectPipelines] = useState(() =>
+    port.projectHandle ? listProjectPipelines(port.orgHandle, port.projectHandle) : []
+  );
+
+  useEffect(() => {
+    if (port.projectHandle) {
+      setProjectPipelines(listProjectPipelines(port.orgHandle, port.projectHandle));
+    }
+  }, [port.orgHandle, port.projectHandle]);
+
+  const handleSubmit = (input: CreatePipelineInput, pipelineId?: string) => {
+    if (pipelineId) {
+      const updated = updatePipeline({ ...input, id: pipelineId });
+      setPipelines(listPipelines());
+      port.notify(`Pipeline "${updated.name}" updated.`, 'success');
+    } else {
+      const created = createPipeline(input);
+      setPipelines(listPipelines());
+      port.notify(`Pipeline "${created.name}" created.`, 'success');
+    }
+    setView('list');
+    setEditingPipelineId(null);
+  };
+
+  const handleDelete = (id: string) => {
+    deletePipeline(id);
+    setPipelines(listPipelines());
+    port.notify('Pipeline deleted.', 'success');
+  };
+
+  const handleEditClick = (id: string) => {
+    setEditingPipelineId(id);
+    setView('edit');
+  };
+
+  if (port.projectHandle) {
+    const projectHandle = port.projectHandle;
+    return (
+      <ProjectPipelinesPage
+        pipelines={projectPipelines}
+        organizationPipelines={listPipelines()}
+        environments={environments}
+        onAssociate={(pipelineIds) => {
+          associateProjectPipelines(port.orgHandle, projectHandle, pipelineIds);
+          setProjectPipelines(listProjectPipelines(port.orgHandle, projectHandle));
+          port.notify(
+            `${pipelineIds.length} pipeline${pipelineIds.length === 1 ? '' : 's'} added to the project.`,
+            'success'
+          );
+        }}
+        onRemove={(pipelineId) => {
+          removeProjectPipeline(port.orgHandle, projectHandle, pipelineId);
+          setProjectPipelines(listProjectPipelines(port.orgHandle, projectHandle));
+          port.notify('Pipeline removed from the project.', 'success');
+        }}
+      />
+    );
+  }
+
+  if (view === 'create' || view === 'edit') {
+    const editingPipeline =
+      view === 'edit' ? pipelines.find((pipeline) => pipeline.id === editingPipelineId) : undefined;
+    return (
+      <PipelineCreatePage
+        environments={environments}
+        mode={view}
+        initialPipeline={editingPipeline}
+        onBack={() => {
+          setView('list');
+          setEditingPipelineId(null);
+        }}
+        onSubmit={handleSubmit}
+      />
+    );
+  }
+
+  return (
+    <PipelinesListPage
+      pipelines={pipelines}
+      environments={environments}
+      onCreateClick={() => setView('create')}
+      onEditClick={handleEditClick}
+      onDelete={handleDelete}
+    />
+  );
+};
+
+export default PipelinesFeature;

--- a/portals/cloud-plugins/apip-cloud-ui-pipelines/src/PipelinesListPage.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-pipelines/src/PipelinesListPage.tsx
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+import { useState, type FC } from 'react';
+import {
+  Box,
+  Button,
+  Chip,
+  Collapse,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  PageContent,
+  PageTitle,
+  SearchBar,
+  Stack,
+  Tooltip,
+  Typography,
+} from '@wso2/oxygen-ui';
+import {
+  ArrowRight,
+  ChevronDown,
+  ChevronUp,
+  Pencil,
+  Plus,
+  Trash2,
+} from '@wso2/oxygen-ui-icons-react';
+import PipelineStageCard from './components/PipelineStageCard';
+import type { Environment, Pipeline } from './types';
+
+export type PipelinesListPageProps = {
+  pipelines: Pipeline[];
+  environments: Environment[];
+  onCreateClick: () => void;
+  onEditClick: (id: string) => void;
+  onDelete: (id: string) => void;
+};
+
+const findEnvironment = (environments: Environment[], environmentId: string) =>
+  environments.find((environment) => environment.id === environmentId);
+
+const findGateway = (environment: Environment | undefined, gatewayId: string) =>
+  environment?.gateways.find((gateway) => gateway.id === gatewayId);
+
+const PipelinesListPage: FC<PipelinesListPageProps> = ({
+  pipelines,
+  environments,
+  onCreateClick,
+  onEditClick,
+  onDelete,
+}) => {
+  const [expandedIds, setExpandedIds] = useState<string[]>(() => pipelines.map((p) => p.id));
+  const [pendingDelete, setPendingDelete] = useState<Pipeline | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const toggleExpanded = (id: string) => {
+    setExpandedIds((prev) =>
+      prev.includes(id) ? prev.filter((existing) => existing !== id) : [...prev, id]
+    );
+  };
+
+  const handleConfirmDelete = () => {
+    if (!pendingDelete) return;
+    onDelete(pendingDelete.id);
+    setPendingDelete(null);
+  };
+
+  const normalizedQuery = searchQuery.trim().toLowerCase();
+  const filteredPipelines = normalizedQuery
+    ? pipelines.filter((pipeline) => pipeline.name.toLowerCase().includes(normalizedQuery))
+    : pipelines;
+
+  return (
+    <PageContent fullWidth>
+      <PageTitle sx={{ mb: 2 }}>
+        <PageTitle.Header>Continuous Deployment Pipelines</PageTitle.Header>
+        <PageTitle.Actions>
+          <Button variant="contained" size="small" startIcon={<Plus size={16} />} onClick={onCreateClick}>
+            Create Pipeline
+          </Button>
+        </PageTitle.Actions>
+      </PageTitle>
+
+      {pipelines.length > 0 ? (
+        <Box sx={{ mb: 2, maxWidth: 360 }}>
+          <SearchBar
+            fullWidth
+            placeholder="Search pipelines"
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+          />
+        </Box>
+      ) : null}
+
+      {pipelines.length === 0 ? (
+        <Box
+          sx={{
+            border: '1px dashed',
+            borderColor: 'divider',
+            borderRadius: 1.5,
+            py: 6,
+            textAlign: 'center',
+          }}
+        >
+          <Typography variant="body2" color="text.secondary">
+            No deployment pipelines yet.
+          </Typography>
+        </Box>
+      ) : filteredPipelines.length === 0 ? (
+        <Box
+          sx={{
+            border: '1px dashed',
+            borderColor: 'divider',
+            borderRadius: 1.5,
+            py: 6,
+            textAlign: 'center',
+          }}
+        >
+          <Typography variant="body2" color="text.secondary">
+            No pipelines match &quot;{searchQuery.trim()}&quot;.
+          </Typography>
+        </Box>
+      ) : (
+        <Stack spacing={2}>
+          {filteredPipelines.map((pipeline) => {
+            const expanded = expandedIds.includes(pipeline.id);
+            return (
+              <Box
+                key={pipeline.id}
+                sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1.5, overflow: 'hidden' }}
+              >
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    px: 2,
+                    py: 1.5,
+                    bgcolor: 'action.hover',
+                  }}
+                >
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <Typography variant="subtitle1" >
+                      {pipeline.name}
+                    </Typography>
+                    {pipeline.isDefault ? (
+                      <Chip label="Default" size="small" color="primary" variant="outlined" />
+                    ) : null}
+                  </Box>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                    <Tooltip title="Edit pipeline">
+                      <IconButton
+                        size="small"
+                        aria-label={`Edit ${pipeline.name}`}
+                        onClick={() => onEditClick(pipeline.id)}
+                      >
+                        <Pencil size={16} />
+                      </IconButton>
+                    </Tooltip>
+                    <IconButton
+                      size="small"
+                      color="error"
+                      aria-label={`Delete ${pipeline.name}`}
+                      onClick={() => setPendingDelete(pipeline)}
+                    >
+                      <Trash2 size={16} />
+                    </IconButton>
+                    <IconButton
+                      size="small"
+                      aria-label={expanded ? 'Collapse' : 'Expand'}
+                      onClick={() => toggleExpanded(pipeline.id)}
+                    >
+                      {expanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+                    </IconButton>
+                  </Box>
+                </Box>
+                <Collapse in={expanded}>
+                  <Box sx={{ px: 2, py: 2, display: 'flex', alignItems: 'center', gap: 1.5, flexWrap: 'wrap' }}>
+                    {pipeline.stages.map((stage, index) => {
+                      const environment = findEnvironment(environments, stage.environmentId);
+                      const gateway = findGateway(environment, stage.defaultGatewayId);
+                      return (
+                        <Box key={stage.id} sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+                          {index > 0 ? (
+                            <Box sx={{ display: 'flex', color: 'text.secondary' }}>
+                              <ArrowRight size={18} />
+                            </Box>
+                          ) : null}
+                          <PipelineStageCard
+                            environmentName={environment?.name ?? stage.environmentId}
+                            gatewayName={gateway?.name ?? stage.defaultGatewayId}
+                            critical={environment?.critical}
+                          />
+                        </Box>
+                      );
+                    })}
+                  </Box>
+                </Collapse>
+              </Box>
+            );
+          })}
+        </Stack>
+      )}
+
+      <Dialog open={!!pendingDelete} onClose={() => setPendingDelete(null)}>
+        <DialogTitle>Delete pipeline?</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2">
+            Are you sure you want to delete <strong>{pendingDelete?.name}</strong>? This action cannot be
+            undone.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setPendingDelete(null)}>Cancel</Button>
+          <Button color="error" variant="contained" onClick={handleConfirmDelete}>
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </PageContent>
+  );
+};
+
+export default PipelinesListPage;

--- a/portals/cloud-plugins/apip-cloud-ui-pipelines/src/ProjectPipelinesPage.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-pipelines/src/ProjectPipelinesPage.tsx
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+import { useMemo, useState, type FC } from 'react';
+import {
+  Box,
+  Button,
+  Checkbox,
+  Chip,
+  Collapse,
+  ComplexSelect,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  ListSubheader,
+  PageContent,
+  PageTitle,
+  Stack,
+  Tooltip,
+  Typography,
+} from '@wso2/oxygen-ui';
+import { ArrowRight, ChevronDown, ChevronUp, Plus, X } from '@wso2/oxygen-ui-icons-react';
+import PipelineStageCard from './components/PipelineStageCard';
+import type { Environment, Pipeline } from './types';
+
+export type ProjectPipelinesPageProps = {
+  pipelines: Pipeline[];
+  organizationPipelines: Pipeline[];
+  environments: Environment[];
+  onAssociate: (pipelineIds: string[]) => void;
+  onRemove: (pipelineId: string) => void;
+};
+
+const ProjectPipelinesPage: FC<ProjectPipelinesPageProps> = ({
+  pipelines,
+  organizationPipelines,
+  environments,
+  onAssociate,
+  onRemove,
+}) => {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [selectorOpen, setSelectorOpen] = useState(false);
+  const [expandedIds, setExpandedIds] = useState<string[]>(() => pipelines.map((pipeline) => pipeline.id));
+
+  const associatedIds = useMemo(() => new Set(pipelines.map((pipeline) => pipeline.id)), [pipelines]);
+  const availablePipelines = organizationPipelines.filter(
+    (pipeline) => !pipeline.isDefault && !associatedIds.has(pipeline.id)
+  );
+
+  const closeDialog = () => {
+    setDialogOpen(false);
+    setSelectorOpen(false);
+    setSelectedIds([]);
+  };
+
+  const handleAdd = () => {
+    onAssociate(selectedIds);
+    setExpandedIds((current) => [...new Set([...current, ...selectedIds])]);
+    closeDialog();
+  };
+
+  return (
+    <PageContent fullWidth>
+      <PageTitle sx={{ mb: 2 }}>
+        <PageTitle.Header>Continuous Deployment Pipelines</PageTitle.Header>
+        <PageTitle.Actions>
+          <Tooltip
+            title={availablePipelines.length === 0 ? 'All organization pipelines are already associated with this project.' : ''}
+          >
+            <span>
+              <Button
+                variant="contained"
+                size="small"
+                startIcon={<Plus size={16} />}
+                onClick={() => setDialogOpen(true)}
+                disabled={availablePipelines.length === 0}
+              >
+                Add
+              </Button>
+            </span>
+          </Tooltip>
+        </PageTitle.Actions>
+      </PageTitle>
+
+      {pipelines.length === 0 ? (
+        <Box sx={{ border: '1px dashed', borderColor: 'divider', borderRadius: 1.5, py: 6, textAlign: 'center' }}>
+          <Typography variant="body2" color="text.secondary">
+            No organization pipelines are available for this project.
+          </Typography>
+        </Box>
+      ) : (
+        <Stack spacing={2}>
+          {pipelines.map((pipeline) => {
+            const expanded = expandedIds.includes(pipeline.id);
+            return (
+              <Box key={pipeline.id} sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1.5, overflow: 'hidden' }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: 2, py: 1.5, bgcolor: 'action.hover' }}>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <Typography variant="subtitle1">{pipeline.name}</Typography>
+                    {pipeline.isDefault ? <Chip label="Default" size="small" color="primary" variant="outlined" /> : null}
+                  </Box>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    {!pipeline.isDefault ? (
+                      <Button size="small" variant="outlined" color="error" onClick={() => onRemove(pipeline.id)}>
+                        Remove
+                      </Button>
+                    ) : null}
+                    <IconButton
+                      size="small"
+                      aria-label={expanded ? `Collapse ${pipeline.name}` : `Expand ${pipeline.name}`}
+                      onClick={() => setExpandedIds((current) =>
+                        current.includes(pipeline.id)
+                          ? current.filter((id) => id !== pipeline.id)
+                          : [...current, pipeline.id]
+                      )}
+                    >
+                      {expanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+                    </IconButton>
+                  </Box>
+                </Box>
+                <Collapse in={expanded}>
+                  <Box sx={{ px: 2, py: 2, display: 'flex', alignItems: 'center', gap: 1.5, flexWrap: 'wrap' }}>
+                    {pipeline.stages.map((stage, index) => {
+                      const environment = environments.find((item) => item.id === stage.environmentId);
+                      const gateway = environment?.gateways.find((item) => item.id === stage.defaultGatewayId);
+                      return (
+                        <Box key={stage.id} sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+                          {index > 0 ? <Box sx={{ display: 'flex', color: 'text.secondary' }}><ArrowRight size={18} /></Box> : null}
+                          <PipelineStageCard
+                            environmentName={environment?.name ?? stage.environmentId}
+                            gatewayName={gateway?.name ?? stage.defaultGatewayId}
+                            critical={environment?.critical}
+                          />
+                        </Box>
+                      );
+                    })}
+                  </Box>
+                </Collapse>
+              </Box>
+            );
+          })}
+        </Stack>
+      )}
+
+      <Dialog open={dialogOpen} onClose={closeDialog} fullWidth maxWidth="sm">
+        <DialogTitle sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          Add Deployment Pipelines
+          <IconButton aria-label="Close" onClick={closeDialog}><X size={20} /></IconButton>
+        </DialogTitle>
+        <DialogContent>
+          <Typography color="text.secondary" sx={{ mb: 2 }}>
+            Select deployment pipelines to add to your project.
+          </Typography>
+          <ComplexSelect
+            fullWidth
+            multiple
+            displayEmpty
+            open={selectorOpen}
+            onOpen={() => setSelectorOpen(true)}
+            onClose={() => setSelectorOpen(false)}
+            value={selectedIds}
+            onChange={(event) => {
+              const value = event.target.value;
+              setSelectedIds(typeof value === 'string' ? value.split(',') : value as string[]);
+            }}
+            renderValue={(selected) => {
+              const ids = selected as string[];
+              if (ids.length === 0) {
+                return <Typography color="text.secondary">Select pipelines</Typography>;
+              }
+              return ids
+                .map((id) => availablePipelines.find((pipeline) => pipeline.id === id)?.name)
+                .filter(Boolean)
+                .join(', ');
+            }}
+            MenuProps={{
+              autoFocus: false,
+              disableAutoFocusItem: true,
+              slotProps: { paper: { sx: { maxHeight: 320 } } },
+            }}
+          >
+            <ListSubheader
+              component="div"
+              sx={{ display: 'flex', justifyContent: 'space-between', borderBottom: '1px solid', borderColor: 'divider' }}
+            >
+              <Button
+                size="small"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  setSelectedIds(availablePipelines.map((pipeline) => pipeline.id));
+                }}
+              >
+                Select All
+              </Button>
+              <Button
+                size="small"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  setSelectedIds([]);
+                }}
+              >
+                Clear
+              </Button>
+            </ListSubheader>
+            {availablePipelines.map((pipeline) => (
+              <ComplexSelect.MenuItem key={pipeline.id} value={pipeline.id}>
+                <Checkbox checked={selectedIds.includes(pipeline.id)} />
+                <ComplexSelect.MenuItem.Text primary={pipeline.name} />
+              </ComplexSelect.MenuItem>
+            ))}
+          </ComplexSelect>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={closeDialog}>Cancel</Button>
+          <Tooltip title={selectedIds.length === 0 ? 'Select at least one pipeline to add.' : ''}>
+            <span>
+              <Button variant="contained" disabled={selectedIds.length === 0} onClick={handleAdd}>
+                Add
+              </Button>
+            </span>
+          </Tooltip>
+        </DialogActions>
+      </Dialog>
+    </PageContent>
+  );
+};
+
+export default ProjectPipelinesPage;

--- a/portals/cloud-plugins/apip-cloud-ui-pipelines/src/components/EnvironmentGatewayPicker.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-pipelines/src/components/EnvironmentGatewayPicker.tsx
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+import { useEffect, useState, type FC } from 'react';
+import {
+  Box,
+  Button,
+  IconButton,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemText,
+  Popover,
+  Switch,
+  Tooltip,
+  Typography,
+} from '@wso2/oxygen-ui';
+import { ChevronLeft } from '@wso2/oxygen-ui-icons-react';
+
+import type { Environment, PipelineStage } from '../types';
+
+export type EnvironmentGatewayPickerProps = {
+  open: boolean;
+  anchorEl: HTMLElement | null;
+  /** All environments the pipeline could target. */
+  environments: Environment[];
+  /** Stages already in this pipeline — an environment used by any of them is offered but disabled, not hidden, so the count stays legible. One pipeline may use a given environment at most once. */
+  usedStages: Pick<PipelineStage, 'environmentId'>[];
+  onClose: () => void;
+  /**
+   * Called once the user confirms adding an environment — the whole
+   * environment (every gateway it has) becomes the stage; `defaultGatewayId`
+   * is whichever gateway they toggled on. An environment with exactly one
+   * gateway skips straight to this call, that gateway as the default — no
+   * toggle step to show.
+   */
+  onAdd: (environmentId: string, defaultGatewayId: string) => void;
+};
+
+/**
+ * The environment picker: step 1 always shows environments; step 2 (marking
+ * the default gateway) only appears when the chosen environment has more
+ * than one gateway — with exactly one, it's the default automatically and
+ * step 2 is skipped.
+ */
+const EnvironmentGatewayPicker: FC<EnvironmentGatewayPickerProps> = ({
+  open,
+  anchorEl,
+  environments,
+  usedStages,
+  onClose,
+  onAdd,
+}) => {
+  const [selectedEnvironmentId, setSelectedEnvironmentId] = useState<string | null>(null);
+  const [defaultGatewayId, setDefaultGatewayId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setSelectedEnvironmentId(null);
+      setDefaultGatewayId(null);
+    }
+  }, [open]);
+
+  const selectedEnvironment = environments.find((env) => env.id === selectedEnvironmentId) ?? null;
+
+  const isEnvironmentUsed = (environmentId: string) =>
+    usedStages.some((stage) => stage.environmentId === environmentId);
+
+  const handleSelectEnvironment = (environment: Environment) => {
+    if (environment.gateways.length <= 1) {
+      const [onlyGateway] = environment.gateways;
+      if (onlyGateway) onAdd(environment.id, onlyGateway.id);
+      onClose();
+      return;
+    }
+    setSelectedEnvironmentId(environment.id);
+    setDefaultGatewayId(environment.gateways[0]?.id ?? null);
+  };
+
+  const handleConfirmAdd = () => {
+    if (!selectedEnvironment || !defaultGatewayId) return;
+    onAdd(selectedEnvironment.id, defaultGatewayId);
+    onClose();
+  };
+
+  return (
+    <Popover
+      open={open}
+      anchorEl={anchorEl}
+      onClose={onClose}
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+      transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+    >
+      <Box sx={{ width: 260 }}>
+        {selectedEnvironment ? (
+          <>
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 0.5,
+                px: 1,
+                py: 1,
+                borderBottom: '1px solid',
+                borderColor: 'divider',
+              }}
+            >
+              <IconButton
+                size="small"
+                aria-label="Back to environments"
+                onClick={() => setSelectedEnvironmentId(null)}
+              >
+                <ChevronLeft size={18} />
+              </IconButton>
+              <Typography variant="subtitle2">
+                Mark default gateway in {selectedEnvironment.name}
+              </Typography>
+            </Box>
+            <List dense sx={{ py: 0.5 }}>
+              {selectedEnvironment.gateways.map((gateway) => (
+                <ListItem
+                  key={gateway.id}
+                  secondaryAction={
+                    <Switch
+                      size="small"
+                      checked={gateway.id === defaultGatewayId}
+                      onChange={() => setDefaultGatewayId(gateway.id)}
+                      inputProps={{ 'aria-label': `Mark ${gateway.name} as default` }}
+                    />
+                  }
+                >
+                  <ListItemText
+                    primary={gateway.name}
+                    secondary={gateway.id === defaultGatewayId ? 'Default' : undefined}
+                  />
+                </ListItem>
+              ))}
+            </List>
+            <Box sx={{ px: 1.5, pb: 1.5, pt: 0.5 }}>
+              <Tooltip title={!defaultGatewayId ? 'Select a default gateway before adding the environment.' : ''}>
+                <span style={{ display: 'block' }}>
+                  <Button fullWidth variant="contained" disabled={!defaultGatewayId} onClick={handleConfirmAdd}>
+                    Add Environment
+                  </Button>
+                </span>
+              </Tooltip>
+            </Box>
+          </>
+        ) : (
+          <>
+            <Typography variant="subtitle2" sx={{ px: 2, pt: 1.5, pb: 0.5 }}>
+              Select Environment
+            </Typography>
+            <List dense sx={{ py: 0.5 }}>
+              {environments.map((environment) => {
+                const disabled = isEnvironmentUsed(environment.id);
+                return (
+                  <Tooltip
+                    key={environment.id}
+                    title={disabled ? 'This environment is already part of the pipeline.' : ''}
+                    placement="right"
+                  >
+                    <Box component="span" sx={{ display: 'block' }}>
+                      <ListItemButton
+                        disabled={disabled}
+                        onClick={() => handleSelectEnvironment(environment)}
+                      >
+                        <ListItemText
+                          primary={environment.name}
+                          secondary={
+                            disabled
+                              ? 'Already added'
+                              : `${environment.gateways.length} gateway${environment.gateways.length === 1 ? '' : 's'}`
+                          }
+                        />
+                      </ListItemButton>
+                    </Box>
+                  </Tooltip>
+                );
+              })}
+              {environments.every((environment) => isEnvironmentUsed(environment.id)) ? (
+                <Typography variant="body2" color="text.secondary" sx={{ px: 2, py: 1 }}>
+                  All environments have been added.
+                </Typography>
+              ) : null}
+            </List>
+          </>
+        )}
+      </Box>
+    </Popover>
+  );
+};
+
+export default EnvironmentGatewayPicker;

--- a/portals/cloud-plugins/apip-cloud-ui-pipelines/src/components/PipelineStageCard.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-pipelines/src/components/PipelineStageCard.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+import type { FC } from 'react';
+import { Box, Chip, IconButton, Typography } from '@wso2/oxygen-ui';
+import { X } from '@wso2/oxygen-ui-icons-react';
+
+export type PipelineStageCardProps = {
+  environmentName: string;
+  /** The stage's default gateway name — the only one shown, even when the environment has others. */
+  gatewayName: string;
+  critical?: boolean;
+  onRemove?: () => void;
+};
+
+const PipelineStageCard: FC<PipelineStageCardProps> = ({
+  environmentName,
+  gatewayName,
+  critical,
+  onRemove,
+}) => {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'flex-start',
+        justifyContent: 'space-between',
+        gap: 1,
+        minWidth: 220,
+        px: 2,
+        py: 1.5,
+        borderRadius: 1.5,
+        border: '1px solid',
+        borderColor: 'divider',
+        bgcolor: 'background.paper',
+      }}
+    >
+      <Box>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Typography variant="body2" sx={{ fontWeight: 600 }}>
+            {environmentName}
+          </Typography>
+          {critical ? (
+            <Chip
+              label="Critical"
+              size="small"
+              color="warning"
+              variant="outlined"
+              sx={{ height: 20, fontSize: '0.7rem' }}
+            />
+          ) : null}
+        </Box>
+        <Typography variant="caption" color="text.secondary">
+          {gatewayName}
+        </Typography>
+      </Box>
+      {onRemove ? (
+        <IconButton
+          size="small"
+          aria-label={`Remove ${environmentName}`}
+          onClick={onRemove}
+          sx={{ mt: -0.5, mr: -1 }}
+        >
+          <X size={16} />
+        </IconButton>
+      ) : null}
+    </Box>
+  );
+};
+
+export default PipelineStageCard;

--- a/portals/cloud-plugins/apip-cloud-ui-pipelines/src/hostPort.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-pipelines/src/hostPort.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+/**
+ * Hand-mirrors `AIWorkspaceHostPort` from api-platform's
+ * `portals/ai-workspace/src/hostPort.tsx` — api-platform and apim-saas are
+ * separate git repos, so this type is duplicated by hand (small, stable,
+ * rarely-changing) rather than imported. This package only ever receives a
+ * value of this shape as a plain prop; never a shared React Context.
+ */
+export type NotifySeverity = 'success' | 'info' | 'warning' | 'error';
+
+export type AIWorkspaceHostPort = {
+  orgHandle: string;
+  projectHandle?: string;
+  navigate: (path: string) => void;
+  notify: (message: string, severity?: NotifySeverity) => void;
+};

--- a/portals/cloud-plugins/apip-cloud-ui-pipelines/src/index.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-pipelines/src/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+export { default as PipelinesFeature } from './PipelinesFeature';
+export type { PipelinesFeatureProps } from './PipelinesFeature';
+export { default as ProjectPipelinesPage } from './ProjectPipelinesPage';
+export type { ProjectPipelinesPageProps } from './ProjectPipelinesPage';
+export type { AIWorkspaceHostPort, NotifySeverity } from './hostPort';
+export type { CreatePipelineInput, Environment, Gateway, Pipeline, PipelineStage, UpdatePipelineInput } from './types';

--- a/portals/cloud-plugins/apip-cloud-ui-pipelines/src/mocks/pipelines.mock.json
+++ b/portals/cloud-plugins/apip-cloud-ui-pipelines/src/mocks/pipelines.mock.json
@@ -1,0 +1,44 @@
+{
+  "environments": [
+    {
+      "id": "env-development",
+      "name": "Development",
+      "gateways": [{ "id": "gw-us-dataplane", "name": "Choreo Cloud US Dataplane" }]
+    },
+    {
+      "id": "env-production",
+      "name": "Production",
+      "critical": true,
+      "gateways": [{ "id": "gw-us-dataplane", "name": "Choreo Cloud US Dataplane" }]
+    },
+    {
+      "id": "env-foo",
+      "name": "foo",
+      "gateways": [{ "id": "gw-foo-primary", "name": "Foo Gateway" }]
+    },
+    {
+      "id": "env-foo2",
+      "name": "foo2",
+      "gateways": [
+        { "id": "gw-foo2-a", "name": "Foo2 Gateway A" },
+        { "id": "gw-foo2-b", "name": "Foo2 Gateway B" }
+      ]
+    },
+    {
+      "id": "env-foo3",
+      "name": "foo3",
+      "gateways": [{ "id": "gw-foo3-primary", "name": "Foo3 Gateway" }]
+    }
+  ],
+  "pipelines": [
+    {
+      "id": "pipeline-default-us-cdp-2",
+      "name": "Default US-CDP-2 Deployment Pipeline",
+      "isDefault": true,
+      "stages": [
+        { "environmentId": "env-development", "defaultGatewayId": "gw-us-dataplane" },
+        { "environmentId": "env-production", "defaultGatewayId": "gw-us-dataplane" }
+      ]
+    }
+  ]
+}

--- a/portals/cloud-plugins/apip-cloud-ui-pipelines/src/mocks/pipelinesStore.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-pipelines/src/mocks/pipelinesStore.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+import mockData from './pipelines.mock.json';
+import type { CreatePipelineInput, Environment, Pipeline, PipelineStage, UpdatePipelineInput } from '../types';
+
+/** The checked-in mock JSON predates per-stage ids; backfill one at seed time. */
+type SeedPipeline = Omit<Pipeline, 'stages'> & { stages: Omit<PipelineStage, 'id'>[] };
+
+/**
+ * In-memory stand-in for the pipelines backend. Seeded once from the checked-in
+ * mock JSON and mutated in place for the lifetime of the tab, so create/delete
+ * are reflected immediately without a real API — swap for real client calls
+ * once the pipelines service exists.
+ */
+let pipelines: Pipeline[] = (mockData.pipelines as SeedPipeline[]).map((pipeline) => ({
+  ...pipeline,
+  stages: pipeline.stages.map((stage) => ({ ...stage, id: crypto.randomUUID() })),
+}));
+
+const environments: Environment[] = mockData.environments as Environment[];
+
+/** Project associations contain only explicitly-added pipeline ids. The
+ * organization default is inherited dynamically and is never persisted here. */
+const projectPipelineIds = new Map<string, Set<string>>();
+
+const projectKey = (orgHandle: string, projectHandle: string) =>
+  `${orgHandle}/${projectHandle}`;
+
+export function listEnvironments(): Environment[] {
+  return environments;
+}
+
+export function listPipelines(): Pipeline[] {
+  return pipelines;
+}
+
+export function createPipeline(input: CreatePipelineInput): Pipeline {
+  const created: Pipeline = {
+    id: `pipeline-${Date.now()}`,
+    name: input.name,
+    isDefault: input.isDefault,
+    stages: input.stages,
+  };
+  pipelines = input.isDefault
+    ? [...pipelines.map((pipeline) => ({ ...pipeline, isDefault: false })), created]
+    : [...pipelines, created];
+  return created;
+}
+
+export function updatePipeline(input: UpdatePipelineInput): Pipeline {
+  const updated: Pipeline = {
+    id: input.id,
+    name: input.name,
+    isDefault: input.isDefault,
+    stages: input.stages,
+  };
+  pipelines = pipelines.map((pipeline) => {
+    if (pipeline.id === input.id) return updated;
+    return input.isDefault ? { ...pipeline, isDefault: false } : pipeline;
+  });
+  return updated;
+}
+
+export function deletePipeline(id: string): void {
+  pipelines = pipelines.filter((pipeline) => pipeline.id !== id);
+  projectPipelineIds.forEach((ids) => ids.delete(id));
+}
+
+export function listProjectPipelines(orgHandle: string, projectHandle: string): Pipeline[] {
+  const associatedIds = projectPipelineIds.get(projectKey(orgHandle, projectHandle)) ?? new Set<string>();
+  return pipelines.filter((pipeline) => pipeline.isDefault || associatedIds.has(pipeline.id));
+}
+
+export function associateProjectPipelines(
+  orgHandle: string,
+  projectHandle: string,
+  pipelineIds: readonly string[]
+): void {
+  const key = projectKey(orgHandle, projectHandle);
+  const ids = new Set(projectPipelineIds.get(key));
+  pipelineIds.forEach((id) => {
+    const pipeline = pipelines.find((candidate) => candidate.id === id);
+    if (pipeline && !pipeline.isDefault) ids.add(id);
+  });
+  projectPipelineIds.set(key, ids);
+}
+
+export function removeProjectPipeline(
+  orgHandle: string,
+  projectHandle: string,
+  pipelineId: string
+): void {
+  projectPipelineIds.get(projectKey(orgHandle, projectHandle))?.delete(pipelineId);
+}

--- a/portals/cloud-plugins/apip-cloud-ui-pipelines/src/types.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-pipelines/src/types.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+export type Gateway = {
+  id: string;
+  name: string;
+};
+
+/** A deployment environment. `gateways` is the set a pipeline stage on this environment may target. */
+export type Environment = {
+  id: string;
+  name: string;
+  gateways: Gateway[];
+  /** Marks an environment as production-grade for the "Critical" badge on its pipeline stages. */
+  critical?: boolean;
+};
+
+/**
+ * One step of a pipeline: an environment, deploying through every gateway it
+ * has — not a single chosen one. `defaultGatewayId` is marked (via toggle) at
+ * the moment the environment is added to the pipeline and is shown as the
+ * "Default" chip among that environment's gateways on the stage card.
+ */
+export type PipelineStage = {
+  /** Stable per-stage id, distinct from `environmentId` — a pipeline can only use a given environment once today, but stages are still id-keyed rather than environmentId-keyed so that isn't baked into every consumer. */
+  id: string;
+  environmentId: string;
+  defaultGatewayId: string;
+};
+
+export type Pipeline = {
+  id: string;
+  name: string;
+  isDefault: boolean;
+  stages: PipelineStage[];
+};
+
+export type CreatePipelineInput = {
+  name: string;
+  isDefault: boolean;
+  stages: PipelineStage[];
+};
+
+export type UpdatePipelineInput = CreatePipelineInput & {
+  id: string;
+};

--- a/portals/cloud-plugins/apip-cloud-ui-pipelines/tsconfig.json
+++ b/portals/cloud-plugins/apip-cloud-ui-pipelines/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "baseUrl": ".",
+    "paths": {
+      "@wso2/oxygen-ui": ["../../ai-workspace/node_modules/@wso2/oxygen-ui"],
+      "@wso2/oxygen-ui-icons-react": ["../../ai-workspace/node_modules/@wso2/oxygen-ui-icons-react"],
+      "react": ["../../ai-workspace/node_modules/@types/react/index.d.ts"],
+      "react/jsx-runtime": ["../../ai-workspace/node_modules/@types/react/jsx-runtime.d.ts"]
+    },
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"]
+}

--- a/portals/cloud-plugins/apip-cloud-ui/README.md
+++ b/portals/cloud-plugins/apip-cloud-ui/README.md
@@ -1,0 +1,25 @@
+# APIP Cloud UI
+
+Shared cloud-plugin registration for API Platform portals. `src/plugin.ts` is
+host-agnostic: it selects one version per plugin ID and flattens that release's
+extensions. Each module under `src/hosts` registers features against a portal's
+native extension contract.
+
+## Layout
+
+- `src/hosts/ai-workspace.tsx` registers the Pipelines feature for AI Workspace.
+- `src/hosts/api-control-plane.tsx` is the API Control Plane registry; it is empty
+  until a control-plane cloud feature is added.
+- `../apip-cloud-ui-pipelines` contains the reusable Pipelines UI.
+
+AI Workspace consumes this package through a local file dependency and re-exports
+its registry from `portals/ai-workspace/src/cloud/index.ts`. Both the web app and
+plugins therefore build from one api-platform revision.
+
+```ts
+import { aiWorkspaceCloudExtensions } from '@wso2-enterprise/apip-cloud-ui';
+```
+
+To add another AI Workspace plugin, create a sibling package in
+`portals/cloud-plugins`, add it as a dependency here, and register its extension in
+`src/hosts/ai-workspace.tsx`.

--- a/portals/cloud-plugins/apip-cloud-ui/package.json
+++ b/portals/cloud-plugins/apip-cloud-ui/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@wso2-enterprise/apip-cloud-ui",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "_phase:build": "tsc --noEmit",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@wso2-enterprise/apip-cloud-ui-pipelines": "file:../apip-cloud-ui-pipelines",
+    "@wso2/oxygen-ui": "0.5.0",
+    "@wso2/oxygen-ui-icons-react": "0.5.0",
+    "react": "19.2.3"
+  },
+  "devDependencies": {
+    "@types/react": "19.2.17",
+    "typescript": "5.9.3"
+  }
+}

--- a/portals/cloud-plugins/apip-cloud-ui/scripts/install-plugin.mjs
+++ b/portals/cloud-plugins/apip-cloud-ui/scripts/install-plugin.mjs
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+// Fills in per-feature version placeholders in a copied host file.
+//
+// api-control-plane's extension seam is native (see api-platform's
+// portals/api-control-plane/src/extensions.tsx) — main.tsx already imports
+// `cloudExtensions` from a checked-in `src/cloud` stub unconditionally, so
+// the Dockerfile only needs to overlay this package's host file over that
+// stub. No App.tsx/main.tsx/sidebar source patching happens here, unlike the
+// older ai-workspace `install-plugin.mjs`, which pre-dates ai-workspace
+// having that same native seam.
+//
+// Usage: node install-plugin.mjs <path-to-host.tsx> [FEATURE_VERSION=x.y.z ...]
+// Each KEY=value replaces the literal token __KEY__ in the target file. A
+// build with zero registered features (the case today) passes zero version
+// arguments and this is a no-op copy.
+import { readFile, writeFile } from 'node:fs/promises';
+
+const [hostFile, ...versionArgs] = process.argv.slice(2);
+if (!hostFile) {
+  throw new Error(
+    'Usage: install-plugin.mjs <path-to-host.tsx> [FEATURE_VERSION=x.y.z ...]'
+  );
+}
+
+let source = await readFile(hostFile, 'utf8');
+
+for (const arg of versionArgs) {
+  const separatorIndex = arg.indexOf('=');
+  if (separatorIndex <= 0) {
+    throw new Error(`Malformed version argument "${arg}" (expected KEY=value)`);
+  }
+  const key = arg.slice(0, separatorIndex);
+  const value = arg.slice(separatorIndex + 1);
+  const token = `__${key}__`;
+  if (!source.includes(token)) {
+    throw new Error(`Placeholder ${token} not found in ${hostFile}`);
+  }
+  source = source.split(token).join(value);
+}
+
+await writeFile(hostFile, source, 'utf8');

--- a/portals/cloud-plugins/apip-cloud-ui/src/hosts/ai-workspace.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui/src/hosts/ai-workspace.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+import { Workflow } from '@wso2/oxygen-ui-icons-react';
+
+import { PipelinesFeature } from '@wso2-enterprise/apip-cloud-ui-pipelines';
+import type { AIWorkspaceExtension } from '../../../../ai-workspace/src/extensions';
+import { defineCloudPlugin, getCloudExtensions, type CloudPluginFeature } from '../plugin';
+
+/**
+ * Cloud features registered for the AI Workspace host. The host owns routing,
+ * organization/project scope, navigation and notifications; each plugin only
+ * renders against the small host port passed to it.
+ */
+export const cloudPluginFeatures: CloudPluginFeature<AIWorkspaceExtension>[] = [
+  defineCloudPlugin({
+    id: 'pipelines',
+    version: '0.1.0',
+    extensions: [
+      {
+        id: 'pipelines',
+        slot: 'sidebar.main',
+        order: 60,
+        path: 'pipelines',
+        label: 'Pipelines',
+        icon: <Workflow size={20} />,
+        render: (port) => <PipelinesFeature port={port} />,
+      },
+    ],
+  }),
+];
+
+export const cloudExtensions = getCloudExtensions(cloudPluginFeatures);
+export type { AIWorkspaceExtension };

--- a/portals/cloud-plugins/apip-cloud-ui/src/hosts/api-control-plane.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui/src/hosts/api-control-plane.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+import type { ReactNode } from 'react';
+
+import { getCloudExtensions, type CloudPluginFeature } from '../plugin';
+
+/**
+ * Mirrors `ApiControlPlaneExtension` from api-platform's
+ * `portals/api-control-plane/src/extensions.tsx`. Duplicated, not imported —
+ * api-platform and apim-saas are separate git repos; this file is only ever
+ * glued to that source at Docker-build time (this package's `src/` is copied
+ * into the cloned portal tree as `src/cloud`, see
+ * `services/apip-api-control-plane/Dockerfile`), never at typecheck time
+ * here. Keep this in sync by hand if that type's shape changes upstream.
+ */
+export type ApiControlPlaneExtension = {
+  id: string;
+  routePath: string;
+  element: ReactNode;
+  label: string;
+  icon?: ReactNode;
+  level: 'organization' | 'project' | 'api';
+  group?: string;
+  order: number;
+  isVisible?: (scope: unknown) => boolean;
+};
+
+/**
+ * No cloud feature has been built for the console yet — this starts empty on
+ * purpose. Add a `defineCloudPlugin<ApiControlPlaneExtension>({...})` entry
+ * here per feature once one exists; `services/apip-api-control-plane/VERSION`
+ * gets a matching `CLOUD_UI_<FEATURE>_VERSION` key at that point.
+ */
+export const cloudPluginFeatures: CloudPluginFeature<ApiControlPlaneExtension>[] =
+  [];
+
+export const cloudExtensions = getCloudExtensions(cloudPluginFeatures);

--- a/portals/cloud-plugins/apip-cloud-ui/src/index.ts
+++ b/portals/cloud-plugins/apip-cloud-ui/src/index.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+export { defineCloudPlugin, getCloudExtensions } from './plugin';
+export type { CloudPluginFeature } from './plugin';
+
+export {
+  cloudExtensions as apiControlPlaneCloudExtensions,
+  cloudPluginFeatures as apiControlPlaneCloudPluginFeatures,
+} from './hosts/api-control-plane';
+export type { ApiControlPlaneExtension } from './hosts/api-control-plane';
+
+export {
+  cloudExtensions as aiWorkspaceCloudExtensions,
+  cloudPluginFeatures as aiWorkspaceCloudPluginFeatures,
+} from './hosts/ai-workspace';
+export type { AIWorkspaceExtension } from './hosts/ai-workspace';

--- a/portals/cloud-plugins/apip-cloud-ui/src/plugin.ts
+++ b/portals/cloud-plugins/apip-cloud-ui/src/plugin.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+/**
+ * Generic, host-agnostic plugin registration: given a set of independently
+ * released feature versions (one `CloudPluginFeature` per plugin id, each
+ * carrying its own version and the extensions it contributes), pick exactly
+ * one release per plugin id and flatten their extensions into a single list.
+ *
+ * Deliberately has no opinion on what an "extension" looks like — each host
+ * module (see `hosts/api-control-plane.tsx`) supplies its own concrete
+ * extension type as `TExtension`, since different host portals need
+ * different extension shapes (e.g. api-control-plane's extensions carry a
+ * sidebar `level`/`order`, ai-workspace's don't).
+ */
+export type CloudPluginFeature<TExtension> = {
+  id: string;
+  version: string;
+  releaseTag?: string;
+  extensions: readonly TExtension[];
+};
+
+export function defineCloudPlugin<
+  TExtension,
+  const T extends CloudPluginFeature<TExtension>,
+>(plugin: T): T {
+  return plugin;
+}
+
+/**
+ * Only one release per plugin id is activated. When multiple releases are
+ * registered for the same id, `enabledVersions[id]` selects one explicitly;
+ * without a selection, the highest semantic version wins.
+ */
+export function getCloudExtensions<TExtension>(
+  plugins: readonly CloudPluginFeature<TExtension>[],
+  enabledVersions: Readonly<Record<string, string>> = {}
+): TExtension[] {
+  const selected = new Map<string, CloudPluginFeature<TExtension>>();
+  for (const plugin of plugins) {
+    const requestedVersion = enabledVersions[plugin.id];
+    if (requestedVersion && requestedVersion !== plugin.version) continue;
+    const current = selected.get(plugin.id);
+    if (!current || compareVersions(plugin.version, current.version) > 0) {
+      selected.set(plugin.id, plugin);
+    }
+  }
+  return [...selected.values()].flatMap((plugin) => [...plugin.extensions]);
+}
+
+function compareVersions(left: string, right: string): number {
+  const parse = (version: string) =>
+    version.split('.').map((part) => Number.parseInt(part, 10) || 0);
+  const a = parse(left);
+  const b = parse(right);
+  for (let index = 0; index < Math.max(a.length, b.length); index += 1) {
+    const difference = (a[index] ?? 0) - (b[index] ?? 0);
+    if (difference !== 0) return difference;
+  }
+  return 0;
+}

--- a/portals/cloud-plugins/apip-cloud-ui/tsconfig.json
+++ b/portals/cloud-plugins/apip-cloud-ui/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "baseUrl": ".",
+    "paths": {
+      "@wso2-enterprise/apip-cloud-ui-pipelines": ["../apip-cloud-ui-pipelines/src/index.ts"],
+      "@wso2/oxygen-ui": ["../../ai-workspace/node_modules/@wso2/oxygen-ui"],
+      "@wso2/oxygen-ui-icons-react": ["../../ai-workspace/node_modules/@wso2/oxygen-ui-icons-react"],
+      "react": ["../../ai-workspace/node_modules/@types/react/index.d.ts"],
+      "react/jsx-runtime": ["../../ai-workspace/node_modules/@types/react/jsx-runtime.d.ts"]
+    },
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
This pull request introduces a new "Deployment Pipelines" feature for the cloud UI as a standalone plugin. It adds a new package with all supporting UI, state management, and integration logic for listing, creating, editing, associating, and removing deployment pipelines. Additionally, there is a minor UI improvement to the sidebar divider in the main app shell.

Issue: https://github.com/wso2-enterprise/apim-saas/issues/2911

<img width="1722" height="953" alt="Screenshot 2026-08-25 at 15 18 49" src="https://github.com/user-attachments/assets/2cd0cebd-f6cf-4c77-bb4c-83e58255e0bb" />
<img width="1719" height="950" alt="Screenshot 2026-08-25 at 15 19 20" src="https://github.com/user-attachments/assets/de5c24a4-cb93-41e3-bc94-b6e329a17dde" />

**Deployment Pipelines Feature:**

* Added a new package `@wso2-enterprise/apip-cloud-ui-pipelines` with its own `package.json`, dependencies, and TypeScript configuration.
* Implemented the main feature container `PipelinesFeature.tsx`, which manages the navigation and state for listing, creating, editing, and associating pipelines, including project-specific logic.
* Added `PipelinesListPage.tsx` for displaying, searching, expanding, editing, and deleting pipelines, with a confirmation dialog for deletions.
* Added `PipelineCreatePage.tsx` for creating and editing pipelines, supporting pipeline name input, environment/gateway stage management, and form submission.

**UI Improvements:**

* In `AppSidebar.tsx`, added a visual divider above the "Cloud" extensions section for improved sidebar organization. [[1]](diffhunk://#diff-b66ed1a354b06c8db170f136461281126bd16f38b2f0a76d0fe8d80aa20956dfR313-L316) [[2]](diffhunk://#diff-b66ed1a354b06c8db170f136461281126bd16f38b2f0a76d0fe8d80aa20956dfR331)