### PR TITLE
feat(helm): fail on contradictory storage dsn + passwordSecretRef

### DIFF
--- a/kubernetes/helm/gateway-helm-chart/templates/gateway/gateway-config.yaml
+++ b/kubernetes/helm/gateway-helm-chart/templates/gateway/gateway-config.yaml
@@ -82,9 +82,12 @@ data:
       is NOT merged into it. Setting both, unless the DSN itself references the
       injected password env token, means the secret is silently ignored and the
       controller connects with no password. Fail loudly instead. The secure way to
-      combine a DSN with the secret is to embed the token in the DSN.
+      combine a DSN with the secret is to embed the token in the DSN. Match the full
+      `{{ env "VAR" }}` interpolation token (tolerating the {{- trim marker, spacing,
+      and the "" default arg), not just the bare variable name, so a DSN that merely
+      mentions the name elsewhere (e.g. in the dbname) still fails the guard.
     */ -}}
-    {{- if and $controller.postgres.passwordSecretRef.name (not (contains "APIP_GW_CONTROLLER_STORAGE_POSTGRES_PASSWORD" $pg.dsn)) }}
+    {{- if and $controller.postgres.passwordSecretRef.name (not (regexMatch `\{\{-? *env +"APIP_GW_CONTROLLER_STORAGE_POSTGRES_PASSWORD"` $pg.dsn)) }}
     {{- fail "gateway.config.controller.storage.postgres.dsn is set together with gateway.controller.postgres.passwordSecretRef, but the DSN does not reference the injected password. A full DSN is used verbatim; the separately-injected password is ignored. Either embed the token in the DSN, e.g. dsn: 'postgres://user:{{ env \"APIP_GW_CONTROLLER_STORAGE_POSTGRES_PASSWORD\" }}@host:5432/db?sslmode=require', or unset gateway.controller.postgres.passwordSecretRef and put the password directly in the DSN." }}
     {{- end }}
     dsn = {{ $pg.dsn | quote }}
@@ -113,9 +116,12 @@ data:
       as-is when set) — the password from gateway.controller.sqlserver.passwordSecretRef
       is NOT merged into it. Setting both, unless the DSN itself references the
       injected password env token, means the secret is silently ignored. Fail loudly
-      instead; embed the token in the DSN to combine a DSN with the secret.
+      instead; embed the token in the DSN to combine a DSN with the secret. Match the
+      full `{{ env "VAR" }}` interpolation token (tolerating the {{- trim marker,
+      spacing, and the "" default arg), not just the bare variable name, so a DSN that
+      merely mentions the name elsewhere (e.g. in the dbname) still fails the guard.
     */ -}}
-    {{- if and $controller.sqlserver.passwordSecretRef.name (not (contains "APIP_GW_CONTROLLER_STORAGE_DATABASE_PASSWORD" $db.dsn)) }}
+    {{- if and $controller.sqlserver.passwordSecretRef.name (not (regexMatch `\{\{-? *env +"APIP_GW_CONTROLLER_STORAGE_DATABASE_PASSWORD"` $db.dsn)) }}
     {{- fail "gateway.config.controller.storage.database.dsn is set together with gateway.controller.sqlserver.passwordSecretRef, but the DSN does not reference the injected password. A full DSN is used verbatim; the separately-injected password is ignored. Either embed the token in the DSN, e.g. dsn: 'sqlserver://user:{{ env \"APIP_GW_CONTROLLER_STORAGE_DATABASE_PASSWORD\" }}@host:1433?database=gateway', or unset gateway.controller.sqlserver.passwordSecretRef and put the password directly in the DSN." }}
     {{- end }}
     dsn = {{ $db.dsn | quote }}

--- a/kubernetes/helm/gateway-helm-chart/templates/gateway/gateway-config.yaml
+++ b/kubernetes/helm/gateway-helm-chart/templates/gateway/gateway-config.yaml
@@ -1,4 +1,5 @@
 {{- $gc := .Values.gateway.config.controller -}}
+{{- $controller := .Values.gateway.controller -}}
 {{- $router := .Values.gateway.config.router -}}
 {{- $pe := .Values.gateway.config.policy_engine -}}
 {{- $pg := $gc.storage.postgres -}}
