### PR TITLE
fix(apicp): API creation flow fixes, new API edit page, API Designer hand-off and login redesign

### DIFF
--- a/portals/api-control-plane/src/api/core/queryClient.test.ts
+++ b/portals/api-control-plane/src/api/core/queryClient.test.ts
@@ -19,7 +19,13 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { ApiError } from './errors';
-import { createQueryClient, retryDelay, shouldRetry, staleTimes } from './queryClient';
+import {
+  createQueryClient,
+  HANDLED_LOCALLY,
+  retryDelay,
+  shouldRetry,
+  staleTimes,
+} from './queryClient';
 
 /**
  * The retry policy is where a wrong answer is expensive in both directions:
@@ -172,6 +178,26 @@ describe('query defaults', () => {
 
     expect(rollback).toHaveBeenCalledTimes(1);
     expect(seen).toHaveLength(1);
+  });
+
+  it('stays quiet for a mutation that reports its own failures', async () => {
+    // The creation wizard binds a rejection onto the form fields that caused
+    // it. Without the opt-out the same failure would also fly past as a
+    // snackbar, which reads as two unrelated problems rather than one.
+    const seen: ApiError[] = [];
+    const client = createQueryClient({ onMutationError: (error) => seen.push(error) });
+
+    await client
+      .getMutationCache()
+      .build(client, {
+        meta: HANDLED_LOCALLY,
+        mutationFn: () => Promise.reject(httpError(409)),
+        retry: false,
+      })
+      .execute(undefined)
+      .catch(() => undefined);
+
+    expect(seen).toHaveLength(0);
   });
 
   it('keeps unused data in memory longer than it stays fresh, so back-navigation is instant', () => {

--- a/portals/api-control-plane/src/api/core/queryClient.ts
+++ b/portals/api-control-plane/src/api/core/queryClient.ts
@@ -71,6 +71,17 @@ export const retryDelay = (attemptIndex: number): number => {
   return Math.round(ceiling * (0.5 + Math.random() * 0.5));
 };
 
+/**
+ * Marks a mutation whose failures its own caller already puts on screen —
+ * bound onto form fields, shown in a panel. The global snackbar skips these,
+ * because a failure that has a home on screen reported *twice* reads worse
+ * than either report alone.
+ *
+ * Opt-in on purpose: a mutation that says nothing still gets the snackbar, so
+ * forgetting to handle an error can never mean swallowing it.
+ */
+export const HANDLED_LOCALLY = { handlesErrors: true } as const;
+
 export type QueryClientHandlers = {
   /** Called for every unhandled *mutation* error — wire to the snackbar. */
   onMutationError?: (error: ApiError) => void;
@@ -87,10 +98,12 @@ export const createQueryClient = (handlers: QueryClientHandlers = {}) =>
      * rather than running alongside it; so putting the global handler there
      * would silence it for exactly the mutations that define one, which is
      * every mutation doing an optimistic rollback. `MutationCache.onError`
-     * fires for all of them regardless.
+     * fires for all of them regardless — except the ones that opted out with
+     * `HANDLED_LOCALLY`, which surface the failure themselves.
      */
     mutationCache: new MutationCache({
-      onError: (error) => {
+      onError: (error, _variables, _onMutateResult, mutation) => {
+        if (mutation.meta?.handlesErrors === true) return;
         if (isApiError(error)) handlers.onMutationError?.(error);
       },
     }),

--- a/portals/api-control-plane/src/api/resources/restApis/restApis.hooks.ts
+++ b/portals/api-control-plane/src/api/resources/restApis/restApis.hooks.ts
@@ -25,6 +25,7 @@ import {
 } from '@tanstack/react-query';
 
 import type { ApiError } from '../../core/errors';
+import { HANDLED_LOCALLY } from '../../core/queryClient';
 import { useApiScope } from '../../core/scope';
 import {
   createRestApi,
@@ -210,12 +211,19 @@ const useInvalidateRestApis = (orgId?: string) => {
   };
 };
 
-export const useCreateRestApi = (overrides: { orgId?: string } = {}) => {
+/**
+ * When `handlesErrors` is true, errors are handled locally and won't trigger
+ * the global snackbar. Otherwise, errors reach the snackbar by default.
+ */
+export const useCreateRestApi = (
+  overrides: { handlesErrors?: boolean; orgId?: string } = {},
+) => {
   const { org, orgId } = useApiScope(overrides);
   const queryClient = useQueryClient();
   const invalidate = useInvalidateRestApis(orgId);
 
   return useMutation<RestApi, ApiError, CreateRestApiBody>({
+    meta: overrides.handlesErrors ? HANDLED_LOCALLY : undefined,
     mutationFn: (body) => createRestApi(body, { orgId }),
     onSuccess: (created) => {
       // Seed the detail cache from the create response so navigating straight

--- a/portals/api-control-plane/src/components/illustrations/ApiDesignerCanvasIllustration.tsx
+++ b/portals/api-control-plane/src/components/illustrations/ApiDesignerCanvasIllustration.tsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ColorSchemeSVG } from '@wso2/oxygen-ui';
+
+/** Dot-grid lattice behind the flow — sparse enough to read as a canvas. */
+const GRID_COLUMNS = 13;
+const GRID_ROWS = 7;
+
+/**
+ * A design canvas seen from a distance: window chrome, an activity rail, a dot
+ * grid, and a flow of operation nodes. It sits behind the hand-off button in
+ * `DesignWithAiPanel` to show what the API Designer extension opens into.
+ *
+ * Drawn through Oxygen's `ColorSchemeSVG` so every fill and stroke resolves to
+ * a theme colour rather than a hex literal — the console has a light/dark
+ * toggle, and a fixed-colour illustration would go muddy in dark mode.
+ *
+ * Purely decorative: the panel's heading and body carry the meaning, so it is
+ * hidden from assistive technology.
+ */
+export function ApiDesignerCanvasIllustration() {
+  return (
+    <ColorSchemeSVG
+      aria-hidden
+      height="auto"
+      sx={{ display: 'block', width: '100%' }}
+      viewBox="0 0 320 180"
+    >
+      {/* Editor window: chrome bar over the canvas body. The second rect
+          squares off the chrome's lower corners, which the rounded one keeps. */}
+      <rect fill="surface" height={180} rx={8} width={320} />
+      <rect fill="muted" height={20} rx={8} width={320} />
+      <rect fill="muted" height={12} width={320} y={8} />
+      <g fill="border">
+        <circle cx={14} cy={10} r={3} />
+        <circle cx={26} cy={10} r={3} />
+        <circle cx={38} cy={10} r={3} />
+      </g>
+
+      {/* Activity rail down the left edge, one item active. */}
+      <rect fill="muted" height={160} width={24} x={0} y={20} />
+      <rect fill="border" height={10} rx={2} width={10} x={7} y={32} />
+      <rect fill="primary" height={10} rx={2} width={10} x={7} y={48} />
+      <rect fill="border" height={10} rx={2} width={10} x={7} y={64} />
+
+      <g fill="border">
+        {Array.from({ length: GRID_ROWS }, (_, row) =>
+          Array.from({ length: GRID_COLUMNS }, (_, column) => (
+            <circle cx={40 + column * 22} cy={36 + row * 20} key={`${row}-${column}`} r={1} />
+          )),
+        )}
+      </g>
+
+      {/* The flow itself: a start pill, an operation card with a branch off it,
+          a decision diamond, and a placeholder waiting to be filled in. */}
+      <g fill="none" stroke="border" strokeWidth={1.5}>
+        <path d="M170 52v16M170 104v14M170 140v12" />
+        <rect height={22} rx={11} width={54} x={143} y={30} />
+        <rect fill="background" height={36} rx={6} width={110} x={115} y={68} />
+        <path d="M225 86h7" />
+        <circle cx={244} cy={86} r={12} />
+        <rect
+          fill="background"
+          height={22}
+          rx={4}
+          transform="rotate(45 170 129)"
+          width={22}
+          x={159}
+          y={118}
+        />
+        <rect height={22} rx={6} strokeDasharray="4 3" width={110} x={115} y={152} />
+      </g>
+
+      {/* Contents of the operation card, and the two accents that give the
+          canvas a focal point. */}
+      <g fill="border">
+        <rect height={8} rx={2} width={8} x={125} y={82} />
+        <rect height={6} rx={3} width={48} x={139} y={83} />
+        <rect height={8} rx={2} width={8} x={205} y={82} />
+      </g>
+      <circle cx={244} cy={86} fill="primary" r={5} />
+      <path d="M166 163h8M170 159v8" stroke="primary" strokeLinecap="round" strokeWidth={1.5} />
+    </ColorSchemeSVG>
+  );
+}

--- a/portals/api-control-plane/src/components/illustrations/MonitorIllustration.tsx
+++ b/portals/api-control-plane/src/components/illustrations/MonitorIllustration.tsx
@@ -63,9 +63,9 @@ export function MonitorIllustration() {
       <rect fill="primary" height={5} rx={2} width={28} x={126} y={82} />
       <rect fill="muted" height={4} rx={2} width={52} x={126} y={92} />
 
-      {/* Stand, and the surface it rests on. */}
+      {/* Stand and surface use `muted` so the line stays visible in both themes. */}
       <rect fill="text-disabled" height={12} rx={1} width={24} x={98} y={118} />
-      <path d="M62 132h96" stroke="border" strokeLinecap="round" strokeWidth={2} />
+      <path d="M62 132h96" stroke="muted" strokeLinecap="round" strokeWidth={2} />
     </ColorSchemeSVG>
   );
 }

--- a/portals/api-control-plane/src/config/runtime.ts
+++ b/portals/api-control-plane/src/config/runtime.ts
@@ -69,6 +69,13 @@ export type RuntimeConfig = {
    * not a hardcoded link.
    */
   moesifWebUrl: string;
+  /**
+   * API Designer for VS Code. The wizard's "design from scratch" step hands
+   * off to the extension rather than hosting a canvas here, so the
+   * deployment's own marketplace and docs links are config, not hardcoded.
+   */
+  apiDesignerVsCodeUrl: string;
+  apiDesignerDocsUrl: string;
   privacyPolicyLink: string;
   projectApiBaseUrl: string;
   termsOfUseLink: string;
@@ -93,6 +100,8 @@ type LegacyWindowConfig = Partial<{
   POLICY_HUB_BASE_URL: string;
   POLICY_HUB_WEB_URL: string;
   MOESIF_WEB_URL: string;
+  API_DESIGNER_VSCODE_URL: string;
+  API_DESIGNER_DOCS_URL: string;
   PRIVACY_POLICY_LINK: string;
   PROJECT_API_BASE_URL: string;
   TERMS_OF_USE_LINK: string;
@@ -214,6 +223,14 @@ export const runtimeConfig: RuntimeConfig = {
     fromWindow().MOESIF_WEB_URL ||
     import.meta.env.VITE_MOESIF_WEB_URL ||
     'https://www.moesif.com/wrap/basic',
+  apiDesignerVsCodeUrl:
+    fromWindow().API_DESIGNER_VSCODE_URL ||
+    import.meta.env.VITE_API_DESIGNER_VSCODE_URL ||
+    'https://marketplace.visualstudio.com/items?itemName=WSO2.api-designer',
+  apiDesignerDocsUrl:
+    fromWindow().API_DESIGNER_DOCS_URL ||
+    import.meta.env.VITE_API_DESIGNER_DOCS_URL ||
+    'https://wso2.com/api-platform/docs/tools/vscode-api-design/getting-started/',
   privacyPolicyLink:
     fromWindow().PRIVACY_POLICY_LINK ||
     fromWindow().privacyPolicyLink ||

--- a/portals/api-control-plane/src/i18n/messages/en.json
+++ b/portals/api-control-plane/src/i18n/messages/en.json
@@ -166,15 +166,6 @@
   "api.create.defineApi.scratch.title": {
     "defaultMessage": "Design from scratch"
   },
-  "api.create.designWithAi.detail": {
-    "defaultMessage": "The skeleton on the right is a starting point — carry on and edit its operations by hand."
-  },
-  "api.create.designWithAi.feature": {
-    "defaultMessage": "Designing an API by chatting with AI"
-  },
-  "api.create.designWithAi.title": {
-    "defaultMessage": "Design with AI"
-  },
   "api.create.fromContract.action.sampleUrl": {
     "defaultMessage": "Try with Sample URL",
     "description": "Fills the field with a ready-made example to try the import with."
@@ -693,6 +684,22 @@
     "defaultMessage": "Transports",
     "description": "Label for the protocols an API is exposed over (HTTP, HTTPS)."
   },
+  "apiControlPlane.pages.appShell.appShellPages.apis.create.components.DesignWithAiPanel.action": {
+    "defaultMessage": "Open API Designer",
+    "description": "Button opening the API Designer VS Code extension listing in a new tab. \"API Designer\" is a product name — leave it untranslated."
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.create.components.DesignWithAiPanel.body": {
+    "defaultMessage": "Draw operations on a canvas, check them against governance rules, and design with AI in VS Code."
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.create.components.DesignWithAiPanel.docs": {
+    "defaultMessage": "How to get started"
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.create.components.DesignWithAiPanel.skeletonHint": {
+    "defaultMessage": "Or carry on here - the skeleton on the right is a starting point you can edit by hand."
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.create.components.DesignWithAiPanel.title": {
+    "defaultMessage": "Design with AI"
+  },
   "apiControlPlane.pages.appShell.appShellPages.apis.develop.DocumentsPage.subtitle": {
     "defaultMessage": "Documentation for {apiName}",
     "description": "Sub-header under the section name; {apiName} is the API display name."
@@ -945,7 +952,7 @@
   },
   "apiControlPlane.pages.appShell.appShellPages.apis.overview.ProgressBanner.step.publish": {
     "defaultMessage": "Publish to API Portal",
-    "description": "Fourth step of the API progress stepper — the API is listed in the developer portal, which ships under the name \"Devportal\"."
+    "description": "Fourth step of the API progress stepper — the API is listed in the developer portal, which ships under the name \"API Portal\"."
   },
   "apiControlPlane.pages.appShell.appShellPages.apis.overview.ProgressBanner.step.test": {
     "defaultMessage": "Test",

--- a/portals/api-control-plane/src/i18n/messages/en.json
+++ b/portals/api-control-plane/src/i18n/messages/en.json
@@ -147,14 +147,15 @@
     "description": "Returns to the previous step of the API creation wizard."
   },
   "api.create.defineApi.action.next": {
-    "defaultMessage": "Next"
+    "defaultMessage": "Continue",
+    "description": "Carries the definition in the preview pane on to the next step."
   },
   "api.create.defineApi.approach.label": {
     "defaultMessage": "How do you want to define this API?",
     "description": "Accessible name for the pair of approach tabs at the top of the step."
   },
   "api.create.defineApi.contract.description": {
-    "defaultMessage": "Import from a URL, file, or SwaggerHub."
+    "defaultMessage": "Import from a URL or a file."
   },
   "api.create.defineApi.contract.title": {
     "defaultMessage": "Start with a contract"
@@ -173,10 +174,6 @@
   },
   "api.create.designWithAi.title": {
     "defaultMessage": "Design with AI"
-  },
-  "api.create.fromContract.action.fetch": {
-    "defaultMessage": "Fetch Contract",
-    "description": "Reads the contract from the chosen source and previews its resources, without leaving the step."
   },
   "api.create.fromContract.action.sampleUrl": {
     "defaultMessage": "Try with Sample URL",
@@ -260,6 +257,10 @@
   "api.create.fromContract.spec.unsupportedSource": {
     "defaultMessage": "Importing from this source is not available yet."
   },
+  "api.create.fromContract.status.fetching": {
+    "defaultMessage": "Reading the contract…",
+    "description": "Shown while the chosen contract is being read and checked, which starts on its own."
+  },
   "api.create.fromContract.swaggerHub.apiLabel": {
     "defaultMessage": "API"
   },
@@ -313,23 +314,29 @@
     "defaultMessage": "Create API Proxy from Contract"
   },
   "api.create.fromContract.upload.accepted": {
-    "defaultMessage": "Accepted file types: {extensions}"
+    "defaultMessage": "Accepted: {extensions} · up to {maxSize}",
+    "description": "Neutral helper line under the drop zone. {maxSize} is a formatted size such as \"10 MB\"."
   },
   "api.create.fromContract.upload.action": {
-    "defaultMessage": "Upload"
+    "defaultMessage": "Select file"
   },
   "api.create.fromContract.upload.hint": {
-    "defaultMessage": "Drag & Drop your files or click to select files"
+    "defaultMessage": "One file · {extensions}",
+    "description": "Sits under the drop-zone heading; {extensions} is a list such as \".json, .yaml\"."
   },
   "api.create.fromContract.upload.remove": {
     "defaultMessage": "Remove {fileName}",
     "description": "Accessible name for the button that discards the chosen file."
   },
+  "api.create.fromContract.upload.replace": {
+    "defaultMessage": "Replace file",
+    "description": "Reopens the file picker so the chosen contract can be swapped for another."
+  },
   "api.create.fromContract.upload.required": {
     "defaultMessage": "Select an API contract file to continue"
   },
   "api.create.fromContract.upload.title": {
-    "defaultMessage": "Upload API Contract"
+    "defaultMessage": "Drag and drop your contract here"
   },
   "api.create.fromContract.upload.unsupported": {
     "defaultMessage": "That file type is not supported. Accepted types: {extensions}"
@@ -352,26 +359,20 @@
   "api.create.generalForm.action.create": {
     "defaultMessage": "Create"
   },
-  "api.create.generalForm.basePath.error.pattern": {
+  "api.create.generalForm.context.error.pattern": {
     "defaultMessage": "Start with / and use only letters, numbers, hyphens, dots and slashes."
   },
-  "api.create.generalForm.basePath.error.required": {
-    "defaultMessage": "Enter a base path."
+  "api.create.generalForm.context.error.required": {
+    "defaultMessage": "Enter a context."
   },
-  "api.create.generalForm.basePath.helper": {
+  "api.create.generalForm.context.helper": {
     "defaultMessage": "Built from the project, identifier and version. Edit it to route this API somewhere else."
   },
-  "api.create.generalForm.basePath.label": {
-    "defaultMessage": "Base Path"
+  "api.create.generalForm.context.label": {
+    "defaultMessage": "Context"
   },
   "api.create.generalForm.description.label": {
     "defaultMessage": "Description"
-  },
-  "api.create.generalForm.displayName.error.required": {
-    "defaultMessage": "Enter a display name."
-  },
-  "api.create.generalForm.displayName.label": {
-    "defaultMessage": "Display name"
   },
   "api.create.generalForm.identifier.error.pattern": {
     "defaultMessage": "Use lowercase letters and numbers, separated by single hyphens."
@@ -400,6 +401,16 @@
   },
   "api.create.generalForm.identifier.status.checking": {
     "defaultMessage": "Checking whether this identifier is free…"
+  },
+  "api.create.generalForm.name.error.required": {
+    "defaultMessage": "Enter a name."
+  },
+  "api.create.generalForm.name.label": {
+    "defaultMessage": "Name"
+  },
+  "api.create.generalForm.rejected.title": {
+    "defaultMessage": "We could not create this API proxy",
+    "description": "Heading of the summary shown when the server rejected the submitted form."
   },
   "api.create.generalForm.section.backendEndpoint": {
     "defaultMessage": "Backend endpoint"
@@ -658,29 +669,13 @@
     "defaultMessage": "Deploy to Gateway",
     "description": "Button on the API overview header that opens the API's deployment page."
   },
-  "apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.description.cancel": {
-    "defaultMessage": "Cancel",
-    "description": "Discards an unsaved edit to the API description."
-  },
-  "apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.description.edit": {
-    "defaultMessage": "Edit description",
-    "description": "Accessible label and tooltip for the pencil button that opens the description for editing."
-  },
-  "apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.description.fieldLabel": {
-    "defaultMessage": "Description",
-    "description": "Label of the text box used to edit the API description."
-  },
   "apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.description.placeholder": {
     "defaultMessage": "No description",
     "description": "Shown in place of the API description when the API has none. Rendered in italics as an absence, not as a value."
   },
-  "apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.description.save": {
-    "defaultMessage": "Save",
-    "description": "Commits an edit to the API description."
-  },
-  "apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.description.saved": {
-    "defaultMessage": "Description updated.",
-    "description": "Confirmation shown after the API description is saved."
+  "apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.editApi": {
+    "defaultMessage": "Edit API details",
+    "description": "Accessible label and tooltip for the button beside the API name, which opens the edit page."
   },
   "apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.gatewayManaged": {
     "defaultMessage": "Gateway-managed",
@@ -718,6 +713,99 @@
   },
   "apiControlPlane.pages.appShell.appShellPages.apis.develop.RoutingPage.title": {
     "defaultMessage": "Routing"
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.edit.ApiEditPage.back": {
+    "defaultMessage": "Back to API",
+    "description": "Back button above the edit form, returning to the API overview."
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.edit.ApiEditPage.loading": {
+    "defaultMessage": "Loading API",
+    "description": "Shown while the API being edited is fetched."
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.edit.ApiEditPage.notFound": {
+    "defaultMessage": "API not found",
+    "description": "Shown when the API to edit could not be loaded."
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.edit.ApiEditPage.readOnly": {
+    "defaultMessage": "This API cannot be edited here",
+    "description": "Title shown when the edit page is opened for a gateway-managed API."
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.edit.ApiEditPage.readOnlyDetail": {
+    "defaultMessage": "It was discovered from a data-plane gateway, so it is read-only in this console.",
+    "description": "Explains why a gateway-managed API cannot be edited."
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.edit.ApiEditPage.saved": {
+    "defaultMessage": "API updated.",
+    "description": "Confirmation shown after the API details are saved."
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.edit.ApiEditPage.subtitle": {
+    "defaultMessage": "Change the name, description, context, version and backend of this API."
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.edit.ApiEditPage.title": {
+    "defaultMessage": "Edit API"
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.action.cancel": {
+    "defaultMessage": "Cancel",
+    "description": "Discards the unsaved edits and returns to the API overview."
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.action.save": {
+    "defaultMessage": "Save changes",
+    "description": "Commits the edits to the API."
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.context.error.pattern": {
+    "defaultMessage": "Start with / and use only letters, numbers, hyphens, dots and slashes."
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.context.error.required": {
+    "defaultMessage": "Enter a context."
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.context.label": {
+    "defaultMessage": "Context"
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.description.label": {
+    "defaultMessage": "Description"
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.identifier.helper": {
+    "defaultMessage": "Fixed once the API is created.",
+    "description": "Helper text under the disabled identifier field on the API edit form."
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.identifier.label": {
+    "defaultMessage": "Identifier"
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.name.error.required": {
+    "defaultMessage": "Enter a name."
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.name.label": {
+    "defaultMessage": "Name"
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.section.backendEndpoint": {
+    "defaultMessage": "Backend endpoint",
+    "description": "Heading of the field group holding the target URL."
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.section.basicInformation": {
+    "defaultMessage": "Basic information",
+    "description": "Heading of the field group holding name, identifier, version, context."
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.targetUrl.error.invalid": {
+    "defaultMessage": "Enter a full URL, for example https://api.example.com."
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.targetUrl.error.required": {
+    "defaultMessage": "Enter a target URL."
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.targetUrl.label": {
+    "defaultMessage": "Target URL"
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.targetUrl.sharedUpstream": {
+    "defaultMessage": "Routed through the shared upstream “{ref}”, so there is no URL to edit here.",
+    "description": "Helper text shown instead of an editable target URL when the API points at a named upstream definition. {ref} is that definition’s name."
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.version.error.pattern": {
+    "defaultMessage": "Use letters, numbers, dots, hyphens and underscores — no spaces or slashes."
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.version.error.required": {
+    "defaultMessage": "Enter a version."
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.version.label": {
+    "defaultMessage": "Version"
   },
   "apiControlPlane.pages.appShell.appShellPages.apis.overview.ApiKeysPanel.add": {
     "defaultMessage": "Add",
@@ -856,7 +944,7 @@
     "description": "Second step of the API progress stepper — the API runs on a gateway. A stage name, not a button command."
   },
   "apiControlPlane.pages.appShell.appShellPages.apis.overview.ProgressBanner.step.publish": {
-    "defaultMessage": "Publish to Devportal",
+    "defaultMessage": "Publish to API Portal",
     "description": "Fourth step of the API progress stepper — the API is listed in the developer portal, which ships under the name \"Devportal\"."
   },
   "apiControlPlane.pages.appShell.appShellPages.apis.overview.ProgressBanner.step.test": {
@@ -1778,6 +1866,107 @@
   "apiControlPlane.pages.appShell.appShellPages.test.TestPage.title": {
     "defaultMessage": "Test {apiName}",
     "description": "Page heading. {apiName} is the API display name, user-supplied; do not translate it."
+  },
+  "apiControlPlane.pages.auth.LoginPage.brandLockup": {
+    "defaultMessage": "<brand>WSO2</brand> API Platform",
+    "description": "Compact brand lockup shown above the sign-in card on narrow screens. WSO2 is the company name and stays as-is; the brand tag only styles it."
+  },
+  "apiControlPlane.pages.auth.LoginPage.brandName": {
+    "defaultMessage": "WSO2",
+    "description": "Company name in the brand lockup. Do not translate."
+  },
+  "apiControlPlane.pages.auth.LoginPage.browserUnsupported": {
+    "defaultMessage": "This console is optimized for Google Chrome and Mozilla Firefox."
+  },
+  "apiControlPlane.pages.auth.LoginPage.continueToConsole": {
+    "defaultMessage": "Continue to your API Platform console."
+  },
+  "apiControlPlane.pages.auth.LoginPage.eyebrow": {
+    "defaultMessage": "AI-NATIVE · SCALABLE SAAS",
+    "description": "Marketing label above the headline, set in upper case. Keep it short — it renders inside a small pill."
+  },
+  "apiControlPlane.pages.auth.LoginPage.featureDeploy": {
+    "defaultMessage": "Deploy and manage with zero friction"
+  },
+  "apiControlPlane.pages.auth.LoginPage.featureDesign": {
+    "defaultMessage": "Design API proxies or MCP servers"
+  },
+  "apiControlPlane.pages.auth.LoginPage.featureMonitor": {
+    "defaultMessage": "Monitor, test, and analyze performance"
+  },
+  "apiControlPlane.pages.auth.LoginPage.featurePublish": {
+    "defaultMessage": "Publish faster with AI-powered capabilities"
+  },
+  "apiControlPlane.pages.auth.LoginPage.featureSecure": {
+    "defaultMessage": "Secure and govern traffic"
+  },
+  "apiControlPlane.pages.auth.LoginPage.headline": {
+    "defaultMessage": "Manage, secure, and scale your <accent>APIs & MCP servers</accent>",
+    "description": "Marketing headline. The accent tag marks the phrase painted in the brand gradient — keep it around the equivalent phrase in the translation."
+  },
+  "apiControlPlane.pages.auth.LoginPage.homePageLink": {
+    "defaultMessage": "More details at <link>wso2.com/api-platform</link>",
+    "description": "Footer line under the sign-in form. The link tag wraps the product home page address, which stays as-is."
+  },
+  "apiControlPlane.pages.auth.LoginPage.invitationVerified": {
+    "defaultMessage": "Invitation verified for {organization}. Sign in to accept it."
+  },
+  "apiControlPlane.pages.auth.LoginPage.oidcAccessDenied": {
+    "defaultMessage": "Access was denied."
+  },
+  "apiControlPlane.pages.auth.LoginPage.oidcAuthFailed": {
+    "defaultMessage": "Unable to complete sign in. Please try again."
+  },
+  "apiControlPlane.pages.auth.LoginPage.oidcGenericError": {
+    "defaultMessage": "Unable to complete sign in.",
+    "description": "Shown when the identity provider returned a failure code this console does not recognise."
+  },
+  "apiControlPlane.pages.auth.LoginPage.oidcSessionFailed": {
+    "defaultMessage": "Unable to establish a session. Please try again."
+  },
+  "apiControlPlane.pages.auth.LoginPage.passwordHide": {
+    "defaultMessage": "Hide",
+    "description": "Toggle that masks the password again. Command, not a noun."
+  },
+  "apiControlPlane.pages.auth.LoginPage.passwordLabel": {
+    "defaultMessage": "Password"
+  },
+  "apiControlPlane.pages.auth.LoginPage.passwordPlaceholder": {
+    "defaultMessage": "Enter your password"
+  },
+  "apiControlPlane.pages.auth.LoginPage.passwordShow": {
+    "defaultMessage": "Show",
+    "description": "Toggle that reveals the typed password. Command, not a noun."
+  },
+  "apiControlPlane.pages.auth.LoginPage.privacyPolicy": {
+    "defaultMessage": "Privacy policy"
+  },
+  "apiControlPlane.pages.auth.LoginPage.productName": {
+    "defaultMessage": "<emphasis>API</emphasis> Platform",
+    "description": "Product name under the WSO2 wordmark. The emphasis tag marks the part set in the stronger weight."
+  },
+  "apiControlPlane.pages.auth.LoginPage.sessionExpired": {
+    "defaultMessage": "Your session has expired. Sign in again to continue."
+  },
+  "apiControlPlane.pages.auth.LoginPage.signInAction": {
+    "defaultMessage": "Sign in",
+    "description": "Label of the button that submits the sign-in form. A command."
+  },
+  "apiControlPlane.pages.auth.LoginPage.tagline": {
+    "defaultMessage": "A comprehensive platform for designing, deploying, governing, and optimizing APIs and MCP servers — end to end."
+  },
+  "apiControlPlane.pages.auth.LoginPage.termsOfUse": {
+    "defaultMessage": "Terms of use"
+  },
+  "apiControlPlane.pages.auth.LoginPage.title": {
+    "defaultMessage": "Sign in",
+    "description": "Heading of the sign-in card. A noun phrase naming the page."
+  },
+  "apiControlPlane.pages.auth.LoginPage.usernameLabel": {
+    "defaultMessage": "Username"
+  },
+  "apiControlPlane.pages.auth.LoginPage.usernamePlaceholder": {
+    "defaultMessage": "Enter your username"
   },
   "apiControlPlane.projects.ProjectQuickActions.importApi": {
     "defaultMessage": "Import an OpenAPI definition"

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/ApiCreationWizard.test.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/ApiCreationWizard.test.tsx
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { resetHttpClient } from '@/api/core/http';
+import { collection, failure } from '@/test/msw';
+import { makeConsoleScope } from '@/test/mockScope';
+import { server } from '@/test/server';
+import { renderWithProviders, screen } from '@/test/utils';
+import { ApiCreationWizard } from './ApiCreationWizard';
+
+/*
+ * The first two steps are stubbed to a single button each. What they collect
+ * is covered by their own suites; these tests are about where a *rejected*
+ * create leaves the user, and reaching that point through the real pickers
+ * would mean rendering Swagger UI and Monaco to get there.
+ */
+vi.mock('./components/ApiTypeSelector', () => ({
+  ApiTypeSelector: ({ onChange }: { onChange: (apiType: unknown) => void }) => (
+    <button
+      onClick={() =>
+        onChange({
+          description: { defaultMessage: 'REST', id: 'test.apiType.description' },
+          enabled: true,
+          icon: null,
+          key: 'rest',
+          title: { defaultMessage: 'REST API', id: 'test.apiType.title' },
+        })
+      }
+      type="button"
+    >
+      Choose REST
+    </button>
+  ),
+}));
+
+vi.mock('./components/DefineApiPanel', () => ({
+  DefineApiPanel: ({ onDataFetched }: { onDataFetched: (draft: unknown) => void }) => (
+    <button
+      onClick={() => onDataFetched({ displayName: 'Orders API', version: '1.0' })}
+      type="button"
+    >
+      Use this contract
+    </button>
+  ),
+}));
+
+const scope = makeConsoleScope();
+const route = '/organizations/api-platform-demo/projects/retail-apis/apis/create';
+
+beforeEach(() => {
+  resetHttpClient();
+  server.use(collection('/rest-apis', []));
+});
+
+/** Runs the wizard as far as a submitted create request. */
+const submitCreate = async () => {
+  const rendered = renderWithProviders(<ApiCreationWizard />, { route, scope });
+  const { user } = rendered;
+
+  await user.click(screen.getByRole('button', { name: 'Choose REST' }));
+  await user.click(screen.getByRole('button', { name: 'Use this contract' }));
+  await user.type(screen.getByLabelText(/Target URL/), 'https://orders.example.com');
+  await user.click(screen.getByRole('button', { name: 'Create' }));
+
+  return rendered;
+};
+
+describe('ApiCreationWizard — a rejected create', () => {
+  it('returns to the form with the reason on the field, when the user can fix it', async () => {
+    server.use(
+      failure('post', '/rest-apis', 409, 'CONFLICT', {
+        errors: [{ field: 'id', message: 'An API with this identifier already exists.' }],
+        message: 'The API could not be created.',
+      }),
+    );
+
+    await submitCreate();
+
+    expect(
+      await screen.findByText('An API with this identifier already exists.'),
+    ).toBeInTheDocument();
+    // Back on the form, not stranded on a progress screen that cannot say why.
+    expect(screen.getByLabelText(/Identifier/)).toHaveValue('orders-api');
+    expect(screen.queryByRole('button', { name: 'Try again' })).not.toBeInTheDocument();
+  });
+
+  it('keeps what the user typed, so nothing has to be entered twice', async () => {
+    server.use(
+      failure('post', '/rest-apis', 400, 'VALIDATION_FAILED', {
+        errors: [{ field: 'upstream.main.url', message: 'Must be reachable over https.' }],
+      }),
+    );
+
+    await submitCreate();
+
+    expect(await screen.findByText('Must be reachable over https.')).toBeInTheDocument();
+    expect(screen.getByLabelText(/Target URL/)).toHaveValue('https://orders.example.com');
+  });
+
+  it('stays on the progress screen for a failure no edit can fix', async () => {
+    // A 500 is not the form's problem: sending the user back to retype fields
+    // that were never wrong would be a lie about what went wrong.
+    server.use(failure('post', '/rest-apis', 500, 'INTERNAL_ERROR'));
+
+    await submitCreate();
+
+    expect(await screen.findByRole('button', { name: 'Try again' })).toBeInTheDocument();
+    expect(screen.queryByLabelText(/Target URL/)).not.toBeInTheDocument();
+  });
+});

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/ApiCreationWizard.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/ApiCreationWizard.tsx
@@ -29,6 +29,7 @@ import { useCreateRestApi } from '@/api/resources/restApis';
 import { useConsoleScope } from '@/scope/ConsoleScopeProvider';
 import { routes } from '@/routes/paths';
 import { toCreateRestApiBody } from './utils/createRestApiBody';
+import { toCreateApiFormErrors, type CreateApiFormErrors } from './utils/serverFieldErrors';
 import {
   ApiCreationProgress,
   type ApiCreationProgressStatus,
@@ -129,7 +130,9 @@ export const ApiCreationWizard = () => {
   };
 
   const navigate = useNavigate();
-  const createRestApiMutation = useCreateRestApi();
+  // `handlesErrors`: a rejection this screen puts back on the form must not
+  // also arrive as a snackbar that has faded by the time the user looks up.
+  const createRestApiMutation = useCreateRestApi({ handlesErrors: true });
   // `projectId` on the request body is the project handle from the route, not
   // something the form collects.
   const { activeScope, params } = useConsoleScope();
@@ -143,6 +146,12 @@ export const ApiCreationWizard = () => {
   const [submittedValues, setSubmittedValues] = useState<GeneralApiCreationFormState | null>(null);
   /** Whether the progress screen stands in for the form. */
   const [creationStarted, setCreationStarted] = useState(false);
+  /**
+   * Why the last attempt was rejected, when the form is where it belongs.
+   * Cleared on the next submission, not on the way back — the form is what
+   * renders it, and it has to survive being returned to.
+   */
+  const [formErrors, setFormErrors] = useState<CreateApiFormErrors | null>(null);
 
   const createApi = (values: GeneralApiCreationFormState) => {
     const projectId = activeScope.projectHandler;
@@ -151,7 +160,25 @@ export const ApiCreationWizard = () => {
       return;
     }
 
-    createRestApiMutation.mutate(toCreateRestApiBody(values, { projectId }));
+    setFormErrors(null);
+    // Clears the previous attempt's error before the next one starts: the
+    // progress screen reads its status from this mutation, and a stale
+    // `isError` would show it as failed for the frame before the retry
+    // registers as pending.
+    createRestApiMutation.reset();
+    createRestApiMutation.mutate(toCreateRestApiBody(values, { projectId }), {
+      onError: (error) => {
+        // A rejection the user can fix by editing goes straight back to the
+        // form with the reason attached. Standing on a screen that says only
+        // "we could not create this" would hide the one thing they need —
+        // which value to change — behind a second click.
+        const rejection = toCreateApiFormErrors(error);
+        if (!rejection) return; // Not the form's to fix: the progress screen keeps it.
+
+        setFormErrors(rejection);
+        setCreationStarted(false);
+      },
+    });
   };
 
   const onGeneralFormSumit = (finalData: GeneralApiCreationFormState) => {
@@ -249,6 +276,7 @@ export const ApiCreationWizard = () => {
                 initialValues={submittedValues ?? prefilledData}
                 onSubmit={onGeneralFormSumit}
                 onBack={() => setStep('source')}
+                serverErrors={formErrors ?? undefined}
               />
             </Box>
           )}

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/ApiCreationProgress.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/ApiCreationProgress.tsx
@@ -133,6 +133,20 @@ const ART = {
 } as const;
 
 /**
+ * Rendered width of the illustration, in px. The drawing scales to it from the
+ * viewBox, so this is the only knob for how large it appears on screen.
+ */
+const ART_DISPLAY_WIDTH = 720;
+
+/**
+ * Tooth counts of the two gears, which double as their turn durations in
+ * seconds. Meshing gears turn at a ratio set by their tooth counts, so one
+ * second per tooth keeps the pair honest — and is slow enough not to nag.
+ */
+const GEAR_TEETH_LARGE = 9;
+const GEAR_TEETH_SMALL = 8;
+
+/**
  * Points of a regular pointy-top hexagon, as an SVG `points` string.
  */
 const hexagonPoints = (cx: number, cy: number, radius: number): string =>
@@ -198,12 +212,41 @@ const ApiProxyAssemblyArt = () => {
   const centreY = ART.height / 2;
   const outline = theme.palette.primary.main;
   const cog = theme.palette.primary.contrastText;
+  // Pivots are stated in viewBox units rather than left to `fill-box`: a gear's
+  // bounding box isn't centred on its axle for odd tooth counts, so the default
+  // origin would make it wobble instead of spin.
+  const largeGear = { cx: centreX + 6, cy: centreY - 6 };
+  const smallGear = { cx: centreX - 14, cy: centreY + 14 };
 
   return (
     <Box
       aria-hidden
       component="svg"
-      sx={{ display: 'block', maxWidth: '100%', width: ART.width }}
+      sx={{
+        // The spin lives here rather than in a `style` prop, so the
+        // reduced-motion rule below can actually override it.
+        '& .gear--large': { animation: `apicpGearSpin ${GEAR_TEETH_LARGE}s linear infinite` },
+        '& .gear--small': {
+          // Meshed with the larger gear, so it has to turn the other way.
+          animation: `apicpGearSpinReverse ${GEAR_TEETH_SMALL}s linear infinite`,
+        },
+        '@keyframes apicpGearSpin': {
+          from: { transform: 'rotate(0deg)' },
+          to: { transform: 'rotate(360deg)' },
+        },
+        '@keyframes apicpGearSpinReverse': {
+          from: { transform: 'rotate(0deg)' },
+          to: { transform: 'rotate(-360deg)' },
+        },
+        // Motion here is decorative; anyone who has asked for less gets the
+        // same illustration, held still.
+        '@media (prefers-reduced-motion: reduce)': {
+          '& .gear--large, & .gear--small': { animation: 'none' },
+        },
+        display: 'block',
+        maxWidth: '100%',
+        width: ART_DISPLAY_WIDTH,
+      }}
       viewBox={`0 0 ${ART.width} ${ART.height}`}
     >
       {/* Client, left: a diamond. */}
@@ -244,14 +287,22 @@ const ApiProxyAssemblyArt = () => {
         </g>
       ))}
 
-      {/* The proxy itself. */}
+      {/* The proxy itself, with its two gears turning against each other. */}
       <polygon fill={outline} points={hexagonPoints(centreX, centreY, ART.hexRadius)} />
-      <path d={gearPath(centreX + 6, centreY - 6, 17, 13, 7, 9)} fill={cog} fillRule="evenodd" />
-      <circle cx={centreX + 6} cy={centreY - 6} fill={cog} r={3.5} />
       <path
-        d={gearPath(centreX - 14, centreY + 14, 10, 7.5, 3.5, 8)}
+        className="gear--large"
+        d={gearPath(largeGear.cx, largeGear.cy, 17, 13, 7, GEAR_TEETH_LARGE)}
         fill={cog}
         fillRule="evenodd"
+        style={{ transformOrigin: `${largeGear.cx}px ${largeGear.cy}px` }}
+      />
+      <circle cx={largeGear.cx} cy={largeGear.cy} fill={cog} r={3.5} />
+      <path
+        className="gear--small"
+        d={gearPath(smallGear.cx, smallGear.cy, 10, 7.5, 3.5, GEAR_TEETH_SMALL)}
+        fill={cog}
+        fillRule="evenodd"
+        style={{ transformOrigin: `${smallGear.cx}px ${smallGear.cy}px` }}
       />
     </Box>
   );

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/ContractSourceForm.test.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/ContractSourceForm.test.tsx
@@ -24,6 +24,35 @@ import { ContractSourceForm, fetchContractForPreview } from './ContractSourceFor
 const yamlFile = (name: string) =>
   new File(['openapi: 3.0.0'], name, { type: 'application/x-yaml' });
 
+/** The smallest document the step accepts: a dialect, a title, an operation. */
+const VALID_SPEC = [
+  'openapi: 3.0.0',
+  'info:',
+  '  title: Orders',
+  "  version: '1.0'",
+  'servers:',
+  '  - url: https://example.com',
+  'paths:',
+  '  /orders:',
+  '    get:',
+  '      responses:',
+  "        '200':",
+  '          description: ok',
+].join('\n');
+
+/** Serves `VALID_SPEC` to every request, and counts them. */
+const stubSpecHost = () => {
+  const fetchMock = vi.fn(() =>
+    Promise.resolve({
+      headers: new Headers(),
+      ok: true,
+      text: () => Promise.resolve(VALID_SPEC),
+    }),
+  );
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+};
+
 /** The hidden `<input type="file">` inside the drop zone. */
 const filePicker = (): HTMLInputElement => {
   const input = document.querySelector('input[type="file"]');
@@ -65,46 +94,96 @@ describe('ContractSourceForm — file upload', () => {
 
     await waitFor(() => expect(screen.queryByText('openapi.yaml')).not.toBeInTheDocument());
     // Removing is not an error, so the neutral line comes back.
-    expect(screen.getByText(/Accepted file types:/)).toBeInTheDocument();
+    expect(screen.getByText(/Accepted: /)).toBeInTheDocument();
     expect(screen.queryByText(/is not supported/)).not.toBeInTheDocument();
   });
 });
 
-describe('ContractSourceForm — unwired controls', () => {
-  it('renders no GitHub authorize button when no handler was given', async () => {
-    const { user } = renderWithProviders(<ContractSourceForm onContractChange={() => {}} />);
+describe('ContractSourceForm — offered sources', () => {
+  it('offers URL and Upload only, while the other flows are undecided', () => {
+    renderWithProviders(<ContractSourceForm onContractChange={() => {}} />);
 
-    await user.click(screen.getByRole('button', { name: 'GitHub' }));
+    expect(screen.getByRole('button', { name: 'URL' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Upload' })).toBeInTheDocument();
+    // Both imports are held back until their flow is settled; everything
+    // behind them is still in the module.
+    expect(screen.queryByRole('button', { name: 'GitHub' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'SwaggerHub' })).not.toBeInTheDocument();
+  });
+});
 
-    // A button with nothing behind it is a dead end, so it isn't rendered at
-    // all until the OAuth flow is wired.
-    expect(
-      screen.queryByRole('button', { name: /Authorize With GitHub/i }),
-    ).not.toBeInTheDocument();
+describe('ContractSourceForm — automatic fetch', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
-  it('renders no SwaggerHub refresh button when no handler was given', async () => {
-    const { user } = renderWithProviders(<ContractSourceForm onContractChange={() => {}} />);
-
-    await user.click(screen.getByRole('button', { name: 'SwaggerHub' }));
-
-    expect(screen.queryByRole('button', { name: /Refresh/i })).not.toBeInTheDocument();
-  });
-
-  it('renders both once handlers are supplied', async () => {
+  it('reads the URL when the field is left, not while it is being typed', async () => {
+    const fetchMock = stubSpecHost();
+    const onContractChange = vi.fn();
     const { user } = renderWithProviders(
-      <ContractSourceForm
-        onAuthorizeGitHub={() => {}}
-        onContractChange={() => {}}
-        onRefreshSwaggerHubOrganizations={() => {}}
-      />,
+      <ContractSourceForm onContractChange={onContractChange} />,
     );
 
-    await user.click(screen.getByRole('button', { name: 'GitHub' }));
-    expect(screen.getByRole('button', { name: /Authorize With GitHub/i })).toBeInTheDocument();
+    await user.type(
+      screen.getByLabelText(/URL for API Contract/),
+      'https://example.com/openapi.yaml',
+    );
+    // A URL passes through many invalid prefixes on the way in; none of them
+    // is worth a request.
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: /Fetch/i })).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: 'SwaggerHub' }));
-    expect(screen.getByRole('button', { name: /Refresh/i })).toBeInTheDocument();
+    await user.tab();
+
+    await waitFor(() =>
+      expect(onContractChange).toHaveBeenCalledWith(
+        expect.objectContaining({ dialect: 'openapi-3.0' }),
+      ),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not read it again when the field is left untouched', async () => {
+    const fetchMock = stubSpecHost();
+    const onContractChange = vi.fn();
+    const { user } = renderWithProviders(
+      <ContractSourceForm onContractChange={onContractChange} />,
+    );
+
+    const field = screen.getByLabelText(/URL for API Contract/);
+    await user.type(field, 'https://example.com/openapi.yaml');
+    await user.tab();
+    await waitFor(() =>
+      expect(onContractChange).toHaveBeenCalledWith(
+        expect.objectContaining({ dialect: 'openapi-3.0' }),
+      ),
+    );
+
+    // Focusing and leaving again would re-download the same document — and
+    // discard whatever has been edited in the preview since.
+    await user.click(field);
+    await user.tab();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('reads an uploaded file as soon as it is chosen', async () => {
+    const onContractChange = vi.fn();
+    const { user } = renderWithProviders(
+      <ContractSourceForm onContractChange={onContractChange} />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Upload' }));
+    await user.upload(
+      filePicker(),
+      new File([VALID_SPEC], 'openapi.yaml', { type: 'application/x-yaml' }),
+    );
+
+    await waitFor(() =>
+      expect(onContractChange).toHaveBeenCalledWith(
+        expect.objectContaining({ dialect: 'openapi-3.0' }),
+      ),
+    );
   });
 });
 

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/ContractSourceForm.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/ContractSourceForm.tsx
@@ -22,8 +22,8 @@ import {
   Button,
   Card,
   CardContent,
+  Chip,
   CircularProgress,
-  Divider,
   Form,
   FormControl,
   FormHelperText,
@@ -39,18 +39,27 @@ import {
   ToggleButtonGroup,
   Tooltip,
   Typography,
+  alpha,
+  type Theme,
 } from '@wso2/oxygen-ui';
-import { Download, GitHub, Pencil, RefreshCw, Upload, X } from '@wso2/oxygen-ui-icons-react';
+import { FileText, GitHub, Pencil, RefreshCw, Upload, X } from '@wso2/oxygen-ui-icons-react';
 import yaml from 'js-yaml';
 import {
   useEffect,
   useMemo,
+  useRef,
   useState,
   type DragEvent,
   type FormEvent,
   type ReactNode,
 } from 'react';
-import { defineMessages, FormattedMessage, useIntl, type MessageDescriptor } from 'react-intl';
+import {
+  defineMessages,
+  FormattedMessage,
+  useIntl,
+  type IntlShape,
+  type MessageDescriptor,
+} from 'react-intl';
 
 import { hairline } from '@/theme/receipes';
 import { GitHubDirectoryDialog, type GitHubDirectorySelection } from './GitHubDirectoryDialog';
@@ -116,7 +125,10 @@ export type ContractSourceFormProps = {
   definitionEdited?: boolean;
   /** Type selected on first render. Defaults to the first entry in `apiTypes`. */
   initialApiTypeKey?: string;
-  /** Starts the GitHub OAuth flow. The button renders either way, inert until wired. */
+  /**
+   * Starts the GitHub OAuth flow. Unused while the GitHub source is withheld
+   * from `CONTRACT_SOURCES_BY_API_TYPE`; kept for when it is offered again.
+   */
   onAuthorizeGitHub?: () => void;
   /**
    * The contract this form currently stands behind: what the last fetch
@@ -125,7 +137,10 @@ export type ContractSourceFormProps = {
    * proceed with.
    */
   onContractChange?: (contract: FetchedContract | null) => void;
-  /** Re-fetches the SwaggerHub organizations. Inert until the import is wired. */
+  /**
+   * Re-fetches the SwaggerHub organizations. Unused while the SwaggerHub
+   * source is withheld, on the same terms as `onAuthorizeGitHub`.
+   */
   onRefreshSwaggerHubOrganizations?: () => void;
 };
 
@@ -135,8 +150,12 @@ export type ContractSourceFormProps = {
  * type absent here is not offered by this step at all.
  */
 const CONTRACT_SOURCES_BY_API_TYPE: Record<string, ContractSourceKey[]> = {
-  rest: ['url', 'file', 'github', 'swaggerhub'],
-  websocket: ['url', 'file', 'github', 'swaggerhub'],
+  // `github` and `swaggerhub` are withheld from every type until their import
+  // flow is settled. Everything behind them; the lookups, the pickers, and
+  // their branches of `fetchContractForPreview`; is left in place, so
+  // offering one again is a matter of listing it here and do necessary changes.
+  rest: ['url', 'file'],
+  websocket: ['url', 'file'],
   graphql: ['url', 'file'],
 };
 
@@ -163,11 +182,11 @@ const SAMPLE_CONTRACT_URLS: Record<string, string> = {
 const SAMPLE_REPOSITORY_URL = 'https://github.com/wso2/bijira-samples';
 
 const messages = defineMessages({
-  fetch: {
-    id: 'api.create.fromContract.action.fetch',
-    defaultMessage: 'Fetch Contract',
+  fetching: {
+    id: 'api.create.fromContract.status.fetching',
+    defaultMessage: 'Reading the contract…',
     description:
-      'Reads the contract from the chosen source and previews its resources, without leaving the step.',
+      'Shown while the chosen contract is being read and checked, which starts on its own.',
   },
   gitHubAuthorize: {
     id: 'api.create.fromContract.gitHub.authorize',
@@ -349,20 +368,28 @@ const messages = defineMessages({
   },
   uploadAccepted: {
     id: 'api.create.fromContract.upload.accepted',
-    defaultMessage: 'Accepted file types: {extensions}',
+    defaultMessage: 'Accepted: {extensions} \u00b7 up to {maxSize}',
+    description:
+      'Neutral helper line under the drop zone. {maxSize} is a formatted size such as "10 MB".',
   },
   uploadAction: {
     id: 'api.create.fromContract.upload.action',
-    defaultMessage: 'Upload',
+    defaultMessage: 'Select file',
   },
   uploadHint: {
     id: 'api.create.fromContract.upload.hint',
-    defaultMessage: 'Drag & Drop your files or click to select files',
+    defaultMessage: 'One file \u00b7 {extensions}',
+    description: 'Sits under the drop-zone heading; {extensions} is a list such as ".json, .yaml".',
   },
   uploadRemove: {
     id: 'api.create.fromContract.upload.remove',
     defaultMessage: 'Remove {fileName}',
     description: 'Accessible name for the button that discards the chosen file.',
+  },
+  uploadReplace: {
+    id: 'api.create.fromContract.upload.replace',
+    defaultMessage: 'Replace file',
+    description: 'Reopens the file picker so the chosen contract can be swapped for another.',
   },
   uploadRequired: {
     id: 'api.create.fromContract.upload.required',
@@ -370,7 +397,7 @@ const messages = defineMessages({
   },
   uploadTitle: {
     id: 'api.create.fromContract.upload.title',
-    defaultMessage: 'Upload API Contract',
+    defaultMessage: 'Drag and drop your contract here',
   },
   uploadUnsupported: {
     id: 'api.create.fromContract.upload.unsupported',
@@ -446,9 +473,7 @@ const useContractTextField = ({
   return {
     commit,
     error,
-    handleBlur: commit,
     handleChange: change,
-    isEmpty: value.trim() === '',
     setValue: change,
     value,
   };
@@ -466,6 +491,12 @@ type ContractTextControlProps = {
   invalidMessage?: MessageDescriptor;
   /** Plain string, not a node: it also sizes the notch it sits in. */
   label: string;
+  /**
+   * The field passed validation on blur, with the trimmed value it holds. This
+   * is where a source acts on a finished value; the URL source fetches from
+   * it; so nothing has to be triggered by hand.
+   */
+  onCommitted?: (value: string) => void;
   placeholder: string;
   requiredMessage: MessageDescriptor;
 };
@@ -479,6 +510,7 @@ const ContractTextControl = ({
   id,
   invalidMessage,
   label,
+  onCommitted,
   placeholder,
   requiredMessage,
 }: ContractTextControlProps) => {
@@ -501,11 +533,15 @@ const ContractTextControl = ({
         aria-describedby={helperId}
         endAdornment={endAdornment}
         id={id}
-        // Cuts the gap in the border the InputLabel floats into — must match
+        // Cuts the gap in the border the InputLabel floats into; must match
         // that label exactly or the notch is the wrong width.
         label={label}
         name={id}
-        onBlur={field.handleBlur}
+        onBlur={() => {
+          if (field.commit()) {
+            onCommitted?.(field.value.trim());
+          }
+        }}
         onChange={(event) => field.handleChange(event.target.value)}
         placeholder={placeholder}
         value={field.value}
@@ -545,12 +581,52 @@ type ContractFileControlProps = {
   onSelect: (file: File) => void;
 };
 
+/** Ceiling for in-browser parsing — a huge document would freeze the tab. */
+const MAX_CONTRACT_BYTES = 10 * 1024 * 1024;
+
+/** Bytes rendered as a locale-aware "13 kB" / "1.4 MB". */
+const formatFileSize = (intl: IntlShape, bytes: number): string => {
+  const asUnit = (value: number, unit: 'kilobyte' | 'megabyte', fractionDigits: number) =>
+    intl.formatNumber(value, {
+      maximumFractionDigits: fractionDigits,
+      style: 'unit',
+      unit,
+      unitDisplay: 'short',
+    });
+  if (bytes >= 1024 * 1024) {
+    return asUnit(bytes / (1024 * 1024), 'megabyte', 1);
+  }
+  // Anything under a kilobyte still reads as "1 kB" rather than a bare "0".
+  return asUnit(Math.max(1, Math.round(bytes / 1024)), 'kilobyte', 0);
+};
+
+/** The extension badge on a chosen file, e.g. `YML`. Empty when there is none. */
+const fileExtensionLabel = (fileName: string): string => {
+  const dot = fileName.lastIndexOf('.');
+  return dot === -1 ? '' : fileName.slice(dot + 1).toUpperCase();
+};
+
+/** The soft tinted square a drop-zone icon sits in. */
+const iconTileSx = (size: number) => (theme: Theme) => ({
+  alignItems: 'center',
+  bgcolor: alpha(theme.palette.primary.main, 0.12),
+  borderRadius: 2,
+  color: 'primary.main',
+  display: 'flex',
+  flexShrink: 0,
+  height: theme.spacing(size),
+  justifyContent: 'center',
+  width: theme.spacing(size),
+});
+
 /**
  * Drop area and file picker for a single contract file.
  *
- * The chosen file is listed below the drop area rather than inside it — the
- * area itself is a `<label>`, so a remove button placed within it would reopen
- * the picker on the very click meant to clear the selection.
+ * The chosen file is summarised inside the drop area, so the area itself
+ * cannot be a `<label>`: the remove and replace controls sitting within it
+ * would reopen the picker on the very click meant to clear or swap the
+ * selection. The hidden input is opened through a ref instead, and the
+ * buttons around it stay real buttons for keyboard and screen-reader users.
  */
 const ContractFileControl = ({
   extensions,
@@ -561,6 +637,7 @@ const ContractFileControl = ({
 }: ContractFileControlProps) => {
   const intl = useIntl();
   const [draggedOver, setDraggedOver] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
   const helperId = 'contractFile-helper';
   const extensionList = extensions.join(', ');
 
@@ -577,6 +654,8 @@ const ContractFileControl = ({
     }
     onReject('unsupported');
   };
+
+  const openPicker = () => inputRef.current?.click();
 
   const handleDrop = (event: DragEvent<HTMLElement>) => {
     event.preventDefault();
@@ -600,13 +679,36 @@ const ContractFileControl = ({
         <FormattedMessage {...messages.uploadUnsupported} values={{ extensions: extensionList }} />
       );
     }
-    return <FormattedMessage {...messages.uploadAccepted} values={{ extensions: extensionList }} />;
+    return (
+      <FormattedMessage
+        {...messages.uploadAccepted}
+        values={{
+          extensions: extensionList,
+          maxSize: formatFileSize(intl, MAX_CONTRACT_BYTES),
+        }}
+      />
+    );
   })();
 
   return (
     <FormControl error={error !== null} fullWidth required>
       <Box
-        component="label"
+        accept={extensions.join(',')}
+        aria-describedby={helperId}
+        component="input"
+        onChange={(event) => {
+          const input = event.target as HTMLInputElement;
+          take(input.files?.[0]);
+          // Lets the same file be picked again after it was removed.
+          input.value = '';
+        }}
+        ref={inputRef}
+        sx={{ display: 'none' }}
+        type="file"
+      />
+
+      <Box
+        onClick={file === null ? openPicker : undefined}
         onDragLeave={() => setDraggedOver(false)}
         onDragOver={handleDragOver}
         onDrop={handleDrop}
@@ -615,65 +717,79 @@ const ContractFileControl = ({
           bgcolor: draggedOver ? 'action.hover' : 'background.default',
           border: hairline(theme),
           borderColor: draggedOver ? 'primary.main' : 'divider',
-          borderRadius: 1,
+          borderRadius: 2,
           borderStyle: 'dashed',
-          cursor: 'pointer',
+          cursor: file === null ? 'pointer' : 'default',
           display: 'flex',
           justifyContent: 'center',
-          minHeight: 260,
           px: 3,
-          py: 5,
+          py: file === null ? 5 : 3,
         })}
       >
-        <Stack spacing={1} sx={{ alignItems: 'center', textAlign: 'center' }}>
-          <Typography sx={{ fontWeight: 700 }} variant="subtitle1">
-            <FormattedMessage {...messages.uploadTitle} />
-          </Typography>
-          <Typography color="text.secondary" variant="body2">
-            <FormattedMessage {...messages.uploadHint} />
-          </Typography>
-          <Box
-            aria-describedby={helperId}
-            accept={extensions.join(',')}
-            component="input"
-            onChange={(event) => {
-              const input = event.target as HTMLInputElement;
-              take(input.files?.[0]);
-              // Lets the same file be picked again after it was removed.
-              input.value = '';
-            }}
-            sx={{ display: 'none' }}
-            type="file"
-          />
-          {/* `span`, not the default `button`: a nested button would swallow
-              the click the surrounding label needs to open the picker. */}
-          <Button
-            component="span"
-            startIcon={<Upload size={18} />}
-            sx={{ mt: 2 }}
-            variant="contained"
-          >
-            <FormattedMessage {...messages.uploadAction} />
-          </Button>
-        </Stack>
+        {file === null ? (
+          <Stack spacing={1} sx={{ alignItems: 'center', textAlign: 'center' }}>
+            <Box sx={iconTileSx(7)}>
+              <Upload size={24} />
+            </Box>
+            <Typography sx={{ fontWeight: 700, pt: 1 }} variant="h6">
+              <FormattedMessage {...messages.uploadTitle} />
+            </Typography>
+            <Typography color="text.secondary" variant="body2">
+              <FormattedMessage {...messages.uploadHint} values={{ extensions: extensionList }} />
+            </Typography>
+            <Button onClick={openPicker} sx={{ mt: 2 }} variant="contained">
+              <FormattedMessage {...messages.uploadAction} />
+            </Button>
+          </Stack>
+        ) : (
+          <Stack spacing={1} sx={{ alignItems: 'center', width: '100%' }}>
+            <Stack
+              direction="row"
+              spacing={2}
+              sx={(theme) => ({
+                alignItems: 'center',
+                bgcolor: 'background.paper',
+                border: hairline(theme),
+                borderColor: 'divider',
+                borderRadius: 2,
+                maxWidth: theme.spacing(60),
+                px: 2,
+                py: 1.5,
+                width: '100%',
+              })}
+            >
+              <Box sx={iconTileSx(5)}>
+                <FileText size={20} />
+              </Box>
+              <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+                <Stack direction="row" spacing={1} sx={{ alignItems: 'center', minWidth: 0 }}>
+                  <Typography noWrap sx={{ fontWeight: 600 }} variant="body1">
+                    {file.name}
+                  </Typography>
+                  {fileExtensionLabel(file.name) === '' ? null : (
+                    <Chip label={fileExtensionLabel(file.name)} size="small" />
+                  )}
+                </Stack>
+                <Typography color="text.secondary" variant="caption">
+                  {formatFileSize(intl, file.size)}
+                </Typography>
+              </Box>
+              <IconButton
+                aria-label={intl.formatMessage(messages.uploadRemove, {
+                  fileName: file.name,
+                })}
+                onClick={() => onReject('removed')}
+                size="small"
+              >
+                <X size={16} />
+              </IconButton>
+            </Stack>
+            <Button onClick={openPicker} sx={{ mt: 1 }} variant="text">
+              <FormattedMessage {...messages.uploadReplace} />
+            </Button>
+          </Stack>
+        )}
       </Box>
-
-      {file === null ? null : (
-        <Stack direction="row" spacing={1} sx={{ alignItems: 'center', mt: 1.5 }}>
-          <Typography sx={{ fontWeight: 600 }} variant="body2">
-            {file.name}
-          </Typography>
-          <IconButton
-            aria-label={intl.formatMessage(messages.uploadRemove, {
-              fileName: file.name,
-            })}
-            onClick={() => onReject('removed')}
-            size="small"
-          >
-            <X size={16} />
-          </IconButton>
-        </Stack>
-      )}
 
       <FormHelperText id={helperId}>{helperText}</FormHelperText>
     </FormControl>
@@ -685,9 +801,6 @@ type SpecDocument = Record<string, unknown>;
 
 /** How long the SwaggerHub organization field settles before it is looked up. */
 const LOOKUP_DEBOUNCE_MS = 450;
-
-/** Ceiling for in-browser parsing — a huge document would freeze the tab. */
-const MAX_CONTRACT_BYTES = 10 * 1024 * 1024;
 
 /** How long a contract download may take before it is abandoned. */
 const CONTRACT_FETCH_TIMEOUT_MS = 20_000;
@@ -881,6 +994,42 @@ export const fetchContractForPreview = async (
   }
 };
 
+/**
+ * Whether two selections name the same contract, comparing only the fields
+ * that belong to their shared source.
+ *
+ * Used both ways round: to tell whether a fetched contract still describes the
+ * form, and to tell whether a fetch about to be queued would return what is
+ * already in hand.
+ */
+const isSameContractSource = (
+  left: ContractValues | undefined,
+  right: ContractValues | undefined,
+): boolean => {
+  if (left === undefined || right === undefined || left.sourceKey !== right.sourceKey) {
+    return false;
+  }
+  switch (left.sourceKey) {
+    case 'url':
+      return left.url === right.url;
+    case 'file':
+      return left.file === right.file;
+    case 'github':
+      return (
+        left.repositoryUrl === right.repositoryUrl &&
+        left.repositoryBranch === right.repositoryBranch &&
+        left.repositoryDirectory === right.repositoryDirectory &&
+        left.repositoryFile === right.repositoryFile
+      );
+    case 'swaggerhub':
+      return (
+        left.swaggerHubOrganization === right.swaggerHubOrganization &&
+        left.swaggerHubApi === right.swaggerHubApi &&
+        left.swaggerHubVersion === right.swaggerHubVersion
+      );
+  }
+};
+
 /** API types this step offers, in the order the map declares them. */
 const CONTRACT_API_TYPES: ApiType[] = Object.keys(CONTRACT_SOURCES_BY_API_TYPE)
   .map((key) => API_TYPES.find((apiType) => apiType.key === key))
@@ -958,6 +1107,13 @@ export const ContractSourceForm = ({
     { status: 'fetched' }
   > | null>(null);
   const [fetching, setFetching] = useState(false);
+  /**
+   * The source a fetch has been asked for, or `null` while none has. Held as
+   * state so the request is made by an effect rather than inside the handler
+   * that raised it, which keeps a reply the form has since moved on from out
+   * of the preview.
+   */
+  const [request, setRequest] = useState<ContractValues | null>(null);
   /**
    * What the last successful fetch returned. Reported upward only while it
    * still describes what the form holds, editing the URL or swapping the file
@@ -1142,16 +1298,47 @@ export const ContractSourceForm = ({
     setFetchError(null);
   };
 
+  /** An accepted file is a finished selection, so it is read straight away. */
   const handleFileSelect = (next: File) => {
     setFileError(null);
     setFetchError(null);
     setFile(next);
+    requestFetch({ apiTypeKey, file: next, sourceKey: 'file' });
   };
 
   /** Rejects the current file using the provided reason. */
   const handleFileReject = (reason: ContractFileRejection) => {
     setFile(null);
     setFileError(reason === 'unsupported' ? 'unsupported' : null);
+  };
+
+  /** What the form holds right now, uncommitted and unvalidated. */
+  const currentValues: ContractValues = {
+    apiTypeKey,
+    file: file ?? undefined,
+    repositoryBranch: branch,
+    repositoryDirectory: directory,
+    repositoryFile: contractFile,
+    repositoryUrl: repositoryUrl.value.trim(),
+    sourceKey,
+    swaggerHubApi: selectedSwaggerHubApi?.slug,
+    swaggerHubOrganization: organizationName,
+    swaggerHubVersion,
+    url: contractUrl.value.trim(),
+  };
+
+  /**
+   * Asks for `values` to be fetched, unless there is nothing to gain: one is
+   * already running, or the contract in hand came from exactly these values.
+   * That second case is what keeps a blur on a field nobody edited from
+   * re-reading the document; and from discarding an edit made in the preview
+   * since it was read.
+   */
+  const requestFetch = (values: ContractValues) => {
+    if (fetching || isSameContractSource(fetched?.values, values)) {
+      return;
+    }
+    setRequest(values);
   };
 
   /**
@@ -1205,29 +1392,60 @@ export const ContractSourceForm = ({
     return null;
   };
 
-  /** Fetch: validates the contract and fills the preview, without advancing. */
-  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+  /**
+   * Enter in a text field. There is no fetch button to press, so this is the
+   * keyboard's way of asking for one without leaving the field first.
+   */
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    setFetchError(null);
-
     const values = collectValues();
-    if (values === null) {
+    if (values !== null) {
+      requestFetch(values);
+    }
+  };
+
+  /**
+   * Reads whatever was last asked for. An effect rather than an `await` in the
+   * handler that asked: a request the form has already moved past is dropped
+   * on arrival instead of landing in the preview behind the current one.
+   */
+  useEffect(() => {
+    if (request === null) {
       return;
     }
 
+    let current = true;
+    setFetchError(null);
     setFetching(true);
-    try {
-      const result = await fetchContractForPreview(values);
+    void fetchContractForPreview(request).then((result) => {
+      if (!current) {
+        return;
+      }
+      setFetching(false);
       if (result.status !== 'fetched') {
         setFetchError(result);
         return;
       }
-
-      // Fetched: the effect below hands it to the panel, which renders it in
-      // the preview and unlocks Next.
+      // Fetched: the effect further down hands it to the panel, which renders
+      // it in the preview and unlocks Next.
       setFetched(result.contract);
-    } finally {
-      setFetching(false);
+    });
+
+    return () => {
+      current = false;
+    };
+  }, [request]);
+
+  /**
+   * Fills the URL field with the sample and reads it straight away. Clicking
+   * the link blurs the field before the value lands, so the blur alone would
+   * fetch the value being replaced rather than the sample.
+   */
+  const fillWithSampleUrl = () => {
+    const sample = SAMPLE_CONTRACT_URLS[apiTypeKey] ?? '';
+    contractUrl.setValue(sample);
+    if (sample !== '') {
+      requestFetch({ apiTypeKey, sourceKey: 'url', url: sample });
     }
   };
 
@@ -1293,56 +1511,12 @@ export const ContractSourceForm = ({
     }
   })();
 
-  /** Fetch stays inert until the active source has something to fetch. */
-  const fetchDisabled = (() => {
-    switch (sourceKey) {
-      case 'file':
-        return file === null;
-      case 'github':
-        // A repository alone isn't enough: the fetch needs a contract file
-        // inside a directory of a branch.
-        return contractFile === '';
-      case 'swaggerhub':
-        // An organization alone isn't enough: the fetch needs the API and the
-        // version chosen inside it.
-        return selectedSwaggerHubApi === undefined || swaggerHubVersion === '';
-      default:
-        return contractUrl.isEmpty;
-    }
-  })();
-
   /**
    * Whether the fetched contract still matches the form. Compared rather than
    * invalidated on every keystroke: one derived answer beats resetting a flag
    * from four separate change handlers.
    */
-  const fetchedIsCurrent = (() => {
-    const fetchedValues = fetched?.values;
-    if (fetchedValues === undefined || fetchedValues.sourceKey !== sourceKey) {
-      return false;
-    }
-    switch (sourceKey) {
-      case 'url':
-        return fetchedValues.url === contractUrl.value.trim();
-      case 'file':
-        return fetchedValues.file === file;
-      case 'github':
-        return (
-          fetchedValues.repositoryUrl === repositoryUrl.value.trim() &&
-          fetchedValues.repositoryBranch === branch &&
-          fetchedValues.repositoryDirectory === directory &&
-          fetchedValues.repositoryFile === contractFile
-        );
-      case 'swaggerhub':
-        return (
-          fetchedValues.swaggerHubOrganization === organizationName &&
-          fetchedValues.swaggerHubApi === selectedSwaggerHubApi?.slug &&
-          fetchedValues.swaggerHubVersion === swaggerHubVersion
-        );
-      default:
-        return false;
-    }
-  })();
+  const fetchedIsCurrent = isSameContractSource(fetched?.values, currentValues);
 
   // Lifted rather than pushed from each change handler: staleness is derived
   // from four inputs, and one effect over the derived answer beats invalidating
@@ -1352,14 +1526,10 @@ export const ContractSourceForm = ({
   }, [fetched, fetchedIsCurrent, onContractChange]);
 
   return (
-    <Stack
-      component="form"
-      noValidate
-      onSubmit={(event: FormEvent<HTMLFormElement>) => {
-        void handleSubmit(event);
-      }}
-      spacing={3}
-    >
+    // Still a form, with no button to submit it: Enter in a text field reads
+    // the contract without having to leave the field first. Back and Next
+    // belong to the panel around this one.
+    <Stack component="form" noValidate onSubmit={handleSubmit} spacing={3}>
       <FormControl>
         <ToggleButtonGroup
           aria-label={intl.formatMessage(messages.sourceLabel)}
@@ -1414,12 +1584,13 @@ export const ContractSourceForm = ({
             id="contractUrl"
             invalidMessage={messages.urlInvalid}
             label={intl.formatMessage(messages.urlLabel)}
+            // Leaving a valid URL is the whole gesture: the contract is read
+            // then, rather than on a button afterwards.
+            onCommitted={(url) => requestFetch({ apiTypeKey, sourceKey: 'url', url })}
             placeholder={intl.formatMessage(messages.urlPlaceholder)}
             requiredMessage={messages.urlRequired}
           />
-          <SampleLink
-            onClick={() => contractUrl.setValue(SAMPLE_CONTRACT_URLS[apiTypeKey] ?? '')}
-          />
+          <SampleLink onClick={fillWithSampleUrl} />
         </Form.Stack>
       ) : null}
 
@@ -1724,6 +1895,17 @@ export const ContractSourceForm = ({
         </Stack>
       ) : null}
 
+      {/* The read starts on its own; on leaving a finished URL, or on
+          choosing a file; so this line is the only sign that it is running. */}
+      {fetching ? (
+        <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+          <CircularProgress size={16} />
+          <Typography color="text.secondary" variant="body2">
+            <FormattedMessage {...messages.fetching} />
+          </Typography>
+        </Stack>
+      ) : null}
+
       {/* Fetch errors appear under the active source panel. */}
       {fetchErrorText === null ? null : <Alert severity="error">{fetchErrorText}</Alert>}
 
@@ -1734,20 +1916,6 @@ export const ContractSourceForm = ({
           <SpecIssueList issues={fetched?.warnings ?? []} />
         </Alert>
       ) : null}
-
-      <Divider />
-
-      {/* Enter in a URL field fetches. Back and Next are in the panel. */}
-      <Button
-        disabled={fetchDisabled}
-        loading={fetching}
-        startIcon={<Download size={18} />}
-        sx={{ alignSelf: 'flex-start' }}
-        type="submit"
-        variant="contained"
-      >
-        <FormattedMessage {...messages.fetch} />
-      </Button>
     </Stack>
   );
 };

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/ContractSourceForm.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/ContractSourceForm.tsx
@@ -1335,7 +1335,7 @@ export const ContractSourceForm = ({
    * since it was read.
    */
   const requestFetch = (values: ContractValues) => {
-    if (fetching || isSameContractSource(fetched?.values, values)) {
+    if (isSameContractSource(fetched?.values, values)) {
       return;
     }
     setRequest(values);

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/DefineApiPanel.test.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/DefineApiPanel.test.tsx
@@ -85,7 +85,7 @@ describe('DefineApiPanel — editing the definition', () => {
       },
     });
     await user.click(screen.getByRole('button', { name: 'Save' }));
-    await user.click(screen.getByRole('button', { name: 'Next' }));
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
 
     expect(onDataFetched).toHaveBeenCalledTimes(1);
     expect(onDataFetched.mock.calls[0][0]).toMatchObject({

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/DefineApiPanel.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/DefineApiPanel.tsx
@@ -68,7 +68,7 @@ const messages = defineMessages({
   },
   contractDescription: {
     id: 'api.create.defineApi.contract.description',
-    defaultMessage: 'Import from a URL, file, or SwaggerHub.',
+    defaultMessage: 'Import from a URL or a file.',
   },
   contractTitle: {
     id: 'api.create.defineApi.contract.title',
@@ -76,7 +76,8 @@ const messages = defineMessages({
   },
   next: {
     id: 'api.create.defineApi.action.next',
-    defaultMessage: 'Next',
+    defaultMessage: 'Continue',
+    description: 'Carries the definition in the preview pane on to the next step.',
   },
   scratchDescription: {
     id: 'api.create.defineApi.scratch.description',
@@ -307,11 +308,9 @@ export const DefineApiPanel = ({
         </Stack>
       </Card>
 
-      <Stack
-        direction="row"
-        spacing={2}
-        sx={{ alignItems: 'center', justifyContent: 'space-between' }}
-      >
+      {/* Both buttons on the trailing edge, Back beside the action it steps
+          away from rather than at the opposite corner of the step. */}
+      <Stack direction="row" spacing={2} sx={{ alignItems: 'center', justifyContent: 'flex-end' }}>
         <Button onClick={onBack} type="button" variant="text">
           <FormattedMessage {...messages.back} />
         </Button>

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/DesignWithAiPanel.test.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/DesignWithAiPanel.test.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { renderWithProviders, screen } from '@/test/utils';
+import { runtimeConfig } from '@/config/runtime';
+import { DesignWithAiPanel } from './DesignWithAiPanel';
+
+describe('DesignWithAiPanel', () => {
+  it('hands off to the API Designer extension in a new tab', () => {
+    renderWithProviders(<DesignWithAiPanel />);
+
+    const action = screen.getByRole('link', { name: /Open API Designer/ });
+    expect(action).toHaveAttribute('href', runtimeConfig.apiDesignerVsCodeUrl);
+    expect(action).toHaveAttribute('target', '_blank');
+    // Keeps the opened tab from reaching back through `window.opener`.
+    expect(action).toHaveAttribute('rel', expect.stringContaining('noopener'));
+  });
+
+  it('links out to the extension documentation', () => {
+    renderWithProviders(<DesignWithAiPanel />);
+
+    expect(screen.getByRole('link', { name: /How to get started/ })).toHaveAttribute(
+      'href',
+      runtimeConfig.apiDesignerDocsUrl,
+    );
+  });
+
+  it('keeps the editable skeleton as an alternative to leaving the wizard', () => {
+    renderWithProviders(<DesignWithAiPanel />);
+
+    expect(screen.getByText(/skeleton on the right/)).toBeInTheDocument();
+  });
+});

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/DesignWithAiPanel.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/DesignWithAiPanel.tsx
@@ -16,23 +16,36 @@
  * under the License.
  */
 
-import { Box, Typography } from '@wso2/oxygen-ui';
+import { Box, Button, Link, Stack, Typography } from '@wso2/oxygen-ui';
+import { ExternalLink } from '@wso2/oxygen-ui-icons-react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
-import { ComingSoon } from '../../../../../../components/ComingSoon';
+import { ApiDesignerCanvasIllustration } from '@/components/illustrations/ApiDesignerCanvasIllustration';
+import { runtimeConfig } from '@/config/runtime';
 
 const messages = defineMessages({
-  detail: {
-    id: 'api.create.designWithAi.detail',
-    defaultMessage:
-      'The skeleton on the right is a starting point — carry on and edit its operations by hand.',
+  action: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.create.components.DesignWithAiPanel.action',
+    defaultMessage: 'Open API Designer',
+    description:
+      'Button opening the API Designer VS Code extension listing in a new tab. "API Designer" is a product name — leave it untranslated.',
   },
-  feature: {
-    id: 'api.create.designWithAi.feature',
-    defaultMessage: 'Designing an API by chatting with AI',
+  body: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.create.components.DesignWithAiPanel.body',
+    defaultMessage:
+      'Draw operations on a canvas, check them against governance rules, and design with AI in VS Code.',
+  },
+  docs: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.create.components.DesignWithAiPanel.docs',
+    defaultMessage: 'How to get started',
+  },
+  skeletonHint: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.create.components.DesignWithAiPanel.skeletonHint',
+    defaultMessage:
+      'Or carry on here - the skeleton on the right is a starting point you can edit by hand.',
   },
   title: {
-    id: 'api.create.designWithAi.title',
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.create.components.DesignWithAiPanel.title',
     defaultMessage: 'Design with AI',
   },
 });
@@ -40,9 +53,11 @@ const messages = defineMessages({
 /**
  * Left-hand panel of the "design from scratch" approach.
  *
- * A placeholder for now: the definition the step carries forward is the
- * skeleton the panel beside it already shows, and this is where the chat that
- * refines it will live.
+ * The visual designer is not hosted in the console; it ships as the API
+ * Designer VS Code extension. So rather than promising a canvas here, this
+ * shows what that canvas looks like and hands the user straight to it — while
+ * the skeleton in the pane beside it stays editable for anyone who would
+ * rather not leave the wizard.
  */
 export const DesignWithAiPanel = () => (
   <Box>
@@ -50,13 +65,53 @@ export const DesignWithAiPanel = () => (
       <FormattedMessage {...messages.title} />
     </Typography>
 
-    {/* `ComingSoon` sizes itself for a whole page (60vh); inside a panel it
-        takes the height it is given instead. */}
-    <Box sx={{ '& > *': { minHeight: 0, py: 4 } }}>
-      <ComingSoon
-        detail={<FormattedMessage {...messages.detail} />}
-        feature={<FormattedMessage {...messages.feature} />}
-      />
-    </Box>
+    <Stack alignItems="center" spacing={2} sx={{ pt: 3, textAlign: 'center' }}>
+      {/* The illustration is the backdrop and the button sits on top of it, so
+          the canvas sets the scene without competing with the call to action. */}
+      <Box sx={{ position: 'relative', width: '100%' }}>
+        <Box sx={{ opacity: 0.5 }}>
+          <ApiDesignerCanvasIllustration />
+        </Box>
+        <Box
+          sx={{
+            alignItems: 'center',
+            display: 'flex',
+            inset: 0,
+            justifyContent: 'center',
+            position: 'absolute',
+          }}
+        >
+          <Button
+            component="a"
+            endIcon={<ExternalLink size={16} />}
+            href={runtimeConfig.apiDesignerVsCodeUrl}
+            // `noopener` keeps the opened tab from reaching back through
+            // `window.opener`; `noreferrer` withholds the console URL from it.
+            rel="noopener noreferrer"
+            target="_blank"
+            variant="contained"
+          >
+            <FormattedMessage {...messages.action} />
+          </Button>
+        </Box>
+      </Box>
+
+      <Typography color="text.secondary" variant="body2">
+        <FormattedMessage {...messages.body} />
+      </Typography>
+
+      <Link
+        href={runtimeConfig.apiDesignerDocsUrl}
+        rel="noopener noreferrer"
+        target="_blank"
+        variant="body2"
+      >
+        <FormattedMessage {...messages.docs} />
+      </Link>
+
+      <Typography color="text.secondary" sx={{ pt: 1 }} variant="body2">
+        <FormattedMessage {...messages.skeletonHint} />
+      </Typography>
+    </Stack>
   </Box>
 );

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/GeneralCreateApiForm.test.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/GeneralCreateApiForm.test.tsx
@@ -22,17 +22,35 @@ import { resetHttpClient } from '@/api/core/http';
 import { server } from '@/test/server';
 import { collection } from '@/test/msw';
 import { makeConsoleScope } from '@/test/mockScope';
-import { renderWithProviders, screen } from '@/test/utils';
+import { renderWithProviders, screen, waitFor } from '@/test/utils';
 import { GeneralCreateApiForm } from './GeneralCreateApiForm';
 
 const scope = makeConsoleScope();
 const route = '/organizations/api-platform-demo/projects/retail-apis/apis/create';
 
-const renderForm = (initialValues?: Parameters<typeof GeneralCreateApiForm>[0]['initialValues']) =>
+type FormProps = Parameters<typeof GeneralCreateApiForm>[0];
+
+const renderForm = (
+  initialValues?: FormProps['initialValues'],
+  serverErrors?: FormProps['serverErrors'],
+) =>
   renderWithProviders(
-    <GeneralCreateApiForm initialValues={initialValues} onBack={() => {}} onSubmit={() => {}} />,
+    <GeneralCreateApiForm
+      initialValues={initialValues}
+      onBack={() => {}}
+      onSubmit={() => {}}
+      serverErrors={serverErrors}
+    />,
     { route, scope },
   );
+
+/** What the wizard hands back after a rejected create. */
+const submitted = {
+  context: '/retail-apis/orders-api/v1.0',
+  displayName: 'Orders API',
+  id: 'orders-api',
+  version: '1.0',
+} as const;
 
 /**
  * The identifier field probes availability as it settles, so the listing that
@@ -49,7 +67,7 @@ describe('GeneralCreateApiForm — initial values', () => {
 
     expect(screen.getByLabelText(/Identifier/)).toHaveValue('orders-api');
     // The platform's own base path shape, not anything read off a document.
-    expect(screen.getByLabelText(/Base Path/)).toHaveValue(
+    expect(screen.getByLabelText(/Context/)).toHaveValue(
       `/${scope.activeScope.projectHandler}/orders-api/v2.1`,
     );
   });
@@ -65,7 +83,7 @@ describe('GeneralCreateApiForm — initial values', () => {
     });
 
     expect(screen.getByLabelText(/Identifier/)).toHaveValue('orders-v2');
-    expect(screen.getByLabelText(/Base Path/)).toHaveValue('/public/orders');
+    expect(screen.getByLabelText(/Context/)).toHaveValue('/public/orders');
   });
 
   it('leaves a restored base path alone when the display name is edited afterwards', async () => {
@@ -76,9 +94,77 @@ describe('GeneralCreateApiForm — initial values', () => {
       version: '2.1',
     });
 
-    await user.type(screen.getByLabelText(/Display name/), ' v2');
+    await user.type(screen.getByLabelText(/^Name/), ' v2');
 
     expect(screen.getByLabelText(/Identifier/)).toHaveValue('orders-v2');
-    expect(screen.getByLabelText(/Base Path/)).toHaveValue('/public/orders');
+    expect(screen.getByLabelText(/Context/)).toHaveValue('/public/orders');
+  });
+});
+
+describe('GeneralCreateApiForm — a rejected submission', () => {
+  it('shows the server’s reason on the field it names', async () => {
+    renderForm(submitted, {
+      fields: { id: 'An API with this identifier already exists.' },
+      unmapped: [],
+    });
+
+    expect(
+      await screen.findByText('An API with this identifier already exists.'),
+    ).toBeInTheDocument();
+    // Pinned to the input, not just announced: the message is what the
+    // identifier field describes itself with.
+    expect(screen.getByLabelText(/Identifier/)).toHaveAccessibleDescription(
+      'An API with this identifier already exists.',
+    );
+  });
+
+  it('moves focus to the first field the server named', async () => {
+    renderForm(submitted, {
+      fields: { context: 'This base path is already in use.' },
+      unmapped: [],
+    });
+
+    await waitFor(() => expect(screen.getByLabelText(/Context/)).toHaveFocus());
+  });
+
+  it('retracts the message once that value is edited', async () => {
+    const { user } = renderForm(submitted, {
+      fields: { id: 'An API with this identifier already exists.' },
+      unmapped: [],
+    });
+
+    await user.type(screen.getByLabelText(/Identifier/), '-v2');
+
+    // The server judged what was sent; it has no opinion on what is being
+    // typed now, so the objection goes with the value that caused it.
+    expect(
+      screen.queryByText('An API with this identifier already exists.'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('summarises a rejection that names no field at all', () => {
+    // A conflict arrives as prose with no `errors[]`, and there is nothing to
+    // pin it to — so the form says it once, at the top, and keeps saying it.
+    renderForm(submitted, {
+      fields: {},
+      message: 'An API with context /orders and version 1.0 already exists.',
+      unmapped: [],
+    });
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'An API with context /orders and version 1.0 already exists.',
+    );
+  });
+
+  it('lists a field error that belongs to no input on this form', () => {
+    renderForm(submitted, { fields: {}, unmapped: ['Unknown project.'] });
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Unknown project.');
+  });
+
+  it('says nothing when the last submission was not rejected', () => {
+    renderForm(submitted);
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 });

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/GeneralCreateApiForm.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/GeneralCreateApiForm.tsx
@@ -17,35 +17,46 @@
  */
 
 import {
+  Alert,
   Box,
   Button,
-  CircularProgress,
   Divider,
   Form,
   FormControl,
   FormHelperText,
   Grid,
-  InputAdornment,
   InputLabel,
   OutlinedInput,
   Paper,
   Stack,
   Typography,
 } from '@wso2/oxygen-ui';
-import { CircleCheck } from '@wso2/oxygen-ui-icons-react';
-import type { FormEvent } from 'react';
-import { useState } from 'react';
+import type { FormEvent, ReactNode } from 'react';
+import { useEffect, useState } from 'react';
 import { defineMessages, FormattedMessage, useIntl, type MessageDescriptor } from 'react-intl';
 
-import { useRestApiIdAvailability } from '@/api/resources/restApis';
-import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 import { useConsoleScope } from '@/scope/ConsoleScopeProvider';
+import {
+  CONTEXT_PATTERN,
+  HANDLE_MAX_LENGTH,
+  HANDLE_PATTERN,
+  isHttpUrl,
+  VERSION_PATTERN,
+} from '../../utils/basicInfoRules';
+import type { CreateApiFormErrors, CreateApiFormField } from '../utils/serverFieldErrors';
 import { ApiCreationWizardDraftState, GeneralApiCreationFormState } from '../types';
 
 export type GeneralCreateApiFormProps = {
   initialValues?: ApiCreationWizardDraftState;
   onSubmit: (values: GeneralApiCreationFormState) => void;
   onBack: () => void;
+  /**
+   * Why the last submission was rejected, when there was one. Rendered as a
+   * summary and pinned to the inputs it names, so the user fixes the problem
+   * where they made it rather than reading about it in a toast that has
+   * already gone.
+   */
+  serverErrors?: CreateApiFormErrors;
 };
 
 const messages = defineMessages({
@@ -53,22 +64,27 @@ const messages = defineMessages({
     id: 'api.create.generalForm.action.back',
     defaultMessage: 'Back',
   },
-  basePathErrorPattern: {
-    id: 'api.create.generalForm.basePath.error.pattern',
+  rejectedTitle: {
+    id: 'api.create.generalForm.rejected.title',
+    defaultMessage: 'We could not create this API proxy',
+    description: 'Heading of the summary shown when the server rejected the submitted form.',
+  },
+  contextErrorPattern: {
+    id: 'api.create.generalForm.context.error.pattern',
     defaultMessage: 'Start with / and use only letters, numbers, hyphens, dots and slashes.',
   },
-  basePathErrorRequired: {
-    id: 'api.create.generalForm.basePath.error.required',
-    defaultMessage: 'Enter a base path.',
+  contextErrorRequired: {
+    id: 'api.create.generalForm.context.error.required',
+    defaultMessage: 'Enter a context.',
   },
-  basePathHelper: {
-    id: 'api.create.generalForm.basePath.helper',
+  contextHelper: {
+    id: 'api.create.generalForm.context.helper',
     defaultMessage:
       'Built from the project, identifier and version. Edit it to route this API somewhere else.',
   },
-  basePathLabel: {
-    id: 'api.create.generalForm.basePath.label',
-    defaultMessage: 'Base Path',
+  contextLabel: {
+    id: 'api.create.generalForm.context.label',
+    defaultMessage: 'Context',
   },
   basicInformation: {
     id: 'api.create.generalForm.section.basicInformation',
@@ -82,13 +98,13 @@ const messages = defineMessages({
     id: 'api.create.generalForm.description.label',
     defaultMessage: 'Description',
   },
-  displayNameErrorRequired: {
-    id: 'api.create.generalForm.displayName.error.required',
-    defaultMessage: 'Enter a display name.',
+  nameErrorRequired: {
+    id: 'api.create.generalForm.name.error.required',
+    defaultMessage: 'Enter a name.',
   },
-  displayNameLabel: {
-    id: 'api.create.generalForm.displayName.label',
-    defaultMessage: 'Display name',
+  nameLabel: {
+    id: 'api.create.generalForm.name.label',
+    defaultMessage: 'Name',
   },
   endpointSection: {
     id: 'api.create.generalForm.section.backendEndpoint',
@@ -183,16 +199,6 @@ const SECTION_LABEL_SX = {
   typography: 'overline',
 } as const;
 
-const HANDLE_MAX_LENGTH = 64;
-
-/** Lowercase words joined by single hyphens — what a URL segment may hold. */
-const HANDLE_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
-
-/** A version has to survive being pasted into a path segment. */
-const VERSION_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
-
-const BASE_PATH_PATTERN = /^\/[A-Za-z0-9\-._~/]*$/;
-
 export const DEFAULT_FORM_STATE: GeneralApiCreationFormState = {
   id: '',
   displayName: '',
@@ -273,19 +279,46 @@ const getInitialValues = (
   };
 };
 
-/** The fields that carry a validation rule. */
-type ValidatedField = 'context' | 'displayName' | 'id' | 'targetUrl' | 'version';
+/**
+ * The fields that carry a validation rule. Shared with the server-error mapper
+ * so a rejection can only ever name an input that exists.
+ */
+type ValidatedField = CreateApiFormField;
+
+/** The input each field is rendered as, for focus and `aria-describedby`. */
+const INPUT_ID: Record<ValidatedField, string> = {
+  context: 'context',
+  displayName: 'displayName',
+  id: 'identifier',
+  targetUrl: 'targetUrl',
+  version: 'version',
+};
+
+/**
+ * Reading order, which is also the order a rejection is announced in — the
+ * first field the server complained about is the one that takes focus.
+ */
+const FIELD_ORDER: readonly ValidatedField[] = [
+  'displayName',
+  'id',
+  'version',
+  'context',
+  'targetUrl',
+];
+
+/**
+ * The value each field submits. A server error describes the values that were
+ * *sent*, so this is what decides whether one is still worth showing.
+ */
+const valueOf: Record<ValidatedField, (state: GeneralApiCreationFormState) => string> = {
+  context: (state) => state.context,
+  displayName: (state) => state.displayName,
+  id: (state) => state.id,
+  targetUrl: (state) => state.upstream.main.url,
+  version: (state) => state.version,
+};
 
 type FieldErrors = Partial<Record<ValidatedField, MessageDescriptor>>;
-
-const isHttpUrl = (value: string): boolean => {
-  try {
-    const { protocol } = new URL(value);
-    return protocol === 'http:' || protocol === 'https:';
-  } catch {
-    return false;
-  }
-};
 
 /**
  * Every rule in one pure pass, so the same answer drives the field errors and
@@ -295,7 +328,7 @@ const validate = (state: GeneralApiCreationFormState): FieldErrors => {
   const errors: FieldErrors = {};
 
   if (state.displayName.trim() === '') {
-    errors.displayName = messages.displayNameErrorRequired;
+    errors.displayName = messages.nameErrorRequired;
   }
 
   const id = state.id.trim();
@@ -316,9 +349,9 @@ const validate = (state: GeneralApiCreationFormState): FieldErrors => {
 
   const context = state.context.trim();
   if (context === '' || context === '/') {
-    errors.context = messages.basePathErrorRequired;
-  } else if (!BASE_PATH_PATTERN.test(context)) {
-    errors.context = messages.basePathErrorPattern;
+    errors.context = messages.contextErrorRequired;
+  } else if (!CONTEXT_PATTERN.test(context)) {
+    errors.context = messages.contextErrorPattern;
   }
 
   const targetUrl = state.upstream.main.url.trim();
@@ -339,9 +372,13 @@ export const GeneralCreateApiForm = (props: GeneralCreateApiFormProps) => {
 
   // Lazy initialiser: `getInitialValues` runs once, on mount, instead of on
   // every render only to have its result thrown away.
-  const [formState, setFormState] = useState<GeneralApiCreationFormState>(() =>
+  const [submittedState] = useState<GeneralApiCreationFormState>(() =>
     getInitialValues(props.initialValues || {}, projectHandler),
   );
+  // The form remounts from what was last submitted, so `submittedState` is
+  // exactly the payload any `serverErrors` were raised against — which is what
+  // lets an edited field drop its server error without tracking dismissals.
+  const [formState, setFormState] = useState<GeneralApiCreationFormState>(submittedState);
 
   // Both fields are generated until the user takes them over. Clearing one
   // hands it back, so there is always a way to return to the default. A draft
@@ -361,33 +398,41 @@ export const GeneralCreateApiForm = (props: GeneralCreateApiFormProps) => {
 
   const errors = validate(formState);
 
-  // Only ask the backend about a handle that already passes the local rules,
-  // and only once typing pauses — the field changes on every keystroke, both
-  // when typed into directly and when it follows the display name.
-  const handle = formState.id.trim().toLowerCase();
-  const probeCandidate = errors.id ? '' : handle;
-  const debouncedCandidate = useDebouncedValue(probeCandidate, 400);
-  const availability = useRestApiIdAvailability(debouncedCandidate);
-
-  // A pending debounce or an in-flight request means any answer on screen is
-  // about an older handle, so it must not be shown against this one.
-  const probeSettled = debouncedCandidate === probeCandidate && !availability.isFetching;
-  const isChecking = probeCandidate !== '' && !probeSettled;
-  // A failed probe (offline, 5xx after retries) leaves `data` undefined: the
-  // field falls back to its plain helper text rather than spinning forever or
-  // claiming a handle is free. A duplicate would still be caught on create.
-  const availabilityAnswered =
-    probeCandidate !== '' && probeSettled && availability.data !== undefined;
-  const isAvailable = availabilityAnswered && availability.data === true;
-  const isTaken = availabilityAnswered && availability.data === false;
-
   const errorFor = (field: ValidatedField): MessageDescriptor | undefined => {
-    if (field === 'id' && isTaken) {
-      // A taken handle outranks the format rules: those already passed.
-      return messages.identifierErrorTaken;
-    }
     return touched[field] ? errors[field] : undefined;
   };
+
+  /**
+   * The server's complaint about this field, while it still stands. Editing
+   * the value retracts it: the server judged what was sent, and it has no
+   * opinion on what the user is typing now. Client rules win where both have
+   * something to say.
+   */
+  const serverErrorFor = (field: ValidatedField): string | undefined => {
+    if (errors[field]) return undefined;
+    if (valueOf[field](formState) !== valueOf[field](submittedState)) return undefined;
+    return props.serverErrors?.fields[field];
+  };
+
+  /** One resolved message per field, so each is decided once per render. */
+  const fieldErrors = FIELD_ORDER.reduce<Record<ValidatedField, ReactNode | undefined>>(
+    (resolved, field) => {
+      const descriptor = errorFor(field);
+      resolved[field] = descriptor ? <FormattedMessage {...descriptor} /> : serverErrorFor(field);
+      return resolved;
+    },
+    {} as Record<ValidatedField, ReactNode | undefined>,
+  );
+
+  // A rejection arrives with the form already rendered and the user's eyes
+  // wherever they left them, so move focus to the first field it names.
+  const rejectedFields = props.serverErrors?.fields;
+  useEffect(() => {
+    if (!rejectedFields) return;
+    const first = FIELD_ORDER.find((field) => rejectedFields[field] !== undefined);
+    if (first) document.getElementById(INPUT_ID[first])?.focus();
+  }, [rejectedFields]);
+
   const markTouched = (field: ValidatedField) =>
     setTouched((current) => ({ ...current, [field]: true }));
 
@@ -448,7 +493,7 @@ export const GeneralCreateApiForm = (props: GeneralCreateApiFormProps) => {
   const onFormSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    if (Object.keys(errors).length > 0 || isTaken) {
+    if (Object.keys(errors).length > 0) {
       // Reveal every rule at once rather than one field per attempt.
       setTouched({
         context: true,
@@ -463,10 +508,21 @@ export const GeneralCreateApiForm = (props: GeneralCreateApiFormProps) => {
     props.onSubmit(formState);
   };
 
-  const displayNameLabel = intl.formatMessage(messages.displayNameLabel);
+  /**
+   * Whether the last rejection is still worth showing. A rejection that named
+   * specific fields has served its purpose once every one of them has been
+   * edited; one that named none (a conflict the server described in prose)
+   * stands until the next attempt, because nothing else carries it.
+   */
+  const pinnedFieldCount = Object.keys(props.serverErrors?.fields ?? {}).length;
+  const showRejection =
+    props.serverErrors !== undefined &&
+    (pinnedFieldCount === 0 || FIELD_ORDER.some((field) => serverErrorFor(field) !== undefined));
+
+  const nameLabel = intl.formatMessage(messages.nameLabel);
   const identifierLabel = intl.formatMessage(messages.identifierLabel);
   const versionLabel = intl.formatMessage(messages.versionLabel);
-  const basePathLabel = intl.formatMessage(messages.basePathLabel);
+  const contextLabel = intl.formatMessage(messages.contextLabel);
   const descriptionLabel = intl.formatMessage(messages.descriptionLabel);
   const targetUrlLabel = intl.formatMessage(messages.targetUrlLabel);
 
@@ -481,6 +537,28 @@ export const GeneralCreateApiForm = (props: GeneralCreateApiFormProps) => {
         </Typography>
       </Box>
 
+      {/* `Alert` carries `role="alert"`, so this is announced when it appears
+        ,the inputs themselves say which values to change. */}
+      {showRejection && (
+        <Alert severity="error">
+          <Typography sx={{ fontWeight: 600 }} variant="body2">
+            <FormattedMessage {...messages.rejectedTitle} />
+          </Typography>
+          {props.serverErrors?.message && (
+            <Typography variant="body2">{props.serverErrors.message}</Typography>
+          )}
+          {props.serverErrors && props.serverErrors.unmapped.length > 0 && (
+            <Box component="ul" sx={{ m: 0, mt: 1, pl: 2.5 }}>
+              {props.serverErrors.unmapped.map((message) => (
+                <Typography component="li" key={message} variant="body2">
+                  {message}
+                </Typography>
+              ))}
+            </Box>
+          )}
+        </Alert>
+      )}
+
       <Paper component="section" sx={{ p: 3 }}>
         <Form.Header sx={SECTION_LABEL_SX}>
           <FormattedMessage {...messages.basicInformation} />
@@ -489,42 +567,26 @@ export const GeneralCreateApiForm = (props: GeneralCreateApiFormProps) => {
         <Form.Stack spacing={2} sx={{ mt: 1.5 }}>
           <Grid container spacing={2}>
             <Grid size={{ xs: 12, md: 4 }}>
-              <FormControl error={Boolean(errorFor('displayName'))} fullWidth required>
-                <InputLabel htmlFor="displayName">{displayNameLabel}</InputLabel>
+              <FormControl error={Boolean(fieldErrors.displayName)} fullWidth required>
+                <InputLabel htmlFor="displayName">{nameLabel}</InputLabel>
                 <OutlinedInput
+                  aria-describedby="displayName-error"
                   id="displayName"
-                  label={displayNameLabel}
+                  label={nameLabel}
                   name="displayName"
                   onBlur={() => markTouched('displayName')}
                   onChange={(event) => handleDisplayNameChange(event.target.value)}
                   value={formState.displayName}
                 />
-                {errorFor('displayName') ? (
-                  <FormHelperText>
-                    <FormattedMessage {...errorFor('displayName')!} />
-                  </FormHelperText>
-                ) : null}
+                <FormHelperText id="displayName-error">{fieldErrors.displayName}</FormHelperText>
               </FormControl>
             </Grid>
 
             <Grid size={{ xs: 12, md: 4 }}>
-              <FormControl error={Boolean(errorFor('id'))} fullWidth required>
+              <FormControl error={Boolean(fieldErrors.id)} fullWidth required>
                 <InputLabel htmlFor="identifier">{identifierLabel}</InputLabel>
                 <OutlinedInput
-                  endAdornment={
-                    <InputAdornment position="end">
-                      {isChecking ? <CircularProgress size={16} /> : null}
-                      {isAvailable ? (
-                        <Box
-                          aria-label={intl.formatMessage(messages.identifierStatusAvailableIcon)}
-                          role="img"
-                          sx={{ color: 'success.main', display: 'flex' }}
-                        >
-                          <CircleCheck size={18} />
-                        </Box>
-                      ) : null}
-                    </InputAdornment>
-                  }
+                  aria-describedby="identifier-error"
                   id="identifier"
                   label={identifierLabel}
                   name="identifier"
@@ -532,24 +594,17 @@ export const GeneralCreateApiForm = (props: GeneralCreateApiFormProps) => {
                   onChange={(event) => handleIdentifierChange(event.target.value)}
                   value={formState.id}
                 />
-                <FormHelperText sx={isAvailable ? { color: 'success.main' } : undefined}>
-                  {errorFor('id') ? (
-                    <FormattedMessage {...errorFor('id')!} values={{ max: HANDLE_MAX_LENGTH }} />
-                  ) : isChecking ? (
-                    <FormattedMessage {...messages.identifierStatusChecking} />
-                  ) : isAvailable ? (
-                    <FormattedMessage {...messages.identifierStatusAvailable} />
-                  ) : (
-                    <FormattedMessage {...messages.identifierHelper} />
-                  )}
-                </FormHelperText>
+                {/* The identifier is the field a duplicate-handle rejection
+                    lands on, so it needs somewhere to say so. */}
+                <FormHelperText id="identifier-error">{fieldErrors.id}</FormHelperText>
               </FormControl>
             </Grid>
 
             <Grid size={{ xs: 12, md: 4 }}>
-              <FormControl error={Boolean(errorFor('version'))} fullWidth required>
+              <FormControl error={Boolean(fieldErrors.version)} fullWidth required>
                 <InputLabel htmlFor="version">{versionLabel}</InputLabel>
                 <OutlinedInput
+                  aria-describedby="version-error"
                   id="version"
                   label={versionLabel}
                   name="version"
@@ -557,34 +612,23 @@ export const GeneralCreateApiForm = (props: GeneralCreateApiFormProps) => {
                   onChange={(event) => handleVersionChange(event.target.value)}
                   value={formState.version}
                 />
-                <FormHelperText>
-                  {errorFor('version') ? (
-                    <FormattedMessage {...errorFor('version')!} />
-                  ) : (
-                    <FormattedMessage {...messages.versionHelper} />
-                  )}
-                </FormHelperText>
+                <FormHelperText id="version-error">{fieldErrors.version}</FormHelperText>
               </FormControl>
             </Grid>
           </Grid>
 
-          <FormControl error={Boolean(errorFor('context'))} fullWidth required>
-            <InputLabel htmlFor="basePath">{basePathLabel}</InputLabel>
+          <FormControl error={Boolean(fieldErrors.context)} fullWidth required>
+            <InputLabel htmlFor="context">{contextLabel}</InputLabel>
             <OutlinedInput
-              id="basePath"
-              label={basePathLabel}
-              name="basePath"
+              aria-describedby="context-error"
+              id="context"
+              label={contextLabel}
+              name="context"
               onBlur={() => markTouched('context')}
               onChange={(event) => handleBasePathChange(event.target.value)}
               value={formState.context}
             />
-            <FormHelperText>
-              {errorFor('context') ? (
-                <FormattedMessage {...errorFor('context')!} />
-              ) : (
-                <FormattedMessage {...messages.basePathHelper} />
-              )}
-            </FormHelperText>
+            <FormHelperText id="context-error">{fieldErrors.context}</FormHelperText>
           </FormControl>
 
           <FormControl fullWidth>
@@ -608,9 +652,10 @@ export const GeneralCreateApiForm = (props: GeneralCreateApiFormProps) => {
         </Form.Header>
 
         <Form.Stack spacing={2} sx={{ mt: 1.5 }}>
-          <FormControl error={Boolean(errorFor('targetUrl'))} fullWidth required>
+          <FormControl error={Boolean(fieldErrors.targetUrl)} fullWidth required>
             <InputLabel htmlFor="targetUrl">{targetUrlLabel}</InputLabel>
             <OutlinedInput
+              aria-describedby="targetUrl-error"
               id="targetUrl"
               label={targetUrlLabel}
               name="targetUrl"
@@ -618,24 +663,16 @@ export const GeneralCreateApiForm = (props: GeneralCreateApiFormProps) => {
               onChange={(event) => setMainUpstreamUrl(event.target.value)}
               value={formState.upstream.main.url}
             />
-            <FormHelperText>
-              {errorFor('targetUrl') ? (
-                <FormattedMessage {...errorFor('targetUrl')!} />
-              ) : (
-                <FormattedMessage {...messages.targetUrlHelper} />
-              )}
-            </FormHelperText>
+            <FormHelperText id="targetUrl-error">{fieldErrors.targetUrl}</FormHelperText>
           </FormControl>
         </Form.Stack>
       </Paper>
 
       <Divider />
 
-      <Stack
-        direction="row"
-        spacing={2}
-        sx={{ alignItems: 'center', justifyContent: 'space-between' }}
-      >
+      {/* Both buttons on the trailing edge, the same pairing as the step
+          before this one. */}
+      <Stack direction="row" spacing={2} sx={{ alignItems: 'center', justifyContent: 'flex-end' }}>
         <Button variant="text" onClick={props.onBack}>
           <FormattedMessage {...messages.back} />
         </Button>

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/GeneralCreateApiForm.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/GeneralCreateApiForm.tsx
@@ -517,7 +517,9 @@ export const GeneralCreateApiForm = (props: GeneralCreateApiFormProps) => {
   const pinnedFieldCount = Object.keys(props.serverErrors?.fields ?? {}).length;
   const showRejection =
     props.serverErrors !== undefined &&
-    (pinnedFieldCount === 0 || FIELD_ORDER.some((field) => serverErrorFor(field) !== undefined));
+    (pinnedFieldCount === 0 ||
+      props.serverErrors.unmapped.length > 0 ||
+      FIELD_ORDER.some((field) => serverErrorFor(field) !== undefined));
 
   const nameLabel = intl.formatMessage(messages.nameLabel);
   const identifierLabel = intl.formatMessage(messages.identifierLabel);

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/utils/serverFieldErrors.test.ts
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/utils/serverFieldErrors.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { ApiError, type FieldError } from '@/api/core/errors';
+import { toCreateApiFormErrors } from './serverFieldErrors';
+
+const rejection = (status: number, fieldErrors: FieldError[] = [], message = 'Rejected.') =>
+  new ApiError(message, { fieldErrors, kind: 'http', status });
+
+describe('toCreateApiFormErrors', () => {
+  it('pins each field error to the input that produced it', () => {
+    const result = toCreateApiFormErrors(
+      rejection(400, [
+        { field: 'displayName', message: 'Name contains an unsupported character.' },
+        { field: 'upstream.main.url', message: 'Must be an http or https URL.' },
+      ]),
+    );
+
+    expect(result?.fields).toEqual({
+      displayName: 'Name contains an unsupported character.',
+      targetUrl: 'Must be an http or https URL.',
+    });
+    expect(result?.unmapped).toEqual([]);
+  });
+
+  it('reads the aliases the server uses for the same input', () => {
+    // `field` is prose in the spec, not an enum — the identifier has been
+    // named both `id` and `handle`, and the base path both ways too.
+    expect(toCreateApiFormErrors(rejection(400, [{ field: 'handle', message: 'Taken.' }]))?.fields)
+      .toEqual({ id: 'Taken.' });
+    expect(
+      toCreateApiFormErrors(rejection(400, [{ field: 'basePath', message: 'In use.' }]))?.fields,
+    ).toEqual({ context: 'In use.' });
+  });
+
+  it('ignores case and array indices when matching a field path', () => {
+    const result = toCreateApiFormErrors(
+      rejection(400, [{ field: 'Upstream.Main[0].Url', message: 'Unreachable.' }]),
+    );
+
+    expect(result?.fields).toEqual({ targetUrl: 'Unreachable.' });
+  });
+
+  it('keeps a field error the form has no input for, rather than dropping it', () => {
+    // Silently swallowing it would leave the user staring at a form with
+    // nothing marked and no idea what the server objected to.
+    const result = toCreateApiFormErrors(
+      rejection(400, [{ field: 'projectId', message: 'Unknown project.' }]),
+    );
+
+    expect(result?.fields).toEqual({});
+    expect(result?.unmapped).toEqual(['Unknown project.']);
+  });
+
+  it('treats a conflict with no field detail as the form’s to fix', () => {
+    // The most common real rejection: a handle or base path already in use,
+    // described in prose with no `errors[]` to pin it to a field.
+    const result = toCreateApiFormErrors(
+      rejection(409, [], 'An API with context /orders and version 1.0.0 already exists.'),
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.fields).toEqual({});
+    expect(result?.message).toBe(
+      'An API with context /orders and version 1.0.0 already exists.',
+    );
+  });
+
+  it('declines a failure that editing the form cannot fix', () => {
+    // These belong to the progress screen: retyping a name does not fix a
+    // 500, a dropped connection, or a missing scope.
+    expect(toCreateApiFormErrors(rejection(500))).toBeNull();
+    expect(toCreateApiFormErrors(rejection(403))).toBeNull();
+    expect(
+      toCreateApiFormErrors(new ApiError('Offline.', { kind: 'network', status: 0 })),
+    ).toBeNull();
+  });
+});

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/utils/serverFieldErrors.ts
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/utils/serverFieldErrors.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { type ApiError } from '@/api/core/errors';
+
+/** The creation form's inputs that a server error can be pinned to. */
+export type CreateApiFormField = 'context' | 'displayName' | 'id' | 'targetUrl' | 'version';
+
+/** A rejected create, expressed in the form's own terms. */
+export type CreateApiFormErrors = {
+  /** Server messages pinned to the input that caused them. */
+  fields: Partial<Record<CreateApiFormField, string>>;
+  /** The server's own sentence about the request as a whole. */
+  message?: string;
+  /**
+   * Field errors naming something this form has no input for — a bad
+   * `projectId`, an operation the imported contract carried. They have nowhere
+   * to point, so they are listed in the summary rather than dropped: an error
+   * the user cannot see is worse than one they cannot click.
+   */
+  unmapped: string[];
+};
+
+/**
+ * Request-body paths, as the server names them, mapped onto form fields.
+ *
+ * Keys are normalized (lower-cased, array indices stripped) before lookup, and
+ * the aliases exist because the field name is prose in the spec, not an enum —
+ * the same input has been called `id` and `handle` in different messages.
+ */
+const FIELD_BY_SERVER_PATH: Record<string, CreateApiFormField> = {
+  apiid: 'id',
+  basepath: 'context',
+  context: 'context',
+  displayname: 'displayName',
+  handle: 'id',
+  id: 'id',
+  upstream: 'targetUrl',
+  'upstream.main': 'targetUrl',
+  'upstream.main.url': 'targetUrl',
+  version: 'version',
+};
+
+/** Lower-cased, with array indices dropped: `errors[0].field` names one input. */
+const normalizePath = (field: string): string =>
+  field
+    .trim()
+    .toLowerCase()
+    .replace(/\[\d+\]/g, '');
+
+/**
+ * Re-expresses a failed create as something the form can show, or `null` when
+ * the form is the wrong place for it.
+ *
+ * Only a rejection the user can act on by editing gets a form: a validation
+ * failure or a conflict (a handle or base path already in use — by far the
+ * most common real failure here). A 5xx, a dropped connection or a permission
+ * problem is not fixed by retyping, so it stays on the progress screen instead
+ * of dumping the user back into a form with nothing to change.
+ */
+export const toCreateApiFormErrors = (error: ApiError): CreateApiFormErrors | null => {
+  const hasFieldDetail = error.fieldErrors.length > 0;
+  if (!hasFieldDetail && !error.isValidation && !error.isConflict) return null;
+
+  const fields: CreateApiFormErrors['fields'] = {};
+  const unmapped: string[] = [];
+
+  for (const [path, message] of Object.entries(error.fieldErrorMap())) {
+    const field = FIELD_BY_SERVER_PATH[normalizePath(path)];
+    if (field === undefined) {
+      unmapped.push(message);
+      continue;
+    }
+    // First wins: two messages for one input would overwrite each other, and
+    // `fieldErrorMap` has already joined the ones the server sent together.
+    fields[field] ??= message;
+  }
+
+  return { fields, message: error.message, unmapped };
+};

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/edit/ApiEditPage.test.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/edit/ApiEditPage.test.tsx
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { ApiScopeProvider } from '@/api/core/ApiScopeProvider';
+import { resetHttpClient } from '@/api/core/http';
+import { routes } from '@/routes/paths';
+import {
+  accepts,
+  aRestApi,
+  recorder,
+  resource,
+  type Recorder,
+  type RestApiFixture,
+} from '@/test/msw';
+import { makeConsoleScope } from '@/test/mockScope';
+import { server } from '@/test/server';
+import { renderWithProviders, screen, waitFor } from '@/test/utils';
+import { ApiEditPage } from './ApiEditPage';
+
+const ORG = 'acme-org';
+const PROJECT = 'retail';
+const API = 'pizza-shack';
+
+const anApi = (overrides: Partial<RestApiFixture> = {}) =>
+  aRestApi({
+    context: '/pizza',
+    description: 'Pizza ordering',
+    displayName: 'Pizza Shack',
+    id: API,
+    projectId: PROJECT,
+    upstream: { main: { url: 'https://upstream.test' } },
+    version: '1.0.0',
+    ...overrides,
+  });
+
+let requests: Recorder;
+
+beforeEach(() => {
+  resetHttpClient();
+  requests = recorder();
+});
+
+/**
+ * The page's hooks read `ApiScopeContext` rather than the console scope, so the
+ * provider is mounted here — without it the detail query stays
+ * `enabled: false` and the page renders its loading state forever.
+ *
+ * The detail route is registered alongside so the redirect after a successful
+ * save is observable, rather than asserted on a spy.
+ */
+function renderPage() {
+  return renderWithProviders(
+    <ApiScopeProvider orgId={ORG} projectId={PROJECT}>
+      <Routes>
+        <Route element={<ApiEditPage />} path={routes.apiEdit()} />
+        <Route element={<div>API overview</div>} path={routes.api()} />
+      </Routes>
+    </ApiScopeProvider>,
+    {
+      route: routes.apiEdit(ORG, PROJECT, API),
+      scope: makeConsoleScope({
+        params: { apiHandler: API, orgHandle: ORG, projectHandler: PROJECT },
+      }),
+    },
+  );
+}
+
+describe('ApiEditPage', () => {
+  it('opens the form on the API named in the URL', async () => {
+    server.use(resource(`/rest-apis/${API}`, anApi()));
+
+    renderPage();
+
+    expect(await screen.findByDisplayValue('Pizza Shack')).toBeInTheDocument();
+    expect(screen.getByLabelText(/Context/)).toHaveValue('/pizza');
+  });
+
+  it('PUTs the whole API back with the edits applied, then returns to the overview', async () => {
+    server.use(resource(`/rest-apis/${API}`, anApi({ operations: [], transport: ['https'] })));
+    server.use(
+      accepts('put', `/rest-apis/${API}`, anApi({ displayName: 'Pizza Palace' }), {
+        record: requests,
+      }),
+    );
+
+    const { user } = renderPage();
+
+    const name = await screen.findByDisplayValue('Pizza Shack');
+    await user.clear(name);
+    await user.type(name, 'Pizza Palace');
+    await user.click(screen.getByRole('button', { name: /Save changes/ }));
+
+    await waitFor(() => expect(requests.count()).toBe(1));
+    const body = JSON.parse(requests.last()!.body) as RestApiFixture;
+
+    expect(body.displayName).toBe('Pizza Palace');
+    // Fields the form doesn't collect have to survive the round trip: the
+    // spec's update body is the whole `RESTAPI`, not a patch.
+    expect(body.id).toBe(API);
+    expect(body.transport).toEqual(['https']);
+    expect(body.upstream.main.url).toBe('https://upstream.test');
+
+    expect(await screen.findByText('API overview')).toBeInTheDocument();
+  });
+
+  it('keeps a shared upstream `ref` intact instead of writing a url beside it', async () => {
+    server.use(
+      resource(`/rest-apis/${API}`, anApi({ upstream: { main: { ref: 'retail-backend' } } })),
+    );
+    server.use(accepts('put', `/rest-apis/${API}`, anApi(), { record: requests }));
+
+    const { user } = renderPage();
+
+    const name = await screen.findByDisplayValue('Pizza Shack');
+    await user.clear(name);
+    await user.type(name, 'Pizza Palace');
+    await user.click(screen.getByRole('button', { name: /Save changes/ }));
+
+    await waitFor(() => expect(requests.count()).toBe(1));
+    const body = JSON.parse(requests.last()!.body) as RestApiFixture;
+
+    expect(body.upstream).toEqual({ main: { ref: 'retail-backend' } });
+  });
+
+  it('refuses a gateway-managed API, even when reached by URL', async () => {
+    server.use(resource(`/rest-apis/${API}`, anApi({ readOnly: true })));
+
+    renderPage();
+
+    expect(await screen.findByText('This API cannot be edited here')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Save changes/ })).not.toBeInTheDocument();
+  });
+});

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/edit/ApiEditPage.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/edit/ApiEditPage.tsx
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { PageTitle } from '@wso2/oxygen-ui';
+import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
+import { Link, useNavigate } from 'react-router-dom';
+
+import { useRestApi, useUpdateRestApi, type RestApi } from '@/api/resources/restApis';
+import { useNotifications } from '@/components/Notifications';
+import { ErrorState, LoadingState } from '@/components/StateViews';
+import { routes } from '@/routes/paths';
+import { useConsoleScope } from '@/scope/ConsoleScopeProvider';
+import { EditApiForm, type ApiBasicInfoFormValues } from './components/EditApiForm';
+
+const messages = defineMessages({
+  back: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.ApiEditPage.back',
+    defaultMessage: 'Back to API',
+    description: 'Back button above the edit form, returning to the API overview.',
+  },
+  loading: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.ApiEditPage.loading',
+    defaultMessage: 'Loading API',
+    description: 'Shown while the API being edited is fetched.',
+  },
+  notFound: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.ApiEditPage.notFound',
+    defaultMessage: 'API not found',
+    description: 'Shown when the API to edit could not be loaded.',
+  },
+  readOnly: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.ApiEditPage.readOnly',
+    defaultMessage: 'This API cannot be edited here',
+    description: 'Title shown when the edit page is opened for a gateway-managed API.',
+  },
+  readOnlyDetail: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.ApiEditPage.readOnlyDetail',
+    defaultMessage:
+      'It was discovered from a data-plane gateway, so it is read-only in this console.',
+    description: 'Explains why a gateway-managed API cannot be edited.',
+  },
+  saved: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.ApiEditPage.saved',
+    defaultMessage: 'API updated.',
+    description: 'Confirmation shown after the API details are saved.',
+  },
+  subtitle: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.ApiEditPage.subtitle',
+    defaultMessage: 'Change the name, description, context, version and backend of this API.',
+  },
+  title: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.ApiEditPage.title',
+    defaultMessage: 'Edit API',
+  },
+});
+
+/**
+ * Applies the form's five fields to the fetched API.
+ *
+ * The spec's update body is the whole `RESTAPI`, so the original is spread back
+ * with the edits laid over it — anything the form does not collect (operations,
+ * policies, transports) has to survive the round trip untouched.
+ *
+ * `upstream` is only rewritten when the API routes to a direct URL. An API
+ * pointing at a shared upstream `ref` keeps it: `url` and `ref` are mutually
+ * exclusive, so writing both would be rejected.
+ */
+const toUpdateBody = (api: RestApi, values: ApiBasicInfoFormValues): RestApi => ({
+  ...api,
+  context: values.context,
+  description: values.description,
+  displayName: values.displayName,
+  version: values.version,
+  upstream: api.upstream?.main?.ref
+    ? api.upstream
+    : {
+        ...api.upstream,
+        main: { ...api.upstream?.main, url: values.targetUrl },
+      },
+});
+
+// No `ScopeGate`: this page is only reachable from the API detail page's own
+// edit button, so it never mounts without an API in scope.
+export function ApiEditPage() {
+  const intl = useIntl();
+  const navigate = useNavigate();
+  const { notify } = useNotifications();
+  const { params } = useConsoleScope();
+
+  const apiQuery = useRestApi(params.apiHandler);
+  const updateApi = useUpdateRestApi();
+
+  const detailPath = routes.api(
+    params.orgHandle ?? '',
+    params.projectHandler ?? '',
+    params.apiHandler ?? '',
+  );
+
+  if (apiQuery.isPending) {
+    return <LoadingState label={intl.formatMessage(messages.loading)} />;
+  }
+  if (apiQuery.error || !apiQuery.data) {
+    return <ErrorState title={intl.formatMessage(messages.notFound)} />;
+  }
+
+  const api = apiQuery.data;
+  const restApiId = api.id ?? params.apiHandler ?? '';
+
+  // The detail page hides the edit button for a gateway-managed API; this is
+  // the same rule enforced at the page, for anyone arriving by URL.
+  if (api.readOnly) {
+    return (
+      <ErrorState
+        message={intl.formatMessage(messages.readOnlyDetail)}
+        title={intl.formatMessage(messages.readOnly)}
+      />
+    );
+  }
+
+  const save = (values: ApiBasicInfoFormValues) => {
+    updateApi.mutate(
+      { restApiId, body: toUpdateBody(api, values) },
+      {
+        onSuccess: () => {
+          notify(intl.formatMessage(messages.saved), 'success');
+          void navigate(detailPath);
+        },
+      },
+    );
+  };
+
+  return (
+    <>
+      <PageTitle>
+        <Link to={detailPath}>
+          <PageTitle.BackButton>
+            <FormattedMessage {...messages.back} />
+          </PageTitle.BackButton>
+        </Link>
+        <PageTitle.Header>
+          <FormattedMessage {...messages.title} />
+        </PageTitle.Header>
+        <PageTitle.SubHeader>
+          <FormattedMessage {...messages.subtitle} />
+        </PageTitle.SubHeader>
+      </PageTitle>
+
+      <EditApiForm
+        api={api}
+        fieldErrors={updateApi.error?.fieldErrorMap()}
+        isSaving={updateApi.isPending}
+        onCancel={() => void navigate(detailPath)}
+        onSubmit={save}
+      />
+    </>
+  );
+}

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/edit/components/EditApiForm.test.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/edit/components/EditApiForm.test.tsx
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { aRestApi, type RestApiFixture } from '@/test/msw';
+import { renderWithProviders, screen } from '@/test/utils';
+import { EditApiForm, type ApiBasicInfoFormValues } from './EditApiForm';
+
+const anApi = (overrides: Partial<RestApiFixture> = {}) =>
+  aRestApi({
+    context: '/pizza',
+    description: 'Pizza ordering',
+    displayName: 'Pizza Shack',
+    id: 'pizza-shack',
+    upstream: { main: { url: 'https://upstream.test' } },
+    version: '1.0.0',
+    ...overrides,
+  });
+
+const renderForm = (
+  options: {
+    api?: RestApiFixture;
+    fieldErrors?: Record<string, string>;
+    isSaving?: boolean;
+    onSubmit?: (values: ApiBasicInfoFormValues) => void;
+  } = {},
+) => {
+  const onSubmit = options.onSubmit ?? vi.fn();
+  const onCancel = vi.fn();
+
+  const result = renderWithProviders(
+    <EditApiForm
+      api={options.api ?? anApi()}
+      fieldErrors={options.fieldErrors}
+      isSaving={options.isSaving ?? false}
+      onCancel={onCancel}
+      onSubmit={onSubmit}
+    />,
+  );
+
+  return { ...result, onCancel, onSubmit };
+};
+
+const save = (user: ReturnType<typeof renderForm>['user']) =>
+  user.click(screen.getByRole('button', { name: /Save changes/ }));
+
+describe('EditApiForm — initial values', () => {
+  it('opens with the API it was given', () => {
+    renderForm();
+
+    expect(screen.getByLabelText(/^Name/)).toHaveValue('Pizza Shack');
+    expect(screen.getByLabelText(/Version/)).toHaveValue('1.0.0');
+    expect(screen.getByLabelText(/Context/)).toHaveValue('/pizza');
+    expect(screen.getByLabelText(/Description/)).toHaveValue('Pizza ordering');
+    expect(screen.getByLabelText(/Target URL/)).toHaveValue('https://upstream.test');
+  });
+
+  it('shows the identifier but does not let it be edited', () => {
+    // `PUT /rest-apis/{restApiId}` rejects a body whose `id` differs from the
+    // path and there is no rename operation, so the handle is reference only.
+    renderForm();
+
+    const identifier = screen.getByLabelText(/Identifier/);
+    expect(identifier).toHaveValue('pizza-shack');
+    expect(identifier).toBeDisabled();
+  });
+
+  it('leaves an absent description as an empty field rather than "undefined"', () => {
+    renderForm({ api: anApi({ description: undefined }) });
+
+    expect(screen.getByLabelText(/Description/)).toHaveValue('');
+  });
+});
+
+describe('EditApiForm — validation', () => {
+  it('refuses to submit without a name, and says so', async () => {
+    const { onSubmit, user } = renderForm();
+
+    await user.clear(screen.getByLabelText(/^Name/));
+    await save(user);
+
+    expect(screen.getByText('Enter a name.')).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('requires the context to be an absolute path', async () => {
+    const { onSubmit, user } = renderForm();
+
+    await user.clear(screen.getByLabelText(/Context/));
+    await user.type(screen.getByLabelText(/Context/), 'pizza');
+    await save(user);
+
+    expect(
+      screen.getByText('Start with / and use only letters, numbers, hyphens, dots and slashes.'),
+    ).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('rejects a version carrying a space', async () => {
+    const { onSubmit, user } = renderForm();
+
+    await user.clear(screen.getByLabelText(/Version/));
+    await user.type(screen.getByLabelText(/Version/), '1 0');
+    await save(user);
+
+    expect(
+      screen.getByText(
+        'Use letters, numbers, dots, hyphens and underscores — no spaces or slashes.',
+      ),
+    ).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('rejects a target URL that is not a full http(s) URL', async () => {
+    const { onSubmit, user } = renderForm();
+
+    await user.clear(screen.getByLabelText(/Target URL/));
+    await user.type(screen.getByLabelText(/Target URL/), 'upstream.test');
+    await save(user);
+
+    expect(
+      screen.getByText('Enter a full URL, for example https://api.example.com.'),
+    ).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet until a rule is actually broken', () => {
+    renderForm();
+
+    expect(screen.queryByText('Enter a name.')).not.toBeInTheDocument();
+  });
+
+  it('binds a rejected save back onto the field the server named', () => {
+    renderForm({ fieldErrors: { context: 'Context already in use by another API.' } });
+
+    expect(screen.getByText('Context already in use by another API.')).toBeInTheDocument();
+  });
+});
+
+describe('EditApiForm — submitting', () => {
+  it('hands back the five fields, trimmed', async () => {
+    const { onSubmit, user } = renderForm();
+
+    await user.clear(screen.getByLabelText(/^Name/));
+    await user.type(screen.getByLabelText(/^Name/), '  Pizza Shack v2  ');
+    await user.clear(screen.getByLabelText(/Description/));
+    await user.type(screen.getByLabelText(/Description/), 'Now with sides');
+    await save(user);
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      context: '/pizza',
+      description: 'Now with sides',
+      displayName: 'Pizza Shack v2',
+      targetUrl: 'https://upstream.test',
+      version: '1.0.0',
+    });
+  });
+
+  it('locks every control while the save is in flight', () => {
+    renderForm({ isSaving: true });
+
+    expect(screen.getByLabelText(/^Name/)).toBeDisabled();
+    expect(screen.getByRole('button', { name: /Save changes/ })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /Cancel/ })).toBeDisabled();
+  });
+
+  it('leaves without saving when cancelled', async () => {
+    const { onCancel, onSubmit, user } = renderForm();
+
+    await user.click(screen.getByRole('button', { name: /Cancel/ }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});
+
+describe('EditApiForm — shared upstream', () => {
+  const withRef = anApi({ upstream: { main: { ref: 'retail-backend' } } });
+
+  it('locks the target URL and names the upstream it points at', () => {
+    renderForm({ api: withRef });
+
+    expect(screen.getByLabelText(/Target URL/)).toBeDisabled();
+    expect(
+      screen.getByText(/Routed through the shared upstream “retail-backend”/),
+    ).toBeInTheDocument();
+  });
+
+  it('still submits: an API with no URL of its own is not an invalid one', async () => {
+    const { onSubmit, user } = renderForm({ api: withRef });
+
+    await save(user);
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ displayName: 'Pizza Shack', targetUrl: '' }),
+    );
+  });
+});

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/edit/components/EditApiForm.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/edit/components/EditApiForm.tsx
@@ -1,0 +1,468 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  Button,
+  Divider,
+  Form,
+  FormControl,
+  FormHelperText,
+  Grid,
+  InputLabel,
+  OutlinedInput,
+  Paper,
+  Stack,
+} from '@wso2/oxygen-ui';
+import type { FormEvent, ReactNode } from 'react';
+import { useState } from 'react';
+import { defineMessages, FormattedMessage, useIntl, type MessageDescriptor } from 'react-intl';
+
+import type { RestApi } from '@/api/resources/restApis';
+import { CONTEXT_PATTERN, isHttpUrl, VERSION_PATTERN } from '../../utils/basicInfoRules';
+
+/**
+ * The five fields this form edits, flattened. `targetUrl` is
+ * `upstream.main.url` — the page puts it back on the API object, because the
+ * spec's update body is the whole `RESTAPI` and only the page holds the
+ * fetched original to merge into.
+ */
+export type ApiBasicInfoFormValues = {
+  context: string;
+  description: string;
+  displayName: string;
+  targetUrl: string;
+  version: string;
+};
+
+export type EditApiFormProps = {
+  api: RestApi;
+  /**
+   * Per-field messages the server rejected the last save with, keyed by the
+   * spec's own field names (`ApiError.fieldErrorMap()`). Shown as-is: this is
+   * backend copy, not something the catalog can translate.
+   */
+  fieldErrors?: Record<string, string>;
+  isSaving: boolean;
+  onCancel: () => void;
+  onSubmit: (values: ApiBasicInfoFormValues) => void;
+};
+
+const messages = defineMessages({
+  basicInformation: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.section.basicInformation',
+    defaultMessage: 'Basic information',
+    description: 'Heading of the field group holding name, identifier, version, context.',
+  },
+  cancel: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.action.cancel',
+    defaultMessage: 'Cancel',
+    description: 'Discards the unsaved edits and returns to the API overview.',
+  },
+  contextErrorPattern: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.context.error.pattern',
+    defaultMessage: 'Start with / and use only letters, numbers, hyphens, dots and slashes.',
+  },
+  contextErrorRequired: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.context.error.required',
+    defaultMessage: 'Enter a context.',
+  },
+  contextLabel: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.context.label',
+    defaultMessage: 'Context',
+  },
+  descriptionLabel: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.description.label',
+    defaultMessage: 'Description',
+  },
+  endpointSection: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.section.backendEndpoint',
+    defaultMessage: 'Backend endpoint',
+    description: 'Heading of the field group holding the target URL.',
+  },
+  identifierHelper: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.identifier.helper',
+    defaultMessage: 'Fixed once the API is created.',
+    description: 'Helper text under the disabled identifier field on the API edit form.',
+  },
+  identifierLabel: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.identifier.label',
+    defaultMessage: 'Identifier',
+  },
+  nameErrorRequired: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.name.error.required',
+    defaultMessage: 'Enter a name.',
+  },
+  nameLabel: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.name.label',
+    defaultMessage: 'Name',
+  },
+  save: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.action.save',
+    defaultMessage: 'Save changes',
+    description: 'Commits the edits to the API.',
+  },
+  targetUrlErrorInvalid: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.targetUrl.error.invalid',
+    defaultMessage: 'Enter a full URL, for example https://api.example.com.',
+  },
+  targetUrlErrorRequired: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.targetUrl.error.required',
+    defaultMessage: 'Enter a target URL.',
+  },
+  targetUrlLabel: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.targetUrl.label',
+    defaultMessage: 'Target URL',
+  },
+  targetUrlSharedUpstream: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.targetUrl.sharedUpstream',
+    defaultMessage: 'Routed through the shared upstream “{ref}”, so there is no URL to edit here.',
+    description:
+      'Helper text shown instead of an editable target URL when the API points at a named upstream definition. {ref} is that definition’s name.',
+  },
+  versionErrorPattern: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.version.error.pattern',
+    defaultMessage: 'Use letters, numbers, dots, hyphens and underscores — no spaces or slashes.',
+  },
+  versionErrorRequired: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.version.error.required',
+    defaultMessage: 'Enter a version.',
+  },
+  versionLabel: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.version.label',
+    defaultMessage: 'Version',
+  },
+});
+
+/**
+ * Small uppercase rule above a group of fields, matching the create form.
+ * `Form.Header` is fixed at `h4`, so the size comes from the theme's `overline`
+ * typography rather than a font-size literal.
+ */
+const SECTION_LABEL_SX = {
+  color: 'text.secondary',
+  typography: 'overline',
+} as const;
+
+/** The fields that carry a validation rule — description has none. */
+type ValidatedField = 'context' | 'displayName' | 'targetUrl' | 'version';
+
+type FieldErrors = Partial<Record<ValidatedField, MessageDescriptor>>;
+
+/**
+ * Which spec field name a server-side field error binds to. The server names
+ * the wire field, which is nested for the upstream URL, so the mapping is
+ * spelled out rather than guessed from the input's own name.
+ */
+const SERVER_FIELD_NAMES: Record<ValidatedField, string[]> = {
+  context: ['context'],
+  displayName: ['displayName'],
+  targetUrl: ['upstream.main.url', 'upstream'],
+  version: ['version'],
+};
+
+/**
+ * Every rule in one pure pass, so the same answer drives the field errors and
+ * the submit gate — there is no second, drifting copy of the rules.
+ *
+ * `targetUrl` is only validated when the API carries a URL to begin with: an
+ * API routed through a shared upstream `ref` has no URL, and requiring one
+ * would make its form unsubmittable.
+ */
+const validate = (values: ApiBasicInfoFormValues, hasEditableUrl: boolean): FieldErrors => {
+  const errors: FieldErrors = {};
+
+  if (values.displayName.trim() === '') {
+    errors.displayName = messages.nameErrorRequired;
+  }
+
+  const version = values.version.trim();
+  if (version === '') {
+    errors.version = messages.versionErrorRequired;
+  } else if (!VERSION_PATTERN.test(version)) {
+    errors.version = messages.versionErrorPattern;
+  }
+
+  const context = values.context.trim();
+  if (context === '' || context === '/') {
+    errors.context = messages.contextErrorRequired;
+  } else if (!CONTEXT_PATTERN.test(context)) {
+    errors.context = messages.contextErrorPattern;
+  }
+
+  if (hasEditableUrl) {
+    const targetUrl = values.targetUrl.trim();
+    if (targetUrl === '') {
+      errors.targetUrl = messages.targetUrlErrorRequired;
+    } else if (!isHttpUrl(targetUrl)) {
+      errors.targetUrl = messages.targetUrlErrorInvalid;
+    }
+  }
+
+  return errors;
+};
+
+/** The form's opening values, read off the fetched API. */
+const toFormValues = (api: RestApi): ApiBasicInfoFormValues => ({
+  context: api.context ?? '',
+  description: api.description ?? '',
+  displayName: api.displayName ?? '',
+  targetUrl: api.upstream?.main?.url ?? '',
+  version: api.version ?? '',
+});
+
+/**
+ * Edit form for an API's basic information: name, description, context, version
+ * and target URL.
+ *
+ * It owns the draft and the validation only. The mutation, the merge back onto
+ * the fetched `RESTAPI` and the navigation belong to `ApiEditPage`, so this
+ * component renders from props alone and can be exercised without a network.
+ */
+export const EditApiForm = (props: EditApiFormProps) => {
+  const intl = useIntl();
+
+  // Lazy initialiser: the API is already loaded when this mounts, so the draft
+  // is seeded once rather than recomputed on every render.
+  const [values, setValues] = useState<ApiBasicInfoFormValues>(() => toFormValues(props.api));
+
+  // Errors are recomputed from state on every render; `touched` decides which
+  // of them the user is ready to see, so nothing shouts before it is typed in.
+  const [touched, setTouched] = useState<Partial<Record<ValidatedField, boolean>>>({});
+
+  // An upstream carries `url` or `ref`, never both. A `ref` names a shared
+  // upstream definition this form does not own, so the URL field goes
+  // read-only rather than silently converting the API to a direct URL.
+  const upstreamRef = props.api.upstream?.main?.ref;
+  const hasEditableUrl = !upstreamRef;
+
+  const errors = validate(values, hasEditableUrl);
+
+  /** Whatever the server said about this field on the last rejected save. */
+  const serverErrorFor = (field: ValidatedField): string | undefined => {
+    const map = props.fieldErrors;
+    if (!map) return undefined;
+    return SERVER_FIELD_NAMES[field].map((name) => map[name]).find(Boolean);
+  };
+
+  const errorFor = (field: ValidatedField): MessageDescriptor | undefined =>
+    touched[field] ? errors[field] : undefined;
+
+  /** Whether the field shows an error at all, from either source. */
+  const hasError = (field: ValidatedField): boolean =>
+    Boolean(errorFor(field)) || Boolean(serverErrorFor(field));
+
+  const markTouched = (field: ValidatedField) =>
+    setTouched((current) => ({ ...current, [field]: true }));
+
+  const setField = <K extends keyof ApiBasicInfoFormValues>(
+    key: K,
+    value: ApiBasicInfoFormValues[K],
+  ) => setValues((current) => ({ ...current, [key]: value }));
+
+  const onFormSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (Object.keys(errors).length > 0) {
+      // Reveal every rule at once rather than one field per attempt.
+      setTouched({ context: true, displayName: true, targetUrl: true, version: true });
+      return;
+    }
+
+    props.onSubmit({
+      context: values.context.trim(),
+      description: values.description.trim(),
+      displayName: values.displayName.trim(),
+      targetUrl: values.targetUrl.trim(),
+      version: values.version.trim(),
+    });
+  };
+
+  /**
+   * The helper line under one field: the local rule first, then whatever the
+   * server rejected it with, then whatever standing note the field passes in.
+   *
+   * It returns the `FormHelperText` itself rather than its contents, so a field
+   * with nothing to say renders no helper row — and, more importantly, so a
+   * field can never end up marked `error` with no message beside it.
+   */
+  const helperFor = (field: ValidatedField, note?: ReactNode): ReactNode => {
+    const local = errorFor(field);
+    if (local) {
+      return (
+        <FormHelperText>
+          <FormattedMessage {...local} />
+        </FormHelperText>
+      );
+    }
+
+    const fromServer = serverErrorFor(field);
+    if (fromServer) return <FormHelperText>{fromServer}</FormHelperText>;
+
+    return note ? <FormHelperText>{note}</FormHelperText> : null;
+  };
+
+  const contextLabel = intl.formatMessage(messages.contextLabel);
+  const descriptionLabel = intl.formatMessage(messages.descriptionLabel);
+  const identifierLabel = intl.formatMessage(messages.identifierLabel);
+  const nameLabel = intl.formatMessage(messages.nameLabel);
+  const targetUrlLabel = intl.formatMessage(messages.targetUrlLabel);
+  const versionLabel = intl.formatMessage(messages.versionLabel);
+
+  return (
+    <Stack component="form" noValidate spacing={3} onSubmit={onFormSubmit}>
+      <Paper component="section" sx={{ p: 3 }}>
+        <Form.Header sx={SECTION_LABEL_SX}>
+          <FormattedMessage {...messages.basicInformation} />
+        </Form.Header>
+
+        <Form.Stack spacing={2} sx={{ mt: 1.5 }}>
+          <Grid container spacing={2}>
+            <Grid size={{ xs: 12, md: 4 }}>
+              <FormControl error={hasError('displayName')} fullWidth required>
+                <InputLabel htmlFor="displayName">{nameLabel}</InputLabel>
+                <OutlinedInput
+                  autoFocus
+                  disabled={props.isSaving}
+                  id="displayName"
+                  label={nameLabel}
+                  name="displayName"
+                  onBlur={() => markTouched('displayName')}
+                  onChange={(event) => setField('displayName', event.target.value)}
+                  value={values.displayName}
+                />
+                {helperFor('displayName')}
+              </FormControl>
+            </Grid>
+
+            {/* The handle addresses the resource: `PUT /rest-apis/{restApiId}`
+                rejects a body whose `id` differs from the path, and there is no
+                rename operation — so it is shown for reference, not for edit. */}
+            <Grid size={{ xs: 12, md: 4 }}>
+              <FormControl disabled fullWidth>
+                <InputLabel htmlFor="identifier">{identifierLabel}</InputLabel>
+                <OutlinedInput
+                  id="identifier"
+                  label={identifierLabel}
+                  name="identifier"
+                  readOnly
+                  value={props.api.id ?? ''}
+                />
+                <FormHelperText>
+                  <FormattedMessage {...messages.identifierHelper} />
+                </FormHelperText>
+              </FormControl>
+            </Grid>
+
+            <Grid size={{ xs: 12, md: 4 }}>
+              <FormControl error={hasError('version')} fullWidth required>
+                <InputLabel htmlFor="version">{versionLabel}</InputLabel>
+                <OutlinedInput
+                  disabled={props.isSaving}
+                  id="version"
+                  label={versionLabel}
+                  name="version"
+                  onBlur={() => markTouched('version')}
+                  onChange={(event) => setField('version', event.target.value)}
+                  value={values.version}
+                />
+                {helperFor('version')}
+              </FormControl>
+            </Grid>
+          </Grid>
+
+          <FormControl error={hasError('context')} fullWidth required>
+            <InputLabel htmlFor="context">{contextLabel}</InputLabel>
+            <OutlinedInput
+              disabled={props.isSaving}
+              id="context"
+              label={contextLabel}
+              name="context"
+              onBlur={() => markTouched('context')}
+              onChange={(event) => setField('context', event.target.value)}
+              value={values.context}
+            />
+            {helperFor('context')}
+          </FormControl>
+
+          <FormControl fullWidth>
+            <InputLabel htmlFor="description">{descriptionLabel}</InputLabel>
+            <OutlinedInput
+              disabled={props.isSaving}
+              id="description"
+              label={descriptionLabel}
+              multiline
+              name="description"
+              onChange={(event) => setField('description', event.target.value)}
+              rows={3}
+              value={values.description}
+            />
+          </FormControl>
+        </Form.Stack>
+      </Paper>
+
+      <Paper component="section" sx={{ mt: 1, p: 3 }}>
+        <Form.Header sx={SECTION_LABEL_SX}>
+          <FormattedMessage {...messages.endpointSection} />
+        </Form.Header>
+
+        <Form.Stack spacing={2} sx={{ mt: 1.5 }}>
+          <FormControl
+            disabled={!hasEditableUrl}
+            error={hasError('targetUrl')}
+            fullWidth
+            required={hasEditableUrl}
+          >
+            <InputLabel htmlFor="targetUrl">{targetUrlLabel}</InputLabel>
+            <OutlinedInput
+              disabled={props.isSaving || !hasEditableUrl}
+              id="targetUrl"
+              label={targetUrlLabel}
+              name="targetUrl"
+              onBlur={() => markTouched('targetUrl')}
+              onChange={(event) => setField('targetUrl', event.target.value)}
+              readOnly={!hasEditableUrl}
+              value={values.targetUrl}
+            />
+            {helperFor(
+              'targetUrl',
+              hasEditableUrl ? null : (
+                <FormattedMessage
+                  {...messages.targetUrlSharedUpstream}
+                  values={{ ref: upstreamRef }}
+                />
+              ),
+            )}
+          </FormControl>
+        </Form.Stack>
+      </Paper>
+
+      <Divider />
+
+      {/* Both buttons on the trailing edge, the same pairing as the create
+          form's last step. */}
+      <Stack direction="row" spacing={2} sx={{ alignItems: 'center', justifyContent: 'flex-end' }}>
+        <Button disabled={props.isSaving} variant="text" onClick={props.onCancel}>
+          <FormattedMessage {...messages.cancel} />
+        </Button>
+        <Button disabled={props.isSaving} type="submit" variant="contained">
+          <FormattedMessage {...messages.save} />
+        </Button>
+      </Stack>
+    </Stack>
+  );
+};

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/edit/index.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/edit/index.tsx
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export { ApiEditPage } from './ApiEditPage';

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/ApiDetailPage.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/ApiDetailPage.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { useState, type ReactNode } from 'react';
+import { type ReactNode } from 'react';
 import {
   Avatar,
   Box,
@@ -25,21 +25,19 @@ import {
   Chip,
   IconButton,
   Stack,
-  TextField,
   Tooltip,
   Typography,
 } from '@wso2/oxygen-ui';
-import { Boxes, Lock, Pencil } from '@wso2/oxygen-ui-icons-react';
+import { Boxes, Edit, Lock } from '@wso2/oxygen-ui-icons-react';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import { Link as RouterLink } from 'react-router-dom';
 
-import { useRestApi, useUpdateRestApi, type RestApi } from '@/api/resources/restApis';
-import { useNotifications } from '@/components/Notifications';
+import { useRestApi } from '@/api/resources/restApis';
 import { ErrorState, LoadingState } from '@/components/StateViews';
 import { useFormatters } from '@/i18n/useFormatters';
 import { routes } from '@/routes/paths';
 import { useConsoleScope } from '@/scope/ConsoleScopeProvider';
-import { LifecycleChip, TransportChips, VersionChip } from '../listing/components/RestApiChips';
+import { VersionChip } from '../listing/components/RestApiChips';
 import { apiInitials } from '../utils/restApiDisplay';
 import { OverviewTab } from './OverviewTab';
 
@@ -60,31 +58,11 @@ const messages = defineMessages({
     description:
       'Shown in place of the API description when the API has none. Rendered in italics as an absence, not as a value.',
   },
-  descriptionSaved: {
-    id: 'apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.description.saved',
-    defaultMessage: 'Description updated.',
-    description: 'Confirmation shown after the API description is saved.',
-  },
-  editCancel: {
-    id: 'apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.description.cancel',
-    defaultMessage: 'Cancel',
-    description: 'Discards an unsaved edit to the API description.',
-  },
-  editDescription: {
-    id: 'apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.description.edit',
-    defaultMessage: 'Edit description',
+  editApi: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.editApi',
+    defaultMessage: 'Edit API details',
     description:
-      'Accessible label and tooltip for the pencil button that opens the description for editing.',
-  },
-  editFieldLabel: {
-    id: 'apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.description.fieldLabel',
-    defaultMessage: 'Description',
-    description: 'Label of the text box used to edit the API description.',
-  },
-  editSave: {
-    id: 'apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.description.save',
-    defaultMessage: 'Save',
-    description: 'Commits an edit to the API description.',
+      'Accessible label and tooltip for the button beside the API name, which opens the edit page.',
   },
   gatewayManaged: {
     id: 'apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.gatewayManaged',
@@ -117,101 +95,36 @@ const AVATAR_ICON_SIZE = 32;
 /** Label column of the metadata rows, wide enough to align their values. */
 const LABEL_COLUMN = 88;
 
-/** Keeps the description editor from stretching the full width of the header. */
-const EDIT_FIELD_MAX_WIDTH = 560;
-
-/** Inline API description editor.
- * Read mode clamps to two lines, shows an italic placeholder when empty,
- * and hides editing for `readOnly` APIs.
+/**
+ * The API description, read-only.
+ *
+ * Clamped to two lines, with an italic placeholder standing in for an absent
+ * description so the row reads as an absence rather than as a value. Editing
+ * lives on the dedicated edit page, reached from the button beside the title.
  */
-function DescriptionField({ api, restApiId }: { api: RestApi; restApiId: string }) {
-  const intl = useIntl();
-  const { notify } = useNotifications();
-  const updateApi = useUpdateRestApi();
-  const [draft, setDraft] = useState<string | null>(null);
-
-  const isEditing = draft !== null;
-  const description = api.description?.trim() ?? '';
-
-  const save = () => {
-    const next = (draft ?? '').trim();
-    // Nothing to persist: close rather than spend a PUT on an identical value.
-    if (next === description) {
-      setDraft(null);
-      return;
-    }
-    // The spec's update body is the whole `RESTAPI`, so the fetched object is
-    // spread back with the edit applied.
-    updateApi.mutate(
-      { restApiId, body: { ...api, description: next } },
-      {
-        onSuccess: () => {
-          setDraft(null);
-          notify(intl.formatMessage(messages.descriptionSaved), 'success');
-        },
-      },
-    );
-  };
-
-  if (isEditing) {
+function DescriptionField({ description }: { description: string }) {
+  if (!description) {
     return (
-      <Stack spacing={1} sx={{ maxWidth: EDIT_FIELD_MAX_WIDTH }}>
-        <TextField
-          autoFocus
-          disabled={updateApi.isPending}
-          fullWidth
-          label={intl.formatMessage(messages.editFieldLabel)}
-          maxRows={6}
-          multiline
-          onChange={(event) => setDraft(event.target.value)}
-          size="small"
-          value={draft}
-        />
-        <Stack direction="row" spacing={1}>
-          <Button disabled={updateApi.isPending} onClick={save} size="small" variant="contained">
-            <FormattedMessage {...messages.editSave} />
-          </Button>
-          <Button disabled={updateApi.isPending} onClick={() => setDraft(null)} size="small">
-            <FormattedMessage {...messages.editCancel} />
-          </Button>
-        </Stack>
-      </Stack>
+      <Typography color="text.disabled" sx={{ fontStyle: 'italic' }} variant="body2">
+        <FormattedMessage {...messages.descriptionPlaceholder} />
+      </Typography>
     );
   }
 
   return (
-    <Stack alignItems="flex-start" direction="row" spacing={0.5} sx={{ minWidth: 0 }}>
-      {description ? (
-        <Typography
-          color="text.secondary"
-          sx={{
-            display: '-webkit-box',
-            overflow: 'hidden',
-            WebkitBoxOrient: 'vertical',
-            WebkitLineClamp: 2,
-          }}
-          variant="body2"
-        >
-          {description}
-        </Typography>
-      ) : (
-        <Typography color="text.disabled" sx={{ fontStyle: 'italic' }} variant="body2">
-          <FormattedMessage {...messages.descriptionPlaceholder} />
-        </Typography>
-      )}
-      {!api.readOnly && (
-        <Tooltip title={intl.formatMessage(messages.editDescription)}>
-          <IconButton
-            aria-label={intl.formatMessage(messages.editDescription)}
-            onClick={() => setDraft(description)}
-            size="small"
-            sx={{ flexShrink: 0 }}
-          >
-            <Pencil size={14} />
-          </IconButton>
-        </Tooltip>
-      )}
-    </Stack>
+    <Typography
+      color="text.secondary"
+      sx={{
+        display: '-webkit-box',
+        minWidth: 0,
+        overflow: 'hidden',
+        WebkitBoxOrient: 'vertical',
+        WebkitLineClamp: 2,
+      }}
+      variant="body2"
+    >
+      {description}
+    </Typography>
   );
 }
 
@@ -265,8 +178,15 @@ export function ApiDetailPage() {
     params.apiHandler ?? null,
   );
 
+  // Same reasoning: the page only mounts fully scoped, so the edit page's path
+  // is always the fully-scoped one.
+  const editPath = routes.apiEdit(
+    params.orgHandle ?? '',
+    params.projectHandler ?? '',
+    params.apiHandler ?? '',
+  );
+
   const displayName = api.displayName || restApiId;
-  const transports = api.transport ?? [];
   // `updatedAt` is absent until the first edit, so a fresh API reads its
   // creation time rather than showing an empty row.
   const updated = api.updatedAt || api.createdAt;
@@ -320,7 +240,21 @@ export function ApiDetailPage() {
                   </Typography>
                 </Tooltip>
                 <VersionChip version={api.version} />
-                {api.lifeCycleStatus && <LifecycleChip status={api.lifeCycleStatus} />}
+                {/* Gateway-managed APIs are read-only in this console, so they
+                    get no way in to the edit form at all. */}
+                {!api.readOnly && (
+                  <Tooltip title={intl.formatMessage(messages.editApi)}>
+                    <IconButton
+                      aria-label={intl.formatMessage(messages.editApi)}
+                      component={RouterLink}
+                      size="small"
+                      sx={{ flexShrink: 0 }}
+                      to={editPath}
+                    >
+                      <Edit size={16} />
+                    </IconButton>
+                  </Tooltip>
+                )}
                 {api.readOnly && (
                   <Tooltip title={intl.formatMessage(messages.gatewayManagedHint)}>
                     <Chip
@@ -334,7 +268,7 @@ export function ApiDetailPage() {
                 )}
               </Stack>
 
-              <DescriptionField api={api} restApiId={restApiId} />
+              <DescriptionField description={api.description?.trim() ?? ''} />
 
               <Stack spacing={0.5}>
                 <MetaItem label={<FormattedMessage {...messages.context} />}>
@@ -342,14 +276,6 @@ export function ApiDetailPage() {
                     {api.context || '/'}
                   </Typography>
                 </MetaItem>
-
-                {transports.length > 0 && (
-                  <MetaItem label={<FormattedMessage {...messages.transports} />}>
-                    <Stack direction="row" sx={{ flexWrap: 'wrap', gap: 0.5 }} useFlexGap>
-                      <TransportChips transports={transports} />
-                    </Stack>
-                  </MetaItem>
-                )}
 
                 {updated && (
                   <MetaItem label={<FormattedMessage {...messages.lastUpdated} />}>
@@ -370,9 +296,6 @@ export function ApiDetailPage() {
         </Box>
       </Card>
 
-      {/* Policy, Routing and Documents used to be tabs here; each is now its own
-          page under the sidebar's Develop menu, leaving Overview as the whole of
-          this page — so no tab bar. */}
       <OverviewTab api={api} />
     </>
   );

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/OverviewTab.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/OverviewTab.tsx
@@ -60,14 +60,12 @@ export function OverviewTab({ api }: { api: RestApi }) {
     return gateways
       .filter((gateway) => latestByGateway.has(gateway.id ?? ''))
       .sort(
-        (a, b) =>
-          (latestByGateway.get(b.id ?? '') || 0) -
-          (latestByGateway.get(a.id ?? '') || 0)
+        (a, b) => (latestByGateway.get(b.id ?? '') || 0) - (latestByGateway.get(a.id ?? '') || 0),
       );
   }, [gatewaysQuery.data, deploymentsQuery.data]);
 
   return (
-    <>
+    <Stack spacing={3}>
       <ProgressBanner api={api} deployed={deployedGateways.length > 0} />
       <Stack direction={{ md: 'row', xs: 'column' }} spacing={2}>
         <ResourcesPanel api={api} />
@@ -94,6 +92,6 @@ export function OverviewTab({ api }: { api: RestApi }) {
           </>
         )}
       </Stack>
-    </>
+    </Stack>
   );
 }

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/ProgressBanner.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/ProgressBanner.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Box, ButtonBase, LinearProgress, Stack, Typography } from '@wso2/oxygen-ui';
+import { Box, ButtonBase, Card, LinearProgress, Stack, Typography } from '@wso2/oxygen-ui';
 import {
   Check,
   FilePlus2,
@@ -52,7 +52,7 @@ const messages = defineMessages({
   },
   stepPublish: {
     id: 'apiControlPlane.pages.appShell.appShellPages.apis.overview.ProgressBanner.step.publish',
-    defaultMessage: 'Publish to Devportal',
+    defaultMessage: 'Publish to API Portal',
     description:
       'Fourth step of the API progress stepper — the API is listed in the developer portal, which ships under the name "Devportal".',
   },
@@ -148,13 +148,8 @@ export function ProgressBanner({ api, deployed }: { api: RestApi; deployed: bool
   };
 
   return (
-    <Box
+    <Card
       sx={{
-        bgcolor: 'background.paper',
-        border: '1px solid',
-        borderColor: 'divider',
-        borderRadius: 1,
-        mb: 3,
         p: 2,
       }}
     >
@@ -188,7 +183,7 @@ export function ProgressBanner({ api, deployed }: { api: RestApi; deployed: bool
           </Stack>
         ))}
       </Stack>
-    </Box>
+    </Card>
   );
 }
 
@@ -225,6 +220,8 @@ function StepPill({ state, step }: { state: StepState; step: ProgressStep }) {
       onClick={onClick}
       sx={{
         border: '1px solid',
+        minWidth: 120,
+        justifyContent: 'flex-start',
         borderColor: complete ? 'success.main' : active ? 'primary.main' : 'divider',
         borderRadius: 5,
         gap: 1,

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/ProgressBanner.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/ProgressBanner.tsx
@@ -54,7 +54,7 @@ const messages = defineMessages({
     id: 'apiControlPlane.pages.appShell.appShellPages.apis.overview.ProgressBanner.step.publish',
     defaultMessage: 'Publish to API Portal',
     description:
-      'Fourth step of the API progress stepper — the API is listed in the developer portal, which ships under the name "Devportal".',
+      'Fourth step of the API progress stepper — the API is listed in the developer portal, which ships under the name "API Portal".',
   },
   stepTest: {
     id: 'apiControlPlane.pages.appShell.appShellPages.apis.overview.ProgressBanner.step.test',

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/ResourcesPanel.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/ResourcesPanel.tsx
@@ -17,7 +17,7 @@
  */
 
 import { useMemo } from 'react';
-import { Box, Typography } from '@wso2/oxygen-ui';
+import { Box, Card, Typography } from '@wso2/oxygen-ui';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 
 import type { RestApi } from '@/api/resources/restApis';
@@ -77,12 +77,8 @@ export function ResourcesPanel({ api }: { api: RestApi }) {
           title={intl.formatMessage(messages.empty)}
         />
       ) : (
-        <Box
+        <Card
           sx={{
-            bgcolor: 'background.paper',
-            border: '1px solid',
-            borderColor: 'divider',
-            borderRadius: 1,
             maxHeight: { md: 520, xs: 320 },
             overflowY: 'auto',
             px: 2,
@@ -110,7 +106,7 @@ export function ResourcesPanel({ api }: { api: RestApi }) {
             hideTagHeaders
             spec={spec}
           />
-        </Box>
+        </Card>
       )}
     </Box>
   );

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/utils/basicInfoRules.ts
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/utils/basicInfoRules.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * The field rules for an API's basic information; the same five fields the
+ * create wizard collects (`displayName`, `id`, `version`, `context`,
+ * `upstream.main.url`) and the edit page later changes.
+ *
+ * They live here rather than in either form because both forms validate the
+ * same platform constraints: a second copy would let the create form accept a
+ * context the edit form rejects, or the reverse.
+ */
+
+/** Longest handle the platform accepts as an API identifier. */
+export const HANDLE_MAX_LENGTH = 64;
+
+/** Lowercase words joined by single hyphens — what a URL segment may hold. */
+export const HANDLE_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+/** A version has to survive being pasted into a path segment. */
+export const VERSION_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+/** A context is an absolute path: leading slash, then path-safe characters. */
+export const CONTEXT_PATTERN = /^\/[A-Za-z0-9\-._~/]*$/;
+
+/** Whether `value` parses as an absolute `http(s)` URL. */
+export const isHttpUrl = (value: string): boolean => {
+  try {
+    const { protocol } = new URL(value);
+    return protocol === 'http:' || protocol === 'https:';
+  } catch {
+    return false;
+  }
+};

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/utils/restApiDisplay.ts
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/utils/restApiDisplay.ts
@@ -16,8 +16,8 @@
  * under the License.
  */
 
-import type { RestApi } from '../../../../../api/resources/restApis';
-import { useDeployments } from '../../../../../api/resources/restApis/deployments/deployments.hooks';
+import type { RestApi } from '@/api/resources/restApis';
+import { useDeployments } from '@/api/resources/restApis/deployments/deployments.hooks';
 
 /**
  * Display helpers for the spec's `RESTAPI` shape — the presentation half of

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/projects/components/ProjectCard.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/projects/components/ProjectCard.tsx
@@ -21,7 +21,6 @@ import {
   alpha,
   Box,
   Card,
-  Chip,
   IconButton,
   ListItemIcon,
   ListItemText,
@@ -121,7 +120,6 @@ export function ProjectCard({ project, orgHandle, onOpen, onDelete }: ProjectCar
     event?.stopPropagation();
     setMenuAnchor(null);
   };
-  const isDefault = project.id === 'default' || project.displayName.toLowerCase() === 'default';
 
   // Scoped to this card's project rather than the route's, so the counts belong
   // to the card the user is looking at and not the project they are currently in.
@@ -165,15 +163,6 @@ export function ProjectCard({ project, orgHandle, onOpen, onDelete }: ProjectCar
               <Typography noWrap sx={{ fontWeight: 600 }} variant="subtitle1">
                 {project.displayName}
               </Typography>
-              {isDefault && (
-                <Chip
-                  color="info"
-                  label={intl.formatMessage(messages.defaultBadge)}
-                  size="small"
-                  sx={{ fontSize: 10, fontWeight: 600, height: 20 }}
-                  variant="outlined"
-                />
-              )}
             </Stack>
             <Typography
               color="text.secondary"

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/projects/components/ProjectMetadata.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/projects/components/ProjectMetadata.tsx
@@ -18,7 +18,7 @@
 
 import type { ReactNode } from 'react';
 import { Avatar, Box, Divider, IconButton, Stack, Tooltip, Typography } from '@wso2/oxygen-ui';
-import { Diamond, Settings } from '@wso2/oxygen-ui-icons-react';
+import { Layers, Settings } from '@wso2/oxygen-ui-icons-react';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import { useNavigate } from 'react-router-dom';
 
@@ -92,7 +92,7 @@ export function ProjectMetadata({ orgHandle, project }: ProjectMetadataProps) {
             }}
             variant="rounded"
           >
-            <Diamond size={28} />
+            <Layers size={28} />
           </Avatar>
           <Stack spacing={1.5} sx={{ minWidth: 0 }}>
             <Box sx={{ minWidth: 0 }}>

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/projects/components/ProjectStatistics.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/projects/components/ProjectStatistics.tsx
@@ -120,6 +120,10 @@ export function ProjectStatistics({ onTypeFilterChange, selectedType }: ProjectS
     onTypeFilterChange(selectedType === type ? null : type);
   const filterLabel = (label: string) => intl.formatMessage(messages.selectType, { type: label });
 
+  if (!apisQuery.isPending && total === 0) {
+    return null;
+  }
+
   return (
     <Grid alignItems="center" container sx={{ minHeight: 80, py: 1.5 }}>
       <Grid size={{ md: 2, xs: 12 }}>

--- a/portals/api-control-plane/src/pages/auth/LoginPage.tsx
+++ b/portals/api-control-plane/src/pages/auth/LoginPage.tsx
@@ -16,21 +16,187 @@
  * under the License.
  */
 
-import { Alert, Box, Button, Link, Typography } from '@wso2/oxygen-ui';
+import {
+  Alert,
+  alpha,
+  Avatar,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Divider,
+  FormLabel,
+  InputAdornment,
+  Link,
+  List,
+  ListItem,
+  ListItemAvatar,
+  ListItemText,
+  Stack,
+  TextField,
+  type Theme,
+  Typography,
+} from '@wso2/oxygen-ui';
 import {
   Activity,
   ArrowRight,
+  Lock,
   PencilRuler,
   Rocket,
   ShieldCheck,
   Sparkles,
+  User,
 } from '@wso2/oxygen-ui-icons-react';
 import type { ReactNode } from 'react';
 import { ChangeEvent, KeyboardEvent, useEffect, useMemo, useRef, useState } from 'react';
+import { defineMessages, FormattedMessage, type MessageDescriptor, useIntl } from 'react-intl';
 import { Navigate, useLocation } from 'react-router-dom';
 
 import { runtimeConfig } from '../../config/runtime';
 import { useAuth } from '../../contexts/auth/AuthProvider';
+import { ambientGlowSx, hairline } from '../../theme/receipes';
+
+const messages = defineMessages({
+  brandLockup: {
+    id: 'apiControlPlane.pages.auth.LoginPage.brandLockup',
+    defaultMessage: '<brand>WSO2</brand> API Platform',
+    description:
+      'Compact brand lockup shown above the sign-in card on narrow screens. WSO2 is the company name and stays as-is; the brand tag only styles it.',
+  },
+  brandName: {
+    id: 'apiControlPlane.pages.auth.LoginPage.brandName',
+    defaultMessage: 'WSO2',
+    description: 'Company name in the brand lockup. Do not translate.',
+  },
+  browserUnsupported: {
+    id: 'apiControlPlane.pages.auth.LoginPage.browserUnsupported',
+    defaultMessage: 'This console is optimized for Google Chrome and Mozilla Firefox.',
+  },
+  continueToConsole: {
+    id: 'apiControlPlane.pages.auth.LoginPage.continueToConsole',
+    defaultMessage: 'Continue to your API Platform console.',
+  },
+  eyebrow: {
+    id: 'apiControlPlane.pages.auth.LoginPage.eyebrow',
+    defaultMessage: 'AI-NATIVE · SCALABLE SAAS',
+    description:
+      'Marketing label above the headline, set in upper case. Keep it short — it renders inside a small pill.',
+  },
+  featureDeploy: {
+    id: 'apiControlPlane.pages.auth.LoginPage.featureDeploy',
+    defaultMessage: 'Deploy and manage with zero friction',
+  },
+  featureDesign: {
+    id: 'apiControlPlane.pages.auth.LoginPage.featureDesign',
+    defaultMessage: 'Design API proxies or MCP servers',
+  },
+  featureMonitor: {
+    id: 'apiControlPlane.pages.auth.LoginPage.featureMonitor',
+    defaultMessage: 'Monitor, test, and analyze performance',
+  },
+  featurePublish: {
+    id: 'apiControlPlane.pages.auth.LoginPage.featurePublish',
+    defaultMessage: 'Publish faster with AI-powered capabilities',
+  },
+  featureSecure: {
+    id: 'apiControlPlane.pages.auth.LoginPage.featureSecure',
+    defaultMessage: 'Secure and govern traffic',
+  },
+  headline: {
+    id: 'apiControlPlane.pages.auth.LoginPage.headline',
+    defaultMessage: 'Manage, secure, and scale your <accent>APIs & MCP servers</accent>',
+    description:
+      'Marketing headline. The accent tag marks the phrase painted in the brand gradient — keep it around the equivalent phrase in the translation.',
+  },
+  homePageLink: {
+    id: 'apiControlPlane.pages.auth.LoginPage.homePageLink',
+    defaultMessage: 'More details at <link>wso2.com/api-platform</link>',
+    description:
+      'Footer line under the sign-in form. The link tag wraps the product home page address, which stays as-is.',
+  },
+  invitationVerified: {
+    id: 'apiControlPlane.pages.auth.LoginPage.invitationVerified',
+    defaultMessage: 'Invitation verified for {organization}. Sign in to accept it.',
+  },
+  oidcAccessDenied: {
+    id: 'apiControlPlane.pages.auth.LoginPage.oidcAccessDenied',
+    defaultMessage: 'Access was denied.',
+  },
+  oidcAuthFailed: {
+    id: 'apiControlPlane.pages.auth.LoginPage.oidcAuthFailed',
+    defaultMessage: 'Unable to complete sign in. Please try again.',
+  },
+  oidcGenericError: {
+    id: 'apiControlPlane.pages.auth.LoginPage.oidcGenericError',
+    defaultMessage: 'Unable to complete sign in.',
+    description:
+      'Shown when the identity provider returned a failure code this console does not recognise.',
+  },
+  oidcSessionFailed: {
+    id: 'apiControlPlane.pages.auth.LoginPage.oidcSessionFailed',
+    defaultMessage: 'Unable to establish a session. Please try again.',
+  },
+  passwordHide: {
+    id: 'apiControlPlane.pages.auth.LoginPage.passwordHide',
+    defaultMessage: 'Hide',
+    description: 'Toggle that masks the password again. Command, not a noun.',
+  },
+  passwordLabel: {
+    id: 'apiControlPlane.pages.auth.LoginPage.passwordLabel',
+    defaultMessage: 'Password',
+  },
+  passwordPlaceholder: {
+    id: 'apiControlPlane.pages.auth.LoginPage.passwordPlaceholder',
+    defaultMessage: 'Enter your password',
+  },
+  passwordShow: {
+    id: 'apiControlPlane.pages.auth.LoginPage.passwordShow',
+    defaultMessage: 'Show',
+    description: 'Toggle that reveals the typed password. Command, not a noun.',
+  },
+  privacyPolicy: {
+    id: 'apiControlPlane.pages.auth.LoginPage.privacyPolicy',
+    defaultMessage: 'Privacy policy',
+  },
+  productName: {
+    id: 'apiControlPlane.pages.auth.LoginPage.productName',
+    defaultMessage: '<emphasis>API</emphasis> Platform',
+    description:
+      'Product name under the WSO2 wordmark. The emphasis tag marks the part set in the stronger weight.',
+  },
+  sessionExpired: {
+    id: 'apiControlPlane.pages.auth.LoginPage.sessionExpired',
+    defaultMessage: 'Your session has expired. Sign in again to continue.',
+  },
+  signInAction: {
+    id: 'apiControlPlane.pages.auth.LoginPage.signInAction',
+    defaultMessage: 'Sign in',
+    description: 'Label of the button that submits the sign-in form. A command.',
+  },
+  tagline: {
+    id: 'apiControlPlane.pages.auth.LoginPage.tagline',
+    defaultMessage:
+      'A comprehensive platform for designing, deploying, governing, and optimizing APIs and MCP servers — end to end.',
+  },
+  termsOfUse: {
+    id: 'apiControlPlane.pages.auth.LoginPage.termsOfUse',
+    defaultMessage: 'Terms of use',
+  },
+  title: {
+    id: 'apiControlPlane.pages.auth.LoginPage.title',
+    defaultMessage: 'Sign in',
+    description: 'Heading of the sign-in card. A noun phrase naming the page.',
+  },
+  usernameLabel: {
+    id: 'apiControlPlane.pages.auth.LoginPage.usernameLabel',
+    defaultMessage: 'Username',
+  },
+  usernamePlaceholder: {
+    id: 'apiControlPlane.pages.auth.LoginPage.usernamePlaceholder',
+    defaultMessage: 'Enter your username',
+  },
+});
 
 type LoginLocationState = {
   confirmationKey?: string;
@@ -40,15 +206,13 @@ type LoginLocationState = {
   returnToUrl?: string;
 };
 
-const FEATURES: { icon: ReactNode; label: string }[] = [
-  { icon: <PencilRuler size={18} />, label: 'Design API proxies or MCP servers' },
-  { icon: <Rocket size={18} />, label: 'Deploy and manage with zero friction' },
-  { icon: <ShieldCheck size={18} />, label: 'Secure and govern traffic' },
-  { icon: <Activity size={18} />, label: 'Monitor, test, and analyze performance' },
-  { icon: <Sparkles size={18} />, label: 'Publish faster with AI-powered capabilities' },
+const FEATURES: { icon: ReactNode; label: MessageDescriptor }[] = [
+  { icon: <PencilRuler size={18} />, label: messages.featureDesign },
+  { icon: <Rocket size={18} />, label: messages.featureDeploy },
+  { icon: <ShieldCheck size={18} />, label: messages.featureSecure },
+  { icon: <Activity size={18} />, label: messages.featureMonitor },
+  { icon: <Sparkles size={18} />, label: messages.featurePublish },
 ];
-
-const ORANGE_GRADIENT = 'linear-gradient(90deg,#F47B20,#EF4223)';
 
 const isSupportedBrowser = () => {
   if (typeof navigator === 'undefined') return true;
@@ -60,54 +224,58 @@ const isSupportedBrowser = () => {
 // (state/nonce mismatch, code exchange failure, or an error the IdP itself
 // returned) — there is no in-app exception to catch, since login() is a full
 // page navigation to the BFF.
-const OIDC_ERROR_MESSAGES: Record<string, string> = {
-  auth_failed: 'Unable to complete sign in. Please try again.',
-  session_failed: 'Unable to establish a session. Please try again.',
-  access_denied: 'Access was denied.',
+const OIDC_ERROR_MESSAGES: Record<string, MessageDescriptor> = {
+  auth_failed: messages.oidcAuthFailed,
+  session_failed: messages.oidcSessionFailed,
+  access_denied: messages.oidcAccessDenied,
 };
 
-const fieldSx = {
-  bgcolor: 'rgba(255,255,255,0.04)',
-  border: '1px solid rgba(255,255,255,0.14)',
-  borderRadius: '10px',
-  color: '#fff',
-  fontFamily: 'inherit',
-  fontSize: 14,
-  fontWeight: 500,
-  height: 44,
-  outline: 'none',
-  px: '14px',
-  width: '100%',
-  '&::placeholder': { color: 'rgba(255,255,255,0.4)' },
-  '&:focus': {
-    borderColor: '#FF7300',
-    boxShadow: '0 0 0 3px rgba(255,115,0,0.22)',
-  },
-};
+/**
+ * The product's brand gradient painted onto text rather than a surface — the
+ * headline's emphasised phrase. `theme.gradient.primary` is the same token the
+ * primary call to action uses, so the two always agree.
+ */
+const gradientTextSx = (theme: Theme) =>
+  ({
+    backgroundClip: 'text',
+    backgroundImage: theme.gradient.primary,
+    color: 'transparent',
+    WebkitBackgroundClip: 'text',
+  }) as const;
 
-const primaryCtaSx = {
-  background: ORANGE_GRADIENT,
-  borderRadius: '23px',
-  boxShadow: '0 8px 22px rgba(239,66,35,0.32)',
-  color: '#fff',
-  fontSize: 14,
-  fontWeight: 600,
-  gap: 1,
-  height: 46,
-  textTransform: 'none',
-  width: '100%',
-  '&:hover': { background: ORANGE_GRADIENT, opacity: 0.92 },
-  '&.Mui-disabled': { background: 'rgba(255,255,255,0.12)', color: 'rgba(255,255,255,0.4)' },
-};
+/**
+ * The single primary action on this page (sign in, in whichever auth mode is
+ * configured), lifted above a plain `contained` button with the brand gradient.
+ * The disabled state drops back to the theme's own treatment, so a disabled
+ * button never reads as available.
+ */
+const signInButtonSx = (theme: Theme) =>
+  ({
+    backgroundImage: theme.gradient.primary,
+    fontSize: theme.typography.h5.fontSize,
+    py: 1.5,
+    '&:hover': { backgroundImage: theme.gradient.primary, filter: 'brightness(1.06)' },
+    '&.Mui-disabled': { backgroundImage: 'none' },
+  }) as const;
+
+/** The label above a field, rather than a floating `TextField` label. */
+const fieldLabelSx = { color: 'text.primary', fontWeight: 500 } as const;
+
+/** Tile behind a feature icon in the left panel's list. */
+const featureIconSx = (theme: Theme) =>
+  ({
+    bgcolor: alpha(theme.palette.primary.main, 0.1),
+    color: 'primary.main',
+    height: 40,
+    width: 40,
+  }) as const;
 
 export function LoginPage() {
   const auth = useAuth();
+  const intl = useIntl();
   const location = useLocation();
   const state = (location.state || {}) as LoginLocationState;
-  const queryParams = useMemo(
-    () => new URLSearchParams(location.search),
-    [location.search]
-  );
+  const queryParams = useMemo(() => new URLSearchParams(location.search), [location.search]);
   const from = state.returnToUrl || state.from?.pathname || '/';
   const isInvitation = Boolean(state.confirmationOrg && state.confirmationKey);
   const isBrowserSupported = isSupportedBrowser();
@@ -115,15 +283,22 @@ export function LoginPage() {
   const autoRedirectStarted = useRef(false);
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
   const [submitting, setSubmitting] = useState(false);
 
   const oidcErrorCode = queryParams.get('error');
   const oidcError = oidcErrorCode
-    ? OIDC_ERROR_MESSAGES[oidcErrorCode] || 'Unable to complete sign in.'
+    ? intl.formatMessage(OIDC_ERROR_MESSAGES[oidcErrorCode] || messages.oidcGenericError)
     : undefined;
 
-  const shouldAutoRedirect =
-    !auth.isAuthenticated && isOidcMode && !isInvitation && !oidcError;
+  // Whether the card shows an alert block at all. Kept as one flag so the
+  // `Stack` wrapping the alerts is skipped entirely when there is nothing to
+  // show — an empty child would still take a gap in the card's stack.
+  const hasAlerts = Boolean(
+    !isBrowserSupported || (isInvitation && state.displayOrgName) || oidcError || auth.error,
+  );
+
+  const shouldAutoRedirect = !auth.isAuthenticated && isOidcMode && !isInvitation && !oidcError;
 
   // In OIDC mode this page is just a redirect step to the IdP, so skip it and
   // go straight there — unless there's an invitation to show or a failed
@@ -140,14 +315,33 @@ export function LoginPage() {
 
   if (auth.isAuthenticated) return <Navigate to={from} replace />;
 
-  const message = auth.status === 'expired'
-    ? 'Your session has expired. Sign in again to continue.'
-    : 'Continue to your API Platform console.';
+  const message = auth.status === 'expired' ? messages.sessionExpired : messages.continueToConsole;
 
-  const handleKeyDown = (
-    event: KeyboardEvent<HTMLInputElement>,
-    action: () => void
-  ) => {
+  const accent = (chunks: ReactNode) => (
+    <Box component="span" sx={gradientTextSx}>
+      {chunks}
+    </Box>
+  );
+
+  const brand = (chunks: ReactNode) => (
+    <Box component="span" sx={{ color: 'text.primary', fontWeight: 700 }}>
+      {chunks}
+    </Box>
+  );
+
+  const emphasis = (chunks: ReactNode) => (
+    <Box component="span" sx={{ color: 'text.primary', fontWeight: 600 }}>
+      {chunks}
+    </Box>
+  );
+
+  const link = (chunks: ReactNode) => (
+    <Link href={runtimeConfig.apiPlatformHomePage} target="_blank">
+      {chunks}
+    </Link>
+  );
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>, action: () => void) => {
     if (event.key === 'Enter') action();
   };
 
@@ -161,271 +355,340 @@ export function LoginPage() {
   return (
     <Box
       sx={{
-        background:
-          'radial-gradient(900px 600px at 85% 8%, rgba(92,209,255,0.16), transparent 60%), radial-gradient(800px 700px at 0% 70%, rgba(255,115,0,0.12), transparent 55%), linear-gradient(135deg,#0B1220 0%,#0E1726 55%,#111A2B 100%)',
-        color: '#fff',
+        bgcolor: 'background.default',
         display: 'flex',
-        flexWrap: { xs: 'wrap', md: 'nowrap' },
+        flexWrap: { md: 'nowrap', xs: 'wrap' },
         minHeight: '100vh',
+        // The washes below bleed past the viewport edges rather than scrolling it.
+        overflow: 'hidden',
+        position: 'relative',
         width: '100%',
       }}
     >
-      {/* LEFT — marketing */}
+      {/* Ambient wash — decorative only, so it stays out of the a11y tree. */}
       <Box
+        aria-hidden
+        sx={(theme) => ({
+          ...ambientGlowSx,
+          bgcolor: alpha(theme.palette.info.light, 0.22),
+          height: 460,
+          right: theme.spacing(-10),
+          top: theme.spacing(-14),
+          width: 560,
+        })}
+      />
+      <Box
+        aria-hidden
+        sx={(theme) => ({
+          ...ambientGlowSx,
+          bgcolor: alpha(theme.palette.primary.light, 0.18),
+          bottom: theme.spacing(-16),
+          height: 480,
+          left: theme.spacing(-12),
+          width: 560,
+        })}
+      />
+
+      {/* LEFT — marketing */}
+      <Stack
+        spacing={4}
         sx={{
-          display: { xs: 'none', md: 'flex' },
-          flex: '1 1 56%',
-          flexDirection: 'column',
-          gap: 4.25,
+          display: { md: 'flex', xs: 'none' },
+          flex: '1 1 50%',
           justifyContent: 'center',
           minWidth: 0,
-          p: '64px 72px',
+          p: { lg: 10, md: 6 },
+          position: 'relative',
         }}
       >
-        <Box sx={{ alignItems: 'center', display: 'flex', gap: 2 }}>
-          <Box
-            sx={{
-              alignItems: 'center',
-              bgcolor: 'rgba(255,255,255,0.08)',
-              border: '1px solid rgba(255,255,255,0.16)',
-              borderRadius: '50%',
-              display: 'inline-flex',
-              height: 70,
-              justifyContent: 'center',
-              width: 70,
-            }}
+        <Stack direction="row" spacing={2} sx={{ alignItems: 'center' }}>
+          <Avatar
+            sx={(theme) => ({
+              bgcolor: alpha(theme.palette.primary.main, 0.1),
+              color: 'primary.main',
+              height: 56,
+              width: 56,
+            })}
           >
-            <Activity color="#ffffff" size={40} />
-          </Box>
-          <Box sx={{ lineHeight: 1 }}>
-            <Typography sx={{ fontSize: 30, fontWeight: 700, letterSpacing: '-.5px' }}>
-              WSO2
+            <Activity size={26} />
+          </Avatar>
+          <Box>
+            <Typography sx={{ fontWeight: 700, letterSpacing: '-0.5px' }} variant="h2">
+              <FormattedMessage {...messages.brandName} />
             </Typography>
-            <Typography sx={{ color: 'rgba(255,255,255,0.7)', fontSize: 18, mt: 0.5 }}>
-              <b style={{ color: '#fff', fontWeight: 600 }}>API</b> Platform
+            <Typography color="text.secondary" variant="subtitle1">
+              <FormattedMessage {...messages.productName} values={{ emphasis }} />
             </Typography>
           </Box>
-        </Box>
+        </Stack>
 
-        <Box sx={{ maxWidth: 560 }}>
-          <Typography
+        <Stack spacing={2.5} sx={{ maxWidth: 620 }}>
+          <Chip
+            color="info"
+            icon={<Box sx={{ bgcolor: 'info.main', borderRadius: '50%', height: 6, width: 6 }} />}
+            label={intl.formatMessage(messages.eyebrow)}
+            size="small"
             sx={{
-              color: '#5CD1FF',
-              fontSize: 11,
+              alignSelf: 'flex-start',
               fontWeight: 600,
+              height: 30,
               letterSpacing: '1.5px',
-              mb: 1.75,
+              px: 0.5,
             }}
-          >
-            AI-NATIVE · SCALABLE SAAS
-          </Typography>
+            variant="outlined"
+          />
           <Typography
             component="h1"
-            sx={{ fontSize: 38, fontWeight: 400, letterSpacing: '-.5px', lineHeight: 1.18, m: 0, mb: 2.25 }}
+            sx={{
+              fontSize: { lg: '3.5rem', md: '2.75rem' },
+              fontWeight: 500,
+              letterSpacing: '-1.5px',
+              lineHeight: 1.1,
+            }}
+            variant="h1"
           >
-            Manage, secure, and scale your{' '}
-            <Box
-              component="span"
-              sx={{
-                background: ORANGE_GRADIENT,
-                backgroundClip: 'text',
-                color: 'transparent',
-                fontWeight: 600,
-                WebkitBackgroundClip: 'text',
-              }}
-            >
-              APIs &amp; MCP servers
-            </Box>
+            <FormattedMessage {...messages.headline} values={{ accent }} />
           </Typography>
-          <Typography sx={{ color: 'rgba(255,255,255,0.62)', fontSize: 15, lineHeight: 1.6, maxWidth: 480 }}>
-            A comprehensive platform for designing, deploying, governing, and
-            optimizing APIs and MCP servers — end to end.
+          <Typography
+            color="text.secondary"
+            sx={{ fontSize: '1.125rem', lineHeight: 1.6, maxWidth: 490 }}
+            variant="body1"
+          >
+            <FormattedMessage {...messages.tagline} />
           </Typography>
-        </Box>
+        </Stack>
 
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.75, maxWidth: 520 }}>
+        <Divider sx={{ maxWidth: 620 }} />
+
+        <List disablePadding sx={{ maxWidth: 620 }}>
           {FEATURES.map((feature) => (
-            <Box key={feature.label} sx={{ alignItems: 'center', display: 'flex', gap: 1.75 }}>
-              <Box
-                sx={{
-                  alignItems: 'center',
-                  bgcolor: 'rgba(255,255,255,0.06)',
-                  border: '1px solid rgba(255,255,255,0.10)',
-                  borderRadius: '9px',
-                  color: '#FF8A33',
-                  display: 'inline-flex',
-                  flex: 'none',
-                  height: 34,
-                  justifyContent: 'center',
-                  width: 34,
-                }}
-              >
-                {feature.icon}
-              </Box>
-              <Typography sx={{ color: 'rgba(255,255,255,0.86)', fontSize: 14.5 }}>
-                {feature.label}
-              </Typography>
-            </Box>
+            <ListItem disableGutters key={feature.label.id} sx={{ py: 1 }}>
+              <ListItemAvatar sx={{ minWidth: 0, mr: 2.5 }}>
+                <Avatar sx={featureIconSx} variant="rounded">
+                  {feature.icon}
+                </Avatar>
+              </ListItemAvatar>
+              <ListItemText
+                primary={<FormattedMessage {...feature.label} />}
+                slotProps={{ primary: { sx: { fontSize: '1.0625rem' } } }}
+              />
+            </ListItem>
           ))}
-        </Box>
-      </Box>
+        </List>
+      </Stack>
 
       {/* RIGHT — sign-in card */}
       <Box
         sx={{
           alignItems: 'center',
           display: 'flex',
-          flex: { xs: '1 1 100%', md: '0 0 480px' },
+          flex: { md: '1 1 50%', xs: '1 1 100%' },
           justifyContent: 'center',
-          maxWidth: { xs: '100%', md: 480 },
-          p: { xs: 3, md: '48px 40px' },
+          p: { md: 6, xs: 3 },
+          position: 'relative',
+          width: '100%',
         }}
       >
-        <Box
-          sx={{
-            backdropFilter: 'blur(16px)',
-            bgcolor: 'rgba(255,255,255,0.05)',
-            border: '1px solid rgba(255,255,255,0.12)',
-            borderRadius: '18px',
-            boxShadow: '0 24px 60px rgba(0,0,0,0.35)',
-            maxWidth: 392,
-            p: { xs: '28px 22px', sm: '34px 32px' },
+        <Card
+          elevation={0}
+          sx={(theme) => ({
+            bgcolor: 'background.paper',
+            border: hairline(theme),
+            borderColor: 'divider',
+            borderRadius: 2,
+            boxShadow: (theme: Theme) =>
+              `0 1px 2px ${alpha(theme.palette.common.black, 0.04)}, 0 24px 56px ${alpha(
+                theme.palette.common.black,
+                0.1,
+              )}`,
+            maxWidth: 540,
             width: '100%',
-          }}
+          })}
         >
-          {/* mobile brand lockup */}
-          <Box sx={{ alignItems: 'center', display: { md: 'none' }, gap: 1.25, mb: 2.5 }}>
-            <Activity color="#ffffff" size={24} style={{ verticalAlign: 'middle' }} />{' '}
-            <Box component="span" sx={{ fontWeight: 700 }}>
-              WSO2
-            </Box>{' '}
-            <Box component="span" sx={{ color: 'rgba(255,255,255,0.7)' }}>
-              API Platform
-            </Box>
-          </Box>
-
-          {/* header */}
-          <Typography sx={{ fontSize: 24, fontWeight: 500, letterSpacing: '-.3px' }}>
-            Sign in
-          </Typography>
-          <Typography sx={{ color: 'rgba(255,255,255,0.55)', fontSize: 13, mt: 0.75 }}>
-            {message}
-          </Typography>
-
-          {/* alerts */}
-          <Box sx={{ '& > *': { mt: 2.5 } }}>
-            {!isBrowserSupported && (
-              <Alert severity="warning">
-                This console is optimized for Google Chrome and Mozilla Firefox.
-              </Alert>
-            )}
-            {isInvitation && state.displayOrgName && (
-              <Alert severity="success">
-                Invitation verified for {state.displayOrgName}. Sign in to accept it.
-              </Alert>
-            )}
-            {oidcError && <Alert severity="error">{oidcError}</Alert>}
-            {auth.error && <Alert severity="error">{auth.error}</Alert>}
-          </Box>
-
-          {isOidcMode ? (
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, mt: 2.75 }}>
-              <Button onClick={() => auth.login(from)} sx={primaryCtaSx}>
-                Sign in
-                <ArrowRight size={17} />
-              </Button>
-            </Box>
-          ) : (
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, mt: 2.75 }}>
-              <Box
-                autoFocus
-                aria-label="Username"
-                autoComplete="username"
-                component="input"
-                name="username"
-                onChange={(event: ChangeEvent<HTMLInputElement>) =>
-                  setUsername(event.target.value)
-                }
-                onKeyDown={(event: KeyboardEvent<HTMLInputElement>) =>
-                  handleKeyDown(event, () => void startBasicLogin())
-                }
-                placeholder="Username"
-                sx={fieldSx}
-                type="text"
-                value={username}
-              />
-              <Box
-                aria-label="Password"
-                autoComplete="current-password"
-                component="input"
-                name="password"
-                onChange={(event: ChangeEvent<HTMLInputElement>) =>
-                  setPassword(event.target.value)
-                }
-                onKeyDown={(event: KeyboardEvent<HTMLInputElement>) =>
-                  handleKeyDown(event, () => void startBasicLogin())
-                }
-                placeholder="Password"
-                sx={fieldSx}
-                type="password"
-                value={password}
-              />
-              <Button
-                disabled={submitting || !username.trim() || !password}
-                onClick={() => void startBasicLogin()}
-                sx={primaryCtaSx}
+          <CardContent sx={{ p: { sm: 5, xs: 3 } }}>
+            <Stack spacing={3}>
+              {/* mobile brand lockup */}
+              <Stack
+                direction="row"
+                spacing={1.25}
+                sx={{ alignItems: 'center', display: { md: 'none', xs: 'flex' } }}
               >
-                Sign in
-                <ArrowRight size={17} />
-              </Button>
-            </Box>
-          )}
+                <Activity size={24} />
+                <Typography color="text.secondary" variant="subtitle1">
+                  <FormattedMessage {...messages.brandLockup} values={{ brand }} />
+                </Typography>
+              </Stack>
 
-          {/* footer */}
-          <Box
-            sx={{
-              borderTop: '1px solid rgba(255,255,255,0.10)',
-              mt: 2.75,
-              pt: 2.25,
-              textAlign: 'center',
-            }}
-          >
-            <Typography sx={{ color: 'rgba(255,255,255,0.45)', fontSize: 12, mb: 1.25 }}>
-              More details at{' '}
-              <Link href={runtimeConfig.apiPlatformHomePage} sx={{ color: '#FF7300' }} target="_blank">
-                wso2.com/api-platform
-              </Link>
-            </Typography>
-            <Box
-              sx={{
-                alignItems: 'center',
-                color: 'rgba(255,255,255,0.4)',
-                display: 'flex',
-                fontSize: 11,
-                gap: 1.75,
-                justifyContent: 'center',
-              }}
-            >
-              <Link
-                href={runtimeConfig.privacyPolicyLink}
-                sx={{ color: 'rgba(255,255,255,0.5)' }}
-                target="_blank"
-              >
-                Privacy policy
-              </Link>
-              <Box component="span" sx={{ opacity: 0.4 }}>
-                ·
+              {/* header */}
+              <Stack spacing={0.75}>
+                <Typography sx={{ letterSpacing: '-0.5px' }} variant="h1">
+                  <FormattedMessage {...messages.title} />
+                </Typography>
+                <Typography color="text.secondary" variant="subtitle1">
+                  <FormattedMessage {...message} />
+                </Typography>
+              </Stack>
+
+              {/* alerts */}
+              {hasAlerts && (
+                <Stack spacing={1.5}>
+                  {!isBrowserSupported && (
+                    <Alert severity="warning">
+                      <FormattedMessage {...messages.browserUnsupported} />
+                    </Alert>
+                  )}
+                  {isInvitation && state.displayOrgName && (
+                    <Alert severity="success">
+                      <FormattedMessage
+                        {...messages.invitationVerified}
+                        values={{ organization: state.displayOrgName }}
+                      />
+                    </Alert>
+                  )}
+                  {oidcError && <Alert severity="error">{oidcError}</Alert>}
+                  {auth.error && <Alert severity="error">{auth.error}</Alert>}
+                </Stack>
+              )}
+
+              {isOidcMode ? (
+                <Button
+                  endIcon={<ArrowRight size={18} />}
+                  fullWidth
+                  onClick={() => auth.login(from)}
+                  size="large"
+                  sx={signInButtonSx}
+                  variant="contained"
+                >
+                  <FormattedMessage {...messages.signInAction} />
+                </Button>
+              ) : (
+                <Stack spacing={2.5}>
+                  <Stack spacing={1}>
+                    <FormLabel htmlFor="login-username" sx={fieldLabelSx}>
+                      <FormattedMessage {...messages.usernameLabel} />
+                    </FormLabel>
+                    <TextField
+                      autoComplete="username"
+                      autoFocus
+                      fullWidth
+                      id="login-username"
+                      name="username"
+                      onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                        setUsername(event.target.value)
+                      }
+                      onKeyDown={(event: KeyboardEvent<HTMLInputElement>) =>
+                        handleKeyDown(event, () => void startBasicLogin())
+                      }
+                      placeholder={intl.formatMessage(messages.usernamePlaceholder)}
+                      slotProps={{
+                        input: {
+                          startAdornment: (
+                            <InputAdornment position="start">
+                              <User size={18} />
+                            </InputAdornment>
+                          ),
+                        },
+                      }}
+                      type="text"
+                      value={username}
+                    />
+                  </Stack>
+
+                  <Stack spacing={1}>
+                    <Stack
+                      direction="row"
+                      sx={{ alignItems: 'center', justifyContent: 'space-between' }}
+                    >
+                      <FormLabel htmlFor="login-password" sx={fieldLabelSx}>
+                        <FormattedMessage {...messages.passwordLabel} />
+                      </FormLabel>
+                      <Link
+                        component="button"
+                        onClick={() => setShowPassword((visible) => !visible)}
+                        sx={{ color: 'text.secondary', fontWeight: 500 }}
+                        type="button"
+                        variant="body2"
+                      >
+                        <FormattedMessage
+                          {...(showPassword ? messages.passwordHide : messages.passwordShow)}
+                        />
+                      </Link>
+                    </Stack>
+                    <TextField
+                      autoComplete="current-password"
+                      fullWidth
+                      id="login-password"
+                      name="password"
+                      onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                        setPassword(event.target.value)
+                      }
+                      onKeyDown={(event: KeyboardEvent<HTMLInputElement>) =>
+                        handleKeyDown(event, () => void startBasicLogin())
+                      }
+                      placeholder={intl.formatMessage(messages.passwordPlaceholder)}
+                      slotProps={{
+                        input: {
+                          startAdornment: (
+                            <InputAdornment position="start">
+                              <Lock size={18} />
+                            </InputAdornment>
+                          ),
+                        },
+                      }}
+                      type={showPassword ? 'text' : 'password'}
+                      value={password}
+                    />
+                  </Stack>
+
+                  <Button
+                    disabled={submitting || !username.trim() || !password}
+                    endIcon={<ArrowRight size={18} />}
+                    fullWidth
+                    onClick={() => void startBasicLogin()}
+                    size="large"
+                    sx={signInButtonSx}
+                    variant="contained"
+                  >
+                    <FormattedMessage {...messages.signInAction} />
+                  </Button>
+                </Stack>
+              )}
+
+              {/* footer */}
+              <Box>
+                <Divider sx={{ mb: 2.5 }} />
+                <Stack spacing={1.25} sx={{ alignItems: 'center' }}>
+                  <Typography color="text.secondary" variant="body2">
+                    <FormattedMessage {...messages.homePageLink} values={{ link }} />
+                  </Typography>
+                  <Stack
+                    direction="row"
+                    divider={<Divider flexItem orientation="vertical" />}
+                    spacing={2}
+                    sx={{ alignItems: 'center' }}
+                  >
+                    <Link
+                      color="text.secondary"
+                      href={runtimeConfig.privacyPolicyLink}
+                      target="_blank"
+                      variant="body2"
+                    >
+                      <FormattedMessage {...messages.privacyPolicy} />
+                    </Link>
+                    <Link
+                      color="text.secondary"
+                      href={runtimeConfig.termsOfUseLink}
+                      target="_blank"
+                      variant="body2"
+                    >
+                      <FormattedMessage {...messages.termsOfUse} />
+                    </Link>
+                  </Stack>
+                </Stack>
               </Box>
-              <Link
-                href={runtimeConfig.termsOfUseLink}
-                sx={{ color: 'rgba(255,255,255,0.5)' }}
-                target="_blank"
-              >
-                Terms of use
-              </Link>
-            </Box>
-          </Box>
-        </Box>
+            </Stack>
+          </CardContent>
+        </Card>
       </Box>
     </Box>
   );

--- a/portals/api-control-plane/src/routes/AppRoutes.tsx
+++ b/portals/api-control-plane/src/routes/AppRoutes.tsx
@@ -91,6 +91,11 @@ const ApiDetailPage = lazy(() =>
     default: m.ApiDetailPage,
   })),
 );
+const ApiEditPage = lazy(() =>
+  import('../pages/appShell/appShellPages/apis/edit').then((m) => ({
+    default: m.ApiEditPage,
+  })),
+);
 const DeployPage = lazy(() =>
   import('../pages/appShell/appShellPages/deploy/DeployPage').then((m) => ({
     default: m.DeployPage,
@@ -304,6 +309,12 @@ export function AppRoutes({ extensions = [] }: AppRoutesProps) {
           <Route path={routes.api()} element={<ApiDetailPage />} />
           {scopedRoutes(projectScopedPaths(routes.apis), <ApiListPage />)}
           <Route path={routes.newApi()} element={<ApiCreatePage />} />
+          {/*
+            Editing basic information is reached from the detail page's own edit
+            button, so — like the create page — it takes the fully-scoped path
+            alone.
+          */}
+          <Route path={routes.apiEdit()} element={<ApiEditPage />} />
           {/*
             Test, Observability and Manage are sidebar parents with no page of
             their own — only their children are routed. Out of API scope a parent

--- a/portals/api-control-plane/src/routes/paths.test.ts
+++ b/portals/api-control-plane/src/routes/paths.test.ts
@@ -135,6 +135,7 @@ describe('path builders', () => {
       routes.projectSettings(ORG, PROJECT),
       routes.projectHome(ORG, PROJECT),
       routes.api(ORG, PROJECT, API),
+      routes.apiEdit(ORG, PROJECT, API),
       ...PROJECT_LEVEL.map(([, build]) => build(ORG, PROJECT)),
       ...API_LEVEL.map(([, build]) => build(ORG, PROJECT, API)),
       routes.newApi(ORG, PROJECT),

--- a/portals/api-control-plane/src/routes/paths.ts
+++ b/portals/api-control-plane/src/routes/paths.ts
@@ -149,6 +149,11 @@ export const routes = {
     projectHandler = ':projectHandler',
     apiHandler = ':apiHandler'
   ) => apiPath(orgHandle, projectHandler, apiHandler),
+  apiEdit: (
+    orgHandle = ':orgHandle',
+    projectHandler = ':projectHandler',
+    apiHandler = ':apiHandler'
+  ) => apiPath(orgHandle, projectHandler, apiHandler, 'edit'),
   // Develop's own submenu: the three panels that used to be tabs on the API
   // overview page.
   apiDevelopPolicies: (


### PR DESCRIPTION
## Purpose

This PR carries a set of UI fixes and small UI additions for the **API Control Plane portal** (`portals/api-control-plane`). It covers three areas: the REST API creation wizard, a new page for editing an existing API's basic information, and a redesign of the login page.

Related https://github.com/wso2-enterprise/apim-saas/issues/2897

## Fixed

**API creation: contract source step**
- Dropped the **Fetch Contract** button: the contract is now read automatically on URL blur, on
  file selection and from the sample link (`Enter` still works for keyboard users).
- Reworked the file drop zone: the chosen file is summarised inside it with an extension chip,
  locale-formatted size and **Replace file** / remove controls. The area is no longer a `<label>`, so removing a file no longer reopens the picker.
- **GitHub** and **SwaggerHub** sources are withheld until their import flow is settled; the code behind them is left intact, so re-offering one is a small change.

**API creation — error handling**
- A rejected create no longer strands the user on a "we couldn't create this" screen. Validation
  failures and conflicts (handle/context already in use) go back to the form, pinned to the field that caused them, with a summary alert and focus on the first offender. Errors retyping can't fix (5xx, network, permission) stay on the progress screen as before.
- New `serverFieldErrors` mapper translates server field paths (`upstream.main.url`, `handle`, `basePath`, …) onto form fields; anything unmappable is listed in the summary, never dropped.
- New opt-in `HANDLED_LOCALLY` mutation meta: a mutation that reports its own failures skips the global snackbar, so one rejection stops reading as two problems.
- Removed the debounced handle-availability probe, duplicates now surface through the path above.
- **Display name → Name**, **Base Path → Context**.

**Minor UI issues**
  project has no APIs; removed the "Default" project badge; project icon `Diamond` → `Layers`.

## Added

- **API edit page** (`/…/apis/:apiHandler/edit`) for name, description, context, version and backend URL, replacing the inline description-only editor on the detail header.
- **API Designer hand-off** in the wizard's "design from scratch" step: a canvas illustration with **Open API Designer** and a docs link, replacing the "coming soon" placeholder. Both URLs are runtime config (`API_DESIGNER_VSCODE_URL` / `API_DESIGNER_DOCS_URL`).
- **Login page redesign**
- **Counter-rotating gears** on the creation progress illustration, held still under `prefers-reduced-motion: reduce`.

## Testing

New/extended coverage:
- `ApiCreationWizard.test.tsx` — a rejected create returns to the form with the reason attached.
- `serverFieldErrors.test.ts` — server field-path → form-field mapping, including unmapped paths.
- `ContractSourceForm.test.tsx` — auto-fetch on blur/select, stale-reply handling, file replace/remove.
- `GeneralCreateApiForm.test.tsx` — server errors pinned to inputs and cleared on edit.
- `ApiEditPage.test.tsx` / `EditApiForm.test.tsx` — load, validate, save, and the read-only path.
- `DesignWithAiPanel.test.tsx` — the designer links resolve from runtime config.
- `queryClient.test.ts` — `HANDLED_LOCALLY` suppresses the global snackbar.

## Screenshots

<img width="2942" height="1682" alt="image" src="https://github.com/user-attachments/assets/268f8db9-25f0-4eb1-a8e7-2b335d771ded" />

<img width="1710" height="1208" alt="image" src="https://github.com/user-attachments/assets/9d145887-4386-44e1-8e58-cca794f8a779" />

<img width="3456" height="1918" alt="image" src="https://github.com/user-attachments/assets/b14a0a06-d250-4226-aa13-4a8a1d8a897c" />

<img width="3452" height="1818" alt="image" src="https://github.com/user-attachments/assets/f63f10f7-9561-4371-97b2-33c5efad4749" />

