### PR TITLE
ci: trigger platform-api cloud release on push, not pull_request

### DIFF
--- a/.github/workflows/platform-api-cloud-release.yml
+++ b/.github/workflows/platform-api-cloud-release.yml
@@ -1,22 +1,22 @@
 name: Platform API Cloud Release
 
 # The cloud image is built and pushed to ACR by an Azure DevOps pipeline. This
-# workflow no longer builds anything: on a merge into a release branch (main or
-# platform-api/v0.10.x) it just calls the Azure pipeline's incoming webhook,
-# passing the repo + branch to build. The payload is authenticated with an
-# HMAC-SHA1 signature.
+# workflow no longer builds anything: on a push to a release branch (main or
+# platform-api/v0.10.x) — which a merge produces — it just calls the Azure
+# pipeline's incoming webhook, passing the repo + branch to build. The payload
+# is authenticated with an HMAC-SHA1 signature.
 #
-# NOTE: pull_request runs the workflow from the PR's base branch, so this file
-# must be kept identical on every branch listed under `branches:` below.
+# Using `push` (not `pull_request: closed`) means the run has access to secrets
+# even when merging a PR opened from a fork, and the workflow that runs is the
+# version on the pushed branch.
 #
 # Required GitHub secrets:
-#   AZURE_WEBHOOK_URL    - https://dev.azure.com/<org>/_apis/public/distributedtask/webhooks/platform-api-cloud-release?api-version=6.0-preview
+#   AZURE_WEBHOOK_URL    - https://dev.azure.com/<org>/_apis/public/distributedtask/webhooks/PlatformApiCloudReleaseWebhook?api-version=6.0-preview
 #   AZURE_WEBHOOK_SECRET - the shared secret configured on the Incoming WebHook service connection
 
 on:
-  # Fire when a PR is merged into a release branch...
-  pull_request:
-    types: [closed]
+  # Fire on a push to a release branch (merging a PR produces such a push)...
+  push:
     branches:
       - main
       - platform-api/v0.10.x
@@ -38,17 +38,16 @@ concurrency:
 jobs:
   trigger-azure-build:
     runs-on: ubuntu-latest
-    # On pull_request only run for actual merges (not closed-without-merge).
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     steps:
       - name: Trigger Azure DevOps pipeline webhook
         env:
           AZURE_WEBHOOK_URL: ${{ secrets.AZURE_WEBHOOK_URL }}
           AZURE_WEBHOOK_SECRET: ${{ secrets.AZURE_WEBHOOK_SECRET }}
           REPO_URL: ${{ github.server_url }}/${{ github.repository }}
-          # base.ref/merge_commit_sha for merges; ref_name/sha for manual runs.
-          BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}
-          COMMIT: ${{ github.event_name == 'pull_request' && github.event.pull_request.merge_commit_sha || github.sha }}
+          # push and workflow_dispatch both expose the branch as ref_name and
+          # its HEAD (the merge commit, for a PR merge) as sha.
+          BRANCH: ${{ github.ref_name }}
+          COMMIT: ${{ github.sha }}
         run: |
           set -euo pipefail
           if [ -z "${AZURE_WEBHOOK_URL:-}" ] || [ -z "${AZURE_WEBHOOK_SECRET:-}" ]; then


### PR DESCRIPTION
## Purpose

Follow-up to #3311. The `Platform API Cloud Release` workflow triggered on `pull_request: [closed]`, but a `pull_request` run for a PR opened from a fork receives no repository secrets. Merges of fork PRs therefore failed the pre-flight check with `AZURE_WEBHOOK_URL` / `AZURE_WEBHOOK_SECRET` unset, and only a manual `workflow_dispatch` could trigger the Azure build.

## Approach

- Switch the trigger from `pull_request: [closed]` to `push` on the release branches (`main`, `platform-api/v0.10.x`). A merge produces a push, which runs with full secret access and executes the workflow version that lives on the pushed branch.
- Drop the now-unneeded merged-PR `if:` guard.
- Replace the `pull_request`-specific `BRANCH`/`COMMIT` expressions with `github.ref_name` / `github.sha`, which are correct for both `push` and `workflow_dispatch`.

## Related Issues

N/A — follow-up to #3311.

## Automation tests

N/A — CI workflow change only.

## Security checks
 - Followed secure coding standards? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes — the secret is still read from `secrets.AZURE_WEBHOOK_SECRET`.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)