@@ -75,6 +76,17 @@ data:
     {{- if eq $gc.storage.type "postgres" }}
     [controller.storage.postgres]
     {{- if $pg.dsn }}
+    {{- /*
+      A full DSN is used verbatim by the controller (buildPostgresDSN returns it
+      as-is when set) — the password from gateway.controller.postgres.passwordSecretRef
+      is NOT merged into it. Setting both, unless the DSN itself references the
+      injected password env token, means the secret is silently ignored and the
+      controller connects with no password. Fail loudly instead. The secure way to
+      combine a DSN with the secret is to embed the token in the DSN.
+    */ -}}
+    {{- if and $controller.postgres.passwordSecretRef.name (not (contains "APIP_GW_CONTROLLER_STORAGE_POSTGRES_PASSWORD" $pg.dsn)) }}
+    {{- fail "gateway.config.controller.storage.postgres.dsn is set together with gateway.controller.postgres.passwordSecretRef, but the DSN does not reference the injected password. A full DSN is used verbatim; the separately-injected password is ignored. Either embed the token in the DSN, e.g. dsn: 'postgres://user:{{ env \"APIP_GW_CONTROLLER_STORAGE_POSTGRES_PASSWORD\" }}@host:5432/db?sslmode=require', or unset gateway.controller.postgres.passwordSecretRef and put the password directly in the DSN." }}
+    {{- end }}
     dsn = {{ $pg.dsn | quote }}
     {{- else }}
     host = {{ required "gateway.config.controller.storage.postgres.host is required when storage.type is \"postgres\" and dsn is unset" $pg.host | quote }}
@@ -96,6 +108,16 @@ data:
     [controller.storage.database]
     driver = {{ default "sqlserver" $db.driver | quote }}
     {{- if $db.dsn }}
+    {{- /*
+      A full DSN is used verbatim by the controller (buildSQLServerDSN returns it
+      as-is when set) — the password from gateway.controller.sqlserver.passwordSecretRef
+      is NOT merged into it. Setting both, unless the DSN itself references the
+      injected password env token, means the secret is silently ignored. Fail loudly
+      instead; embed the token in the DSN to combine a DSN with the secret.
+    */ -}}
+    {{- if and $controller.sqlserver.passwordSecretRef.name (not (contains "APIP_GW_CONTROLLER_STORAGE_DATABASE_PASSWORD" $db.dsn)) }}
+    {{- fail "gateway.config.controller.storage.database.dsn is set together with gateway.controller.sqlserver.passwordSecretRef, but the DSN does not reference the injected password. A full DSN is used verbatim; the separately-injected password is ignored. Either embed the token in the DSN, e.g. dsn: 'sqlserver://user:{{ env \"APIP_GW_CONTROLLER_STORAGE_DATABASE_PASSWORD\" }}@host:1433?database=gateway', or unset gateway.controller.sqlserver.passwordSecretRef and put the password directly in the DSN." }}
+    {{- end }}
     dsn = {{ $db.dsn | quote }}
     {{- else }}
     host = {{ required "gateway.config.controller.storage.database.host is required when storage.type is \"sqlserver\" and dsn is unset" $db.host | quote }}

--- a/kubernetes/helm/gateway-helm-chart/values.yaml
+++ b/kubernetes/helm/gateway-helm-chart/values.yaml
@@ -133,11 +133,19 @@ gateway:
         sqlite:
           path: ./data/gateway.db
 
-        # PostgreSQL configuration (used when type=postgres)
-        # Password is injected separately via gateway.controller.postgres.passwordSecretRef
+        # PostgreSQL configuration (used when type=postgres). Configure EITHER the
+        # individual fields (host/port/database/user) with the password injected from a
+        # Secret via gateway.controller.postgres.passwordSecretRef, OR a full dsn below —
+        # the two are mutually exclusive, not complementary.
         postgres:
