### PR TITLE
Add usage extraction fields to the Azure OpenAI and Azure AI Foundry templates and enhance fallback identifiers of the others

### DIFF
--- a/gateway/gateway-controller/default-llm-provider-templates/anthropic-template.yaml
+++ b/gateway/gateway-controller/default-llm-provider-templates/anthropic-template.yaml
@@ -56,6 +56,9 @@ spec:
     identifier: $.usage.cache_creation.ephemeral_5m_input_tokens
     fallbackIdentifiers:
       - $.message.usage.cache_creation.ephemeral_5m_input_tokens
+      # The TTL breakdown is optional; the flat total keeps the tokens billed.
+      - $.usage.cache_creation_input_tokens
+      - $.message.usage.cache_creation_input_tokens
   cacheWrite1hTokens:
     location: payload
     identifier: $.usage.cache_creation.ephemeral_1h_input_tokens

--- a/gateway/gateway-controller/default-llm-provider-templates/azureaifoundry-template.yaml
+++ b/gateway/gateway-controller/default-llm-provider-templates/azureaifoundry-template.yaml
@@ -94,9 +94,3 @@ spec:
           identifier: $.usage.output_tokens_details.reasoning_tokens
           fallbackIdentifiers:
             - $.response.usage.output_tokens_details.reasoning_tokens
-        audioInputTokens:
-          location: payload
-          identifier: $.usage.input_tokens_details.audio_tokens
-        audioOutputTokens:
-          location: payload
-          identifier: $.usage.output_tokens_details.audio_tokens

--- a/gateway/gateway-controller/default-llm-provider-templates/azureaifoundry-template.yaml
+++ b/gateway/gateway-controller/default-llm-provider-templates/azureaifoundry-template.yaml
@@ -34,6 +34,8 @@ spec:
   totalTokens:
     location: payload
     identifier: $.usage.total_tokens
+    fallbackIdentifiers:
+      - $.response.usage.total_tokens
   remainingTokens:
     location: header
     identifier: x-ratelimit-remaining-tokens
@@ -43,12 +45,58 @@ spec:
   responseModel:
     location: payload
     identifier: $.model
+    fallbackIdentifiers:
+      - $.response.model
+  cachedTokens:
+    location: payload
+    identifier: $.usage.prompt_tokens_details.cached_tokens
+    fallbackIdentifiers:
+      # Assistants thread runs spell it singular.
+      - $.usage.prompt_token_details.cached_tokens
+  reasoningTokens:
+    location: payload
+    identifier: $.usage.completion_tokens_details.reasoning_tokens
+  audioInputTokens:
+    location: payload
+    identifier: $.usage.prompt_tokens_details.audio_tokens
+  audioOutputTokens:
+    location: payload
+    identifier: $.usage.completion_tokens_details.audio_tokens
+  serviceTier:
+    location: payload
+    identifier: $.service_tier
+    fallbackIdentifiers:
+      - $.response.service_tier
+    valueMap:
+      priority: priority
+  cacheAccounting: inclusive
   resourceMappings:
     resources:
+      # A streamed response nests the whole document under "response".
       - resource: /responses
         promptTokens:
           location: payload
           identifier: $.usage.input_tokens
+          fallbackIdentifiers:
+            - $.response.usage.input_tokens
         completionTokens:
           location: payload
           identifier: $.usage.output_tokens
+          fallbackIdentifiers:
+            - $.response.usage.output_tokens
+        cachedTokens:
+          location: payload
+          identifier: $.usage.input_tokens_details.cached_tokens
+          fallbackIdentifiers:
+            - $.response.usage.input_tokens_details.cached_tokens
+        reasoningTokens:
+          location: payload
+          identifier: $.usage.output_tokens_details.reasoning_tokens
+          fallbackIdentifiers:
+            - $.response.usage.output_tokens_details.reasoning_tokens
+        audioInputTokens:
+          location: payload
+          identifier: $.usage.input_tokens_details.audio_tokens
+        audioOutputTokens:
+          location: payload
+          identifier: $.usage.output_tokens_details.audio_tokens

--- a/gateway/gateway-controller/default-llm-provider-templates/azureopenai-template.yaml
+++ b/gateway/gateway-controller/default-llm-provider-templates/azureopenai-template.yaml
@@ -94,9 +94,3 @@ spec:
           identifier: $.usage.output_tokens_details.reasoning_tokens
           fallbackIdentifiers:
             - $.response.usage.output_tokens_details.reasoning_tokens
-        audioInputTokens:
-          location: payload
-          identifier: $.usage.input_tokens_details.audio_tokens
-        audioOutputTokens:
-          location: payload
-          identifier: $.usage.output_tokens_details.audio_tokens

--- a/gateway/gateway-controller/default-llm-provider-templates/azureopenai-template.yaml
+++ b/gateway/gateway-controller/default-llm-provider-templates/azureopenai-template.yaml
@@ -34,6 +34,8 @@ spec:
   totalTokens:
     location: payload
     identifier: $.usage.total_tokens
