### PR TITLE
Retry apt acquisitions so a mirror flake stops failing image builds

### DIFF
--- a/event-gateway/gateway-controller/Dockerfile
+++ b/event-gateway/gateway-controller/Dockerfile
@@ -104,8 +104,17 @@ FROM ubuntu:24.04 AS production
 ARG VERSION=0.0.1-SNAPSHOT
 ARG ENABLE_COVERAGE=false
 
+# Retry transient mirror failures and disable HTTP pipelining (some Ubuntu
+# mirrors serve it badly): a single connection reset or half-synced index here
+# otherwise fails the whole build. The apt lists cache mount is cleared first,
+# because a partial index left in it resurfaces as "File has unexpected size
+# ... Mirror sync in progress?" on a later build. `apt-get upgrade` is kept on
+# purpose — this image is Trivy-scanned for fixable OS vulnerabilities, and
+# upgrading in this layer is what clears them.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    printf 'Acquire::Retries "5";\nAcquire::http::Pipeline-Depth "0";\n' > /etc/apt/apt.conf.d/99-retries && \
+    rm -rf /var/lib/apt/lists/* && \
     apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \

--- a/gateway/gateway-builder/Dockerfile
+++ b/gateway/gateway-builder/Dockerfile
@@ -78,9 +78,18 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 
 FROM golang:1.26.5-bookworm
 
-# Install runtime dependencies (upgrade first to pull in Debian security fixes)
+# Install runtime dependencies (upgrade first to pull in Debian security fixes,
+# which this image is Trivy-scanned for — so the upgrade stays).
+#
+# Retry transient mirror failures and disable HTTP pipelining, which some Debian
+# mirrors serve badly: a single connection reset or half-synced index here
+# otherwise fails the whole build. The apt lists cache mount is cleared first,
+# because a partial index left in it resurfaces as "File has unexpected size
+# ... Mirror sync in progress?" on a later build.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    printf 'Acquire::Retries "5";\nAcquire::http::Pipeline-Depth "0";\n' > /etc/apt/apt.conf.d/99-retries && \
+    rm -rf /var/lib/apt/lists/* && \
     apt-get update && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
     git \

--- a/gateway/gateway-controller/Dockerfile
+++ b/gateway/gateway-controller/Dockerfile
@@ -109,8 +109,17 @@ FROM ubuntu:24.04 AS production
 ARG VERSION=0.0.1-SNAPSHOT
 ARG ENABLE_COVERAGE=false
 
+# Retry transient mirror failures and disable HTTP pipelining (some Ubuntu
+# mirrors serve it badly): a single connection reset or half-synced index here
+# otherwise fails the whole build. The apt lists cache mount is cleared first,
+# because a partial index left in it resurfaces as "File has unexpected size
+# ... Mirror sync in progress?" on a later build. `apt-get upgrade` is kept on
+# purpose — this image is Trivy-scanned for fixable OS vulnerabilities, and
+# upgrading in this layer is what clears them.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    printf 'Acquire::Retries "5";\nAcquire::http::Pipeline-Depth "0";\n' > /etc/apt/apt.conf.d/99-retries && \
+    rm -rf /var/lib/apt/lists/* && \
     apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \

--- a/platform-api/Dockerfile
+++ b/platform-api/Dockerfile
@@ -87,7 +87,19 @@ ARG USER_GID=$USER_UID
 
 LABEL org.opencontainers.image.experimental="${EXPERIMENTAL}"
 
-RUN apt-get update && apt-get upgrade -y \
+# A single transient mirror failure otherwise fails the whole image build. CI
+# has hit both "Connection failed" fetching security.ubuntu.com and "File has
+# unexpected size ... Mirror sync in progress?" at this step, so retry
+# acquisitions and disable HTTP pipelining, which some Ubuntu mirrors serve
+# badly.
+#
+# `apt-get upgrade` is deliberately not run: it downloads every upgradable
+# package in the base image in order to install two, which is a large amount of
+# extra network for no benefit this image relies on. The `ubuntu:24.04` tag is
+# itself rebuilt with security fixes, so OS patching comes from refreshing the
+# base image rather than upgrading in this layer.
+RUN printf 'Acquire::Retries "5";\nAcquire::http::Pipeline-Depth "0";\n' > /etc/apt/apt.conf.d/99-retries \
+    && apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \


### PR DESCRIPTION
## Purpose

Image builds fail intermittently in CI at the runtime stage's `apt-get update`,
before any application code is compiled. Two variants have been observed on the
same workflow (`platform-api-gateway-e2e.yml`) within a few hours:

- `platform-api/Dockerfile` — `Connection failed` fetching
  `http://security.ubuntu.com/ubuntu noble-security InRelease`, reported as
  `The repository ... is not signed` (apt could not fetch the index at all, so it
  treats the repo as unsigned; the signature itself is fine).
- `gateway/gateway-controller/Dockerfile` — `File has unexpected size ... Mirror
  sync in progress?`

Both are index-acquisition failures against distro mirrors, not build errors. A
single reset currently fails the entire image build and therefore the whole e2e
job, so unrelated PRs go red and have to be re-run by hand.

## Goals

Make the runtime-stage package step tolerate a transient mirror failure instead
of aborting the build, without weakening the CVE posture of the images that are
scanned for it.

## Approach

Every affected `RUN` now writes an apt config before invoking apt:

```
Acquire::Retries "5";
Acquire::http::Pipeline-Depth "0";
```

`Acquire::Retries` is what actually addresses the failure — apt retries a failed
acquisition rather than aborting — and applies to the package downloads as well
as the index fetch, which a per-command `-o` on `apt-get update` alone would not.
Pipelining is disabled because some mirrors serve pipelined requests badly, which
is a known source of the "unexpected size" variant.

For the three Dockerfiles that mount the apt lists directory as a build cache,
the cache is cleared before `apt-get update`. A half-synced index persisted in
that cache is what makes the "File has unexpected size" failure recur on later
builds; clearing it costs a little index re-download for a deterministic start.

**`apt-get upgrade` is kept in the three gateway images.** They are Trivy-scanned
for OS vulnerabilities with `ignore-unfixed: true`
(`.github/workflows/trivy-scan.yaml`), which means the report surfaces precisely
the *fixable* OS CVEs — and upgrading in that layer is what clears them.
`gateway/gateway-builder/Dockerfile` also documents the upgrade as intentional in
its own comment. Dropping it would quietly grow the nightly CVE list rather than
fail CI, so it is left alone here.

**`apt-get upgrade` is dropped from `platform-api/Dockerfile`,** the image that
triggered this. It is not covered by `trivy-scan.yaml` and carries no documented
upgrade intent, and upgrading every upgradable package in order to install two
(`ca-certificates`, `curl`) is a large amount of extra network — the download
phase is itself failure surface. Base-image refreshes (`ubuntu:24.04` is rebuilt
with security fixes) are the patching path for it. Worth noting separately that
`platform-api` appears to be missing from Trivy coverage; that looks like a gap
worth closing independently of this PR.

Considered and rejected: rewriting the sources to `https://`. It works (verified
in a clean `ubuntu:24.04`, which does resolve HTTPS mirrors even though
`ca-certificates` is not installed in the base image), but HTTPS does not make a
flaky mirror more reliable — it changes transport, not availability — so it adds
churn without addressing the failure. Retries do.

## User stories

- As a contributor, my PR's e2e job does not go red because an Ubuntu mirror was
  mid-sync while an unrelated image was being built.

## Release note

Build reliability only; no runtime behaviour change.

## Documentation

N/A — build-time change; the rationale is in comments next to each modified
layer.

## Automation tests

- Unit tests
  > N/A — Dockerfile change, no application code.
- Integration tests
  > The rewritten `platform-api` layer was executed verbatim in a clean
  > `ubuntu:24.04` container: `apt-config dump` confirms `Acquire::Retries "5"`
  > and `Acquire::http::Pipeline-Depth "0"` are in effect, and
  > `ca-certificates`/`curl` install successfully. The existing e2e workflow
  > exercises all four images.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? no — Dockerfile change, no Java/Go code
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

Note on scope: apt's GPG verification of indexes and packages is untouched —
retrying an acquisition does not bypass signature checks, and the "not signed"
message in the failure log was a symptom of the index never arriving.

## Samples

N/A

## Related PRs

N/A

## Test environment

Docker (buildx) on macOS arm64 for the layer verification; GitHub-hosted Ubuntu
runners for CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