-          # Full DSN takes precedence over individual fields when set.
-          # Example: "postgres://user:password@host:5432/dbname?sslmode=require"
+          # Full DSN. When set, the individual fields below are ignored and the DSN is
+          # used VERBATIM — the passwordSecretRef password is NOT merged in, so the DSN
+          # must carry its own credentials. A literal password here is written into the
+          # ConfigMap in plaintext; to keep it in a Secret while using a DSN, reference
+          # the injected token in the DSN and keep passwordSecretRef set, e.g.:
+          #   dsn: 'postgres://user:{{ env "APIP_GW_CONTROLLER_STORAGE_POSTGRES_PASSWORD" }}@host:5432/dbname?sslmode=require'
+          # (The chart fails to render if a DSN is set alongside passwordSecretRef but
+          # does not reference the token.)
           dsn: ""
 
           host: ""
@@ -156,13 +164,21 @@ gateway:
           conn_max_idle_time: 5m
           application_name: gateway-controller
 
-        # Global database configuration (used for type=sqlserver).
-        # Password is injected separately via gateway.controller.sqlserver.passwordSecretRef.
-        # This shape maps to [controller.storage.database] in config.toml.
+        # Global database configuration (used for type=sqlserver). Configure EITHER the
+        # individual fields (host/port/database/user) with the password injected from a
+        # Secret via gateway.controller.sqlserver.passwordSecretRef, OR a full dsn below —
+        # the two are mutually exclusive. This shape maps to [controller.storage.database]
+        # in config.toml.
         database:
           driver: sqlserver
-          # Full DSN takes precedence over individual fields when set.
-          # Example: "sqlserver://gateway@host:1433?database=gateway"
+          # Full DSN. When set, the individual fields below are ignored and the DSN is
+          # used VERBATIM — the passwordSecretRef password is NOT merged in, so the DSN
+          # must carry its own credentials. A literal password here is written into the
+          # ConfigMap in plaintext; to keep it in a Secret while using a DSN, reference
+          # the injected token in the DSN and keep passwordSecretRef set, e.g.:
+          #   dsn: 'sqlserver://user:{{ env "APIP_GW_CONTROLLER_STORAGE_DATABASE_PASSWORD" }}@host:1433?database=gateway'
+          # (The chart fails to render if a DSN is set alongside passwordSecretRef but
+          # does not reference the token.)
           dsn: ""
 
           host: ""
@@ -726,14 +742,20 @@ gateway:
       secretName: ""
       # Mount path inside the container — must match controller.encryption.providers[].keys[].file paths
       mountPath: /app/data/aesgcm-keys
-    # PostgreSQL password secret reference (used when gateway.config.controller.storage.type=postgres).
-    # The password is injected from this Secret rather than stored in the ConfigMap (see README).
+    # PostgreSQL password secret reference (used when gateway.config.controller.storage.type=postgres
+    # and gateway.config.controller.storage.postgres.dsn is NOT set). The password is injected from
+    # this Secret rather than stored in the ConfigMap (see README). It has NO effect when a dsn is set
+    # unless the dsn references the injected token {{ env "APIP_GW_CONTROLLER_STORAGE_POSTGRES_PASSWORD" }};
+    # the chart fails to render if a dsn is set alongside this without referencing the token.
     postgres:
       passwordSecretRef:
         name: ""
         key: password
-    # SQL Server password secret reference (used when gateway.config.controller.storage.type=sqlserver).
-    # The password is injected from this Secret rather than stored in the ConfigMap (see README).
+    # SQL Server password secret reference (used when gateway.config.controller.storage.type=sqlserver
+    # and gateway.config.controller.storage.database.dsn is NOT set). The password is injected from
+    # this Secret rather than stored in the ConfigMap (see README). It has NO effect when a dsn is set
+    # unless the dsn references the injected token {{ env "APIP_GW_CONTROLLER_STORAGE_DATABASE_PASSWORD" }};
+    # the chart fails to render if a dsn is set alongside this without referencing the token.
     sqlserver:
       passwordSecretRef:
         name: ""


### PR DESCRIPTION
## Purpose

The `gateway-helm-chart` lets an operator configure the controller's external database (`postgres`/`sqlserver`) either via a full `dsn` or via individual `host`/`port`/`database`/`user` fields with the password injected separately from a Secret (`passwordSecretRef`). These two modes are mutually exclusive, but the chart neither enforced nor clearly documented that, so a common misconfiguration passed silently.

