### PR TITLE
ci: disable platform-api cloud release on main branch

### DIFF
--- a/.github/workflows/platform-api-cloud-release.yml
+++ b/.github/workflows/platform-api-cloud-release.yml
@@ -18,7 +18,7 @@ on:
   # Fire on a push to a release branch (merging a PR produces such a push)...
   push:
     branches:
-      - main
+      # main is temporarily disabled while Platform API v1 is in progress.
       - platform-api/v0.10.x
     paths:
       - 'platform-api/**'


### PR DESCRIPTION
## Purpose

Platform API v1 is still in progress, so the Platform API cloud image should not be released off `main` yet. This PR temporarily disables the cloud release trigger for the `main` branch while keeping it active for `platform-api/v0.10.x`.

## Goals

Stop the `Platform API Cloud Release` workflow from firing on merges into `main`, without affecting the `platform-api/v0.10.x` release line.

## Approach

- Remove `main` from the `push:` trigger's `branches:` list in `.github/workflows/platform-api-cloud-release.yml`, leaving only `platform-api/v0.10.x`.
- Since the workflow uses a `push` trigger, the workflow that runs is the version on the pushed branch, so removing `main` here takes effect once merged into `main`.
- `workflow_dispatch` is intentionally left in place, so a cloud release can still be triggered manually against `main` if ever needed.

This is a temporary change intended to be reverted once Platform API v1 work is complete.

## User stories

N/A

## Documentation

N/A — CI-only change with no product or API surface impact.

## Automation tests

- Unit tests
  > N/A — GitHub Actions workflow configuration change only.
- Integration tests
  > N/A

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (no code change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

N/A

## Test environment

N/A — GitHub Actions workflow change.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)