### PR TITLE
ci: fix platform-api cloud-release webhook trigger and signature

### DIFF
--- a/.github/workflows/platform-api-cloud-release.yml
+++ b/.github/workflows/platform-api-cloud-release.yml
@@ -1,22 +1,22 @@
 name: Platform API Cloud Release
 
 # The cloud image is built and pushed to ACR by an Azure DevOps pipeline. This
-# workflow no longer builds anything: on a merge into a release branch (main or
-# platform-api/v0.10.x) it just calls the Azure pipeline's incoming webhook,
-# passing the repo + branch to build. The payload is authenticated with an
-# HMAC-SHA1 signature.
+# workflow no longer builds anything: on a push to a release branch (main or
+# platform-api/v0.10.x) — which a merge produces — it just calls the Azure
+# pipeline's incoming webhook, passing the repo + branch to build. The payload
+# is authenticated with an HMAC-SHA1 signature.
 #
-# NOTE: pull_request runs the workflow from the PR's base branch, so this file
-# must be kept identical on every branch listed under `branches:` below.
+# Using `push` (not `pull_request: closed`) means the run has access to secrets
+# even when merging a PR opened from a fork, and the workflow that runs is the
+# version on the pushed branch.
 #
 # Required GitHub secrets:
-#   AZURE_WEBHOOK_URL    - https://dev.azure.com/<org>/_apis/public/distributedtask/webhooks/platform-api-cloud-release?api-version=6.0-preview
+#   AZURE_WEBHOOK_URL    - https://dev.azure.com/<org>/_apis/public/distributedtask/webhooks/PlatformApiCloudReleaseWebhook?api-version=6.0-preview
 #   AZURE_WEBHOOK_SECRET - the shared secret configured on the Incoming WebHook service connection
 
 on:
-  # Fire when a PR is merged into a release branch...
-  pull_request:
-    types: [closed]
+  # Fire on a push to a release branch (merging a PR produces such a push)...
+  push:
     branches:
       - main
       - platform-api/v0.10.x
@@ -38,17 +38,16 @@ concurrency:
 jobs:
   trigger-azure-build:
     runs-on: ubuntu-latest
-    # On pull_request only run for actual merges (not closed-without-merge).
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     steps:
       - name: Trigger Azure DevOps pipeline webhook
         env:
           AZURE_WEBHOOK_URL: ${{ secrets.AZURE_WEBHOOK_URL }}
           AZURE_WEBHOOK_SECRET: ${{ secrets.AZURE_WEBHOOK_SECRET }}
           REPO_URL: ${{ github.server_url }}/${{ github.repository }}
-          # base.ref/merge_commit_sha for merges; ref_name/sha for manual runs.
-          BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}
-          COMMIT: ${{ github.event_name == 'pull_request' && github.event.pull_request.merge_commit_sha || github.sha }}
+          # push and workflow_dispatch both expose the branch as ref_name and
+          # its HEAD (the merge commit, for a PR merge) as sha.
+          BRANCH: ${{ github.ref_name }}
+          COMMIT: ${{ github.sha }}
         run: |
           set -euo pipefail
           if [ -z "${AZURE_WEBHOOK_URL:-}" ] || [ -z "${AZURE_WEBHOOK_SECRET:-}" ]; then

--- a/.github/workflows/platform-api-cloud-release.yml
+++ b/.github/workflows/platform-api-cloud-release.yml
@@ -67,13 +67,13 @@ jobs:
 
           echo "Payload:"; cat payload.json
 
-          # Azure verifies HMAC-SHA1(secret, body) against the X-Hub-Signature header,
-          # formatted as "sha1=<hex>".
-          SIG="sha1=$(openssl dgst -sha1 -hmac "$AZURE_WEBHOOK_SECRET" payload.json | awk '{print $NF}')"
+          # Azure verifies HMAC-SHA1(secret, body) against the x-webhook-checksum
+          # header. The value is the bare hex digest (no "sha1=" prefix).
+          CHECKSUM="$(openssl dgst -sha1 -hmac "$AZURE_WEBHOOK_SECRET" payload.json | awk '{print $NF}')"
 
           HTTP_CODE=$(curl -sS --connect-timeout 10 --max-time 60 -o response.txt -w '%{http_code}' -X POST "$AZURE_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
-            -H "X-Hub-Signature: $SIG" \
+            -H "x-webhook-checksum: $CHECKSUM" \
             --data-binary @payload.json)
 
           echo "Azure webhook responded with HTTP ${HTTP_CODE}"


### PR DESCRIPTION
## Purpose

Bring the `Platform API Cloud Release` workflow fixes already landed on (or in flight for) `platform-api/v0.10.x` over to `main`, so a merge into `main` triggers the Azure DevOps build correctly. The workflow header comment requires this file to stay identical across the release branches it lists. On `main` today it still has two problems:

1. **Wrong signature header/format.** Azure's Incoming WebHook service connection reads the HMAC from the `x-webhook-checksum` header and expects the bare hex digest, but the workflow sent GitHub's `X-Hub-Signature: sha1=<hex>`, so Azure rejected requests with `RequiredHeaderSignatureNotFound` (HTTP 500).
2. **Secrets unset on fork-PR merges.** The `pull_request: [closed]` trigger gives no repository secrets to runs for PRs opened from forks, so those merges failed the pre-flight secret check.

## Approach

- Send the HMAC-SHA1 checksum under the `x-webhook-checksum` header and drop the `sha1=` prefix (bare hex digest).
- Switch the trigger from `pull_request: [closed]` to `push` on the release branches (`main`, `platform-api/v0.10.x`); a merge produces a push, which runs with full secret access and executes the workflow version on the pushed branch.
- Drop the merged-PR `if:` guard and replace the `pull_request`-specific `BRANCH`/`COMMIT` expressions with `github.ref_name` / `github.sha`.

## Related Issues

N/A

## Related PRs

- #3311 (header/checksum fix, merged into `platform-api/v0.10.x`)
- #3312 (push-trigger, open against `platform-api/v0.10.x`)

## Automation tests

N/A — CI workflow change only. Verified against the Azure DevOps webhook with a manual `curl` matching the header/checksum format, and via a manual `workflow_dispatch` run.

## Security checks
 - Followed secure coding standards? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes — the secret is still read from `secrets.AZURE_WEBHOOK_SECRET`.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)