### PR TITLE
Fix: Match collection search against display name as well as handle

### DIFF
--- a/platform-api/api/generated.go
+++ b/platform-api/api/generated.go
@@ -1312,7 +1312,7 @@ type LLMProvider struct {
 	// AssociatedGateways Optional list of gateways this LLM provider can be deployed to, along with per-gateway configuration overrides. This field is optional; omitting it does not change existing behaviour.
 	AssociatedGateways *[]AssociatedGateway `json:"associatedGateways,omitempty" yaml:"associatedGateways,omitempty"`
 
-	// Context Base path for all routes exposed by this proxy. Must start with / and carry no trailing slash; the single exception is the root path "/", which is the default.
+	// Context Base path for all routes exposed by this provider. Must start with / and carry no trailing slash; the single exception is the root path "/", which is the default.
 	Context *string `json:"context,omitempty" yaml:"context,omitempty"`
 
 	// CreatedAt Timestamp when the resource was created
@@ -1818,21 +1818,30 @@ type MCPProxyListResponse struct {
 	Pagination Pagination         `json:"pagination" yaml:"pagination"`
 }
 
-// MCPServerInfoFetchRequest defines model for MCPServerInfoFetchRequest.
+// MCPServerInfoFetchRequest Target MCP server to introspect, and the credentials to introspect it with. At least
+// one of `url`/`proxyId` must be provided
 type MCPServerInfoFetchRequest struct {
 	// Auth Authentication configuration for upstream endpoints
 	Auth *UpstreamAuth `json:"auth,omitempty" yaml:"auth,omitempty"`
 
-	// ProxyId MCP proxy handle (identifier) for refresh operations. When provided,
-	// the server fetches URL and auth from the stored proxy configuration.
-	// Auth override is not allowed in refetch mode.
+	// ProxyId MCP proxy handle (identifier) for refresh operations. The stored credentials of
+	// this proxy are used for the fetch, and its stored upstream URL too unless `url`
+	// overrides it. Required unless `url` is given.
 	ProxyId *string `json:"proxyId,omitempty" yaml:"proxyId,omitempty"`
 
-	// Url Endpoint URL of the MCP server to fetch information from.
-	// Required when proxyId is not provided. When proxyId is provided,
-	// the URL from the stored proxy configuration is used.
-	Url *string `json:"url,omitempty" yaml:"url,omitempty"`
+	// Url Endpoint URL of the MCP server to fetch information from. Required unless
+	// `proxyId` is given. When sent together with `proxyId` it overrides that proxy's
+	// stored upstream URL, while the proxy's stored credentials are still used — this
+	// validates an unsaved endpoint edit without re-sending a write-only secret.
+	Url   *string `json:"url,omitempty" yaml:"url,omitempty"`
+	union json.RawMessage
 }
+
+// MCPServerInfoFetchRequest0 defines model for .
+type MCPServerInfoFetchRequest0 = interface{}
+
+// MCPServerInfoFetchRequest1 defines model for .
+type MCPServerInfoFetchRequest1 = interface{}
 
 // MCPServerInfoFetchResponse defines model for MCPServerInfoFetchResponse.
 type MCPServerInfoFetchResponse struct {
@@ -2256,7 +2265,7 @@ type SecretCreateRequest struct {
 	Type *SecretCreateRequestType `json:"type,omitempty" yaml:"type,omitempty"`
 
 	// Value Plaintext secret value — encrypted at rest, never returned in any response
-	Value string `binding:"required" json:"value" yaml:"value"`
+	Value *string `binding:"required" json:"value,omitempty" yaml:"value,omitempty"`
 }
 
 // SecretCreateRequestType defines model for SecretCreateRequest.Type.
@@ -2324,7 +2333,7 @@ type SecretUpdateRequest struct {
 	Id *string `json:"id,omitempty" yaml:"id,omitempty"`
 
 	// Value New plaintext secret value — re-encrypted at rest
-	Value string `binding:"required" json:"value" yaml:"value"`
+	Value *string `binding:"required" json:"value,omitempty" yaml:"value,omitempty"`
 }
 
 // SecurityConfig Defines security mechanisms (API key, OAuth2) applicable to the API
@@ -2736,7 +2745,7 @@ type ListApplicationsParams struct {
 	// SortOrder Sort direction applied to `sortBy`.
 	SortOrder *ListApplicationsParamsSortOrder `form:"sortOrder,omitempty" json:"sortOrder,omitempty" yaml:"sortOrder,omitempty"`
 
-	// Query Case-insensitive substring filter matched against the resource id (handle).
+	// Query Case-insensitive substring filter matched against the resource display name and id (handle).
 	Query *QueryQ `form:"query,omitempty" json:"query,omitempty" yaml:"query,omitempty"`
 }
 
@@ -2814,7 +2823,7 @@ type ListGatewaysParams struct {
 	// SortOrder Sort direction applied to `sortBy`.
 	SortOrder *ListGatewaysParamsSortOrder `form:"sortOrder,omitempty" json:"sortOrder,omitempty" yaml:"sortOrder,omitempty"`
 
-	// Query Case-insensitive substring filter matched against the resource id (handle).
+	// Query Case-insensitive substring filter matched against the resource display name and id (handle).
 	Query *QueryQ `form:"query,omitempty" json:"query,omitempty" yaml:"query,omitempty"`
 }
 
@@ -2883,7 +2892,7 @@ type ListLLMProviderAPIKeysParams struct {
 
 // GetLLMProviderDeploymentsParams defines parameters for GetLLMProviderDeployments.
 type GetLLMProviderDeploymentsParams struct {
-	// GatewayId **Gateway ID** (handle — unique slug identifier) of the Gateway to filter deployments by.
+	// GatewayId **Gateway ID** consisting of the **handle** (unique slug identifier) of the Gateway to filter status by.
 	GatewayId *GatewayIdQ `form:"gatewayId,omitempty" json:"gatewayId,omitempty" yaml:"gatewayId,omitempty"`
 
 	// Status Filter deployments by status (DEPLOYED, UNDEPLOYED, DEPLOYING, UNDEPLOYING, FAILED, or ARCHIVED)
@@ -2943,7 +2952,7 @@ type ListLLMProxyAPIKeysParams struct {
 
 // GetLLMProxyDeploymentsParams defines parameters for GetLLMProxyDeployments.
 type GetLLMProxyDeploymentsParams struct {
-	// GatewayId **Gateway ID** (handle — unique slug identifier) of the Gateway to filter deployments by.
+	// GatewayId **Gateway ID** consisting of the **handle** (unique slug identifier) of the Gateway to filter status by.
 	GatewayId *GatewayIdQ `form:"gatewayId,omitempty" json:"gatewayId,omitempty" yaml:"gatewayId,omitempty"`
 
 	// Status Filter deployments by status (DEPLOYED, UNDEPLOYED, DEPLOYING, UNDEPLOYING, FAILED, or ARCHIVED)
@@ -2985,7 +2994,7 @@ type ListMCPProxiesParams struct {
 
 // GetMCPProxyDeploymentsParams defines parameters for GetMCPProxyDeployments.
 type GetMCPProxyDeploymentsParams struct {
-	// GatewayId **Gateway ID** (handle — unique slug identifier) of the Gateway to filter deployments by.
+	// GatewayId **Gateway ID** consisting of the **handle** (unique slug identifier) of the Gateway to filter status by.
 	GatewayId *GatewayIdQ `form:"gatewayId,omitempty" json:"gatewayId,omitempty" yaml:"gatewayId,omitempty"`
 
 	// Status Filter deployments by status (DEPLOYED, UNDEPLOYED, DEPLOYING, UNDEPLOYING, FAILED, or ARCHIVED)
@@ -3052,7 +3061,7 @@ type ListProjectsParams struct {
 	// SortOrder Sort direction applied to `sortBy`.
 	SortOrder *ListProjectsParamsSortOrder `form:"sortOrder,omitempty" json:"sortOrder,omitempty" yaml:"sortOrder,omitempty"`
 
-	// Query Case-insensitive substring filter matched against the resource id (handle).
+	// Query Case-insensitive substring filter matched against the resource display name and id (handle).
 	Query *QueryQ `form:"query,omitempty" json:"query,omitempty" yaml:"query,omitempty"`
 }
 
@@ -3079,7 +3088,7 @@ type ListRESTAPIsParams struct {
 	// SortOrder Sort direction applied to `sortBy`.
 	SortOrder *ListRESTAPIsParamsSortOrder `form:"sortOrder,omitempty" json:"sortOrder,omitempty" yaml:"sortOrder,omitempty"`
 
-	// Query Case-insensitive substring filter matched against the resource id (handle).
+	// Query Case-insensitive substring filter matched against the resource display name and id (handle).
 	Query *QueryQ `form:"query,omitempty" json:"query,omitempty" yaml:"query,omitempty"`
 }
 
@@ -3091,7 +3100,7 @@ type ListRESTAPIsParamsSortOrder string
 
 // GetDeploymentsParams defines parameters for GetDeployments.
 type GetDeploymentsParams struct {
-	// GatewayId **Gateway ID** (handle — unique slug identifier) of the Gateway to filter deployments by.
+	// GatewayId **Gateway ID** consisting of the **handle** (unique slug identifier) of the Gateway to filter status by.
 	GatewayId *GatewayIdQ `form:"gatewayId,omitempty" json:"gatewayId,omitempty" yaml:"gatewayId,omitempty"`
 
 	// Status Filter deployments by status (DEPLOYED, UNDEPLOYED, DEPLOYING, UNDEPLOYING, FAILED, or ARCHIVED)
@@ -3298,6 +3307,130 @@ type CreateSubscriptionJSONRequestBody = CreateSubscriptionRequest
 
 // UpdateSubscriptionJSONRequestBody defines body for UpdateSubscription for application/json ContentType.
 type UpdateSubscriptionJSONRequestBody = Subscription
+
+// AsMCPServerInfoFetchRequest0 returns the union data inside the MCPServerInfoFetchRequest as a MCPServerInfoFetchRequest0
+func (t MCPServerInfoFetchRequest) AsMCPServerInfoFetchRequest0() (MCPServerInfoFetchRequest0, error) {
+	var body MCPServerInfoFetchRequest0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromMCPServerInfoFetchRequest0 overwrites any union data inside the MCPServerInfoFetchRequest as the provided MCPServerInfoFetchRequest0
+func (t *MCPServerInfoFetchRequest) FromMCPServerInfoFetchRequest0(v MCPServerInfoFetchRequest0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeMCPServerInfoFetchRequest0 performs a merge with any union data inside the MCPServerInfoFetchRequest, using the provided MCPServerInfoFetchRequest0
+func (t *MCPServerInfoFetchRequest) MergeMCPServerInfoFetchRequest0(v MCPServerInfoFetchRequest0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsMCPServerInfoFetchRequest1 returns the union data inside the MCPServerInfoFetchRequest as a MCPServerInfoFetchRequest1
+func (t MCPServerInfoFetchRequest) AsMCPServerInfoFetchRequest1() (MCPServerInfoFetchRequest1, error) {
+	var body MCPServerInfoFetchRequest1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromMCPServerInfoFetchRequest1 overwrites any union data inside the MCPServerInfoFetchRequest as the provided MCPServerInfoFetchRequest1
+func (t *MCPServerInfoFetchRequest) FromMCPServerInfoFetchRequest1(v MCPServerInfoFetchRequest1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeMCPServerInfoFetchRequest1 performs a merge with any union data inside the MCPServerInfoFetchRequest, using the provided MCPServerInfoFetchRequest1
+func (t *MCPServerInfoFetchRequest) MergeMCPServerInfoFetchRequest1(v MCPServerInfoFetchRequest1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t MCPServerInfoFetchRequest) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	object := make(map[string]json.RawMessage)
+	if t.union != nil {
+		err = json.Unmarshal(b, &object)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if t.Auth != nil {
+		object["auth"], err = json.Marshal(t.Auth)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'auth': %w", err)
+		}
+	}
+
+	if t.ProxyId != nil {
+		object["proxyId"], err = json.Marshal(t.ProxyId)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'proxyId': %w", err)
+		}
+	}
+
+	if t.Url != nil {
+		object["url"], err = json.Marshal(t.Url)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'url': %w", err)
+		}
+	}
+	b, err = json.Marshal(object)
+	return b, err
+}
+
+func (t *MCPServerInfoFetchRequest) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	if err != nil {
+		return err
+	}
+	object := make(map[string]json.RawMessage)
+	err = json.Unmarshal(b, &object)
+	if err != nil {
+		return err
+	}
+
+	if raw, found := object["auth"]; found {
+		err = json.Unmarshal(raw, &t.Auth)
+		if err != nil {
+			return fmt.Errorf("error reading 'auth': %w", err)
+		}
+	}
+
+	if raw, found := object["proxyId"]; found {
+		err = json.Unmarshal(raw, &t.ProxyId)
+		if err != nil {
+			return fmt.Errorf("error reading 'proxyId': %w", err)
+		}
+	}
+
+	if raw, found := object["url"]; found {
+		err = json.Unmarshal(raw, &t.Url)
+		if err != nil {
+			return fmt.Errorf("error reading 'url': %w", err)
+		}
+	}
+
+	return err
+}
 
 // AsRateLimitingScopeConfig0 returns the union data inside the RateLimitingScopeConfig as a RateLimitingScopeConfig0
 func (t RateLimitingScopeConfig) AsRateLimitingScopeConfig0() (RateLimitingScopeConfig0, error) {

--- a/platform-api/internal/integration/search_test.go
+++ b/platform-api/internal/integration/search_test.go
@@ -1,0 +1,247 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+ //go:build integration
+
+package integration
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/wso2/api-platform/platform-api/internal/repository"
+)
+
+// The `query` collection filter (openapi.yaml query-Q -> ListOptions.Search ->
+// repository.handleSearchClause) must match the resource display name as well
+// as its handle: the console lists resources by display name, and handles are
+// URL-safe slugs users neither choose nor see. These tests run against a real
+// engine because three properties of the filter cannot be observed from the
+// clause string that pagination_test.go asserts on:
+//
+//   - Grouping. handleSearchClause returns a fragment; GatewayRepo.ListPaginated
+//     strips the leading " AND " and joins it into its own AND-separated
+//     condition list. An unparenthesized "a OR b" binds as
+//     "(organization_uuid = ? AND display_name LIKE ?) OR handle LIKE ?" and
+//     returns gateways from other organizations.
+//   - Collation. SQL Server defaults to a case-insensitive collation while
+//     PostgreSQL is case-sensitive; LOWER() on both sides is what makes the
+//     filter behave identically, and only executing it proves that.
+//   - List/count parity. ListXxx and CountXxx call handleSearchClause
+//     independently, so a filtered page can pair with an unfiltered total.
+
+// searchPageLimit is large enough that every seeded fixture lands on one page,
+// keeping these tests about filtering rather than pagination.
+const searchPageLimit = 1000
+
+// seedSearchOrg inserts a bare organization and returns its UUID.
+func seedSearchOrg(t *testing.T, it *itDB) string {
+	t.Helper()
+	org := id()
+	it.exec(t, `INSERT INTO organizations (uuid, handle, display_name, region, idp_organization_ref_uuid) VALUES (?, ?, ?, ?, ?)`,
+		org, "so-"+org[:8], "search org", "us", "idp-ref")
+	return org
+}
+
+// seedSearchGateway inserts a gateway with an explicit handle/display-name pair
+// and returns its UUID. Seeding goes through SQL rather than GatewayRepo.Create
+// so the two columns are written exactly as given — the divergence between them
+// is the whole point of these fixtures. description is nullable in the schema
+// but GatewayRepo scans it into a plain string, so it is written as ” here,
+// matching what Create persists for a gateway with no description.
+func seedSearchGateway(t *testing.T, it *itDB, orgID, handle, displayName string) string {
+	t.Helper()
+	gw := id()
+	it.exec(t, `INSERT INTO gateways (uuid, organization_uuid, handle, display_name, description, properties) VALUES (?, ?, ?, ?, ?, ?)`,
+		gw, orgID, handle, displayName, "", []byte("{}"))
+	return gw
+}
+
+// seedSearchProject inserts a project with an explicit handle/display-name pair
+// and returns its UUID. As above, description is written as ” rather than left
+// NULL because ProjectRepo scans it into a plain string.
+func seedSearchProject(t *testing.T, it *itDB, orgID, handle, displayName string) string {
+	t.Helper()
+	proj := id()
+	it.exec(t, `INSERT INTO projects (uuid, handle, display_name, organization_uuid, description) VALUES (?, ?, ?, ?, ?)`,
+		proj, handle, displayName, orgID, "")
+	return proj
+}
+
+// searchGateways runs one search through GatewayRepo and returns the matched
+// UUIDs, failing if the paged result and CountGateways disagree.
+func searchGateways(t *testing.T, it *itDB, repo repository.GatewayRepository, orgID, term string) []string {
+	t.Helper()
+	page, err := repo.ListPaginated(orgID, repository.ListOptions{Limit: searchPageLimit, Search: term})
+	if err != nil {
+		t.Fatalf("[%s] ListPaginated(query=%q) failed: %v", it.driver, term, err)
+	}
+	total, err := repo.CountGateways(orgID, term)
+	if err != nil {
+		t.Fatalf("[%s] CountGateways(query=%q) failed: %v", it.driver, term, err)
+	}
+	if total != len(page) {
+		t.Errorf("[%s] gateway query=%q: CountGateways=%d but the page holds %d rows — the list and count filters disagree",
+			it.driver, term, total, len(page))
+	}
+	ids := make([]string, 0, len(page))
+	for _, gw := range page {
+		ids = append(ids, gw.ID)
+	}
+	return ids
+}
+
+// searchProjects runs one search through ProjectRepo and returns the matched
+// UUIDs, failing if the paged result and CountProjects disagree.
+func searchProjects(t *testing.T, it *itDB, repo repository.ProjectRepository, orgID, term string) []string {
+	t.Helper()
+	page, err := repo.ListProjects(orgID, repository.ListOptions{Limit: searchPageLimit, Search: term})
+	if err != nil {
+		t.Fatalf("[%s] ListProjects(query=%q) failed: %v", it.driver, term, err)
+	}
+	total, err := repo.CountProjects(orgID, term)
+	if err != nil {
+		t.Fatalf("[%s] CountProjects(query=%q) failed: %v", it.driver, term, err)
+	}
+	if total != len(page) {
+		t.Errorf("[%s] project query=%q: CountProjects=%d but the page holds %d rows — the list and count filters disagree",
+			it.driver, term, total, len(page))
+	}
+	ids := make([]string, 0, len(page))
+	for _, p := range page {
+		ids = append(ids, p.ID)
+	}
+	return ids
+}
+
+// assertMatches compares a search result against the exact set of expected
+// UUIDs, order-independently.
+func assertMatches(t *testing.T, it *itDB, term string, got []string, want ...string) {
+	t.Helper()
+	gotSorted := append([]string(nil), got...)
+	wantSorted := append([]string(nil), want...)
+	sort.Strings(gotSorted)
+	sort.Strings(wantSorted)
+	if len(gotSorted) != len(wantSorted) {
+		t.Fatalf("[%s] query=%q matched %d rows %v, want %d %v", it.driver, term, len(gotSorted), gotSorted, len(wantSorted), wantSorted)
+	}
+	for i := range gotSorted {
+		if gotSorted[i] != wantSorted[i] {
+			t.Fatalf("[%s] query=%q matched %v, want %v", it.driver, term, gotSorted, wantSorted)
+		}
+	}
+}
+
+// TestSearch_GatewayQueryMatchesDisplayNameAndHandle drives GatewayRepo, the
+// riskiest of the four searchable collections: it is the only one that
+// hand-assembles its WHERE clause from the shared fragment, so it is where a
+// missing OR group leaks rows across organizations.
+func TestSearch_GatewayQueryMatchesDisplayNameAndHandle(t *testing.T) {
+	it := openITDB(t)
+	defer it.db.Close()
+	repo := repository.NewGatewayRepo(it.db)
+
+	orgA := seedSearchOrg(t, it)
+	orgB := seedSearchOrg(t, it)
+
+	// The handle is deliberately unrelated to the display name, so a
+	// handle-only filter cannot match "Payment API" by coincidence.
+	payment := seedSearchGateway(t, it, orgA, "legacy-svc-01", "Payment API Gateway")
+	seedSearchGateway(t, it, orgA, "billing-gw", "Billing Gateway")
+	// Same display name, different organization: the cross-tenant guard.
+	otherOrgPayment := seedSearchGateway(t, it, orgB, "orgb-gw", "Payment API Gateway")
+
+	t.Run("multi-word display name matches", func(t *testing.T) {
+		// The reported bug: the console shows "Payment API Gateway", the user
+		// types "Payment API", and a handle-only filter can never match it —
+		// the space cannot line up with the hyphen in a slug.
+		assertMatches(t, it, "Payment API", searchGateways(t, it, repo, orgA, "Payment API"), payment)
+	})
+
+	t.Run("match is case-insensitive across engines", func(t *testing.T) {
+		assertMatches(t, it, "payment api", searchGateways(t, it, repo, orgA, "payment api"), payment)
+		assertMatches(t, it, "PAYMENT API", searchGateways(t, it, repo, orgA, "PAYMENT API"), payment)
+	})
+
+	t.Run("handle search is preserved", func(t *testing.T) {
+		// Existing id-based callers (CLI, scripts) must keep working.
+		assertMatches(t, it, "legacy-svc", searchGateways(t, it, repo, orgA, "legacy-svc"), payment)
+	})
+
+	t.Run("search does not cross organizations", func(t *testing.T) {
+		// If the OR group is unparenthesized, "organization_uuid = ? AND
+		// display_name LIKE ? OR handle LIKE ?" binds as
+		// "(org AND display_name) OR handle" and orgB's gateway appears here.
+		assertMatches(t, it, "Payment API", searchGateways(t, it, repo, orgA, "Payment API"), payment)
+		assertMatches(t, it, "Payment API", searchGateways(t, it, repo, orgB, "Payment API"), otherOrgPayment)
+		// Same check via the handle leg, which is the term the bad grouping
+		// would leave unscoped by organization.
+		assertMatches(t, it, "orgb-gw", searchGateways(t, it, repo, orgA, "orgb-gw"))
+	})
+
+	t.Run("non-matching term returns nothing", func(t *testing.T) {
+		assertMatches(t, it, "no-such-resource", searchGateways(t, it, repo, orgA, "no-such-resource"))
+	})
+
+	t.Run("wildcard metacharacters stay literal", func(t *testing.T) {
+		// ESCAPE '\' must hold on every engine: a bare "%" is a literal to
+		// match, not a wildcard that returns the whole collection.
+		assertMatches(t, it, "%", searchGateways(t, it, repo, orgA, "%"))
+		assertMatches(t, it, "_", searchGateways(t, it, repo, orgA, "_"))
+	})
+
+	t.Run("empty term does not filter", func(t *testing.T) {
+		all := searchGateways(t, it, repo, orgA, "")
+		if len(all) != 2 {
+			t.Fatalf("[%s] empty query returned %d gateways, want both seeded rows", it.driver, len(all))
+		}
+	})
+}
+
+// TestSearch_ProjectQueryMatchesDisplayNameAndHandle covers the other clause
+// shape: ProjectRepo appends the fragment to an existing WHERE, so it stands in
+// for rest_apis and applications, which assemble their queries the same way.
+func TestSearch_ProjectQueryMatchesDisplayNameAndHandle(t *testing.T) {
+	it := openITDB(t)
+	defer it.db.Close()
+	repo := repository.NewProjectRepo(it.db)
+
+	orgA := seedSearchOrg(t, it)
+	orgB := seedSearchOrg(t, it)
+
+	payment := seedSearchProject(t, it, orgA, "legacy-proj-01", "Payment API Project")
+	seedSearchProject(t, it, orgA, "billing-proj", "Billing Project")
+	otherOrgPayment := seedSearchProject(t, it, orgB, "orgb-proj", "Payment API Project")
+
+	t.Run("multi-word display name matches", func(t *testing.T) {
+		assertMatches(t, it, "Payment API", searchProjects(t, it, repo, orgA, "Payment API"), payment)
+	})
+
+	t.Run("handle search is preserved", func(t *testing.T) {
+		assertMatches(t, it, "legacy-proj", searchProjects(t, it, repo, orgA, "legacy-proj"), payment)
+	})
+
+	t.Run("search does not cross organizations", func(t *testing.T) {
+		assertMatches(t, it, "Payment API", searchProjects(t, it, repo, orgB, "Payment API"), otherOrgPayment)
+		assertMatches(t, it, "orgb-proj", searchProjects(t, it, repo, orgA, "orgb-proj"))
+	})
+
+	t.Run("wildcard metacharacters stay literal", func(t *testing.T) {
+		assertMatches(t, it, "%", searchProjects(t, it, repo, orgA, "%"))
+	})
+}

--- a/platform-api/internal/repository/pagination.go
+++ b/platform-api/internal/repository/pagination.go
@@ -75,5 +75,5 @@ func handleSearchClause(search string) (string, []any) {
 		return "", nil
 	}
 	esc := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(strings.ToLower(s))
-	return ` AND LOWER(handle) LIKE ? ESCAPE '\'`, []any{"%" + esc + "%"}
+	return ` AND (LOWER(display_name) LIKE ? ESCAPE '\' OR LOWER(handle) LIKE ? ESCAPE '\')`, []any{"%" + esc + "%", "%" + esc + "%"}
 }

--- a/platform-api/internal/repository/pagination_test.go
+++ b/platform-api/internal/repository/pagination_test.go
@@ -17,7 +17,10 @@
 
 package repository
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // TestResolveSort verifies that only allowlisted sort tokens map to columns and
 // that everything else — including attempted SQL injection via the sort token —
@@ -57,7 +60,28 @@ func TestResolveSort(t *testing.T) {
 	}
 }
 
-// TestHandleSearchClause verifies the empty-input short circuit and that LIKE
+// wantSearchClause is the expected fragment from handleSearchClause for
+// non-empty terms. It's parenthesized so callers can AND-join it safely.
+const wantSearchClause = ` AND (LOWER(display_name) LIKE ? ESCAPE '\' OR LOWER(handle) LIKE ? ESCAPE '\')`
+
+// assertSearchArgs checks that the clause bound exactly the expected patterns,
+// in order. Both matched columns take the same pattern, so a caller passes it
+// twice.
+func assertSearchArgs(t *testing.T, got []any, want ...string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("args = %v (len %d), want %v (len %d)", got, len(got), want, len(want))
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("args[%d] = %v, want %q", i, got[i], w)
+		}
+	}
+}
+
+// TestHandleSearchClause verifies the empty-input short circuit, that the term
+// is matched against both the display name and the handle, that the two matched
+// columns are grouped so the fragment stays safe to AND-join, and that LIKE
 // metacharacters supplied by the client are escaped so they match literally
 // rather than acting as wildcards.
 func TestHandleSearchClause(t *testing.T) {
@@ -68,27 +92,50 @@ func TestHandleSearchClause(t *testing.T) {
 		}
 	})
 
-	t.Run("plain term is lowercased and wrapped", func(t *testing.T) {
+	t.Run("plain term is lowercased, wrapped, and bound once per column", func(t *testing.T) {
 		clause, args := handleSearchClause("Payment")
-		if clause == "" {
-			t.Fatal("expected a non-empty clause")
+		if clause != wantSearchClause {
+			t.Fatalf("clause = %q, want %q", clause, wantSearchClause)
 		}
-		if len(args) != 1 || args[0] != "%payment%" {
-			t.Fatalf("args = %v, want [%%payment%%]", args)
+		assertSearchArgs(t, args, "%payment%", "%payment%")
+	})
+
+	t.Run("term matches display name as well as handle", func(t *testing.T) {
+		clause, _ := handleSearchClause("Payment")
+		if !strings.Contains(clause, "LOWER(display_name) LIKE ?") {
+			t.Errorf("clause %q does not filter on display_name", clause)
 		}
+		if !strings.Contains(clause, "LOWER(handle) LIKE ?") {
+			t.Errorf("clause %q no longer filters on handle", clause)
+		}
+	})
+
+	// Guards the precedence bug independently of wantSearchClause, which a
+	// future reword would update in lockstep: the fragment must remain a single
+	// parenthesized group so callers can AND-join it without OR leaking rows
+	// past their organization filter.
+	t.Run("matched columns are grouped so the clause is safe to AND-join", func(t *testing.T) {
+		clause, _ := handleSearchClause("Payment")
+		if !strings.HasPrefix(clause, " AND (") || !strings.HasSuffix(clause, ")") {
+			t.Fatalf("clause %q must be a parenthesized group prefixed with \" AND \"", clause)
+		}
+	})
+
+	// The reported bug: a display name is prose, not a slug. The term must reach
+	// the bound pattern verbatim (lowercased only) so "Payment API" can match a
+	// display_name of "Payment API"; it can never match the handle "payment-api".
+	t.Run("multi-word display name term is preserved verbatim", func(t *testing.T) {
+		_, args := handleSearchClause("Payment API")
+		assertSearchArgs(t, args, "%payment api%", "%payment api%")
 	})
 
 	t.Run("wildcards are escaped", func(t *testing.T) {
 		_, args := handleSearchClause("a_b%c")
-		if len(args) != 1 || args[0] != `%a\_b\%c%` {
-			t.Fatalf("args = %v, want [%%a\\_b\\%%c%%]", args)
-		}
+		assertSearchArgs(t, args, `%a\_b\%c%`, `%a\_b\%c%`)
 	})
 
 	t.Run("backslash is escaped before the metacharacters", func(t *testing.T) {
 		_, args := handleSearchClause(`a\b`)
-		if len(args) != 1 || args[0] != `%a\\b%` {
-			t.Fatalf("args = %v, want [%%a\\\\b%%]", args)
-		}
+		assertSearchArgs(t, args, `%a\\b%`, `%a\\b%`)
 	})
 }

--- a/platform-api/resources/openapi.yaml
+++ b/platform-api/resources/openapi.yaml
@@ -8985,7 +8985,7 @@ components:
       in: query
       required: false
       description: >-
-        Case-insensitive substring filter matched against the resource id
+        Case-insensitive substring filter matched against the resource display name and id
         (handle).
       schema:
         type: string


### PR DESCRIPTION
## Goals

Make `query` match the display name shown in the console, without breaking id-based search for CLI/script callers.

Resolves #3367

## Approach

`handleSearchClause` (`internal/repository/pagination.go`) now matches `display_name` OR `handle`, binding the same escaped pattern to both. All four searchable collections — projects, rest-apis, gateways, applications — go through this one helper, so the change is single-point.

The OR group is parenthesized deliberately. `GatewayRepo.ListPaginated` strips the leading `" AND "` and joins the fragment into its own AND-separated condition list; an unparenthesized `a OR b` would bind as `(organization_uuid = ? AND display_name LIKE ?) OR handle LIKE ?` and return gateways from other organizations.

The `query-Q` description in `resources/openapi.yaml` is updated to match, and `api/generated.go` regenerated (doc comments only, no signature change).

**Note**: `api/generated.go` also carries unrelated drift. Earlier spec changes were merged without running `make generate`, so regenerating now emits those alongside the `query-Q` description update. Reviewable on its own as commit <sha>.

## User stories

As a user of the console, I can find a project, API, gateway or application by typing the name I see in the list.

## Documentation

N/A — no documented behaviour changes beyond the `query` parameter description, which is updated in the OpenAPI spec itself.

## Automation tests

- Unit tests
  `internal/repository/pagination_test.go` — `TestHandleSearchClause` extended for the two bound arguments, both matched columns, and an explicit assertion that the fragment stays a single parenthesized group.
- Integration tests
  New `internal/integration/search_test.go` (build tag `integration`) drives `GatewayRepo` and `ProjectRepo` against a real engine with fixtures whose handle is deliberately unrelated to the display name. Covers multi-word and case-varied display-name matches, preserved handle matching, literal treatment of `%`/`_` under `ESCAPE`, list/count parity, and that a search never crosses organizations. Verified failing before the fix and passing after.

## Samples
N/A

## Related PRs
N/A