### PR TITLE
ci: fix platform-api cloud-release webhook trigger and signature

### DIFF
--- a/.github/workflows/platform-api-cloud-release.yml
+++ b/.github/workflows/platform-api-cloud-release.yml
@@ -67,13 +67,13 @@ jobs:
 
           echo "Payload:"; cat payload.json
 
-          # Azure verifies HMAC-SHA1(secret, body) against the X-Hub-Signature header,
-          # formatted as "sha1=<hex>".
-          SIG="sha1=$(openssl dgst -sha1 -hmac "$AZURE_WEBHOOK_SECRET" payload.json | awk '{print $NF}')"
+          # Azure verifies HMAC-SHA1(secret, body) against the x-webhook-checksum
+          # header. The value is the bare hex digest (no "sha1=" prefix).
+          CHECKSUM="$(openssl dgst -sha1 -hmac "$AZURE_WEBHOOK_SECRET" payload.json | awk '{print $NF}')"
 
           HTTP_CODE=$(curl -sS --connect-timeout 10 --max-time 60 -o response.txt -w '%{http_code}' -X POST "$AZURE_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
-            -H "X-Hub-Signature: $SIG" \
+            -H "x-webhook-checksum: $CHECKSUM" \
             --data-binary @payload.json)
 
           echo "Azure webhook responded with HTTP ${HTTP_CODE}"


### PR DESCRIPTION
## Purpose

The `Platform API Cloud Release` workflow triggers the Azure DevOps build by POSTing a signed payload to an Incoming WebHook service connection. Two problems prevented it from working:

1. **Secrets unset on fork-PR merges.** The workflow triggered on `pull_request: [closed]`, but a `pull_request` run for a PR opened from a fork receives no repository secrets, so `AZURE_WEBHOOK_URL` / `AZURE_WEBHOOK_SECRET` were empty and the job failed the pre-flight secret check.
2. **Signature rejected by Azure.** Even on a manual run, Azure returned `RequiredHeaderSignatureNotFound` (HTTP 500) because the workflow sent the HMAC under GitHub's `X-Hub-Signature: sha1=<hex>` convention, while the Azure service connection reads it from the `x-webhook-checksum` header and expects the bare hex digest.

## Approach

- Switch the trigger from `pull_request: [closed]` to `push` on the release branches (`main`, `platform-api/v0.10.x`). A merge produces a push, which runs with full secret access and executes the workflow version on the pushed branch.
- Drop the now-unneeded merged-PR `if:` guard and the `pull_request`-specific `BRANCH`/`COMMIT` expressions in favour of `github.ref_name` / `github.sha`.
- Send the HMAC-SHA1 checksum under the `x-webhook-checksum` header, and drop the `sha1=` prefix so the value is the bare hex digest Azure expects.

## Related Issues

N/A

## Automation tests

N/A — CI workflow change only. Verified against the Azure DevOps webhook with a manual `curl` matching the header/checksum format, and via a manual `workflow_dispatch` run.

## Security checks
 - Followed secure coding standards? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes — the secret is still read from `secrets.AZURE_WEBHOOK_SECRET`.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)