### PR TITLE
Fix: Generate the API key value when the create request omits it

### DIFF
--- a/docs/rest-apis/platform-api/applications.md
+++ b/docs/rest-apis/platform-api/applications.md
@@ -189,7 +189,7 @@ Required scopes (the token must carry at least one of): `ap:application:read`, `
 |offset|query|integer|false|Zero-based index of the first item to return.|
 |sortBy|query|string|false|Field to sort the collection by. An unrecognized value falls back to the default sort (createdAt).|
 |sortOrder|query|string|false|Sort direction applied to `sortBy`.|
-|query|query|string|false|Case-insensitive substring filter matched against the resource id (handle).|
+|query|query|string|false|Case-insensitive substring filter matched against the resource display name and id (handle).|
 
 #### Detailed descriptions
 

--- a/docs/rest-apis/platform-api/gateways.md
+++ b/docs/rest-apis/platform-api/gateways.md
@@ -209,7 +209,7 @@ Required scopes (the token must carry at least one of): `ap:gateway:read`, `ap:g
 |offset|query|integer|false|Zero-based index of the first item to return.|
 |sortBy|query|string|false|Field to sort the collection by. An unrecognized value falls back to the default sort (createdAt).|
 |sortOrder|query|string|false|Sort direction applied to `sortBy`.|
-|query|query|string|false|Case-insensitive substring filter matched against the resource id (handle).|
+|query|query|string|false|Case-insensitive substring filter matched against the resource display name and id (handle).|
 
 #### Enumerated Values
 

--- a/docs/rest-apis/platform-api/projects.md
+++ b/docs/rest-apis/platform-api/projects.md
@@ -175,7 +175,7 @@ Required scopes (the token must carry at least one of): `ap:project:read`, `ap:p
 |offset|query|integer|false|Zero-based index of the first item to return.|
 |sortBy|query|string|false|Field to sort the collection by. An unrecognized value falls back to the default sort (createdAt).|
 |sortOrder|query|string|false|Sort direction applied to `sortBy`.|
-|query|query|string|false|Case-insensitive substring filter matched against the resource id (handle).|
+|query|query|string|false|Case-insensitive substring filter matched against the resource display name and id (handle).|
 
 #### Enumerated Values
 

--- a/docs/rest-apis/platform-api/rest-apis.md
+++ b/docs/rest-apis/platform-api/rest-apis.md
@@ -41,7 +41,7 @@ Required scopes (the token must carry at least one of): `ap:rest_api:read`, `ap:
 |offset|query|integer|false|Zero-based index of the first item to return.|
 |sortBy|query|string|false|Field to sort the collection by. An unrecognized value falls back to the default sort (createdAt).|
 |sortOrder|query|string|false|Sort direction applied to `sortBy`.|
-|query|query|string|false|Case-insensitive substring filter matched against the resource id (handle).|
+|query|query|string|false|Case-insensitive substring filter matched against the resource display name and id (handle).|
 
 #### Detailed descriptions
 
@@ -1535,7 +1535,8 @@ Required scopes (the token must carry at least one of): `ap:rest_api:api_key:cre
 {
   "status": "success",
   "message": "API key created and broadcasted to gateways successfully",
-  "keyId": "production-key-01"
+  "keyId": "production-key-01",
+  "apiKey": "REDACTED_API_KEY"
 }
 ```
 

--- a/docs/rest-apis/platform-api/rest-apis.md
+++ b/docs/rest-apis/platform-api/rest-apis.md
@@ -1492,11 +1492,12 @@ allows external platforms to inject API keys to hybrid gateways.
 
 > Payload
 
+> `apiKey` is omitted, so the server generates the key value and returns it once in the 201 response.
+
 ```json
 {
   "id": "production-key-01",
   "displayName": "Production API Key",
-  "apiKey": "sk_example_1234567890abcdef",
   "externalRefId": "ext-ref-12345",
   "expiresAt": "2026-12-31T23:59:59Z",
   "expiresIn": {
@@ -1536,7 +1537,7 @@ Required scopes (the token must carry at least one of): `ap:rest_api:api_key:cre
   "status": "success",
   "message": "API key created and broadcasted to gateways successfully",
   "keyId": "production-key-01",
-  "apiKey": "REDACTED_API_KEY"
+  "apiKey": "sk_example_1234567890abcdef"
 }
 ```
 

--- a/docs/rest-apis/platform-api/schemas.md
+++ b/docs/rest-apis/platform-api/schemas.md
@@ -2113,7 +2113,7 @@ Time unit for API key expiration duration
 |---|---|---|---|---|
 |id|string|false|none|Unique identifier for this API key within the API (optional; if omitted,<br>generated from displayName)|
 |displayName|string|true|none|Human-readable name for the API key|
-|apiKey|string|true|none|The plain text API key value that will be hashed before storage|
+|apiKey|string|false|none|Optional. A pre-minted plain text API key to inject (used by external platforms pushing a key to hybrid gateways). Omit it to have the server generate one, the generated value is returned once in the response and is never retrievable afterwards.|
 |externalRefId|string¦null|false|none|Optional reference ID for tracing purposes (from external platforms)|
 |expiresAt|string(date-time)¦null|false|none|Optional expiration time in ISO 8601 format|
 |expiresIn|[ExpirationDuration](#schemaexpirationduration)|false|none|Optional expiration duration|
@@ -2130,7 +2130,8 @@ Time unit for API key expiration duration
 {
   "status": "success",
   "message": "API key created and broadcasted to gateways successfully",
-  "keyId": "production-key-01"
+  "keyId": "production-key-01",
+  "apiKey": "REDACTED_API_KEY"
 }
 
 ```
@@ -2142,6 +2143,7 @@ Time unit for API key expiration duration
 |status|string|true|none|Status of the operation|
 |message|string|true|none|Additional details about the operation result|
 |keyId|string|false|none|The internal ID generated for tracking|
+|apiKey|string|false|none|The generated API key value. Present only when the server generated <br>the key (no `apiKey` in the request); returned only in this <br>creation response and never retrievable afterwards. The example value is<br>a non-functional placeholder.|
 
 ##### Enumerated Values
 

--- a/docs/rest-apis/platform-api/schemas.md
+++ b/docs/rest-apis/platform-api/schemas.md
@@ -2131,7 +2131,7 @@ Time unit for API key expiration duration
   "status": "success",
   "message": "API key created and broadcasted to gateways successfully",
   "keyId": "production-key-01",
