### PR TITLE
Preserve merged SSE fields when a later chunk repeats them as null

### DIFF
--- a/sdk/ai/llmusage/decode.go
+++ b/sdk/ai/llmusage/decode.go
@@ -102,9 +102,12 @@ func mergeSSEEvents(body []byte) ([]byte, bool) {
 // field across events: a "usage" carrying only completion tokens must not erase
 // the prompt tokens an earlier event reported. Arrays and scalars are replaced,
 // so the latest event wins, and an empty string never displaces a value already
-// seen.
+// seen. A null never displaces one either.
 func mergeEventFields(dst, src map[string]interface{}) {
 	for key, value := range src {
+		if value == nil {
+			continue
+		}
 		if str, ok := value.(string); ok && str == "" {
 			continue
 		}

--- a/sdk/ai/llmusage/decode_test.go
+++ b/sdk/ai/llmusage/decode_test.go
@@ -148,6 +148,24 @@ data: {"model":"","usage":{"prompt_tokens":5,"completion_tokens":1}}
 	}
 }
 
+func TestExtractUsage_SSENullDoesNotOverwrite(t *testing.T) {
+	// Providers repeat a field as null in the chunks carrying no value for it,
+	// including after the chunk that did; that must not erase what was reported.
+	body := []byte(`data: {"model":"gpt-4o-mini","usage":{"prompt_tokens":5,"completion_tokens":1}}
+
+data: {"model":"","usage":null}
+`)
+
+	got, err := extractUsage(openAITemplate(), body, nil, "/chat/completions")
+	if err != nil {
+		t.Fatalf("extractUsage returned error: %v", err)
+	}
+
+	if got.TotalInputTokens != 5 || got.OutputTokens != 1 {
+		t.Errorf("usage = %d in / %d out, want 5 / 1 preserved", got.TotalInputTokens, got.OutputTokens)
+	}
+}
+
 func TestExtractUsage_NoUsageObject(t *testing.T) {
 	body := []byte(`{"model":"gpt-4o-mini","choices":[]}`)
 


### PR DESCRIPTION
- mergeEventFields already skipped a later empty string so it could not erase an earlier value, but a later null replaced it outright
- Providers repeat a field as null in chunks carrying no value for it, including after the chunk that did, which is how Azure closes a stream with content filter chunks, leaving a streamed response with no usage and a cost policy pricing the call at zero
- A null is now skipped the same way an empty string was; nested objects still merge member by member and later scalars still replace
- Adds TestExtractUsage_SSENullDoesNotOverwrite, which fails without the fix