### PR TITLE
Add gateway listing and configuration editing to the console

### DIFF
--- a/portals/api-control-plane/src/App.tsx
+++ b/portals/api-control-plane/src/App.tsx
@@ -28,7 +28,7 @@ import { runtimeConfig } from './config/runtime';
 import { AuthProvider } from './contexts/auth/AuthProvider';
 import { ProductActivation } from './hooks/ProductActivation';
 import { AppRoutes } from './routes/AppRoutes';
-import { ExtensionsProvider, type ApiControlPlaneExtension } from './extensions';
+import { ExtensionsProvider, type ApiControlPlaneCloudEntry } from './extensions';
 import { I18nProvider } from './i18n';
 
 /**
@@ -71,7 +71,7 @@ function AppQueryProvider({ children }: { children: ReactNode }) {
 }
 
 export type AppProps = {
-  extensions?: readonly ApiControlPlaneExtension[];
+  extensions?: readonly ApiControlPlaneCloudEntry[];
 };
 
 export default function App({ extensions = [] }: AppProps) {

--- a/portals/api-control-plane/src/cloud/index.ts
+++ b/portals/api-control-plane/src/cloud/index.ts
@@ -22,6 +22,6 @@
  * features, without ever touching App.tsx/main.tsx/extensions.tsx.
  */
 
-import type { ApiControlPlaneExtension } from '../extensions';
+import type { ApiControlPlaneCloudEntry } from '../extensions';
 
-export const cloudExtensions: ApiControlPlaneExtension[] = [];
+export const cloudExtensions: ApiControlPlaneCloudEntry[] = [];

--- a/portals/api-control-plane/src/extensions.tsx
+++ b/portals/api-control-plane/src/extensions.tsx
@@ -52,8 +52,32 @@ export type ApiControlPlaneExtension = SlotEntry & {
 };
 
 /**
- * Slot names core knows about. Both live here rather than being spelled out at
- * each use site, so the sidebar route builder and the nav pipeline (and the
+ * A host-injected replacement for one specific built-in page. Unlike
+ * `ApiControlPlaneExtension` this is not a new nav item and deliberately
+ * carries no `routePath`, `label`, `level` or `icon`: the built-in page keeps
+ * its own route and its own sidebar entry, and only what renders at that route
+ * changes. That also means it can never reach the nav pipeline or a Settings
+ * tab — both filter on `slot` (and `level`) first, and this entry has neither
+ * a `sidebar.` slot nor a level.
+ */
+export type ApiControlPlanePageOverride = SlotEntry & {
+  render: (port: CloudHostPort) => ReactNode;
+};
+
+/**
+ * Every registered cloud entry. Sidebar items, Settings tabs and page
+ * overrides share one slot registry (see `slots/index.tsx`) and are told apart
+ * by `slot` at each consumption site, so this union — not
+ * `ApiControlPlaneExtension` — is what `App`, `AppRoutes` and the registry
+ * accept.
+ */
+export type ApiControlPlaneCloudEntry =
+  | ApiControlPlaneExtension
+  | ApiControlPlanePageOverride;
+
+/**
+ * The slot names core knows about. They live here rather than being spelled out
+ * at each use site, so the sidebar route builder and the nav pipeline (and the
  * Settings tab list and its routes) can never drift apart on a string literal.
  */
 const SIDEBAR_SLOT_PREFIX = 'sidebar.';
@@ -62,10 +86,27 @@ const SIDEBAR_SLOT_PREFIX = 'sidebar.';
 export const settingsTabSlot = (level: NavigationLevel): string =>
   `settings.${level}.tabs`;
 
-/** Whether this entry is a top-level sidebar item rather than a nested one. */
+/**
+ * Slot for overriding the built-in API Gateways pages (list, create, detail)
+ * without changing anything under `pages/appShell/appShellPages/gateways`.
+ * Pairs with the `Hideable name={API_CONTROL_PLANE_GATEWAYS_SLOT}` wrapping
+ * those pages in `AppRoutes` — Slot supplies the replacement, Hideable
+ * suppresses the built-in, the same split the header comment in
+ * `slots/index.tsx` describes.
+ */
+export const API_CONTROL_PLANE_GATEWAYS_SLOT = 'page.gateways';
+
+/**
+ * Whether this entry is a top-level sidebar item rather than a nested one.
+ *
+ * A type predicate, not a plain boolean: the registry holds the
+ * `ApiControlPlaneCloudEntry` union, and only a `sidebar.`-slotted entry
+ * carries the `routePath`/`level` the route and nav passes go on to read.
+ */
 export const isSidebarExtension = (
-  extension: ApiControlPlaneExtension
-): boolean => extension.slot.startsWith(SIDEBAR_SLOT_PREFIX);
+  entry: ApiControlPlaneCloudEntry
+): entry is ApiControlPlaneExtension =>
+  entry.slot.startsWith(SIDEBAR_SLOT_PREFIX);
 
 /**
  * Entries for `settingsTabSlot(level)`, sorted by `order`.
@@ -76,13 +117,15 @@ export const isSidebarExtension = (
  * in the matching route pass rather than half-honoured.
  */
 export const settingsTabExtensions = (
-  extensions: readonly ApiControlPlaneExtension[],
+  extensions: readonly ApiControlPlaneCloudEntry[],
   level: NavigationLevel
 ): ApiControlPlaneExtension[] =>
   extensions
     .filter(
-      (extension) =>
-        extension.slot === settingsTabSlot(level) && extension.level === level
+      (entry): entry is ApiControlPlaneExtension =>
+        entry.slot === settingsTabSlot(level) &&
+        'level' in entry &&
+        entry.level === level
     )
     .sort((left, right) => left.order - right.order);
 