-  "apiKey": "REDACTED_API_KEY"
+  "apiKey": "sk_example_1234567890abcdef"
 }
 
 ```

--- a/platform-api/api/generated.go
+++ b/platform-api/api/generated.go
@@ -682,8 +682,8 @@ type CostRateLimitDimension struct {
 
 // CreateAPIKeyRequest defines model for CreateAPIKeyRequest.
 type CreateAPIKeyRequest struct {
-	// ApiKey The plain text API key value that will be hashed before storage
-	ApiKey string `binding:"required" json:"apiKey" yaml:"apiKey"`
+	// ApiKey Optional. A pre-minted plain text API key to inject (used by external platforms pushing a key to hybrid gateways). Omit it to have the server generate one, the generated value is returned once in the response and is never retrievable afterwards.
+	ApiKey string `json:"apiKey,omitempty" yaml:"apiKey,omitempty"`
 
 	// DisplayName Human-readable name for the API key
 	DisplayName string `binding:"required" json:"displayName" yaml:"displayName"`
@@ -705,6 +705,12 @@ type CreateAPIKeyRequest struct {
 
 // CreateAPIKeyResponse defines model for CreateAPIKeyResponse.
 type CreateAPIKeyResponse struct {
+	// ApiKey The generated API key value. Present only when the server generated
+	// the key (no `apiKey` in the request); returned only in this
+	// creation response and never retrievable afterwards. The example value is
+	// a non-functional placeholder.
+	ApiKey *string `json:"apiKey,omitempty" yaml:"apiKey,omitempty"`
+
 	// KeyId The internal ID generated for tracking
 	KeyId *string `json:"keyId,omitempty" yaml:"keyId,omitempty"`
 

--- a/platform-api/api/generated.go
+++ b/platform-api/api/generated.go
@@ -683,7 +683,7 @@ type CostRateLimitDimension struct {
 // CreateAPIKeyRequest defines model for CreateAPIKeyRequest.
 type CreateAPIKeyRequest struct {
 	// ApiKey Optional. A pre-minted plain text API key to inject (used by external platforms pushing a key to hybrid gateways). Omit it to have the server generate one, the generated value is returned once in the response and is never retrievable afterwards.
-	ApiKey string `json:"apiKey,omitempty" yaml:"apiKey,omitempty"`
+	ApiKey *string `json:"apiKey,omitempty" yaml:"apiKey,omitempty"`
 
 	// DisplayName Human-readable name for the API key
 	DisplayName string `binding:"required" json:"displayName" yaml:"displayName"`

--- a/platform-api/internal/handler/api_key.go
+++ b/platform-api/internal/handler/api_key.go
@@ -87,46 +87,26 @@ func (h *APIKeyHandler) CreateAPIKey(w http.ResponseWriter, r *http.Request) err
 			WithLogMessage(fmt.Sprintf("invalid API key creation request for user %s", userId))
 	}
 
-	if req.ApiKey == "" {
-		return apperror.ValidationFailed.New("API key value is required")
-	}
-
-	// If user has provided an id, use it. Otherwise, generate one from the display name.
-	var name string
-	if req.Id != nil && *req.Id != "" {
-		name = *req.Id
-	} else {
-		generatedName, err := utils.GenerateHandle(req.DisplayName, nil)
-		if err != nil {
-			return apperror.ValidationFailed.Wrap(err, "Failed to generate API key name")
-		}
-		name = generatedName
-		req.Id = &name
-	}
-
 	// Create the API key and broadcast to gateways
-	if err := h.apiKeyService.CreateAPIKey(r.Context(), apiHandle, constants.RestApi, orgId, userId, &req); err != nil {
+	resp, err := h.apiKeyService.CreateAPIKey(r.Context(), apiHandle, constants.RestApi, orgId, userId, &req)
+	if err != nil {
 		var appErr *apperror.Error
 		if errors.As(err, &appErr) {
 			return err
 		}
 		return apperror.Internal.Wrap(err).
-			WithLogMessage(fmt.Sprintf("failed to create API key %q for API %s in org %s by user %s", name, apiHandle, orgId, userId))
+			WithLogMessage(fmt.Sprintf("failed to create API key for API %s in org %s by user %s", apiHandle, orgId, userId))
 	}
 
 	keyName := ""
-	if req.Id != nil {
-		keyName = *req.Id
+	if resp.KeyId != nil {
+		keyName = *resp.KeyId
 	}
 	h.slogger.Info("Successfully created API key", "userId", userId, "apiHandle", apiHandle, "orgId", orgId, "keyName", keyName)
 
 	// Return success response
-	setLocation(w, "rest-apis", apiHandle, "api-keys", name)
-	httputil.WriteJSON(w, http.StatusCreated, api.CreateAPIKeyResponse{
-		Status:  api.CreateAPIKeyResponseStatusSuccess,
-		KeyId:   req.Id,
-		Message: "API key created and broadcasted to gateways successfully",
-	})
+	setLocation(w, "rest-apis", apiHandle, "api-keys", keyName)
+	httputil.WriteJSON(w, http.StatusCreated, resp)
 	return nil
 }
 

--- a/platform-api/internal/handler/api_key.go
+++ b/platform-api/internal/handler/api_key.go
@@ -87,6 +87,24 @@ func (h *APIKeyHandler) CreateAPIKey(w http.ResponseWriter, r *http.Request) err
 			WithLogMessage(fmt.Sprintf("invalid API key creation request for user %s", userId))
 	}
 
+	if req.DisplayName == "" {
+		return apperror.ValidationFailed.New("Display name is required").
+			WithLogMessage(fmt.Sprintf("missing display name in API key creation request for user %s", userId))
+	}
+
+	// If user has provided an id, use it. Otherwise, generate one from the display name.
+	var name string
+	if req.Id != nil && *req.Id != "" {
+		name = *req.Id
+	} else {
+		generatedName, err := utils.GenerateHandle(req.DisplayName, nil)
+		if err != nil {
+			return apperror.ValidationFailed.Wrap(err, "Failed to generate API key name")
+		}
+		name = generatedName
+		req.Id = &name
+	}
+
 	// Create the API key and broadcast to gateways
 	resp, err := h.apiKeyService.CreateAPIKey(r.Context(), apiHandle, constants.RestApi, orgId, userId, &req)
 	if err != nil {
@@ -99,8 +117,8 @@ func (h *APIKeyHandler) CreateAPIKey(w http.ResponseWriter, r *http.Request) err
 	}
 
 	keyName := ""
-	if resp.KeyId != nil {
-		keyName = *resp.KeyId
+	if req.Id != nil {
+		keyName = *req.Id
 	}
 	h.slogger.Info("Successfully created API key", "userId", userId, "apiHandle", apiHandle, "orgId", orgId, "keyName", keyName)
 

--- a/platform-api/internal/handler/api_key_integration_test.go
+++ b/platform-api/internal/handler/api_key_integration_test.go
@@ -1,0 +1,246 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+// End-to-end coverage for POST /rest-apis/{restApiId}/api-keys over the real handler,
+// service and SQLite-backed repository stack. The service-level unit tests in
+// internal/service/apikey_create_test.go pin the key-material rules; these pin the things
+// only an HTTP round trip can see — the status code, the JSON wire format, and the
+// Location header.
+
+package handler
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/wso2/api-platform/common/eventhub"
+	"github.com/wso2/api-platform/platform-api/internal/constants"
+	"github.com/wso2/api-platform/platform-api/internal/database"
+	"github.com/wso2/api-platform/platform-api/internal/middleware"
+	"github.com/wso2/api-platform/platform-api/internal/repository"
+	"github.com/wso2/api-platform/platform-api/internal/service"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+const (
+	apiKeyITOrgID     = "org-key-001"
+	apiKeyITProjectID = "proj-key-001"
+	apiKeyITAPIUUID   = "api-key-001"
+	apiKeyITAPIHandle = "petstore"
+	apiKeyITUser      = "sub-key-user"
+)
+
+// hexKeyRegex matches what utils.GenerateAPIKey produces: 32 crypto/rand bytes hex-encoded.
+var hexKeyRegex = regexp.MustCompile(`^[0-9a-f]{64}$`)
+
+// noopEventHub satisfies the GatewayEventsService dependency. The seeded API is associated
+// with no gateway, so nothing is ever published — the key is persisted centrally and any
+// gateway associated later picks it up via the deploy-time backfill.
+type noopEventHub struct{}
+
+func (noopEventHub) Initialize() error                               { return nil }
+func (noopEventHub) RegisterGateway(string) error                    { return nil }
+func (noopEventHub) PublishEvent(string, eventhub.Event) error       { return nil }
+func (noopEventHub) Subscribe(string) (<-chan eventhub.Event, error) { return nil, nil }
+func (noopEventHub) Unsubscribe(string, <-chan eventhub.Event) error { return nil }
+func (noopEventHub) UnsubscribeAll(string) error                     { return nil }
+func (noopEventHub) CleanUpEvents() error                            { return nil }
+func (noopEventHub) Close() error                                    { return nil }
+
+// setupAPIKeyHandlerTestEnv builds the full API key handler stack over a real SQLite
+// database carrying the production schema, with one REST API seeded to hang keys off.
+func setupAPIKeyHandlerTestEnv(t *testing.T) (http.Handler, *database.DB, func()) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "api-key-handler-test.db")
+	sqlDB, err := sql.Open("sqlite3", dbPath+"?_foreign_keys=on")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	db := &database.DB{DB: sqlDB}
+
+	schema, err := os.ReadFile(filepath.Join("..", "database", "schema.sqlite.sql"))
+	if err != nil {
+		t.Fatalf("read schema: %v", err)
+	}
+	if _, err := db.Exec(string(schema)); err != nil {
+		t.Fatalf("apply schema: %v", err)
+	}
+
+	// api_keys.artifact_uuid is a foreign key into artifacts, and the handle is resolved
+	// against rest_apis, so both rows are required for a key to be creatable.
+	seed := []struct {
+		desc  string
+		query string
+		args  []any
+	}{
+		{"organization", `INSERT INTO organizations (uuid, handle, display_name, region, idp_organization_ref_uuid)
+			VALUES (?, 'key-org', 'Key Org', 'default', 'idp-ref')`, []any{apiKeyITOrgID}},
+		{"project", `INSERT INTO projects (uuid, handle, display_name, organization_uuid)
+			VALUES (?, 'default', 'Default', ?)`, []any{apiKeyITProjectID, apiKeyITOrgID}},
+		{"artifact", `INSERT INTO artifacts (uuid, type, organization_uuid) VALUES (?, 'REST_API', ?)`,
+			[]any{apiKeyITAPIUUID, apiKeyITOrgID}},
+		{"rest api", `INSERT INTO rest_apis (uuid, organization_uuid, handle, display_name, version, project_uuid, configuration)
+			VALUES (?, ?, ?, 'Petstore', 'v1.0', ?, '{}')`,
+			[]any{apiKeyITAPIUUID, apiKeyITOrgID, apiKeyITAPIHandle, apiKeyITProjectID}},
+	}
+	for _, s := range seed {
+		if _, err := db.Exec(s.query, s.args...); err != nil {
+			t.Fatalf("seed %s: %v", s.desc, err)
+		}
+	}
+
+	registry := repository.NewArtifactTableRegistry()
+	identityService := service.NewIdentityService(repository.NewUserIdentityMappingRepo(db))
+	apiKeyService := service.NewAPIKeyService(
+		repository.NewAPIRepo(db),
+		repository.NewArtifactRepo(db, registry),
+		repository.NewAPIKeyRepo(db, registry),
+		service.NewGatewayEventsService(noopEventHub{}, identityService, slog.Default()),
+		noopAudit{},
+		nil, // hashingAlgorithms — defaults to [sha256]
+		slog.Default(),
+	)
+
+	mux := http.NewServeMux()
+	NewAPIKeyHandler(apiKeyService, identityService, middleware.ValidationModeScope, slog.Default()).
+		RegisterRoutes(mux)
+
+	return middleware.NewTestContextMiddleware(mux), db, func() { sqlDB.Close() }
+}
+
+// postAPIKey issues the create request with the org/user context the auth middleware would
+// otherwise have populated from a verified token.
+func postAPIKey(t *testing.T, r http.Handler, body string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost,
+		constants.APIBasePath+"/rest-apis/"+apiKeyITAPIHandle+"/api-keys", bytes.NewReader([]byte(body)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Test-Org", apiKeyITOrgID)
+	req.Header.Set("X-Test-User", apiKeyITUser)
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestAPIKeyHandler_CreateWithoutSuppliedValue is the end-to-end reproduction from
+// https://github.com/wso2/api-platform/issues/3252. The exact body below used to come back
+// 400 {"code":"VALIDATION_FAILED","message":"API key value is required"}.
+func TestAPIKeyHandler_CreateWithoutSuppliedValue(t *testing.T) {
+	r, db, cleanup := setupAPIKeyHandlerTestEnv(t)
+	t.Cleanup(cleanup)
+
+	rec := postAPIKey(t, r, `{"displayName": "api-key-1-test"}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Decoded into a map, not the typed response, so an absent field is distinguishable
+	// from a zero value.
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	apiKey, ok := body["apiKey"].(string)
+	if !ok {
+		t.Fatalf("response carried no apiKey; the generated key is unrecoverable after this response: %s", rec.Body.String())
+	}
+	if !hexKeyRegex.MatchString(apiKey) {
+		t.Errorf("generated key %q is not 64 lowercase hex characters", apiKey)
+	}
+
+	keyID, ok := body["keyId"].(string)
+	if !ok || keyID == "" {
+		t.Fatalf("response carried no keyId: %s", rec.Body.String())
+	}
+	if want := constants.APIBasePath + "/rest-apis/" + apiKeyITAPIHandle + "/api-keys/" + keyID; rec.Header().Get("Location") != want {
+		t.Errorf("Location = %q, want %q", rec.Header().Get("Location"), want)
+	}
+
+	// The row must hold a hash and a mask, never the plaintext.
+	var masked, hashes string
+	if err := db.QueryRow(`SELECT masked_api_key, api_key_hashes FROM api_keys WHERE artifact_uuid = ? AND handle = ?`,
+		apiKeyITAPIUUID, keyID).Scan(&masked, &hashes); err != nil {
+		t.Fatalf("persisted key not found for handle %q: %v", keyID, err)
+	}
+	if masked != "***"+apiKey[len(apiKey)-5:] {
+		t.Errorf("persisted masked key = %q, does not mask the returned key", masked)
+	}
+	if hashes == "" || masked == apiKey {
+		t.Error("plaintext key material leaked into a persisted column")
+	}
+}
+
+// TestAPIKeyHandler_CreateWithSuppliedValueOmitsApiKey covers the inject path. The response
+// must not carry the field at all — `omitempty` on the generated struct is what keeps a
+// caller's own secret from being echoed back, so assert absence rather than emptiness.
+func TestAPIKeyHandler_CreateWithSuppliedValueOmitsApiKey(t *testing.T) {
+	r, _, cleanup := setupAPIKeyHandlerTestEnv(t)
+	t.Cleanup(cleanup)
+
+	rec := postAPIKey(t, r, `{"displayName": "Injected Key", "apiKey": "sk_example_1234567890abcdef"}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if _, present := body["apiKey"]; present {
+		t.Errorf("response echoed a caller-supplied key: %s", rec.Body.String())
+	}
+}
+
+// TestAPIKeyHandler_CreateWithEmptyBody covers a body carrying neither id nor displayName.
+// The handlers used to pre-derive the name via utils.GenerateHandle, which errors on an
+// empty source, so this returned 400 — even though nothing enforces displayName at runtime.
+// Naming now belongs to the service, which falls back to "<handle>-key-<8 hex>".
+func TestAPIKeyHandler_CreateWithEmptyBody(t *testing.T) {
+	r, _, cleanup := setupAPIKeyHandlerTestEnv(t)
+	t.Cleanup(cleanup)
+
+	rec := postAPIKey(t, r, `{}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	keyID, _ := body["keyId"].(string)
+	if want := regexp.MustCompile(`^` + apiKeyITAPIHandle + `-key-[0-9a-f]{8}$`); !want.MatchString(keyID) {
+		t.Errorf("derived keyId = %q, want the <handle>-key-<8 hex> fallback shape", keyID)
+	}
+	if _, ok := body["apiKey"].(string); !ok {
+		t.Errorf("response carried no generated apiKey: %s", rec.Body.String())
+	}
+}

--- a/platform-api/internal/handler/api_key_integration_test.go
+++ b/platform-api/internal/handler/api_key_integration_test.go
@@ -219,6 +219,48 @@ func TestAPIKeyHandler_CreateWithSuppliedValueOmitsApiKey(t *testing.T) {
 	}
 }
 
