### PR TITLE
Add apiFetch to the console host Port for extensions

### DIFF
--- a/portals/api-control-plane/src/hostPort.tsx
+++ b/portals/api-control-plane/src/hostPort.tsx
@@ -32,13 +32,69 @@
 
 import { createContext, useContext, type ReactNode } from 'react';
 
+import { runtimeConfig } from './config/runtime';
+import { CSRF_HEADER, CSRF_HEADER_VALUE } from './contexts/auth/authConstants';
+
 export type NotifySeverity = 'success' | 'info' | 'warning' | 'error';
+
+/**
+ * A same-origin, host-authenticated call to platform-api that an extension can
+ * make without knowing this portal's transport. `path` is relative to the API
+ * base (e.g. `/pipelines`). Resolves parsed JSON (or `undefined` for 204) and
+ * rejects with an `Error` carrying the API's message on failure.
+ */
+export type ApiFetch = <T = unknown>(
+  method: string,
+  path: string,
+  body?: unknown
+) => Promise<T>;
 
 export type CloudHostPort = {
   orgHandle: string;
   projectHandle?: string;
   navigate: (path: string) => void;
   notify: (message: string, severity?: NotifySeverity) => void;
+  apiFetch: ApiFetch;
+};
+
+const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+/**
+ * The Port's `apiFetch`: a same-origin fetch through the BFF proxy, which
+ * injects the bearer token from the session cookie (the browser never holds a
+ * token) and validates the CSRF header on mutations. The org is resolved by
+ * platform-api from that token, so no `X-Org-Id` is sent here. Kept as a small
+ * self-contained wrapper rather than reusing the api layer's transport so it
+ * stays on the UI side of the api-layer import boundary.
+ */
+export const extensionApiFetch: ApiFetch = async <T = unknown>(
+  method: string,
+  path: string,
+  body?: unknown
+): Promise<T> => {
+  const base = `${runtimeConfig.platformApiBaseUrl}/api/${runtimeConfig.platformApiVersion}`;
+  const verb = method.toUpperCase();
+  const headers: Record<string, string> = { Accept: 'application/json' };
+  if (body !== undefined) headers['Content-Type'] = 'application/json';
+  if (MUTATING_METHODS.has(verb)) headers[CSRF_HEADER] = CSRF_HEADER_VALUE;
+  const response = await fetch(`${base}${path}`, {
+    method: verb,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  if (!response.ok) {
+    let message = `Request failed (${response.status})`;
+    try {
+      const parsed = (await response.json()) as { message?: string } | null;
+      if (parsed?.message) message = parsed.message;
+    } catch {
+      /* non-JSON error body — keep the status-based default */
+    }
+    throw new Error(message);
+  }
+  if (response.status === 204 || response.status === 205) return undefined as T;
+  const text = await response.text();
+  return (text ? JSON.parse(text) : undefined) as T;
 };
 
 const PortContext = createContext<CloudHostPort | null>(null);

--- a/portals/api-control-plane/src/pages/appShell/AppLayout.tsx
+++ b/portals/api-control-plane/src/pages/appShell/AppLayout.tsx
@@ -40,7 +40,7 @@ import { runtimeConfig } from '../../config/runtime';
 import { routes } from '../../routes/paths';
 import { useConsoleScope } from '../../scope/ConsoleScopeProvider';
 import { useNotifications } from '../../components/Notifications';
-import { PortProvider, type CloudHostPort } from '../../hostPort';
+import { extensionApiFetch, PortProvider, type CloudHostPort } from '../../hostPort';
 import { AppHeader } from './AppHeader';
 import { APP_FOOTER_ID } from './appLayoutConstants';
 import { AppSidebar } from './AppSidebar';
@@ -75,6 +75,7 @@ export default function AppLayout() {
     projectHandle: params.projectHandler,
     navigate,
     notify,
+    apiFetch: extensionApiFetch,
   };
 
   const crumbs: BreadcrumbItem[] = [];

--- a/portals/api-control-plane/src/routes/AppRoutes.tsx
+++ b/portals/api-control-plane/src/routes/AppRoutes.tsx
@@ -79,8 +79,8 @@ const ApiListPage = lazy(() =>
   }))
 );
 const ApiCreatePage = lazy(() =>
-  import('../pages/appShell/appShellPages/apis/create/ApiCreationWizard').then((m) => ({
-    default: m.ApiCreationWizard,
+  import('../pages/appShell/appShellPages/apis/ApiCreatePage').then((m) => ({
+    default: m.ApiCreatePage,
   }))
 );
 const ApiDetailPage = lazy(() =>


### PR DESCRIPTION
## Purpose
Plugins rendered in the api-control-plane console need a way to call platform-api through the host without importing the portal's api layer (which the console's lint rules forbid for components). The console host Port exposed no such capability.

## Goals
- Add an `apiFetch` capability to the console host Port.

## Approach
- `hostPort.tsx`: export an `ApiFetch` type and a self-contained `extensionApiFetch` that issues a fetch to the platform-api base, adds a CSRF header on mutating requests, maps 204 to `undefined`, and throws an `Error` carrying the API message on failure.
- `AppLayout.tsx`: supply `apiFetch: extensionApiFetch` on the Port handed to plugins.
- Fix a broken lazy import in `AppRoutes.tsx` (`ApiCreationWizard` → `ApiCreatePage`) that prevented the build.

## User stories
A plugin author can call platform-api from a console-hosted feature via the host Port.

## Documentation
N/A — host wiring.

## Automation tests
 - Unit tests
   > Covered by the console typecheck/build.
 - Integration tests
   > Verified the pipelines plugin loads and calls platform-api.

## Security checks
 - Followed secure coding standards? yes
 - Ran FindSecurityBugs plugin and verified report? no (TypeScript/React change)
 - Confirmed no keys/passwords/tokens/secrets committed? yes

## Samples
N/A

## Related PRs
- Pipelines plugin + ai-workspace Port apiFetch (companion): apip-pipelines-plugin-aiw

## Test environment
Built with the portals workspace toolchain; Chrome.
