### PR TITLE
ai-workspace: add configurable HTTP client and TLS listener settings

### DIFF
--- a/portals/ai-workspace/bff/go.mod
+++ b/portals/ai-workspace/bff/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/knadh/koanf/providers/file v1.2.1
 	github.com/knadh/koanf/v2 v2.3.2
 	github.com/wso2/api-platform/common v0.0.0
+	github.com/wso2/api-platform/httpkit v0.0.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/portals/ai-workspace/bff/internal/config/config.go
+++ b/portals/ai-workspace/bff/internal/config/config.go
@@ -53,6 +53,7 @@ type Config struct {
 	Server       ServerConfig       `koanf:"server"`
 	Logging      LoggingConfig      `koanf:"logging"`
 	ControlPlane ControlPlaneConfig `koanf:"control_plane"`
+	HTTPClient   HTTPClientConfig   `koanf:"http_client"`
 	Session      SessionConfig      `koanf:"session"`
 	Auth         AuthConfig         `koanf:"auth"`
 
@@ -90,6 +91,28 @@ type HTTPSListener struct {
 	Port     int    `koanf:"port"`
 	CertFile string `koanf:"cert_file"`
 	KeyFile  string `koanf:"key_file"`
+
+	// MinimumProtocolVersion and MaximumProtocolVersion bound the negotiated
+	// TLS version: one of "TLS1_0", "TLS1_1", "TLS1_2", "TLS1_3".
+	MinimumProtocolVersion string `koanf:"minimum_protocol_version"`
+	MaximumProtocolVersion string `koanf:"maximum_protocol_version"`
+
+	// Ciphers is a comma-separated list of Go crypto/tls cipher suite names
+	// (e.g. "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"), restricting which
+	// suites this listener will negotiate. Empty by default, meaning Go's own
+	// secure default set/order applies. Only affects TLS 1.2 and below — TLS
+	// 1.3 suite selection is not configurable in Go's crypto/tls.
+	Ciphers string `koanf:"ciphers"`
+
+	// EcdhCurves is a comma-separated list of TLS 1.3 key-exchange groups,
+	// most preferred first (e.g. "X25519,P-256"). Classical curves only by
+	// default. A hybrid post-quantum group ("X25519MLKEM768", FIPS 203
+	// ML-KEM-768 + X25519) can be prepended as an explicit opt-in once the
+	// clients that reach this listener are confirmed to support it — TLS 1.3
+	// negotiation simply falls back to a later classical entry in this same
+	// list for a client that doesn't offer the hybrid group, so enabling it
+	// never breaks a legacy peer. See post-quantum-cryptography.md.
+	EcdhCurves string `koanf:"ecdh_curves"`
 }
 
 // LoggingConfig is [ai_workspace.logging]. Level/Format are this process's own logs;
@@ -349,6 +372,17 @@ func (c *Config) validate() error {
 	}
 	if c.Server.HTTP.Enabled && c.Server.HTTPS.Enabled && c.Server.HTTP.Port == c.Server.HTTPS.Port {
 		return fmt.Errorf("[server.http] port and [server.https] port must differ, both are %d", c.Server.HTTP.Port)
+	}
+	if c.Server.HTTPS.Enabled {
+		if err := ValidateHTTPSTLSVersions(c.Server.HTTPS.MinimumProtocolVersion, c.Server.HTTPS.MaximumProtocolVersion); err != nil {
+			return fmt.Errorf("[server.https]: %w", err)
+		}
+		if _, err := ParseHTTPSCiphers(c.Server.HTTPS.Ciphers); err != nil {
+			return fmt.Errorf("[server.https] ciphers: %w", err)
+		}
+		if _, err := ParseHTTPSEcdhCurves(c.Server.HTTPS.EcdhCurves); err != nil {
+			return fmt.Errorf("[server.https] ecdh_curves: %w", err)
+		}
 	}
 	// Every session duration is a lifetime, where <= 0 is never meaningful.
 	if c.Session.IdleTimeout <= 0 {

--- a/portals/ai-workspace/bff/internal/config/default_config.go
+++ b/portals/ai-workspace/bff/internal/config/default_config.go
@@ -40,7 +40,7 @@ func defaultConfig() *Config {
 				MinimumProtocolVersion: "TLS1_2",
 				MaximumProtocolVersion: "TLS1_3",
 				Ciphers:                "",
-				EcdhCurves:             "X25519,P-256",
+				EcdhCurves:             "X25519MLKEM768,X25519,P-256,P-384",
 			},
 		},
 		Logging: LoggingConfig{

--- a/portals/ai-workspace/bff/internal/config/default_config.go
+++ b/portals/ai-workspace/bff/internal/config/default_config.go
@@ -35,13 +35,47 @@ func defaultConfig() *Config {
 				Port:    9643,
 				// Convention matches the container's mount path. A certificate pair is
 				// required there whenever the listener terminates TLS.
-				CertFile: "/etc/ai-workspace/tls/cert.pem",
-				KeyFile:  "/etc/ai-workspace/tls/key.pem",
+				CertFile:               "/etc/ai-workspace/tls/cert.pem",
+				KeyFile:                "/etc/ai-workspace/tls/key.pem",
+				MinimumProtocolVersion: "TLS1_2",
+				MaximumProtocolVersion: "TLS1_3",
+				Ciphers:                "",
+				EcdhCurves:             "X25519,P-256",
 			},
 		},
 		Logging: LoggingConfig{
 			Level:  "info",
 			Format: "text",
+		},
+		// HTTPClient defaults reproduce exactly what proxy.NewTransport hardcoded
+		// before this became configurable, so an existing deployment that omits
+		// [ai_workspace.http_client] entirely sees zero behavior change. Everything
+		// else (Pooling.MaxIdleConns, Timeouts.Dial/TLSHandshake/ResponseHeader/
+		// ExpectContinue) already matches httpclient.DefaultConfig()'s own values, so
+		// only the previously-hardcoded overrides are set explicitly below.
+		HTTPClient: HTTPClientConfig{
+			Pooling: HTTPClientPoolingConfig{
+				MaxIdleConns:        100,
+				MaxIdleConnsPerHost: 20,
+				MaxConnsPerHost:     0,
+				IdleConnTimeout:     90 * time.Second,
+				KeepAlive:           30 * time.Second,
+				EnableHTTP2:         true,
+			},
+			Timeouts: HTTPClientTimeoutsConfig{
+				Overall:          30 * time.Second,
+				Dial:             10 * time.Second,
+				TLSHandshake:     10 * time.Second,
+				ResponseHeader:   10 * time.Second,
+				ExpectContinue:   1 * time.Second,
+				MaxResponseBytes: -1,
+			},
+			// TLS.MinVersion/MaxVersion/CipherSuites/CurvePreferences stay empty:
+			// Go's own crypto/tls default (TLS 1.2 floor, no configured ceiling)
+			// applies, matching today's behavior.
+			Proxy: HTTPClientProxyConfig{
+				Mode: "environment", // matches the previous hardcoded http.ProxyFromEnvironment
+			},
 		},
 		Session: SessionConfig{
 			Store:       "memory",

--- a/portals/ai-workspace/bff/internal/config/http_client.go
+++ b/portals/ai-workspace/bff/internal/config/http_client.go
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the
+ * License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package config
+
+import "time"
+
+// HTTPClientConfig is [ai_workspace.http_client]: configures the single outbound
+// *http.Transport this BFF uses for every call to its upstream Platform API (see
+// proxy.NewTransport, and server.New's one call site). It mirrors
+// github.com/wso2/api-platform/httpkit/httpclient.Config field-for-field (see that package's own
+// doc comments for full semantics) — the same shape gateway-controller's and
+// platform-api's own HTTPClientConfig use (gateway/gateway-controller/pkg/config/config.go,
+// platform-api/config/config.go) — so every knob the library exposes that has a natural
+// TOML shape is operator-configurable here rather than hardcoded in transport.go.
+//
+// SSRF is deliberately not represented here (unlike platform-api's HTTPClientConfig):
+// this transport only ever talks to the fixed, operator-configured Platform API
+// (ControlPlaneConfig.URL) — never a tenant/end-user-supplied destination — so there is
+// nothing for httpclient's SSRF guard to protect against. See transport.go's own doc
+// comment.
+//
+// TLS.RootCAFile/ClientCertFile/ClientKeyFile/InsecureSkipVerify are also deliberately
+// not fields here: this component already has an existing setting for that same trust
+// decision — ControlPlaneConfig.CAFile / ControlPlaneConfig.TLSSkipVerify, wired through
+// proxy.TLSClientOptions — and duplicating it here would create two settings that must
+// always be kept in sync.
+type HTTPClientConfig struct {
+	Pooling  HTTPClientPoolingConfig  `koanf:"pooling"`
+	Timeouts HTTPClientTimeoutsConfig `koanf:"timeouts"`
+	TLS      HTTPClientTLSConfig      `koanf:"tls"`
+	Proxy    HTTPClientProxyConfig    `koanf:"proxy"`
+}
+
+// HTTPClientPoolingConfig mirrors httpclient.PoolingConfig.
+type HTTPClientPoolingConfig struct {
+	MaxIdleConns        int           `koanf:"max_idle_conns"`
+	MaxIdleConnsPerHost int           `koanf:"max_idle_conns_per_host"`
+	MaxConnsPerHost     int           `koanf:"max_conns_per_host"`
+	IdleConnTimeout     time.Duration `koanf:"idle_conn_timeout"`
+	KeepAlive           time.Duration `koanf:"keep_alive"`
+	DisableKeepAlives   bool          `koanf:"disable_keep_alives"`
+	// EnableHTTP2 opts into HTTP/2. See httpclient.PoolingConfig.EnableHTTP2's doc
+	// comment on the HTTP/2 connection-coalescing caveat before disabling — true by
+	// default here, matching this transport's previous hardcoded
+	// ForceAttemptHTTP2: true behavior.
+	EnableHTTP2 bool `koanf:"enable_http2"`
+}
+
+// HTTPClientTimeoutsConfig mirrors httpclient.TimeoutsConfig.
+//
+// Overall has no observable effect at this call site today: NewTransport extracts only
+// the *http.Transport out of httpclient.New's *http.Client (see transport.go), and
+// server.New applies its own, separate 60s http.Client.Timeout on top of it. Kept here
+// anyway, defaulted to httpclient.DefaultConfig()'s own value, for shape parity with
+// gateway-controller/platform-api and in case a future caller reads the full
+// *http.Client instead.
+type HTTPClientTimeoutsConfig struct {
+	Overall        time.Duration `koanf:"overall"`
+	Dial           time.Duration `koanf:"dial"`
+	TLSHandshake   time.Duration `koanf:"tls_handshake"`
+	ResponseHeader time.Duration `koanf:"response_header"`
+	ExpectContinue time.Duration `koanf:"expect_continue"`
+	// MaxResponseBytes bounds the response body read through this transport. Defaults
+	// to -1 (disabled): this transport backs a reverse proxy streaming SSE/long-running
+	// LLM output between the BFF and its own fixed, trusted Platform API — not an
+	// arbitrary or tenant-supplied target — so truncating a legitimate long stream would
+	// be worse than not bounding it. 0 = httpclient's own package default (10MiB); a
+	// positive value applies that exact cap instead.
+	MaxResponseBytes int64 `koanf:"max_response_bytes"`
+}
+
+// HTTPClientTLSConfig mirrors the TOML-expressible subset of httpclient.TLSConfig that
+// is not already sourced from ControlPlaneConfig (see HTTPClientConfig's doc comment).
+// MinVersion/MaxVersion both empty (the default) preserves today's behavior of "no
+// override, use Go's own crypto/tls default" (currently a TLS 1.2 floor with no
+// configured ceiling).
+type HTTPClientTLSConfig struct {
+	MinVersion string `koanf:"min_version"` // one of "TLS1_0".."TLS1_3"
+	MaxVersion string `koanf:"max_version"` // one of "TLS1_0".."TLS1_3"
+	// CipherSuites is a comma-separated list of Go crypto/tls cipher suite names.
+	// Empty uses Go's own default secure set. Only affects TLS 1.2 and below.
+	CipherSuites string `koanf:"cipher_suites"`
+	// CurvePreferences is a comma-separated, order-significant list of curve/group
+	// names, e.g. "X25519MLKEM768,X25519,P-256" to opt into the FIPS 203 ML-KEM-768
+	// hybrid group while retaining classical fallbacks for a Platform API build that
+	// doesn't support it yet. Empty (the default) uses Go's own defaults (no PQC).
+	CurvePreferences string `koanf:"curve_preferences"`
+}
+
+// HTTPClientProxyConfig mirrors the TOML-expressible subset of httpclient.ProxyConfig.
+// Egress is deliberately not a field here: httpclient.New only requires it when SSRF is
+// also enabled, and this component has no SSRF field at all (see HTTPClientConfig's doc
+// comment), so it would otherwise sit unused.
+type HTTPClientProxyConfig struct {
+	// Mode selects how the proxy is determined: "none", "environment"
+	// (HTTP_PROXY/HTTPS_PROXY/NO_PROXY — matches this transport's previous hardcoded
+	// http.ProxyFromEnvironment behavior, and remains the default here), or "url" (URL/
+	// Username/Password/NoProxy below).
+	Mode     string   `koanf:"mode"`
+	URL      string   `koanf:"url"`
+	Username string   `koanf:"username"`
+	Password string   `koanf:"password"`
+	NoProxy  []string `koanf:"no_proxy"` // exact host, ".suffix", or CIDR entries; only used when mode == "url"
+
+	TLS HTTPClientProxyTLSConfig `koanf:"tls"`
+}
+
+// HTTPClientProxyTLSConfig mirrors httpclient.ProxyTLSConfig (the proxy's own TLS
+// handshake, fully decoupled from the origin TLS handshake in HTTPClientTLSConfig).
+type HTTPClientProxyTLSConfig struct {
+	RootCAFile         string `koanf:"root_ca_file"`
+	ClientCertFile     string `koanf:"client_cert_file"`
+	ClientKeyFile      string `koanf:"client_key_file"`
+	InsecureSkipVerify bool   `koanf:"insecure_skip_verify"`
+}

--- a/portals/ai-workspace/bff/internal/config/server_tls.go
+++ b/portals/ai-workspace/bff/internal/config/server_tls.go
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the
+ * License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package config
+
+import (
+	"crypto/tls"
+	"fmt"
+	"strings"
+
+	"github.com/wso2/api-platform/httpkit/tlsconfig"
+)
+
+// ParseHTTPSEcdhCurves parses a comma-separated EcdhCurves preference list
+// (e.g. "X25519MLKEM768,X25519,P-256") into the tls.CurveID slice consumed by
+// tls.Config.CurvePreferences. Used both to fail config validation closed on
+// an unrecognized curve name and to build the HTTPS listener's TLS config.
+//
+// The name-to-tls.CurveID vocabulary is sourced from httpkit/tlsconfig (the
+// shared, direction-neutral implementation, also used by platform-api's and
+// gateway-controller's server TLS listeners); this function keeps its own
+// wrapper for the "empty string is an error" behavior, which differs from
+// tlsconfig.ParseCurvePreferences's "empty means use Go's defaults" stance —
+// an explicit, always-on TLS listener config has no notion of "unset".
+func ParseHTTPSEcdhCurves(raw string) ([]tls.CurveID, error) {
+	parts := strings.Split(raw, ",")
+	curves := make([]tls.CurveID, 0, len(parts))
+	for _, part := range parts {
+		name := strings.TrimSpace(part)
+		if name == "" {
+			continue
+		}
+		curve, ok := tlsconfig.CurvesByName[name]
+		if !ok {
+			return nil, fmt.Errorf("unsupported ecdh curve %q (supported: X25519, P-256, P-384, P-521, X25519MLKEM768)", name)
+		}
+		curves = append(curves, curve)
+	}
+	if len(curves) == 0 {
+		return nil, fmt.Errorf("must specify at least one ecdh curve")
+	}
+	return curves, nil
+}
+
+// ValidateHTTPSTLSVersions checks that min and max are both recognized
+// version names and that min does not come after max. Unlike
+// tlsconfig.ValidateVersionRange (which treats both-empty as "use Go's
+// defaults"), this listener's config always requires both fields to name a
+// real version — there is no "unset" state for an always-on TLS listener.
+// tls.VersionTLSxx constants are monotonically increasing, so comparing the
+// parsed values directly replaces a separate ordering table.
+func ValidateHTTPSTLSVersions(minVersion, maxVersion string) error {
+	minV, ok := tlsconfig.ParseVersion(minVersion)
+	if !ok {
+		return fmt.Errorf("minimum_protocol_version must be one of TLS1_0, TLS1_1, TLS1_2, TLS1_3, got: %q", minVersion)
+	}
+	maxV, ok := tlsconfig.ParseVersion(maxVersion)
+	if !ok {
+		return fmt.Errorf("maximum_protocol_version must be one of TLS1_0, TLS1_1, TLS1_2, TLS1_3, got: %q", maxVersion)
+	}
+	if minV > maxV {
+		return fmt.Errorf("minimum_protocol_version (%s) cannot be greater than maximum_protocol_version (%s)", minVersion, maxVersion)
+	}
+	return nil
+}
+
+// ParseHTTPSTLSVersion converts a validated version name to its crypto/tls
+// identifier. Callers should run ValidateHTTPSTLSVersions first; an
+// unrecognized name here returns ok=false rather than panicking.
+func ParseHTTPSTLSVersion(name string) (version uint16, ok bool) {
+	return tlsconfig.ParseVersion(name)
+}
+
+// ParseHTTPSCiphers parses a comma-separated list of Go crypto/tls cipher
+// suite names (e.g. "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256") into the
+// []uint16 consumed by tls.Config.CipherSuites. An empty string is valid and
+// returns (nil, nil) — Go's own default suite set/order applies. Only
+// affects TLS 1.2 (and below) connections; TLS 1.3 ignores this field.
+func ParseHTTPSCiphers(raw string) ([]uint16, error) {
+	return tlsconfig.ParseCipherSuites(raw)
+}

--- a/portals/ai-workspace/bff/internal/proxy/transport.go
+++ b/portals/ai-workspace/bff/internal/proxy/transport.go
@@ -38,7 +38,7 @@ type TLSClientOptions struct {
 	SkipVerify bool
 }
 
-// NewTransport builds an *http.Transport for upstream calls with explicit
+// NewTransport builds an http.RoundTripper for upstream calls with explicit
 // timeouts and connection pooling, via the shared httpkit/httpclient builder.
 // hc supplies every knob sourced from [ai_workspace.http_client] in config.toml
 // (see config.HTTPClientConfig's doc comment); opts supplies the upstream TLS
@@ -52,7 +52,13 @@ type TLSClientOptions struct {
 // This transport only ever talks to the fixed, operator-configured Platform
 // API (cfg.ControlPlane.URL) — never a tenant/end-user-supplied destination —
 // so no SSRF guard (httpclient's Config.SSRF) is enabled here.
-func NewTransport(hc config.HTTPClientConfig, opts TLSClientOptions) (*http.Transport, error) {
+//
+// The return type is the interface, not the concrete *http.Transport:
+// hc.Timeouts.MaxResponseBytes >= 0 (see HTTPClientTimeoutsConfig's doc
+// comment) makes httpclient.New wrap the transport in its own
+// maxBytesRoundTripper, which every caller here (http.Client.Transport,
+// proxy.ReverseProxy) already accepts as an http.RoundTripper.
+func NewTransport(hc config.HTTPClientConfig, opts TLSClientOptions) (http.RoundTripper, error) {
 	cfg := httpclient.DefaultConfig()
 
 	cfg.Pooling.MaxIdleConns = hc.Pooling.MaxIdleConns
@@ -130,18 +136,7 @@ func NewTransport(hc config.HTTPClientConfig, opts TLSClientOptions) (*http.Tran
 	if err != nil {
 		return nil, err
 	}
-	// client.Transport is a concrete *http.Transport here as long as
-	// Timeouts.MaxResponseBytes stays negative (the shipped default) — this
-	// config never sets Proxy.Egress = ProxyEgressManualCONNECT, and a negative
-	// MaxResponseBytes means httpclient.New never wraps the transport in its own
-	// maxBytesRoundTripper. An operator who explicitly sets
-	// [ai_workspace.http_client.timeouts] max_response_bytes >= 0 gets a clear
-	// startup error below instead of a silently-wrong cap.
-	transport, ok := client.Transport.(*http.Transport)
-	if !ok {
-		return nil, fmt.Errorf("httpkit: unexpected transport type %T (set [ai_workspace.http_client.timeouts] max_response_bytes back to a negative value)", client.Transport)
-	}
-	return transport, nil
+	return client.Transport, nil
 }
 
 // caPool returns the system root pool with the PEM bundle at path appended, so

--- a/portals/ai-workspace/bff/internal/proxy/transport.go
+++ b/portals/ai-workspace/bff/internal/proxy/transport.go
@@ -17,13 +17,14 @@
 package proxy
 
 import (
-	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"net"
 	"net/http"
 	"os"
-	"time"
+
+	"github.com/wso2/api-platform/httpkit/httpclient"
+
+	"ai-workspace-bff/internal/config"
 )
 
 // TLSClientOptions configures how the upstream (Platform API) certificate is
@@ -38,36 +39,109 @@ type TLSClientOptions struct {
 }
 
 // NewTransport builds an *http.Transport for upstream calls with explicit
-// timeouts and connection pooling. TLS applies only when the upstream URL is
-// https:// — this transport is scheme-agnostic and does nothing for http://.
-func NewTransport(opts TLSClientOptions) (*http.Transport, error) {
-	tlsConf := &tls.Config{
-		MinVersion: tls.VersionTLS12,
-		// #nosec G402 — SkipVerify is an explicit, demo-gated escape hatch
-		// (validated in config); the secure default is false.
-		InsecureSkipVerify: opts.SkipVerify,
-	}
-	if !opts.SkipVerify && opts.CAFile != "" {
+// timeouts and connection pooling, via the shared httpkit/httpclient builder.
+// hc supplies every knob sourced from [ai_workspace.http_client] in config.toml
+// (see config.HTTPClientConfig's doc comment); opts supplies the upstream TLS
+// trust settings, sourced from [ai_workspace.control_plane] instead — kept as a
+// separate parameter because that trust decision already has its own existing
+// config keys (ControlPlaneConfig.CAFile/TLSSkipVerify) which must stay the
+// single source of truth, never duplicated onto HTTPClientConfig. TLS applies
+// only when the upstream URL is https:// — this transport is scheme-agnostic
+// and does nothing for http://.
+//
+// This transport only ever talks to the fixed, operator-configured Platform
+// API (cfg.ControlPlane.URL) — never a tenant/end-user-supplied destination —
+// so no SSRF guard (httpclient's Config.SSRF) is enabled here.
+func NewTransport(hc config.HTTPClientConfig, opts TLSClientOptions) (*http.Transport, error) {
+	cfg := httpclient.DefaultConfig()
+
+	cfg.Pooling.MaxIdleConns = hc.Pooling.MaxIdleConns
+	cfg.Pooling.MaxIdleConnsPerHost = hc.Pooling.MaxIdleConnsPerHost
+	cfg.Pooling.MaxConnsPerHost = hc.Pooling.MaxConnsPerHost
+	cfg.Pooling.IdleConnTimeout = hc.Pooling.IdleConnTimeout
+	cfg.Pooling.KeepAlive = hc.Pooling.KeepAlive
+	cfg.Pooling.DisableKeepAlives = hc.Pooling.DisableKeepAlives
+	cfg.Pooling.EnableHTTP2 = hc.Pooling.EnableHTTP2
+
+	cfg.Timeouts.Overall = hc.Timeouts.Overall
+	cfg.Timeouts.Dial = hc.Timeouts.Dial
+	cfg.Timeouts.TLSHandshake = hc.Timeouts.TLSHandshake
+	cfg.Timeouts.ResponseHeader = hc.Timeouts.ResponseHeader
+	cfg.Timeouts.ExpectContinue = hc.Timeouts.ExpectContinue
+	// The default (see config.defaultConfig) is -1: this transport backs a reverse
+	// proxy that streams SSE/long-running LLM output (see ReverseProxy's
+	// FlushInterval) to/from the BFF's own fixed, trusted backend — not an
+	// arbitrary or tenant-supplied target — so disabling httpclient's default
+	// 10MiB cap is the documented default for exactly this case. An operator can
+	// still opt into a cap via config; see the type-assertion note below.
+	cfg.Timeouts.MaxResponseBytes = hc.Timeouts.MaxResponseBytes
+
+	cfg.TLS.MinVersion = hc.TLS.MinVersion
+	cfg.TLS.MaxVersion = hc.TLS.MaxVersion
+	cfg.TLS.CipherSuites = hc.TLS.CipherSuites
+	cfg.TLS.CurvePreferences = hc.TLS.CurvePreferences
+
+	// #nosec G402 — SkipVerify is an explicit, demo-gated escape hatch
+	// (validated in config); the secure default is false.
+	cfg.TLS.InsecureSkipVerify = opts.SkipVerify
+	if opts.SkipVerify {
+		// Required by httpclient.New alongside InsecureSkipVerify=true: this
+		// toggle is already an explicit, operator-controlled config option
+		// (see TLSClientOptions.SkipVerify), so acknowledging it here
+		// preserves behavior without weakening httpclient's safety gate.
+		cfg.TLS.InsecureSkipVerifyAcknowledged = true
+	} else if opts.CAFile != "" {
+		// Built via caPool (system roots + this bundle appended) rather than
+		// cfg.TLS.RootCAFile, which would replace the trust store outright —
+		// this preserves the original "PEM bundle appended to the system
+		// roots" behavior documented on CAFile above.
 		pool, err := caPool(opts.CAFile)
 		if err != nil {
 			return nil, err
 		}
-		tlsConf.RootCAs = pool
+		cfg.TLS.RootCAs = pool
 	}
-	return &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout:   10 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).DialContext,
-		ForceAttemptHTTP2:     true,
-		MaxIdleConns:          100,
-		MaxIdleConnsPerHost:   20,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
-		TLSClientConfig:       tlsConf,
-	}, nil
+
+	switch hc.Proxy.Mode {
+	case "", "none":
+		// no proxy — cfg.Proxy stays at its zero value
+	case "environment":
+		cfg.Proxy.Mode = "environment"
+	case "url":
+		cfg.Proxy.Mode = "url"
+		cfg.Proxy.URL = hc.Proxy.URL
+		cfg.Proxy.Username = hc.Proxy.Username
+		cfg.Proxy.Password = hc.Proxy.Password
+		cfg.Proxy.NoProxy = hc.Proxy.NoProxy
+		if hc.Proxy.TLS != (config.HTTPClientProxyTLSConfig{}) {
+			cfg.Proxy.ProxyTLS = &httpclient.ProxyTLSConfig{
+				RootCAFile:                     hc.Proxy.TLS.RootCAFile,
+				ClientCertFile:                 hc.Proxy.TLS.ClientCertFile,
+				ClientKeyFile:                  hc.Proxy.TLS.ClientKeyFile,
+				InsecureSkipVerify:             hc.Proxy.TLS.InsecureSkipVerify,
+				InsecureSkipVerifyAcknowledged: hc.Proxy.TLS.InsecureSkipVerify,
+			}
+		}
+	default:
+		return nil, fmt.Errorf("ai_workspace.http_client.proxy.mode: unrecognized value %q (want \"none\", \"environment\", or \"url\")", hc.Proxy.Mode)
+	}
+
+	client, err := httpclient.New(cfg)
+	if err != nil {
+		return nil, err
+	}
+	// client.Transport is a concrete *http.Transport here as long as
+	// Timeouts.MaxResponseBytes stays negative (the shipped default) — this
+	// config never sets Proxy.Egress = ProxyEgressManualCONNECT, and a negative
+	// MaxResponseBytes means httpclient.New never wraps the transport in its own
+	// maxBytesRoundTripper. An operator who explicitly sets
+	// [ai_workspace.http_client.timeouts] max_response_bytes >= 0 gets a clear
+	// startup error below instead of a silently-wrong cap.
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		return nil, fmt.Errorf("httpkit: unexpected transport type %T (set [ai_workspace.http_client.timeouts] max_response_bytes back to a negative value)", client.Transport)
+	}
+	return transport, nil
 }
 
 // caPool returns the system root pool with the PEM bundle at path appended, so

--- a/portals/ai-workspace/bff/internal/server/composite_handlers_test.go
+++ b/portals/ai-workspace/bff/internal/server/composite_handlers_test.go
@@ -96,7 +96,14 @@ func TestExtractSecretHandle(t *testing.T) {
 func buildTestServer(t *testing.T, platformURL, jwt string) (*Server, *httptest.Server) {
 	t.Helper()
 
-	transport, err := proxy.NewTransport(proxy.TLSClientOptions{SkipVerify: true})
+	// MaxResponseBytes: -1 matches the shipped default (see config.defaultConfig) —
+	// a zero value here would make httpclient wrap the transport in its own
+	// maxBytesRoundTripper, which NewTransport's concrete *http.Transport
+	// type-assertion rejects.
+	transport, err := proxy.NewTransport(
+		config.HTTPClientConfig{Timeouts: config.HTTPClientTimeoutsConfig{MaxResponseBytes: -1}},
+		proxy.TLSClientOptions{SkipVerify: true},
+	)
 	if err != nil {
 		t.Fatalf("NewTransport: %v", err)
 	}
@@ -273,7 +280,14 @@ func TestHandleCreateWithSecretCompensation_Unauthenticated(t *testing.T) {
 		ControlPlane: config.ControlPlaneConfig{URL: platform.URL},
 		Cookie:       config.CookieConfig{Name: "_ai_workspace_session"},
 	}
-	transport, err := proxy.NewTransport(proxy.TLSClientOptions{SkipVerify: true})
+	// MaxResponseBytes: -1 matches the shipped default (see config.defaultConfig) —
+	// a zero value here would make httpclient wrap the transport in its own
+	// maxBytesRoundTripper, which NewTransport's concrete *http.Transport
+	// type-assertion rejects.
+	transport, err := proxy.NewTransport(
+		config.HTTPClientConfig{Timeouts: config.HTTPClientTimeoutsConfig{MaxResponseBytes: -1}},
+		proxy.TLSClientOptions{SkipVerify: true},
+	)
 	if err != nil {
 		t.Fatalf("NewTransport: %v", err)
 	}

--- a/portals/ai-workspace/bff/internal/server/composite_handlers_test.go
+++ b/portals/ai-workspace/bff/internal/server/composite_handlers_test.go
@@ -97,9 +97,8 @@ func buildTestServer(t *testing.T, platformURL, jwt string) (*Server, *httptest.
 	t.Helper()
 
 	// MaxResponseBytes: -1 matches the shipped default (see config.defaultConfig) —
-	// a zero value here would make httpclient wrap the transport in its own
-	// maxBytesRoundTripper, which NewTransport's concrete *http.Transport
-	// type-assertion rejects.
+	// the zero value would instead apply httpclient's own 10MiB cap, which these
+	// tests don't need.
 	transport, err := proxy.NewTransport(
 		config.HTTPClientConfig{Timeouts: config.HTTPClientTimeoutsConfig{MaxResponseBytes: -1}},
 		proxy.TLSClientOptions{SkipVerify: true},
@@ -281,9 +280,8 @@ func TestHandleCreateWithSecretCompensation_Unauthenticated(t *testing.T) {
 		Cookie:       config.CookieConfig{Name: "_ai_workspace_session"},
 	}
 	// MaxResponseBytes: -1 matches the shipped default (see config.defaultConfig) —
-	// a zero value here would make httpclient wrap the transport in its own
-	// maxBytesRoundTripper, which NewTransport's concrete *http.Transport
-	// type-assertion rejects.
+	// the zero value would instead apply httpclient's own 10MiB cap, which these
+	// tests don't need.
 	transport, err := proxy.NewTransport(
 		config.HTTPClientConfig{Timeouts: config.HTTPClientTimeoutsConfig{MaxResponseBytes: -1}},
 		proxy.TLSClientOptions{SkipVerify: true},

--- a/portals/ai-workspace/bff/internal/server/server.go
+++ b/portals/ai-workspace/bff/internal/server/server.go
@@ -67,7 +67,7 @@ func New(ctx context.Context, cfg *config.Config) (*Server, error) {
 		return nil, err
 	}
 
-	transport, err := proxy.NewTransport(proxy.TLSClientOptions{
+	transport, err := proxy.NewTransport(cfg.HTTPClient, proxy.TLSClientOptions{
 		CAFile:     cfg.ControlPlane.CAFile,
 		SkipVerify: cfg.ControlPlane.TLSSkipVerify,
 	})

--- a/portals/ai-workspace/bff/main.go
+++ b/portals/ai-workspace/bff/main.go
@@ -273,7 +273,33 @@ func buildTLS(c config.HTTPSListener) (*tls.Config, error) {
 		return nil, err
 	}
 	slog.Info("TLS: using mounted certificate", "cert", c.CertFile)
-	return &tls.Config{Certificates: []tls.Certificate{cert}, MinVersion: tls.VersionTLS12}, nil
+
+	// Config.validate already rejects a bad version/cipher/curve value before
+	// this ever runs in production, so an error here can only come from a
+	// caller that bypassed validation.
+	if err := config.ValidateHTTPSTLSVersions(c.MinimumProtocolVersion, c.MaximumProtocolVersion); err != nil {
+		return nil, err
+	}
+	minVersion, _ := config.ParseHTTPSTLSVersion(c.MinimumProtocolVersion)
+	maxVersion, _ := config.ParseHTTPSTLSVersion(c.MaximumProtocolVersion)
+
+	cipherSuites, err := config.ParseHTTPSCiphers(c.Ciphers)
+	if err != nil {
+		return nil, err
+	}
+
+	curves, err := config.ParseHTTPSEcdhCurves(c.EcdhCurves)
+	if err != nil {
+		return nil, err
+	}
+
+	return &tls.Config{
+		Certificates:     []tls.Certificate{cert},
+		MinVersion:       minVersion,
+		MaxVersion:       maxVersion,
+		CipherSuites:     cipherSuites, // nil == Go's own secure default set/order
+		CurvePreferences: curves,
+	}, nil
 }
 
 func fileExists(p string) bool {

--- a/portals/ai-workspace/configs/config-template.toml
+++ b/portals/ai-workspace/configs/config-template.toml
@@ -118,6 +118,27 @@ port      = 9643
 cert_file = "/etc/ai-workspace/tls/cert.pem"
 key_file  = "/etc/ai-workspace/tls/key.pem"
 
+# minimum_protocol_version / maximum_protocol_version bound the negotiated TLS
+# version: one of "TLS1_0", "TLS1_1", "TLS1_2", "TLS1_3".
+minimum_protocol_version = "TLS1_2"
+maximum_protocol_version = "TLS1_3"
+
+# ciphers is a comma-separated list of Go crypto/tls cipher suite names
+# (e.g. "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256") restricting which suites
+# this listener will negotiate. Empty means Go's own secure default set/order
+# applies. Only affects TLS 1.2 and below — TLS 1.3 suite selection is not
+# configurable in Go's crypto/tls.
+ciphers = ""
+
+# ecdh_curves is a comma-separated list of TLS 1.3 key-exchange groups, most
+# preferred first. Classical curves only by default. Prepend the hybrid
+# post-quantum group "X25519MLKEM768" (FIPS 203 ML-KEM-768 + X25519) as an
+# explicit opt-in once clients reaching this listener are confirmed to
+# support it, e.g. "X25519MLKEM768,X25519,P-256" — a client that doesn't
+# offer the hybrid group simply falls back to a later classical entry in this
+# same list, so enabling it never breaks a legacy peer.
+ecdh_curves = "X25519,P-256"
+
 
 # ---------------------------------------------------------------------------
 # Logging. level/format are this process's own logs; browser_debug is
@@ -149,6 +170,88 @@ tls_skip_verify = "false"
 
 # PEM bundle to trust for the upstream's TLS certificate, appended to system roots.
 ca_file = "/etc/ai-workspace/tls/cert.pem"
+
+
+# ---------------------------------------------------------------------------
+# Outbound *http.Transport used for every call this BFF makes to the Platform API
+# above (see internal/proxy/transport.go's NewTransport, and its one call site in
+# internal/server/server.go). Mirrors github.com/wso2/go-httpkit/httpclient.Config
+# field-for-field, the same shape gateway-controller's and platform-api's own
+# [*.http_client] tables use. Every key below is optional — omitting a subsection
+# entirely keeps its Go-level default, and every default here reproduces exactly
+# what this transport hardcoded before these keys existed, so a deployment that
+# omits this whole table sees zero behavior change.
+#
+# Not configurable here (see [ai_workspace.control_plane] above instead):
+#   - TLS trust for the ORIGIN (Platform API) certificate — tls_skip_verify /
+#     ca_file above already govern that one trust decision; duplicating it here
+#     would create two settings that must always be kept in sync.
+#   - SSRF guarding — this transport only ever talks to the fixed url above, never
+#     a tenant/end-user-supplied destination, so there is nothing to guard against.
+# ---------------------------------------------------------------------------
+[ai_workspace.http_client.pooling]
+max_idle_conns          = 100
+max_idle_conns_per_host = 20
+max_conns_per_host      = 0    # 0 = no per-host cap
+idle_conn_timeout       = "90s"
+keep_alive              = "30s"
+disable_keep_alives     = false
+# HTTP/2 is on by default here (unlike gateway-controller/platform-api, which default
+# it off): this transport already sets a custom TLS config, so Go's own Transport
+# would otherwise conservatively disable HTTP/2 — see
+# httpclient.PoolingConfig.EnableHTTP2's doc comment on the connection-coalescing
+# caveat before disabling.
+enable_http2 = true
+
+[ai_workspace.http_client.timeouts]
+# Overall has no observable effect at this call site today — NewTransport extracts
+# only the *http.Transport, and server.go applies its own separate 60s
+# http.Client.Timeout on top of it. Kept for shape parity / future use.
+overall          = "30s"
+dial             = "10s"
+tls_handshake    = "10s"
+response_header  = "10s"
+expect_continue  = "1s"
+# 0 = httpclient's own package default (10MiB); a negative value disables the
+# response-size bound entirely. Negative by default: this transport backs a reverse
+# proxy that streams SSE / long-running LLM output between the BFF and its own
+# fixed, trusted Platform API — not an arbitrary or tenant-supplied target — so
+# truncating a legitimate long stream would be worse than not bounding it.
+max_response_bytes = -1
+
+[ai_workspace.http_client.tls]
+# Both empty (the default) leaves Go's own crypto/tls default in effect (currently a
+# TLS 1.2 floor with no configured ceiling) — set explicitly to bound the negotiated
+# version instead.
+min_version = ""
+max_version = ""
+# Comma-separated Go crypto/tls cipher suite names; only affects TLS 1.2 and below.
+# Empty uses Go's own default secure set.
+cipher_suites = ""
+# Comma-separated, order-significant TLS 1.3 key-exchange groups, e.g.
+# "X25519MLKEM768,X25519,P-256" to opt into the FIPS 203 ML-KEM-768 hybrid group
+# while retaining classical fallbacks for a Platform API build that doesn't support
+# it yet. Empty (the default) uses Go's own defaults (no PQC).
+curve_preferences = ""
+
+[ai_workspace.http_client.proxy]
+# "none" | "environment" (HTTP_PROXY/HTTPS_PROXY/NO_PROXY — matches this
+# transport's previous hardcoded http.ProxyFromEnvironment behavior, and remains
+# the default here) | "url" (url/username/password/no_proxy below)
+mode     = "environment"
+url      = ""
+username = ""
+password = ""
+no_proxy = []
+
+[ai_workspace.http_client.proxy.tls]
+# Configures a SEPARATE TLS handshake to an https:// proxy itself, decoupled from
+# ai_workspace.http_client.tls above (which always governs the origin handshake).
+# Only used when [ai_workspace.http_client.proxy] mode = "url".
+root_ca_file         = ""
+client_cert_file     = ""
+client_key_file      = ""
+insecure_skip_verify = false
 
 
 # ---------------------------------------------------------------------------

--- a/portals/ai-workspace/configs/config.toml
+++ b/portals/ai-workspace/configs/config.toml
@@ -18,6 +18,11 @@ url = '{{ env "APIP_AIW_CONTROL_PLANE_URL" "https://platform-api:9243" }}'
 tls_skip_verify = '{{ env "APIP_AIW_CONTROL_PLANE_TLS_SKIP_VERIFY" "false" }}'
 ca_file = "/etc/ai-workspace/tls/cert.pem"
 
+# The outbound *http.Transport used for every call to the Platform API above is left
+# entirely at its built-in default here — see configs/config-template.toml's
+# [ai_workspace.http_client.*] tables for the fully documented reference (each key's
+# meaning, and how to opt into a PQC-hybrid curve_preferences).
+
 
 [ai_workspace.gateway]
 controlplane_host = '{{ env "APIP_AIW_GATEWAY_CONTROLPLANE_HOST" "host.docker.internal:9243" }}'


### PR DESCRIPTION
## Summary
- Extracts the `portals/ai-workspace` changes from #3222 into their own branch/PR so they can be reviewed and merged independently of the other components in that PR.
- Adds a shared, configurable HTTP client (connection pooling, timeouts, proxy, TLS options) for the BFF's outbound calls to the Platform API, replacing the previously hardcoded transport settings.
- Adds configurable minimum/maximum TLS protocol version, cipher suite, and curve preference options for the BFF's own HTTPS listener.

## Notes
- All new settings default to values that reproduce prior behavior exactly, so an existing deployment sees no change unless it opts into the new configuration keys.
- No changes to `go.sum` were required (the new module dependency resolves via a local `replace` directive already present on `main`).

## Test plan
- [x] `go build ./...` in `portals/ai-workspace/bff`
- [x] `go vet ./...` in `portals/ai-workspace/bff`
- [x] `go test ./...` in `portals/ai-workspace/bff` — all packages pass