### PR TITLE
Fix Policy definition issue

### DIFF
--- a/portals/ai-workspace/src/pages/appShell/PolicyParameterEditor/schemaUtils.ts
+++ b/portals/ai-workspace/src/pages/appShell/PolicyParameterEditor/schemaUtils.ts
@@ -488,7 +488,7 @@ export function createDefaultArrayItem(itemSchema: ParameterSchema): unknown {
     return itemSchema.default ?? false;
   }
   if (itemSchema.type === 'number' || itemSchema.type === 'integer') {
-    return itemSchema.default ?? 0;
+    return itemSchema.default ?? '';
   }
   if (itemSchema.type === 'array') {
     return [];

--- a/portals/ai-workspace/src/pages/appShell/PolicyParameterEditor/schemaUtils.ts
+++ b/portals/ai-workspace/src/pages/appShell/PolicyParameterEditor/schemaUtils.ts
@@ -231,21 +231,39 @@ export function deleteValueByPath(
 }
 
 /**
- * Initialize default values from schema
+ * Initialize default values from schema.
+ *
+ * Schema defaults are only backfilled into missing leaf values when adding a
+ * brand-new policy instance (no `existingValues`). When editing an
+ * already-saved instance, a missing key means the user's prior save either
+ * never configured that field or explicitly cleared it — `omitOptionalEmptyValues`
+ * strips empty optional fields before submission, so an absent key can't be
+ * told apart from "never touched" once persisted. Backfilling the schema
+ * default in that case would silently resurrect a value the user removed, the
+ * moment they reopen the form. `applySchemaDefaults` defaults to whether
+ * `existingValues` was passed at all, and is threaded through recursion so a
+ * nested object that's entirely missing from `existingValues` still renders
+ * blank rather than pre-filled, while a fresh "add" form keeps showing
+ * defaults as before.
  */
 export function initializeDefaultValues(
   schema: ParameterSchema,
-  existingValues?: ParameterValues
+  existingValues?: ParameterValues,
+  applySchemaDefaults: boolean = existingValues === undefined
 ): ParameterValues {
   const result: ParameterValues = existingValues ? { ...existingValues } : {};
 
   if (schema.type === 'object' && schema.properties) {
     Object.entries(schema.properties).forEach(([key, propSchema]) => {
       if (result[key] === undefined) {
-        if (propSchema.default !== undefined) {
+        if (applySchemaDefaults && propSchema.default !== undefined) {
           result[key] = propSchema.default;
         } else if (propSchema.type === 'object' && propSchema.properties) {
-          result[key] = initializeDefaultValues(propSchema);
+          result[key] = initializeDefaultValues(
+            propSchema,
+            undefined,
+            applySchemaDefaults
+          );
         } else if (propSchema.type === 'array') {
           result[key] = [];
         } else if (propSchema.type === 'boolean') {
@@ -254,7 +272,7 @@ export function initializeDefaultValues(
           propSchema.type === 'number' ||
           propSchema.type === 'integer'
         ) {
-          result[key] = propSchema.default ?? '';
+          result[key] = '';
         } else {
           result[key] = '';
         }
@@ -265,7 +283,8 @@ export function initializeDefaultValues(
       ) {
         result[key] = initializeDefaultValues(
           propSchema,
-          result[key] as ParameterValues
+          result[key] as ParameterValues,
+          applySchemaDefaults
         );
       }
     });


### PR DESCRIPTION
This pull request updates the logic for initializing default values from a schema in `schemaUtils.ts`, making the handling of schema defaults more robust and user-friendly. The main improvement is that schema defaults are now only applied when creating a new policy instance, and not when editing an existing one. This prevents accidentally restoring values that a user had previously cleared.

Key improvements to schema default handling:

* Schema defaults are now only backfilled into missing leaf values when adding a brand-new policy instance (i.e., when `existingValues` is not provided). When editing an existing instance, missing keys are left blank, preventing previously cleared values from reappearing unexpectedly.
* The `applySchemaDefaults` flag is introduced and threaded through recursive calls to ensure nested objects are handled consistently, so defaults are only applied when appropriate. [[1]](diffhunk://#diff-d445ce7ab4fde97ea4c12657aa55dea388920c115f38a92da5d943973947aa78L234-R266) [[2]](diffhunk://#diff-d445ce7ab4fde97ea4c12657aa55dea388920c115f38a92da5d943973947aa78L268-R287)
* For number and integer fields, the default value is now always set to an empty string when no default is specified, instead of possibly using the schema's default.