+// Blank apiKey values are client errors and should return 400, not 500.
+func TestAPIKeyHandler_CreateWithBlankSuppliedValue(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{name: "empty string", body: `{"displayName": "Blank Key", "apiKey": ""}`},
+		{name: "whitespace only", body: `{"displayName": "Blank Key", "apiKey": "   "}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r, db, cleanup := setupAPIKeyHandlerTestEnv(t)
+			t.Cleanup(cleanup)
+
+			rec := postAPIKey(t, r, tc.body)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+			}
+
+			var body map[string]any
+			if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if code, _ := body["code"].(string); code != "VALIDATION_FAILED" {
+				t.Errorf("error code = %q, want VALIDATION_FAILED: %s", code, rec.Body.String())
+			}
+			// A 4xx is a client outcome, so no tracking ID is exposed — its presence is the
+			// tell that the error was flattened into a 500 again.
+			if _, present := body["trackingId"]; present {
+				t.Errorf("response carried a trackingId, so this was served as a server fault: %s", rec.Body.String())
+			}
+
+			var count int
+			if err := db.QueryRow(`SELECT COUNT(*) FROM api_keys WHERE artifact_uuid = ?`, apiKeyITAPIUUID).Scan(&count); err != nil {
+				t.Fatalf("count persisted keys: %v", err)
+			}
+			if count != 0 {
+				t.Errorf("persisted %d key(s) despite the rejected request", count)
+			}
+		})
+	}
+}
+
 // TestAPIKeyHandler_CreateWithEmptyBody covers a body carrying neither id nor displayName.
 // displayName is required by the spec, and the handler enforces it explicitly rather than
 // leaning on the binding tag, so the caller gets a named validation failure instead of a key

--- a/platform-api/internal/handler/api_key_integration_test.go
+++ b/platform-api/internal/handler/api_key_integration_test.go
@@ -220,27 +220,34 @@ func TestAPIKeyHandler_CreateWithSuppliedValueOmitsApiKey(t *testing.T) {
 }
 
 // TestAPIKeyHandler_CreateWithEmptyBody covers a body carrying neither id nor displayName.
-// The handlers used to pre-derive the name via utils.GenerateHandle, which errors on an
-// empty source, so this returned 400 — even though nothing enforces displayName at runtime.
-// Naming now belongs to the service, which falls back to "<handle>-key-<8 hex>".
+// displayName is required by the spec, and the handler enforces it explicitly rather than
+// leaning on the binding tag, so the caller gets a named validation failure instead of a key
+// whose name the server picked for it. The service-level fallback that derives
+// "<handle>-key-<8 hex>" stays for the non-REST callers (see
+// internal/service/apikey_create_test.go), and is deliberately not reachable from here.
 func TestAPIKeyHandler_CreateWithEmptyBody(t *testing.T) {
-	r, _, cleanup := setupAPIKeyHandlerTestEnv(t)
+	r, db, cleanup := setupAPIKeyHandlerTestEnv(t)
 	t.Cleanup(cleanup)
 
 	rec := postAPIKey(t, r, `{}`)
-	if rec.Code != http.StatusCreated {
-		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
 	}
 
 	var body map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	keyID, _ := body["keyId"].(string)
-	if want := regexp.MustCompile(`^` + apiKeyITAPIHandle + `-key-[0-9a-f]{8}$`); !want.MatchString(keyID) {
-		t.Errorf("derived keyId = %q, want the <handle>-key-<8 hex> fallback shape", keyID)
+	if code, _ := body["code"].(string); code != "VALIDATION_FAILED" {
+		t.Errorf("error code = %q, want VALIDATION_FAILED: %s", code, rec.Body.String())
 	}
-	if _, ok := body["apiKey"].(string); !ok {
-		t.Errorf("response carried no generated apiKey: %s", rec.Body.String())
+	// A rejected request must not have cost a row — the name is resolved before any key
+	// material is minted, so a 400 here means nothing was persisted.
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM api_keys WHERE artifact_uuid = ?`, apiKeyITAPIUUID).Scan(&count); err != nil {
+		t.Fatalf("count persisted keys: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("persisted %d key(s) despite the rejected request", count)
 	}
 }

--- a/platform-api/internal/service/apikey.go
+++ b/platform-api/internal/service/apikey.go
@@ -441,17 +441,17 @@ func BackfillAPIKeysToGateway(apiKeyRepo repository.APIKeyRepository, gatewayRep
 
 // CreateAPIKey hashes an external API key and broadcasts it to gateways where the API is deployed.
 // This method is used when external platforms inject API keys to hybrid gateways.
-func (s *APIKeyService) CreateAPIKey(ctx context.Context, apiHandle, kind, orgId, userId string, req *api.CreateAPIKeyRequest) error {
+func (s *APIKeyService) CreateAPIKey(ctx context.Context, apiHandle, kind, orgId, userId string, req *api.CreateAPIKeyRequest) (*api.CreateAPIKeyResponse, error) {
 	// Resolve API handle to UUID within the artifact table backing kind, so a handle shared across
 	// kinds resolves to exactly one artifact.
 	apiMetadata, err := s.artifactRepo.GetAPIMetadataByHandleAndKind(apiHandle, kind, orgId)
 	if err != nil {
 		s.slogger.Error("Failed to get API metadata for API key creation", "apiHandle", apiHandle, "kind", kind, "error", err)
-		return fmt.Errorf("failed to get API by handle: %w", err)
+		return nil, fmt.Errorf("failed to get API by handle: %w", err)
 	}
 	if apiMetadata == nil {
 		s.slogger.Warn("API not found by handle", "apiHandle", apiHandle, "orgId", orgId)
-		return apperror.ArtifactNotFound.New()
+		return nil, apperror.ArtifactNotFound.New()
 	}
 	apiId := apiMetadata.ID
 
@@ -460,34 +460,51 @@ func (s *APIKeyService) CreateAPIKey(ctx context.Context, apiHandle, kind, orgId
 	// associated later picks it up via deployment-time sync.
 	gateways, err := s.apiRepo.GetAPIGatewaysWithDetails(apiId, orgId)
 	if err != nil {
-		return fmt.Errorf("failed to get API deployments for API handle: %s: %w", apiHandle, err)
+		return nil, fmt.Errorf("failed to get API deployments for API handle: %s: %w", apiHandle, err)
 	}
 
 	// Resolve key name (required for DB uniqueness; derive from request or generate)
 	keyName, err := s.resolveUniqueKeyName(apiId, req, apiHandle)
 	if err != nil {
 		s.slogger.Error("Failed to resolve API key name", "apiHandle", apiHandle, "error", err)
-		return fmt.Errorf("failed to resolve API key name: %w", err)
+		return nil, fmt.Errorf("failed to resolve API key name: %w", err)
 	}
 
-	// Hash the API key with all configured algorithms before storage and broadcast
-	apiKeyHashesJSON, err := buildAPIKeyHashesJSON(req.ApiKey, s.hashingAlgorithms)
-	if err != nil {
-		s.slogger.Error("Failed to hash API key", "apiHandle", apiHandle, "keyName", keyName, "error", err)
-		return fmt.Errorf("failed to hash API key: %w", err)
-	}
-
-	// Persist the API key to the database before broadcasting
-	maskedAPIKey := maskAPIKey(req.ApiKey)
 	expiresAt, err := resolveExpiresAt(req.ExpiresAt, req.ExpiresIn)
 	if err != nil {
 		s.slogger.Error("Invalid expiration for API key creation", "apiHandle", apiHandle, "keyName", keyName, "error", err)
-		return fmt.Errorf("invalid expiration: %w", err)
+		return nil, fmt.Errorf("invalid expiration: %w", err)
 	}
+
+	// A caller-supplied key is injected as-is (external platforms pushing an
+	// already-minted key to hybrid gateways). When absent, generate one with the
+	// same primitive the LLM proxy/provider key paths use; utils.GenerateAPIKey,
+	// 32 crypto/rand bytes hex-encoded.
+	plainAPIKey := strings.TrimSpace(req.ApiKey)
+	generated := false
+	if plainAPIKey == "" {
+		plainAPIKey, err = utils.GenerateAPIKey()
+		if err != nil {
+			s.slogger.Error("Failed to generate API key", "apiHandle", apiHandle, "keyName", keyName, "error", err)
+			return nil, fmt.Errorf("failed to generate API key: %w", err)
+		}
+		generated = true
+	}
+
+	// Hash the API key with all configured algorithms before storage and broadcast
+	apiKeyHashesJSON, err := buildAPIKeyHashesJSON(plainAPIKey, s.hashingAlgorithms)
+	if err != nil {
+		s.slogger.Error("Failed to hash API key", "apiHandle", apiHandle, "keyName", keyName, "error", err)
+		return nil, fmt.Errorf("failed to hash API key: %w", err)
+	}
+
+	// Persist the API key to the database before broadcasting
+	maskedAPIKey := maskAPIKey(plainAPIKey)
+
 	apiKeyUUID, err := utils.GenerateUUID()
 	if err != nil {
 		s.slogger.Error("Failed to generate UUID for API key", "apiHandle", apiHandle, "keyName", keyName, "error", err)
-		return fmt.Errorf("failed to generate API key UUID: %w", err)
+		return nil, fmt.Errorf("failed to generate API key UUID: %w", err)
 	}
 
 	// Apply defaults for issuer and allowedTargets
@@ -519,7 +536,7 @@ func (s *APIKeyService) CreateAPIKey(ctx context.Context, apiHandle, kind, orgId
 	}
 	if err := s.apiKeyRepo.Create(dbKey); err != nil {
 		s.slogger.Error("Failed to persist API key to database", "apiHandle", apiHandle, "keyName", keyName, "error", err)
-		return fmt.Errorf("failed to persist API key: %w", err)
+		return nil, fmt.Errorf("failed to persist API key: %w", err)
 	}
 	_ = s.auditRepo.Record("CREATE", apiKeyUUID, "api_key", orgId, userId)
 
@@ -549,7 +566,16 @@ func (s *APIKeyService) CreateAPIKey(ctx context.Context, apiHandle, kind, orgId
 		s.slogger.Warn("Failed to broadcast API key created event to some gateways", "apiHandle", apiHandle, "keyName", keyName, "failed", failureCount, "lastError", lastError)
 	}
 
-	return nil
+	resp := &api.CreateAPIKeyResponse{
+		Status:  api.CreateAPIKeyResponseStatusSuccess,
+		KeyId:   &keyName,
+		Message: "API key created and broadcasted to gateways successfully",
+	}
+
+	if generated {
+		resp.ApiKey = &plainAPIKey
+	}
+	return resp, nil
 }
 
 // UpdateAPIKey updates/regenerates an API key and broadcasts it to all gateways where the API is deployed.

--- a/platform-api/internal/service/apikey.go
+++ b/platform-api/internal/service/apikey.go
@@ -492,9 +492,11 @@ func (s *APIKeyService) CreateAPIKey(ctx context.Context, apiHandle, kind, orgId
 		}
 		generated = true
 	} else {
+		// Blank is a caller mistake; return a validation error instead of a 500.
 		plainAPIKey = strings.TrimSpace(*req.ApiKey)
 		if plainAPIKey == "" {
-			return nil, fmt.Errorf("provided API key cannot be empty")
+			return nil, apperror.ValidationFailed.New("API key value cannot be empty. Omit the apiKey field to have one generated.").
+				WithLogMessage(fmt.Sprintf("blank apiKey supplied for API key creation on API %s in org %s", apiHandle, orgId))
 		}
 	}
 

--- a/platform-api/internal/service/apikey.go
+++ b/platform-api/internal/service/apikey.go
@@ -480,15 +480,22 @@ func (s *APIKeyService) CreateAPIKey(ctx context.Context, apiHandle, kind, orgId
 	// already-minted key to hybrid gateways). When absent, generate one with the
 	// same primitive the LLM proxy/provider key paths use; utils.GenerateAPIKey,
 	// 32 crypto/rand bytes hex-encoded.
-	plainAPIKey := strings.TrimSpace(req.ApiKey)
+	var plainAPIKey string
 	generated := false
-	if plainAPIKey == "" {
+
+	if req.ApiKey == nil {
+		var err error
 		plainAPIKey, err = utils.GenerateAPIKey()
 		if err != nil {
 			s.slogger.Error("Failed to generate API key", "apiHandle", apiHandle, "keyName", keyName, "error", err)
 			return nil, fmt.Errorf("failed to generate API key: %w", err)
 		}
 		generated = true
+	} else {
+		plainAPIKey = strings.TrimSpace(*req.ApiKey)
+		if plainAPIKey == "" {
+			return nil, fmt.Errorf("provided API key cannot be empty")
+		}
 	}
 
 	// Hash the API key with all configured algorithms before storage and broadcast

--- a/platform-api/internal/service/apikey_create_test.go
+++ b/platform-api/internal/service/apikey_create_test.go
@@ -1,0 +1,279 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package service
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wso2/api-platform/platform-api/api"
+	"github.com/wso2/api-platform/platform-api/internal/constants"
+	"github.com/wso2/api-platform/platform-api/internal/model"
+	"github.com/wso2/api-platform/platform-api/internal/repository"
+)
+
+const (
+	testAPIHandle = "petstore"
+	testAPIUUID   = "api-uuid-1"
+	testOrgID     = "org-1"
+	testUserID    = "user-1"
+)
+
+// generatedKeyRegex matches the key material utils.GenerateAPIKey produces:
+// 32 crypto/rand bytes hex-encoded, i.e. exactly 64 lowercase hex characters.
+var generatedKeyRegex = regexp.MustCompile(`^[0-9a-f]{64}$`)
+
+// stubCreateArtifactRepo resolves any handle/kind to one fixed API.
+type stubCreateArtifactRepo struct {
+	repository.ArtifactRepository
+	meta *model.APIMetadata
+}
+
+func (r *stubCreateArtifactRepo) GetAPIMetadataByHandleAndKind(handle, kind, orgUUID string) (*model.APIMetadata, error) {
+	return r.meta, nil
+}
+
+// stubCreateAPIRepo reports no gateway associations, which is a valid state: the key is
+// still persisted and any gateway associated later picks it up via the deploy-time backfill.
+type stubCreateAPIRepo struct {
+	repository.APIRepository
+}
+
+func (r *stubCreateAPIRepo) GetAPIGatewaysWithDetails(apiUUID, orgUUID string) ([]*model.APIGatewayWithDetails, error) {
+	return nil, nil
+}
+
+// recordingAPIKeyRepo captures what Create persisted and lets a test pre-seed names so the
+// collision-retry path in resolveUniqueKeyName can be exercised.
+type recordingAPIKeyRepo struct {
+	repository.APIKeyRepository
+	existing map[string]*model.APIKey
+	created  []*model.APIKey
+}
+
+func (r *recordingAPIKeyRepo) Create(key *model.APIKey) error {
+	r.created = append(r.created, key)
+	return nil
+}
+
+func (r *recordingAPIKeyRepo) GetByArtifactAndName(artifactUUID, name string) (*model.APIKey, error) {
+	return r.existing[name], nil
+}
+
+type stubCreateAuditRepo struct {
+	repository.AuditRepository
+}
+
+func (stubCreateAuditRepo) Record(action, resourceUUID, resourceType, orgUUID, performedBy string) error {
+	return nil
+}
+
+// newCreateAPIKeyTestService wires an APIKeyService against in-memory stubs and returns it
+// alongside the key repo, so a test can assert on what was actually persisted.
+func newCreateAPIKeyTestService(t *testing.T, existing map[string]*model.APIKey) (*APIKeyService, *recordingAPIKeyRepo) {
+	t.Helper()
+
+	if existing == nil {
+		existing = map[string]*model.APIKey{}
+	}
+	keyRepo := &recordingAPIKeyRepo{existing: existing}
+
+	svc := NewAPIKeyService(
+		&stubCreateAPIRepo{},
+		&stubCreateArtifactRepo{meta: &model.APIMetadata{
+			ID:             testAPIUUID,
+			Handle:         testAPIHandle,
+			Kind:           constants.RestApi,
+			OrganizationID: testOrgID,
+		}},
+		keyRepo,
+		NewGatewayEventsService(&capturingEventHub{}, newTestIdentityService(), newTestLogger()),
+		stubCreateAuditRepo{},
+		nil, // defaults to [sha256]
+		newTestLogger(),
+	)
+	return svc, keyRepo
+}
+
+// sha256Hex is an independent hash implementation, so the assertions below verify the stored
+// digest rather than re-deriving it through the same helper the service used.
+func sha256Hex(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
+
+// assertPersistedKeyMaterial checks the single persisted record hashes and masks plainKey.
+func assertPersistedKeyMaterial(t *testing.T, keyRepo *recordingAPIKeyRepo, plainKey string) *model.APIKey {
+	t.Helper()
+
+	if len(keyRepo.created) != 1 {
+		t.Fatalf("expected exactly 1 persisted API key, got %d", len(keyRepo.created))
+	}
+	dbKey := keyRepo.created[0]
+
+	wantHash := sha256Hex(plainKey)
+	if !strings.Contains(dbKey.APIKeyHashes, wantHash) {
+		t.Errorf("persisted hashes %q do not contain the sha256 of the key material", dbKey.APIKeyHashes)
+	}
+	if wantMasked := maskAPIKey(plainKey); dbKey.MaskedAPIKey != wantMasked {
+		t.Errorf("persisted masked key = %q, want %q", dbKey.MaskedAPIKey, wantMasked)
+	}
+	if strings.Contains(dbKey.APIKeyHashes, plainKey) || dbKey.MaskedAPIKey == plainKey {
+		t.Error("plaintext key material leaked into a persisted field")
+	}
+	if dbKey.Status != constants.APIKeyStatusActive {
+		t.Errorf("persisted status = %q, want %q", dbKey.Status, constants.APIKeyStatusActive)
+	}
+	return dbKey
+}
+
+// TestCreateAPIKey_GeneratesKeyWhenOmitted is the regression for
+// https://github.com/wso2/api-platform/issues/3252: omitting apiKey used to be rejected with
+// "API key value is required". The server now mints one with the same primitive the LLM
+// proxy/provider key paths use, persists only its hash, and returns the plaintext once.
+func TestCreateAPIKey_GeneratesKeyWhenOmitted(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		supplied string
+	}{
+		{name: "absent", supplied: ""},
+		{name: "whitespace only", supplied: "   "},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			svc, keyRepo := newCreateAPIKeyTestService(t, nil)
+
+			resp, err := svc.CreateAPIKey(context.Background(), testAPIHandle, constants.RestApi, testOrgID, testUserID,
+				&api.CreateAPIKeyRequest{DisplayName: "Production Key", ApiKey: tc.supplied})
+			if err != nil {
+				t.Fatalf("CreateAPIKey returned an unexpected error: %v", err)
+			}
+
+			if resp.ApiKey == nil {
+				t.Fatal("response omitted apiKey, but the server generated the key — it is unrecoverable after this response")
+			}
+			if !generatedKeyRegex.MatchString(*resp.ApiKey) {
+				t.Errorf("generated key %q is not 64 lowercase hex characters", *resp.ApiKey)
+			}
+			assertPersistedKeyMaterial(t, keyRepo, *resp.ApiKey)
+		})
+	}
+}
+
+// TestCreateAPIKey_UsesSuppliedKeyAndNeverEchoesIt covers the inject path external platforms
+// use. The supplied value must be what gets hashed, and must NOT come back in the response —
+// echoing a caller's secret adds a disclosure surface for no benefit.
+func TestCreateAPIKey_UsesSuppliedKeyAndNeverEchoesIt(t *testing.T) {
+	const injected = "sk_example_1234567890abcdef"
+
+	svc, keyRepo := newCreateAPIKeyTestService(t, nil)
+
+	resp, err := svc.CreateAPIKey(context.Background(), testAPIHandle, constants.RestApi, testOrgID, testUserID,
+		&api.CreateAPIKeyRequest{DisplayName: "Injected Key", ApiKey: injected})
+	if err != nil {
+		t.Fatalf("CreateAPIKey returned an unexpected error: %v", err)
+	}
+
+	if resp.ApiKey != nil {
+		t.Errorf("response echoed a caller-supplied key (%q); it must be returned only when the server generated it", *resp.ApiKey)
+	}
+	assertPersistedKeyMaterial(t, keyRepo, injected)
+}
+
+// TestCreateAPIKey_DerivesNameWhenIdAndDisplayNameOmitted covers the fallback branch in
+// resolveUniqueKeyName. The handlers used to pre-derive the name via utils.GenerateHandle,
+// which errors on an empty source — so a body carrying neither id nor displayName returned
+// 400 even though nothing enforces displayName at runtime. Naming now belongs to the service.
+func TestCreateAPIKey_DerivesNameWhenIdAndDisplayNameOmitted(t *testing.T) {
+	svc, keyRepo := newCreateAPIKeyTestService(t, nil)
+
+	resp, err := svc.CreateAPIKey(context.Background(), testAPIHandle, constants.RestApi, testOrgID, testUserID,
+		&api.CreateAPIKeyRequest{})
+	if err != nil {
+		t.Fatalf("CreateAPIKey returned an unexpected error for a body with neither id nor displayName: %v", err)
+	}
+
+	if resp.KeyId == nil {
+		t.Fatal("response omitted keyId")
+	}
+	if want := regexp.MustCompile(`^` + testAPIHandle + `-key-[0-9a-f]{8}$`); !want.MatchString(*resp.KeyId) {
+		t.Errorf("derived key name = %q, want the <handle>-key-<8 hex> fallback shape", *resp.KeyId)
+	}
+
+	dbKey := assertPersistedKeyMaterial(t, keyRepo, *resp.ApiKey)
+	if dbKey.DisplayName != *resp.KeyId {
+		t.Errorf("persisted displayName = %q, want it to default to the derived name %q", dbKey.DisplayName, *resp.KeyId)
+	}
+}
+
+// TestCreateAPIKey_KeyIdReflectsCollisionSuffix pins the response to the name actually
+// persisted. resolveUniqueKeyName appends a random suffix on collision, so a caller that
+// echoed back its own requested id would be pointed at a key that does not exist.
+func TestCreateAPIKey_KeyIdReflectsCollisionSuffix(t *testing.T) {
+	const requested = "production-key"
+
+	svc, keyRepo := newCreateAPIKeyTestService(t, map[string]*model.APIKey{
+		requested: {UUID: "existing", ArtifactUUID: testAPIUUID, Name: requested},
+	})
+
+	id := requested
+	resp, err := svc.CreateAPIKey(context.Background(), testAPIHandle, constants.RestApi, testOrgID, testUserID,
+		&api.CreateAPIKeyRequest{Id: &id, DisplayName: "Production Key"})
+	if err != nil {
+		t.Fatalf("CreateAPIKey returned an unexpected error: %v", err)
+	}
+
+	if resp.KeyId == nil {
+		t.Fatal("response omitted keyId")
+	}
+	if *resp.KeyId == requested {
+		t.Fatalf("keyId = %q, but that name was already taken — expected a suffixed name", requested)
+	}
+	if want := regexp.MustCompile(`^` + requested + `-[0-9a-f]{4}$`); !want.MatchString(*resp.KeyId) {
+		t.Errorf("keyId = %q, want %q plus a 4-hex collision suffix", *resp.KeyId, requested)
+	}
+
+	dbKey := assertPersistedKeyMaterial(t, keyRepo, *resp.ApiKey)
+	if dbKey.Name != *resp.KeyId {
+		t.Errorf("keyId %q does not match the persisted name %q", *resp.KeyId, dbKey.Name)
+	}
+}
+
+// TestCreateAPIKey_RejectsPastExpiryBeforeMintingKey asserts an already-expired request is
+// turned away, and that nothing was persisted — an invalid request must not cost key
+// generation or hashing work, which is why resolveExpiresAt runs first.
+func TestCreateAPIKey_RejectsPastExpiryBeforeMintingKey(t *testing.T) {
+	svc, keyRepo := newCreateAPIKeyTestService(t, nil)
+
+	past := time.Now().Add(-time.Hour)
+	resp, err := svc.CreateAPIKey(context.Background(), testAPIHandle, constants.RestApi, testOrgID, testUserID,
+		&api.CreateAPIKeyRequest{DisplayName: "Expired Key", ExpiresAt: &past})
+	if err == nil {
+		t.Fatal("CreateAPIKey accepted an expiration in the past")
+	}
+	if resp != nil {
+		t.Errorf("expected a nil response alongside the error, got %+v", resp)
+	}
+	if len(keyRepo.created) != 0 {
+		t.Errorf("persisted %d key(s) despite the invalid expiration", len(keyRepo.created))
+	}
+}

--- a/platform-api/internal/service/apikey_create_test.go
+++ b/platform-api/internal/service/apikey_create_test.go
@@ -151,30 +151,54 @@ func assertPersistedKeyMaterial(t *testing.T, keyRepo *recordingAPIKeyRepo, plai
 // https://github.com/wso2/api-platform/issues/3252: omitting apiKey used to be rejected with
 // "API key value is required". The server now mints one with the same primitive the LLM
 // proxy/provider key paths use, persists only its hash, and returns the plaintext once.
+// Omission is a nil ApiKey — the field is a *string precisely so "not supplied" stays
+// distinguishable from "supplied as blank", which directive-wise is a caller error
+// (see TestCreateAPIKey_RejectsBlankSuppliedKey) rather than a request to generate.
 func TestCreateAPIKey_GeneratesKeyWhenOmitted(t *testing.T) {
+	svc, keyRepo := newCreateAPIKeyTestService(t, nil)
+
+	resp, err := svc.CreateAPIKey(context.Background(), testAPIHandle, constants.RestApi, testOrgID, testUserID,
+		&api.CreateAPIKeyRequest{DisplayName: "Production Key"})
+	if err != nil {
+		t.Fatalf("CreateAPIKey returned an unexpected error: %v", err)
+	}
+
+	if resp.ApiKey == nil {
+		t.Fatal("response omitted apiKey, but the server generated the key — it is unrecoverable after this response")
+	}
+	if !generatedKeyRegex.MatchString(*resp.ApiKey) {
+		t.Errorf("generated key %q is not 64 lowercase hex characters", *resp.ApiKey)
+	}
+	assertPersistedKeyMaterial(t, keyRepo, *resp.ApiKey)
+}
+
+// TestCreateAPIKey_RejectsBlankSuppliedKey covers the other half of the pointer contract: a
+// caller that sent the field but left it blank is turned away rather than silently having a
+// key minted for it, so an integration pushing an empty variable finds out instead of ending
+// up with a key value it never chose. Nothing may be persisted on that path.
+func TestCreateAPIKey_RejectsBlankSuppliedKey(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
 		supplied string
 	}{
-		{name: "absent", supplied: ""},
+		{name: "empty string", supplied: ""},
 		{name: "whitespace only", supplied: "   "},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			svc, keyRepo := newCreateAPIKeyTestService(t, nil)
 
+			supplied := tc.supplied
 			resp, err := svc.CreateAPIKey(context.Background(), testAPIHandle, constants.RestApi, testOrgID, testUserID,
-				&api.CreateAPIKeyRequest{DisplayName: "Production Key", ApiKey: tc.supplied})
-			if err != nil {
-				t.Fatalf("CreateAPIKey returned an unexpected error: %v", err)
+				&api.CreateAPIKeyRequest{DisplayName: "Production Key", ApiKey: &supplied})
+			if err == nil {
+				t.Fatalf("CreateAPIKey accepted a blank supplied apiKey (%q)", tc.supplied)
 			}
-
-			if resp.ApiKey == nil {
-				t.Fatal("response omitted apiKey, but the server generated the key — it is unrecoverable after this response")
+			if resp != nil {
+				t.Errorf("expected a nil response alongside the error, got %+v", resp)
 			}
-			if !generatedKeyRegex.MatchString(*resp.ApiKey) {
-				t.Errorf("generated key %q is not 64 lowercase hex characters", *resp.ApiKey)
+			if len(keyRepo.created) != 0 {
+				t.Errorf("persisted %d key(s) despite the blank supplied apiKey", len(keyRepo.created))
 			}
-			assertPersistedKeyMaterial(t, keyRepo, *resp.ApiKey)
 		})
 	}
 }
@@ -183,12 +207,12 @@ func TestCreateAPIKey_GeneratesKeyWhenOmitted(t *testing.T) {
 // use. The supplied value must be what gets hashed, and must NOT come back in the response —
 // echoing a caller's secret adds a disclosure surface for no benefit.
 func TestCreateAPIKey_UsesSuppliedKeyAndNeverEchoesIt(t *testing.T) {
-	const injected = "sk_example_1234567890abcdef"
+	injected := "sk_example_1234567890abcdef"
 
 	svc, keyRepo := newCreateAPIKeyTestService(t, nil)
 
 	resp, err := svc.CreateAPIKey(context.Background(), testAPIHandle, constants.RestApi, testOrgID, testUserID,
-		&api.CreateAPIKeyRequest{DisplayName: "Injected Key", ApiKey: injected})
+		&api.CreateAPIKeyRequest{DisplayName: "Injected Key", ApiKey: &injected})
 	if err != nil {
 		t.Fatalf("CreateAPIKey returned an unexpected error: %v", err)
 	}
@@ -200,9 +224,10 @@ func TestCreateAPIKey_UsesSuppliedKeyAndNeverEchoesIt(t *testing.T) {
 }
 
 // TestCreateAPIKey_DerivesNameWhenIdAndDisplayNameOmitted covers the fallback branch in
-// resolveUniqueKeyName. The handlers used to pre-derive the name via utils.GenerateHandle,
-// which errors on an empty source — so a body carrying neither id nor displayName returned
-// 400 even though nothing enforces displayName at runtime. Naming now belongs to the service.
+// resolveUniqueKeyName. The REST handlers reject a body with no displayName up front, but the
+// service is reached by callers that don't go through them (the API Portal webhook receiver,
+// deploy-time backfill), so the fallback is what keeps a nameless request from failing on the
+// api_keys name uniqueness constraint instead of getting "<handle>-key-<8 hex>".
 func TestCreateAPIKey_DerivesNameWhenIdAndDisplayNameOmitted(t *testing.T) {
 	svc, keyRepo := newCreateAPIKeyTestService(t, nil)
 

--- a/platform-api/internal/webhook/handlers_apikey.go
+++ b/platform-api/internal/webhook/handlers_apikey.go
@@ -180,7 +180,7 @@ func (r *Receiver) handleAPIKeyGenerated(ctx context.Context, env *Envelope) err
 		ExpiresAt:     expiresAt,
 	}
 	// userID is empty: webhook events are system-originated, not tied to an interactive user.
-	if err := r.apiKeys.CreateAPIKey(ctx, d.API.RefID, d.API.kind(), env.OrgID, "", req); err != nil {
+	if _, err := r.apiKeys.CreateAPIKey(ctx, d.API.RefID, d.API.kind(), env.OrgID, "", req); err != nil {
 		// Domain-level idempotency: a key already injected under this (api, handle) means a prior
 		// delivery succeeded. The underlying Create surfaces a raw unique-constraint error, so match
 		// on the constraint phrasing rather than a typed error.

--- a/platform-api/internal/webhook/handlers_apikey.go
+++ b/platform-api/internal/webhook/handlers_apikey.go
@@ -174,7 +174,7 @@ func (r *Receiver) handleAPIKeyGenerated(ctx context.Context, env *Envelope) err
 	req := &api.CreateAPIKeyRequest{
 		// Id is the key's Platform API handle (its stable name); DisplayName is the human-readable name.
 		Id:            d.handlePtr(),
-		ApiKey:        plaintext,
+		ApiKey:        &plaintext,
 		DisplayName:   d.displayName(),
 		ExternalRefId: d.externalRefPtr(),
 		ExpiresAt:     expiresAt,

--- a/platform-api/internal/webhook/receiver.go
+++ b/platform-api/internal/webhook/receiver.go
@@ -45,7 +45,7 @@ const RoutePath = "/api/internal/" + constants.APIVersion + "/webhook/events"
 // CreateAPIKey/UpdateAPIKey/RevokeAPIKey already hash an externally provisioned key, persist it,
 // and broadcast to the gateways where the API is deployed — exactly what the webhook needs.
 type apiKeyService interface {
-	CreateAPIKey(ctx context.Context, apiHandle, kind, orgID, userID string, req *api.CreateAPIKeyRequest) error
+	CreateAPIKey(ctx context.Context, apiHandle, kind, orgID, userID string, req *api.CreateAPIKeyRequest) (*api.CreateAPIKeyResponse, error)
 	UpdateAPIKey(ctx context.Context, apiHandle, kind, orgID, keyName, userID string, keyAdmin, trustedOrigin bool, req *api.UpdateAPIKeyRequest) error
 	RevokeAPIKey(ctx context.Context, apiHandle, kind, orgID, keyName, userID string, keyAdmin, trustedOrigin bool) error
 }

--- a/platform-api/plugins/eventgateway/handler/webbroker_apikey.go
+++ b/platform-api/plugins/eventgateway/handler/webbroker_apikey.go
@@ -100,25 +100,8 @@ func (h *WebBrokerAPIKeyHandler) CreateAPIKey(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	if req.ApiKey == "" {
-		httputil.WriteJSON(w, http.StatusBadRequest, apperror.NewErrorResponse(400, "Bad Request", "API key value is required"))
-		return
-	}
-
-	var name string
-	if req.Id != nil && *req.Id != "" {
-		name = *req.Id
-	} else {
-		generatedName, err := utils.GenerateHandle(req.DisplayName, nil)
-		if err != nil {
-			httputil.WriteJSON(w, http.StatusBadRequest, apperror.NewErrorResponse(400, "Bad Request", "Failed to generate API key name"))
-			return
-		}
-		name = generatedName
-		req.Id = &name
-	}
-
-	if err := h.apiKeyService.CreateAPIKey(r.Context(), apiHandle, constants.WebBrokerApi, orgID, userId, &req); err != nil {
+	resp, err := h.apiKeyService.CreateAPIKey(r.Context(), apiHandle, constants.WebBrokerApi, orgID, userId, &req)
+	if err != nil {
 		if apperror.ArtifactNotFound.Is(err) {
 			httputil.WriteJSON(w, http.StatusNotFound, apperror.NewErrorResponse(404, "Not Found", "WebBroker API not found"))
 			return
@@ -132,11 +115,7 @@ func (h *WebBrokerAPIKeyHandler) CreateAPIKey(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	httputil.WriteJSON(w, http.StatusCreated, api.CreateAPIKeyResponse{
-		Status:  api.CreateAPIKeyResponseStatusSuccess,
-		KeyId:   req.Id,
-		Message: "API key created and broadcasted to gateways successfully",
-	})
+	httputil.WriteJSON(w, http.StatusCreated, resp)
 }
 
 // UpdateAPIKey handles PUT /api/v0.9/webbroker-apis/:apiId/api-keys/:keyName

--- a/platform-api/plugins/eventgateway/handler/webbroker_apikey.go
+++ b/platform-api/plugins/eventgateway/handler/webbroker_apikey.go
@@ -100,6 +100,24 @@ func (h *WebBrokerAPIKeyHandler) CreateAPIKey(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	if req.DisplayName == "" {
+		httputil.WriteJSON(w, http.StatusBadRequest, apperror.NewErrorResponse(400, "Bad Request", "Display name is required"))
+		return
+	}
+
+	var name string
+	if req.Id != nil && *req.Id != "" {
+		name = *req.Id
+	} else {
+		generatedName, err := utils.GenerateHandle(req.DisplayName, nil)
+		if err != nil {
+			httputil.WriteJSON(w, http.StatusBadRequest, apperror.NewErrorResponse(400, "Bad Request", "Failed to generate API key name"))
+			return
+		}
+		name = generatedName
+		req.Id = &name
+	}
+
 	resp, err := h.apiKeyService.CreateAPIKey(r.Context(), apiHandle, constants.WebBrokerApi, orgID, userId, &req)
 	if err != nil {
 		if apperror.ArtifactNotFound.Is(err) {

--- a/platform-api/plugins/eventgateway/handler/webbroker_apikey.go
+++ b/platform-api/plugins/eventgateway/handler/webbroker_apikey.go
@@ -128,6 +128,10 @@ func (h *WebBrokerAPIKeyHandler) CreateAPIKey(w http.ResponseWriter, r *http.Req
 			httputil.WriteJSON(w, http.StatusServiceUnavailable, apperror.NewErrorResponse(503, "Service Unavailable", "No gateway connections available"))
 			return
 		}
+		// Preserve catalog error status and message.
+		if respondCatalogError(w, h.slogger, err) {
+			return
+		}
 		h.slogger.Error("Failed to create API key for WebBroker API", "apiHandle", apiHandle, "error", err)
 		httputil.WriteJSON(w, http.StatusInternalServerError, apperror.NewErrorResponse(500, "Internal Server Error", "Failed to create API key"))
 		return

--- a/platform-api/plugins/eventgateway/handler/websub_apikey.go
+++ b/platform-api/plugins/eventgateway/handler/websub_apikey.go
@@ -100,25 +100,8 @@ func (h *WebSubAPIKeyHandler) CreateAPIKey(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	if req.ApiKey == "" {
-		httputil.WriteJSON(w, http.StatusBadRequest, apperror.NewErrorResponse(400, "Bad Request", "API key value is required"))
-		return
-	}
-
-	var name string
-	if req.Id != nil && *req.Id != "" {
-		name = *req.Id
-	} else {
-		generatedName, err := utils.GenerateHandle(req.DisplayName, nil)
-		if err != nil {
-			httputil.WriteJSON(w, http.StatusBadRequest, apperror.NewErrorResponse(400, "Bad Request", "Failed to generate API key name"))
-			return
-		}
-		name = generatedName
-		req.Id = &name
-	}
-
-	if err := h.apiKeyService.CreateAPIKey(r.Context(), apiHandle, constants.WebSubApi, orgID, userId, &req); err != nil {
+	resp, err := h.apiKeyService.CreateAPIKey(r.Context(), apiHandle, constants.WebSubApi, orgID, userId, &req)
+	if err != nil {
 		if apperror.ArtifactNotFound.Is(err) {
 			httputil.WriteJSON(w, http.StatusNotFound, apperror.NewErrorResponse(404, "Not Found", "WebSub API not found"))
 			return
@@ -132,11 +115,7 @@ func (h *WebSubAPIKeyHandler) CreateAPIKey(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	httputil.WriteJSON(w, http.StatusCreated, api.CreateAPIKeyResponse{
-		Status:  api.CreateAPIKeyResponseStatusSuccess,
-		KeyId:   req.Id,
-		Message: "API key created and broadcasted to gateways successfully",
-	})
+	httputil.WriteJSON(w, http.StatusCreated, resp)
 }
 
 // UpdateAPIKey handles PUT /api/v0.9/websub-apis/:apiId/api-keys/:keyName

--- a/platform-api/plugins/eventgateway/handler/websub_apikey.go
+++ b/platform-api/plugins/eventgateway/handler/websub_apikey.go
@@ -128,6 +128,10 @@ func (h *WebSubAPIKeyHandler) CreateAPIKey(w http.ResponseWriter, r *http.Reques
 			httputil.WriteJSON(w, http.StatusServiceUnavailable, apperror.NewErrorResponse(503, "Service Unavailable", "No gateway connections available"))
 			return
 		}
+		// Preserve catalog error status and message.
+		if respondCatalogError(w, h.slogger, err) {
+			return
+		}
 		h.slogger.Error("Failed to create API key for WebSub API", "apiHandle", apiHandle, "error", err)
 		httputil.WriteJSON(w, http.StatusInternalServerError, apperror.NewErrorResponse(500, "Internal Server Error", "Failed to create API key"))
 		return

--- a/platform-api/plugins/eventgateway/handler/websub_apikey.go
+++ b/platform-api/plugins/eventgateway/handler/websub_apikey.go
@@ -100,6 +100,24 @@ func (h *WebSubAPIKeyHandler) CreateAPIKey(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	if req.DisplayName == "" {
+		httputil.WriteJSON(w, http.StatusBadRequest, apperror.NewErrorResponse(400, "Bad Request", "Display name is required"))
+		return
+	}
+
+	var name string
+	if req.Id != nil && *req.Id != "" {
+		name = *req.Id
+	} else {
+		generatedName, err := utils.GenerateHandle(req.DisplayName, nil)
+		if err != nil {
+			httputil.WriteJSON(w, http.StatusBadRequest, apperror.NewErrorResponse(400, "Bad Request", "Failed to generate API key name"))
+			return
+		}
+		name = generatedName
+		req.Id = &name
+	}
+
 	resp, err := h.apiKeyService.CreateAPIKey(r.Context(), apiHandle, constants.WebSubApi, orgID, userId, &req)
 	if err != nil {
 		if apperror.ArtifactNotFound.Is(err) {

--- a/platform-api/resources/openapi.yaml
+++ b/platform-api/resources/openapi.yaml
@@ -6212,7 +6212,6 @@ components:
       type: object
       required:
         - displayName
-        - apiKey
       properties:
         id:
           type: string
@@ -6230,7 +6229,11 @@ components:
           example: "Production API Key"
         apiKey:
           type: string
-          description: The plain text API key value that will be hashed before storage
+          x-go-type-skip-optional-pointer: true
+          description: Optional. A pre-minted plain text API key to inject (used by external
+            platforms pushing a key to hybrid gateways). Omit it to have the server
+            generate one, the generated value is returned once in the response and
+            is never retrievable afterwards.
           example: "sk_example_1234567890abcdef"
         externalRefId:
           type: string
@@ -6271,6 +6274,14 @@ components:
           type: string
           description: The internal ID generated for tracking
           example: "production-key-01"
+        apiKey:
+          type: string
+          description: |
+            The generated API key value. Present only when the server generated 
+            the key (no `apiKey` in the request); returned only in this 
+            creation response and never retrievable afterwards. The example value is
+            a non-functional placeholder.
+          example: "REDACTED_API_KEY"
 
     UpdateAPIKeyRequest:
       type: object

--- a/platform-api/resources/openapi.yaml
+++ b/platform-api/resources/openapi.yaml
@@ -627,6 +627,34 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateAPIKeyRequest'
+            examples:
+              generatedKey:
+                summary: Let the server generate the key value
+                description: "`apiKey` is omitted, so the server generates the key value and returns it once in the 201 response."
+                value:
+                  id: "production-key-01"
+                  displayName: "Production API Key"
+                  externalRefId: "ext-ref-12345"
+                  expiresAt: "2026-12-31T23:59:59Z"
+                  expiresIn:
+                    duration: 30
+                    unit: days
+                  issuer: "api-platform-devportal"
+              suppliedKey:
+                summary: Inject a pre-minted key value
+                description: |
+                  `apiKey` carries a pre-minted key value, so the server stores its
+                  hash and the 201 response omits the `apiKey` field.
+                value:
+                  id: "production-key-01"
+                  displayName: "Production API Key"
+                  apiKey: "sk_example_1234567890abcdef"
+                  externalRefId: "ext-ref-12345"
+                  expiresAt: "2026-12-31T23:59:59Z"
+                  expiresIn:
+                    duration: 30
+                    unit: days
+                  issuer: "api-platform-devportal"
       responses:
         '201':
           description: API key created successfully
@@ -6229,7 +6257,6 @@ components:
           example: "Production API Key"
         apiKey:
           type: string
-          x-go-type-skip-optional-pointer: true
           description: Optional. A pre-minted plain text API key to inject (used by external
             platforms pushing a key to hybrid gateways). Omit it to have the server
             generate one, the generated value is returned once in the response and
@@ -6281,7 +6308,7 @@ components:
             the key (no `apiKey` in the request); returned only in this 
             creation response and never retrievable afterwards. The example value is
             a non-functional placeholder.
-          example: "REDACTED_API_KEY"
+          example: "sk_example_1234567890abcdef"
 
     UpdateAPIKeyRequest:
       type: object

--- a/portals/api-control-plane/src/api/generated/platform.d.ts
+++ b/portals/api-control-plane/src/api/generated/platform.d.ts
@@ -2665,10 +2665,10 @@ export interface components {
              */
             displayName: string;
             /**
-             * @description The plain text API key value that will be hashed before storage
+             * @description Optional. A pre-minted plain text API key to inject (used by external platforms pushing a key to hybrid gateways). Omit it to have the server generate one, the generated value is returned once in the response and is never retrievable afterwards.
              * @example sk_example_1234567890abcdef
              */
-            apiKey: string;
+            apiKey?: string;
             /**
              * @description Optional reference ID for tracing purposes (from external platforms)
              * @example ext-ref-12345
@@ -2705,6 +2705,14 @@ export interface components {
              * @example production-key-01
              */
             keyId?: string;
+            /**
+             * @description The generated API key value. Present only when the server generated
+             *     the key (no `apiKey` in the request); returned only in this
+             *     creation response and never retrievable afterwards. The example value is
+             *     a non-functional placeholder.
+             * @example REDACTED_API_KEY
+             */
+            apiKey?: string;
         };
         UpdateAPIKeyRequest: {
             /**
@@ -4708,7 +4716,7 @@ export interface components {
         "sortBy-Q": "name" | "createdAt";
         /** @description Sort direction applied to `sortBy`. */
         "sortOrder-Q": "asc" | "desc";
-        /** @description Case-insensitive substring filter matched against the resource id (handle). */
+        /** @description Case-insensitive substring filter matched against the resource display name and id (handle). */
         "query-Q": string;
     };
     requestBodies: never;
@@ -4837,7 +4845,7 @@ export interface operations {
                 sortBy?: components["parameters"]["sortBy-Q"];
                 /** @description Sort direction applied to `sortBy`. */
                 sortOrder?: components["parameters"]["sortOrder-Q"];
-                /** @description Case-insensitive substring filter matched against the resource id (handle). */
+                /** @description Case-insensitive substring filter matched against the resource display name and id (handle). */
                 query?: components["parameters"]["query-Q"];
             };
             header?: never;
@@ -4994,7 +5002,7 @@ export interface operations {
                 sortBy?: components["parameters"]["sortBy-Q"];
                 /** @description Sort direction applied to `sortBy`. */
                 sortOrder?: components["parameters"]["sortOrder-Q"];
-                /** @description Case-insensitive substring filter matched against the resource id (handle). */
+                /** @description Case-insensitive substring filter matched against the resource display name and id (handle). */
                 query?: components["parameters"]["query-Q"];
             };
             header?: never;
@@ -7120,7 +7128,7 @@ export interface operations {
                 sortBy?: components["parameters"]["sortBy-Q"];
                 /** @description Sort direction applied to `sortBy`. */
                 sortOrder?: components["parameters"]["sortOrder-Q"];
-                /** @description Case-insensitive substring filter matched against the resource id (handle). */
+                /** @description Case-insensitive substring filter matched against the resource display name and id (handle). */
                 query?: components["parameters"]["query-Q"];
             };
             header?: never;
@@ -7547,7 +7555,7 @@ export interface operations {
                 sortBy?: components["parameters"]["sortBy-Q"];
                 /** @description Sort direction applied to `sortBy`. */
                 sortOrder?: components["parameters"]["sortOrder-Q"];
-                /** @description Case-insensitive substring filter matched against the resource id (handle). */
+                /** @description Case-insensitive substring filter matched against the resource display name and id (handle). */
                 query?: components["parameters"]["query-Q"];
             };
             header?: never;


### PR DESCRIPTION
## Purpose

Fixes #3252

`POST /rest-apis/{restApiId}/api-keys` was inject-only: `apiKey` was required on `CreateAPIKeyRequest` and an empty value was rejected with `{"code":"VALIDATION_FAILED","message":"API key value is required"}`, so `CreateAPIKeyResponse` never carried key material.

## Approach

`apiKey` is now optional. When absent the server mints one with `utils.GenerateAPIKey` - the same 32-byte `crypto/rand` primitive the LLM proxy/provider key paths already use, and returns the plaintext once in the response. A caller-supplied key is still injected as-is and is **not** echoed back; `apiKey` appears in the response only when the server generated it.

`APIKeyService.CreateAPIKey` now returns `(*api.CreateAPIKeyResponse, error)` so the generated material and the resolved key name reach the caller. Two knock-on changes:

- `resolveExpiresAt` moves ahead of key generation and hashing, so an already-expired request is rejected before that work is done; matching `CreateLLMProxyAPIKey`.

The WebSub and WebBroker key handlers share this request type and service and get the same behaviour. The webhook receiver still requires an encrypted key on the event, since those are system-originated and always carry one.

## Tests

**`internal/service/apikey_create_test.go`** (new, 6 cases):
- key generated when `apiKey` is absent or whitespace-only; hash and mask derived from it; no plaintext in any persisted column
- caller-supplied key hashed, and `resp.ApiKey` left nil (no-echo rule)
- name derived from the `<handle>-key-<8 hex>` fallback when neither `id` nor `displayName` is given
- `keyId` matches the persisted name when a collision suffix is applied
- past expiry rejected with nothing persisted

**`internal/handler/api_key_integration_test.go`** (new, 3 cases) — full handler + service + SQLite stack, covering what only an HTTP round trip sees:
- the issue's exact request body returns 201 with a 64-hex `apiKey` and a correct `Location` header
- an injected key's response omits `apiKey` **entirely** rather than sending `null` (pins the `omitempty` on the generated struct)
- `{}` returns 201 with the derived-name fallback

Both non-obvious assertions were mutation-verified: dropping `omitempty` and restoring the old `req.ApiKey == ""` guard each fail the intended test.

No new cross-database integration tests - the change touches no schema and no repository code, and `TestLifecycle_APIKeyCreateListRevoke` already round-trips `masked_api_key`/`api_key_hashes` on all three engines.