### PR TITLE
Fix cloud Gateways nav placement, show the environment, and validate gateway names

### DIFF
--- a/portals/ai-workspace/src/App.tsx
+++ b/portals/ai-workspace/src/App.tsx
@@ -89,11 +89,12 @@ import {
   AI_WORKSPACE_GATEWAYS_SLOT,
   AI_WORKSPACE_SIDEBAR_SLOT,
   ExtensionsProvider,
+  hiddenRegionsOf,
   type AIWorkspaceCloudEntry,
   type AIWorkspaceExtension,
   type AIWorkspacePageOverride,
 } from './extensions';
-import { Hideable, useSlot } from './slots';
+import { Hideable, HiddenRegionsProvider, useSlot } from './slots';
 import { usePort } from './hostPort';
 
 /**
@@ -864,9 +865,14 @@ function WorkspaceRoutes({ extensions = [] }: AppProps) {
 }
 
 export default function App({ extensions = [] }: AppProps) {
+  // Slot adds, Hideable suppresses: entries declare which built-in regions they
+  // replace via `hides`, so a built-in item is only ever hidden when something
+  // actually took its place. With no extensions registered nothing is hidden.
   return (
     <ExtensionsProvider extensions={extensions}>
-      <WorkspaceRoutes extensions={extensions} />
+      <HiddenRegionsProvider hidden={hiddenRegionsOf(extensions)}>
+        <WorkspaceRoutes extensions={extensions} />
+      </HiddenRegionsProvider>
     </ExtensionsProvider>
   );
 }

--- a/portals/ai-workspace/src/extensions.tsx
+++ b/portals/ai-workspace/src/extensions.tsx
@@ -65,7 +65,33 @@ export const AI_WORKSPACE_GATEWAYS_SLOT = 'page.gateways';
  */
 export type AIWorkspacePageOverride = SlotEntry & {
   render: (port: AIWorkspaceHostPort) => ReactNode;
+  /**
+   * Optional nav placement for the built-in item this override replaces. When
+   * `label` is given the sidebar renders the override alongside the sidebar
+   * extensions, ordered by `order` — so a cloud build can move the entry into
+   * the extension cluster instead of leaving it where the built-in sits. Pair
+   * it with `hides` naming the built-in item's own region, or both appear.
+   */
+  label?: string;
+  icon?: ReactNode;
+  path?: string;
+  /** Built-in `Hideable` regions this entry suppresses (see `slots/index.tsx`). */
+  hides?: readonly string[];
 };
+
+/**
+ * `Hideable` region wrapping the built-in AI Gateways *sidebar item* (the page
+ * itself is `AI_WORKSPACE_GATEWAYS_SLOT`). Separate name because a cloud build
+ * may want to reposition the nav entry while still rendering at the built-in
+ * route.
+ */
+export const AI_WORKSPACE_GATEWAYS_NAV_REGION = 'nav.gateways';
+
+/** Every `Hideable` region the registered entries suppress. */
+export const hiddenRegionsOf = (
+  entries: readonly AIWorkspaceCloudEntry[]
+): readonly string[] =>
+  entries.flatMap((entry) => ('hides' in entry ? (entry.hides ?? []) : []));
 
 /** Every registered cloud entry — sidebar items and page overrides share one slot registry (see `slots/index.tsx`), filtered by `slot` at each consumption site. */
 export type AIWorkspaceCloudEntry = AIWorkspaceExtension | AIWorkspacePageOverride;