@@ -90,7 +133,7 @@ export function ExtensionsProvider({
   extensions,
   children,
 }: {
-  extensions: readonly ApiControlPlaneExtension[];
+  extensions: readonly ApiControlPlaneCloudEntry[];
   children: ReactNode;
 }) {
   return (
@@ -98,8 +141,8 @@ export function ExtensionsProvider({
   );
 }
 
-export function useExtensions(): readonly ApiControlPlaneExtension[] {
-  return useSlotEntries<ApiControlPlaneExtension>();
+export function useExtensions(): readonly ApiControlPlaneCloudEntry[] {
+  return useSlotEntries<ApiControlPlaneCloudEntry>();
 }
 
 /**

--- a/portals/api-control-plane/src/index.ts
+++ b/portals/api-control-plane/src/index.ts
@@ -25,5 +25,12 @@
 export { default as App } from './App';
 export type { AppProps } from './App';
 export { loadRuntimeConfigScripts } from './config/loadRuntimeConfigScripts';
-export type { ApiControlPlaneExtension } from './extensions';
-export { buildScopedExtensionPath } from './extensions';
+export type {
+  ApiControlPlaneCloudEntry,
+  ApiControlPlaneExtension,
+  ApiControlPlanePageOverride,
+} from './extensions';
+export {
+  API_CONTROL_PLANE_GATEWAYS_SLOT,
+  buildScopedExtensionPath,
+} from './extensions';

--- a/portals/api-control-plane/src/routes/AppRoutes.gatewaysPage.test.tsx
+++ b/portals/api-control-plane/src/routes/AppRoutes.gatewaysPage.test.tsx
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  API_CONTROL_PLANE_GATEWAYS_SLOT,
+  ExtensionsProvider,
+  type ApiControlPlanePageOverride,
+} from '../extensions';
+import { HiddenRegionsProvider } from '../slots';
+import { AppRoutes } from './AppRoutes';
+import { aGateway, anOrganization, aProject, collection, resource } from '../test/msw';
+import { authStatePresets } from '../test/mockAuthState';
+import { server } from '../test/server';
+import { renderWithProviders, screen } from '../test/utils';
+
+/*
+ * Covers the `page.gateways` override slot — the console's only page-override
+ * position, and the two primitives behind it at a page (rather than a tab)
+ * position, which nothing else here exercises.
+ *
+ * The built-ins moved one level down to make room for it, so half of these
+ * tests are the regression guard for that: `routes.gateways()`,
+ * `routes.newGateway()` and `routes.gateway()` still answer exactly as before
+ * whenever no override is registered.
+ */
+describe('AppRoutes gateways page override', () => {
+  const org = anOrganization({
+    id: 'api-platform-demo',
+    displayName: 'API Platform Demo',
+  });
+  const project = aProject({ id: 'retail-apis', displayName: 'Retail APIs' });
+
+  beforeEach(() => {
+    vi.stubEnv('VITE_USE_MOCK_API', 'true');
+    server.use(
+      collection('/organizations', [org]),
+      resource('/organizations/:organizationId', org),
+      collection('/projects', [project]),
+      resource('/projects/:projectId', project),
+      collection('/rest-apis', []),
+      collection('/gateways', []),
+    );
+  });
+  afterEach(() => vi.unstubAllEnvs());
+
+  const GATEWAYS = '/organizations/api-platform-demo/gateways';
+
+  /** Only the built-in list page carries this sentence. */
+  const BUILT_IN_LIST = /Provision and manage self-hosted or WSO2-managed/;
+
+  const override: ApiControlPlanePageOverride = {
+    id: 'gateways',
+    order: 0,
+    render: () => <div>Cloud gateways page</div>,
+    slot: API_CONTROL_PLANE_GATEWAYS_SLOT,
+  };
+
+  const renderAt = (route: string, entries: readonly ApiControlPlanePageOverride[] = []) =>
+    renderWithProviders(
+      <ExtensionsProvider extensions={entries}>
+        <AppRoutes extensions={entries} />
+      </ExtensionsProvider>,
+      { authState: authStatePresets.authenticated(), route },
+    );
+
+  it('renders the built-in list page when nothing is registered', async () => {
+    renderAt(GATEWAYS);
+
+    expect(await screen.findByText(BUILT_IN_LIST)).toBeInTheDocument();
+  });
+
+  it('keeps the built-in create and detail URLs answering after the re-nesting', async () => {
+    renderAt(`${GATEWAYS}/new`);
+
+    expect(await screen.findByText('Provision a gateway')).toBeInTheDocument();
+  });
+
+  it('passes ancestor route params down into the re-nested detail page', async () => {
+    // The detail page reads BOTH `orgHandle` (matched by the outer `gateways/*`
+    // route) and `gatewayId` (matched by the inner one). A page that renders
+    // the fetched gateway at all is the proof the two accumulated across the
+    // nested `<Routes>`: match the inner route alone and `gatewayId` is
+    // undefined, which leaves the query disabled and the page on its loading
+    // state forever.
+    server.use(
+      resource(
+        '/gateways/:gatewayId',
+        aGateway({ displayName: 'Shared Gateway', id: 'shared-gateway' })
+      )
+    );
+
+    renderAt(`${GATEWAYS}/shared-gateway`);
+
+    expect(await screen.findByText('Shared Gateway')).toBeInTheDocument();
+  });
+
+  it('renders a registered override instead of the built-in list page', async () => {
+    renderAt(GATEWAYS, [override]);
+
+    expect(await screen.findByText('Cloud gateways page')).toBeInTheDocument();
+    expect(screen.queryByText(BUILT_IN_LIST)).not.toBeInTheDocument();
+  });
+
+  it('mounts the override with a trailing wildcard so its own nested routes resolve', async () => {
+    // The override renders its own `<Routes>`; `gateways/create` is a path only
+    // it knows about. Drop the `/*` on the host route and this is a 404 while
+    // the index route above still passes, which is the failure that looks like
+    // a routing bug inside the plugin.
+    const nested: ApiControlPlanePageOverride = {
+      ...override,
+      render: () => (
+        <Routes>
+          <Route index element={<div>Cloud gateways page</div>} />
+          <Route path="create" element={<div>Cloud provision form</div>} />
+        </Routes>
+      ),
+    };
+
+    renderAt(`${GATEWAYS}/create`, [nested]);
+
+    expect(await screen.findByText('Cloud provision form')).toBeInTheDocument();
+  });
+
+  it('hands the override a Port carrying the scope it rendered in', async () => {
+    const portAware: ApiControlPlanePageOverride = {
+      ...override,
+      render: (port) => <div>Port org: {port.orgHandle}</div>,
+    };
+
+    renderAt(GATEWAYS, [portAware]);
+
+    expect(await screen.findByText('Port org: api-platform-demo')).toBeInTheDocument();
+  });
+
+  it('suppresses the built-in page when the region is hidden and nothing replaces it', async () => {
+    // Slot adds, Hideable suppresses: hiding the region without registering an
+    // override has to leave the position empty rather than fall back to the
+    // built-in.
+    renderWithProviders(
+      <HiddenRegionsProvider hidden={[API_CONTROL_PLANE_GATEWAYS_SLOT]}>
+        <AppRoutes />
+      </HiddenRegionsProvider>,
+      { authState: authStatePresets.authenticated(), route: GATEWAYS },
+    );
+
+    expect(await screen.findByText('API Platform Demo')).toBeInTheDocument();
+    expect(screen.queryByText(BUILT_IN_LIST)).not.toBeInTheDocument();
+  });
+});

--- a/portals/api-control-plane/src/routes/AppRoutes.tsx
+++ b/portals/api-control-plane/src/routes/AppRoutes.tsx
@@ -31,13 +31,17 @@ import {
 import { ConsoleScopeProvider } from '@/scope/ConsoleScopeProvider';
 import AppLayout from '@/pages/appShell/AppLayout';
 import {
+  API_CONTROL_PLANE_GATEWAYS_SLOT,
   extensionScopedPaths,
   isSidebarExtension,
   settingsTabExtensions,
+  type ApiControlPlaneCloudEntry,
   type ApiControlPlaneExtension,
+  type ApiControlPlanePageOverride,
 } from '@/extensions';
 import type { NavigationLevel } from '@/navigation/navigationTypes';
 import { usePort } from '@/hostPort';
+import { Hideable, useSlot } from '@/slots';
 import { ProtectedRoute } from './ProtectedRoute';
 import { apiScopedPaths, projectScopedPaths, routes } from './paths';
 
@@ -174,7 +178,7 @@ const GeneralSettingsPage = lazy(() =>
 );
 
 export type AppRoutesProps = {
-  extensions?: readonly ApiControlPlaneExtension[];
+  extensions?: readonly ApiControlPlaneCloudEntry[];
 };
 
 /**
@@ -196,6 +200,38 @@ const scopedRoutes = (paths: string[], element: ReactNode) =>
 function ExtensionRoute({ extension }: { extension: ApiControlPlaneExtension }) {
   const port = usePort();
   return <>{extension.render(port)}</>;
+}
+
+/**
+ * Renders a cloud-registered replacement for the built-in API Gateways pages
+ * when one is registered against `API_CONTROL_PLANE_GATEWAYS_SLOT`, otherwise
+ * the built-in list/create/detail pages — suppressible on their own via
+ * `Hideable`, per `slots/index.tsx`'s Slot-adds/Hideable-suppresses split.
+ *
+ * The built-ins are re-nested one level down rather than deleted, and
+ * `routes.gateways()`, `routes.newGateway()` and `routes.gateway()` keep the
+ * exact strings they had, so every link, the nav matcher and any bookmarked
+ * URL answer the same as before whenever no override is registered.
+ *
+ * The mount path ends in `/*` because an override renders its own `<Routes>`
+ * below this point; without it the override's index route would render while
+ * every path under it fell through to the 404.
+ */
+function GatewaysRoute() {
+  const port = usePort();
+  const [override] = useSlot<ApiControlPlanePageOverride>(
+    API_CONTROL_PLANE_GATEWAYS_SLOT
+  );
+  if (override) return <>{override.render(port)}</>;
+  return (
+    <Hideable name={API_CONTROL_PLANE_GATEWAYS_SLOT}>
+      <Routes>
+        <Route index element={<GatewaysPage />} />
+        <Route path="new" element={<GatewayCreatePage />} />
+        <Route path=":gatewayId" element={<GatewayDetailPage />} />
+      </Routes>
+    </Hideable>
+  );
 }
 
 export function AppRoutes({ extensions = [] }: AppRoutesProps) {
@@ -245,9 +281,7 @@ export function AppRoutes({ extensions = [] }: AppRoutesProps) {
           <Route path={routes.organizations} element={<OrganizationRedirectPage />} />
           <Route path={routes.organizationHome()} element={<OrganizationHomePage />} />
           <Route path={routes.projects()} element={<ProjectListPage />} />
-          <Route path={routes.gateways()} element={<GatewaysPage />} />
-          <Route path={routes.newGateway()} element={<GatewayCreatePage />} />
-          <Route path={routes.gateway()} element={<GatewayDetailPage />} />
+          <Route path={`${routes.gateways()}/*`} element={<GatewaysRoute />} />
           {/*
             Project and API overview take a single fully-scoped path each: they
             are the deeper tiers of the sidebar's Overview item, which degrades

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/GatewaysFeature.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/GatewaysFeature.tsx
@@ -46,9 +46,9 @@ const GatewaysListRoute: FC<{ port: AIWorkspaceHostPort }> = ({ port }) => {
   const navigate = useNavigate();
   return (
     <GatewaysList
+      port={port}
       onAddClick={() => navigate('create')}
       onEditClick={(gatewayId) => navigate(`edit/${gatewayId}`)}
-      notify={port.notify}
     />
   );
 };

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/GatewaysList.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/GatewaysList.tsx
@@ -16,8 +16,9 @@
  * under the License.
  */
 
-import { useMemo, useState, type FC } from 'react';
+import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import {
+  Alert,
   Avatar,
   Box,
   Button,
@@ -45,17 +46,18 @@ import {
 } from '@wso2/oxygen-ui';
 import { Edit, Plus, Search, Settings, Trash2 } from '@wso2/oxygen-ui-icons-react';
 import GatewaySettingsDrawer from './components/GatewaySettingsDrawer';
-import { deleteGateway, listEnvironments, listGateways } from './mocks/gatewaysStore';
+import { listGateways as listRealGateways } from './data/gatewaysData';
+import { deleteGateway, listGateways } from './mocks/gatewaysStore';
 import { relativeTime } from './utils/time';
 import { gatewayTypeLabel } from './utils/gateway';
 import NoGatewaysImage from './assets/images/NoGW.svg';
-import type { NotifySeverity } from './hostPort';
+import type { AIWorkspaceHostPort } from './hostPort';
 import type { Gateway } from './types';
 
 export type GatewaysListProps = {
+  port: AIWorkspaceHostPort;
   onAddClick: () => void;
   onEditClick: (gatewayId: string) => void;
-  notify?: (message: string, severity?: NotifySeverity) => void;
 };
 
 function truncateText(text: string, maxLength: number): string {
@@ -63,12 +65,32 @@ function truncateText(text: string, maxLength: number): string {
   return `${text.slice(0, maxLength).trim()}…`;
 }
 
-const GatewaysList: FC<GatewaysListProps> = ({ onAddClick, onEditClick, notify }) => {
-  const [gateways, setGateways] = useState<Gateway[]>(() => listGateways());
-  const [environments] = useState(() => listEnvironments());
+const GatewaysList: FC<GatewaysListProps> = ({ port, onAddClick, onEditClick }) => {
+  const { apiFetch, notify } = port;
+  const [gateways, setGateways] = useState<Gateway[]>(() => (apiFetch ? [] : listGateways()));
   const [searchQuery, setSearchQuery] = useState('');
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<{ id: string; name: string } | null>(null);
   const [settingsGateway, setSettingsGateway] = useState<Gateway | null>(null);
+
+  // Real gateways where the host's Port can reach platform-api (the console);
+  // the in-memory store otherwise, which is what the AI Workspace runs on.
+  const load = useCallback(async () => {
+    if (!apiFetch) {
+      setGateways(listGateways());
+      return;
+    }
+    try {
+      setGateways(await listRealGateways(apiFetch));
+      setLoadError(null);
+    } catch (error) {
+      setLoadError(error instanceof Error ? error.message : 'Gateways could not be loaded.');
+    }
+  }, [apiFetch]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
 
   const filteredGateways = useMemo(() => {
     const query = searchQuery.trim().toLowerCase();
@@ -81,7 +103,7 @@ const GatewaysList: FC<GatewaysListProps> = ({ onAddClick, onEditClick, notify }
   const handleDeleteConfirm = () => {
     if (!deleteTarget) return;
     deleteGateway(deleteTarget.id);
-    setGateways(listGateways());
+    void load();
     notify?.(`Gateway "${deleteTarget.name}" deleted.`, 'success');
     setDeleteTarget(null);
   };
@@ -105,6 +127,21 @@ const GatewaysList: FC<GatewaysListProps> = ({ onAddClick, onEditClick, notify }
             </Stack>
           </Box>
         </Grid>
+
+        {loadError ? (
+          <Grid size={{ xs: 12 }}>
+            <Alert
+              severity="error"
+              action={
+                <Button size="small" onClick={() => void load()}>
+                  Retry
+                </Button>
+              }
+            >
+              {loadError}
+            </Alert>
+          </Grid>
+        ) : null}
 
         {gateways.length === 0 ? (
           <Grid size={{ xs: 12 }}>
@@ -213,13 +250,15 @@ const GatewaysList: FC<GatewaysListProps> = ({ onAddClick, onEditClick, notify }
                               <IconButton size="small" onClick={() => onEditClick(gateway.id)} aria-label={`Edit ${gateway.name}`}>
                                 <Edit size={16} />
                               </IconButton>
-                              <IconButton
-                                size="small"
-                                onClick={() => setSettingsGateway(gateway)}
-                                aria-label={`Configure ${gateway.name}`}
-                              >
-                                <Settings size={16} />
-                              </IconButton>
+                              {apiFetch && gateway.isManaged ? (
+                                <IconButton
+                                  size="small"
+                                  onClick={() => setSettingsGateway(gateway)}
+                                  aria-label={`Configure ${gateway.name}`}
+                                >
+                                  <Settings size={16} />
+                                </IconButton>
+                              ) : null}
                               <IconButton
                                 size="small"
                                 color="error"
@@ -257,10 +296,11 @@ const GatewaysList: FC<GatewaysListProps> = ({ onAddClick, onEditClick, notify }
       </Dialog>
 
       <GatewaySettingsDrawer
+        key={settingsGateway?.id ?? 'none'}
         open={settingsGateway !== null}
         onClose={() => setSettingsGateway(null)}
         gateway={settingsGateway}
-        environments={environments}
+        port={port}
       />
     </PageContent>
   );

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/GatewaysList.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/GatewaysList.tsx
@@ -70,6 +70,8 @@ const GatewaysList: FC<GatewaysListProps> = ({ port, onAddClick, onEditClick }) 
   const [gateways, setGateways] = useState<Gateway[]>(() => (apiFetch ? [] : listGateways()));
   const [searchQuery, setSearchQuery] = useState('');
   const [loadError, setLoadError] = useState<string | null>(null);
+  /** `/managed-gateways` did not answer, so no row can offer configuration. */
+  const [managedUnavailable, setManagedUnavailable] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<{ id: string; name: string } | null>(null);
   const [settingsGateway, setSettingsGateway] = useState<Gateway | null>(null);
 
@@ -81,7 +83,9 @@ const GatewaysList: FC<GatewaysListProps> = ({ port, onAddClick, onEditClick }) 
       return;
     }
     try {
-      setGateways(await listRealGateways(apiFetch));
+      const listing = await listRealGateways(apiFetch);
+      setGateways(listing.gateways);
+      setManagedUnavailable(listing.managedUnavailable);
       setLoadError(null);
     } catch (error) {
       setLoadError(error instanceof Error ? error.message : 'Gateways could not be loaded.');
@@ -100,6 +104,11 @@ const GatewaysList: FC<GatewaysListProps> = ({ port, onAddClick, onEditClick }) 
     );
   }, [gateways, searchQuery]);
 
+  // Delete is mock-only, exactly as the AI Workspace has it -- there is no
+  // platform delete for this list to call. On an API-backed list it therefore
+  // removes nothing: `load()` refetches and the row comes straight back, so
+  // reporting success would be a plain untruth. The button is not offered
+  // there (see `canDelete`), and this stays the store-backed path.
   const handleDeleteConfirm = () => {
     if (!deleteTarget) return;
     deleteGateway(deleteTarget.id);
@@ -107,6 +116,9 @@ const GatewaysList: FC<GatewaysListProps> = ({ port, onAddClick, onEditClick }) 
     notify?.(`Gateway "${deleteTarget.name}" deleted.`, 'success');
     setDeleteTarget(null);
   };
+
+  /** Only the in-memory store can actually delete, so only it offers to. */
+  const canDelete = !apiFetch;
 
   return (
     <PageContent fullWidth>
@@ -139,6 +151,29 @@ const GatewaysList: FC<GatewaysListProps> = ({ port, onAddClick, onEditClick }) 
               }
             >
               {loadError}
+            </Alert>
+          </Grid>
+        ) : null}
+
+        {/*
+          The gateways loaded but the managed-gateway list did not, so no row
+          can be shown as configurable. A warning rather than an error: the
+          list itself is complete and correct, and only the Configure action is
+          missing -- which would otherwise just be absent, with nothing on
+          screen to say why.
+        */}
+        {managedUnavailable && !loadError ? (
+          <Grid size={{ xs: 12 }}>
+            <Alert
+              severity="warning"
+              action={
+                <Button size="small" onClick={() => void load()}>
+                  Retry
+                </Button>
+              }
+            >
+              Gateway configuration is unavailable right now, so no gateway can
+              be configured from this page. The list below is complete.
             </Alert>
           </Grid>
         ) : null}
@@ -259,14 +294,16 @@ const GatewaysList: FC<GatewaysListProps> = ({ port, onAddClick, onEditClick }) 
                                   <Settings size={16} />
                                 </IconButton>
                               ) : null}
-                              <IconButton
-                                size="small"
-                                color="error"
-                                onClick={() => setDeleteTarget({ id: gateway.id, name: gateway.name })}
-                                aria-label={`Delete ${gateway.name}`}
-                              >
-                                <Trash2 size={16} />
-                              </IconButton>
+                              {canDelete ? (
+                                <IconButton
+                                  size="small"
+                                  color="error"
+                                  onClick={() => setDeleteTarget({ id: gateway.id, name: gateway.name })}
+                                  aria-label={`Delete ${gateway.name}`}
+                                >
+                                  <Trash2 size={16} />
+                                </IconButton>
+                              ) : null}
                             </TableCell>
                           </TableRow>
                         ))

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/ConfigStatusBar.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/ConfigStatusBar.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { FC } from 'react';
+import { Box, IconButton, Tooltip, Typography } from '@wso2/oxygen-ui';
+import { CircleAlert, CircleCheck, RefreshCw } from '@wso2/oxygen-ui-icons-react';
+import type { ConfigPhase, ConfigStatus } from '../types';
+
+export type ConfigStatusBarProps = {
+  status: ConfigStatus;
+  onRefresh: () => void;
+  refreshing?: boolean;
+};
+
+/**
+ * The phase of the last configuration change. `applying` is the expected state
+ * immediately after ANY write and can persist for minutes — it is not a
+ * failure, and the `message` that often comes with it is prose, not an error.
+ */
+const PHASES: Record<
+  ConfigPhase,
+  { label: string; color: string; Icon: typeof CircleCheck }
+> = {
+  applying: { color: 'info.main', Icon: RefreshCw, label: 'Applying' },
+  failed: { color: 'error.main', Icon: CircleAlert, label: 'Failed' },
+  healthy: { color: 'success.main', Icon: CircleCheck, label: 'Healthy' },
+};
+
+const ConfigStatusBar: FC<ConfigStatusBarProps> = ({
+  status,
+  onRefresh,
+  refreshing = false,
+}) => {
+  // An unrecognised phase is a newer platform than this build; say the word it
+  // sent rather than mislabelling it as healthy.
+  const phase = PHASES[status.phase] ?? {
+    color: 'text.secondary',
+    Icon: CircleAlert,
+    label: status.phase,
+  };
+
+  return (
+    <Box
+      sx={{
+        alignItems: 'center',
+        borderBottom: 1,
+        borderColor: 'divider',
+        display: 'flex',
+        gap: 1,
+        px: 3,
+        py: 1.25,
+      }}
+    >
+      <Box sx={{ color: phase.color, display: 'flex' }}>
+        <phase.Icon size={18} />
+      </Box>
+      <Typography sx={{ color: phase.color, fontWeight: 600 }} variant="body2">
+        {phase.label}
+      </Typography>
+      {status.message ? (
+        <Typography
+          color="text.secondary"
+          sx={{ flex: 1, minWidth: 0 }}
+          variant="body2"
+        >
+          {status.message}
+        </Typography>
+      ) : null}
+      <Tooltip title="Refresh status">
+        <IconButton
+          aria-label="Refresh status"
+          disabled={refreshing}
+          onClick={onRefresh}
+          size="small"
+          sx={{ ml: 'auto' }}
+        >
+          <RefreshCw size={16} />
+        </IconButton>
+      </Tooltip>
+    </Box>
+  );
+};
+
+export default ConfigStatusBar;

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/ConfigStatusBar.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/ConfigStatusBar.tsx
@@ -17,8 +17,8 @@
  */
 
 import type { FC } from 'react';
-import { Box, IconButton, Tooltip, Typography } from '@wso2/oxygen-ui';
-import { CircleAlert, CircleCheck, RefreshCw } from '@wso2/oxygen-ui-icons-react';
+import { Box, Chip, IconButton, Tooltip } from '@wso2/oxygen-ui';
+import { RefreshCw } from '@wso2/oxygen-ui-icons-react';
 import type { ConfigPhase, ConfigStatus } from '../types';
 
 export type ConfigStatusBarProps = {
@@ -28,17 +28,21 @@ export type ConfigStatusBarProps = {
 };
 
 /**
- * The phase of the last configuration change. `applying` is the expected state
- * immediately after ANY write and can persist for minutes — it is not a
- * failure, and the `message` that often comes with it is prose, not an error.
+ * The phase of the last configuration change, as one chip beside the gateway
+ * name.
+ *
+ * `applying` is the expected state immediately after ANY write and can persist
+ * for minutes -- it is not a failure. The `message` that often accompanies it
+ * is deliberately NOT shown: it is prose of unbounded length, it pushed the
+ * form down the drawer, and the phase word is the part a reader acts on. It
+ * stays in the response for anyone reading the endpoint directly.
  */
-const PHASES: Record<
-  ConfigPhase,
-  { label: string; color: string; Icon: typeof CircleCheck }
-> = {
-  applying: { color: 'info.main', Icon: RefreshCw, label: 'Applying' },
-  failed: { color: 'error.main', Icon: CircleAlert, label: 'Failed' },
-  healthy: { color: 'success.main', Icon: CircleCheck, label: 'Healthy' },
+type ChipColor = 'default' | 'info' | 'error' | 'success';
+
+const PHASES: Record<ConfigPhase, { color: ChipColor; label: string }> = {
+  applying: { color: 'info', label: 'Applying' },
+  failed: { color: 'error', label: 'Failed' },
+  healthy: { color: 'success', label: 'Healthy' },
 };
 
 const ConfigStatusBar: FC<ConfigStatusBarProps> = ({
@@ -49,48 +53,32 @@ const ConfigStatusBar: FC<ConfigStatusBarProps> = ({
   // An unrecognised phase is a newer platform than this build; say the word it
   // sent rather than mislabelling it as healthy.
   const phase = PHASES[status.phase] ?? {
-    color: 'text.secondary',
-    Icon: CircleAlert,
+    color: 'default' as ChipColor,
     label: status.phase,
   };
 
   return (
-    <Box
-      sx={{
-        alignItems: 'center',
-        borderBottom: 1,
-        borderColor: 'divider',
-        display: 'flex',
-        gap: 1,
-        px: 3,
-        py: 1.25,
-      }}
-    >
-      <Box sx={{ color: phase.color, display: 'flex' }}>
-        <phase.Icon size={18} />
-      </Box>
-      <Typography sx={{ color: phase.color, fontWeight: 600 }} variant="body2">
-        {phase.label}
-      </Typography>
-      {status.message ? (
-        <Typography
-          color="text.secondary"
-          sx={{ flex: 1, minWidth: 0 }}
-          variant="body2"
-        >
-          {status.message}
-        </Typography>
-      ) : null}
+    <Box sx={{ alignItems: 'center', display: 'flex', gap: 0.5 }}>
+      <Chip
+        color={phase.color}
+        label={phase.label}
+        size="small"
+        sx={{ flexShrink: 0 }}
+        variant="outlined"
+      />
       <Tooltip title="Refresh status">
-        <IconButton
-          aria-label="Refresh status"
-          disabled={refreshing}
-          onClick={onRefresh}
-          size="small"
-          sx={{ ml: 'auto' }}
-        >
-          <RefreshCw size={16} />
-        </IconButton>
+        {/* Wrapped: a disabled button fires no events, so the tooltip on it
+            would never open while a refresh is in flight. */}
+        <Box component="span">
+          <IconButton
+            aria-label="Refresh status"
+            disabled={refreshing}
+            onClick={onRefresh}
+            size="small"
+          >
+            <RefreshCw size={14} />
+          </IconButton>
+        </Box>
       </Tooltip>
     </Box>
   );

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/GatewaySettingsDrawer.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/GatewaySettingsDrawer.tsx
@@ -31,6 +31,7 @@ import { readConfiguration, writeConfiguration } from '../config/api';
 import {
   fieldForServerMessage,
   validateForm,
+  withoutPathPrefix,
   type FieldErrors,
 } from '../config/validate';
 import type { AIWorkspaceHostPort } from '../hostPort';
@@ -109,9 +110,18 @@ const GatewaySettingsDrawer: FC<GatewaySettingsDrawerProps> = ({
   const patch = useMemo<ConfigValues>(() => {
     if (!config) return {};
     return Object.fromEntries(
-      Object.entries(drafts).filter(
-        ([path, value]) => value !== config.values[path]
-      )
+      Object.entries(drafts).filter(([path, value]) => {
+        // Typing into a field the platform carries NO value for and then
+        // clearing it again is not an edit. The stored value reads back
+        // `undefined` while an emptied input reads `''`, so a plain `!==`
+        // called that a change and left the form permanently dirty — with a
+        // validation error under a field the user had just put back the way
+        // they found it. There is no "unset" operation on the endpoint: an
+        // empty input on an unset field means the chart default still stands,
+        // which is exactly the state before the typing.
+        if (!(path in config.values)) return value !== '' && value !== undefined;
+        return value !== config.values[path];
+      })
     );
   }, [config, drafts]);
 
@@ -157,7 +167,10 @@ const GatewaySettingsDrawer: FC<GatewaySettingsDrawerProps> = ({
         message,
         config.editable.map((field) => field.path)
       );
-      if (path) setServerErrors({ [path]: message });
+      // Under a field the path is dropped — the label already says which
+      // setting this is. The banner keeps the full sentence, having no label
+      // to lean on.
+      if (path) setServerErrors({ [path]: withoutPathPrefix(message, path) });
       else setSaveError(message);
     } finally {
       setSaving(false);
@@ -199,18 +212,31 @@ const GatewaySettingsDrawer: FC<GatewaySettingsDrawerProps> = ({
               <X size={18} />
             </IconButton>
           </Box>
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-            {gateway.name}
-          </Typography>
+          <Box
+            sx={{
+              alignItems: 'center',
+              display: 'flex',
+              gap: 1,
+              mb: 2,
+              minHeight: 32,
+            }}
+          >
+            <Typography
+              color="text.secondary"
+              sx={{ flex: 1, minWidth: 0 }}
+              variant="body2"
+            >
+              {gateway.name}
+            </Typography>
+            {config ? (
+              <ConfigStatusBar
+                status={config.status}
+                refreshing={loading}
+                onRefresh={() => gatewayId && void load(gatewayId)}
+              />
+            ) : null}
+          </Box>
         </Box>
-
-        {config ? (
-          <ConfigStatusBar
-            status={config.status}
-            refreshing={loading}
-            onRefresh={() => gatewayId && void load(gatewayId)}
-          />
-        ) : null}
 
         <Box sx={{ flex: 1, minHeight: 0, overflowY: 'auto', px: 3 }}>
           {loading && !config ? (

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/GatewaySettingsDrawer.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/GatewaySettingsDrawer.tsx
@@ -273,7 +273,6 @@ const GatewaySettingsDrawer: FC<GatewaySettingsDrawerProps> = ({
               key={field.path}
               field={field}
               value={currentValue(field.path)}
-              present={config ? field.path in config.values : false}
               error={errors[field.path]}
               readOnly={saving}
               onChange={(value) => setDraft(field.path, value)}

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/GatewaySettingsDrawer.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/GatewaySettingsDrawer.tsx
@@ -16,70 +16,287 @@
  * under the License.
  */
 
-import type { FC } from 'react';
-import { Box, Divider, Drawer, IconButton, Typography } from '@wso2/oxygen-ui';
+import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Drawer,
+  IconButton,
+  Typography,
+} from '@wso2/oxygen-ui';
 import { X } from '@wso2/oxygen-ui-icons-react';
-import { relativeTime } from '../utils/time';
-import { gatewayTypeLabel } from '../utils/gateway';
-import type { Gateway, Environment } from '../types';
+import { readConfiguration, writeConfiguration } from '../config/api';
+import {
+  fieldForServerMessage,
+  validateForm,
+  type FieldErrors,
+} from '../config/validate';
+import type { AIWorkspaceHostPort } from '../hostPort';
+import type { ConfigValues, Gateway, GatewayConfiguration } from '../types';
+import ConfigStatusBar from './ConfigStatusBar';
+import SettingField from './SettingField';
+import TomlField from './TomlField';
 
 export type GatewaySettingsDrawerProps = {
   open: boolean;
   onClose: () => void;
   gateway: Gateway | null;
-  environments: Environment[];
+  port: AIWorkspaceHostPort;
 };
 
-const GatewaySettingsDrawer: FC<GatewaySettingsDrawerProps> = ({ open, onClose, gateway, environments }) => {
+/**
+ * The gateway's configuration form.
+ *
+ * Rendered entirely FROM THE RESPONSE: the platform reads its allowlist at
+ * request time, so `editable[]` is the field list and `constraints[]` the
+ * cross-field rules, and there is deliberately no client-side copy of either. A
+ * setting the deployment adds or withdraws appears or disappears here without a
+ * plugin release.
+ *
+ * The caller mounts this with `key={gateway.id}`, so its state belongs to one
+ * gateway and cannot outlive it.
+ */
+
+const DRAWER_WIDTH = 520;
+
+const GatewaySettingsDrawer: FC<GatewaySettingsDrawerProps> = ({
+  open,
+  onClose,
+  gateway,
+  port,
+}) => {
+  const { apiFetch, notify } = port;
+  const gatewayId = gateway?.id;
+
+  const [config, setConfig] = useState<GatewayConfiguration | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  /** Only the paths the user has touched. The request body is a sparse patch of exactly these. */
+  const [drafts, setDrafts] = useState<ConfigValues>({});
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [serverErrors, setServerErrors] = useState<FieldErrors>({});
+
+  /** Re-seeds `config` only. Pending edits survive, so Refresh cannot discard them. */
+  const load = useCallback(
+    async (id: string) => {
+      if (!apiFetch) return;
+      setLoading(true);
+      setLoadError(null);
+      try {
+        setConfig(await readConfiguration(apiFetch, id));
+      } catch (error) {
+        setLoadError(
+          error instanceof Error
+            ? error.message
+            : 'The configuration could not be loaded.'
+        );
+      } finally {
+        setLoading(false);
+      }
+    },
+    [apiFetch]
+  );
+
+  useEffect(() => {
+    if (!open || !gatewayId) return;
+    void load(gatewayId);
+  }, [gatewayId, load, open]);
+
+  /** Edits that actually differ from what is stored — editing a field back to its original un-dirties it. */
+  const patch = useMemo<ConfigValues>(() => {
+    if (!config) return {};
+    return Object.fromEntries(
+      Object.entries(drafts).filter(
+        ([path, value]) => value !== config.values[path]
+      )
+    );
+  }, [config, drafts]);
+
+  const clientErrors = useMemo<FieldErrors>(
+    () => (config ? validateForm(config, patch) : {}),
+    [config, patch]
+  );
+  const errors = { ...serverErrors, ...clientErrors };
+
+  const dirtyCount = Object.keys(patch).length;
+  const canSave =
+    dirtyCount > 0 && Object.keys(clientErrors).length === 0 && !saving;
+
+  const setDraft = (path: string, value: unknown) => {
+    setDrafts((current) => ({ ...current, [path]: value }));
+    // A server message is about the value that was sent, so it stops applying
+    // the moment the field changes.
+    setServerErrors(({ [path]: _sent, ...rest }) => rest);
+  };
+
+  const save = async () => {
+    if (!config || !gatewayId || !apiFetch) return;
+    setSaving(true);
+    setSaveError(null);
+    setServerErrors({});
+    try {
+      // The response is the WHOLE configuration after the write, in the GET's
+      // shape — so it is both the confirmation and the new baseline. Re-seeding
+      // from it is what makes a canonicalized quantity ("1000m" -> "1") stop
+      // looking edited, and why there is no second GET here.
+      setConfig(await writeConfiguration(apiFetch, gatewayId, patch));
+      setDrafts({});
+      notify('Configuration saved.', 'success');
+    } catch (error) {
+      const message =
+        error instanceof Error && error.message
+          ? error.message
+          : 'The configuration could not be saved.';
+      // A field-level message begins with the setting path it is about;
+      // anything else is form-level. Either way the platform's own sentence is
+      // user-presentable prose, so it is surfaced verbatim.
+      const path = fieldForServerMessage(
+        message,
+        config.editable.map((field) => field.path)
+      );
+      if (path) setServerErrors({ [path]: message });
+      else setSaveError(message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
   if (!gateway) return null;
 
-  const environmentName = environments.find((environment) => environment.id === gateway.environmentId)?.name ?? '—';
-
-  const rows = [
-    { label: 'Type', value: gatewayTypeLabel(gateway.type) },
-    { label: 'Environment', value: environmentName },
-    { label: 'URL', value: gateway.url },
-    { label: 'Status', value: gateway.status === 'active' ? 'Active' : 'Inactive' },
-    { label: 'Last Updated', value: relativeTime(gateway.updatedAt) },
-  ];
+  // `string` carries its own warnings and character budget, so it is
+  // partitioned out of the flat list and rendered by `TomlField`.
+  const listed = config?.editable.filter((field) => field.type !== 'string') ?? [];
+  const freeText = config?.editable.filter((field) => field.type === 'string') ?? [];
+  const currentValue = (path: string): unknown =>
+    path in drafts ? drafts[path] : config?.values[path];
 
   return (
     <Drawer anchor="right" open={open} onClose={onClose}>
-      <Box sx={{ width: 360, p: 3 }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 0.5 }}>
-          <Typography sx={{ fontSize: 16, fontWeight: 600 }}>Gateway Configuration</Typography>
-          <IconButton size="small" onClick={onClose} aria-label="Close">
-            <X size={18} />
-          </IconButton>
+      <Box
+        sx={{
+          width: DRAWER_WIDTH,
+          display: 'flex',
+          flexDirection: 'column',
+          height: '100%',
+        }}
+      >
+        <Box sx={{ px: 3, pt: 3 }}>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              mb: 0.5,
+            }}
+          >
+            <Typography sx={{ fontSize: 16, fontWeight: 600 }}>
+              Gateway Configuration
+            </Typography>
+            <IconButton size="small" onClick={onClose} aria-label="Close">
+              <X size={18} />
+            </IconButton>
+          </Box>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            {gateway.name}
+          </Typography>
         </Box>
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-          {gateway.name}
-        </Typography>
 
-        <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-          {rows.map((row, index) => (
-            <Box key={row.label}>
-              <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', py: 1.25 }}>
-                <Typography variant="body2">{row.label}</Typography>
-                <Typography variant="body2" color="text.secondary" sx={{ wordBreak: 'break-all', textAlign: 'right', ml: 2 }}>
-                  {row.value}
-                </Typography>
-              </Box>
-              {index < rows.length - 1 ? <Divider sx={{ borderStyle: 'dashed' }} /> : null}
+        {config ? (
+          <ConfigStatusBar
+            status={config.status}
+            refreshing={loading}
+            onRefresh={() => gatewayId && void load(gatewayId)}
+          />
+        ) : null}
+
+        <Box sx={{ flex: 1, minHeight: 0, overflowY: 'auto', px: 3 }}>
+          {loading && !config ? (
+            <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+              <CircularProgress size={28} />
             </Box>
+          ) : null}
+
+          {loadError ? (
+            <Alert
+              severity="error"
+              sx={{ my: 2 }}
+              action={
+                <Button
+                  size="small"
+                  onClick={() => gatewayId && void load(gatewayId)}
+                >
+                  Retry
+                </Button>
+              }
+            >
+              {loadError}
+            </Alert>
+          ) : null}
+
+          {saveError ? (
+            <Alert severity="error" sx={{ my: 2 }}>
+              {saveError}
+            </Alert>
+          ) : null}
+
+          {listed.map((field) => (
+            <SettingField
+              key={field.path}
+              field={field}
+              value={currentValue(field.path)}
+              present={config ? field.path in config.values : false}
+              error={errors[field.path]}
+              readOnly={saving}
+              onChange={(value) => setDraft(field.path, value)}
+            />
+          ))}
+
+          {freeText.map((field) => (
+            <TomlField
+              key={field.path}
+              field={field}
+              value={currentValue(field.path)}
+              error={errors[field.path]}
+              readOnly={saving}
+              onChange={(value) => setDraft(field.path, value)}
+            />
           ))}
         </Box>
 
-        {gateway.description ? (
-          <>
-            <Divider sx={{ mt: 1, mb: 1.5 }} />
-            <Typography variant="body2" sx={{ fontWeight: 500, mb: 0.5 }}>
-              Description
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              {gateway.description}
-            </Typography>
-          </>
+        {config ? (
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'flex-end',
+              gap: 1,
+              px: 3,
+              py: 2,
+              borderTop: 1,
+              borderColor: 'divider',
+            }}
+          >
+            {/* Restores the last loaded values — NOT platform defaults, which is not an operation the endpoint has. */}
+            <Button
+              variant="outlined"
+              color="secondary"
+              disabled={dirtyCount === 0 || saving}
+              onClick={() => {
+                setDrafts({});
+                setServerErrors({});
+                setSaveError(null);
+              }}
+            >
+              Reset
+            </Button>
+            <Button variant="contained" disabled={!canSave} onClick={save}>
+              {dirtyCount === 0
+                ? 'Save'
+                : `Save ${dirtyCount} ${dirtyCount === 1 ? 'change' : 'changes'}`}
+            </Button>
+          </Box>
         ) : null}
       </Box>
     </Drawer>

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/GatewaySettingsDrawer.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/GatewaySettingsDrawer.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type FC } from 'react';
 import {
   Alert,
   Box,
@@ -80,22 +80,39 @@ const GatewaySettingsDrawer: FC<GatewaySettingsDrawerProps> = ({
   const [saveError, setSaveError] = useState<string | null>(null);
   const [serverErrors, setServerErrors] = useState<FieldErrors>({});
 
+  /**
+   * Bumped by every read AND every write, so a response can tell whether it is
+   * still the newest thing in flight.
+   *
+   * A refresh started before a save can land after it. Both call `setConfig`,
+   * so without this the older GET would replace the configuration the PUT just
+   * confirmed -- leaving stale values on screen with no pending edits, which
+   * reads as "saved" and is not.
+   */
+  const generation = useRef(0);
+
   /** Re-seeds `config` only. Pending edits survive, so Refresh cannot discard them. */
   const load = useCallback(
     async (id: string) => {
       if (!apiFetch) return;
+      const mine = ++generation.current;
       setLoading(true);
       setLoadError(null);
       try {
-        setConfig(await readConfiguration(apiFetch, id));
+        const loaded = await readConfiguration(apiFetch, id);
+        if (mine !== generation.current) return;
+        setConfig(loaded);
       } catch (error) {
+        if (mine !== generation.current) return;
         setLoadError(
           error instanceof Error
             ? error.message
             : 'The configuration could not be loaded.'
         );
       } finally {
-        setLoading(false);
+        // Only the newest request owns the spinner; a superseded one must not
+        // turn it off while its replacement is still running.
+        if (mine === generation.current) setLoading(false);
       }
     },
     [apiFetch]
@@ -144,6 +161,9 @@ const GatewaySettingsDrawer: FC<GatewaySettingsDrawerProps> = ({
 
   const save = async () => {
     if (!config || !gatewayId || !apiFetch) return;
+    // Invalidates any read still in flight: what the write returns is newer
+    // than anything a GET started before it can report.
+    const mine = ++generation.current;
     setSaving(true);
     setSaveError(null);
     setServerErrors({});
@@ -152,7 +172,13 @@ const GatewaySettingsDrawer: FC<GatewaySettingsDrawerProps> = ({
       // shape — so it is both the confirmation and the new baseline. Re-seeding
       // from it is what makes a canonicalized quantity ("1000m" -> "1") stop
       // looking edited, and why there is no second GET here.
-      setConfig(await writeConfiguration(apiFetch, gatewayId, patch));
+      const written = await writeConfiguration(apiFetch, gatewayId, patch);
+      // The write happened, so it is confirmed and the edits are no longer
+      // pending whatever else is in flight. Only the BASELINE is conditional:
+      // a refresh started after this write owns the newer generation and its
+      // response is about to arrive, so let it install the values rather than
+      // fighting over them.
+      if (mine === generation.current) setConfig(written);
       setDrafts({});
       notify('Configuration saved.', 'success');
     } catch (error) {

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/SettingField.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/SettingField.tsx
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { FC } from 'react';
+import {
+  Box,
+  FormHelperText,
+  IconButton,
+  MenuItem,
+  Select,
+  Switch,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@wso2/oxygen-ui';
+import { CircleHelp } from '@wso2/oxygen-ui-icons-react';
+import type { EditableField } from '../types';
+
+export type SettingFieldProps = {
+  field: EditableField;
+  /** The value to show: the pending edit if there is one, else the stored value. */
+  value: unknown;
+  /** Whether the platform carries a stored value for this path at all. */
+  present: boolean;
+  error?: string;
+  readOnly?: boolean;
+  onChange: (value: unknown) => void;
+};
+
+/**
+ * One `editable` entry rendered as one row.
+ *
+ * Everything shown comes from the response — `label` and `description` are the
+ * platform's own user-facing copy and are used verbatim, not shortened. In
+ * particular the two replica labels ("Gateway controller replicas" vs "Gateway
+ * runtime replicas") name DIFFERENT pods and must never both become "Replicas".
+ *
+ * The three things that used to share one helper line are split by WHEN they
+ * are needed, because sixteen fields of prose is three screens of scrolling:
+ *
+ *   bounds       needed WHILE editing  -> inline under the control
+ *   error        needed always         -> inline, and never behind a hover
+ *   description  needed once, before   -> behind the `?`
+ *
+ * `string` is not handled here: its one field today is a multi-line TOML block
+ * whose copy is an operational warning rather than a description, so it keeps
+ * persistent text and its own component (`TomlField`).
+ */
+
+/** What to put in a text input for a value that may not be a string yet. */
+const inputText = (value: unknown): string =>
+  value === undefined || value === null ? '' : String(value);
+
+const SettingField: FC<SettingFieldProps> = ({
+  field,
+  value,
+  present,
+  error,
+  readOnly = false,
+  onChange,
+}) => {
+  const label = field.label || field.path;
+
+  // A path the values document does not carry is not "set to nothing": the
+  // chart's own values.yaml is the merge base, so what runs is the chart
+  // default. Say so, rather than letting a blank input imply an empty value.
+  const hint =
+    error ??
+    [
+      field.min !== undefined && field.max !== undefined
+        ? `${field.min} – ${field.max}`
+        : null,
+      present ? null : 'Not set — the platform default applies.',
+    ]
+      .filter(Boolean)
+      .join('  ');
+
+  const control = () => {
+    switch (field.type) {
+      case 'enum':
+        return (
+          <Select
+            disabled={readOnly}
+            displayEmpty
+            fullWidth
+            size="small"
+            value={inputText(value)}
+            onChange={(event) => onChange(event.target.value)}
+          >
+            {(field.values ?? []).map((option) => (
+              <MenuItem key={option} value={option}>
+                {option}
+              </MenuItem>
+            ))}
+          </Select>
+        );
+
+      case 'boolean':
+        return (
+          <Switch
+            checked={value === true}
+            disabled={readOnly}
+            size="small"
+            inputProps={{ 'aria-label': label }}
+            onChange={(event) => onChange(event.target.checked)}
+          />
+        );
+
+      case 'integer':
+        return (
+          <TextField
+            disabled={readOnly}
+            error={Boolean(error)}
+            fullWidth
+            size="small"
+            type="number"
+            slotProps={{ htmlInput: { min: field.min, max: field.max } }}
+            value={inputText(value)}
+            // An emptied input becomes '' rather than 0 or "unedited": the
+            // former would save a number nobody typed, the latter would put the
+            // old value back under the cursor. As '' it fails validation with
+            // the platform's own "must be a whole number".
+            onChange={(event) =>
+              onChange(
+                event.target.value === '' ? '' : Number(event.target.value)
+              )
+            }
+          />
+        );
+
+      // Free text with a syntax the platform parses. A duration is stored
+      // exactly as spelled ("5m" stays "5m") and a quantity IS canonicalized on
+      // write, which is why the drawer re-seeds from the PUT response.
+      //
+      // NO PLACEHOLDER. An example value in a greyed-out input is read as the
+      // setting's current value, and for the ten paths the response carries no
+      // value for, that is exactly the wrong thing to imply. The bounds hint
+      // ("30s – 1h") already shows the syntax, and it does not look like data.
+      case 'duration':
+      case 'quantity':
+        return (
+          <TextField
+            disabled={readOnly}
+            error={Boolean(error)}
+            fullWidth
+            size="small"
+            value={inputText(value)}
+            onChange={(event) => onChange(event.target.value)}
+          />
+        );
+
+      default:
+        return null;
+    }
+  };
+
+  const rendered = control();
+  if (!rendered) return null;
+
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2, py: 1 }}>
+      <Box
+        sx={{
+          flex: 1,
+          minWidth: 0,
+          minHeight: 40,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 0.25,
+        }}
+      >
+        <Typography variant="body2" sx={{ fontWeight: 500 }}>
+          {label}
+        </Typography>
+        {field.description ? (
+          // An IconButton rather than a bare span: a tooltip on something
+          // unfocusable is unreachable by keyboard. `describeChild` keeps the
+          // button's own label and exposes the text as its description, and the
+          // touch delays make a tap show it and hold it long enough to read.
+          <Tooltip
+            title={field.description}
+            describeChild
+            enterTouchDelay={0}
+            leaveTouchDelay={8000}
+          >
+            <IconButton
+              aria-label={`About ${label}`}
+              size="small"
+              sx={{ p: 0.25, color: 'text.disabled' }}
+            >
+              <CircleHelp size={14} />
+            </IconButton>
+          </Tooltip>
+        ) : null}
+      </Box>
+
+      <Box sx={{ flex: '0 0 200px', minHeight: 40 }}>
+        {rendered}
+        {hint ? (
+          <FormHelperText error={Boolean(error)} sx={{ mx: 0 }}>
+            {hint}
+          </FormHelperText>
+        ) : null}
+      </Box>
+    </Box>
+  );
+};
+
+export default SettingField;

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/SettingField.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/SettingField.tsx
@@ -35,8 +35,6 @@ export type SettingFieldProps = {
   field: EditableField;
   /** The value to show: the pending edit if there is one, else the stored value. */
   value: unknown;
-  /** Whether the platform carries a stored value for this path at all. */
-  present: boolean;
   error?: string;
   readOnly?: boolean;
   onChange: (value: unknown) => void;
@@ -50,12 +48,15 @@ export type SettingFieldProps = {
  * particular the two replica labels ("Gateway controller replicas" vs "Gateway
  * runtime replicas") name DIFFERENT pods and must never both become "Replicas".
  *
- * The three things that used to share one helper line are split by WHEN they
- * are needed, because sixteen fields of prose is three screens of scrolling:
+ * Only two things ever sit beside a control, split by WHEN they are needed,
+ * because sixteen fields of prose is three screens of scrolling:
  *
- *   bounds       needed WHILE editing  -> inline under the control
  *   error        needed always         -> inline, and never behind a hover
  *   description  needed once, before   -> behind the `?`
+ *
+ * Bounds are NOT shown. They were a permanent second line under every field
+ * for something that only matters while typing, and the message that arrives
+ * when a value is actually out of range states them anyway.
  *
  * `string` is not handled here: its one field today is a multi-line TOML block
  * whose copy is an operational warning rather than a description, so it keeps
@@ -69,26 +70,12 @@ const inputText = (value: unknown): string =>
 const SettingField: FC<SettingFieldProps> = ({
   field,
   value,
-  present,
   error,
   readOnly = false,
   onChange,
 }) => {
   const label = field.label || field.path;
 
-  // A path the values document does not carry is not "set to nothing": the
-  // chart's own values.yaml is the merge base, so what runs is the chart
-  // default. Say so, rather than letting a blank input imply an empty value.
-  const hint =
-    error ??
-    [
-      field.min !== undefined && field.max !== undefined
-        ? `${field.min} – ${field.max}`
-        : null,
-      present ? null : 'Not set — the platform default applies.',
-    ]
-      .filter(Boolean)
-      .join('  ');
 
   const control = () => {
     switch (field.type) {
@@ -149,8 +136,12 @@ const SettingField: FC<SettingFieldProps> = ({
       //
       // NO PLACEHOLDER. An example value in a greyed-out input is read as the
       // setting's current value, and for the ten paths the response carries no
-      // value for, that is exactly the wrong thing to imply. The bounds hint
-      // ("30s – 1h") already shows the syntax, and it does not look like data.
+      // value for, that is exactly the wrong thing to imply.
+      //
+      // With the bounds line gone there is now nothing on screen that spells
+      // the syntax before a value is typed: the `?` carries the platform's
+      // description, and an out-of-range value is told its bounds when it is
+      // rejected. That is the accepted cost of a quieter form.
       case 'duration':
       case 'quantity':
         return (
@@ -211,9 +202,9 @@ const SettingField: FC<SettingFieldProps> = ({
 
       <Box sx={{ flex: '0 0 200px', minHeight: 40 }}>
         {rendered}
-        {hint ? (
-          <FormHelperText error={Boolean(error)} sx={{ mx: 0 }}>
-            {hint}
+        {error ? (
+          <FormHelperText error sx={{ mx: 0 }}>
+            {error}
           </FormHelperText>
         ) : null}
       </Box>

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/SettingField.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/SettingField.tsx
@@ -67,6 +67,14 @@ export type SettingFieldProps = {
 const inputText = (value: unknown): string =>
   value === undefined || value === null ? '' : String(value);
 
+/*
+ * Every control carries `aria-label={label}`. The visible label is a
+ * `Typography` in the row beside it, not an `<label htmlFor>`, so nothing
+ * associates the two -- a screen reader would announce the enum as an unnamed
+ * combobox. Naming the control directly is the smaller fix here: the layout is
+ * a two-column row shared by six widget types, and `InputLabel` would put a
+ * floating label inside each one.
+ */
 const SettingField: FC<SettingFieldProps> = ({
   field,
   value,
@@ -82,6 +90,7 @@ const SettingField: FC<SettingFieldProps> = ({
       case 'enum':
         return (
           <Select
+            aria-label={label}
             disabled={readOnly}
             displayEmpty
             fullWidth
@@ -116,7 +125,9 @@ const SettingField: FC<SettingFieldProps> = ({
             fullWidth
             size="small"
             type="number"
-            slotProps={{ htmlInput: { min: field.min, max: field.max } }}
+            slotProps={{
+              htmlInput: { 'aria-label': label, min: field.min, max: field.max },
+            }}
             value={inputText(value)}
             // An emptied input becomes '' rather than 0 or "unedited": the
             // former would save a number nobody typed, the latter would put the
@@ -150,6 +161,7 @@ const SettingField: FC<SettingFieldProps> = ({
             error={Boolean(error)}
             fullWidth
             size="small"
+            slotProps={{ htmlInput: { 'aria-label': label } }}
             value={inputText(value)}
             onChange={(event) => onChange(event.target.value)}
           />

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/TomlField.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/TomlField.tsx
@@ -24,6 +24,7 @@ import {
   FormHelperText,
   IconButton,
   TextField,
+  Tooltip,
   Typography,
 } from '@wso2/oxygen-ui';
 import { ChevronDown, TriangleAlert } from '@wso2/oxygen-ui-icons-react';
@@ -47,12 +48,29 @@ export type TomlFieldProps = {
  * already written. TOML forbids declaring a table twice, so a block repeating a
  * section the structured values already emitted is a startup parse error rather
  * than an override. Nothing on the server checks for that yet — it is the known
- * gap this field shipped with — and the warning below does not close it. It
- * only means the user is told before they find out from a dead gateway.
+ * gap this field shipped with, and nothing here closes it.
+ *
+ * The append-not-merge warning sits behind the triangle beside the label. It
+ * used to be a persistent Alert on the argument that a tooltip is not read by
+ * someone already typing — which is true, and the reason the REDECLARED-SECTION
+ * Alert below stays persistent. That one fires on the actual mistake, naming
+ * the offending sections, so the case that kills a gateway is still called out
+ * inline; the general caution is what moved behind the hover.
  *
  * No Monaco: the console does not ship it, and this component renders in both
  * hosts.
  */
+
+/**
+ * Why this field is not an override. Plain text rather than markup: a tooltip
+ * title is read out as its text content, and the emphasis the Alert carried
+ * cannot survive the move anyway.
+ */
+const APPEND_WARNING =
+  'This text is appended to the configuration the gateway already generates — ' +
+  'it does not merge with it. A section the gateway already configures cannot ' +
+  'be redefined here, and repeating one stops the gateway from starting. ' +
+  'Clear the field to remove it.';
 
 const TomlField: FC<TomlFieldProps> = ({
   field,
@@ -85,6 +103,24 @@ const TomlField: FC<TomlFieldProps> = ({
         <Typography sx={{ fontWeight: 500 }} variant="body2">
           {field.label || field.path}
         </Typography>
+        <Tooltip
+          describeChild
+          enterTouchDelay={0}
+          leaveTouchDelay={8000}
+          title={APPEND_WARNING}
+        >
+          <IconButton
+            aria-label="About this field"
+            // The whole row toggles the section, so the icon must not: a hover
+            // that collapses the editor under the cursor is worse than no
+            // tooltip at all.
+            onClick={(event) => event.stopPropagation()}
+            size="small"
+            sx={{ p: 0.25, color: 'warning.main' }}
+          >
+            <TriangleAlert size={14} />
+          </IconButton>
+        </Tooltip>
         <Typography
           color={error ? 'error.main' : 'text.secondary'}
           sx={{ ml: 'auto' }}
@@ -106,22 +142,6 @@ const TomlField: FC<TomlFieldProps> = ({
       </Box>
 
       <Collapse in={open}>
-        {/*
-          Persistent copy, not a tooltip: this is the one thing a user has to
-          know before typing, and a tooltip is not read by someone who is
-          already typing.
-        */}
-        <Alert
-          icon={<TriangleAlert size={18} />}
-          severity="warning"
-          sx={{ mb: 1.5 }}
-        >
-          This text is <strong>appended</strong> to the configuration the gateway
-          already generates — it does not merge with it. A section the gateway
-          already configures cannot be redefined here, and repeating one stops
-          the gateway from starting.
-        </Alert>
-
         {redeclared.length > 0 ? (
           <Alert severity="error" sx={{ mb: 1.5 }}>
             {redeclared.join(' and ')}{' '}
@@ -150,10 +170,11 @@ const TomlField: FC<TomlFieldProps> = ({
           value={text}
         />
 
-        <FormHelperText error={Boolean(error)} sx={{ mx: 0 }}>
-          {/* An empty value is how the field is cleared — there is no other way. */}
-          {error ?? `${field.description ?? ''} Clear the field to remove it.`}
-        </FormHelperText>
+        {error ? (
+          <FormHelperText error sx={{ mx: 0 }}>
+            {error}
+          </FormHelperText>
+        ) : null}
       </Collapse>
     </Box>
   );

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/TomlField.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/TomlField.tsx
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useState, type FC } from 'react';
+import {
+  Alert,
+  Box,
+  Collapse,
+  FormHelperText,
+  IconButton,
+  TextField,
+  Typography,
+} from '@wso2/oxygen-ui';
+import { ChevronDown, TriangleAlert } from '@wso2/oxygen-ui-icons-react';
+import { redeclaredSections } from '../config/toml';
+import { characterCount } from '../config/validate';
+import type { EditableField } from '../types';
+
+export type TomlFieldProps = {
+  field: EditableField;
+  value: unknown;
+  error?: string;
+  readOnly?: boolean;
+  onChange: (value: string) => void;
+};
+
+/**
+ * `gateway.config_toml` — the raw-TOML append hatch, and the one field where a
+ * value that passes every check can stop the gateway MINUTES after a 200.
+ *
+ * The chart appends this text, verbatim and last, to a config.toml it has
+ * already written. TOML forbids declaring a table twice, so a block repeating a
+ * section the structured values already emitted is a startup parse error rather
+ * than an override. Nothing on the server checks for that yet — it is the known
+ * gap this field shipped with — and the warning below does not close it. It
+ * only means the user is told before they find out from a dead gateway.
+ *
+ * No Monaco: the console does not ship it, and this component renders in both
+ * hosts.
+ */
+
+const TomlField: FC<TomlFieldProps> = ({
+  field,
+  value,
+  error,
+  readOnly = false,
+  onChange,
+}) => {
+  const [open, setOpen] = useState(false);
+
+  const text = typeof value === 'string' ? value : '';
+  // Code points, matching the platform's `len([]rune(text))` — a ceiling on how
+  // much a person may type, and a multi-byte character is one character to them.
+  const length = characterCount(text);
+  const max = field.max ? Number.parseInt(field.max, 10) : null;
+  const redeclared = redeclaredSections(text);
+
+  return (
+    <Box sx={{ borderTop: 1, borderColor: 'divider', mt: 1, pt: 1 }}>
+      <Box
+        onClick={() => setOpen((current) => !current)}
+        sx={{
+          alignItems: 'center',
+          cursor: 'pointer',
+          display: 'flex',
+          gap: 1,
+          py: 1,
+        }}
+      >
+        <Typography sx={{ fontWeight: 500 }} variant="body2">
+          {field.label || field.path}
+        </Typography>
+        <Typography
+          color={error ? 'error.main' : 'text.secondary'}
+          sx={{ ml: 'auto' }}
+          variant="caption"
+        >
+          {max === null ? length : `${length}/${max}`}
+        </Typography>
+        <IconButton
+          aria-expanded={open}
+          aria-label={open ? 'Collapse advanced configuration' : 'Expand advanced configuration'}
+          size="small"
+          sx={{
+            transform: open ? 'rotate(180deg)' : 'none',
+            transition: 'transform 150ms',
+          }}
+        >
+          <ChevronDown size={16} />
+        </IconButton>
+      </Box>
+
+      <Collapse in={open}>
+        {/*
+          Persistent copy, not a tooltip: this is the one thing a user has to
+          know before typing, and a tooltip is not read by someone who is
+          already typing.
+        */}
+        <Alert
+          icon={<TriangleAlert size={18} />}
+          severity="warning"
+          sx={{ mb: 1.5 }}
+        >
+          This text is <strong>appended</strong> to the configuration the gateway
+          already generates — it does not merge with it. A section the gateway
+          already configures cannot be redefined here, and repeating one stops
+          the gateway from starting.
+        </Alert>
+
+        {redeclared.length > 0 ? (
+          <Alert severity="error" sx={{ mb: 1.5 }}>
+            {redeclared.join(' and ')}{' '}
+            {redeclared.length === 1 ? 'is' : 'are'} already configured by the
+            platform. Re-declaring{' '}
+            {redeclared.length === 1 ? 'it' : 'them'} here will stop the gateway
+            from starting.
+          </Alert>
+        ) : null}
+
+        <TextField
+          disabled={readOnly}
+          error={Boolean(error)}
+          fullWidth
+          maxRows={20}
+          minRows={6}
+          multiline
+          onChange={(event) => onChange(event.target.value)}
+          placeholder={'[some.section]\nkey = "value"'}
+          slotProps={{
+            htmlInput: {
+              spellCheck: false,
+              style: { fontFamily: 'monospace', fontSize: 12 },
+            },
+          }}
+          value={text}
+        />
+
+        <FormHelperText error={Boolean(error)} sx={{ mx: 0 }}>
+          {/* An empty value is how the field is cleared — there is no other way. */}
+          {error ?? `${field.description ?? ''} Clear the field to remove it.`}
+        </FormHelperText>
+      </Collapse>
+    </Box>
+  );
+};
+
+export default TomlField;

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/api.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/api.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { ApiFetch } from '../hostPort';
+import type { ConfigValues, GatewayConfiguration } from '../types';
+
+const configurationPath = (gatewayId: string) =>
+  `/managed-gateways/${encodeURIComponent(gatewayId)}/configuration`;
+
+/** Scopes: `ap:gateway:read` or `ap:gateway:manage`. 404 for a gateway with no managed binding. */
+export const readConfiguration = (apiFetch: ApiFetch, gatewayId: string) =>
+  apiFetch<GatewayConfiguration>('GET', configurationPath(gatewayId));
+
+/**
+ * A SPARSE PATCH: send only the settings that changed. `values` must name at
+ * least one — `{}` and `{"values":{}}` are both a 400 — and no other top-level
+ * key may appear, which is also a 400.
+ *
+ * The response is the WHOLE configuration after the write, in the GET's shape.
+ * Use it as the confirmation and as the new baseline; do not re-GET.
+ *
+ * Scopes: `ap:gateway:update` or `ap:gateway:manage`.
+ */
+export const writeConfiguration = (
+  apiFetch: ApiFetch,
+  gatewayId: string,
+  values: ConfigValues
+) =>
+  apiFetch<GatewayConfiguration>('PUT', configurationPath(gatewayId), {
+    values,
+  });

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/duration.test.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/duration.test.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { parseDurationSeconds } from './duration';
+
+describe('parseDurationSeconds', () => {
+  it('reads the bounds the platform declares for the one duration field', () => {
+    // `…ratelimit_v1.memory.cleanup_interval` is bounded 30s – 1h.
+    expect(parseDurationSeconds('30s')).toBe(30);
+    expect(parseDurationSeconds('1h')).toBe(3600);
+    expect(parseDurationSeconds('5m')).toBe(300);
+  });
+
+  it('sums a multi-unit duration', () => {
+    expect(parseDurationSeconds('1h30m')).toBe(5400);
+    expect(parseDurationSeconds('1m30s')).toBe(90);
+    expect(parseDurationSeconds('1h0m0s')).toBe(3600);
+  });
+
+  it('accepts fractions and sub-second units', () => {
+    expect(parseDurationSeconds('1.5h')).toBe(5400);
+    expect(parseDurationSeconds('500ms')).toBeCloseTo(0.5);
+    expect(parseDurationSeconds('1us')).toBeCloseTo(1e-6);
+    expect(parseDurationSeconds('1µs')).toBeCloseTo(1e-6);
+    expect(parseDurationSeconds('100ns')).toBeCloseTo(1e-7);
+  });
+
+  it('reads ms as milliseconds, not as minutes plus a stray s', () => {
+    // The unit alternation is longest-first for this; read the other way
+    // "500ms" would be 500 minutes and pass a 1h ceiling check backwards.
+    expect(parseDurationSeconds('500ms')).not.toBe(500 * 60);
+  });
+
+  it('accepts a bare zero and a sign', () => {
+    expect(parseDurationSeconds('0')).toBe(0);
+    expect(parseDurationSeconds('-5m')).toBe(-300);
+    expect(parseDurationSeconds('+5m')).toBe(300);
+  });
+
+  it('makes the two spellings of the same duration compare equal', () => {
+    // The server stores a duration exactly as spelled — "5m" is never
+    // re-spelled "5m0s" — so equality has to come from the parse, not the text.
+    expect(parseDurationSeconds('5m')).toBe(parseDurationSeconds('5m0s'));
+    expect(parseDurationSeconds('60s')).toBe(parseDurationSeconds('1m'));
+  });
+
+  it('rejects anything that is not a Go duration', () => {
+    expect(parseDurationSeconds('')).toBeNull();
+    expect(parseDurationSeconds('soon')).toBeNull();
+    // Unitless, and not the one spelling Go allows unitless.
+    expect(parseDurationSeconds('5')).toBeNull();
+    expect(parseDurationSeconds('5x')).toBeNull();
+    // Trailing junk: the whole string has to be consumed.
+    expect(parseDurationSeconds('5m30')).toBeNull();
+    expect(parseDurationSeconds('5m junk')).toBeNull();
+  });
+});

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/duration.test.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/duration.test.ts
@@ -71,4 +71,14 @@ describe('parseDurationSeconds', () => {
     expect(parseDurationSeconds('5m30')).toBeNull();
     expect(parseDurationSeconds('5m junk')).toBeNull();
   });
+
+  it('rejects surrounding whitespace, which Go rejects too', () => {
+    // The drawer sends the text verbatim, so accepting padding here would turn
+    // a catchable typo into a 400 from the platform.
+    expect(parseDurationSeconds(' 5m')).toBeNull();
+    expect(parseDurationSeconds('5m ')).toBeNull();
+    expect(parseDurationSeconds(' 5m ')).toBeNull();
+    expect(parseDurationSeconds('5 m')).toBeNull();
+    expect(parseDurationSeconds('5m')).toBe(300);
+  });
 });

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/duration.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/duration.ts
@@ -43,7 +43,12 @@ const TOKEN = /(\d+(?:\.\d*)?|\.\d+)(ns|us|µs|μs|ms|s|m|h)/y;
 
 /** The duration in seconds, or `null` when the text is not a Go duration. */
 export function parseDurationSeconds(text: string): number | null {
-  let rest = text.trim();
+  // NOT trimmed. The drawer sends the user's text verbatim, so anything this
+  // accepts must be something Go's time.ParseDuration accepts -- and it takes
+  // no surrounding whitespace. Trimming here made " 5m " pass in the browser
+  // and 400 on the server, which is the one outcome this parser exists to
+  // prevent.
+  let rest = text;
   if (!rest) return null;
 
   let sign = 1;

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/duration.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/duration.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Go duration parsing (`time.ParseDuration`), enough to compare a typed value
+ * against the declared `min`/`max`, which are duration strings themselves.
+ *
+ * Like `quantity.ts` this does not normalise: the server stores a duration
+ * exactly as it was spelled — "5m" stays "5m", not "5m0s" — precisely so an
+ * unchanged save does not look like a change and roll the gateway pods. Never
+ * write the parsed value back.
+ */
+
+/** Longest unit first, so `ms` is never read as `m` followed by a stray `s`. */
+const UNIT_SECONDS = new Map<string, number>([
+  ['ns', 1e-9],
+  ['us', 1e-6],
+  ['µs', 1e-6],
+  ['μs', 1e-6],
+  ['ms', 1e-3],
+  ['s', 1],
+  ['m', 60],
+  ['h', 3600],
+]);
+
+/** Sticky, so the loop below can require that the WHOLE string was consumed. */
+const TOKEN = /(\d+(?:\.\d*)?|\.\d+)(ns|us|µs|μs|ms|s|m|h)/y;
+
+/** The duration in seconds, or `null` when the text is not a Go duration. */
+export function parseDurationSeconds(text: string): number | null {
+  let rest = text.trim();
+  if (!rest) return null;
+
+  let sign = 1;
+  if (rest.startsWith('-')) {
+    sign = -1;
+    rest = rest.slice(1);
+  } else if (rest.startsWith('+')) {
+    rest = rest.slice(1);
+  }
+
+  // The one spelling with no unit. Go accepts it; nothing else unitless.
+  if (rest === '0') return 0;
+
+  TOKEN.lastIndex = 0;
+  let total = 0;
+  for (let match = TOKEN.exec(rest); match; match = TOKEN.exec(rest)) {
+    const seconds = UNIT_SECONDS.get(match[2]);
+    if (seconds === undefined) return null;
+    total += Number(match[1]) * seconds;
+    if (TOKEN.lastIndex === rest.length) return sign * total;
+  }
+  // Ran out of matches before the end: there is trailing junk, or a unit this
+  // does not know. Either way it is not a duration.
+  return null;
+}

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/quantity.test.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/quantity.test.ts
@@ -76,4 +76,13 @@ describe('parseQuantity', () => {
     expect(parseQuantity('1constructor')).toBeNull();
     expect(parseQuantity('1toString')).toBeNull();
   });
+
+  it('rejects a value that overflows once its suffix is applied', () => {
+    // Finite before scaling, Infinity after. Infinity compares greater than
+    // any declared `max`, but a field without one would have accepted it.
+    const huge = '1'.padEnd(309, '0');
+    expect(Number.isFinite(Number(huge))).toBe(true);
+    expect(parseQuantity(`${huge}E`)).toBeNull();
+    expect(parseQuantity('8Gi')).toBe(8589934592);
+  });
 });

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/quantity.test.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/quantity.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { parseQuantity } from './quantity';
+
+describe('parseQuantity', () => {
+  it('reads the bounds the platform actually declares', () => {
+    // Every one of these is a `min` or `max` from the deployed allowlist, and
+    // all of them arrive as strings — `Number('50m')` is NaN, which is the
+    // whole reason this function exists.
+    expect(parseQuantity('50m')).toBeCloseTo(0.05);
+    expect(parseQuantity('4')).toBe(4);
+    expect(parseQuantity('128Mi')).toBe(134217728);
+    expect(parseQuantity('8Gi')).toBe(8589934592);
+  });
+
+  it('makes the spellings the server canonicalizes compare equal', () => {
+    // "1000m" comes back "1" and "1024Mi" comes back "1Gi" — a client that
+    // compared strings would report a change that is not one.
+    expect(parseQuantity('1000m')).toBe(parseQuantity('1'));
+    expect(parseQuantity('1024Mi')).toBe(parseQuantity('1Gi'));
+    expect(parseQuantity('500m')).toBeCloseTo(0.5);
+  });
+
+  it('tells the milli and mega suffixes apart', () => {
+    expect(parseQuantity('1m')).toBeCloseTo(1e-3);
+    expect(parseQuantity('1M')).toBe(1e6);
+    expect(parseQuantity('1Mi')).toBe(1048576);
+  });
+
+  it('treats an exponent as part of the number and a bare E as exa', () => {
+    expect(parseQuantity('1e3')).toBe(1000);
+    expect(parseQuantity('1E3')).toBe(1000);
+    expect(parseQuantity('1E')).toBe(1e18);
+    expect(parseQuantity('1Ei')).toBe(2 ** 60);
+  });
+
+  it('accepts decimals and surrounding whitespace', () => {
+    expect(parseQuantity('1.5Gi')).toBe(1610612736);
+    expect(parseQuantity('  256Mi  ')).toBe(268435456);
+    expect(parseQuantity('.5')).toBeCloseTo(0.5);
+  });
+
+  it('rejects anything that is not a quantity', () => {
+    expect(parseQuantity('')).toBeNull();
+    expect(parseQuantity('abc')).toBeNull();
+    expect(parseQuantity('1x')).toBeNull();
+    expect(parseQuantity('1e')).toBeNull();
+    expect(parseQuantity('1 Mi')).toBeNull();
+    // Kubernetes allows an exponent OR a suffix, never both — and the server
+    // rejects it, so accepting it here would only cost a round trip.
+    expect(parseQuantity('1e3Mi')).toBeNull();
+  });
+
+  it('does not resolve a suffix through the prototype chain', () => {
+    // The suffix comes from user input and the lookup tables are Maps for
+    // exactly this reason: on a plain object `'constructor' in table` is true,
+    // and the multiplier would come back as a function.
+    expect(parseQuantity('1constructor')).toBeNull();
+    expect(parseQuantity('1toString')).toBeNull();
+  });
+});

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/quantity.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/quantity.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Kubernetes quantity parsing, enough to compare a typed value against the
+ * `min`/`max` the platform declares — both of which arrive as quantity strings
+ * too, so this is the only way to check a bound at all.
+ *
+ * It deliberately does NOT canonicalize. The server does that on write
+ * ("1000m" comes back "1", "1024Mi" comes back "1Gi"), and a client that
+ * re-spelled the value locally would either fight the response or make an
+ * unchanged save look like a change. Re-render a quantity field from the PUT
+ * response instead.
+ */
+
+/** Binary suffixes. A `Map`, so a suffix like `constructor` cannot resolve through the prototype. */
+const BINARY = new Map<string, number>([
+  ['Ki', 2 ** 10],
+  ['Mi', 2 ** 20],
+  ['Gi', 2 ** 30],
+  ['Ti', 2 ** 40],
+  ['Pi', 2 ** 50],
+  ['Ei', 2 ** 60],
+]);
+
+/** Decimal SI suffixes, including the empty one. Case matters: `m` is milli, `M` is mega. */
+const DECIMAL = new Map<string, number>([
+  ['n', 1e-9],
+  ['u', 1e-6],
+  ['m', 1e-3],
+  ['', 1],
+  ['k', 1e3],
+  ['M', 1e6],
+  ['G', 1e9],
+  ['T', 1e12],
+  ['P', 1e15],
+  ['E', 1e18],
+]);
+
+/**
+ * Either a number with a suffix, or a number in exponent form with none —
+ * Kubernetes allows both but not together, so `1e3` is a thousand, `1E` is one
+ * exa, and `1e3Mi` is not a quantity at all.
+ */
+const QUANTITY = /^([+-]?(?:\d+|\d*\.\d+))([A-Za-z]*)$|^([+-]?(?:\d+|\d*\.\d+)[eE][+-]?\d+)$/;
+
+/** The quantity as a plain number, or `null` when the text is not one. */
+export function parseQuantity(text: string): number | null {
+  const match = QUANTITY.exec(text.trim());
+  if (!match) return null;
+  const value = Number(match[1] ?? match[3]);
+  if (!Number.isFinite(value)) return null;
+  const suffix = match[1] === undefined ? '' : match[2];
+  const multiplier = BINARY.get(suffix) ?? DECIMAL.get(suffix);
+  if (multiplier === undefined) return null;
+  return value * multiplier;
+}

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/quantity.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/quantity.ts
@@ -68,5 +68,9 @@ export function parseQuantity(text: string): number | null {
   const suffix = match[1] === undefined ? '' : match[2];
   const multiplier = BINARY.get(suffix) ?? DECIMAL.get(suffix);
   if (multiplier === undefined) return null;
-  return value * multiplier;
+  // The value was finite; the product need not be. 308 digits with an `E`
+  // suffix overflows to Infinity, which compares greater than any `max` but
+  // would slip past a field that declares none.
+  const scaled = value * multiplier;
+  return Number.isFinite(scaled) ? scaled : null;
 }

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/toml.test.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/toml.test.ts
@@ -75,4 +75,18 @@ describe('redeclaredSections', () => {
       redeclaredSections('[policy_configurations.ratelimit_v2]\nx = 1')
     ).toEqual([]);
   });
+
+  it('sees a seeded header that carries a trailing comment', () => {
+    // TOML comments run to end of line, so this declares the table just as
+    // surely as the bare form -- and it is the form that kills a gateway
+    // silently if the warning misses it.
+    expect(
+      redeclaredSections('[policy_configurations.ratelimit_v1] # note')
+    ).toEqual(['policy_configurations.ratelimit_v1']);
+    expect(
+      tomlSections('[a.b]\t#  trailing\n[c]#tight\n')
+    ).toEqual(['a.b', 'c']);
+    // A commented-OUT header is still a comment, not a declaration.
+    expect(tomlSections('# [policy_configurations.ratelimit_v1]')).toEqual([]);
+  });
 });

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/toml.test.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/toml.test.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { redeclaredSections, tomlSections } from './toml';
+
+describe('tomlSections', () => {
+  it('finds table headers at the start of a line', () => {
+    expect(tomlSections('[mcp]\nenabled = true\n\n[other]\nx = 1')).toEqual([
+      'mcp',
+      'other',
+    ]);
+  });
+
+  it('tolerates indentation and trailing spaces around a header', () => {
+    expect(tomlSections('  [mcp]  \n')).toEqual(['mcp']);
+    expect(tomlSections('\t[mcp]\t\n')).toEqual(['mcp']);
+  });
+
+  it('ignores a bracketed value, which is not a table declaration', () => {
+    // Only a header occupies a line on its own, so an array value must not read
+    // as a section — otherwise every list would produce a false warning.
+    expect(tomlSections('hosts = ["a", "b"]')).toEqual([]);
+    expect(tomlSections('key = [1]')).toEqual([]);
+  });
+});
+
+describe('redeclaredSections', () => {
+  it('warns about the two sections the bootstrap seed already emits', () => {
+    // TOML forbids declaring a table twice and the chart APPENDS this text to a
+    // config.toml it has already written, so either of these is a parse error
+    // at gateway startup rather than an override.
+    expect(
+      redeclaredSections('[policy_configurations.ratelimit_v1]\nx = 1')
+    ).toEqual(['policy_configurations.ratelimit_v1']);
+    expect(
+      redeclaredSections(
+        '[policy_configurations.llm_cost_ratelimit_v1]\nx = 1'
+      )
+    ).toEqual(['policy_configurations.llm_cost_ratelimit_v1']);
+  });
+
+  it('reports each seeded section once, however often it appears', () => {
+    expect(
+      redeclaredSections(
+        '[policy_configurations.ratelimit_v1]\na = 1\n[policy_configurations.ratelimit_v1]\nb = 2'
+      )
+    ).toEqual(['policy_configurations.ratelimit_v1']);
+  });
+
+  it('says nothing about a section the platform does not emit', () => {
+    // A new section is exactly what this field is for; only a REPEAT is fatal.
+    expect(redeclaredSections('[mcp]\nenabled = true')).toEqual([]);
+    expect(redeclaredSections('')).toEqual([]);
+  });
+
+  it('does not match a section whose name merely starts the same way', () => {
+    expect(
+      redeclaredSections('[policy_configurations.ratelimit_v2]\nx = 1')
+    ).toEqual([]);
+  });
+});

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/toml.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/toml.ts
@@ -44,7 +44,11 @@ export const SEEDED_SECTIONS = [
  * is the normal state of a text area, and a parser would spend most of its life
  * reporting syntax errors about text the user has not finished writing.
  */
-const SECTION_HEADER = /^[ \t]*\[([^\]]+)\][ \t]*$/gm;
+// A header may be followed by a comment: TOML treats `#` as a comment to the
+// end of the line, so `[policy_configurations.ratelimit_v1] # note` declares
+// that table just as surely as the bare form. Missing it meant the redeclared
+// -section warning stayed silent for the exact text that kills a gateway.
+const SECTION_HEADER = /^[ \t]*\[([^\]]+)\][ \t]*(?:#[^\n]*)?$/gm;
 
 /** Every table header the text declares, in order of appearance. */
 export function tomlSections(text: string): string[] {

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/toml.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/toml.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * The one guard `gateway.config_toml` gets, and it is only a warning.
+ *
+ * The chart appends this text, verbatim and last, to a config.toml it has
+ * already written, and TOML forbids declaring a table twice — so a block
+ * repeating a section the structured values already emitted is a parse error at
+ * gateway startup rather than an override. The bootstrap seed emits two such
+ * sections, so those two in particular cannot be re-declared.
+ *
+ * NOTHING ON THE SERVER CHECKS THIS. It is the known gap the field shipped
+ * with, and a client-side scan does not close it: a request that skips this UI
+ * still gets a 200 and a gateway that will not start. What this buys is that
+ * someone typing into the form is told before they find out from a dead
+ * gateway.
+ */
+
+/** The sections the bootstrap seed already emits. */
+export const SEEDED_SECTIONS = [
+  'policy_configurations.ratelimit_v1',
+  'policy_configurations.llm_cost_ratelimit_v1',
+];
+
+/**
+ * Table headers at the start of a line, which is the only position TOML
+ * declares one in. Deliberately not a TOML parser: a partially-typed document
+ * is the normal state of a text area, and a parser would spend most of its life
+ * reporting syntax errors about text the user has not finished writing.
+ */
+const SECTION_HEADER = /^[ \t]*\[([^\]]+)\][ \t]*$/gm;
+
+/** Every table header the text declares, in order of appearance. */
+export function tomlSections(text: string): string[] {
+  const found: string[] = [];
+  SECTION_HEADER.lastIndex = 0;
+  for (
+    let match = SECTION_HEADER.exec(text);
+    match;
+    match = SECTION_HEADER.exec(text)
+  ) {
+    found.push(match[1].trim());
+  }
+  return found;
+}
+
+/** The seeded sections this text re-declares. A warning, never a block. */
+export function redeclaredSections(text: string): string[] {
+  return [
+    ...new Set(
+      tomlSections(text).filter((section) => SEEDED_SECTIONS.includes(section))
+    ),
+  ];
+}

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/validate.test.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/validate.test.ts
@@ -1,0 +1,356 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import type { EditableField, GatewayConfiguration } from '../types';
+import {
+  fieldForServerMessage,
+  validateFieldValue,
+  validateForm,
+} from './validate';
+
+/*
+ * Every expected message below is the sentence the PLATFORM returns for the
+ * same value, taken from the rejection list that was run against a cluster on
+ * 2026-08-30 (and the config_toml ones on 2026-08-31). That is the point of the
+ * assertions: a user must read the same wording whichever side caught it, so a
+ * drift here is a real defect even though the value is refused either way.
+ */
+
+const LOG_LEVEL: EditableField = {
+  label: 'Gateway controller log level',
+  path: 'gateway.config.controller.logging.level',
+  type: 'enum',
+  values: ['debug', 'info', 'warn', 'error'],
+};
+
+const ACCESS_LOGS: EditableField = {
+  path: 'gateway.config.router.access_logs.enabled',
+  type: 'boolean',
+};
+
+const ROUTE_TIMEOUT: EditableField = {
+  max: '300000',
+  min: '1000',
+  path: 'gateway.config.router.upstream.timeouts.route_timeout_ms',
+  type: 'integer',
+};
+
+const COST_SCALE: EditableField = {
+  max: '1000000000000',
+  min: '1',
+  path: 'gateway.config.policy_configurations.llm_cost_ratelimit_v1.cost_scale_factor',
+  type: 'integer',
+};
+
+const CLEANUP: EditableField = {
+  max: '1h',
+  min: '30s',
+  path: 'gateway.config.policy_configurations.ratelimit_v1.memory.cleanup_interval',
+  type: 'duration',
+};
+
+const CPU_REQUEST: EditableField = {
+  max: '4',
+  min: '50m',
+  path: 'gateway.controller.deployment.resources.requests.cpu',
+  type: 'quantity',
+};
+
+const MEMORY_REQUEST: EditableField = {
+  max: '8Gi',
+  min: '128Mi',
+  path: 'gateway.controller.deployment.resources.requests.memory',
+  type: 'quantity',
+};
+
+const MEMORY_LIMIT: EditableField = {
+  max: '8Gi',
+  min: '128Mi',
+  path: 'gateway.controller.deployment.resources.limits.memory',
+  type: 'quantity',
+};
+
+const CONFIG_TOML: EditableField = {
+  max: '8192',
+  path: 'gateway.config_toml',
+  type: 'string',
+};
+
+describe('validateFieldValue', () => {
+  it('passes an untouched field', () => {
+    expect(validateFieldValue(ROUTE_TIMEOUT, undefined)).toBeNull();
+  });
+
+  it('names the permitted values for an enum', () => {
+    expect(validateFieldValue(LOG_LEVEL, 'debug')).toBeNull();
+    expect(validateFieldValue(LOG_LEVEL, 'trace')).toBe(
+      'gateway.config.controller.logging.level must be one of debug, info, warn, error'
+    );
+  });
+
+  it('refuses a string for a boolean', () => {
+    expect(validateFieldValue(ACCESS_LOGS, false)).toBeNull();
+    // A literal "yes" is a 400 on the wire, so the widget must never send one.
+    expect(validateFieldValue(ACCESS_LOGS, 'yes')).toBe(
+      'gateway.config.router.access_logs.enabled must be true or false'
+    );
+  });
+
+  it('bounds an integer, and reports the bound the platform declared', () => {
+    expect(validateFieldValue(ROUTE_TIMEOUT, 60000)).toBeNull();
+    expect(validateFieldValue(ROUTE_TIMEOUT, 999)).toBe(
+      'gateway.config.router.upstream.timeouts.route_timeout_ms must be between 1000 and 300000'
+    );
+    expect(validateFieldValue(ROUTE_TIMEOUT, 300001)).not.toBeNull();
+  });
+
+  it('refuses a non-integer, an emptied input and a value past 2^53', () => {
+    expect(validateFieldValue(ROUTE_TIMEOUT, 1500.5)).toBe(
+      'gateway.config.router.upstream.timeouts.route_timeout_ms must be a whole number'
+    );
+    // An emptied number input arrives as '' rather than 0, so it is refused
+    // instead of silently saving a number nobody typed.
+    expect(validateFieldValue(ROUTE_TIMEOUT, '')).not.toBeNull();
+    expect(validateFieldValue(COST_SCALE, 2 ** 53)).not.toBeNull();
+  });
+
+  it('accepts the whole integer range up to the 1e12 ceiling', () => {
+    // A double holds 1e12 exactly; the guard is only against what is past 2^53.
+    expect(validateFieldValue(COST_SCALE, 1_000_000_000_000)).toBeNull();
+    expect(validateFieldValue(COST_SCALE, 1)).toBeNull();
+    expect(validateFieldValue(COST_SCALE, 0)).not.toBeNull();
+  });
+
+  it('bounds a duration without normalising its spelling', () => {
+    expect(validateFieldValue(CLEANUP, '5m')).toBeNull();
+    expect(validateFieldValue(CLEANUP, '10s')).toBe(
+      'gateway.config.policy_configurations.ratelimit_v1.memory.cleanup_interval must be between 30s and 1h'
+    );
+    expect(validateFieldValue(CLEANUP, 'soon')).toBe(
+      'gateway.config.policy_configurations.ratelimit_v1.memory.cleanup_interval must be a duration such as "5m"'
+    );
+  });
+
+  it('bounds a quantity and refuses one that is not positive', () => {
+    expect(validateFieldValue(CPU_REQUEST, '500m')).toBeNull();
+    expect(validateFieldValue(CPU_REQUEST, '10m')).toBe(
+      'gateway.controller.deployment.resources.requests.cpu must be between 50m and 4'
+    );
+    expect(validateFieldValue(CPU_REQUEST, '8')).not.toBeNull();
+    // Zero is legal to Kubernetes and meaningless for a gateway; a zero limit
+    // would mean "no limit", which the ceiling assumes away.
+    expect(validateFieldValue(CPU_REQUEST, '0')).toBe(
+      'gateway.controller.deployment.resources.requests.cpu must be greater than zero'
+    );
+    expect(validateFieldValue(CPU_REQUEST, 'lots')).toBe(
+      'gateway.controller.deployment.resources.requests.cpu must be a quantity such as "500m" or "512Mi"'
+    );
+  });
+
+  it('counts the string field in code points, not bytes', () => {
+    const ascii = 'a'.repeat(8192);
+    expect(validateFieldValue(CONFIG_TOML, ascii)).toBeNull();
+    expect(validateFieldValue(CONFIG_TOML, `${ascii}a`)).toBe(
+      'gateway.config_toml must be between 0 and 8192 characters'
+    );
+
+    // 8192 astral characters are 16384 UTF-16 units and 32768 bytes, and are
+    // 8192 characters to the person who typed them.
+    const astral = '\u{1F600}'.repeat(8192);
+    expect(astral.length).toBe(16384);
+    expect(validateFieldValue(CONFIG_TOML, astral)).toBeNull();
+  });
+
+  it('clears the string field with an empty value', () => {
+    expect(validateFieldValue(CONFIG_TOML, '')).toBeNull();
+  });
+
+  it('refuses the characters the values document cannot carry', () => {
+    // Built from char codes rather than written literally: these are exactly
+    // the characters that would be invisible in a source file.
+    const nul = String.fromCharCode(0);
+    const verticalTab = String.fromCharCode(11);
+    const escape = String.fromCharCode(27);
+    const del = String.fromCharCode(127);
+    const nextLine = String.fromCharCode(0x85);
+    const lineSeparator = String.fromCharCode(0x2028);
+    const paragraphSeparator = String.fromCharCode(0x2029);
+    const refused =
+      'gateway.config_toml must not contain control characters or line separators';
+
+    for (const character of [
+      nul,
+      verticalTab,
+      escape,
+      del,
+      nextLine,
+      lineSeparator,
+      paragraphSeparator,
+    ]) {
+      expect(validateFieldValue(CONFIG_TOML, `[a]\nb = "${character}"`)).toBe(
+        refused
+      );
+    }
+  });
+
+  it('allows tab, newline and carriage return, which a TOML block needs', () => {
+    expect(validateFieldValue(CONFIG_TOML, '[a]\r\n\tb = 1\n')).toBeNull();
+  });
+
+  it('refuses a non-string for the string field', () => {
+    expect(validateFieldValue(CONFIG_TOML, 42)).toBe(
+      'gateway.config_toml must be a string'
+    );
+  });
+});
+
+const configuration = (
+  values: Record<string, unknown>
+): GatewayConfiguration => ({
+  constraints: [
+    {
+      message:
+        'the controller memory request must not exceed the controller memory limit',
+      path: MEMORY_REQUEST.path,
+      than: MEMORY_LIMIT.path,
+      type: 'notGreaterThan',
+    },
+  ],
+  editable: [
+    LOG_LEVEL,
+    ROUTE_TIMEOUT,
+    CPU_REQUEST,
+    MEMORY_REQUEST,
+    MEMORY_LIMIT,
+    CONFIG_TOML,
+  ],
+  id: 'wc-org-development-apip-default-gw',
+  status: { phase: 'healthy' },
+  values,
+});
+
+describe('validateForm', () => {
+  const stored = {
+    [MEMORY_LIMIT.path]: '512Mi',
+    [MEMORY_REQUEST.path]: '256Mi',
+    [ROUTE_TIMEOUT.path]: 60000,
+  };
+
+  it('reports nothing for an empty patch', () => {
+    expect(validateForm(configuration(stored), {})).toEqual({});
+  });
+
+  it('refuses a path the response did not list', () => {
+    const errors = validateForm(configuration(stored), { 'gateway.nope': 'x' });
+    expect(errors['gateway.nope']).toBe(
+      'gateway.nope is not an editable gateway setting'
+    );
+  });
+
+  it('catches lowering only the limit, against the STORED request', () => {
+    // 200Mi is inside the limit's own 128Mi–8Gi bounds, so per-field validation
+    // accepts it. It is refused because the document the write would produce has
+    // the stored 256Mi request above the new limit — which is what the server
+    // checks, and what the kubelet would otherwise fail asynchronously long
+    // after the 200.
+    const errors = validateForm(configuration(stored), {
+      [MEMORY_LIMIT.path]: '200Mi',
+    });
+    expect(errors[MEMORY_LIMIT.path]).toBe(
+      'the controller memory request must not exceed the controller memory limit'
+    );
+    // On the edited field, not on the request the user never touched.
+    expect(errors[MEMORY_REQUEST.path]).toBeUndefined();
+  });
+
+  it('accepts lowering both sides together', () => {
+    expect(
+      validateForm(configuration(stored), {
+        [MEMORY_LIMIT.path]: '200Mi',
+        [MEMORY_REQUEST.path]: '128Mi',
+      })
+    ).toEqual({});
+  });
+
+  it('compares canonicalized spellings rather than text', () => {
+    // request 1024Mi === limit 1Gi, so equal is allowed — `notGreaterThan`.
+    expect(
+      validateForm(configuration(stored), {
+        [MEMORY_LIMIT.path]: '1Gi',
+        [MEMORY_REQUEST.path]: '1024Mi',
+      })
+    ).toEqual({});
+  });
+
+  it('skips a constraint whose other side the document does not carry', () => {
+    // The missing side falls back to the chart's own default at render time, so
+    // there is nothing to compare and nothing to refuse.
+    const errors = validateForm(
+      configuration({ [MEMORY_REQUEST.path]: '256Mi' }),
+      { [MEMORY_REQUEST.path]: '8Gi' }
+    );
+    expect(errors).toEqual({});
+  });
+
+  it('does not run constraints while a field is individually malformed', () => {
+    // Comparing against a value already known to be nonsense says nothing, so
+    // the only message is the field's own.
+    const errors = validateForm(configuration(stored), {
+      [MEMORY_LIMIT.path]: 'not-a-quantity',
+    });
+    expect(Object.keys(errors)).toEqual([MEMORY_LIMIT.path]);
+    expect(errors[MEMORY_LIMIT.path]).toContain('must be a quantity');
+  });
+});
+
+describe('fieldForServerMessage', () => {
+  const paths = [
+    'gateway.config_toml',
+    'gateway.config.router.upstream.timeouts.route_timeout_ms',
+    'gateway.controller.deployment.replicaCount',
+  ];
+
+  it('attaches a field-level message to the field it names', () => {
+    expect(
+      fieldForServerMessage(
+        'gateway.controller.deployment.replicaCount must be between 1 and 5',
+        paths
+      )
+    ).toBe('gateway.controller.deployment.replicaCount');
+  });
+
+  it('prefers the longest matching path', () => {
+    expect(
+      fieldForServerMessage('gateway.config_toml.inner must be a string', [
+        'gateway.config_toml',
+        'gateway.config_toml.inner',
+      ])
+    ).toBe('gateway.config_toml.inner');
+  });
+
+  it('returns null for a message that names no field', () => {
+    expect(
+      fieldForServerMessage(
+        'the controller CPU request must not exceed the controller CPU limit',
+        paths
+      )
+    ).toBeNull();
+  });
+});

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/validate.test.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/validate.test.ts
@@ -23,14 +23,17 @@ import {
   fieldForServerMessage,
   validateFieldValue,
   validateForm,
+  withoutPathPrefix,
 } from './validate';
 
 /*
  * Every expected message below is the sentence the PLATFORM returns for the
- * same value, taken from the rejection list that was run against a cluster on
- * 2026-08-30 (and the config_toml ones on 2026-08-31). That is the point of the
- * assertions: a user must read the same wording whichever side caught it, so a
- * drift here is a real defect even though the value is refused either way.
+ * same value -- taken from the rejection list run against a cluster on
+ * 2026-08-30 (and the config_toml ones on 2026-08-31) -- MINUS its leading
+ * setting path. A user must read the same wording whichever side caught it, so
+ * a drift in the words is still a real defect; only the path is dropped, and it
+ * is dropped on both sides (see `withoutPathPrefix` for the server's copy)
+ * because these render under a control whose label already names the setting.
  */
 
 const LOG_LEVEL: EditableField = {
@@ -81,6 +84,7 @@ const MEMORY_REQUEST: EditableField = {
 };
 
 const MEMORY_LIMIT: EditableField = {
+  label: 'Gateway controller memory limit',
   max: '8Gi',
   min: '128Mi',
   path: 'gateway.controller.deployment.resources.limits.memory',
@@ -101,7 +105,7 @@ describe('validateFieldValue', () => {
   it('names the permitted values for an enum', () => {
     expect(validateFieldValue(LOG_LEVEL, 'debug')).toBeNull();
     expect(validateFieldValue(LOG_LEVEL, 'trace')).toBe(
-      'gateway.config.controller.logging.level must be one of debug, info, warn, error'
+      'Must be one of debug, info, warn, error'
     );
   });
 
@@ -109,21 +113,21 @@ describe('validateFieldValue', () => {
     expect(validateFieldValue(ACCESS_LOGS, false)).toBeNull();
     // A literal "yes" is a 400 on the wire, so the widget must never send one.
     expect(validateFieldValue(ACCESS_LOGS, 'yes')).toBe(
-      'gateway.config.router.access_logs.enabled must be true or false'
+      'Must be true or false'
     );
   });
 
   it('bounds an integer, and reports the bound the platform declared', () => {
     expect(validateFieldValue(ROUTE_TIMEOUT, 60000)).toBeNull();
     expect(validateFieldValue(ROUTE_TIMEOUT, 999)).toBe(
-      'gateway.config.router.upstream.timeouts.route_timeout_ms must be between 1000 and 300000'
+      'Must be between 1000 and 300000'
     );
     expect(validateFieldValue(ROUTE_TIMEOUT, 300001)).not.toBeNull();
   });
 
   it('refuses a non-integer, an emptied input and a value past 2^53', () => {
     expect(validateFieldValue(ROUTE_TIMEOUT, 1500.5)).toBe(
-      'gateway.config.router.upstream.timeouts.route_timeout_ms must be a whole number'
+      'Must be a whole number'
     );
     // An emptied number input arrives as '' rather than 0, so it is refused
     // instead of silently saving a number nobody typed.
@@ -141,26 +145,26 @@ describe('validateFieldValue', () => {
   it('bounds a duration without normalising its spelling', () => {
     expect(validateFieldValue(CLEANUP, '5m')).toBeNull();
     expect(validateFieldValue(CLEANUP, '10s')).toBe(
-      'gateway.config.policy_configurations.ratelimit_v1.memory.cleanup_interval must be between 30s and 1h'
+      'Must be between 30s and 1h'
     );
     expect(validateFieldValue(CLEANUP, 'soon')).toBe(
-      'gateway.config.policy_configurations.ratelimit_v1.memory.cleanup_interval must be a duration such as "5m"'
+      'Must be a duration such as "5m"'
     );
   });
 
   it('bounds a quantity and refuses one that is not positive', () => {
     expect(validateFieldValue(CPU_REQUEST, '500m')).toBeNull();
     expect(validateFieldValue(CPU_REQUEST, '10m')).toBe(
-      'gateway.controller.deployment.resources.requests.cpu must be between 50m and 4'
+      'Must be between 50m and 4'
     );
     expect(validateFieldValue(CPU_REQUEST, '8')).not.toBeNull();
     // Zero is legal to Kubernetes and meaningless for a gateway; a zero limit
     // would mean "no limit", which the ceiling assumes away.
     expect(validateFieldValue(CPU_REQUEST, '0')).toBe(
-      'gateway.controller.deployment.resources.requests.cpu must be greater than zero'
+      'Must be greater than zero'
     );
     expect(validateFieldValue(CPU_REQUEST, 'lots')).toBe(
-      'gateway.controller.deployment.resources.requests.cpu must be a quantity such as "500m" or "512Mi"'
+      'Must be a quantity such as "500m" or "512Mi"'
     );
   });
 
@@ -168,7 +172,7 @@ describe('validateFieldValue', () => {
     const ascii = 'a'.repeat(8192);
     expect(validateFieldValue(CONFIG_TOML, ascii)).toBeNull();
     expect(validateFieldValue(CONFIG_TOML, `${ascii}a`)).toBe(
-      'gateway.config_toml must be between 0 and 8192 characters'
+      'Must be between 0 and 8192 characters'
     );
 
     // 8192 astral characters are 16384 UTF-16 units and 32768 bytes, and are
@@ -193,7 +197,7 @@ describe('validateFieldValue', () => {
     const lineSeparator = String.fromCharCode(0x2028);
     const paragraphSeparator = String.fromCharCode(0x2029);
     const refused =
-      'gateway.config_toml must not contain control characters or line separators';
+      'Must not contain control characters or line separators';
 
     for (const character of [
       nul,
@@ -216,7 +220,7 @@ describe('validateFieldValue', () => {
 
   it('refuses a non-string for the string field', () => {
     expect(validateFieldValue(CONFIG_TOML, 42)).toBe(
-      'gateway.config_toml must be a string'
+      'Must be a string'
     );
   });
 });
@@ -316,9 +320,57 @@ describe('validateForm', () => {
       [MEMORY_LIMIT.path]: 'not-a-quantity',
     });
     expect(Object.keys(errors)).toEqual([MEMORY_LIMIT.path]);
-    expect(errors[MEMORY_LIMIT.path]).toContain('must be a quantity');
+    expect(errors[MEMORY_LIMIT.path]).toContain('Must be a quantity');
+  });
+  it('names the compared field by its label when the platform sends no message', () => {
+    // The response usually carries its own `message`; when it does not, the
+    // fallback must still be readable under a field, which means the OTHER
+    // field's label rather than its path.
+    const config = configuration({
+      [MEMORY_LIMIT.path]: '256Mi',
+      [MEMORY_REQUEST.path]: '256Mi',
+    });
+    const errors = validateForm(
+      {
+        ...config,
+        constraints: [
+          {
+            path: MEMORY_REQUEST.path,
+            than: MEMORY_LIMIT.path,
+            type: 'notGreaterThan',
+          },
+        ],
+      },
+      { [MEMORY_REQUEST.path]: '512Mi' }
+    );
+
+    expect(errors[MEMORY_REQUEST.path]).toBe(
+      'Must not exceed Gateway controller memory limit'
+    );
   });
 });
+
+describe('withoutPathPrefix', () => {
+  const PATH = 'gateway.config.policy_configurations.ratelimit_v1.enabled';
+
+  it('drops the leading path and opens the remainder with a capital', () => {
+    expect(withoutPathPrefix(`${PATH} must be true or false`, PATH)).toBe(
+      'Must be true or false'
+    );
+  });
+
+  it('leaves a message that does not begin with the path alone', () => {
+    const message = 'The gateway is still applying an earlier change.';
+    expect(withoutPathPrefix(message, PATH)).toBe(message);
+  });
+
+  it('keeps a message that is nothing but the path', () => {
+    // Stripping would leave an empty helper line under the field, which says
+    // less than the odd-looking path does.
+    expect(withoutPathPrefix(PATH, PATH)).toBe(PATH);
+  });
+});
+
 
 describe('fieldForServerMessage', () => {
   const paths = [

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/validate.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/validate.ts
@@ -67,60 +67,64 @@ export const characterCount = (text: string): number => [...text].length;
  * One value against one field declaration, or `null` when it passes.
  * `undefined` means the field was never edited and the stored value stands, so
  * there is nothing to check.
+ *
+ * Messages are FIELD-RELATIVE: they never name the setting path, because they
+ * render directly under the control whose label already says which setting this
+ * is. A path here would be both redundant and, for the deeper policy settings,
+ * longer than the message it prefixes.
  */
 export function validateFieldValue(
   field: EditableField,
   value: unknown
 ): string | null {
   if (value === undefined) return null;
-  const { path } = field;
 
   switch (field.type) {
     case 'enum': {
       const permitted = field.values ?? [];
       if (typeof value !== 'string' || !permitted.includes(value)) {
-        return `${path} must be one of ${permitted.join(', ')}`;
+        return `Must be one of ${permitted.join(', ')}`;
       }
       return null;
     }
 
     case 'boolean':
       // A string "yes" is a 400 — the widget must produce a real boolean.
-      return typeof value === 'boolean' ? null : `${path} must be true or false`;
+      return typeof value === 'boolean' ? null : 'Must be true or false';
 
     case 'integer': {
       if (typeof value !== 'number' || !Number.isSafeInteger(value)) {
         // Also the guard for the `cost_scale_factor` ceiling of 1e12: a double
         // holds that exactly, but anything past 2^53 has silently stopped being
         // the number that was typed.
-        return `${path} must be a whole number`;
+        return 'Must be a whole number';
       }
       const low = boundInteger(field.min);
       const high = boundInteger(field.max);
       if ((low !== null && value < low) || (high !== null && value > high)) {
-        return `${path} must be between ${low} and ${high}`;
+        return `Must be between ${low} and ${high}`;
       }
       return null;
     }
 
     case 'quantity': {
-      const example = `${path} must be a quantity such as "500m" or "512Mi"`;
+      const example = 'Must be a quantity such as "500m" or "512Mi"';
       if (typeof value !== 'string') return example;
       const parsed = parseQuantity(value);
       if (parsed === null) return example;
       // Zero or negative is legal to Kubernetes and meaningless for a gateway;
       // a zero limit means "no limit", which the ceiling assumes away.
-      if (parsed <= 0) return `${path} must be greater than zero`;
+      if (parsed <= 0) return 'Must be greater than zero';
       const low = field.min === undefined ? null : parseQuantity(field.min);
       const high = field.max === undefined ? null : parseQuantity(field.max);
       if ((low !== null && parsed < low) || (high !== null && parsed > high)) {
-        return `${path} must be between ${field.min} and ${field.max}`;
+        return `Must be between ${field.min} and ${field.max}`;
       }
       return null;
     }
 
     case 'duration': {
-      const example = `${path} must be a duration such as "5m"`;
+      const example = 'Must be a duration such as "5m"';
       if (typeof value !== 'string') return example;
       const parsed = parseDurationSeconds(value);
       if (parsed === null) return example;
@@ -129,21 +133,21 @@ export function validateFieldValue(
       const high =
         field.max === undefined ? null : parseDurationSeconds(field.max);
       if ((low !== null && parsed < low) || (high !== null && parsed > high)) {
-        return `${path} must be between ${field.min} and ${field.max}`;
+        return `Must be between ${field.min} and ${field.max}`;
       }
       return null;
     }
 
     case 'string': {
-      if (typeof value !== 'string') return `${path} must be a string`;
+      if (typeof value !== 'string') return 'Must be a string';
       const length = characterCount(value);
       const low = boundInteger(field.min) ?? 0;
       const high = boundInteger(field.max);
       if (high !== null && (length < low || length > high)) {
-        return `${path} must be between ${low} and ${high} characters`;
+        return `Must be between ${low} and ${high} characters`;
       }
       if (UNRENDERABLE.test(value)) {
-        return `${path} must not contain control characters or line separators`;
+        return 'Must not contain control characters or line separators';
       }
       return null;
     }
@@ -217,9 +221,12 @@ export function validateConstraints(
     );
     if (comparison === null || comparison <= 0) continue;
 
-    const message =
-      constraint.message ??
-      `${constraint.path} must not exceed ${constraint.than}`;
+    // Names the OTHER field by its label, not its path: this message renders
+    // under a field whose own label is already on screen, so the only thing
+    // worth spelling out is the one it is being compared against.
+    const thanLabel =
+      fieldsByPath.get(constraint.than)?.label ?? constraint.than;
+    const message = constraint.message ?? `Must not exceed ${thanLabel}`;
     const edited = [constraint.path, constraint.than].filter(
       (path) => dirty[path] !== undefined
     );
@@ -290,4 +297,19 @@ export function fieldForServerMessage(
     if (best === null || path.length > best.length) best = path;
   }
   return best;
+}
+
+/**
+ * A server message with its leading setting path removed, so it reads like the
+ * client-side messages above when shown under the field it belongs to.
+ *
+ * The platform's own sentence is kept verbatim apart from that prefix — it is
+ * user-presentable prose and may say things this client cannot derive. Only the
+ * banner keeps the full text, where there is no field label to supply context.
+ */
+export function withoutPathPrefix(message: string, path: string): string {
+  if (!message.startsWith(path)) return message;
+  const rest = message.slice(path.length).trim();
+  if (rest === '') return message;
+  return rest.charAt(0).toUpperCase() + rest.slice(1);
 }

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/validate.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/validate.ts
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type {
+  ConfigConstraint,
+  ConfigValues,
+  EditableField,
+  GatewayConfiguration,
+} from '../types';
+import { parseDurationSeconds } from './duration';
+import { parseQuantity } from './quantity';
+
+/**
+ * Client-side validation, which exists so a round trip is not the only way to
+ * learn a value is out of range. THE SERVER IS THE AUTHORITY: every message
+ * below deliberately repeats the sentence the platform returns for the same
+ * value, so the user reads the same wording whichever side caught it.
+ *
+ * Two layers live here, both read from the response and neither from a
+ * hardcoded copy of the field list:
+ *
+ *   1. per field, against its own `editable` entry;
+ *   2. across the form, against `constraints`, evaluated on the MERGED document
+ *      (loaded values overlaid with the dirty edits) rather than on the edits
+ *      alone — which is what the server does, and the only way to catch
+ *      "lower just the limit".
+ */
+
+/** Setting path → the message to show under that field. */
+export type FieldErrors = Record<string, string>;
+
+/**
+ * Everything Go's `unicode.IsControl` refuses (Unicode Cc: U+0000–U+001F and
+ * U+007F–U+009F) plus the two line separators, less tab, LF and CR, which the
+ * platform allows. These are the characters CEL's `strings.quote()` does not
+ * escape, so a value carrying one cannot be rendered into the gateway's values
+ * document at all — hence a refusal rather than a warning.
+ */
+const UNRENDERABLE = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F-\u009F\u2028\u2029]/;
+
+/** Bounds arrive as strings for every type; the platform parses this one with `%d`. */
+const boundInteger = (text: string | undefined): number | null => {
+  if (text === undefined) return null;
+  const value = Number.parseInt(text.trim(), 10);
+  return Number.isFinite(value) ? value : null;
+};
+
+/** Character count in CODE POINTS, matching the platform's `len([]rune(text))`. */
+export const characterCount = (text: string): number => [...text].length;
+
+/**
+ * One value against one field declaration, or `null` when it passes.
+ * `undefined` means the field was never edited and the stored value stands, so
+ * there is nothing to check.
+ */
+export function validateFieldValue(
+  field: EditableField,
+  value: unknown
+): string | null {
+  if (value === undefined) return null;
+  const { path } = field;
+
+  switch (field.type) {
+    case 'enum': {
+      const permitted = field.values ?? [];
+      if (typeof value !== 'string' || !permitted.includes(value)) {
+        return `${path} must be one of ${permitted.join(', ')}`;
+      }
+      return null;
+    }
+
+    case 'boolean':
+      // A string "yes" is a 400 — the widget must produce a real boolean.
+      return typeof value === 'boolean' ? null : `${path} must be true or false`;
+
+    case 'integer': {
+      if (typeof value !== 'number' || !Number.isSafeInteger(value)) {
+        // Also the guard for the `cost_scale_factor` ceiling of 1e12: a double
+        // holds that exactly, but anything past 2^53 has silently stopped being
+        // the number that was typed.
+        return `${path} must be a whole number`;
+      }
+      const low = boundInteger(field.min);
+      const high = boundInteger(field.max);
+      if ((low !== null && value < low) || (high !== null && value > high)) {
+        return `${path} must be between ${low} and ${high}`;
+      }
+      return null;
+    }
+
+    case 'quantity': {
+      const example = `${path} must be a quantity such as "500m" or "512Mi"`;
+      if (typeof value !== 'string') return example;
+      const parsed = parseQuantity(value);
+      if (parsed === null) return example;
+      // Zero or negative is legal to Kubernetes and meaningless for a gateway;
+      // a zero limit means "no limit", which the ceiling assumes away.
+      if (parsed <= 0) return `${path} must be greater than zero`;
+      const low = field.min === undefined ? null : parseQuantity(field.min);
+      const high = field.max === undefined ? null : parseQuantity(field.max);
+      if ((low !== null && parsed < low) || (high !== null && parsed > high)) {
+        return `${path} must be between ${field.min} and ${field.max}`;
+      }
+      return null;
+    }
+
+    case 'duration': {
+      const example = `${path} must be a duration such as "5m"`;
+      if (typeof value !== 'string') return example;
+      const parsed = parseDurationSeconds(value);
+      if (parsed === null) return example;
+      const low =
+        field.min === undefined ? null : parseDurationSeconds(field.min);
+      const high =
+        field.max === undefined ? null : parseDurationSeconds(field.max);
+      if ((low !== null && parsed < low) || (high !== null && parsed > high)) {
+        return `${path} must be between ${field.min} and ${field.max}`;
+      }
+      return null;
+    }
+
+    case 'string': {
+      if (typeof value !== 'string') return `${path} must be a string`;
+      const length = characterCount(value);
+      const low = boundInteger(field.min) ?? 0;
+      const high = boundInteger(field.max);
+      if (high !== null && (length < low || length > high)) {
+        return `${path} must be between ${low} and ${high} characters`;
+      }
+      if (UNRENDERABLE.test(value)) {
+        return `${path} must not contain control characters or line separators`;
+      }
+      return null;
+    }
+
+    default:
+      return null;
+  }
+}
+
+/**
+ * Compares two values of a field's type. `null` when either side is
+ * unparseable, which the caller must treat as "skip": such a value cannot have
+ * come through the allowlist, so it is a pre-existing platform value the user
+ * can do nothing about, and refusing their save for it would be blaming them
+ * for someone else's write. The server reasons the same way.
+ */
+function compareByType(
+  field: EditableField | undefined,
+  left: unknown,
+  right: unknown
+): number | null {
+  const asNumber = (value: unknown): number | null => {
+    switch (field?.type) {
+      case 'integer':
+        return typeof value === 'number' && Number.isFinite(value)
+          ? value
+          : null;
+      case 'quantity':
+        return typeof value === 'string' ? parseQuantity(value) : null;
+      case 'duration':
+        return typeof value === 'string' ? parseDurationSeconds(value) : null;
+      default:
+        // Only ordered types can be compared. `enum`, `boolean` and `string`
+        // have no ordering, so no constraint can be declared over them.
+        return null;
+    }
+  };
+  const a = asNumber(left);
+  const b = asNumber(right);
+  if (a === null || b === null) return null;
+  if (a === b) return 0;
+  return a < b ? -1 : 1;
+}
+
+/**
+ * The declared constraints against a whole values document.
+ *
+ * A message lands on whichever side of the pair the user actually edited, so
+ * "lower just the limit" reports on the limit rather than on the request they
+ * never touched. When neither side is dirty the violation is pre-existing and
+ * reports on the bounded side.
+ */
+export function validateConstraints(
+  constraints: readonly ConfigConstraint[],
+  merged: ConfigValues,
+  fieldsByPath: ReadonlyMap<string, EditableField>,
+  dirty: ConfigValues = {}
+): FieldErrors {
+  const errors: FieldErrors = {};
+  for (const constraint of constraints) {
+    if (constraint.type !== 'notGreaterThan') continue;
+    const left = merged[constraint.path];
+    const right = merged[constraint.than];
+    // A document carrying only one side cannot violate the rule; the missing
+    // side falls back to the chart's own default at render time.
+    if (left === undefined || right === undefined) continue;
+    const comparison = compareByType(
+      fieldsByPath.get(constraint.path),
+      left,
+      right
+    );
+    if (comparison === null || comparison <= 0) continue;
+
+    const message =
+      constraint.message ??
+      `${constraint.path} must not exceed ${constraint.than}`;
+    const edited = [constraint.path, constraint.than].filter(
+      (path) => dirty[path] !== undefined
+    );
+    for (const path of edited.length > 0 ? edited : [constraint.path]) {
+      errors[path] ??= message;
+    }
+  }
+  return errors;
+}
+
+/**
+ * Both client-side layers over a loaded configuration and the edits pending on
+ * it. Empty means `Save` may be enabled — not that the write will succeed.
+ */
+export function validateForm(
+  config: GatewayConfiguration,
+  dirty: ConfigValues
+): FieldErrors {
+  const fieldsByPath = new Map(
+    config.editable.map((field) => [field.path, field])
+  );
+
+  const errors: FieldErrors = {};
+  for (const [path, value] of Object.entries(dirty)) {
+    const field = fieldsByPath.get(path);
+    if (!field) {
+      // Never render, and never send, a setting the response did not list.
+      errors[path] = `${path} is not an editable gateway setting`;
+      continue;
+    }
+    const message = validateFieldValue(field, value);
+    if (message) errors[path] = message;
+  }
+
+  // Constraints run over the document the write WOULD produce, and only once
+  // every field in it is individually sound — comparing against a value already
+  // known to be malformed says nothing.
+  if (Object.keys(errors).length === 0) {
+    Object.assign(
+      errors,
+      validateConstraints(
+        config.constraints ?? [],
+        { ...config.values, ...dirty },
+        fieldsByPath,
+        dirty
+      )
+    );
+  }
+  return errors;
+}
+
+/**
+ * The field a server message belongs under, found by longest matching setting
+ * path — a field-level message begins with the path it is about
+ * (`…route_timeout_ms must be between 1000 and 300000`). `null` means it is
+ * form-level and belongs in a banner.
+ *
+ * Longest wins because one path can prefix another: `gateway.config_toml` also
+ * prefixes any message about a `gateway.config_toml.*` field.
+ */
+export function fieldForServerMessage(
+  message: string,
+  paths: readonly string[]
+): string | null {
+  let best: string | null = null;
+  for (const path of paths) {
+    if (!message.startsWith(path)) continue;
+    if (best === null || path.length > best.length) best = path;
+  }
+  return best;
+}

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/data/gatewaysData.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/data/gatewaysData.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { ApiFetch } from '../hostPort';
+import type { Gateway, GatewayType } from '../types';
+
+/**
+ * The list is a JOIN of two resources, because neither answers the whole
+ * question:
+ *
+ *   GET /gateways          every gateway the organization has, self-hosted and
+ *                          WSO2-managed alike, with the live `isActive` flag and
+ *                          the registered `functionalityType`. Carries no
+ *                          environment.
+ *   GET /managed-gateways  the gateway-to-environment bindings — i.e. exactly
+ *                          which gateways are WSO2-managed, and the only
+ *                          authoritative source of a gateway's environment.
+ *
+ * The binding list is what gates the configuration action: a gateway with no
+ * binding row has no cloud-managed configuration and that path answers 404, so
+ * the icon must not be offered rather than offered and then failed.
+ */
+
+/** `GatewayResponse`, only the fields this list reads. */
+type NativeGateway = {
+  id: string;
+  displayName?: string;
+  description?: string;
+  endpoints?: string[];
+  functionalityType?: GatewayType;
+  isActive?: boolean;
+  updatedAt?: string;
+};
+
+type NativeGatewayList = { list?: NativeGateway[] };
+type BindingList = { list?: Array<{ id: string; environment: string }> };
+
+/**
+ * The environment a gateway lives in, recovered from its id for a gateway with
+ * no binding row. Ids are `wc-<org>-<env>-apip-<name>-gw`, so the environment
+ * is the last segment before `-apip-`. A display fallback only — it does not
+ * make the row manageable.
+ */
+export function environmentFromGatewayId(id: string): string {
+  const head = id.split('-apip-')[0];
+  if (head === id) return '';
+  const parts = head.split('-');
+  return parts[parts.length - 1] ?? '';
+}
+
+export async function listGateways(apiFetch: ApiFetch): Promise<Gateway[]> {
+  const [gateways, bindings] = await Promise.all([
+    apiFetch<NativeGatewayList>('GET', '/gateways'),
+    apiFetch<BindingList>('GET', '/managed-gateways'),
+  ]);
+
+  const environmentById = new Map(
+    (bindings.list ?? []).map((binding) => [binding.id, binding.environment])
+  );
+
+  return (gateways.list ?? []).map((native) => ({
+    description: native.description,
+    environmentId:
+      environmentById.get(native.id) ?? environmentFromGatewayId(native.id),
+    id: native.id,
+    isManaged: environmentById.has(native.id),
+    name: native.displayName || native.id,
+    status: native.isActive ? 'active' : 'inactive',
+    // The field is required on create and defaults to `regular` in the schema,
+    // so an absent one is a wire anomaly and `regular` is what it would be.
+    type: native.functionalityType ?? 'regular',
+    updatedAt: native.updatedAt ?? '',
+    url: native.endpoints?.[0] ?? '',
+  }));
+}

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/data/gatewaysData.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/data/gatewaysData.ts
@@ -63,17 +63,40 @@ export function environmentFromGatewayId(id: string): string {
   return parts[parts.length - 1] ?? '';
 }
 
-export async function listGateways(apiFetch: ApiFetch): Promise<Gateway[]> {
+/**
+ * The gateway rows, plus whether the managed-gateway half of the join could be
+ * read at all.
+ */
+export type GatewayListing = {
+  gateways: Gateway[];
+  /**
+   * `/managed-gateways` did not answer, so no row can be known to be managed
+   * and every one reports `isManaged: false`. The caller must say so rather
+   * than let the configuration affordance quietly disappear.
+   */
+  managedUnavailable: boolean;
+};
+
+export async function listGateways(
+  apiFetch: ApiFetch
+): Promise<GatewayListing> {
+  // The binding list is an ENRICHMENT: it decides which rows are configurable,
+  // while `/gateways` decides which rows exist. So its failure must not take
+  // the page down with it -- a caller without the managed-gateway permission,
+  // or an outage on that one route, would otherwise see no gateways at all
+  // rather than the list it is entitled to.
   const [gateways, bindings] = await Promise.all([
     apiFetch<NativeGatewayList>('GET', '/gateways'),
-    apiFetch<BindingList>('GET', '/managed-gateways'),
+    apiFetch<BindingList>('GET', '/managed-gateways').catch(() => null),
   ]);
 
   const environmentById = new Map(
-    (bindings.list ?? []).map((binding) => [binding.id, binding.environment])
+    (bindings?.list ?? []).map((binding) => [binding.id, binding.environment])
   );
 
-  return (gateways.list ?? []).map((native) => ({
+  // Annotated: without a contextual type the ternaries below widen to `string`
+  // and stop matching the union.
+  const rows: Gateway[] = (gateways.list ?? []).map((native) => ({
     description: native.description,
     environmentId:
       environmentById.get(native.id) ?? environmentFromGatewayId(native.id),
@@ -87,4 +110,6 @@ export async function listGateways(apiFetch: ApiFetch): Promise<Gateway[]> {
     updatedAt: native.updatedAt ?? '',
     url: native.endpoints?.[0] ?? '',
   }));
+
+  return { gateways: rows, managedUnavailable: bindings === null };
 }

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/hostPort.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/hostPort.ts
@@ -25,9 +25,23 @@
  */
 export type NotifySeverity = 'success' | 'info' | 'warning' | 'error';
 
+/**
+ * A same-origin, host-authenticated call to platform-api. `path` is relative to
+ * the API base the host prepends (`/proxy/api/v0.9` in the console), so no base
+ * URL, token, organization header or CSRF header belongs in this package — the
+ * Port owns all four. Rejects with an `Error` carrying the API's own message.
+ */
+export type ApiFetch = <T = unknown>(
+  method: string,
+  path: string,
+  body?: unknown
+) => Promise<T>;
+
 export type AIWorkspaceHostPort = {
   orgHandle: string;
   projectHandle?: string;
   navigate: (path: string) => void;
   notify: (message: string, severity?: NotifySeverity) => void;
+  /** Optional: the console's Port carries it, the AI Workspace's does not yet. */
+  apiFetch?: ApiFetch;
 };

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/index.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/index.ts
@@ -22,5 +22,5 @@ export { default as GatewaysList } from './GatewaysList';
 export type { GatewaysListProps } from './GatewaysList';
 export { default as GatewayForm } from './GatewayForm';
 export type { GatewayFormProps } from './GatewayForm';
-export type { AIWorkspaceHostPort, NotifySeverity } from './hostPort';
+export type { AIWorkspaceHostPort, ApiFetch, NotifySeverity } from './hostPort';
 export type { Environment, Gateway, GatewayInput, GatewayStatus, GatewayType } from './types';

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/types.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/types.ts
@@ -16,7 +16,8 @@
  * under the License.
  */
 
-export type GatewayType = 'ai' | 'event';
+/** The wire vocabulary: `GatewayResponse.functionalityType`, which defaults to `regular`. */
+export type GatewayType = 'regular' | 'ai' | 'event';
 
 export type GatewayStatus = 'active' | 'inactive';
 
@@ -34,6 +35,12 @@ export type Gateway = {
   url: string;
   status: GatewayStatus;
   updatedAt: string;
+  /**
+   * Whether the gateway has a WSO2-managed environment binding. Only a managed
+   * gateway has a cloud-managed configuration — the endpoint answers 404 for
+   * anything else — so this gates the configuration action.
+   */
+  isManaged?: boolean;
 };
 
 /** Fields the create/edit form collects — everything else (`id`, `status`, `updatedAt`) is store-assigned. */
@@ -43,4 +50,71 @@ export type GatewayInput = {
   type: GatewayType;
   environmentId: string;
   url: string;
+};
+
+/* ── gateway configuration ─────────────────────────────────────────────────── */
+
+/**
+ * `applying` is the expected state immediately after ANY write and can persist
+ * for minutes. It is not a failure and not an unfinished save.
+ */
+export type ConfigPhase = 'applying' | 'healthy' | 'failed';
+
+export type ConfigStatus = {
+  phase: ConfigPhase;
+  /** Platform detail, present when the phase is not healthy. Prose, not a code. */
+  message?: string;
+};
+
+export type ConfigFieldType =
+  | 'enum'
+  | 'boolean'
+  | 'integer'
+  | 'duration'
+  | 'quantity'
+  | 'string';
+
+/**
+ * One setting the organization may change. The platform reads its allowlist at
+ * request time, so this array is the form definition — never a client-side copy
+ * of it — and `label`/`description` are the platform's own user-facing copy.
+ */
+export type EditableField = {
+  path: string;
+  type: ConfigFieldType;
+  label?: string;
+  description?: string;
+  /** Permitted values, present when `type` is `enum`. */
+  values?: string[];
+  /**
+   * Inclusive bounds. STRINGS for every type — `Number('50m')` is `NaN`. For
+   * `string`, `max` is a length in characters and `min` is absent.
+   */
+  min?: string;
+  max?: string;
+};
+
+/**
+ * A rule between two settings. Evaluated by the platform against the document a
+ * write would PRODUCE, so a client checks it across the whole form.
+ */
+export type ConfigConstraint = {
+  type: 'notGreaterThan';
+  path: string;
+  than: string;
+  /** The platform's own sentence for the violation. Surface it verbatim. */
+  message?: string;
+};
+
+export type ConfigValues = Record<string, unknown>;
+
+export type GatewayConfiguration = {
+  id: string;
+  name?: string;
+  environment?: string;
+  /** Current value of every editable setting, keyed exactly as a request body is. */
+  values: ConfigValues;
+  editable: EditableField[];
+  constraints?: ConfigConstraint[];
+  status: ConfigStatus;
 };

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/utils/gateway.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/utils/gateway.ts
@@ -18,6 +18,12 @@
 
 import type { GatewayType } from '../types';
 
+const TYPE_LABEL: Record<GatewayType, string> = {
+  regular: 'API Gateway',
+  ai: 'AI Gateway',
+  event: 'Event Gateway',
+};
+
 export function gatewayTypeLabel(type: GatewayType): string {
-  return type === 'ai' ? 'AI Gateway' : 'Event Gateway';
+  return TYPE_LABEL[type];
 }

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/tsconfig.console.json
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/tsconfig.console.json
@@ -1,0 +1,22 @@
+{
+  // The same options as tsconfig.json with `paths` pointed at the API Control
+  // Plane's node_modules, because the console's image build is the only thing
+  // that ever typechecks this package (its `npm run build` is `tsc --noEmit &&
+  // vite build`, and the plugin is copied into node_modules with `types`
+  // pointing at TS source, so `skipLibCheck` does not skip it). Run BOTH
+  // configs — clean under one host's dependency versions is not clean under the
+  // other's. Also the config the tests typecheck and run under, since the
+  // console is the only portal with vitest installed.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@wso2/oxygen-ui": ["../../api-control-plane/node_modules/@wso2/oxygen-ui"],
+      "@wso2/oxygen-ui-icons-react": ["../../api-control-plane/node_modules/@wso2/oxygen-ui-icons-react"],
+      "react": ["../../api-control-plane/node_modules/@types/react/index.d.ts"],
+      "react/jsx-runtime": ["../../api-control-plane/node_modules/@types/react/jsx-runtime.d.ts"],
+      "react-router-dom": ["../../api-control-plane/node_modules/react-router-dom/dist/index.d.ts"],
+      "vitest": ["../../api-control-plane/node_modules/vitest/dist/index.d.ts"]
+    }
+  },
+  "exclude": []
+}

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/tsconfig.json
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/tsconfig.json
@@ -17,5 +17,8 @@
     "skipLibCheck": true,
     "resolveJsonModule": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  // The AI Workspace has no vitest installed, so the tests cannot resolve it
+  // under these paths. tsconfig.console.json typechecks and runs them.
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/portals/cloud-plugins/apip-cloud-ui/src/hosts/api-control-plane.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui/src/hosts/api-control-plane.tsx
@@ -10,12 +10,15 @@
 import { Layers, Workflow } from '@wso2/oxygen-ui-icons-react';
 
 import { EnvironmentsFeature } from '@wso2-enterprise/apip-cloud-ui-environments-new';
+import { GatewaysFeature } from '@wso2-enterprise/apip-cloud-ui-gateways';
 import {
   PipelinesFeature,
   ProjectPipelinesFeature,
 } from '@wso2-enterprise/apip-cloud-ui-pipelines';
 import {
+  API_CONTROL_PLANE_GATEWAYS_SLOT,
   settingsTabSlot,
+  type ApiControlPlaneCloudEntry,
   type ApiControlPlaneExtension,
 } from '../../../../api-control-plane/src/extensions';
 import { defineCloudPlugin, getCloudExtensions, type CloudPluginFeature } from '../plugin';
@@ -44,8 +47,16 @@ import { defineCloudPlugin, getCloudExtensions, type CloudPluginFeature } from '
  * scope, so each is gated by `isVisible` on whether a project is in scope, and
  * exactly one is shown at a time. Data flows through the host port's `apiFetch`
  * to the platform-api REST endpoints.
+ *
+ * `gateways` is a page override rather than a new nav item: it registers
+ * against the host's `page.gateways` slot to replace what renders behind the
+ * existing, built-in "API Gateways" sidebar entry -- see `GatewaysRoute` in
+ * `api-control-plane/src/routes/AppRoutes.tsx`. The console therefore shows
+ * one gateways page, not two, and nothing under
+ * `api-control-plane/src/pages/appShell/appShellPages/gateways` is touched:
+ * unregister this entry and all three built-in routes answer again.
  */
-export const cloudPluginFeatures: CloudPluginFeature<ApiControlPlaneExtension>[] = [
+export const cloudPluginFeatures: CloudPluginFeature<ApiControlPlaneCloudEntry>[] = [
   defineCloudPlugin({
     id: 'environments',
     version: '0.1.0',
@@ -89,6 +100,18 @@ export const cloudPluginFeatures: CloudPluginFeature<ApiControlPlaneExtension>[]
         icon: <Workflow size={20} />,
         level: 'project',
         isVisible: (scope) => scope.isProjectScope,
+      },
+    ],
+  }),
+  defineCloudPlugin({
+    id: 'gateways',
+    version: '0.1.0',
+    extensions: [
+      {
+        id: 'gateways',
+        slot: API_CONTROL_PLANE_GATEWAYS_SLOT,
+        order: 0,
+        render: (port) => <GatewaysFeature port={port} />,
       },
     ],
   }),

--- a/portals/cloud-plugins/apip-cloud-ui/src/index.ts
+++ b/portals/cloud-plugins/apip-cloud-ui/src/index.ts
@@ -14,7 +14,6 @@ export {
   cloudExtensions as apiControlPlaneCloudExtensions,
   cloudPluginFeatures as apiControlPlaneCloudPluginFeatures,
 } from './hosts/api-control-plane';
-export type { ApiControlPlaneExtension } from './hosts/api-control-plane';
 
 export {
   cloudExtensions as aiWorkspaceCloudExtensions,


### PR DESCRIPTION
## Purpose

An org admin can provision an APIP gateway from the console but cannot see or change its
configuration afterwards. Replica counts, CPU/memory, log levels, timeouts and the gateway's own
`config.toml` are all set at provision time and then unreachable, so every subsequent change is a
platform-team ticket.

The platform side of this already exists — `GET`/`PUT /managed-gateways/{id}/configuration` — but
nothing in the console calls it.

## Goals

Two things, and deliberately nothing else:

1. **List gateways from the real API** rather than the mock store.
2. **Edit a managed gateway's configuration** through the endpoints above.

Create, edit and delete stay mock-backed and unwired, exactly as the AI Workspace has them today.
This PR does not change that design.

## Approach

**A page override, not a new nav item.** The gateways plugin registers against a new
`page.gateways` slot, replacing what renders behind the existing "API Gateways" sidebar entry.
The console therefore shows one gateways page, not two, and nothing under
`appShellPages/gateways` is touched — unregister the entry and all three built-in routes answer
again exactly as before. The three gateway routes collapse into one `GatewaysRoute` that either
defers to the override or renders the built-ins inside a `Hideable`.

**The form is rendered entirely from the response.** The platform reads its allowlist at request
time, so `editable[]` is the field list and `constraints[]` the cross-field rules; there is no
client-side copy of either. A setting the deployment opens or withdraws appears or disappears
without a plugin release.

**Validation mirrors the platform's own parsers** so a bad value is caught before the round trip:
Kubernetes quantity parsing (`config/quantity.ts`) and Go `time.ParseDuration` semantics
(`config/duration.ts`). Both are needed because bounds arrive as strings for every type —
`Number('50m')` is `NaN` — and because the server canonicalizes on write (`1000m` comes back `1`),
which a string comparison would report as an unsaved change.

The `PUT` body is a sparse patch of only the paths the user touched, and its response is the whole
configuration in the `GET`'s shape, so it doubles as the new baseline — no second `GET` after save.

**Shared plugin, so the AI Workspace is unaffected.** `apip-cloud-ui-gateways` is used by both
hosts, so `apiFetch` is optional on the port: the console passes one and gets live data, the AI
Workspace passes none and keeps its mock store. `hosts/ai-workspace.tsx` is untouched.

Sizing note: the response carries a value only for paths the tenant has actually overridden, so
unset fields render blank with `Not set — the platform default applies.` rather than an invented
placeholder that would read as the gateway's current setting.

## User stories

- As an org admin I can see my organization's gateways in the console, with their real state.
- As an org admin I can open a gateway's configuration, see what is set, change it and save.
- As an org admin I am told why a value is rejected before it is sent, and what the bounds are.

## Documentation

N/A for this PR — no user-facing docs exist for the configuration endpoints yet. Doc impact is
tracked with the platform-side change that introduced them.

## Automation tests

- **Unit tests**
  - 44 new tests in `apip-cloud-ui-gateways` across four files, covering the two parsers and the
    validator: `quantity` (7), `duration` (7), `toml` (7), `validate` (23). They pin the bounds the
    deployed allowlist actually declares, the spellings the server canonicalizes, and the cases
    that previously slipped through (`1e3Mi` is rejected; suffixes are resolved through `Map`s so
    `1constructor` cannot resolve through the prototype chain).
  - 7 new tests in `AppRoutes.gatewaysPage.test.tsx` covering the `page.gateways` slot — the
    console's only page-override position. Half of them are the regression guard for the
    re-nesting: `routes.gateways()`, `routes.newGateway()` and `routes.gateway()` still answer
    exactly as before when nothing is registered, and ancestor route params still reach the
    re-nested detail page.
- **Integration tests** — none added. The two endpoints are covered on the platform side; this
  change is the client for them.
- Full existing suite re-run on this branch: **66 files, 775 tests, 0 failures.** `tsc --noEmit`,
  `vite build` and `eslint --quiet` all clean, and the plugin typechecks under both hosts' configs.

## Security checks

- Followed secure coding standards: **yes**
- Ran FindSecurityBugs plugin and verified report: **n/a** — TypeScript only, no Java in this change
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets:
  **yes**

## Samples

N/A.

## Related PRs

Depends on the platform-side configuration endpoints, which are **not yet merged**:

- `wso2cloud` — `GET`/`PUT /cloud/gateways/{id}/configuration`, the editable-fields allowlist
- `apim-saas` #2914 — the `/api/v0.9/managed-gateways/{id}/configuration` pass-through the console
  actually calls

Until those land, the console half of this has nothing to talk to. The AI Workspace half is
unaffected either way, since it keeps its mock store.

## Test environment

- Node 24 (repo `engines`), npm 10
- macOS 15 (darwin 25.6.0), Chrome
- End to end against a local k3d cluster (`k3d-openchoreo`), org `kavtestorg`, gateway
  `wc-…-development-apip-default-gw`: `GET` renders the form and `PUT` reaches the gateway's own
  `config.toml`.