The controller's `buildPostgresDSN` (`gateway/gateway-controller/pkg/storage/postgres.go:140`) and `buildSQLServerDSN` (`pkg/storage/sqlserver.go`) return the `dsn` verbatim when set and never merge the separately-configured password. At the chart level the `password = '{{ env ... }}'` line is only rendered in the non-DSN branch, so when a `dsn` is set the injected `APIP_GW_CONTROLLER_STORAGE_POSTGRES_PASSWORD` env var has nothing to consume it. An operator who set a password-less `dsn` alongside a `passwordSecretRef` got a controller that connected with no password and crashlooped on an opaque Postgres `password authentication failed` error that pointed at the database, not at the contradictory Helm values. The `values.yaml` comments made it worse by stating both "Full DSN takes precedence over individual fields when set" and "Password is injected separately via passwordSecretRef", which read as if a password-less DSN plus a separate secret works.

Resolves #3318.

## Goals

- Turn the silent misconfiguration into a clear, pre-deploy failure.
- Correct the misleading documentation so operators pick the right mode up front.
- Preserve the legitimate secure pattern of embedding an `{{ env ... }}` token inside the DSN so the password stays in a Secret rather than the ConfigMap.

## Approach

- Add a render-time guard in `templates/gateway/gateway-config.yaml` for both the `postgres` and `sqlserver`/`database` blocks: `fail` when a `dsn` is set and the matching `passwordSecretRef.name` is set and the `dsn` does not reference the injected password env token. The error message tells the operator to either embed the token in the DSN or drop the secret ref. This is consistent with the chart's existing `fail`/`required` validation (removed `sqlserver` key, missing host/db/user, `encrypt` enum).
- The token check (`contains "APIP_GW_CONTROLLER_STORAGE_POSTGRES_PASSWORD"` / `..._DATABASE_PASSWORD`) intentionally allows the secure "token inside the DSN" pattern to keep working.
- Rewrite the `values.yaml` comments in the `postgres`, `database`, and both `passwordSecretRef` blocks to state that the two modes are mutually exclusive, that the DSN is used verbatim, that a literal password in the DSN lands in the ConfigMap in plaintext, and to show a copy-pasteable token example.

## User stories

As an operator deploying the gateway against an external database, when I misconfigure the connection by setting a `dsn` alongside a `passwordSecretRef` that the DSN does not use, I get an immediate, actionable Helm render error instead of a controller crashloop with a misleading database error.

## Documentation

N/A. The change is limited to in-chart `values.yaml` comments and a render-time error message; there is no external product documentation impacted.

## Automation tests

- Unit tests
  > N/A. This is a Helm chart templating change with no Go/Java code path; the chart has no unit-test harness. Verification was done via `helm template` and `helm lint`.
- Integration tests
  > Validated with `helm template` across the full matrix for both engines, plus a no-regression check and `helm lint`:
  >
  > | Scenario | Expected | Result |
  > |---|---|---|
  > | postgres: individual fields + `passwordSecretRef` (no dsn) | render | pass |
  > | postgres: `dsn` only, no `passwordSecretRef` | render | pass |
  > | postgres: `dsn` (no token) + `passwordSecretRef` | fail | fails with clear message |
  > | postgres: `dsn` with token + `passwordSecretRef` | render (token preserved) | pass |
  > | sqlserver: individual fields + `passwordSecretRef` (no dsn) | render | pass |
  > | sqlserver: `dsn` (no token) + `passwordSecretRef` | fail | fails with clear message |
  > | sqlserver: `dsn` with token + `passwordSecretRef` | render (token preserved) | pass |
  > | default sqlite path | render | pass (no regression) |
  >
  > `helm lint .` reports 0 charts failed.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (Helm chart change; FindSecurityBugs targets Java bytecode, no Java/Go code changed)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

N/A

## Test environment

Helm v3.18.3, macOS (Darwin 25.5.0). Chart rendered and linted locally; no live database connection required for these tests.