+    fallbackIdentifiers:
+      - $.response.usage.total_tokens
   remainingTokens:
     location: header
     identifier: x-ratelimit-remaining-tokens
@@ -43,12 +45,58 @@ spec:
   responseModel:
     location: payload
     identifier: $.model
+    fallbackIdentifiers:
+      - $.response.model
+  cachedTokens:
+    location: payload
+    identifier: $.usage.prompt_tokens_details.cached_tokens
+    fallbackIdentifiers:
+      # Assistants thread runs spell it singular.
+      - $.usage.prompt_token_details.cached_tokens
+  reasoningTokens:
+    location: payload
+    identifier: $.usage.completion_tokens_details.reasoning_tokens
+  audioInputTokens:
+    location: payload
+    identifier: $.usage.prompt_tokens_details.audio_tokens
+  audioOutputTokens:
+    location: payload
+    identifier: $.usage.completion_tokens_details.audio_tokens
+  serviceTier:
+    location: payload
+    identifier: $.service_tier
+    fallbackIdentifiers:
+      - $.response.service_tier
+    valueMap:
+      priority: priority
+  cacheAccounting: inclusive
   resourceMappings:
     resources:
+      # A streamed response nests the whole document under "response".
       - resource: /responses
         promptTokens:
           location: payload
           identifier: $.usage.input_tokens
+          fallbackIdentifiers:
+            - $.response.usage.input_tokens
         completionTokens:
           location: payload
           identifier: $.usage.output_tokens
+          fallbackIdentifiers:
+            - $.response.usage.output_tokens
+        cachedTokens:
+          location: payload
+          identifier: $.usage.input_tokens_details.cached_tokens
+          fallbackIdentifiers:
+            - $.response.usage.input_tokens_details.cached_tokens
+        reasoningTokens:
+          location: payload
+          identifier: $.usage.output_tokens_details.reasoning_tokens
+          fallbackIdentifiers:
+            - $.response.usage.output_tokens_details.reasoning_tokens
+        audioInputTokens:
+          location: payload
+          identifier: $.usage.input_tokens_details.audio_tokens
+        audioOutputTokens:
+          location: payload
+          identifier: $.usage.output_tokens_details.audio_tokens

--- a/gateway/gateway-controller/default-llm-provider-templates/openai-template.yaml
+++ b/gateway/gateway-controller/default-llm-provider-templates/openai-template.yaml
@@ -34,6 +34,8 @@ spec:
   totalTokens:
     location: payload
     identifier: $.usage.total_tokens
+    fallbackIdentifiers:
+      - $.response.usage.total_tokens
   remainingTokens:
     location: header
     identifier: x-ratelimit-remaining-tokens
@@ -43,6 +45,8 @@ spec:
   responseModel:
     location: payload
     identifier: $.model
+    fallbackIdentifiers:
+      - $.response.model
   cachedTokens:
     location: payload
     identifier: $.usage.prompt_tokens_details.cached_tokens
@@ -58,6 +62,8 @@ spec:
   serviceTier:
     location: payload
     identifier: $.service_tier
+    fallbackIdentifiers:
+      - $.response.service_tier
     valueMap:
       priority: priority
       flex: flex
@@ -74,16 +80,26 @@ spec:
   cacheAccounting: inclusive
   resourceMappings:
     resources:
+      # A streamed response nests the whole document under "response", so each
+      # identifier carries its nested form as a fallback.
       - resource: /responses
         promptTokens:
           location: payload
           identifier: $.usage.input_tokens
+          fallbackIdentifiers:
+            - $.response.usage.input_tokens
         completionTokens:
           location: payload
           identifier: $.usage.output_tokens
+          fallbackIdentifiers:
+            - $.response.usage.output_tokens
         cachedTokens:
           location: payload
           identifier: $.usage.input_tokens_details.cached_tokens
+          fallbackIdentifiers:
+            - $.response.usage.input_tokens_details.cached_tokens
         reasoningTokens:
           location: payload
           identifier: $.usage.output_tokens_details.reasoning_tokens
+          fallbackIdentifiers:
+            - $.response.usage.output_tokens_details.reasoning_tokens


### PR DESCRIPTION
- Azure OpenAI: adds cachedTokens, reasoningTokens, audioInputTokens, audioOutputTokens, serviceTier with its value map, and cacheAccounting. The template declared only the token totals before, so those categories were invisible and all of them were billed at the standard input rate.
- Azure AI Foundry: the same additions, since it serves the same OpenAI compatible response shapes.
- Both Azure templates: also gain a /responses mapping, because that surface reports input_tokens and output_tokens instead of prompt_tokens and completion_tokens. They also pick up a singular prompt_token_details fallback for cached tokens, which is how Assistants thread runs spell it.
- OpenAI: adds nested $.response.* fallbacks for the total, the model, the service tier, and the four counts inside the /responses mapping. A streamed Responses reply wraps the whole document under response, where the plain paths find nothing.
- Anthropic: adds the flat cache_creation_input_tokens as a fallback for cache write tokens, in both the plain and the streamed shape. The per TTL breakdown is optional, so cache writes were missed whenever it was absent.