### PR TITLE
Add the gateway configuration drawer on top of the cloud gateways wiring

### DIFF
--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/GatewaysFeature.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/GatewaysFeature.tsx
@@ -193,6 +193,7 @@ const GatewaysFeature: FC<GatewaysFeatureProps> = ({ port, gatewayTypes }) => {
     <GatewaysList
       gateways={gateways}
       environments={environments}
+      port={port}
       onAddClick={() => setView('create')}
       onEditClick={(gatewayId) => {
         setEditingGatewayId(gatewayId);

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/GatewaysList.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/GatewaysList.tsx
@@ -47,11 +47,14 @@ import { Edit, Plus, Search, Settings, Trash2 } from '@wso2/oxygen-ui-icons-reac
 import GatewaySettingsDrawer from './components/GatewaySettingsDrawer';
 import { gatewayTypeLabel } from './utils/gateway';
 import NoGatewaysImage from './assets/images/NoGW.svg';
+import type { AIWorkspaceHostPort } from './hostPort';
 import type { Environment, Gateway } from './types';
 
 export type GatewaysListProps = {
   gateways: Gateway[];
   environments: Environment[];
+  /** Passed through to the configuration drawer, which calls platform-api itself. */
+  port: AIWorkspaceHostPort;
   onAddClick: () => void;
   onEditClick: (gatewayId: string) => void;
   onDelete: (gatewayId: string, name: string) => void;
@@ -65,6 +68,7 @@ function truncateText(text: string, maxLength: number): string {
 const GatewaysList: FC<GatewaysListProps> = ({
   gateways,
   environments,
+  port,
   onAddClick,
   onEditClick,
   onDelete,
@@ -270,11 +274,13 @@ const GatewaysList: FC<GatewaysListProps> = ({
         </DialogActions>
       </Dialog>
 
+      {/* Keyed by gateway so the form's draft state belongs to one gateway and cannot outlive it. */}
       <GatewaySettingsDrawer
+        key={settingsGateway?.id ?? 'none'}
         open={settingsGateway !== null}
         onClose={() => setSettingsGateway(null)}
         gateway={settingsGateway}
-        environments={environments}
+        port={port}
       />
     </PageContent>
   );

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/ConfigStatusBar.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/ConfigStatusBar.tsx
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { FC } from 'react';
+import { Box, Chip, IconButton, Tooltip } from '@wso2/oxygen-ui';
+import { RefreshCw } from '@wso2/oxygen-ui-icons-react';
+import type { ConfigPhase, ConfigStatus } from '../types';
+
+export type ConfigStatusBarProps = {
+  status: ConfigStatus;
+  onRefresh: () => void;
+  refreshing?: boolean;
+};
+
+/**
+ * The phase of the last configuration change, as one chip beside the gateway
+ * name.
+ *
+ * `applying` is the expected state immediately after ANY write and can persist
+ * for minutes -- it is not a failure. The `message` that often accompanies it
+ * is deliberately NOT shown: it is prose of unbounded length, it pushed the
+ * form down the drawer, and the phase word is the part a reader acts on. It
+ * stays in the response for anyone reading the endpoint directly.
+ */
+type ChipColor = 'default' | 'info' | 'error' | 'success';
+
+const PHASES: Record<ConfigPhase, { color: ChipColor; label: string }> = {
+  applying: { color: 'info', label: 'Applying' },
+  failed: { color: 'error', label: 'Failed' },
+  healthy: { color: 'success', label: 'Healthy' },
+};
+
+const ConfigStatusBar: FC<ConfigStatusBarProps> = ({
+  status,
+  onRefresh,
+  refreshing = false,
+}) => {
+  // An unrecognised phase is a newer platform than this build; say the word it
+  // sent rather than mislabelling it as healthy.
+  const phase = PHASES[status.phase] ?? {
+    color: 'default' as ChipColor,
+    label: status.phase,
+  };
+
+  return (
+    <Box sx={{ alignItems: 'center', display: 'flex', gap: 0.5 }}>
+      <Chip
+        color={phase.color}
+        label={phase.label}
+        size="small"
+        sx={{ flexShrink: 0 }}
+        variant="outlined"
+      />
+      <Tooltip title="Refresh status">
+        {/* Wrapped: a disabled button fires no events, so the tooltip on it
+            would never open while a refresh is in flight. */}
+        <Box component="span">
+          <IconButton
+            aria-label="Refresh status"
+            disabled={refreshing}
+            onClick={onRefresh}
+            size="small"
+          >
+            <RefreshCw size={14} />
+          </IconButton>
+        </Box>
+      </Tooltip>
+    </Box>
+  );
+};
+
+export default ConfigStatusBar;

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/ConfigStatusBar.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/ConfigStatusBar.tsx
@@ -17,9 +17,10 @@
  */
 
 import type { FC } from 'react';
-import { Box, Chip, IconButton, Tooltip } from '@wso2/oxygen-ui';
+import { Box, IconButton, Tooltip, Typography } from '@wso2/oxygen-ui';
 import { RefreshCw } from '@wso2/oxygen-ui-icons-react';
-import type { ConfigPhase, ConfigStatus } from '../types';
+import { describeStatus } from '../config/status';
+import type { ConfigStatus } from '../types';
 
 export type ConfigStatusBarProps = {
   status: ConfigStatus;
@@ -28,44 +29,37 @@ export type ConfigStatusBarProps = {
 };
 
 /**
- * The phase of the last configuration change, as one chip beside the gateway
- * name.
+ * The configuration's phase as one line of text beside the gateway name — no
+ * chip: a healthy gateway shows when its configuration last landed, and only a
+ * phase that is still moving or has gone wrong spends the line on a word.
+ * `config/status.ts` decides what that line says and why.
  *
- * `applying` is the expected state immediately after ANY write and can persist
- * for minutes -- it is not a failure. The `message` that often accompanies it
- * is deliberately NOT shown: it is prose of unbounded length, it pushed the
- * form down the drawer, and the phase word is the part a reader acts on. It
- * stays in the response for anyone reading the endpoint directly.
+ * The Refresh button stays even though the drawer polls: polling is on a
+ * 20-second clock and someone watching a change land wants it now. It is also
+ * the only path that surfaces a read failure, a background poll being silent by
+ * design.
  */
-type ChipColor = 'default' | 'info' | 'error' | 'success';
-
-const PHASES: Record<ConfigPhase, { color: ChipColor; label: string }> = {
-  applying: { color: 'info', label: 'Applying' },
-  failed: { color: 'error', label: 'Failed' },
-  healthy: { color: 'success', label: 'Healthy' },
-};
-
 const ConfigStatusBar: FC<ConfigStatusBarProps> = ({
   status,
   onRefresh,
   refreshing = false,
 }) => {
-  // An unrecognised phase is a newer platform than this build; say the word it
-  // sent rather than mislabelling it as healthy.
-  const phase = PHASES[status.phase] ?? {
-    color: 'default' as ChipColor,
-    label: status.phase,
-  };
+  const display = describeStatus(status);
 
   return (
     <Box sx={{ alignItems: 'center', display: 'flex', gap: 0.5 }}>
-      <Chip
-        color={phase.color}
-        label={phase.label}
-        size="small"
-        sx={{ flexShrink: 0 }}
-        variant="outlined"
-      />
+      {display ? (
+        // An empty title renders no tooltip, so an absent detail needs no branch.
+        <Tooltip title={display.detail ?? ''}>
+          <Typography
+            color={display.tone === 'error' ? 'error.main' : 'text.secondary'}
+            sx={{ flexShrink: 0 }}
+            variant="body2"
+          >
+            {display.text}
+          </Typography>
+        </Tooltip>
+      ) : null}
       <Tooltip title="Refresh status">
         {/* Wrapped: a disabled button fires no events, so the tooltip on it
             would never open while a refresh is in flight. */}

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/GatewaySettingsDrawer.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/GatewaySettingsDrawer.tsx
@@ -24,10 +24,12 @@ import {
   CircularProgress,
   Drawer,
   IconButton,
+  Tooltip,
   Typography,
 } from '@wso2/oxygen-ui';
 import { X } from '@wso2/oxygen-ui-icons-react';
 import { readConfiguration, writeConfiguration } from '../config/api';
+import { isApplying } from '../config/status';
 import {
   fieldForServerMessage,
   validateForm,
@@ -62,6 +64,21 @@ export type GatewaySettingsDrawerProps = {
 
 const DRAWER_WIDTH = 520;
 
+/**
+ * How often the drawer re-reads the configuration while it is open.
+ *
+ * The phase moves on the platform's clock, not the user's: a write comes back
+ * `applying` and the data plane takes minutes to catch up (10m07s measured on
+ * 2026-08-31), so nothing the user does will ever be the event that turns the
+ * line to `healthy`. A read is cheap and idempotent, and it re-seeds `config`
+ * only — pending edits are untouched — so the cost of polling is one GET and
+ * the benefit is a status line that is true without anyone pressing anything.
+ *
+ * The PUT is never re-sent. Only the phase is being waited on, and it settles on
+ * its own.
+ */
+const POLL_INTERVAL_MS = 20_000;
+
 const GatewaySettingsDrawer: FC<GatewaySettingsDrawerProps> = ({
   open,
   onClose,
@@ -77,6 +94,13 @@ const GatewaySettingsDrawer: FC<GatewaySettingsDrawerProps> = ({
   /** Only the paths the user has touched. The request body is a sparse patch of exactly these. */
   const [drafts, setDrafts] = useState<ConfigValues>({});
   const [saving, setSaving] = useState(false);
+  /**
+   * The same flag the poll timer reads. `saving` itself cannot be: the interval
+   * callback closes over the render that created it, so it would see `false`
+   * forever unless the timer were torn down and rebuilt on every keystroke-
+   * adjacent state change.
+   */
+  const savingRef = useRef(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [serverErrors, setServerErrors] = useState<FieldErrors>({});
 
@@ -91,18 +115,31 @@ const GatewaySettingsDrawer: FC<GatewaySettingsDrawerProps> = ({
    */
   const generation = useRef(0);
 
-  /** Re-seeds `config` only. Pending edits survive, so Refresh cannot discard them. */
+  /**
+   * Re-seeds `config` only. Pending edits survive, so neither Refresh nor the
+   * poll below can discard them.
+   *
+   * `background: true` is the poll's read: it owns no spinner, and a failure
+   * leaves the form exactly as it is. A poll that lost the network must not
+   * replace a working form with an error banner every twenty seconds — the
+   * Refresh button is the path that reports a read failure, because someone
+   * pressed it and is waiting for an answer.
+   */
   const load = useCallback(
-    async (id: string) => {
+    async (id: string, { background = false }: { background?: boolean } = {}) => {
       const mine = ++generation.current;
-      setLoading(true);
-      setLoadError(null);
+      if (!background) {
+        setLoading(true);
+        setLoadError(null);
+      }
       try {
         const loaded = await readConfiguration(apiFetch, id);
         if (mine !== generation.current) return;
         setConfig(loaded);
+        // A read that worked settles any banner an earlier one left behind.
+        setLoadError(null);
       } catch (error) {
-        if (mine !== generation.current) return;
+        if (mine !== generation.current || background) return;
         setLoadError(
           error instanceof Error
             ? error.message
@@ -111,7 +148,7 @@ const GatewaySettingsDrawer: FC<GatewaySettingsDrawerProps> = ({
       } finally {
         // Only the newest request owns the spinner; a superseded one must not
         // turn it off while its replacement is still running.
-        if (mine === generation.current) setLoading(false);
+        if (!background && mine === generation.current) setLoading(false);
       }
     },
     [apiFetch]
@@ -120,6 +157,25 @@ const GatewaySettingsDrawer: FC<GatewaySettingsDrawerProps> = ({
   useEffect(() => {
     if (!open || !gatewayId) return;
     void load(gatewayId);
+  }, [gatewayId, load, open]);
+
+  /**
+   * Poll while the drawer is open, so `Applying…` becomes a timestamp on its own.
+   *
+   * A tick is SKIPPED while a write is in flight. The generation counter settles
+   * which response wins by which started last, and a read that started before
+   * the PUT returned can legitimately own the newer generation while carrying
+   * pre-write values — the one ordering that would leave stale values on screen
+   * with no pending edits, which reads as "saved" and is not. Once the PUT has
+   * returned, the binding is written and any read reflects it.
+   */
+  useEffect(() => {
+    if (!open || !gatewayId) return;
+    const timer = setInterval(() => {
+      if (savingRef.current) return;
+      void load(gatewayId, { background: true });
+    }, POLL_INTERVAL_MS);
+    return () => clearInterval(timer);
   }, [gatewayId, load, open]);
 
   /** Edits that actually differ from what is stored — editing a field back to its original un-dirties it. */
@@ -148,8 +204,18 @@ const GatewaySettingsDrawer: FC<GatewaySettingsDrawerProps> = ({
   const errors = { ...serverErrors, ...clientErrors };
 
   const dirtyCount = Object.keys(patch).length;
+  /**
+   * The previous change has not reached the data plane yet. Writing again on top
+   * of it re-renders the release from a document the gateway has not finished
+   * picking up, so Save waits — and this is the state EVERY write lands in, for
+   * minutes, which is why the button explains itself rather than just greying out.
+   */
+  const applying = isApplying(config?.status);
   const canSave =
-    dirtyCount > 0 && Object.keys(clientErrors).length === 0 && !saving;
+    dirtyCount > 0 &&
+    Object.keys(clientErrors).length === 0 &&
+    !saving &&
+    !applying;
 
   const setDraft = (path: string, value: unknown) => {
     setDrafts((current) => ({ ...current, [path]: value }));
@@ -163,6 +229,7 @@ const GatewaySettingsDrawer: FC<GatewaySettingsDrawerProps> = ({
     // Invalidates any read still in flight: what the write returns is newer
     // than anything a GET started before it can report.
     const mine = ++generation.current;
+    savingRef.current = true;
     setSaving(true);
     setSaveError(null);
     setServerErrors({});
@@ -198,6 +265,7 @@ const GatewaySettingsDrawer: FC<GatewaySettingsDrawerProps> = ({
       if (path) setServerErrors({ [path]: withoutPathPrefix(message, path) });
       else setSaveError(message);
     } finally {
+      savingRef.current = false;
       setSaving(false);
     }
   };
@@ -341,11 +409,23 @@ const GatewaySettingsDrawer: FC<GatewaySettingsDrawerProps> = ({
             >
               Reset
             </Button>
-            <Button variant="contained" disabled={!canSave} onClick={save}>
-              {dirtyCount === 0
-                ? 'Save'
-                : `Save ${dirtyCount} ${dirtyCount === 1 ? 'change' : 'changes'}`}
-            </Button>
+            <Tooltip
+              title={
+                applying
+                  ? 'The previous change is still being applied. Saving is available once it has landed.'
+                  : ''
+              }
+            >
+              {/* Wrapped: a disabled button fires no events, so the tooltip
+                  explaining why it is disabled would never open. */}
+              <Box component="span">
+                <Button variant="contained" disabled={!canSave} onClick={save}>
+                  {dirtyCount === 0
+                    ? 'Save'
+                    : `Save ${dirtyCount} ${dirtyCount === 1 ? 'change' : 'changes'}`}
+                </Button>
+              </Box>
+            </Tooltip>
           </Box>
         ) : null}
       </Box>

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/GatewaySettingsDrawer.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/GatewaySettingsDrawer.tsx
@@ -224,6 +224,18 @@ const GatewaySettingsDrawer: FC<GatewaySettingsDrawerProps> = ({
     setServerErrors(({ [path]: _sent, ...rest }) => rest);
   };
 
+  /**
+   * Both user-initiated reads. Refused while a write is in flight: such a read
+   * carries pre-write values and yet owns the NEWER generation, so the PUT's
+   * response loses the check below while the drafts clear anyway -- the form
+   * then shows the pre-write configuration with nothing pending, which reads as
+   * "saved" and is not. The poll skips its tick for the same reason.
+   */
+  const refresh = () => {
+    if (savingRef.current || !gatewayId) return;
+    void load(gatewayId);
+  };
+
   const save = async () => {
     if (!config || !gatewayId) return;
     // Invalidates any read still in flight: what the write returns is newer
@@ -324,8 +336,8 @@ const GatewaySettingsDrawer: FC<GatewaySettingsDrawerProps> = ({
             {config ? (
               <ConfigStatusBar
                 status={config.status}
-                refreshing={loading}
-                onRefresh={() => gatewayId && void load(gatewayId)}
+                refreshing={loading || saving}
+                onRefresh={refresh}
               />
             ) : null}
           </Box>
@@ -345,7 +357,8 @@ const GatewaySettingsDrawer: FC<GatewaySettingsDrawerProps> = ({
               action={
                 <Button
                   size="small"
-                  onClick={() => gatewayId && void load(gatewayId)}
+                  disabled={saving}
+                  onClick={refresh}
                 >
                   Retry
                 </Button>

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/GatewaySettingsDrawer.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/GatewaySettingsDrawer.tsx
@@ -16,73 +16,337 @@
  * under the License.
  */
 
-import type { FC } from 'react';
-import { Box, Divider, Drawer, IconButton, Typography } from '@wso2/oxygen-ui';
+import { useCallback, useEffect, useMemo, useRef, useState, type FC } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Drawer,
+  IconButton,
+  Typography,
+} from '@wso2/oxygen-ui';
 import { X } from '@wso2/oxygen-ui-icons-react';
-import { relativeTime } from '../utils/time';
-import { gatewayTypeLabel } from '../utils/gateway';
-import type { Gateway, Environment } from '../types';
+import { readConfiguration, writeConfiguration } from '../config/api';
+import {
+  fieldForServerMessage,
+  validateForm,
+  withoutPathPrefix,
+  type FieldErrors,
+} from '../config/validate';
+import type { AIWorkspaceHostPort } from '../hostPort';
+import type { ConfigValues, Gateway, GatewayConfiguration } from '../types';
+import ConfigStatusBar from './ConfigStatusBar';
+import SettingField from './SettingField';
+import TomlField from './TomlField';
 
 export type GatewaySettingsDrawerProps = {
   open: boolean;
   onClose: () => void;
   gateway: Gateway | null;
-  environments: Environment[];
+  port: AIWorkspaceHostPort;
 };
 
-const GatewaySettingsDrawer: FC<GatewaySettingsDrawerProps> = ({ open, onClose, gateway, environments }) => {
+/**
+ * The gateway's configuration form.
+ *
+ * Rendered entirely FROM THE RESPONSE: the platform reads its allowlist at
+ * request time, so `editable[]` is the field list and `constraints[]` the
+ * cross-field rules, and there is deliberately no client-side copy of either. A
+ * setting the deployment adds or withdraws appears or disappears here without a
+ * plugin release.
+ *
+ * The caller mounts this with `key={gateway.id}`, so its state belongs to one
+ * gateway and cannot outlive it.
+ */
+
+const DRAWER_WIDTH = 520;
+
+const GatewaySettingsDrawer: FC<GatewaySettingsDrawerProps> = ({
+  open,
+  onClose,
+  gateway,
+  port,
+}) => {
+  const { apiFetch, notify } = port;
+  const gatewayId = gateway?.id;
+
+  const [config, setConfig] = useState<GatewayConfiguration | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  /** Only the paths the user has touched. The request body is a sparse patch of exactly these. */
+  const [drafts, setDrafts] = useState<ConfigValues>({});
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [serverErrors, setServerErrors] = useState<FieldErrors>({});
+
+  /**
+   * Bumped by every read AND every write, so a response can tell whether it is
+   * still the newest thing in flight.
+   *
+   * A refresh started before a save can land after it. Both call `setConfig`,
+   * so without this the older GET would replace the configuration the PUT just
+   * confirmed -- leaving stale values on screen with no pending edits, which
+   * reads as "saved" and is not.
+   */
+  const generation = useRef(0);
+
+  /** Re-seeds `config` only. Pending edits survive, so Refresh cannot discard them. */
+  const load = useCallback(
+    async (id: string) => {
+      const mine = ++generation.current;
+      setLoading(true);
+      setLoadError(null);
+      try {
+        const loaded = await readConfiguration(apiFetch, id);
+        if (mine !== generation.current) return;
+        setConfig(loaded);
+      } catch (error) {
+        if (mine !== generation.current) return;
+        setLoadError(
+          error instanceof Error
+            ? error.message
+            : 'The configuration could not be loaded.'
+        );
+      } finally {
+        // Only the newest request owns the spinner; a superseded one must not
+        // turn it off while its replacement is still running.
+        if (mine === generation.current) setLoading(false);
+      }
+    },
+    [apiFetch]
+  );
+
+  useEffect(() => {
+    if (!open || !gatewayId) return;
+    void load(gatewayId);
+  }, [gatewayId, load, open]);
+
+  /** Edits that actually differ from what is stored — editing a field back to its original un-dirties it. */
+  const patch = useMemo<ConfigValues>(() => {
+    if (!config) return {};
+    return Object.fromEntries(
+      Object.entries(drafts).filter(([path, value]) => {
+        // Typing into a field the platform carries NO value for and then
+        // clearing it again is not an edit. The stored value reads back
+        // `undefined` while an emptied input reads `''`, so a plain `!==`
+        // called that a change and left the form permanently dirty — with a
+        // validation error under a field the user had just put back the way
+        // they found it. There is no "unset" operation on the endpoint: an
+        // empty input on an unset field means the chart default still stands,
+        // which is exactly the state before the typing.
+        if (!(path in config.values)) return value !== '' && value !== undefined;
+        return value !== config.values[path];
+      })
+    );
+  }, [config, drafts]);
+
+  const clientErrors = useMemo<FieldErrors>(
+    () => (config ? validateForm(config, patch) : {}),
+    [config, patch]
+  );
+  const errors = { ...serverErrors, ...clientErrors };
+
+  const dirtyCount = Object.keys(patch).length;
+  const canSave =
+    dirtyCount > 0 && Object.keys(clientErrors).length === 0 && !saving;
+
+  const setDraft = (path: string, value: unknown) => {
+    setDrafts((current) => ({ ...current, [path]: value }));
+    // A server message is about the value that was sent, so it stops applying
+    // the moment the field changes.
+    setServerErrors(({ [path]: _sent, ...rest }) => rest);
+  };
+
+  const save = async () => {
+    if (!config || !gatewayId) return;
+    // Invalidates any read still in flight: what the write returns is newer
+    // than anything a GET started before it can report.
+    const mine = ++generation.current;
+    setSaving(true);
+    setSaveError(null);
+    setServerErrors({});
+    try {
+      // The response is the WHOLE configuration after the write, in the GET's
+      // shape — so it is both the confirmation and the new baseline. Re-seeding
+      // from it is what makes a canonicalized quantity ("1000m" -> "1") stop
+      // looking edited, and why there is no second GET here.
+      const written = await writeConfiguration(apiFetch, gatewayId, patch);
+      // The write happened, so it is confirmed and the edits are no longer
+      // pending whatever else is in flight. Only the BASELINE is conditional:
+      // a refresh started after this write owns the newer generation and its
+      // response is about to arrive, so let it install the values rather than
+      // fighting over them.
+      if (mine === generation.current) setConfig(written);
+      setDrafts({});
+      notify('Configuration saved.', 'success');
+    } catch (error) {
+      const message =
+        error instanceof Error && error.message
+          ? error.message
+          : 'The configuration could not be saved.';
+      // A field-level message begins with the setting path it is about;
+      // anything else is form-level. Either way the platform's own sentence is
+      // user-presentable prose, so it is surfaced verbatim.
+      const path = fieldForServerMessage(
+        message,
+        config.editable.map((field) => field.path)
+      );
+      // Under a field the path is dropped — the label already says which
+      // setting this is. The banner keeps the full sentence, having no label
+      // to lean on.
+      if (path) setServerErrors({ [path]: withoutPathPrefix(message, path) });
+      else setSaveError(message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
   if (!gateway) return null;
 
-  const environmentName = environments.find((environment) => environment.id === gateway.environmentId)?.name ?? '—';
-
-  const rows = [
-    { label: 'Type', value: gatewayTypeLabel(gateway.type) },
-    { label: 'Environment', value: environmentName },
-    { label: 'URL', value: gateway.url || '—' },
-    { label: 'Status', value: gateway.status === 'active' ? 'Active' : 'Inactive' },
-    { label: 'Version', value: gateway.version || '—' },
-    { label: 'Critical', value: gateway.isCritical ? 'Yes' : 'No' },
-    { label: 'Created', value: relativeTime(gateway.createdAt) },
-    { label: 'Last Updated', value: relativeTime(gateway.updatedAt) },
-  ];
+  // `string` carries its own warnings and character budget, so it is
+  // partitioned out of the flat list and rendered by `TomlField`.
+  const listed = config?.editable.filter((field) => field.type !== 'string') ?? [];
+  const freeText = config?.editable.filter((field) => field.type === 'string') ?? [];
+  const currentValue = (path: string): unknown =>
+    path in drafts ? drafts[path] : config?.values[path];
 
   return (
     <Drawer anchor="right" open={open} onClose={onClose}>
-      <Box sx={{ width: 360, p: 3 }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 0.5 }}>
-          <Typography sx={{ fontSize: 16, fontWeight: 600 }}>Gateway Configuration</Typography>
-          <IconButton size="small" onClick={onClose} aria-label="Close">
-            <X size={18} />
-          </IconButton>
+      <Box
+        sx={{
+          width: DRAWER_WIDTH,
+          display: 'flex',
+          flexDirection: 'column',
+          height: '100%',
+        }}
+      >
+        <Box sx={{ px: 3, pt: 3 }}>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              mb: 0.5,
+            }}
+          >
+            <Typography sx={{ fontSize: 16, fontWeight: 600 }}>
+              Gateway Configuration
+            </Typography>
+            <IconButton size="small" onClick={onClose} aria-label="Close">
+              <X size={18} />
+            </IconButton>
+          </Box>
+          <Box
+            sx={{
+              alignItems: 'center',
+              display: 'flex',
+              gap: 1,
+              mb: 2,
+              minHeight: 32,
+            }}
+          >
+            <Typography
+              color="text.secondary"
+              sx={{ flex: 1, minWidth: 0 }}
+              variant="body2"
+            >
+              {gateway.name}
+            </Typography>
+            {config ? (
+              <ConfigStatusBar
+                status={config.status}
+                refreshing={loading}
+                onRefresh={() => gatewayId && void load(gatewayId)}
+              />
+            ) : null}
+          </Box>
         </Box>
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-          {gateway.name}
-        </Typography>
 
-        <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-          {rows.map((row, index) => (
-            <Box key={row.label}>
-              <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', py: 1.25 }}>
-                <Typography variant="body2">{row.label}</Typography>
-                <Typography variant="body2" color="text.secondary" sx={{ wordBreak: 'break-all', textAlign: 'right', ml: 2 }}>
-                  {row.value}
-                </Typography>
-              </Box>
-              {index < rows.length - 1 ? <Divider sx={{ borderStyle: 'dashed' }} /> : null}
+        <Box sx={{ flex: 1, minHeight: 0, overflowY: 'auto', px: 3 }}>
+          {loading && !config ? (
+            <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+              <CircularProgress size={28} />
             </Box>
+          ) : null}
+
+          {loadError ? (
+            <Alert
+              severity="error"
+              sx={{ my: 2 }}
+              action={
+                <Button
+                  size="small"
+                  onClick={() => gatewayId && void load(gatewayId)}
+                >
+                  Retry
+                </Button>
+              }
+            >
+              {loadError}
+            </Alert>
+          ) : null}
+
+          {saveError ? (
+            <Alert severity="error" sx={{ my: 2 }}>
+              {saveError}
+            </Alert>
+          ) : null}
+
+          {listed.map((field) => (
+            <SettingField
+              key={field.path}
+              field={field}
+              value={currentValue(field.path)}
+              error={errors[field.path]}
+              readOnly={saving}
+              onChange={(value) => setDraft(field.path, value)}
+            />
+          ))}
+
+          {freeText.map((field) => (
+            <TomlField
+              key={field.path}
+              field={field}
+              value={currentValue(field.path)}
+              error={errors[field.path]}
+              readOnly={saving}
+              onChange={(value) => setDraft(field.path, value)}
+            />
           ))}
         </Box>
 
-        {gateway.description ? (
-          <>
-            <Divider sx={{ mt: 1, mb: 1.5 }} />
-            <Typography variant="body2" sx={{ fontWeight: 500, mb: 0.5 }}>
-              Description
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              {gateway.description}
-            </Typography>
-          </>
+        {config ? (
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'flex-end',
+              gap: 1,
+              px: 3,
+              py: 2,
+              borderTop: 1,
+              borderColor: 'divider',
+            }}
+          >
+            {/* Restores the last loaded values — NOT platform defaults, which is not an operation the endpoint has. */}
+            <Button
+              variant="outlined"
+              color="secondary"
+              disabled={dirtyCount === 0 || saving}
+              onClick={() => {
+                setDrafts({});
+                setServerErrors({});
+                setSaveError(null);
+              }}
+            >
+              Reset
+            </Button>
+            <Button variant="contained" disabled={!canSave} onClick={save}>
+              {dirtyCount === 0
+                ? 'Save'
+                : `Save ${dirtyCount} ${dirtyCount === 1 ? 'change' : 'changes'}`}
+            </Button>
+          </Box>
         ) : null}
       </Box>
     </Drawer>

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/SettingField.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/SettingField.tsx
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { FC } from 'react';
+import {
+  Box,
+  FormHelperText,
+  IconButton,
+  MenuItem,
+  Select,
+  Switch,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@wso2/oxygen-ui';
+import { CircleHelp } from '@wso2/oxygen-ui-icons-react';
+import type { EditableField } from '../types';
+
+export type SettingFieldProps = {
+  field: EditableField;
+  /** The value to show: the pending edit if there is one, else the stored value. */
+  value: unknown;
+  error?: string;
+  readOnly?: boolean;
+  onChange: (value: unknown) => void;
+};
+
+/**
+ * One `editable` entry rendered as one row.
+ *
+ * Everything shown comes from the response — `label` and `description` are the
+ * platform's own user-facing copy and are used verbatim, not shortened. In
+ * particular the two replica labels ("Gateway controller replicas" vs "Gateway
+ * runtime replicas") name DIFFERENT pods and must never both become "Replicas".
+ *
+ * Only two things ever sit beside a control, split by WHEN they are needed,
+ * because sixteen fields of prose is three screens of scrolling:
+ *
+ *   error        needed always         -> inline, and never behind a hover
+ *   description  needed once, before   -> behind the `?`
+ *
+ * Bounds are NOT shown. They were a permanent second line under every field
+ * for something that only matters while typing, and the message that arrives
+ * when a value is actually out of range states them anyway.
+ *
+ * `string` is not handled here: its one field today is a multi-line TOML block
+ * whose copy is an operational warning rather than a description, so it keeps
+ * persistent text and its own component (`TomlField`).
+ */
+
+/** What to put in a text input for a value that may not be a string yet. */
+const inputText = (value: unknown): string =>
+  value === undefined || value === null ? '' : String(value);
+
+/*
+ * Every control carries `aria-label={label}`. The visible label is a
+ * `Typography` in the row beside it, not an `<label htmlFor>`, so nothing
+ * associates the two -- a screen reader would announce the enum as an unnamed
+ * combobox. Naming the control directly is the smaller fix here: the layout is
+ * a two-column row shared by six widget types, and `InputLabel` would put a
+ * floating label inside each one.
+ */
+const SettingField: FC<SettingFieldProps> = ({
+  field,
+  value,
+  error,
+  readOnly = false,
+  onChange,
+}) => {
+  const label = field.label || field.path;
+
+
+  const control = () => {
+    switch (field.type) {
+      case 'enum':
+        return (
+          <Select
+            aria-label={label}
+            disabled={readOnly}
+            displayEmpty
+            fullWidth
+            size="small"
+            value={inputText(value)}
+            onChange={(event) => onChange(event.target.value)}
+          >
+            {(field.values ?? []).map((option) => (
+              <MenuItem key={option} value={option}>
+                {option}
+              </MenuItem>
+            ))}
+          </Select>
+        );
+
+      case 'boolean':
+        return (
+          <Switch
+            checked={value === true}
+            disabled={readOnly}
+            size="small"
+            inputProps={{ 'aria-label': label }}
+            onChange={(event) => onChange(event.target.checked)}
+          />
+        );
+
+      case 'integer':
+        return (
+          <TextField
+            disabled={readOnly}
+            error={Boolean(error)}
+            fullWidth
+            size="small"
+            type="number"
+            slotProps={{
+              htmlInput: { 'aria-label': label, min: field.min, max: field.max },
+            }}
+            value={inputText(value)}
+            // An emptied input becomes '' rather than 0 or "unedited": the
+            // former would save a number nobody typed, the latter would put the
+            // old value back under the cursor. As '' it fails validation with
+            // the platform's own "must be a whole number".
+            onChange={(event) =>
+              onChange(
+                event.target.value === '' ? '' : Number(event.target.value)
+              )
+            }
+          />
+        );
+
+      // Free text with a syntax the platform parses. A duration is stored
+      // exactly as spelled ("5m" stays "5m") and a quantity IS canonicalized on
+      // write, which is why the drawer re-seeds from the PUT response.
+      //
+      // NO PLACEHOLDER. An example value in a greyed-out input is read as the
+      // setting's current value, and for the ten paths the response carries no
+      // value for, that is exactly the wrong thing to imply.
+      //
+      // With the bounds line gone there is now nothing on screen that spells
+      // the syntax before a value is typed: the `?` carries the platform's
+      // description, and an out-of-range value is told its bounds when it is
+      // rejected. That is the accepted cost of a quieter form.
+      case 'duration':
+      case 'quantity':
+        return (
+          <TextField
+            disabled={readOnly}
+            error={Boolean(error)}
+            fullWidth
+            size="small"
+            slotProps={{ htmlInput: { 'aria-label': label } }}
+            value={inputText(value)}
+            onChange={(event) => onChange(event.target.value)}
+          />
+        );
+
+      default:
+        return null;
+    }
+  };
+
+  const rendered = control();
+  if (!rendered) return null;
+
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2, py: 1 }}>
+      <Box
+        sx={{
+          flex: 1,
+          minWidth: 0,
+          minHeight: 40,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 0.25,
+        }}
+      >
+        <Typography variant="body2" sx={{ fontWeight: 500 }}>
+          {label}
+        </Typography>
+        {field.description ? (
+          // An IconButton rather than a bare span: a tooltip on something
+          // unfocusable is unreachable by keyboard. `describeChild` keeps the
+          // button's own label and exposes the text as its description, and the
+          // touch delays make a tap show it and hold it long enough to read.
+          <Tooltip
+            title={field.description}
+            describeChild
+            enterTouchDelay={0}
+            leaveTouchDelay={8000}
+          >
+            <IconButton
+              aria-label={`About ${label}`}
+              size="small"
+              sx={{ p: 0.25, color: 'text.disabled' }}
+            >
+              <CircleHelp size={14} />
+            </IconButton>
+          </Tooltip>
+        ) : null}
+      </Box>
+
+      <Box sx={{ flex: '0 0 200px', minHeight: 40 }}>
+        {rendered}
+        {error ? (
+          <FormHelperText error sx={{ mx: 0 }}>
+            {error}
+          </FormHelperText>
+        ) : null}
+      </Box>
+    </Box>
+  );
+};
+
+export default SettingField;

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/TomlField.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/TomlField.tsx
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useState, type FC } from 'react';
+import {
+  Alert,
+  Box,
+  Collapse,
+  FormHelperText,
+  IconButton,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@wso2/oxygen-ui';
+import { ChevronDown, TriangleAlert } from '@wso2/oxygen-ui-icons-react';
+import { redeclaredSections } from '../config/toml';
+import { characterCount } from '../config/validate';
+import type { EditableField } from '../types';
+
+export type TomlFieldProps = {
+  field: EditableField;
+  value: unknown;
+  error?: string;
+  readOnly?: boolean;
+  onChange: (value: string) => void;
+};
+
+/**
+ * `gateway.config_toml` — the raw-TOML append hatch, and the one field where a
+ * value that passes every check can stop the gateway MINUTES after a 200.
+ *
+ * The chart appends this text, verbatim and last, to a config.toml it has
+ * already written. TOML forbids declaring a table twice, so a block repeating a
+ * section the structured values already emitted is a startup parse error rather
+ * than an override. Nothing on the server checks for that yet — it is the known
+ * gap this field shipped with, and nothing here closes it.
+ *
+ * The append-not-merge warning sits behind the triangle beside the label. It
+ * used to be a persistent Alert on the argument that a tooltip is not read by
+ * someone already typing — which is true, and the reason the REDECLARED-SECTION
+ * Alert below stays persistent. That one fires on the actual mistake, naming
+ * the offending sections, so the case that kills a gateway is still called out
+ * inline; the general caution is what moved behind the hover.
+ *
+ * No Monaco: the console does not ship it, and this component renders in both
+ * hosts.
+ */
+
+/**
+ * Why this field is not an override. Plain text rather than markup: a tooltip
+ * title is read out as its text content, and the emphasis the Alert carried
+ * cannot survive the move anyway.
+ */
+const APPEND_WARNING =
+  'This text is appended to the configuration the gateway already generates — ' +
+  'it does not merge with it. A section the gateway already configures cannot ' +
+  'be redefined here, and repeating one stops the gateway from starting. ' +
+  'Clear the field to remove it.';
+
+const TomlField: FC<TomlFieldProps> = ({
+  field,
+  value,
+  error,
+  readOnly = false,
+  onChange,
+}) => {
+  const [open, setOpen] = useState(false);
+
+  const text = typeof value === 'string' ? value : '';
+  // Code points, matching the platform's `len([]rune(text))` — a ceiling on how
+  // much a person may type, and a multi-byte character is one character to them.
+  const length = characterCount(text);
+  const max = field.max ? Number.parseInt(field.max, 10) : null;
+  const redeclared = redeclaredSections(text);
+
+  return (
+    <Box sx={{ borderTop: 1, borderColor: 'divider', mt: 1, pt: 1 }}>
+      <Box
+        onClick={() => setOpen((current) => !current)}
+        sx={{
+          alignItems: 'center',
+          cursor: 'pointer',
+          display: 'flex',
+          gap: 1,
+          py: 1,
+        }}
+      >
+        <Typography sx={{ fontWeight: 500 }} variant="body2">
+          {field.label || field.path}
+        </Typography>
+        <Tooltip
+          describeChild
+          enterTouchDelay={0}
+          leaveTouchDelay={8000}
+          title={APPEND_WARNING}
+        >
+          <IconButton
+            aria-label="About this field"
+            // The whole row toggles the section, so the icon must not: a hover
+            // that collapses the editor under the cursor is worse than no
+            // tooltip at all.
+            onClick={(event) => event.stopPropagation()}
+            size="small"
+            sx={{ p: 0.25, color: 'warning.main' }}
+          >
+            <TriangleAlert size={14} />
+          </IconButton>
+        </Tooltip>
+        <Typography
+          color={error ? 'error.main' : 'text.secondary'}
+          sx={{ ml: 'auto' }}
+          variant="caption"
+        >
+          {max === null ? length : `${length}/${max}`}
+        </Typography>
+        <IconButton
+          aria-expanded={open}
+          aria-label={open ? 'Collapse advanced configuration' : 'Expand advanced configuration'}
+          size="small"
+          sx={{
+            transform: open ? 'rotate(180deg)' : 'none',
+            transition: 'transform 150ms',
+          }}
+        >
+          <ChevronDown size={16} />
+        </IconButton>
+      </Box>
+
+      <Collapse in={open}>
+        {redeclared.length > 0 ? (
+          <Alert severity="error" sx={{ mb: 1.5 }}>
+            {redeclared.join(' and ')}{' '}
+            {redeclared.length === 1 ? 'is' : 'are'} already configured by the
+            platform. Re-declaring{' '}
+            {redeclared.length === 1 ? 'it' : 'them'} here will stop the gateway
+            from starting.
+          </Alert>
+        ) : null}
+
+        <TextField
+          disabled={readOnly}
+          error={Boolean(error)}
+          fullWidth
+          maxRows={20}
+          minRows={6}
+          multiline
+          onChange={(event) => onChange(event.target.value)}
+          placeholder={'[some.section]\nkey = "value"'}
+          slotProps={{
+            htmlInput: {
+              spellCheck: false,
+              style: { fontFamily: 'monospace', fontSize: 12 },
+            },
+          }}
+          value={text}
+        />
+
+        {error ? (
+          <FormHelperText error sx={{ mx: 0 }}>
+            {error}
+          </FormHelperText>
+        ) : null}
+      </Collapse>
+    </Box>
+  );
+};
+
+export default TomlField;

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/api.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/api.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { ApiFetch } from '../hostPort';
+import type { ConfigValues, GatewayConfiguration } from '../types';
+
+const configurationPath = (gatewayId: string) =>
+  `/managed-gateways/${encodeURIComponent(gatewayId)}/configuration`;
+
+/**
+ * The Port resolves `undefined` for an empty successful body (a 204, say). Both
+ * endpoints below always answer with the whole configuration, so an empty body
+ * is a broken response rather than an "unset" configuration — fail loudly here
+ * instead of leaking `undefined` into a form that has no way to render it.
+ */
+async function required(
+  call: Promise<GatewayConfiguration | undefined>
+): Promise<GatewayConfiguration> {
+  const configuration = await call;
+  if (!configuration) {
+    throw new Error('The gateway configuration service returned an empty response.');
+  }
+  return configuration;
+}
+
+/** Scopes: `ap:gateway:read` or `ap:gateway:manage`. 404 for a gateway with no managed binding. */
+export const readConfiguration = (apiFetch: ApiFetch, gatewayId: string) =>
+  required(apiFetch<GatewayConfiguration>('GET', configurationPath(gatewayId)));
+
+/**
+ * A SPARSE PATCH: send only the settings that changed. `values` must name at
+ * least one — `{}` and `{"values":{}}` are both a 400 — and no other top-level
+ * key may appear, which is also a 400.
+ *
+ * The response is the WHOLE configuration after the write, in the GET's shape.
+ * Use it as the confirmation and as the new baseline; do not re-GET.
+ *
+ * Scopes: `ap:gateway:update` or `ap:gateway:manage`.
+ */
+export const writeConfiguration = (
+  apiFetch: ApiFetch,
+  gatewayId: string,
+  values: ConfigValues
+) =>
+  required(
+    apiFetch<GatewayConfiguration>('PUT', configurationPath(gatewayId), {
+      values,
+    })
+  );

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/duration.test.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/duration.test.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { parseDurationSeconds } from './duration';
+
+describe('parseDurationSeconds', () => {
+  it('reads the bounds the platform declares for the one duration field', () => {
+    // `…ratelimit_v1.memory.cleanup_interval` is bounded 30s – 1h.
+    expect(parseDurationSeconds('30s')).toBe(30);
+    expect(parseDurationSeconds('1h')).toBe(3600);
+    expect(parseDurationSeconds('5m')).toBe(300);
+  });
+
+  it('sums a multi-unit duration', () => {
+    expect(parseDurationSeconds('1h30m')).toBe(5400);
+    expect(parseDurationSeconds('1m30s')).toBe(90);
+    expect(parseDurationSeconds('1h0m0s')).toBe(3600);
+  });
+
+  it('accepts fractions and sub-second units', () => {
+    expect(parseDurationSeconds('1.5h')).toBe(5400);
+    expect(parseDurationSeconds('500ms')).toBeCloseTo(0.5);
+    expect(parseDurationSeconds('1us')).toBeCloseTo(1e-6);
+    expect(parseDurationSeconds('1µs')).toBeCloseTo(1e-6);
+    expect(parseDurationSeconds('100ns')).toBeCloseTo(1e-7);
+  });
+
+  it('reads ms as milliseconds, not as minutes plus a stray s', () => {
+    // The unit alternation is longest-first for this; read the other way
+    // "500ms" would be 500 minutes and pass a 1h ceiling check backwards.
+    expect(parseDurationSeconds('500ms')).not.toBe(500 * 60);
+  });
+
+  it('accepts a bare zero and a sign', () => {
+    expect(parseDurationSeconds('0')).toBe(0);
+    expect(parseDurationSeconds('-5m')).toBe(-300);
+    expect(parseDurationSeconds('+5m')).toBe(300);
+  });
+
+  it('makes the two spellings of the same duration compare equal', () => {
+    // The server stores a duration exactly as spelled — "5m" is never
+    // re-spelled "5m0s" — so equality has to come from the parse, not the text.
+    expect(parseDurationSeconds('5m')).toBe(parseDurationSeconds('5m0s'));
+    expect(parseDurationSeconds('60s')).toBe(parseDurationSeconds('1m'));
+  });
+
+  it('rejects anything that is not a Go duration', () => {
+    expect(parseDurationSeconds('')).toBeNull();
+    expect(parseDurationSeconds('soon')).toBeNull();
+    // Unitless, and not the one spelling Go allows unitless.
+    expect(parseDurationSeconds('5')).toBeNull();
+    expect(parseDurationSeconds('5x')).toBeNull();
+    // Trailing junk: the whole string has to be consumed.
+    expect(parseDurationSeconds('5m30')).toBeNull();
+    expect(parseDurationSeconds('5m junk')).toBeNull();
+  });
+
+  it('rejects surrounding whitespace, which Go rejects too', () => {
+    // The drawer sends the text verbatim, so accepting padding here would turn
+    // a catchable typo into a 400 from the platform.
+    expect(parseDurationSeconds(' 5m')).toBeNull();
+    expect(parseDurationSeconds('5m ')).toBeNull();
+    expect(parseDurationSeconds(' 5m ')).toBeNull();
+    expect(parseDurationSeconds('5 m')).toBeNull();
+    expect(parseDurationSeconds('5m')).toBe(300);
+  });
+});

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/duration.test.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/duration.test.ts
@@ -72,6 +72,20 @@ describe('parseDurationSeconds', () => {
     expect(parseDurationSeconds('5m junk')).toBeNull();
   });
 
+  it("rejects a duration past Go's int64 nanosecond range", () => {
+    // `time.Duration` is int64 nanoseconds, so ~292 years is the ceiling and
+    // `time.ParseDuration` errors above it. Accepting one here would put a
+    // value in the request that the platform answers 400 to -- the outcome this
+    // parser exists to prevent. Unreachable through the one duration field the
+    // allowlist declares today (bounded 30s - 1h, and core requires both
+    // bounds), so this holds the contract rather than a live path.
+    expect(parseDurationSeconds('10000000000s')).toBeNull();
+    // Enough digits that Number() itself overflows to Infinity.
+    expect(parseDurationSeconds(`${'9'.repeat(400)}s`)).toBeNull();
+    // Still inside the range, so still a duration: ~292 years in hours.
+    expect(parseDurationSeconds('2562047h')).toBe(2562047 * 3600);
+  });
+
   it('rejects surrounding whitespace, which Go rejects too', () => {
     // The drawer sends the text verbatim, so accepting padding here would turn
     // a catchable typo into a 400 from the platform.

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/duration.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/duration.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Go duration parsing (`time.ParseDuration`), enough to compare a typed value
+ * against the declared `min`/`max`, which are duration strings themselves.
+ *
+ * Like `quantity.ts` this does not normalise: the server stores a duration
+ * exactly as it was spelled — "5m" stays "5m", not "5m0s" — precisely so an
+ * unchanged save does not look like a change and roll the gateway pods. Never
+ * write the parsed value back.
+ */
+
+/** Longest unit first, so `ms` is never read as `m` followed by a stray `s`. */
+const UNIT_SECONDS = new Map<string, number>([
+  ['ns', 1e-9],
+  ['us', 1e-6],
+  ['µs', 1e-6],
+  ['μs', 1e-6],
+  ['ms', 1e-3],
+  ['s', 1],
+  ['m', 60],
+  ['h', 3600],
+]);
+
+/** Sticky, so the loop below can require that the WHOLE string was consumed. */
+const TOKEN = /(\d+(?:\.\d*)?|\.\d+)(ns|us|µs|μs|ms|s|m|h)/y;
+
+/** The duration in seconds, or `null` when the text is not a Go duration. */
+export function parseDurationSeconds(text: string): number | null {
+  // NOT trimmed. The drawer sends the user's text verbatim, so anything this
+  // accepts must be something Go's time.ParseDuration accepts -- and it takes
+  // no surrounding whitespace. Trimming here made " 5m " pass in the browser
+  // and 400 on the server, which is the one outcome this parser exists to
+  // prevent.
+  let rest = text;
+  if (!rest) return null;
+
+  let sign = 1;
+  if (rest.startsWith('-')) {
+    sign = -1;
+    rest = rest.slice(1);
+  } else if (rest.startsWith('+')) {
+    rest = rest.slice(1);
+  }
+
+  // The one spelling with no unit. Go accepts it; nothing else unitless.
+  if (rest === '0') return 0;
+
+  TOKEN.lastIndex = 0;
+  let total = 0;
+  for (let match = TOKEN.exec(rest); match; match = TOKEN.exec(rest)) {
+    const seconds = UNIT_SECONDS.get(match[2]);
+    if (seconds === undefined) return null;
+    total += Number(match[1]) * seconds;
+    if (TOKEN.lastIndex === rest.length) return sign * total;
+  }
+  // Ran out of matches before the end: there is trailing junk, or a unit this
+  // does not know. Either way it is not a duration.
+  return null;
+}

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/duration.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/duration.ts
@@ -38,6 +38,18 @@ const UNIT_SECONDS = new Map<string, number>([
   ['h', 3600],
 ]);
 
+/**
+ * Go's `time.Duration` is int64 NANOSECONDS, so it tops out just under 292
+ * years and `time.ParseDuration` rejects anything past that. So must this: the
+ * contract of this module is that whatever it accepts, the platform accepts.
+ *
+ * Approximate on purpose. A float64 count of seconds cannot resolve the last
+ * few nanoseconds of the int64 range, so a value within an ULP of the ceiling
+ * may pass here and be settled by the server. The reachable mistake is orders
+ * of magnitude out ("10000000000s"), and that is caught exactly.
+ */
+const MAX_SECONDS = 2 ** 63 / 1e9;
+
 /** Sticky, so the loop below can require that the WHOLE string was consumed. */
 const TOKEN = /(\d+(?:\.\d*)?|\.\d+)(ns|us|µs|μs|ms|s|m|h)/y;
 
@@ -68,7 +80,12 @@ export function parseDurationSeconds(text: string): number | null {
     const seconds = UNIT_SECONDS.get(match[2]);
     if (seconds === undefined) return null;
     total += Number(match[1]) * seconds;
-    if (TOKEN.lastIndex === rest.length) return sign * total;
+    if (TOKEN.lastIndex === rest.length) {
+      // Out of Go's range, or a digit string long enough that `Number` already
+      // overflowed to Infinity. `time.ParseDuration` refuses both.
+      if (!Number.isFinite(total) || total > MAX_SECONDS) return null;
+      return sign * total;
+    }
   }
   // Ran out of matches before the end: there is trailing junk, or a unit this
   // does not know. Either way it is not a duration.

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/quantity.test.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/quantity.test.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { parseQuantity } from './quantity';
+
+describe('parseQuantity', () => {
+  it('reads the bounds the platform actually declares', () => {
+    // Every one of these is a `min` or `max` from the deployed allowlist, and
+    // all of them arrive as strings — `Number('50m')` is NaN, which is the
+    // whole reason this function exists.
+    expect(parseQuantity('50m')).toBeCloseTo(0.05);
+    expect(parseQuantity('4')).toBe(4);
+    expect(parseQuantity('128Mi')).toBe(134217728);
+    expect(parseQuantity('8Gi')).toBe(8589934592);
+  });
+
+  it('makes the spellings the server canonicalizes compare equal', () => {
+    // "1000m" comes back "1" and "1024Mi" comes back "1Gi" — a client that
+    // compared strings would report a change that is not one.
+    expect(parseQuantity('1000m')).toBe(parseQuantity('1'));
+    expect(parseQuantity('1024Mi')).toBe(parseQuantity('1Gi'));
+    expect(parseQuantity('500m')).toBeCloseTo(0.5);
+  });
+
+  it('tells the milli and mega suffixes apart', () => {
+    expect(parseQuantity('1m')).toBeCloseTo(1e-3);
+    expect(parseQuantity('1M')).toBe(1e6);
+    expect(parseQuantity('1Mi')).toBe(1048576);
+  });
+
+  it('treats an exponent as part of the number and a bare E as exa', () => {
+    expect(parseQuantity('1e3')).toBe(1000);
+    expect(parseQuantity('1E3')).toBe(1000);
+    expect(parseQuantity('1E')).toBe(1e18);
+    expect(parseQuantity('1Ei')).toBe(2 ** 60);
+  });
+
+  it('accepts decimals and surrounding whitespace', () => {
+    expect(parseQuantity('1.5Gi')).toBe(1610612736);
+    expect(parseQuantity('  256Mi  ')).toBe(268435456);
+    expect(parseQuantity('.5')).toBeCloseTo(0.5);
+  });
+
+  it('rejects anything that is not a quantity', () => {
+    expect(parseQuantity('')).toBeNull();
+    expect(parseQuantity('abc')).toBeNull();
+    expect(parseQuantity('1x')).toBeNull();
+    expect(parseQuantity('1e')).toBeNull();
+    expect(parseQuantity('1 Mi')).toBeNull();
+    // Kubernetes allows an exponent OR a suffix, never both — and the server
+    // rejects it, so accepting it here would only cost a round trip.
+    expect(parseQuantity('1e3Mi')).toBeNull();
+  });
+
+  it('does not resolve a suffix through the prototype chain', () => {
+    // The suffix comes from user input and the lookup tables are Maps for
+    // exactly this reason: on a plain object `'constructor' in table` is true,
+    // and the multiplier would come back as a function.
+    expect(parseQuantity('1constructor')).toBeNull();
+    expect(parseQuantity('1toString')).toBeNull();
+  });
+
+  it('rejects a value that overflows once its suffix is applied', () => {
+    // Finite before scaling, Infinity after. Infinity compares greater than
+    // any declared `max`, but a field without one would have accepted it.
+    const huge = '1'.padEnd(309, '0');
+    expect(Number.isFinite(Number(huge))).toBe(true);
+    expect(parseQuantity(`${huge}E`)).toBeNull();
+    expect(parseQuantity('8Gi')).toBe(8589934592);
+  });
+});

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/quantity.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/quantity.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Kubernetes quantity parsing, enough to compare a typed value against the
+ * `min`/`max` the platform declares — both of which arrive as quantity strings
+ * too, so this is the only way to check a bound at all.
+ *
+ * It deliberately does NOT canonicalize. The server does that on write
+ * ("1000m" comes back "1", "1024Mi" comes back "1Gi"), and a client that
+ * re-spelled the value locally would either fight the response or make an
+ * unchanged save look like a change. Re-render a quantity field from the PUT
+ * response instead.
+ */
+
+/** Binary suffixes. A `Map`, so a suffix like `constructor` cannot resolve through the prototype. */
+const BINARY = new Map<string, number>([
+  ['Ki', 2 ** 10],
+  ['Mi', 2 ** 20],
+  ['Gi', 2 ** 30],
+  ['Ti', 2 ** 40],
+  ['Pi', 2 ** 50],
+  ['Ei', 2 ** 60],
+]);
+
+/** Decimal SI suffixes, including the empty one. Case matters: `m` is milli, `M` is mega. */
+const DECIMAL = new Map<string, number>([
+  ['n', 1e-9],
+  ['u', 1e-6],
+  ['m', 1e-3],
+  ['', 1],
+  ['k', 1e3],
+  ['M', 1e6],
+  ['G', 1e9],
+  ['T', 1e12],
+  ['P', 1e15],
+  ['E', 1e18],
+]);
+
+/**
+ * Either a number with a suffix, or a number in exponent form with none —
+ * Kubernetes allows both but not together, so `1e3` is a thousand, `1E` is one
+ * exa, and `1e3Mi` is not a quantity at all.
+ */
+const QUANTITY = /^([+-]?(?:\d+|\d*\.\d+))([A-Za-z]*)$|^([+-]?(?:\d+|\d*\.\d+)[eE][+-]?\d+)$/;
+
+/** The quantity as a plain number, or `null` when the text is not one. */
+export function parseQuantity(text: string): number | null {
+  const match = QUANTITY.exec(text.trim());
+  if (!match) return null;
+  const value = Number(match[1] ?? match[3]);
+  if (!Number.isFinite(value)) return null;
+  const suffix = match[1] === undefined ? '' : match[2];
+  const multiplier = BINARY.get(suffix) ?? DECIMAL.get(suffix);
+  if (multiplier === undefined) return null;
+  // The value was finite; the product need not be. 308 digits with an `E`
+  // suffix overflows to Infinity, which compares greater than any `max` but
+  // would slip past a field that declares none.
+  const scaled = value * multiplier;
+  return Number.isFinite(scaled) ? scaled : null;
+}

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/status.test.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/status.test.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { describeStatus, isApplying } from './status';
+import type { ConfigPhase } from '../types';
+
+/** A fixed clock, so "5 minutes ago" is a fact and not the time of the run. */
+const NOW = Date.parse('2026-09-04T10:00:00Z');
+const FIVE_MINUTES_AGO = '2026-09-04T09:55:00Z';
+
+describe('describeStatus', () => {
+  it('spends the line on the timestamp when the gateway is healthy', () => {
+    // The point of removing the chip: "Healthy" is the resting state of every
+    // configured gateway and tells the reader nothing. When the configuration
+    // last landed does.
+    const display = describeStatus(
+      { phase: 'healthy', lastTransitionTime: FIVE_MINUTES_AGO },
+      NOW
+    );
+    expect(display?.text).toBe('Updated 5 minutes ago');
+    expect(display?.tone).toBe('muted');
+  });
+
+  it('puts the exact moment behind the hover, for correlating with a deployment', () => {
+    const display = describeStatus(
+      { phase: 'healthy', lastTransitionTime: FIVE_MINUTES_AGO },
+      NOW
+    );
+    // Locale- and zone-dependent, so assert only that it resolved to something
+    // other than the relative form.
+    expect(display?.detail).toBeTruthy();
+    expect(display?.detail).not.toBe(display?.text);
+  });
+
+  it('shows nothing for a healthy gateway with no recorded transition', () => {
+    // The platform records none until the resources report, and an empty line
+    // beats "Updated —".
+    expect(describeStatus({ phase: 'healthy' }, NOW)).toBeNull();
+    expect(describeStatus({ phase: 'healthy', lastTransitionTime: '' }, NOW)).toBeNull();
+    expect(
+      describeStatus({ phase: 'healthy', lastTransitionTime: 'not a date' }, NOW)
+    ).toBeNull();
+  });
+
+  it('says Applying while the change is still reaching the data plane', () => {
+    const display = describeStatus({ phase: 'applying' }, NOW);
+    expect(display?.text).toBe('Applying…');
+    // Not an error: this is the expected state for minutes after ANY write.
+    expect(display?.tone).toBe('muted');
+  });
+
+  it('ignores the transition time while applying', () => {
+    // `applying` reads the same minutes after a write and stalled an hour
+    // later; the phase is what the reader acts on, so the phase is the line.
+    const display = describeStatus(
+      { phase: 'applying', lastTransitionTime: FIVE_MINUTES_AGO },
+      NOW
+    );
+    expect(display?.text).toBe('Applying…');
+  });
+
+  it('colours only a failure', () => {
+    const display = describeStatus({ phase: 'failed', message: 'render failed' }, NOW);
+    expect(display?.text).toBe('Failed');
+    expect(display?.tone).toBe('error');
+  });
+
+  it('keeps the platform message out of the line and in the hover', () => {
+    // Unbounded prose. In the line it pushed the form down the drawer.
+    const message = 'Resource "apigateway" readyWhen returned false';
+    expect(describeStatus({ phase: 'applying', message }, NOW)).toMatchObject({
+      text: 'Applying…',
+      detail: message,
+    });
+    expect(describeStatus({ phase: 'failed', message }, NOW)?.detail).toBe(message);
+  });
+
+  it('does not promise a settling for a phase the platform never reported', () => {
+    // `unknown` will not resolve on its own, so it must not borrow
+    // `applying`'s copy.
+    const display = describeStatus({ phase: 'unknown' }, NOW);
+    expect(display?.text).toBe('Status unavailable');
+    expect(display?.text).not.toBe('Applying…');
+  });
+
+  it('says the word a newer platform sent rather than rounding it to healthy', () => {
+    const display = describeStatus(
+      { phase: 'superseding' as ConfigPhase, message: 'from a newer platform' },
+      NOW
+    );
+    expect(display?.text).toBe('superseding');
+    expect(display?.detail).toBe('from a newer platform');
+  });
+});
+
+describe('isApplying', () => {
+  it('gates the Save button on the phase, and only on applying', () => {
+    expect(isApplying({ phase: 'applying' })).toBe(true);
+    expect(isApplying({ phase: 'healthy' })).toBe(false);
+    // A failure is a reason to write again, not a reason to be locked out; and
+    // `unknown` never settles, so gating on it would lock the form forever.
+    expect(isApplying({ phase: 'failed' })).toBe(false);
+    expect(isApplying({ phase: 'unknown' })).toBe(false);
+  });
+
+  it('does not gate a form that has no configuration loaded yet', () => {
+    expect(isApplying(undefined)).toBe(false);
+  });
+});

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/status.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/status.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { ConfigStatus } from '../types';
+import { absoluteTime, relativeTime } from '../utils/time';
+
+/**
+ * The reconcile phase turned into the one line of text the drawer shows beside
+ * the gateway name.
+ *
+ * There is deliberately no phase chip. A chip is a badge you are meant to
+ * notice, and three of the four phases are things nobody can act on: `healthy`
+ * is the resting state of every gateway that has ever been configured, so a
+ * green "Healthy" on the drawer is decoration. What a reader actually wants to
+ * know is *when the configuration last landed* — so `healthy` spends the line on
+ * the timestamp, and only a phase that is still moving or has gone wrong spends
+ * it on a word.
+ */
+
+/** `error` is for a phase the reader has to act on; everything else is quiet. */
+export type StatusTone = 'muted' | 'error';
+
+export type StatusDisplay = {
+  text: string;
+  tone: StatusTone;
+  /**
+   * Hover detail — the absolute timestamp, or the platform's own message. The
+   * message is kept OUT of the line itself: it is prose of unbounded length
+   * (`Resource "apigateway" readyWhen returned false`) and it pushed the form
+   * down the drawer. A tooltip costs no layout, so the detail is available
+   * without the line growing.
+   */
+  detail?: string;
+};
+
+/**
+ * `null` for "show nothing", which is a real outcome: a healthy gateway whose
+ * transition time the platform has not recorded has nothing to say, and an
+ * empty line beats "Updated —".
+ *
+ * `now` is a parameter for the tests; leave it unset in the component.
+ */
+export function describeStatus(
+  status: ConfigStatus,
+  now: number = Date.now()
+): StatusDisplay | null {
+  switch (status.phase) {
+    case 'applying':
+      // Not a failure and not an unfinished save. The write is committed; the
+      // data plane is catching up, and the measured lag is minutes (10m07s on
+      // 2026-08-31, with the gateway already ready underneath). The trailing
+      // ellipsis is the whole signal that something is still in motion — a
+      // spinner here would read as "the save has not finished", which is wrong.
+      return { text: 'Applying…', tone: 'muted', detail: status.message };
+    case 'healthy': {
+      const when = status.lastTransitionTime;
+      if (!when || Number.isNaN(Date.parse(when))) return null;
+      return {
+        text: `Updated ${relativeTime(when, now)}`,
+        tone: 'muted',
+        detail: absoluteTime(when),
+      };
+    }
+    case 'failed':
+      // The platform could not render or apply the spec, so nothing downstream
+      // happens without another write. This is the one phase worth colouring.
+      return { text: 'Failed', tone: 'error', detail: status.message };
+    case 'unknown':
+      // Core answered without a phase. Say so plainly rather than borrowing
+      // `applying`'s copy, which would promise a settling that is not coming.
+      return { text: 'Status unavailable', tone: 'muted', detail: status.message };
+    default:
+      // A phase this build has never heard of is a newer platform, not a
+      // broken one. Say the word it sent; do not round it to healthy.
+      return { text: status.phase, tone: 'muted', detail: status.message };
+  }
+}
+
+/**
+ * Whether a write should be held back.
+ *
+ * `applying` means the previous change has not reached the data plane yet, and a
+ * second write on top of it re-renders the release from a document the gateway
+ * has not finished picking up — so the phase gates the Save button.
+ */
+export const isApplying = (status: ConfigStatus | undefined): boolean =>
+  status?.phase === 'applying';

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/toml.test.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/toml.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { redeclaredSections, tomlSections } from './toml';
+
+describe('tomlSections', () => {
+  it('finds table headers at the start of a line', () => {
+    expect(tomlSections('[mcp]\nenabled = true\n\n[other]\nx = 1')).toEqual([
+      'mcp',
+      'other',
+    ]);
+  });
+
+  it('tolerates indentation and trailing spaces around a header', () => {
+    expect(tomlSections('  [mcp]  \n')).toEqual(['mcp']);
+    expect(tomlSections('\t[mcp]\t\n')).toEqual(['mcp']);
+  });
+
+  it('ignores a bracketed value, which is not a table declaration', () => {
+    // Only a header occupies a line on its own, so an array value must not read
+    // as a section — otherwise every list would produce a false warning.
+    expect(tomlSections('hosts = ["a", "b"]')).toEqual([]);
+    expect(tomlSections('key = [1]')).toEqual([]);
+  });
+});
+
+describe('redeclaredSections', () => {
+  it('warns about the two sections the bootstrap seed already emits', () => {
+    // TOML forbids declaring a table twice and the chart APPENDS this text to a
+    // config.toml it has already written, so either of these is a parse error
+    // at gateway startup rather than an override.
+    expect(
+      redeclaredSections('[policy_configurations.ratelimit_v1]\nx = 1')
+    ).toEqual(['policy_configurations.ratelimit_v1']);
+    expect(
+      redeclaredSections(
+        '[policy_configurations.llm_cost_ratelimit_v1]\nx = 1'
+      )
+    ).toEqual(['policy_configurations.llm_cost_ratelimit_v1']);
+  });
+
+  it('reports each seeded section once, however often it appears', () => {
+    expect(
+      redeclaredSections(
+        '[policy_configurations.ratelimit_v1]\na = 1\n[policy_configurations.ratelimit_v1]\nb = 2'
+      )
+    ).toEqual(['policy_configurations.ratelimit_v1']);
+  });
+
+  it('says nothing about a section the platform does not emit', () => {
+    // A new section is exactly what this field is for; only a REPEAT is fatal.
+    expect(redeclaredSections('[mcp]\nenabled = true')).toEqual([]);
+    expect(redeclaredSections('')).toEqual([]);
+  });
+
+  it('does not match a section whose name merely starts the same way', () => {
+    expect(
+      redeclaredSections('[policy_configurations.ratelimit_v2]\nx = 1')
+    ).toEqual([]);
+  });
+
+  it('sees a seeded header that carries a trailing comment', () => {
+    // TOML comments run to end of line, so this declares the table just as
+    // surely as the bare form -- and it is the form that kills a gateway
+    // silently if the warning misses it.
+    expect(
+      redeclaredSections('[policy_configurations.ratelimit_v1] # note')
+    ).toEqual(['policy_configurations.ratelimit_v1']);
+    expect(
+      tomlSections('[a.b]\t#  trailing\n[c]#tight\n')
+    ).toEqual(['a.b', 'c']);
+    // A commented-OUT header is still a comment, not a declaration.
+    expect(tomlSections('# [policy_configurations.ratelimit_v1]')).toEqual([]);
+  });
+});

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/toml.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/toml.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * The one guard `gateway.config_toml` gets, and it is only a warning.
+ *
+ * The chart appends this text, verbatim and last, to a config.toml it has
+ * already written, and TOML forbids declaring a table twice — so a block
+ * repeating a section the structured values already emitted is a parse error at
+ * gateway startup rather than an override. The bootstrap seed emits two such
+ * sections, so those two in particular cannot be re-declared.
+ *
+ * NOTHING ON THE SERVER CHECKS THIS. It is the known gap the field shipped
+ * with, and a client-side scan does not close it: a request that skips this UI
+ * still gets a 200 and a gateway that will not start. What this buys is that
+ * someone typing into the form is told before they find out from a dead
+ * gateway.
+ */
+
+/** The sections the bootstrap seed already emits. */
+export const SEEDED_SECTIONS = [
+  'policy_configurations.ratelimit_v1',
+  'policy_configurations.llm_cost_ratelimit_v1',
+];
+
+/**
+ * Table headers at the start of a line, which is the only position TOML
+ * declares one in. Deliberately not a TOML parser: a partially-typed document
+ * is the normal state of a text area, and a parser would spend most of its life
+ * reporting syntax errors about text the user has not finished writing.
+ */
+// A header may be followed by a comment: TOML treats `#` as a comment to the
+// end of the line, so `[policy_configurations.ratelimit_v1] # note` declares
+// that table just as surely as the bare form. Missing it meant the redeclared
+// -section warning stayed silent for the exact text that kills a gateway.
+const SECTION_HEADER = /^[ \t]*\[([^\]]+)\][ \t]*(?:#[^\n]*)?$/gm;
+
+/** Every table header the text declares, in order of appearance. */
+export function tomlSections(text: string): string[] {
+  const found: string[] = [];
+  SECTION_HEADER.lastIndex = 0;
+  for (
+    let match = SECTION_HEADER.exec(text);
+    match;
+    match = SECTION_HEADER.exec(text)
+  ) {
+    found.push(match[1].trim());
+  }
+  return found;
+}
+
+/** The seeded sections this text re-declares. A warning, never a block. */
+export function redeclaredSections(text: string): string[] {
+  return [
+    ...new Set(
+      tomlSections(text).filter((section) => SEEDED_SECTIONS.includes(section))
+    ),
+  ];
+}

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/validate.test.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/validate.test.ts
@@ -1,0 +1,408 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import type { EditableField, GatewayConfiguration } from '../types';
+import {
+  fieldForServerMessage,
+  validateFieldValue,
+  validateForm,
+  withoutPathPrefix,
+} from './validate';
+
+/*
+ * Every expected message below is the sentence the PLATFORM returns for the
+ * same value -- taken from the rejection list run against a cluster on
+ * 2026-08-30 (and the config_toml ones on 2026-08-31) -- MINUS its leading
+ * setting path. A user must read the same wording whichever side caught it, so
+ * a drift in the words is still a real defect; only the path is dropped, and it
+ * is dropped on both sides (see `withoutPathPrefix` for the server's copy)
+ * because these render under a control whose label already names the setting.
+ */
+
+const LOG_LEVEL: EditableField = {
+  label: 'Gateway controller log level',
+  path: 'gateway.config.controller.logging.level',
+  type: 'enum',
+  values: ['debug', 'info', 'warn', 'error'],
+};
+
+const ACCESS_LOGS: EditableField = {
+  path: 'gateway.config.router.access_logs.enabled',
+  type: 'boolean',
+};
+
+const ROUTE_TIMEOUT: EditableField = {
+  max: '300000',
+  min: '1000',
+  path: 'gateway.config.router.upstream.timeouts.route_timeout_ms',
+  type: 'integer',
+};
+
+const COST_SCALE: EditableField = {
+  max: '1000000000000',
+  min: '1',
+  path: 'gateway.config.policy_configurations.llm_cost_ratelimit_v1.cost_scale_factor',
+  type: 'integer',
+};
+
+const CLEANUP: EditableField = {
+  max: '1h',
+  min: '30s',
+  path: 'gateway.config.policy_configurations.ratelimit_v1.memory.cleanup_interval',
+  type: 'duration',
+};
+
+const CPU_REQUEST: EditableField = {
+  max: '4',
+  min: '50m',
+  path: 'gateway.controller.deployment.resources.requests.cpu',
+  type: 'quantity',
+};
+
+const MEMORY_REQUEST: EditableField = {
+  max: '8Gi',
+  min: '128Mi',
+  path: 'gateway.controller.deployment.resources.requests.memory',
+  type: 'quantity',
+};
+
+const MEMORY_LIMIT: EditableField = {
+  label: 'Gateway controller memory limit',
+  max: '8Gi',
+  min: '128Mi',
+  path: 'gateway.controller.deployment.resources.limits.memory',
+  type: 'quantity',
+};
+
+const CONFIG_TOML: EditableField = {
+  max: '8192',
+  path: 'gateway.config_toml',
+  type: 'string',
+};
+
+describe('validateFieldValue', () => {
+  it('passes an untouched field', () => {
+    expect(validateFieldValue(ROUTE_TIMEOUT, undefined)).toBeNull();
+  });
+
+  it('names the permitted values for an enum', () => {
+    expect(validateFieldValue(LOG_LEVEL, 'debug')).toBeNull();
+    expect(validateFieldValue(LOG_LEVEL, 'trace')).toBe(
+      'Must be one of debug, info, warn, error'
+    );
+  });
+
+  it('refuses a string for a boolean', () => {
+    expect(validateFieldValue(ACCESS_LOGS, false)).toBeNull();
+    // A literal "yes" is a 400 on the wire, so the widget must never send one.
+    expect(validateFieldValue(ACCESS_LOGS, 'yes')).toBe(
+      'Must be true or false'
+    );
+  });
+
+  it('bounds an integer, and reports the bound the platform declared', () => {
+    expect(validateFieldValue(ROUTE_TIMEOUT, 60000)).toBeNull();
+    expect(validateFieldValue(ROUTE_TIMEOUT, 999)).toBe(
+      'Must be between 1000 and 300000'
+    );
+    expect(validateFieldValue(ROUTE_TIMEOUT, 300001)).not.toBeNull();
+  });
+
+  it('refuses a non-integer, an emptied input and a value past 2^53', () => {
+    expect(validateFieldValue(ROUTE_TIMEOUT, 1500.5)).toBe(
+      'Must be a whole number'
+    );
+    // An emptied number input arrives as '' rather than 0, so it is refused
+    // instead of silently saving a number nobody typed.
+    expect(validateFieldValue(ROUTE_TIMEOUT, '')).not.toBeNull();
+    expect(validateFieldValue(COST_SCALE, 2 ** 53)).not.toBeNull();
+  });
+
+  it('accepts the whole integer range up to the 1e12 ceiling', () => {
+    // A double holds 1e12 exactly; the guard is only against what is past 2^53.
+    expect(validateFieldValue(COST_SCALE, 1_000_000_000_000)).toBeNull();
+    expect(validateFieldValue(COST_SCALE, 1)).toBeNull();
+    expect(validateFieldValue(COST_SCALE, 0)).not.toBeNull();
+  });
+
+  it('bounds a duration without normalising its spelling', () => {
+    expect(validateFieldValue(CLEANUP, '5m')).toBeNull();
+    expect(validateFieldValue(CLEANUP, '10s')).toBe(
+      'Must be between 30s and 1h'
+    );
+    expect(validateFieldValue(CLEANUP, 'soon')).toBe(
+      'Must be a duration such as "5m"'
+    );
+  });
+
+  it('bounds a quantity and refuses one that is not positive', () => {
+    expect(validateFieldValue(CPU_REQUEST, '500m')).toBeNull();
+    expect(validateFieldValue(CPU_REQUEST, '10m')).toBe(
+      'Must be between 50m and 4'
+    );
+    expect(validateFieldValue(CPU_REQUEST, '8')).not.toBeNull();
+    // Zero is legal to Kubernetes and meaningless for a gateway; a zero limit
+    // would mean "no limit", which the ceiling assumes away.
+    expect(validateFieldValue(CPU_REQUEST, '0')).toBe(
+      'Must be greater than zero'
+    );
+    expect(validateFieldValue(CPU_REQUEST, 'lots')).toBe(
+      'Must be a quantity such as "500m" or "512Mi"'
+    );
+  });
+
+  it('counts the string field in code points, not bytes', () => {
+    const ascii = 'a'.repeat(8192);
+    expect(validateFieldValue(CONFIG_TOML, ascii)).toBeNull();
+    expect(validateFieldValue(CONFIG_TOML, `${ascii}a`)).toBe(
+      'Must be between 0 and 8192 characters'
+    );
+
+    // 8192 astral characters are 16384 UTF-16 units and 32768 bytes, and are
+    // 8192 characters to the person who typed them.
+    const astral = '\u{1F600}'.repeat(8192);
+    expect(astral.length).toBe(16384);
+    expect(validateFieldValue(CONFIG_TOML, astral)).toBeNull();
+  });
+
+  it('clears the string field with an empty value', () => {
+    expect(validateFieldValue(CONFIG_TOML, '')).toBeNull();
+  });
+
+  it('refuses the characters the values document cannot carry', () => {
+    // Built from char codes rather than written literally: these are exactly
+    // the characters that would be invisible in a source file.
+    const nul = String.fromCharCode(0);
+    const verticalTab = String.fromCharCode(11);
+    const escape = String.fromCharCode(27);
+    const del = String.fromCharCode(127);
+    const nextLine = String.fromCharCode(0x85);
+    const lineSeparator = String.fromCharCode(0x2028);
+    const paragraphSeparator = String.fromCharCode(0x2029);
+    const refused =
+      'Must not contain control characters or line separators';
+
+    for (const character of [
+      nul,
+      verticalTab,
+      escape,
+      del,
+      nextLine,
+      lineSeparator,
+      paragraphSeparator,
+    ]) {
+      expect(validateFieldValue(CONFIG_TOML, `[a]\nb = "${character}"`)).toBe(
+        refused
+      );
+    }
+  });
+
+  it('allows tab, newline and carriage return, which a TOML block needs', () => {
+    expect(validateFieldValue(CONFIG_TOML, '[a]\r\n\tb = 1\n')).toBeNull();
+  });
+
+  it('refuses a non-string for the string field', () => {
+    expect(validateFieldValue(CONFIG_TOML, 42)).toBe(
+      'Must be a string'
+    );
+  });
+});
+
+const configuration = (
+  values: Record<string, unknown>
+): GatewayConfiguration => ({
+  constraints: [
+    {
+      message:
+        'the controller memory request must not exceed the controller memory limit',
+      path: MEMORY_REQUEST.path,
+      than: MEMORY_LIMIT.path,
+      type: 'notGreaterThan',
+    },
+  ],
+  editable: [
+    LOG_LEVEL,
+    ROUTE_TIMEOUT,
+    CPU_REQUEST,
+    MEMORY_REQUEST,
+    MEMORY_LIMIT,
+    CONFIG_TOML,
+  ],
+  id: 'wc-org-development-apip-default-gw',
+  status: { phase: 'healthy' },
+  values,
+});
+
+describe('validateForm', () => {
+  const stored = {
+    [MEMORY_LIMIT.path]: '512Mi',
+    [MEMORY_REQUEST.path]: '256Mi',
+    [ROUTE_TIMEOUT.path]: 60000,
+  };
+
+  it('reports nothing for an empty patch', () => {
+    expect(validateForm(configuration(stored), {})).toEqual({});
+  });
+
+  it('refuses a path the response did not list', () => {
+    const errors = validateForm(configuration(stored), { 'gateway.nope': 'x' });
+    expect(errors['gateway.nope']).toBe(
+      'gateway.nope is not an editable gateway setting'
+    );
+  });
+
+  it('catches lowering only the limit, against the STORED request', () => {
+    // 200Mi is inside the limit's own 128Mi–8Gi bounds, so per-field validation
+    // accepts it. It is refused because the document the write would produce has
+    // the stored 256Mi request above the new limit — which is what the server
+    // checks, and what the kubelet would otherwise fail asynchronously long
+    // after the 200.
+    const errors = validateForm(configuration(stored), {
+      [MEMORY_LIMIT.path]: '200Mi',
+    });
+    expect(errors[MEMORY_LIMIT.path]).toBe(
+      'the controller memory request must not exceed the controller memory limit'
+    );
+    // On the edited field, not on the request the user never touched.
+    expect(errors[MEMORY_REQUEST.path]).toBeUndefined();
+  });
+
+  it('accepts lowering both sides together', () => {
+    expect(
+      validateForm(configuration(stored), {
+        [MEMORY_LIMIT.path]: '200Mi',
+        [MEMORY_REQUEST.path]: '128Mi',
+      })
+    ).toEqual({});
+  });
+
+  it('compares canonicalized spellings rather than text', () => {
+    // request 1024Mi === limit 1Gi, so equal is allowed — `notGreaterThan`.
+    expect(
+      validateForm(configuration(stored), {
+        [MEMORY_LIMIT.path]: '1Gi',
+        [MEMORY_REQUEST.path]: '1024Mi',
+      })
+    ).toEqual({});
+  });
+
+  it('skips a constraint whose other side the document does not carry', () => {
+    // The missing side falls back to the chart's own default at render time, so
+    // there is nothing to compare and nothing to refuse.
+    const errors = validateForm(
+      configuration({ [MEMORY_REQUEST.path]: '256Mi' }),
+      { [MEMORY_REQUEST.path]: '8Gi' }
+    );
+    expect(errors).toEqual({});
+  });
+
+  it('does not run constraints while a field is individually malformed', () => {
+    // Comparing against a value already known to be nonsense says nothing, so
+    // the only message is the field's own.
+    const errors = validateForm(configuration(stored), {
+      [MEMORY_LIMIT.path]: 'not-a-quantity',
+    });
+    expect(Object.keys(errors)).toEqual([MEMORY_LIMIT.path]);
+    expect(errors[MEMORY_LIMIT.path]).toContain('Must be a quantity');
+  });
+  it('names the compared field by its label when the platform sends no message', () => {
+    // The response usually carries its own `message`; when it does not, the
+    // fallback must still be readable under a field, which means the OTHER
+    // field's label rather than its path.
+    const config = configuration({
+      [MEMORY_LIMIT.path]: '256Mi',
+      [MEMORY_REQUEST.path]: '256Mi',
+    });
+    const errors = validateForm(
+      {
+        ...config,
+        constraints: [
+          {
+            path: MEMORY_REQUEST.path,
+            than: MEMORY_LIMIT.path,
+            type: 'notGreaterThan',
+          },
+        ],
+      },
+      { [MEMORY_REQUEST.path]: '512Mi' }
+    );
+
+    expect(errors[MEMORY_REQUEST.path]).toBe(
+      'Must not exceed Gateway controller memory limit'
+    );
+  });
+});
+
+describe('withoutPathPrefix', () => {
+  const PATH = 'gateway.config.policy_configurations.ratelimit_v1.enabled';
+
+  it('drops the leading path and opens the remainder with a capital', () => {
+    expect(withoutPathPrefix(`${PATH} must be true or false`, PATH)).toBe(
+      'Must be true or false'
+    );
+  });
+
+  it('leaves a message that does not begin with the path alone', () => {
+    const message = 'The gateway is still applying an earlier change.';
+    expect(withoutPathPrefix(message, PATH)).toBe(message);
+  });
+
+  it('keeps a message that is nothing but the path', () => {
+    // Stripping would leave an empty helper line under the field, which says
+    // less than the odd-looking path does.
+    expect(withoutPathPrefix(PATH, PATH)).toBe(PATH);
+  });
+});
+
+
+describe('fieldForServerMessage', () => {
+  const paths = [
+    'gateway.config_toml',
+    'gateway.config.router.upstream.timeouts.route_timeout_ms',
+    'gateway.controller.deployment.replicaCount',
+  ];
+
+  it('attaches a field-level message to the field it names', () => {
+    expect(
+      fieldForServerMessage(
+        'gateway.controller.deployment.replicaCount must be between 1 and 5',
+        paths
+      )
+    ).toBe('gateway.controller.deployment.replicaCount');
+  });
+
+  it('prefers the longest matching path', () => {
+    expect(
+      fieldForServerMessage('gateway.config_toml.inner must be a string', [
+        'gateway.config_toml',
+        'gateway.config_toml.inner',
+      ])
+    ).toBe('gateway.config_toml.inner');
+  });
+
+  it('returns null for a message that names no field', () => {
+    expect(
+      fieldForServerMessage(
+        'the controller CPU request must not exceed the controller CPU limit',
+        paths
+      )
+    ).toBeNull();
+  });
+});

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/validate.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/config/validate.ts
@@ -1,0 +1,315 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type {
+  ConfigConstraint,
+  ConfigValues,
+  EditableField,
+  GatewayConfiguration,
+} from '../types';
+import { parseDurationSeconds } from './duration';
+import { parseQuantity } from './quantity';
+
+/**
+ * Client-side validation, which exists so a round trip is not the only way to
+ * learn a value is out of range. THE SERVER IS THE AUTHORITY: every message
+ * below deliberately repeats the sentence the platform returns for the same
+ * value, so the user reads the same wording whichever side caught it.
+ *
+ * Two layers live here, both read from the response and neither from a
+ * hardcoded copy of the field list:
+ *
+ *   1. per field, against its own `editable` entry;
+ *   2. across the form, against `constraints`, evaluated on the MERGED document
+ *      (loaded values overlaid with the dirty edits) rather than on the edits
+ *      alone — which is what the server does, and the only way to catch
+ *      "lower just the limit".
+ */
+
+/** Setting path → the message to show under that field. */
+export type FieldErrors = Record<string, string>;
+
+/**
+ * Everything Go's `unicode.IsControl` refuses (Unicode Cc: U+0000–U+001F and
+ * U+007F–U+009F) plus the two line separators, less tab, LF and CR, which the
+ * platform allows. These are the characters CEL's `strings.quote()` does not
+ * escape, so a value carrying one cannot be rendered into the gateway's values
+ * document at all — hence a refusal rather than a warning.
+ */
+const UNRENDERABLE = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F-\u009F\u2028\u2029]/;
+
+/** Bounds arrive as strings for every type; the platform parses this one with `%d`. */
+const boundInteger = (text: string | undefined): number | null => {
+  if (text === undefined) return null;
+  const value = Number.parseInt(text.trim(), 10);
+  return Number.isFinite(value) ? value : null;
+};
+
+/** Character count in CODE POINTS, matching the platform's `len([]rune(text))`. */
+export const characterCount = (text: string): number => [...text].length;
+
+/**
+ * One value against one field declaration, or `null` when it passes.
+ * `undefined` means the field was never edited and the stored value stands, so
+ * there is nothing to check.
+ *
+ * Messages are FIELD-RELATIVE: they never name the setting path, because they
+ * render directly under the control whose label already says which setting this
+ * is. A path here would be both redundant and, for the deeper policy settings,
+ * longer than the message it prefixes.
+ */
+export function validateFieldValue(
+  field: EditableField,
+  value: unknown
+): string | null {
+  if (value === undefined) return null;
+
+  switch (field.type) {
+    case 'enum': {
+      const permitted = field.values ?? [];
+      if (typeof value !== 'string' || !permitted.includes(value)) {
+        return `Must be one of ${permitted.join(', ')}`;
+      }
+      return null;
+    }
+
+    case 'boolean':
+      // A string "yes" is a 400 — the widget must produce a real boolean.
+      return typeof value === 'boolean' ? null : 'Must be true or false';
+
+    case 'integer': {
+      if (typeof value !== 'number' || !Number.isSafeInteger(value)) {
+        // Also the guard for the `cost_scale_factor` ceiling of 1e12: a double
+        // holds that exactly, but anything past 2^53 has silently stopped being
+        // the number that was typed.
+        return 'Must be a whole number';
+      }
+      const low = boundInteger(field.min);
+      const high = boundInteger(field.max);
+      if ((low !== null && value < low) || (high !== null && value > high)) {
+        return `Must be between ${low} and ${high}`;
+      }
+      return null;
+    }
+
+    case 'quantity': {
+      const example = 'Must be a quantity such as "500m" or "512Mi"';
+      if (typeof value !== 'string') return example;
+      const parsed = parseQuantity(value);
+      if (parsed === null) return example;
+      // Zero or negative is legal to Kubernetes and meaningless for a gateway;
+      // a zero limit means "no limit", which the ceiling assumes away.
+      if (parsed <= 0) return 'Must be greater than zero';
+      const low = field.min === undefined ? null : parseQuantity(field.min);
+      const high = field.max === undefined ? null : parseQuantity(field.max);
+      if ((low !== null && parsed < low) || (high !== null && parsed > high)) {
+        return `Must be between ${field.min} and ${field.max}`;
+      }
+      return null;
+    }
+
+    case 'duration': {
+      const example = 'Must be a duration such as "5m"';
+      if (typeof value !== 'string') return example;
+      const parsed = parseDurationSeconds(value);
+      if (parsed === null) return example;
+      const low =
+        field.min === undefined ? null : parseDurationSeconds(field.min);
+      const high =
+        field.max === undefined ? null : parseDurationSeconds(field.max);
+      if ((low !== null && parsed < low) || (high !== null && parsed > high)) {
+        return `Must be between ${field.min} and ${field.max}`;
+      }
+      return null;
+    }
+
+    case 'string': {
+      if (typeof value !== 'string') return 'Must be a string';
+      const length = characterCount(value);
+      const low = boundInteger(field.min) ?? 0;
+      const high = boundInteger(field.max);
+      if (high !== null && (length < low || length > high)) {
+        return `Must be between ${low} and ${high} characters`;
+      }
+      if (UNRENDERABLE.test(value)) {
+        return 'Must not contain control characters or line separators';
+      }
+      return null;
+    }
+
+    default:
+      return null;
+  }
+}
+
+/**
+ * Compares two values of a field's type. `null` when either side is
+ * unparseable, which the caller must treat as "skip": such a value cannot have
+ * come through the allowlist, so it is a pre-existing platform value the user
+ * can do nothing about, and refusing their save for it would be blaming them
+ * for someone else's write. The server reasons the same way.
+ */
+function compareByType(
+  field: EditableField | undefined,
+  left: unknown,
+  right: unknown
+): number | null {
+  const asNumber = (value: unknown): number | null => {
+    switch (field?.type) {
+      case 'integer':
+        return typeof value === 'number' && Number.isFinite(value)
+          ? value
+          : null;
+      case 'quantity':
+        return typeof value === 'string' ? parseQuantity(value) : null;
+      case 'duration':
+        return typeof value === 'string' ? parseDurationSeconds(value) : null;
+      default:
+        // Only ordered types can be compared. `enum`, `boolean` and `string`
+        // have no ordering, so no constraint can be declared over them.
+        return null;
+    }
+  };
+  const a = asNumber(left);
+  const b = asNumber(right);
+  if (a === null || b === null) return null;
+  if (a === b) return 0;
+  return a < b ? -1 : 1;
+}
+
+/**
+ * The declared constraints against a whole values document.
+ *
+ * A message lands on whichever side of the pair the user actually edited, so
+ * "lower just the limit" reports on the limit rather than on the request they
+ * never touched. When neither side is dirty the violation is pre-existing and
+ * reports on the bounded side.
+ */
+export function validateConstraints(
+  constraints: readonly ConfigConstraint[],
+  merged: ConfigValues,
+  fieldsByPath: ReadonlyMap<string, EditableField>,
+  dirty: ConfigValues = {}
+): FieldErrors {
+  const errors: FieldErrors = {};
+  for (const constraint of constraints) {
+    if (constraint.type !== 'notGreaterThan') continue;
+    const left = merged[constraint.path];
+    const right = merged[constraint.than];
+    // A document carrying only one side cannot violate the rule; the missing
+    // side falls back to the chart's own default at render time.
+    if (left === undefined || right === undefined) continue;
+    const comparison = compareByType(
+      fieldsByPath.get(constraint.path),
+      left,
+      right
+    );
+    if (comparison === null || comparison <= 0) continue;
+
+    // Names the OTHER field by its label, not its path: this message renders
+    // under a field whose own label is already on screen, so the only thing
+    // worth spelling out is the one it is being compared against.
+    const thanLabel =
+      fieldsByPath.get(constraint.than)?.label ?? constraint.than;
+    const message = constraint.message ?? `Must not exceed ${thanLabel}`;
+    const edited = [constraint.path, constraint.than].filter(
+      (path) => dirty[path] !== undefined
+    );
+    for (const path of edited.length > 0 ? edited : [constraint.path]) {
+      errors[path] ??= message;
+    }
+  }
+  return errors;
+}
+
+/**
+ * Both client-side layers over a loaded configuration and the edits pending on
+ * it. Empty means `Save` may be enabled — not that the write will succeed.
+ */
+export function validateForm(
+  config: GatewayConfiguration,
+  dirty: ConfigValues
+): FieldErrors {
+  const fieldsByPath = new Map(
+    config.editable.map((field) => [field.path, field])
+  );
+
+  const errors: FieldErrors = {};
+  for (const [path, value] of Object.entries(dirty)) {
+    const field = fieldsByPath.get(path);
+    if (!field) {
+      // Never render, and never send, a setting the response did not list.
+      errors[path] = `${path} is not an editable gateway setting`;
+      continue;
+    }
+    const message = validateFieldValue(field, value);
+    if (message) errors[path] = message;
+  }
+
+  // Constraints run over the document the write WOULD produce, and only once
+  // every field in it is individually sound — comparing against a value already
+  // known to be malformed says nothing.
+  if (Object.keys(errors).length === 0) {
+    Object.assign(
+      errors,
+      validateConstraints(
+        config.constraints ?? [],
+        { ...config.values, ...dirty },
+        fieldsByPath,
+        dirty
+      )
+    );
+  }
+  return errors;
+}
+
+/**
+ * The field a server message belongs under, found by longest matching setting
+ * path — a field-level message begins with the path it is about
+ * (`…route_timeout_ms must be between 1000 and 300000`). `null` means it is
+ * form-level and belongs in a banner.
+ *
+ * Longest wins because one path can prefix another: `gateway.config_toml` also
+ * prefixes any message about a `gateway.config_toml.*` field.
+ */
+export function fieldForServerMessage(
+  message: string,
+  paths: readonly string[]
+): string | null {
+  let best: string | null = null;
+  for (const path of paths) {
+    if (!message.startsWith(path)) continue;
+    if (best === null || path.length > best.length) best = path;
+  }
+  return best;
+}
+
+/**
+ * A server message with its leading setting path removed, so it reads like the
+ * client-side messages above when shown under the field it belongs to.
+ *
+ * The platform's own sentence is kept verbatim apart from that prefix — it is
+ * user-presentable prose and may say things this client cannot derive. Only the
+ * banner keeps the full text, where there is no field label to supply context.
+ */
+export function withoutPathPrefix(message: string, path: string): string {
+  if (!message.startsWith(path)) return message;
+  const rest = message.slice(path.length).trim();
+  if (rest === '') return message;
+  return rest.charAt(0).toUpperCase() + rest.slice(1);
+}

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/types.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/types.ts
@@ -63,3 +63,70 @@ export type GatewayInput = {
   type: GatewayType;
   environmentId: string;
 };
+
+/* ── gateway configuration ─────────────────────────────────────────────────── */
+
+/**
+ * `applying` is the expected state immediately after ANY write and can persist
+ * for minutes. It is not a failure and not an unfinished save.
+ */
+export type ConfigPhase = 'applying' | 'healthy' | 'failed';
+
+export type ConfigStatus = {
+  phase: ConfigPhase;
+  /** Platform detail, present when the phase is not healthy. Prose, not a code. */
+  message?: string;
+};
+
+export type ConfigFieldType =
+  | 'enum'
+  | 'boolean'
+  | 'integer'
+  | 'duration'
+  | 'quantity'
+  | 'string';
+
+/**
+ * One setting the organization may change. The platform reads its allowlist at
+ * request time, so this array is the form definition — never a client-side copy
+ * of it — and `label`/`description` are the platform's own user-facing copy.
+ */
+export type EditableField = {
+  path: string;
+  type: ConfigFieldType;
+  label?: string;
+  description?: string;
+  /** Permitted values, present when `type` is `enum`. */
+  values?: string[];
+  /**
+   * Inclusive bounds. STRINGS for every type — `Number('50m')` is `NaN`. For
+   * `string`, `max` is a length in characters and `min` is absent.
+   */
+  min?: string;
+  max?: string;
+};
+
+/**
+ * A rule between two settings. Evaluated by the platform against the document a
+ * write would PRODUCE, so a client checks it across the whole form.
+ */
+export type ConfigConstraint = {
+  type: 'notGreaterThan';
+  path: string;
+  than: string;
+  /** The platform's own sentence for the violation. Surface it verbatim. */
+  message?: string;
+};
+
+export type ConfigValues = Record<string, unknown>;
+
+export type GatewayConfiguration = {
+  id: string;
+  name?: string;
+  environment?: string;
+  /** Current value of every editable setting, keyed exactly as a request body is. */
+  values: ConfigValues;
+  editable: EditableField[];
+  constraints?: ConfigConstraint[];
+  status: ConfigStatus;
+};

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/types.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/types.ts
@@ -69,13 +69,28 @@ export type GatewayInput = {
 /**
  * `applying` is the expected state immediately after ANY write and can persist
  * for minutes. It is not a failure and not an unfinished save.
+ *
+ * `unknown` is the platform reporting no phase at all: whether the last change
+ * has landed cannot be said, and it will not settle on its own — so it is a
+ * fourth case to render, not a variant of `applying` to keep waiting on.
  */
-export type ConfigPhase = 'applying' | 'healthy' | 'failed';
+export type ConfigPhase = 'applying' | 'healthy' | 'failed' | 'unknown';
 
 export type ConfigStatus = {
   phase: ConfigPhase;
   /** Platform detail, present when the phase is not healthy. Prose, not a code. */
   message?: string;
+  /**
+   * RFC 3339 — when the gateway ENTERED this phase, already validated as a
+   * timestamp by platform-api (a bad one is dropped rather than forwarded).
+   *
+   * Read it with `phase`, never instead of it: `applying` reads the same five
+   * minutes after a write and stalled an hour later, and this is the only thing
+   * that separates them. Absent on the response to a write — the phase there is
+   * `applying` before the data plane has seen the change — and on a gateway
+   * whose resources have not reported yet.
+   */
+  lastTransitionTime?: string;
 };
 
 export type ConfigFieldType =

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/utils/time.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/utils/time.ts
@@ -24,17 +24,43 @@ const UNITS: [Intl.RelativeTimeFormatUnit, number][] = [
   ['minute', 1000 * 60],
 ];
 
-const formatter = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+const relative = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
 
-/** e.g. "2 hours ago", "just now". Falls back to that floor once a value is under a minute. Renders "—" for a missing or unparseable timestamp (managed gateways carry none). */
-export function relativeTime(iso: string): string {
+/**
+ * e.g. "2 hours ago", "just now". Falls back to that floor once a value is under
+ * a minute. Renders "—" for a missing or unparseable timestamp (managed gateways
+ * carry none).
+ *
+ * `now` is a parameter so a caller can be tested without a fake clock; leave it
+ * unset everywhere else.
+ */
+export function relativeTime(iso: string, now: number = Date.now()): string {
   const parsed = Date.parse(iso);
   if (Number.isNaN(parsed)) return '—';
-  const diffMs = parsed - Date.now();
+  const diffMs = parsed - now;
   for (const [unit, ms] of UNITS) {
     if (Math.abs(diffMs) >= ms) {
-      return formatter.format(Math.round(diffMs / ms), unit);
+      return relative.format(Math.round(diffMs / ms), unit);
     }
   }
   return 'just now';
+}
+
+const absolute = new Intl.DateTimeFormat(undefined, {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+});
+
+/**
+ * The same instant spelled out in the viewer's own locale and zone, for the
+ * hover behind a relative time — "5 minutes ago" is the readable form and the
+ * exact moment is what someone correlating with a deployment actually needs.
+ *
+ * Empty for a missing or unparseable timestamp, so a caller can use it directly
+ * as a tooltip title (an empty title renders no tooltip).
+ */
+export function absoluteTime(iso: string): string {
+  const parsed = Date.parse(iso);
+  if (Number.isNaN(parsed)) return '';
+  return absolute.format(parsed);
 }

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/tsconfig.console.json
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/tsconfig.console.json
@@ -1,0 +1,22 @@
+{
+  // The same options as tsconfig.json with `paths` pointed at the API Control
+  // Plane's node_modules, because the console's image build is the only thing
+  // that ever typechecks this package (its `npm run build` is `tsc --noEmit &&
+  // vite build`, and the plugin is copied into node_modules with `types`
+  // pointing at TS source, so `skipLibCheck` does not skip it). Run BOTH
+  // configs — clean under one host's dependency versions is not clean under the
+  // other's. Also the config the tests typecheck and run under, since the
+  // console is the only portal with vitest installed.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@wso2/oxygen-ui": ["../../api-control-plane/node_modules/@wso2/oxygen-ui"],
+      "@wso2/oxygen-ui-icons-react": ["../../api-control-plane/node_modules/@wso2/oxygen-ui-icons-react"],
+      "react": ["../../api-control-plane/node_modules/@types/react/index.d.ts"],
+      "react/jsx-runtime": ["../../api-control-plane/node_modules/@types/react/jsx-runtime.d.ts"],
+      "react-router-dom": ["../../api-control-plane/node_modules/react-router-dom/dist/index.d.ts"],
+      "vitest": ["../../api-control-plane/node_modules/vitest/dist/index.d.ts"]
+    }
+  },
+  "exclude": []
+}

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/tsconfig.json
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/tsconfig.json
@@ -17,5 +17,8 @@
     "skipLibCheck": true,
     "resolveJsonModule": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  // The AI Workspace has no vitest installed, so the tests cannot resolve it
+  // under these paths. tsconfig.console.json typechecks and runs them.
+  "exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
Adds the gateway **configuration drawer** to the cloud gateways plugin, on top of the platform-api wiring from #3362.

### Depends on #3362 — read the diff accordingly

#3362's head branch lives on a fork, so GitHub won't let this PR be based on it. This branch is therefore `main` + #3362's commit + one commit of its own, and the file list below shows both. **Review only the second commit** (`Add the gateway configuration drawer to the cloud gateways plugin`); once #3362 merges, rebasing this reduces it to exactly that commit.

### What this adds

A drawer on each gateway row that reads and writes the gateway's managed configuration through `/managed-gateways/{id}/configuration`.

It is rendered **entirely from the response**. The platform reads its editable-field allowlist at request time, so `editable[]` is the form definition and `constraints[]` the cross-field rules — there is deliberately no client-side copy of either, and a setting the deployment adds or withdraws appears or disappears without a plugin release.

Writes are a **sparse patch** of only the paths the user touched. The response is the whole configuration after the write, so it serves as both the confirmation and the new baseline — that is what makes a canonicalized quantity (`1000m` → `1`) stop looking edited, and why there is no second GET. A read in flight when a write lands is discarded by generation counter, so a stale GET can't overwrite what the PUT just confirmed.

New files: `GatewaySettingsDrawer` (rewritten), `ConfigStatusBar`, `SettingField`, `TomlField`, and `config/{api,duration,quantity,toml,validate}.ts` with 51 unit tests.

### Relationship to #3357

#3357 carried both a listing implementation and this drawer. **Only the drawer is brought across** — its listing, page-override and routing work is superseded by #3362's and is not included here.

Three adaptations follow from #3362's Port and data flow:

- `apiFetch` is required and resolves `T | undefined` for an empty body. Both configuration endpoints always answer with the whole document, so `config/api.ts` treats an empty one as a broken response rather than letting `undefined` reach a form that cannot render it.
- **No `isManaged`.** #3362 lists `/managed-gateways`, so every row already has a managed binding and the Configure action needs no gate. #3357 needed one only because it listed `/gateways` and joined against the bindings.
- `GatewaysList` takes `port` (for the drawer) and no longer takes `environments` — the old drawer was the only thing that read it.

### Verification

- `tsc --noEmit` clean under **both** `tsconfig.json` (AI Workspace dependency versions) and `tsconfig.console.json` (console's) — clean under one host's versions is not clean under the other's.
- 51/51 unit tests pass.
- Built into the `apip-console` image and deployed to a local k3d cluster; the served bundle carries the drawer and the page renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)