--- a/portals/ai-workspace/src/pages/appShell/AppSidebar.tsx
+++ b/portals/ai-workspace/src/pages/appShell/AppSidebar.tsx
@@ -77,19 +77,25 @@ export default function AppSidebar({
   // Those render here rather than where the built-in item sits, so a cloud build
   // can move the entry into this cluster — it suppresses the built-in via `hides`.
   const gatewayOverrides = useSlot<AIWorkspacePageOverride>(AI_WORKSPACE_GATEWAYS_SLOT);
+  // The override stands in for the built-in Gateways item, which is gated below
+  // on GATEWAY_READ — so it carries the same gate rather than showing the entry
+  // to someone the built-in one would have hidden it from.
+  const canReadGateways = hasPermission(SCOPES.GATEWAY_READ);
   const extensions = useMemo(
     () =>
       [
         ...sidebarExtensions,
-        ...gatewayOverrides
-          .filter((override) => Boolean(override.label))
-          .map((override) => ({
-            ...override,
-            label: override.label as string,
-            path: override.path ?? 'gateways',
-          })),
+        ...(canReadGateways
+          ? gatewayOverrides
+              .filter((override) => Boolean(override.label))
+              .map((override) => ({
+                ...override,
+                label: override.label as string,
+                path: override.path ?? 'gateways',
+              }))
+          : []),
       ].sort((a, b) => a.order - b.order),
-    [sidebarExtensions, gatewayOverrides]
+    [sidebarExtensions, gatewayOverrides, canReadGateways]
   );
 
   const handleDismissIntro = () => {

--- a/portals/ai-workspace/src/pages/appShell/AppSidebar.tsx
+++ b/portals/ai-workspace/src/pages/appShell/AppSidebar.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { NavLink, useLocation, useNavigate } from 'react-router-dom';
 import { Box, Sidebar } from '@wso2/oxygen-ui';
 import {
@@ -39,10 +39,13 @@ import QuickStartIntroPopup, {
   QS_INTRO_STORAGE_KEY,
 } from './QuickStartIntroPopup';
 import {
+  AI_WORKSPACE_GATEWAYS_NAV_REGION,
+  AI_WORKSPACE_GATEWAYS_SLOT,
   AI_WORKSPACE_SIDEBAR_SLOT,
   type AIWorkspaceExtension,
+  type AIWorkspacePageOverride,
 } from '../../extensions';
-import { useSlot } from '../../slots';
+import { Hideable, useSlot } from '../../slots';
 
 const navLinkStyle: React.CSSProperties = {
   textDecoration: 'none',
@@ -69,7 +72,25 @@ export default function AppSidebar({
   const [showIntro, setShowIntro] = useState(
     () => !localStorage.getItem(QS_INTRO_STORAGE_KEY)
   );
-  const extensions = useSlot<AIWorkspaceExtension>(AI_WORKSPACE_SIDEBAR_SLOT);
+  const sidebarExtensions = useSlot<AIWorkspaceExtension>(AI_WORKSPACE_SIDEBAR_SLOT);
+  // A page override may carry its own nav placement (see `AIWorkspacePageOverride`).
+  // Those render here rather than where the built-in item sits, so a cloud build
+  // can move the entry into this cluster — it suppresses the built-in via `hides`.
+  const gatewayOverrides = useSlot<AIWorkspacePageOverride>(AI_WORKSPACE_GATEWAYS_SLOT);
+  const extensions = useMemo(
+    () =>
+      [
+        ...sidebarExtensions,
+        ...gatewayOverrides
+          .filter((override) => Boolean(override.label))
+          .map((override) => ({
+            ...override,
+            label: override.label as string,
+            path: override.path ?? 'gateways',
+          })),
+      ].sort((a, b) => a.order - b.order),
+    [sidebarExtensions, gatewayOverrides]
+  );
 
   const handleDismissIntro = () => {
     localStorage.setItem(QS_INTRO_STORAGE_KEY, '1');
@@ -289,14 +310,16 @@ export default function AppSidebar({
               </NavLink>
             )}
             {hasPermission(SCOPES.GATEWAY_READ) && (
-              <NavLink to={gatewaysPath} style={navLinkStyle}>
-                <Sidebar.Item id="gateways">
-                  <Sidebar.ItemIcon>
-                    <Network size={20} />
-                  </Sidebar.ItemIcon>
-                  <Sidebar.ItemLabel>AI Gateways</Sidebar.ItemLabel>
-                </Sidebar.Item>
-              </NavLink>
+              <Hideable name={AI_WORKSPACE_GATEWAYS_NAV_REGION}>
+                <NavLink to={gatewaysPath} style={navLinkStyle}>
+                  <Sidebar.Item id="gateways">
+                    <Sidebar.ItemIcon>
+                      <Network size={20} />
+                    </Sidebar.ItemIcon>
+                    <Sidebar.ItemLabel>AI Gateways</Sidebar.ItemLabel>
+                  </Sidebar.Item>
+                </NavLink>
+              </Hideable>
             )}
             {isAuthenticated && (
               <NavLink to={insightsPath} style={navLinkStyle}>

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/GatewayForm.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/GatewayForm.tsx
@@ -32,6 +32,7 @@ import {
 import { ChevronLeft } from '@wso2/oxygen-ui-icons-react';
 import EnvironmentSelect from './components/EnvironmentSelect';
 import GatewayTypeSelector from './components/GatewayTypeSelector';
+import { validateGatewayName } from './utils/name';
 import type { Environment, Gateway, GatewayInput, GatewayType } from './types';
 
 export type GatewayFormProps = {
@@ -65,7 +66,14 @@ const GatewayForm: FC<GatewayFormProps> = ({
   const [description, setDescription] = useState(gateway?.description ?? '');
   const [environmentId, setEnvironmentId] = useState(gateway?.environmentId ?? '');
 
-  const canSubmit = name.trim().length > 0 && environmentId.length > 0;
+  // The name is only constrained on create, where the backend derives the
+  // gateway's handle from it. It is a plain display name from then on — the
+  // handle is immutable — so an edit must not be blocked by rules that no longer
+  // apply to what it changes.
+  const nameError = isEdit ? undefined : validateGatewayName(name, environmentId);
+
+  const missingRequired = name.trim().length === 0 || environmentId.length === 0;
+  const canSubmit = !missingRequired && !nameError;
 
   const handleSubmit = () => {
     onSubmit({
@@ -108,6 +116,8 @@ const GatewayForm: FC<GatewayFormProps> = ({
                 placeholder="Enter gateway name"
                 value={name}
                 onChange={(event) => setName(event.target.value)}
+                error={Boolean(nameError)}
+                helperText={nameError}
                 autoFocus
               />
             </FormControl>
@@ -145,7 +155,9 @@ const GatewayForm: FC<GatewayFormProps> = ({
           <Button variant="outlined" color="secondary" onClick={onBack}>
             Cancel
           </Button>
-          <Tooltip title={!canSubmit ? 'Fill in the required fields to continue.' : ''}>
+          {/* An invalid name explains itself in the field's helper text, so the
+              tooltip only covers the still-empty case. */}
+          <Tooltip title={missingRequired ? 'Fill in the required fields to continue.' : ''}>
             <span>
               <Button variant="contained" disabled={!canSubmit} onClick={handleSubmit}>
                 {isEdit ? 'Save Changes' : 'Add Gateway'}

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/GatewaysList.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/GatewaysList.tsx
@@ -45,7 +45,6 @@ import {
 } from '@wso2/oxygen-ui';
 import { Edit, Plus, Search, Settings, Trash2 } from '@wso2/oxygen-ui-icons-react';
 import GatewaySettingsDrawer from './components/GatewaySettingsDrawer';
-import { relativeTime } from './utils/time';
 import { gatewayTypeLabel } from './utils/gateway';
 import NoGatewaysImage from './assets/images/NoGW.svg';
 import type { Environment, Gateway } from './types';
@@ -73,6 +72,14 @@ const GatewaysList: FC<GatewaysListProps> = ({
   const [searchQuery, setSearchQuery] = useState('');
   const [deleteTarget, setDeleteTarget] = useState<{ id: string; name: string } | null>(null);
   const [settingsGateway, setSettingsGateway] = useState<Gateway | null>(null);
+
+  // Environments are keyed by name, so a gateway that points at an environment
+  // missing from the list (deleted, or not yet loaded) still shows its raw
+  // `environmentId` rather than nothing.
+  const environmentNames = useMemo(
+    () => new Map(environments.map((environment) => [environment.id, environment.name])),
+    [environments]
+  );
 
   const filteredGateways = useMemo(() => {
     const query = searchQuery.trim().toLowerCase();
@@ -152,7 +159,7 @@ const GatewaysList: FC<GatewaysListProps> = ({
                         <TableCell>Description</TableCell>
                         <TableCell>Type</TableCell>
                         <TableCell>Status</TableCell>
-                        <TableCell>Last Updated</TableCell>
+                        <TableCell>Environment</TableCell>
                         <TableCell align="right">Actions</TableCell>
                       </TableRow>
                     </TableHead>
@@ -211,7 +218,9 @@ const GatewaysList: FC<GatewaysListProps> = ({
                             </TableCell>
                             <TableCell>
                               <Typography variant="body2" color="text.secondary">
-                                {relativeTime(gateway.updatedAt)}
+                                {environmentNames.get(gateway.environmentId) ||
+                                  gateway.environmentId ||
+                                  '—'}
                               </Typography>
                             </TableCell>
                             <TableCell align="right">

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/GatewayTypeCard.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/GatewayTypeCard.tsx
@@ -24,15 +24,26 @@ export type GatewayTypeCardProps = {
   label: string;
   badge?: string;
   selected: boolean;
+  /** Shown but not selectable — a type that is announced before it can be created. */
+  disabled?: boolean;
   onClick: () => void;
 };
 
-const GatewayTypeCard: FC<GatewayTypeCardProps> = ({ icon, label, badge, selected, onClick }) => (
+const GatewayTypeCard: FC<GatewayTypeCardProps> = ({
+  icon,
+  label,
+  badge,
+  selected,
+  disabled,
+  onClick,
+}) => (
   <Box
+    aria-disabled={disabled || undefined}
     role="button"
-    tabIndex={0}
-    onClick={onClick}
+    tabIndex={disabled ? -1 : 0}
+    onClick={disabled ? undefined : onClick}
     onKeyDown={(event) => {
+      if (disabled) return;
       if (event.key === 'Enter' || event.key === ' ') onClick();
     }}
     sx={{
@@ -46,19 +57,27 @@ const GatewayTypeCard: FC<GatewayTypeCardProps> = ({ icon, label, badge, selecte
       borderColor: selected ? 'primary.main' : 'divider',
       bgcolor: selected ? 'action.selected' : 'background.paper',
       borderRadius: '10px',
-      cursor: 'pointer',
+      cursor: disabled ? 'not-allowed' : 'pointer',
+      opacity: disabled ? 0.6 : 1,
       transition: 'border-color 0.15s ease, background-color 0.15s ease',
-      '&:hover': selected ? undefined : { borderColor: 'text.disabled' },
+      '&:hover': selected || disabled ? undefined : { borderColor: 'text.disabled' },
     }}
   >
-    <Box sx={{ display: 'flex', color: selected ? 'primary.main' : 'text.secondary' }}>{icon}</Box>
+    <Box sx={{ display: 'flex', color: selected && !disabled ? 'primary.main' : 'text.secondary' }}>{icon}</Box>
     <Typography
       variant="body2"
-      sx={{ fontWeight: 600, flexGrow: 1, color: selected ? 'text.primary' : 'text.secondary' }}
+      sx={{ fontWeight: 600, flexGrow: 1, color: selected && !disabled ? 'text.primary' : 'text.secondary' }}
     >
       {label}
     </Typography>
-    {badge ? <Chip label={badge} size="small" color="info" sx={{ height: 20, fontSize: 11 }} /> : null}
+    {badge ? (
+      <Chip
+        color={disabled ? 'default' : 'info'}
+        label={badge}
+        size="small"
+        sx={{ height: 20, fontSize: 11 }}
+      />
+    ) : null}
   </Box>
 );
 

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/GatewayTypeSelector.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/components/GatewayTypeSelector.tsx
@@ -28,10 +28,15 @@ import type { GatewayType } from '../types';
  * host may offer is guaranteed to have a card — icons and labels match the
  * built-in console's own type selector.
  */
-const TYPE_CARDS: Record<GatewayType, { icon: FC<{ size?: number }>; badge?: string }> = {
+const TYPE_CARDS: Record<
+  GatewayType,
+  { icon: FC<{ size?: number }>; badge?: string; comingSoon?: boolean }
+> = {
   regular: { icon: Network },
   ai: { icon: Sparkles },
-  event: { icon: Zap, badge: 'Beta' },
+  // Announced but not yet creatable: the card stays visible so the type is
+  // discoverable, and is rendered unselectable rather than dropped from the row.
+  event: { icon: Zap, badge: 'Coming soon', comingSoon: true },
 };
 
 export type GatewayTypeSelectorProps = {
@@ -54,7 +59,7 @@ const GatewayTypeSelector: FC<GatewayTypeSelectorProps> = ({ types, value, onCha
   return (
     <Box sx={{ display: 'flex', gap: 2, mt: 1 }}>
       {visibleTypes.map((type) => {
-        const { icon: Icon, badge } = TYPE_CARDS[type];
+        const { icon: Icon, badge, comingSoon } = TYPE_CARDS[type];
         return (
           <GatewayTypeCard
             key={type}
@@ -62,6 +67,7 @@ const GatewayTypeSelector: FC<GatewayTypeSelectorProps> = ({ types, value, onCha
             label={gatewayTypeLabel(type)}
             badge={badge}
             selected={value === type}
+            disabled={comingSoon}
             onClick={() => onChange(type)}
           />
         );

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/utils/name.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/utils/name.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * The gateway handle limit enforced by platform-api's `gateways.handle` column.
+ * The handle is built as `<environment>-<name>`, so the environment's own length
+ * eats into what is left for the name.
+ */
+export const MAX_GATEWAY_HANDLE_LENGTH = 40;
+
+/** The longest name any environment can accommodate (a one-character one). */
+const MAX_GATEWAY_NAME_LENGTH = MAX_GATEWAY_HANDLE_LENGTH - 2;
+
+/** Reserved for the gateway provisioned automatically with the environment. */
+const RESERVED_GATEWAY_NAME = 'default';
+
+const DNS1123_NAME = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
+
+/** How many characters a gateway name may use in the given environment. */
+export function gatewayNameBudget(environment: string): number {
+  return environment
+    ? MAX_GATEWAY_HANDLE_LENGTH - environment.length - 1
+    : MAX_GATEWAY_NAME_LENGTH;
+}
+
+/**
+ * Validates a new gateway's name against the same rules the backend applies to
+ * it, returning the message to show or `undefined` when the name is fine.
+ *
+ * On create the name is what the gateway's handle is derived from, so it has to
+ * be a DNS-1123 name that fits the handle column alongside the environment —
+ * otherwise the create call fails after the form has already been submitted.
+ * Case is not part of it: the backend lowercases before validating, so `Prod-1`
+ * is accepted and becomes `prod-1`. An empty name is left to the field's own
+ * `required` handling rather than reported here.
+ */
+export function validateGatewayName(name: string, environment: string): string | undefined {
+  const handle = name.trim().toLowerCase();
+  if (!handle) return undefined;
+
+  if (handle === RESERVED_GATEWAY_NAME) {
+    return `"${RESERVED_GATEWAY_NAME}" is reserved for the gateway created with the environment.`;
+  }
+  if (!DNS1123_NAME.test(handle)) {
+    return 'Use only letters, digits and hyphens, starting and ending with a letter or digit.';
+  }
+
+  const budget = gatewayNameBudget(environment);
+  if (handle.length > budget) {
+    return environment
+      ? `Too long for the "${environment}" environment: use at most ${budget} characters (the handle "${environment}-<name>" must fit ${MAX_GATEWAY_HANDLE_LENGTH} characters).`
+      : `Use at most ${budget} characters.`;
+  }
+  return undefined;
+}

--- a/portals/cloud-plugins/apip-cloud-ui/src/hosts/ai-workspace.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui/src/hosts/ai-workspace.tsx
@@ -7,13 +7,14 @@
  * You may not alter or remove any copyright or other notice from copies of this content.
  */
 
-import { Boxes, Rocket, Workflow } from '@wso2/oxygen-ui-icons-react';
+import { Boxes, Network, Rocket, Workflow } from '@wso2/oxygen-ui-icons-react';
 
 import { DeployFeature } from '@wso2-enterprise/apip-cloud-ui-deploy';
 import { EnvironmentsFeature } from '@wso2-enterprise/apip-cloud-ui-environments-new';
 import { GatewaysFeature } from '@wso2-enterprise/apip-cloud-ui-gateways';
 import { PipelinesFeature, ProjectPipelinesFeature } from '@wso2-enterprise/apip-cloud-ui-pipelines';
 import {
+  AI_WORKSPACE_GATEWAYS_NAV_REGION,
   AI_WORKSPACE_GATEWAYS_SLOT,
   type AIWorkspaceCloudEntry,
   type AIWorkspaceExtension,
@@ -32,6 +33,8 @@ import { defineCloudPlugin, getCloudExtensions, type CloudPluginFeature } from '
  * new one. Nothing under `ai-workspace/src/pages/appShell/appShellPages/gateways`
  * is touched by this. Every gateway in this workspace is an AI gateway, so it
  * registers `ai` as the only type and the create form shows no type picker.
+ * It also carries nav placement so the entry sits between Environments and
+ * Pipelines, suppressing the built-in item via `hides`.
  */
 export const cloudPluginFeatures: CloudPluginFeature<AIWorkspaceCloudEntry>[] = [
   defineCloudPlugin({
@@ -93,7 +96,16 @@ export const cloudPluginFeatures: CloudPluginFeature<AIWorkspaceCloudEntry>[] = 
       {
         id: 'gateways',
         slot: AI_WORKSPACE_GATEWAYS_SLOT,
-        order: 0,
+        // Nav placement: between Environments (50) and Pipelines (60). The
+        // override carries it (rather than a second sidebar entry) so the
+        // gateways route keeps rendering here, while `hides` suppresses the
+        // built-in nav item that would otherwise appear higher up in its own
+        // category. Without `hides` both entries would show.
+        order: 55,
+        path: 'gateways',
+        label: 'AI Gateways',
+        icon: <Network size={20} />,
+        hides: [AI_WORKSPACE_GATEWAYS_NAV_REGION],
         render: (port) => <GatewaysFeature gatewayTypes={['ai']} port={port} />,
       },
     ],

--- a/portals/cloud-plugins/apip-cloud-ui/src/hosts/api-control-plane.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui/src/hosts/api-control-plane.tsx
@@ -78,6 +78,14 @@ export const cloudPluginFeatures: CloudPluginFeature<ApiControlPlaneExtension>[]
         // built-in placement. `routePath`/`level` are inert (the page override
         // is consumed by the `gateways/*` route wrapper in `AppRoutes`, not the
         // nav/Settings-tab pipeline) but required by the shared extension type.
+        //
+        // `group` must be set explicitly, and to the same cluster Environments
+        // and Pipelines fall into. Those are sidebar extensions that declare no
+        // group, so they share the unnamed divider cluster (`item.group ?? ''`
+        // in `useNavigationClusters`), while the built-in Gateways item lives in
+        // the "place" cluster higher up. Omitting it here would keep that
+        // built-in cluster and leave Gateways above Environments.
+        group: '',
         order: 45,
         routePath: 'gateways',
         render: (port) => <GatewaysFeature gatewayTypes={['regular', 'event']} port={port} />,


### PR DESCRIPTION
## Purpose

Four follow-ups to #3362:

1. In the cloud build the Gateways nav item rendered above Environments, not between Environments and Pipelines as intended. `#3362` merged a change that fell back to the built-in item's `group`, which put it back in the built-in "place" cluster.
2. Event gateways cannot be created yet, but the type was offered as a selectable option.
3. The gateways list showed "Last Updated", which says less about a gateway than the environment it lives in.
4. An invalid gateway name only failed at submit time, as a 400 from the backend.

## Goals

Gateways sits between Environments and Pipelines in both cloud portals, Event Gateway is visible but not selectable, the list shows each gateway's environment, and an unusable name is reported in the form.

## Approach

**Nav placement (api-control-plane)** — the page override now sets `group: ''` explicitly, joining the same cluster as the Environments and Pipelines sidebar extensions. The `override.group ?? definition.group` fallback stays, so an override that only reorders still keeps its group.

**Nav placement (ai-workspace)** — its sidebar is hardcoded JSX with extensions in a separate category below, so `order` alone cannot move the item. Enabled the Slot/Hideable split the portal already documents:
- mounted `HiddenRegionsProvider` (it existed in `slots/` but nothing provided it, so `Hideable` was inert)
- entries may declare `hides: [...]`; the built-in Gateways sidebar item is wrapped in `Hideable name="nav.gateways"`
- `AIWorkspacePageOverride` may carry nav placement (`label`/`icon`/`path`/`order`), as api-control-plane's override already carries `group`/`order`
- the override-carried entry is gated on `SCOPES.GATEWAY_READ`, the same scope the built-in item it stands in for is gated on

With no extensions registered nothing is hidden, so the open-source build is unchanged. Kept as one registration carrying nav metadata rather than a second sidebar entry, which would auto-generate a `<Route path="gateways">` colliding with the built-in `gateways/*`.

**Event Gateway** — `GatewayTypeCard` gained a `disabled` prop: "Coming soon" chip, `aria-disabled`, `tabIndex={-1}`, no click/keydown handler, dimmed, `cursor: not-allowed`. The card stays visible so the type remains discoverable.

**Environment column** — replaces the "Last Updated" column in the list, resolved from the environments the feature already loads and falling back to the gateway's raw environment when it is not in that list. Created/Last Updated are still in the settings drawer.

**Name validation** — new `validateGatewayName` mirrors the backend's rules for the name a gateway's handle is derived from: DNS-1123, not the reserved `default`, and short enough to fit the `<environment>-<name>` handle limit alongside the selected environment (so the message names the remaining budget). Case is not part of it — the backend lowercases first. Applied on create only: from then on the name is a display name and the handle is immutable, so an edit must not be blocked by rules that no longer apply to what it changes.

## User stories

- As a cloud user I find Gateways grouped with Environments and Pipelines in both portals.
- As a cloud user I can see that event gateways are coming without being able to select one.
- As a cloud user I see which environment each gateway belongs to in the list.
- As a cloud user I am told why a gateway name is unusable while typing it, not after submitting.

## Documentation

N/A — UI placement, an unselectable option, a swapped column and form validation.

## Automation tests

- Unit tests
  > No new tests: the plugin packages have no test setup, and the changes are nav placement, a disabled card state, a column swap and form validation. `AppRoutes.gatewaysOverride.test.tsx` (added in #3362) still passes.
- Integration tests
  > Typechecked the plugin packages and the `apip-cloud-ui` host. `portals/ai-workspace` typecheck shows no new errors (20 before, 20 after; the remaining ones are pre-existing on main). Exercised `validateGatewayName` against the boundary cases (reserved name, invalid characters, leading/trailing hyphen, and the exact per-environment length budget).

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? no — TypeScript UI change
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

- #3362 — the wiring this follows up on.

## Test environment

macOS (arm64), Node 24, Chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
