### PR TITLE
Update Grafana dashboard path and Prometheus targets for observability

### DIFF
--- a/gateway/distribution/docker-compose.yaml
+++ b/gateway/distribution/docker-compose.yaml
@@ -162,7 +162,7 @@ services:
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=admin
       - GF_USERS_ALLOW_SIGN_UP=false
-      - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/etc/grafana/provisioning/dashboards/infrastructure-overview.json
+      - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/etc/grafana/dashboards/infrastructure-overview.json
     volumes:
       - grafana-data:/var/lib/grafana
       - ./observability/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro

--- a/gateway/docker-compose-perf.yaml
+++ b/gateway/docker-compose-perf.yaml
@@ -188,7 +188,7 @@ services:
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=admin
       - GF_USERS_ALLOW_SIGN_UP=false
-      - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/etc/grafana/provisioning/dashboards/infrastructure-overview.json
+      - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/etc/grafana/dashboards/infrastructure-overview.json
     volumes:
       - grafana-data:/var/lib/grafana
       - ./observability/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro

--- a/gateway/docker-compose.yaml
+++ b/gateway/docker-compose.yaml
@@ -171,7 +171,7 @@ services:
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=admin
       - GF_USERS_ALLOW_SIGN_UP=false
-      - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/etc/grafana/provisioning/dashboards/infrastructure-overview.json
+      - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/etc/grafana/dashboards/infrastructure-overview.json
     volumes:
       - grafana-data:/var/lib/grafana
       - ./observability/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro

--- a/gateway/observability/prometheus/prometheus.yml
+++ b/gateway/observability/prometheus/prometheus.yml
@@ -13,11 +13,11 @@ scrape_configs:
   # Policy Engine metrics
   - job_name: 'policy-engine'
     static_configs:
-      - targets: ['policy-engine:9003']
+      - targets: ['gateway-runtime:9003']
     metrics_path: /metrics
 
   # Envoy Router stats (built-in Prometheus format)
   - job_name: 'router'
     static_configs:
-      - targets: ['router:9901']
+      - targets: ['gateway-runtime:9901']
     metrics_path: /stats/prometheus


### PR DESCRIPTION
## Purpose

Prometheus scrapes `policy-engine` and `router`, which no longer exist as services. They were merged into `gateway-runtime`. Policy Engine and Router metrics are never collected, and the dashboards silently stay empty. Also fixes the issue Grafana's home dashboard pointed at a directory containing no dashboards, so it opened on a blank page.

Resolves #3343

## Goals

Restore Policy Engine and Router metrics, and make Grafana open on the Infrastructure Overview dashboard.

## Approach

- Point the `policy-engine` and `router` scrape jobs at `gateway-runtime`. Job names unchanged, so existing dashboards and alerts are unaffected.
- Point `GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH` at `/etc/grafana/dashboards/`, where the dashboards are mounted.

5 lines across 4 files.

## Documentation

N/A — corrections to existing internal values, no documented behaviour changes.

## Automation tests

N/A — configuration-only change. Verified manually: Prometheus reports the corrected scrape URLs, and Grafana's home dashboard path now resolves to an existing file.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
- Ran FindSecurityBugs plugin and verified report? **no** — no Java code in this change.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Test environment

macOS (Apple Silicon), Rancher Desktop, Docker Compose v2.
