### PR TITLE
feat(platform-api): make Gin access-log format configurable

### DIFF
--- a/platform-api/src/config/config.go
+++ b/platform-api/src/config/config.go
@@ -86,6 +86,7 @@ type Server struct {
 	APIKey           APIKey           `koanf:"api_key"`
 	Gateway          Gateway          `koanf:"gateway"`
 	EventHub         EventHub         `koanf:"event_hub"`
+	Logging          Logging          `koanf:"logging"`
 
 	EnableScopeValidation      bool `koanf:"enable_scope_validation"`
 	OrgCreationRequiresAuth    bool `koanf:"org_creation_requires_auth"`
@@ -129,6 +130,22 @@ type EventHub struct {
 	CleanupInterval time.Duration `koanf:"cleanup_interval"`
 	RetentionPeriod time.Duration `koanf:"retention_period"`
 }
+
+// Logging holds access-log configuration.
+type Logging struct {
+	// AccessLogFormat is the template used for each Gin access-log line.
+	// Named tokens are substituted per request; see DefaultAccessLogFormat and
+	// the accessLogFormatter in internal/server for the supported tokens
+	// (e.g. %time%, %status%, %latency%, %clientip%, %method%, %path%,
+	// %useragent%, %org%, %username%). Any request error is appended after
+	// the rendered line, mirroring Gin's default behaviour.
+	AccessLogFormat string `koanf:"access_log_format"`
+}
+
+// DefaultAccessLogFormat is the access-log template used when none is configured.
+// It mirrors Gin's default line (without color) and includes the authenticated
+// organization ID and the request User-Agent.
+const DefaultAccessLogFormat = `[GIN] %time% | %status% | %latency% | %clientip% | %method% "%path%" | org="%org%" | "%useragent%"`
 
 // Gateway holds gateway-related configuration.
 type Gateway struct {
@@ -430,6 +447,9 @@ func envToKoanfKey(s string) string {
 	case "event_hub_poll_interval":    return "event_hub.poll_interval"
 	case "event_hub_cleanup_interval": return "event_hub.cleanup_interval"
 	case "event_hub_retention_period": return "event_hub.retention_period"
+
+	// Logging
+	case "logging_access_log_format": return "logging.access_log_format"
 
 	default:
 		return ""

--- a/platform-api/src/config/config.toml
+++ b/platform-api/src/config/config.toml
@@ -23,6 +23,16 @@
 log_level = "INFO"   # DEBUG | INFO | WARN | ERROR
 port      = "9243"
 
+# Access logging
+[logging]
+# access_log_format is the template for each access-log line. Named %token%
+# placeholders are substituted per request, so you control which fields are
+# logged and in what layout. Any request error is appended after the line.
+# Supported tokens: %time% %status% %latency% %clientip% %method% %path%
+#   %proto% %useragent% %bodysize% %org% %orgname% %orghandle% %user%
+#   %username% %email%
+# access_log_format = '[GIN] %time% | %status% | %latency% | %clientip% | %method% "%path%" | org="%org%" | "%useragent%"'
+
 # ---------------------------------------------------------------------------
 # Database
 # ---------------------------------------------------------------------------

--- a/platform-api/src/config/default_config.go
+++ b/platform-api/src/config/default_config.go
@@ -131,5 +131,8 @@ func defaultConfig() *Server {
 			CleanupInterval: 10 * time.Minute,
 			RetentionPeriod: 1 * time.Hour,
 		},
+		Logging: Logging{
+			AccessLogFormat: DefaultAccessLogFormat,
+		},
 	}
 }

--- a/platform-api/src/internal/server/server.go
+++ b/platform-api/src/internal/server/server.go
@@ -34,6 +34,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"platform-api/src/internal/middleware"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -331,7 +332,7 @@ func StartPlatformAPIServer(cfg *config.Server, slogger *slog.Logger) (*Server, 
 	// Setup router. Use gin.New() with explicit middleware (instead of gin.Default())
 	// so the access log can include the request User-Agent.
 	router := gin.New()
-	router.Use(gin.LoggerWithFormatter(accessLogFormatter))
+	router.Use(gin.LoggerWithFormatter(accessLogFormatter(cfg.Logging.AccessLogFormat)))
 	router.Use(gin.Recovery())
 
 	// Configure and apply CORS middleware first (before auth middleware)
@@ -448,24 +449,66 @@ func StartPlatformAPIServer(cfg *config.Server, slogger *slog.Logger) (*Server, 
 	}, nil
 }
 
-// accessLogFormatter mirrors gin's default access-log format (without color)
-// and appends the request's User-Agent so the client is identified in the logs.
-func accessLogFormatter(param gin.LogFormatterParams) string {
-	latency := param.Latency
-	if latency > time.Minute {
-		latency = latency.Truncate(time.Second)
+// accessLogFormatter returns a Gin log formatter that renders each access-log
+// line from the given template. Named %token% placeholders are substituted per
+// request, so operators can choose which fields to log (and in what layout) via
+// config. Any request error is appended after the rendered line, mirroring Gin's
+// default behaviour. An empty format falls back to config.DefaultAccessLogFormat.
+//
+// Supported tokens:
+//
+//	%time%       request timestamp (2006/01/02 - 15:04:05)
+//	%status%     HTTP status code
+//	%latency%    request latency
+//	%clientip%   client IP
+//	%method%     HTTP method
+//	%path%       request path
+//	%proto%      request protocol (e.g. HTTP/1.1)
+//	%useragent%  request User-Agent
+//	%bodysize%   response body size in bytes
+//	%org%        authenticated organization ID   (from the request context)
+//	%orgname%    authenticated organization name (from the request context)
+//	%orghandle%  authenticated organization handle (from the request context)
+//	%user%       authenticated user ID           (from the request context)
+//	%username%   authenticated username          (from the request context)
+//	%email%      authenticated user email        (from the request context)
+func accessLogFormatter(format string) gin.LogFormatter {
+	if strings.TrimSpace(format) == "" {
+		format = config.DefaultAccessLogFormat
 	}
+	return func(param gin.LogFormatterParams) string {
+		latency := param.Latency
+		if latency > time.Minute {
+			latency = latency.Truncate(time.Second)
+		}
+		key := func(k string) string {
+			if v, ok := param.Keys[k].(string); ok {
+				return v
+			}
+			return ""
+		}
+		line := strings.NewReplacer(
+			"%time%", param.TimeStamp.Format("2006/01/02 - 15:04:05"),
+			"%status%", strconv.Itoa(param.StatusCode),
+			"%latency%", latency.String(),
+			"%clientip%", param.ClientIP,
+			"%method%", param.Method,
+			"%path%", param.Path,
+			"%proto%", param.Request.Proto,
+			"%useragent%", param.Request.UserAgent(),
+			"%bodysize%", strconv.Itoa(param.BodySize),
+			"%org%", key("organization"),
+			"%orgname%", key("org_name"),
+			"%orghandle%", key("org_handle"),
+			"%user%", key("user_id"),
+			"%username%", key("username"),
+			"%email%", key("email"),
+		).Replace(format)
 
-	return fmt.Sprintf("[GIN] %v | %3d | %13v | %15s | %-7s %#v | %q\n%s",
-		param.TimeStamp.Format("2006/01/02 - 15:04:05"),
-		param.StatusCode,
-		latency,
-		param.ClientIP,
-		param.Method,
-		param.Path,
-		param.Request.UserAgent(),
-		param.ErrorMessage,
-	)
+		// Emit exactly one trailing newline, then surface any request error
+		// after it (Gin's ErrorMessage is already newline-terminated).
+		return strings.TrimRight(line, "\n") + "\n" + param.ErrorMessage
+	}
 }
 
 // demoMode reports whether APIP_DEMO_MODE is enabled.


### PR DESCRIPTION
## Purpose

The Platform API access log emitted a fixed Gin log line, so operators could not choose what each line contained — most notably there was no way to include the authenticated organization ID, which is essential for correlating requests to tenants in a multi-org deployment.

## Goals

Make the access-log line fully configurable so operators can decide which fields are logged (including the organization ID) and in what layout, without code changes.

## Approach

- Add a `logging.access_log_format` config option (via `config.toml` `[logging]` or the `LOGGING_ACCESS_LOG_FORMAT` env var) that holds a template string for each access-log line.
- Introduce an exported `config.DefaultAccessLogFormat` used when none is configured; the default now includes the authenticated organization ID (`org="<org-id>"`) alongside the existing fields and User-Agent.
- Rewrite `accessLogFormatter` into a template renderer that substitutes named `%token%` placeholders per request: `%time%`, `%status%`, `%latency%`, `%clientip%`, `%method%`, `%path%`, `%proto%`, `%useragent%`, `%bodysize%`, and auth-context fields `%org%`, `%orgname%`, `%orghandle%`, `%user%`, `%username%`, `%email%`.
- Substitute using a single-pass `strings.NewReplacer` so field values that happen to contain token-like text are never re-substituted.
- The organization ID is read from the request context (`c.Keys["organization"]`), which Gin's logger captures after the auth middleware runs, so authenticated requests log the org while unauthenticated ones (health/metrics, login) log an empty value.
- Any request error is appended after the rendered line, preserving Gin's existing error-surfacing behaviour.

## User stories

As a Platform API operator, I want the organization ID (and other fields I choose) in each access-log line so I can correlate requests to tenants and tailor log output to my log pipeline.

## Documentation

N/A — the new option is self-documented in `config.toml` with the full list of supported tokens.

## Automation tests
 - Unit tests
   > No new unit tests; the formatter is a pure template substitution and the change is covered by existing server startup paths. Verified locally with `go build ./...` and `go vet`.
 - Integration tests
   > Manually verified: minted a local dev token with an `organization` claim and confirmed the access log renders `org="<org-id>"`, and that a custom `access_log_format` changes the emitted fields.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

Follows up #049aeff8a (feat(platform-api): include user-agent in access logs).

## Test environment

Go (platform-api module), macOS.

## Related Issues

N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)