### PR TITLE
Fix broken README documentation links after `docs/gateway` and `docs/ai-gateway` removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ The API Platform covers the complete API lifecycle:
 
 Refer to the documentation for setup guides, component-specific quick starts, and usage details.
 
-- [Gateway Documentation](docs/gateway/README.md)
-- [Gateway Quick Start](docs/gateway/quick-start-guide.md)
-- [AI Gateway Documentation](docs/ai-gateway/README.md)
-- [AI Gateway LLM Quick Start](docs/ai-gateway/llm/quick-start-guide.md)
-- [AI Gateway MCP Quick Start](docs/ai-gateway/mcp/quick-start-guide.md)
+- [Gateway Documentation](gateway/README.md)
+- [Gateway Quick Start](gateway/distribution/README.md)
+- [AI Gateway LLM Quick Start](samples/ai-gw-llm-proxy/README.md)
+- [AI Gateway MCP Quick Start](samples/ai-gw-mcp-claude-desktop/README.md)
+- [CLI Documentation](docs/cli/README.md)
 - [CLI Quick Start](docs/cli/quick-start-guide.md)
 
 ## Platform Components

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,11 +42,10 @@ Standalone design tool for REST, GraphQL, and AsyncAPI specifications.
 
 ## Documentation
 
-- [Gateway](gateway/README.md) — API gateway setup, configuration, and policy management
-- [Gateway Quick Start Guide](gateway/quick-start-guide.md) — Download, run, and test the API gateway
-- [AI Gateway](ai-gateway/README.md) — Managing and securing AI traffic including LLM APIs and MCP servers
-- [AI Gateway LLM Quick Start Guide](ai-gateway/llm/quick-start-guide.md) — Download and run the AI Gateway, then route traffic to LLM providers like OpenAI
-- [AI Gateway MCP Quick Start Guide](ai-gateway/mcp/quick-start-guide.md) — Download and run the AI Gateway, then route traffic to MCP servers
+- [Gateway](../gateway/README.md) — API gateway setup, configuration, and policy management
+- [Gateway Quick Start Guide](../gateway/distribution/README.md) — Download, run, and test the API gateway
+- [AI Gateway LLM Quick Start Guide](../samples/ai-gw-llm-proxy/README.md) — Route traffic to LLM providers like OpenAI
+- [AI Gateway MCP Quick Start Guide](../samples/ai-gw-mcp-claude-desktop/README.md) — Route traffic to MCP servers
 - [CLI](cli/README.md) — Command-line tool for managing the API Platform Gateway Controller
 - [REST APIs](rest-apis/) — REST API references for platform components
 - [Policies and Guardrails](https://github.com/wso2/gateway-controllers/blob/main/docs/README.md) — Gateway policies and guardrails for API traffic control

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -2,7 +2,7 @@
 
 A complete API gateway system consisting of Gateway-Controller (xDS control plane), Router (Envoy Proxy data plane), Policy Engine (request/response processing), and Policy Builder (policy compilation tooling).
 
-For end-user documentation, see [docs/gateway/](../docs/gateway/).
+For end-user documentation, see the [Gateway distribution README](distribution/README.md).
 
 ## Components
 
@@ -68,7 +68,7 @@ password, and rewrite `api-platform.env`).
 
 For the full setup reference — flags (`--force`, `--certs-only`), control-plane
 connection, at-rest encryption, and how configuration is delivered — see
-[docs/gateway/quick-start-guide.md](../docs/gateway/quick-start-guide.md).
+[distribution/README.md](distribution/README.md).
 
 ### Test
 


### PR DESCRIPTION
## Purpose
Root `README.md`, `docs/README.md`, and `gateway/README.md` still pointed at `docs/gateway/` and `docs/ai-gateway/`. Those trees were deleted in `f515e8af7` ("Remove unnecessary docs"), so every Gateway / AI Gateway doc link 404s.

Resolves: #3375 

## Goals
Point the documentation indexes at files that actually exist in the repo so setup/quick-start links work.

## Approach
Retargeted the stale markdown links:

- Gateway docs → `gateway/README.md`
- Gateway quick start → `gateway/distribution/README.md`
- AI Gateway LLM quick start → `samples/ai-gw-llm-proxy/README.md`
- AI Gateway MCP quick start → `samples/ai-gw-mcp-claude-desktop/README.md`
- CLI docs → `docs/cli/README.md` (CLI quick start was already valid)
- Dropped the standalone AI Gateway docs link — that tree has no replacement
- Updated `gateway/README.md` pointers that still referenced the deleted `docs/gateway/` tree

No UI changes.

## User stories
As a new contributor/user, I can click documentation links from the repo README and land on real setup/quick-start guides instead of 404s.

## Documentation
This PR **is** the doc-link fix. No product-doc update beyond the README retargets.

## Automation tests
 - Unit tests  
   N/A — markdown link updates only
 - Integration tests  
   N/A — markdown link updates only

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? N/A (docs-only)
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
LLM/MCP quick-start links now point at the existing samples (`samples/ai-gw-llm-proxy`, `samples/ai-gw-mcp-claude-desktop`). Samples themselves are unchanged.

## Related PRs
N/A

## Test environment
Manual: verified each updated relative link resolves on disk on macOS. No runtime/JDK/browser testing required.