### PR TITLE
Change API Overview page UI

### DIFF
--- a/portals/api-control-plane/src/api/resources/apiKeys/apiKeys.hooks.test.ts
+++ b/portals/api-control-plane/src/api/resources/apiKeys/apiKeys.hooks.test.ts
@@ -31,12 +31,7 @@ import {
 import { renderApiHook, settle } from '../../../test/renderApiHook';
 import { server } from '../../../test/server';
 import { resetHttpClient } from '../../core/http';
-import {
-  useCreateApiKey,
-  useMyApiKeys,
-  useRevokeApiKey,
-  useUpdateApiKey,
-} from './apiKeys.hooks';
+import { useCreateApiKey, useMyApiKeys, useRevokeApiKey, useUpdateApiKey } from './apiKeys.hooks';
 import { apiKeyKeys } from './apiKeys.queries';
 
 /**
@@ -96,17 +91,11 @@ describe('useMyApiKeys', () => {
   it('keeps differently-filtered lists in separate cache entries', async () => {
     server.use(resource('/me/api-keys', listEnvelope([])));
 
-    const { result, queryClient, org } = renderApiHook(() =>
-      useMyApiKeys({ type: ['RestApi'] })
-    );
+    const { result, queryClient, org } = renderApiHook(() => useMyApiKeys({ type: ['RestApi'] }));
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(
-      queryClient.getQueryData(apiKeyKeys.list(org, { type: ['RestApi'] }))
-    ).toBeDefined();
-    expect(
-      queryClient.getQueryData(apiKeyKeys.list(org, { type: ['LlmProxy'] }))
-    ).toBeUndefined();
+    expect(queryClient.getQueryData(apiKeyKeys.list(org, { type: ['RestApi'] }))).toBeDefined();
+    expect(queryClient.getQueryData(apiKeyKeys.list(org, { type: ['LlmProxy'] }))).toBeUndefined();
   });
 });
 
@@ -120,7 +109,7 @@ describe('useCreateApiKey', () => {
         message: 'created',
         keyId: 'key-1',
         apiKey: 'plaintext-once',
-      })
+      }),
     );
 
     const { result, queryClient } = renderApiHook(() => useCreateApiKey());
@@ -129,7 +118,10 @@ describe('useCreateApiKey', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     const everythingCached = JSON.stringify(
-      queryClient.getQueryCache().getAll().map((query) => query.state.data)
+      queryClient
+        .getQueryCache()
+        .getAll()
+        .map((query) => query.state.data),
     );
     expect(everythingCached).not.toContain('plaintext-once');
   });
@@ -140,7 +132,7 @@ describe('useCreateApiKey', () => {
         status: 'success',
         message: 'created',
         apiKey: 'plaintext-once',
-      })
+      }),
     );
 
     const { result } = renderApiHook(() => useCreateApiKey());
@@ -162,9 +154,7 @@ describe('useCreateApiKey', () => {
     result.current.mutate({ restApiId: API_ID, body: { name: 'ci-key' } as never });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    await waitFor(() =>
-      expect(queryClient.getQueryState(listKey)?.isInvalidated).toBe(true)
-    );
+    await waitFor(() => expect(queryClient.getQueryState(listKey)?.isInvalidated).toBe(true));
   });
 });
 
@@ -195,14 +185,37 @@ describe('useRevokeApiKey', () => {
 
     const { result, queryClient, org } = renderApiHook(() => useRevokeApiKey());
     const listKey = apiKeyKeys.list(org);
-    queryClient.setQueryData(listKey, listEnvelope([]));
+    queryClient.setQueryData(
+      listKey,
+      listEnvelope([
+        {
+          id: 'key-1',
+          artifactId: API_ID,
+          artifactType: 'RestApi',
+          displayName: 'Production key',
+          status: 'active',
+        },
+        {
+          id: 'key-1',
+          artifactId: 'another-api',
+          artifactType: 'RestApi',
+          displayName: 'Other API key',
+          status: 'active',
+        },
+      ] as never[]),
+    );
 
     result.current.mutate({ restApiId: API_ID, apiKeyId: 'key-1' });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    await waitFor(() =>
-      expect(queryClient.getQueryState(listKey)?.isInvalidated).toBe(true)
-    );
+    await waitFor(() => expect(queryClient.getQueryState(listKey)?.isInvalidated).toBe(true));
+    expect(
+      queryClient.getQueryData<{ list: Array<{ artifactId: string }> }>(listKey)?.list,
+    ).toHaveLength(1);
+    expect(
+      queryClient.getQueryData<{ list: Array<{ artifactId: string }> }>(listKey)?.list[0]
+        ?.artifactId,
+    ).toBe('another-api');
   });
 
   it('does not invalidate when revocation fails', async () => {

--- a/portals/api-control-plane/src/api/resources/apiKeys/apiKeys.hooks.ts
+++ b/portals/api-control-plane/src/api/resources/apiKeys/apiKeys.hooks.ts
@@ -29,6 +29,7 @@ import {
   type ListMyApiKeysQuery,
   type UpdateApiKeyBody,
   type UpdateApiKeyResponse,
+  type UserApiKeyListResponse,
 } from './apiKeys.endpoints';
 import { apiKeyKeys, apiKeyQueries } from './apiKeys.queries';
 
@@ -53,7 +54,7 @@ export type ApiKeyListFilters = ListMyApiKeysQuery;
  */
 export const useMyApiKeys = (
   filters: ApiKeyListFilters = {},
-  overrides: { orgId?: string } = {}
+  overrides: { orgId?: string } = {},
 ) => {
   const { org } = useApiScope(overrides);
 
@@ -92,14 +93,12 @@ export const useCreateApiKey = (overrides: { orgId?: string } = {}) => {
   const { orgId } = useApiScope(overrides);
   const invalidate = useInvalidateApiKeys(orgId);
 
-  return useMutation<
-    CreateApiKeyResponse,
-    ApiError,
-    { restApiId: string; body: CreateApiKeyBody }
-  >({
-    mutationFn: ({ restApiId, body }) => createApiKey(restApiId, body, { orgId }),
-    onSuccess: () => invalidate(),
-  });
+  return useMutation<CreateApiKeyResponse, ApiError, { restApiId: string; body: CreateApiKeyBody }>(
+    {
+      mutationFn: ({ restApiId, body }) => createApiKey(restApiId, body, { orgId }),
+      onSuccess: () => invalidate(),
+    },
+  );
 };
 
 export const useUpdateApiKey = (overrides: { orgId?: string } = {}) => {
@@ -122,12 +121,39 @@ export const useUpdateApiKey = (overrides: { orgId?: string } = {}) => {
 
 /** Revokes a key. Any client using it starts failing immediately. */
 export const useRevokeApiKey = (overrides: { orgId?: string } = {}) => {
-  const { orgId } = useApiScope(overrides);
+  const queryClient = useQueryClient();
+  const { org, orgId } = useApiScope(overrides);
   const invalidate = useInvalidateApiKeys(orgId);
 
   return useMutation<void, ApiError, { restApiId: string; apiKeyId: string }>({
-    mutationFn: ({ restApiId, apiKeyId }) =>
-      revokeApiKey(restApiId, apiKeyId, { orgId }),
-    onSuccess: () => invalidate(),
+    mutationFn: ({ restApiId, apiKeyId }) => revokeApiKey(restApiId, apiKeyId, { orgId }),
+    onSuccess: (_data, { restApiId, apiKeyId }) => {
+      // A revoke is represented as a status change by `/me/api-keys`, so merely
+      // refetching can leave the revoked credential visible. Remove the exact
+      // REST API key from every filtered caller list immediately; invalidation
+      // still follows to refresh pagination and counts from the server.
+      if (org) {
+        queryClient.setQueriesData<UserApiKeyListResponse>(
+          { queryKey: apiKeyKeys.all(org) },
+          (current) => {
+            if (!current) return current;
+            const list = current.list.filter(
+              (key) =>
+                !(
+                  key.artifactType === 'RestApi' &&
+                  key.artifactId === restApiId &&
+                  key.id === apiKeyId
+                ),
+            );
+            return {
+              ...current,
+              count: Math.max(0, current.count - (current.list.length - list.length)),
+              list,
+            };
+          },
+        );
+      }
+      invalidate();
+    },
   });
 };

--- a/portals/api-control-plane/src/i18n/messages/en.json
+++ b/portals/api-control-plane/src/i18n/messages/en.json
@@ -652,9 +652,21 @@
   "apiControlPlane.pages.appShell.ProjectQuickSelector.projects": {
     "defaultMessage": "Projects"
   },
+  "apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.by.label": {
+    "defaultMessage": "by",
+    "description": "Label between the API creation time and creator."
+  },
   "apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.context.label": {
     "defaultMessage": "Context",
     "description": "Label for the API base path shown in the API detail header, e.g. \"/orders\"."
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.copyContext": {
+    "defaultMessage": "Copy API context",
+    "description": "Accessible label for the button that copies the API context."
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.created.label": {
+    "defaultMessage": "Created",
+    "description": "Label before the API creation time in the API detail header."
   },
   "apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.deployToGateway": {
     "defaultMessage": "Deploy to Gateway",
@@ -675,10 +687,6 @@
   "apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.gatewayManagedHint": {
     "defaultMessage": "Discovered from a data-plane gateway, so it is read-only in this console.",
     "description": "Tooltip explaining the gateway-managed chip."
-  },
-  "apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.lastUpdated.label": {
-    "defaultMessage": "Last updated",
-    "description": "Label for when the API definition last changed, shown in the API detail header."
   },
   "apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.transports.label": {
     "defaultMessage": "Transports",
@@ -940,7 +948,11 @@
   },
   "apiControlPlane.pages.appShell.appShellPages.apis.overview.ProgressBanner.progress": {
     "defaultMessage": "{completed} of {total} completed",
-    "description": "Counter beside the progress bar, e.g. \"2 of 4 completed\". Counts the steps of getting an API live, not APIs."
+    "description": "Counter beside the lifecycle steps, e.g. \"2 of 4 completed\". Counts the steps of getting an API live, not APIs."
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.overview.ProgressBanner.next": {
+    "defaultMessage": "Next: {step}",
+    "description": "The next incomplete lifecycle step shown beside the progress counter."
   },
   "apiControlPlane.pages.appShell.appShellPages.apis.overview.ProgressBanner.step.create": {
     "defaultMessage": "Create",
@@ -951,20 +963,20 @@
     "description": "Second step of the API progress stepper — the API runs on a gateway. A stage name, not a button command."
   },
   "apiControlPlane.pages.appShell.appShellPages.apis.overview.ProgressBanner.step.publish": {
-    "defaultMessage": "Publish to API Portal",
-    "description": "Fourth step of the API progress stepper — the API is listed in the developer portal, which ships under the name \"API Portal\"."
+    "defaultMessage": "Publish to Devportal",
+    "description": "Fourth step of the API progress stepper — the API is listed in the developer portal."
   },
   "apiControlPlane.pages.appShell.appShellPages.apis.overview.ProgressBanner.step.test": {
     "defaultMessage": "Test",
     "description": "Third step of the API progress stepper — the API has been called from the test console. A stage name, not a button command."
   },
-  "apiControlPlane.pages.appShell.appShellPages.apis.overview.ProgressBanner.title": {
-    "defaultMessage": "Track your progress here",
-    "description": "Heading of the banner that walks the user through creating, deploying, testing and publishing an API."
-  },
   "apiControlPlane.pages.appShell.appShellPages.apis.overview.ResourcesPanel.empty": {
     "defaultMessage": "No available resources.",
     "description": "Shown in place of the operation list when the API definition exposes none."
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.overview.ResourcesPanel.count": {
+    "defaultMessage": "Showing {count} of {count} resources",
+    "description": "Number of API operations displayed in the resources panel."
   },
   "apiControlPlane.pages.appShell.appShellPages.apis.overview.ResourcesPanel.emptyDescription": {
     "defaultMessage": "This API’s definition does not expose any operations yet.",

--- a/portals/api-control-plane/src/i18n/messages/en.json
+++ b/portals/api-control-plane/src/i18n/messages/en.json
@@ -657,7 +657,7 @@
     "description": "Label between the API creation time and creator."
   },
   "apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.context.label": {
-    "defaultMessage": "Context",
+    "defaultMessage": "Context:",
     "description": "Label for the API base path shown in the API detail header, e.g. \"/orders\"."
   },
   "apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.copyContext": {
@@ -687,6 +687,9 @@
   "apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.gatewayManagedHint": {
     "defaultMessage": "Discovered from a data-plane gateway, so it is read-only in this console.",
     "description": "Tooltip explaining the gateway-managed chip."
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.unknownCreator": {
+    "defaultMessage": "—"
   },
   "apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.transports.label": {
     "defaultMessage": "Transports",
@@ -870,6 +873,13 @@
     "defaultMessage": "Add an API key to authenticate requests through the deployed gateways.",
     "description": "Explains what an API key is for, above the button that adds one."
   },
+  "apiControlPlane.pages.appShell.appShellPages.apis.overview.ApiKeysPanel.createdMetadata": {
+    "defaultMessage": "Created {time} by {creator}",
+    "description": "Creation time and creator shown beside an API key."
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.overview.ApiKeysPanel.closeDrawer": {
+    "defaultMessage": "Close API keys"
+  },
   "apiControlPlane.pages.appShell.appShellPages.apis.overview.ApiKeysPanel.keyNameLabel": {
     "defaultMessage": "Key Name",
     "description": "Label of the field naming the new key."
@@ -910,6 +920,12 @@
     "defaultMessage": "Revoke API key",
     "description": "Tooltip on the button that revokes one key from the table."
   },
+  "apiControlPlane.pages.appShell.appShellPages.apis.overview.ApiKeysPanel.seeMore": {
+    "defaultMessage": "See more"
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.overview.ApiKeysPanel.separator": {
+    "defaultMessage": "·"
+  },
   "apiControlPlane.pages.appShell.appShellPages.apis.overview.ApiKeysPanel.revoking": {
     "defaultMessage": "Revoking...",
     "description": "Label of the revoke button while the request is in flight."
@@ -917,6 +933,25 @@
   "apiControlPlane.pages.appShell.appShellPages.apis.overview.ApiKeysPanel.title": {
     "defaultMessage": "API Keys",
     "description": "Heading of the section listing the keys accepted for this API."
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.overview.DeployedGatewaysPanel.seeMore": {
+    "defaultMessage": "See more"
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.overview.DeployedGatewaysPanel.status": {
+    "defaultMessage": "{status, select, DEPLOYED {Deployed} UNDEPLOYED {Undeployed} DEPLOYING {Deploying} UNDEPLOYING {Undeploying} FAILED {Failed} ARCHIVED {Archived} other {{status}}}"
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.overview.DeployedGatewaysPanel.title": {
+    "defaultMessage": "Deployed gateways"
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.overview.DocumentsPanel.description": {
+    "defaultMessage": "Guides, references, and specifications published with this API."
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.overview.DocumentsPanel.title": {
+    "defaultMessage": "Documents"
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.overview.DocumentsPanel.updated": {
+    "defaultMessage": "2 days ago",
+    "description": "Temporary relative update time for demo document data."
   },
   "apiControlPlane.pages.appShell.appShellPages.apis.overview.InvokeUrlPanel.copy": {
     "defaultMessage": "Copy URL",
@@ -975,7 +1010,7 @@
     "description": "Shown in place of the operation list when the API definition exposes none."
   },
   "apiControlPlane.pages.appShell.appShellPages.apis.overview.ResourcesPanel.count": {
-    "defaultMessage": "Showing {count} of {count} resources",
+    "defaultMessage": "Showing {count, plural, one {# resource} other {# resources}}",
     "description": "Number of API operations displayed in the resources panel."
   },
   "apiControlPlane.pages.appShell.appShellPages.apis.overview.ResourcesPanel.emptyDescription": {

--- a/portals/api-control-plane/src/pages/appShell/AppLayout.tsx
+++ b/portals/api-control-plane/src/pages/appShell/AppLayout.tsx
@@ -129,6 +129,7 @@ export default function AppLayout() {
                   <AppBreadcrumbs
                     items={breadcrumbItems}
                     sx={(theme) => ({
+                      mb: 1,
                       '& .MuiBreadcrumbs-li .MuiTypography-root': {
                         fontSize: theme.typography.body2.fontSize,
                         opacity: 0.55,

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/edit/ApiEditPage.test.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/edit/ApiEditPage.test.tsx
@@ -121,25 +121,6 @@ describe('ApiEditPage', () => {
     expect(await screen.findByText('API overview')).toBeInTheDocument();
   });
 
-  it('keeps a shared upstream `ref` intact instead of writing a url beside it', async () => {
-    server.use(
-      resource(`/rest-apis/${API}`, anApi({ upstream: { main: { ref: 'retail-backend' } } })),
-    );
-    server.use(accepts('put', `/rest-apis/${API}`, anApi(), { record: requests }));
-
-    const { user } = renderPage();
-
-    const name = await screen.findByDisplayValue('Pizza Shack');
-    await user.clear(name);
-    await user.type(name, 'Pizza Palace');
-    await user.click(screen.getByRole('button', { name: /Save changes/ }));
-
-    await waitFor(() => expect(requests.count()).toBe(1));
-    const body = JSON.parse(requests.last()!.body) as RestApiFixture;
-
-    expect(body.upstream).toEqual({ main: { ref: 'retail-backend' } });
-  });
-
   it('refuses a gateway-managed API, even when reached by URL', async () => {
     server.use(resource(`/rest-apis/${API}`, anApi({ readOnly: true })));
 

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/edit/ApiEditPage.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/edit/ApiEditPage.tsx
@@ -61,7 +61,7 @@ const messages = defineMessages({
   },
   subtitle: {
     id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.ApiEditPage.subtitle',
-    defaultMessage: 'Change the name, description, context, version and backend of this API.',
+    defaultMessage: 'Change the name, description, context and version of this API.',
   },
   title: {
     id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.ApiEditPage.title',
@@ -70,15 +70,11 @@ const messages = defineMessages({
 });
 
 /**
- * Applies the form's five fields to the fetched API.
+ * Applies the form's four fields to the fetched API.
  *
  * The spec's update body is the whole `RESTAPI`, so the original is spread back
- * with the edits laid over it — anything the form does not collect (operations,
- * policies, transports) has to survive the round trip untouched.
- *
- * `upstream` is only rewritten when the API routes to a direct URL. An API
- * pointing at a shared upstream `ref` keeps it: `url` and `ref` are mutually
- * exclusive, so writing both would be rejected.
+ * with the edits laid over it — anything the form does not collect (upstream,
+ * operations, policies, transports) has to survive the round trip untouched.
  */
 const toUpdateBody = (api: RestApi, values: ApiBasicInfoFormValues): RestApi => ({
   ...api,
@@ -86,12 +82,6 @@ const toUpdateBody = (api: RestApi, values: ApiBasicInfoFormValues): RestApi => 
   description: values.description,
   displayName: values.displayName,
   version: values.version,
-  upstream: api.upstream?.main?.ref
-    ? api.upstream
-    : {
-        ...api.upstream,
-        main: { ...api.upstream?.main, url: values.targetUrl },
-      },
 });
 
 // No `ScopeGate`: this page is only reachable from the API detail page's own
@@ -147,15 +137,21 @@ export function ApiEditPage() {
   return (
     <>
       <PageTitle>
-        <Link to={detailPath}>
-          <PageTitle.BackButton>
-            <FormattedMessage {...messages.back} />
-          </PageTitle.BackButton>
-        </Link>
+        <PageTitle.BackButton
+          component={<Link to={detailPath} />}
+          sx={{
+            alignItems: 'center',
+            display: 'flex',
+            marginLeft: '-10px',
+            textDecoration: 'none',
+          }}
+        >
+          <FormattedMessage {...messages.back} />
+        </PageTitle.BackButton>
         <PageTitle.Header>
           <FormattedMessage {...messages.title} />
         </PageTitle.Header>
-        <PageTitle.SubHeader>
+        <PageTitle.SubHeader variant="caption">
           <FormattedMessage {...messages.subtitle} />
         </PageTitle.SubHeader>
       </PageTitle>

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/edit/components/EditApiForm.test.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/edit/components/EditApiForm.test.tsx
@@ -68,17 +68,6 @@ describe('EditApiForm — initial values', () => {
     expect(screen.getByLabelText(/Version/)).toHaveValue('1.0.0');
     expect(screen.getByLabelText(/Context/)).toHaveValue('/pizza');
     expect(screen.getByLabelText(/Description/)).toHaveValue('Pizza ordering');
-    expect(screen.getByLabelText(/Target URL/)).toHaveValue('https://upstream.test');
-  });
-
-  it('shows the identifier but does not let it be edited', () => {
-    // `PUT /rest-apis/{restApiId}` rejects a body whose `id` differs from the
-    // path and there is no rename operation, so the handle is reference only.
-    renderForm();
-
-    const identifier = screen.getByLabelText(/Identifier/);
-    expect(identifier).toHaveValue('pizza-shack');
-    expect(identifier).toBeDisabled();
   });
 
   it('leaves an absent description as an empty field rather than "undefined"', () => {
@@ -127,19 +116,6 @@ describe('EditApiForm — validation', () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
-  it('rejects a target URL that is not a full http(s) URL', async () => {
-    const { onSubmit, user } = renderForm();
-
-    await user.clear(screen.getByLabelText(/Target URL/));
-    await user.type(screen.getByLabelText(/Target URL/), 'upstream.test');
-    await save(user);
-
-    expect(
-      screen.getByText('Enter a full URL, for example https://api.example.com.'),
-    ).toBeInTheDocument();
-    expect(onSubmit).not.toHaveBeenCalled();
-  });
-
   it('stays quiet until a rule is actually broken', () => {
     renderForm();
 
@@ -154,7 +130,7 @@ describe('EditApiForm — validation', () => {
 });
 
 describe('EditApiForm — submitting', () => {
-  it('hands back the five fields, trimmed', async () => {
+  it('hands back the four fields, trimmed', async () => {
     const { onSubmit, user } = renderForm();
 
     await user.clear(screen.getByLabelText(/^Name/));
@@ -167,7 +143,6 @@ describe('EditApiForm — submitting', () => {
       context: '/pizza',
       description: 'Now with sides',
       displayName: 'Pizza Shack v2',
-      targetUrl: 'https://upstream.test',
       version: '1.0.0',
     });
   });
@@ -190,25 +165,38 @@ describe('EditApiForm — submitting', () => {
   });
 });
 
-describe('EditApiForm — shared upstream', () => {
-  const withRef = anApi({ upstream: { main: { ref: 'retail-backend' } } });
+describe('EditApiForm — save button reflects unsaved changes', () => {
+  const saveButton = () => screen.getByRole('button', { name: /Save changes/ });
 
-  it('locks the target URL and names the upstream it points at', () => {
-    renderForm({ api: withRef });
+  it('starts disabled: nothing has been changed yet', () => {
+    renderForm();
 
-    expect(screen.getByLabelText(/Target URL/)).toBeDisabled();
-    expect(
-      screen.getByText(/Routed through the shared upstream “retail-backend”/),
-    ).toBeInTheDocument();
+    expect(saveButton()).toBeDisabled();
   });
 
-  it('still submits: an API with no URL of its own is not an invalid one', async () => {
-    const { onSubmit, user } = renderForm({ api: withRef });
+  it('enables once any field diverges from what the API was opened with', async () => {
+    const { user } = renderForm();
 
-    await save(user);
+    await user.type(screen.getByLabelText(/^Name/), ' v2');
 
-    expect(onSubmit).toHaveBeenCalledWith(
-      expect.objectContaining({ displayName: 'Pizza Shack', targetUrl: '' }),
-    );
+    expect(saveButton()).toBeEnabled();
+  });
+
+  it('disables again when every field is edited back to its original value', async () => {
+    const { user } = renderForm();
+
+    const name = screen.getByLabelText(/^Name/);
+    await user.type(name, ' v2');
+    expect(saveButton()).toBeEnabled();
+
+    await user.clear(name);
+    await user.type(name, 'Pizza Shack');
+    expect(saveButton()).toBeDisabled();
+  });
+
+  it('never enables just because the save is in flight, even if untouched', () => {
+    renderForm({ isSaving: true });
+
+    expect(saveButton()).toBeDisabled();
   });
 });

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/edit/components/EditApiForm.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/edit/components/EditApiForm.tsx
@@ -18,34 +18,27 @@
 
 import {
   Button,
-  Divider,
   Form,
   FormControl,
   FormHelperText,
+  FormLabel,
   Grid,
-  InputLabel,
   OutlinedInput,
   Paper,
   Stack,
 } from '@wso2/oxygen-ui';
 import type { FormEvent, ReactNode } from 'react';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { defineMessages, FormattedMessage, useIntl, type MessageDescriptor } from 'react-intl';
 
 import type { RestApi } from '@/api/resources/restApis';
-import { CONTEXT_PATTERN, isHttpUrl, VERSION_PATTERN } from '../../utils/basicInfoRules';
+import { CONTEXT_PATTERN, VERSION_PATTERN } from '../../utils/basicInfoRules';
 
-/**
- * The five fields this form edits, flattened. `targetUrl` is
- * `upstream.main.url` — the page puts it back on the API object, because the
- * spec's update body is the whole `RESTAPI` and only the page holds the
- * fetched original to merge into.
- */
+/** The four fields this form edits. */
 export type ApiBasicInfoFormValues = {
   context: string;
   description: string;
   displayName: string;
-  targetUrl: string;
   version: string;
 };
 
@@ -63,11 +56,6 @@ export type EditApiFormProps = {
 };
 
 const messages = defineMessages({
-  basicInformation: {
-    id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.section.basicInformation',
-    defaultMessage: 'Basic information',
-    description: 'Heading of the field group holding name, identifier, version, context.',
-  },
   cancel: {
     id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.action.cancel',
     defaultMessage: 'Cancel',
@@ -89,20 +77,6 @@ const messages = defineMessages({
     id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.description.label',
     defaultMessage: 'Description',
   },
-  endpointSection: {
-    id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.section.backendEndpoint',
-    defaultMessage: 'Backend endpoint',
-    description: 'Heading of the field group holding the target URL.',
-  },
-  identifierHelper: {
-    id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.identifier.helper',
-    defaultMessage: 'Fixed once the API is created.',
-    description: 'Helper text under the disabled identifier field on the API edit form.',
-  },
-  identifierLabel: {
-    id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.identifier.label',
-    defaultMessage: 'Identifier',
-  },
   nameErrorRequired: {
     id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.name.error.required',
     defaultMessage: 'Enter a name.',
@@ -115,24 +89,6 @@ const messages = defineMessages({
     id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.action.save',
     defaultMessage: 'Save changes',
     description: 'Commits the edits to the API.',
-  },
-  targetUrlErrorInvalid: {
-    id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.targetUrl.error.invalid',
-    defaultMessage: 'Enter a full URL, for example https://api.example.com.',
-  },
-  targetUrlErrorRequired: {
-    id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.targetUrl.error.required',
-    defaultMessage: 'Enter a target URL.',
-  },
-  targetUrlLabel: {
-    id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.targetUrl.label',
-    defaultMessage: 'Target URL',
-  },
-  targetUrlSharedUpstream: {
-    id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.targetUrl.sharedUpstream',
-    defaultMessage: 'Routed through the shared upstream “{ref}”, so there is no URL to edit here.',
-    description:
-      'Helper text shown instead of an editable target URL when the API points at a named upstream definition. {ref} is that definition’s name.',
   },
   versionErrorPattern: {
     id: 'apiControlPlane.pages.appShell.appShellPages.apis.edit.EditApiForm.version.error.pattern',
@@ -148,42 +104,27 @@ const messages = defineMessages({
   },
 });
 
-/**
- * Small uppercase rule above a group of fields, matching the create form.
- * `Form.Header` is fixed at `h4`, so the size comes from the theme's `overline`
- * typography rather than a font-size literal.
- */
-const SECTION_LABEL_SX = {
-  color: 'text.secondary',
-  typography: 'overline',
-} as const;
-
 /** The fields that carry a validation rule — description has none. */
-type ValidatedField = 'context' | 'displayName' | 'targetUrl' | 'version';
+type ValidatedField = 'context' | 'displayName' | 'version';
 
 type FieldErrors = Partial<Record<ValidatedField, MessageDescriptor>>;
 
 /**
  * Which spec field name a server-side field error binds to. The server names
- * the wire field, which is nested for the upstream URL, so the mapping is
- * spelled out rather than guessed from the input's own name.
+ * the wire field, so the mapping is spelled out rather than guessed from the
+ * input's own name.
  */
 const SERVER_FIELD_NAMES: Record<ValidatedField, string[]> = {
   context: ['context'],
   displayName: ['displayName'],
-  targetUrl: ['upstream.main.url', 'upstream'],
   version: ['version'],
 };
 
 /**
  * Every rule in one pure pass, so the same answer drives the field errors and
  * the submit gate — there is no second, drifting copy of the rules.
- *
- * `targetUrl` is only validated when the API carries a URL to begin with: an
- * API routed through a shared upstream `ref` has no URL, and requiring one
- * would make its form unsubmittable.
  */
-const validate = (values: ApiBasicInfoFormValues, hasEditableUrl: boolean): FieldErrors => {
+const validate = (values: ApiBasicInfoFormValues): FieldErrors => {
   const errors: FieldErrors = {};
 
   if (values.displayName.trim() === '') {
@@ -204,15 +145,6 @@ const validate = (values: ApiBasicInfoFormValues, hasEditableUrl: boolean): Fiel
     errors.context = messages.contextErrorPattern;
   }
 
-  if (hasEditableUrl) {
-    const targetUrl = values.targetUrl.trim();
-    if (targetUrl === '') {
-      errors.targetUrl = messages.targetUrlErrorRequired;
-    } else if (!isHttpUrl(targetUrl)) {
-      errors.targetUrl = messages.targetUrlErrorInvalid;
-    }
-  }
-
   return errors;
 };
 
@@ -221,13 +153,12 @@ const toFormValues = (api: RestApi): ApiBasicInfoFormValues => ({
   context: api.context ?? '',
   description: api.description ?? '',
   displayName: api.displayName ?? '',
-  targetUrl: api.upstream?.main?.url ?? '',
   version: api.version ?? '',
 });
 
 /**
- * Edit form for an API's basic information: name, description, context, version
- * and target URL.
+ * Edit form for an API's basic information: name, description, context and
+ * version. The backend endpoint is not editable here.
  *
  * It owns the draft and the validation only. The mutation, the merge back onto
  * the fetched `RESTAPI` and the navigation belong to `ApiEditPage`, so this
@@ -240,17 +171,20 @@ export const EditApiForm = (props: EditApiFormProps) => {
   // is seeded once rather than recomputed on every render.
   const [values, setValues] = useState<ApiBasicInfoFormValues>(() => toFormValues(props.api));
 
+  // Captured once, alongside `values` — the baseline the Save button compares
+  // the live draft against, so editing a field back to its original value
+  // disables Save again instead of latching "dirty" on the first keystroke.
+  const initialValues = useRef(values).current;
+
   // Errors are recomputed from state on every render; `touched` decides which
   // of them the user is ready to see, so nothing shouts before it is typed in.
   const [touched, setTouched] = useState<Partial<Record<ValidatedField, boolean>>>({});
 
-  // An upstream carries `url` or `ref`, never both. A `ref` names a shared
-  // upstream definition this form does not own, so the URL field goes
-  // read-only rather than silently converting the API to a direct URL.
-  const upstreamRef = props.api.upstream?.main?.ref;
-  const hasEditableUrl = !upstreamRef;
+  const errors = validate(values);
 
-  const errors = validate(values, hasEditableUrl);
+  const isDirty = (Object.keys(initialValues) as (keyof ApiBasicInfoFormValues)[]).some(
+    (field) => values[field] !== initialValues[field],
+  );
 
   /** Whatever the server said about this field on the last rejected save. */
   const serverErrorFor = (field: ValidatedField): string | undefined => {
@@ -279,7 +213,7 @@ export const EditApiForm = (props: EditApiFormProps) => {
 
     if (Object.keys(errors).length > 0) {
       // Reveal every rule at once rather than one field per attempt.
-      setTouched({ context: true, displayName: true, targetUrl: true, version: true });
+      setTouched({ context: true, displayName: true, version: true });
       return;
     }
 
@@ -287,7 +221,6 @@ export const EditApiForm = (props: EditApiFormProps) => {
       context: values.context.trim(),
       description: values.description.trim(),
       displayName: values.displayName.trim(),
-      targetUrl: values.targetUrl.trim(),
       version: values.version.trim(),
     });
   };
@@ -318,28 +251,21 @@ export const EditApiForm = (props: EditApiFormProps) => {
 
   const contextLabel = intl.formatMessage(messages.contextLabel);
   const descriptionLabel = intl.formatMessage(messages.descriptionLabel);
-  const identifierLabel = intl.formatMessage(messages.identifierLabel);
   const nameLabel = intl.formatMessage(messages.nameLabel);
-  const targetUrlLabel = intl.formatMessage(messages.targetUrlLabel);
   const versionLabel = intl.formatMessage(messages.versionLabel);
 
   return (
     <Stack component="form" noValidate spacing={3} onSubmit={onFormSubmit}>
       <Paper component="section" sx={{ p: 3 }}>
-        <Form.Header sx={SECTION_LABEL_SX}>
-          <FormattedMessage {...messages.basicInformation} />
-        </Form.Header>
-
-        <Form.Stack spacing={2} sx={{ mt: 1.5 }}>
+        <Form.Stack spacing={2}>
           <Grid container spacing={2}>
-            <Grid size={{ xs: 12, md: 4 }}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <FormControl error={hasError('displayName')} fullWidth required>
-                <InputLabel htmlFor="displayName">{nameLabel}</InputLabel>
+                <FormLabel htmlFor="displayName">{nameLabel}</FormLabel>
                 <OutlinedInput
                   autoFocus
                   disabled={props.isSaving}
                   id="displayName"
-                  label={nameLabel}
                   name="displayName"
                   onBlur={() => markTouched('displayName')}
                   onChange={(event) => setField('displayName', event.target.value)}
@@ -349,32 +275,12 @@ export const EditApiForm = (props: EditApiFormProps) => {
               </FormControl>
             </Grid>
 
-            {/* The handle addresses the resource: `PUT /rest-apis/{restApiId}`
-                rejects a body whose `id` differs from the path, and there is no
-                rename operation — so it is shown for reference, not for edit. */}
-            <Grid size={{ xs: 12, md: 4 }}>
-              <FormControl disabled fullWidth>
-                <InputLabel htmlFor="identifier">{identifierLabel}</InputLabel>
-                <OutlinedInput
-                  id="identifier"
-                  label={identifierLabel}
-                  name="identifier"
-                  readOnly
-                  value={props.api.id ?? ''}
-                />
-                <FormHelperText>
-                  <FormattedMessage {...messages.identifierHelper} />
-                </FormHelperText>
-              </FormControl>
-            </Grid>
-
-            <Grid size={{ xs: 12, md: 4 }}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <FormControl error={hasError('version')} fullWidth required>
-                <InputLabel htmlFor="version">{versionLabel}</InputLabel>
+                <FormLabel htmlFor="version">{versionLabel}</FormLabel>
                 <OutlinedInput
                   disabled={props.isSaving}
                   id="version"
-                  label={versionLabel}
                   name="version"
                   onBlur={() => markTouched('version')}
                   onChange={(event) => setField('version', event.target.value)}
@@ -386,11 +292,10 @@ export const EditApiForm = (props: EditApiFormProps) => {
           </Grid>
 
           <FormControl error={hasError('context')} fullWidth required>
-            <InputLabel htmlFor="context">{contextLabel}</InputLabel>
+            <FormLabel htmlFor="context">{contextLabel}</FormLabel>
             <OutlinedInput
               disabled={props.isSaving}
               id="context"
-              label={contextLabel}
               name="context"
               onBlur={() => markTouched('context')}
               onChange={(event) => setField('context', event.target.value)}
@@ -400,11 +305,10 @@ export const EditApiForm = (props: EditApiFormProps) => {
           </FormControl>
 
           <FormControl fullWidth>
-            <InputLabel htmlFor="description">{descriptionLabel}</InputLabel>
+            <FormLabel htmlFor="description">{descriptionLabel}</FormLabel>
             <OutlinedInput
               disabled={props.isSaving}
               id="description"
-              label={descriptionLabel}
               multiline
               name="description"
               onChange={(event) => setField('description', event.target.value)}
@@ -414,52 +318,13 @@ export const EditApiForm = (props: EditApiFormProps) => {
           </FormControl>
         </Form.Stack>
       </Paper>
-
-      <Paper component="section" sx={{ mt: 1, p: 3 }}>
-        <Form.Header sx={SECTION_LABEL_SX}>
-          <FormattedMessage {...messages.endpointSection} />
-        </Form.Header>
-
-        <Form.Stack spacing={2} sx={{ mt: 1.5 }}>
-          <FormControl
-            disabled={!hasEditableUrl}
-            error={hasError('targetUrl')}
-            fullWidth
-            required={hasEditableUrl}
-          >
-            <InputLabel htmlFor="targetUrl">{targetUrlLabel}</InputLabel>
-            <OutlinedInput
-              disabled={props.isSaving || !hasEditableUrl}
-              id="targetUrl"
-              label={targetUrlLabel}
-              name="targetUrl"
-              onBlur={() => markTouched('targetUrl')}
-              onChange={(event) => setField('targetUrl', event.target.value)}
-              readOnly={!hasEditableUrl}
-              value={values.targetUrl}
-            />
-            {helperFor(
-              'targetUrl',
-              hasEditableUrl ? null : (
-                <FormattedMessage
-                  {...messages.targetUrlSharedUpstream}
-                  values={{ ref: upstreamRef }}
-                />
-              ),
-            )}
-          </FormControl>
-        </Form.Stack>
-      </Paper>
-
-      <Divider />
-
       {/* Both buttons on the trailing edge, the same pairing as the create
           form's last step. */}
       <Stack direction="row" spacing={2} sx={{ alignItems: 'center', justifyContent: 'flex-end' }}>
         <Button disabled={props.isSaving} variant="text" onClick={props.onCancel}>
           <FormattedMessage {...messages.cancel} />
         </Button>
-        <Button disabled={props.isSaving} type="submit" variant="contained">
+        <Button disabled={props.isSaving || !isDirty} type="submit" variant="contained">
           <FormattedMessage {...messages.save} />
         </Button>
       </Stack>

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/ApiDetailPage.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/ApiDetailPage.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { type ReactNode } from 'react';
+import { useMemo } from 'react';
 import {
   Avatar,
   Box,
@@ -28,24 +28,43 @@ import {
   Tooltip,
   Typography,
 } from '@wso2/oxygen-ui';
-import { Boxes, Edit, Lock } from '@wso2/oxygen-ui-icons-react';
+import { Boxes, Clock, Copy, Edit, Lock, Rocket } from '@wso2/oxygen-ui-icons-react';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import { Link as RouterLink } from 'react-router-dom';
 
 import { useRestApi } from '@/api/resources/restApis';
+import type { Gateway } from '@/api/resources/gateways';
+import { useDeployments } from '@/api/resources/restApis/deployments';
+import { useRestApiGateways } from '@/api/resources/restApis/apiGateways/apiGateways.hooks';
 import { ErrorState, LoadingState } from '@/components/StateViews';
 import { useFormatters } from '@/i18n/useFormatters';
 import { routes } from '@/routes/paths';
 import { useConsoleScope } from '@/scope/ConsoleScopeProvider';
-import { VersionChip } from '../listing/components/RestApiChips';
+import { ApiKindChip, VersionChip } from '../listing/components/RestApiChips';
 import { apiInitials } from '../utils/restApiDisplay';
 import { OverviewTab } from './OverviewTab';
+import { ProgressBanner } from './ProgressBanner';
 
 const messages = defineMessages({
   context: {
     id: 'apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.context.label',
     defaultMessage: 'Context',
     description: 'Label for the API base path shown in the API detail header, e.g. "/orders".',
+  },
+  copyContext: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.copyContext',
+    defaultMessage: 'Copy API context',
+    description: 'Accessible label for the button that copies the API context.',
+  },
+  created: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.created.label',
+    defaultMessage: 'Created',
+    description: 'Label before the API creation time in the API detail header.',
+  },
+  by: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.by.label',
+    defaultMessage: 'by',
+    description: 'Label between the API creation time and creator.',
   },
   deployToGateway: {
     id: 'apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.deployToGateway',
@@ -75,11 +94,6 @@ const messages = defineMessages({
     defaultMessage: 'Discovered from a data-plane gateway, so it is read-only in this console.',
     description: 'Tooltip explaining the gateway-managed chip.',
   },
-  lastUpdated: {
-    id: 'apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.lastUpdated.label',
-    defaultMessage: 'Last updated',
-    description: 'Label for when the API definition last changed, shown in the API detail header.',
-  },
   transports: {
     id: 'apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.transports.label',
     defaultMessage: 'Transports',
@@ -88,12 +102,9 @@ const messages = defineMessages({
 });
 
 /** Edge of the square kind tile, the monogram inside it, and the fallback icon. */
-const AVATAR_SIZE = 70;
+const AVATAR_SIZE = 72;
 const AVATAR_FONT_SIZE = 32;
 const AVATAR_ICON_SIZE = 32;
-
-/** Label column of the metadata rows, wide enough to align their values. */
-const LABEL_COLUMN = 88;
 
 /**
  * The API description, read-only.
@@ -116,7 +127,12 @@ function DescriptionField({ description }: { description: string }) {
       color="text.secondary"
       sx={{
         display: '-webkit-box',
+        fontSize: '0.875rem',
+        fontWeight: 400,
+        lineHeight: 1.5,
+        maxWidth: 860,
         minWidth: 0,
+        opacity: 0.8,
         overflow: 'hidden',
         WebkitBoxOrient: 'vertical',
         WebkitLineClamp: 2,
@@ -128,38 +144,33 @@ function DescriptionField({ description }: { description: string }) {
   );
 }
 
-/**
- * One `label: value` row in the header's metadata block.
- *
- * A single component for all of them is what keeps the rows aligned: the label
- * always takes the theme's `caption` scale and secondary tone, the value always
- * `body2`, so adding a field cannot introduce a fourth type treatment.
- */
-function MetaItem({ children, label }: { children: ReactNode; label: ReactNode }) {
-  return (
-    <Stack alignItems="center" direction="row" spacing={2} sx={{ minWidth: 0 }}>
-      {/* `minWidth` rather than a fixed width: it lines the values up into a
-          column for the labels we ship, and a longer translation pushes its own
-          row wider instead of clipping. */}
-      <Typography
-        color="text.secondary"
-        sx={{ flexShrink: 0, minWidth: LABEL_COLUMN }}
-        variant="caption"
-      >
-        {label}
-      </Typography>
-      {children}
-    </Stack>
-  );
-}
-
 // No `ScopeGate`: this page is the API tier of the sidebar's Overview item, which
 // degrades to a shallower tier rather than linking here without an API.
 export function ApiDetailPage() {
   const { params } = useConsoleScope();
   const apiQuery = useRestApi(params.apiHandler);
+  const apiGatewaysQuery = useRestApiGateways(apiQuery.data?.id);
+  const deploymentsQuery = useDeployments(apiQuery.data?.id);
   const { dateTime, relativeTime } = useFormatters();
   const intl = useIntl();
+  const deployedGateways = useMemo((): Gateway[] => {
+    const gateways = apiGatewaysQuery.data?.list ?? [];
+    const deployments = deploymentsQuery.data?.list ?? [];
+    const latestByGateway = new Map<string, number>();
+    deployments
+      .filter((deployment) => deployment.status === 'DEPLOYED')
+      .forEach((deployment) => {
+        const time = new Date(deployment.createdAt || 0).getTime();
+        const current = latestByGateway.get(deployment.gatewayId);
+        if (current === undefined || time > current)
+          latestByGateway.set(deployment.gatewayId, time);
+      });
+    return gateways
+      .filter((gateway) => gateway.isDeployed || latestByGateway.has(gateway.id ?? ''))
+      .sort(
+        (a, b) => (latestByGateway.get(b.id ?? '') || 0) - (latestByGateway.get(a.id ?? '') || 0),
+      );
+  }, [apiGatewaysQuery.data, deploymentsQuery.data]);
 
   if (apiQuery.isLoading) return <LoadingState label="Loading API" />;
   if (apiQuery.error || !apiQuery.data) {
@@ -187,20 +198,18 @@ export function ApiDetailPage() {
   );
 
   const displayName = api.displayName || restApiId;
-  // `updatedAt` is absent until the first edit, so a fresh API reads its
-  // creation time rather than showing an empty row.
-  const updated = api.updatedAt || api.createdAt;
-
+  const context = api.context || '/';
   return (
     <>
       <Card sx={{ mb: 3 }}>
         <Box
           sx={{
             display: 'flex',
+            flexDirection: { sm: 'row', xs: 'column' },
             alignItems: 'flex-start',
-            gap: 2,
+            gap: 3,
             justifyContent: 'space-between',
-            p: 2,
+            p: { sm: 2.5, xs: 2 },
           }}
         >
           <Box
@@ -225,78 +234,135 @@ export function ApiDetailPage() {
               {apiInitials(displayName) || <Boxes size={AVATAR_ICON_SIZE} />}
             </Avatar>
 
-            <Stack spacing={1} sx={{ minWidth: 0 }}>
+            <Stack spacing={1.5} sx={{ minWidth: 0 }}>
               {/* Identity: name, version, lifecycle, and whether this console
                   may edit the API at all. */}
-              <Stack
-                alignItems="center"
-                direction="row"
-                sx={{ flexWrap: 'wrap', gap: 1, minWidth: 0 }}
-                useFlexGap
-              >
-                <Tooltip title={displayName}>
-                  <Typography noWrap variant="h3">
-                    {displayName}
-                  </Typography>
-                </Tooltip>
-                <VersionChip version={api.version} />
-                {/* Gateway-managed APIs are read-only in this console, so they
-                    get no way in to the edit form at all. */}
-                {!api.readOnly && (
-                  <Tooltip title={intl.formatMessage(messages.editApi)}>
-                    <IconButton
-                      aria-label={intl.formatMessage(messages.editApi)}
-                      component={RouterLink}
-                      size="small"
-                      sx={{ flexShrink: 0 }}
-                      to={editPath}
-                    >
-                      <Edit size={16} />
-                    </IconButton>
+              <Stack alignItems="flex-start" spacing={1}>
+                <Stack alignItems="center" direction="row" spacing={1} sx={{ minWidth: 0 }}>
+                  <Tooltip title={displayName}>
+                    <Typography noWrap sx={{ fontWeight: 700, lineHeight: 1.2 }} variant="h3">
+                      {displayName}
+                    </Typography>
                   </Tooltip>
-                )}
-                {api.readOnly && (
-                  <Tooltip title={intl.formatMessage(messages.gatewayManagedHint)}>
-                    <Chip
-                      icon={<Lock size={12} />}
-                      label={intl.formatMessage(messages.gatewayManaged)}
-                      size="small"
-                      sx={{ flexShrink: 0, typography: 'caption' }}
-                      variant="outlined"
-                    />
-                  </Tooltip>
-                )}
+                  {api.readOnly && (
+                    <Tooltip title={intl.formatMessage(messages.gatewayManagedHint)}>
+                      <Chip
+                        icon={<Lock size={12} />}
+                        label={intl.formatMessage(messages.gatewayManaged)}
+                        size="small"
+                        sx={{ flexShrink: 0, typography: 'caption' }}
+                        variant="outlined"
+                      />
+                    </Tooltip>
+                  )}
+                </Stack>
+                <Stack alignItems="center" direction="row" spacing={0.75}>
+                  <VersionChip version={api.version} />
+                  <ApiKindChip kind={api.kind} />
+                </Stack>
               </Stack>
 
               <DescriptionField description={api.description?.trim() ?? ''} />
 
-              <Stack spacing={0.5}>
-                <MetaItem label={<FormattedMessage {...messages.context} />}>
-                  <Typography noWrap variant="body2">
-                    {api.context || '/'}
-                  </Typography>
-                </MetaItem>
-
-                {updated && (
-                  <MetaItem label={<FormattedMessage {...messages.lastUpdated} />}>
-                    {/* Relative reads faster; the exact stamp is one hover
-                        away for anyone auditing a change. */}
-                    <Tooltip title={dateTime(updated)}>
-                      <Typography variant="body2">{relativeTime(updated)}</Typography>
-                    </Tooltip>
-                  </MetaItem>
+              <Stack
+                alignItems="center"
+                direction="row"
+                divider={<Box sx={{ bgcolor: 'divider', height: 24, width: '1px' }} />}
+                spacing={1.5}
+                sx={{ flexWrap: 'wrap', rowGap: 1 }}
+              >
+                {api.createdAt && (
+                  <Tooltip title={dateTime(api.createdAt)}>
+                    <Stack alignItems="center" direction="row" spacing={0.5}>
+                      <Box
+                        sx={{
+                          alignItems: 'center',
+                          color: 'text.secondary',
+                          display: 'flex',
+                          flexShrink: 0,
+                          opacity: 0.75,
+                        }}
+                      >
+                        <Clock color="currentColor" size={16} />
+                      </Box>
+                      <Typography color="text.secondary" sx={{ opacity: 0.75 }} variant="body2">
+                        <FormattedMessage {...messages.created} />
+                      </Typography>
+                      <Typography variant="body2">{relativeTime(api.createdAt)}</Typography>
+                      <Typography color="text.secondary" sx={{ opacity: 0.75 }} variant="body2">
+                        <FormattedMessage {...messages.by} />
+                      </Typography>
+                      <Typography variant="body2">{api.createdBy || '—'}</Typography>
+                    </Stack>
+                  </Tooltip>
                 )}
+                <Stack alignItems="center" direction="row" spacing={1}>
+                  <Typography
+                    color="text.secondary"
+                    sx={{ fontWeight: 400, opacity: 0.75 }}
+                    variant="body2"
+                  >
+                    <FormattedMessage {...messages.context} />:
+                  </Typography>
+                  <Typography noWrap variant="body2">
+                    {context}
+                  </Typography>
+                  <Tooltip title={intl.formatMessage(messages.copyContext)}>
+                    <IconButton
+                      aria-label={intl.formatMessage(messages.copyContext)}
+                      onClick={() => void navigator.clipboard?.writeText(context)}
+                      size="small"
+                    >
+                      <Copy size={16} />
+                    </IconButton>
+                  </Tooltip>
+                </Stack>
               </Stack>
             </Stack>
           </Box>
 
-          <Button component={RouterLink} sx={{ flexShrink: 0 }} to={deployPath} variant="contained">
-            <FormattedMessage {...messages.deployToGateway} />
-          </Button>
+          <Stack
+            alignItems="center"
+            direction="row"
+            spacing={1.5}
+            sx={{ alignSelf: { sm: 'flex-start', xs: 'stretch' }, flexShrink: 0 }}
+          >
+            {!api.readOnly && (
+              <Tooltip title={intl.formatMessage(messages.editApi)}>
+                <IconButton
+                  aria-label={intl.formatMessage(messages.editApi)}
+                  component={RouterLink}
+                  sx={{
+                    border: '1px solid',
+                    borderColor: 'divider',
+                    height: 52,
+                    width: 52,
+                  }}
+                  to={editPath}
+                >
+                  <Edit size={22} />
+                </IconButton>
+              </Tooltip>
+            )}
+            <Button
+              component={RouterLink}
+              startIcon={<Rocket size={18} />}
+              sx={{ flexShrink: 0 }}
+              to={deployPath}
+              variant="contained"
+            >
+              <FormattedMessage {...messages.deployToGateway} />
+            </Button>
+          </Stack>
         </Box>
+        <ProgressBanner api={api} deployed={deployedGateways.length > 0} />
       </Card>
 
-      <OverviewTab api={api} />
+      <OverviewTab
+        api={api}
+        deployedGateways={deployedGateways}
+        deployments={deploymentsQuery.data?.list ?? []}
+      />
     </>
   );
 }

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/ApiDetailPage.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/ApiDetailPage.tsx
@@ -48,7 +48,7 @@ import { ProgressBanner } from './ProgressBanner';
 const messages = defineMessages({
   context: {
     id: 'apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.context.label',
-    defaultMessage: 'Context',
+    defaultMessage: 'Context:',
     description: 'Label for the API base path shown in the API detail header, e.g. "/orders".',
   },
   copyContext: {
@@ -60,6 +60,10 @@ const messages = defineMessages({
     id: 'apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.created.label',
     defaultMessage: 'Created',
     description: 'Label before the API creation time in the API detail header.',
+  },
+  unknownCreator: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.unknownCreator',
+    defaultMessage: '—',
   },
   by: {
     id: 'apiControlPlane.pages.appShell.appShellPages.apis.ApiDetailPage.by.label',
@@ -292,7 +296,9 @@ export function ApiDetailPage() {
                       <Typography color="text.secondary" sx={{ opacity: 0.75 }} variant="body2">
                         <FormattedMessage {...messages.by} />
                       </Typography>
-                      <Typography variant="body2">{api.createdBy || '—'}</Typography>
+                      <Typography variant="body2">
+                        {api.createdBy || intl.formatMessage(messages.unknownCreator)}
+                      </Typography>
                     </Stack>
                   </Tooltip>
                 )}
@@ -302,7 +308,7 @@ export function ApiDetailPage() {
                     sx={{ fontWeight: 400, opacity: 0.75 }}
                     variant="body2"
                   >
-                    <FormattedMessage {...messages.context} />:
+                    <FormattedMessage {...messages.context} />
                   </Typography>
                   <Typography noWrap variant="body2">
                     {context}

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/ApiKeysPanel.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/ApiKeysPanel.tsx
@@ -25,20 +25,21 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
+  Drawer,
   FormControl,
   FormLabel,
   IconButton,
-  ListingTable,
   Stack,
   TextField,
   Tooltip,
   Typography,
 } from '@wso2/oxygen-ui';
-import { Trash2 } from '@wso2/oxygen-ui-icons-react';
+import { ChevronLeft, Clock, Plus, Trash2 } from '@wso2/oxygen-ui-icons-react';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 
 import { useCreateApiKey, useMyApiKeys, useRevokeApiKey } from '@/api/resources/apiKeys';
 import { useNotifications } from '@/components/Notifications';
+import { useFormatters } from '@/i18n/useFormatters';
 
 const messages = defineMessages({
   add: {
@@ -171,12 +172,6 @@ const API_KEY_PAGE_SIZE = 100;
  * definition so the table and the date formatter can't drift apart. */
 const EMPTY_VALUE = '-';
 
-const formatDate = (value?: string): string => {
-  if (!value) return EMPTY_VALUE;
-  const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? EMPTY_VALUE : date.toLocaleDateString();
-};
-
 /** The key the revoke dialog is armed for: its id addresses the request, its
  * name is what the dialog and the toast show. */
 type RevokeTarget = { id: string; displayName: string };
@@ -188,6 +183,7 @@ type RevokeTarget = { id: string; displayName: string };
  */
 export function ApiKeysPanel({ restApiId }: { restApiId: string }) {
   const intl = useIntl();
+  const { dateTime, relativeTime } = useFormatters();
   const { notify } = useNotifications();
   // The spec has no per-API key listing — the only read is the caller's own
   // inventory across artifacts, so this narrows to REST API keys server-side
@@ -201,12 +197,16 @@ export function ApiKeysPanel({ restApiId }: { restApiId: string }) {
   const revokeMutation = useRevokeApiKey();
 
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [drawerOpen, setDrawerOpen] = useState(false);
   const [displayName, setDisplayName] = useState('');
   const [keyValue, setKeyValue] = useState('');
   const [revokeTarget, setRevokeTarget] = useState<RevokeTarget | null>(null);
 
   const keys = useMemo(
-    () => (keysQuery.data?.list ?? []).filter((key) => key.artifactId === restApiId),
+    () =>
+      (keysQuery.data?.list ?? [])
+        .filter((key) => key.artifactId === restApiId && key.status === 'active')
+        .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()),
     [keysQuery.data, restApiId],
   );
 
@@ -251,32 +251,27 @@ export function ApiKeysPanel({ restApiId }: { restApiId: string }) {
   };
 
   const canSubmit = Boolean(displayName.trim() && keyValue.trim()) && !createMutation.isPending;
+  const recentKeys = keys.slice(0, 5);
 
   return (
     <Box>
-      <Typography sx={{ fontWeight: 600, mb: 1.5 }} variant="h6">
-        <FormattedMessage {...messages.title} />
-      </Typography>
-      <Stack spacing={2}>
-        <Stack
-          alignItems={{ sm: 'center', xs: 'flex-start' }}
-          direction={{ sm: 'row', xs: 'column' }}
-          spacing={2}
-          sx={{
-            bgcolor: 'background.paper',
-            border: '1px solid',
-            borderColor: 'divider',
-            borderRadius: 1,
-            p: 2,
-          }}
-        >
+      <Stack spacing={1.5}>
+        <Stack alignItems="center" direction="row" justifyContent="space-between" spacing={1}>
           <Box sx={{ flex: 1 }}>
-            <Typography color="text.secondary" variant="body2">
+            <Typography sx={{ fontWeight: 600 }} variant="h6">
+              <FormattedMessage {...messages.title} />
+            </Typography>
+            <Typography color="text.secondary" sx={{ lineHeight: 1.25 }} variant="caption">
               <FormattedMessage {...messages.description} />
             </Typography>
           </Box>
-          <Button onClick={() => setDialogOpen(true)} size="medium" variant="contained">
-            <FormattedMessage {...messages.addButton} />
+          <Button
+            onClick={() => setDialogOpen(true)}
+            size="small"
+            startIcon={<Plus size={16} />}
+            variant="outlined"
+          >
+            <FormattedMessage {...messages.add} />
           </Button>
         </Stack>
 
@@ -285,61 +280,148 @@ export function ApiKeysPanel({ restApiId }: { restApiId: string }) {
             <CircularProgress />
           </Box>
         ) : keys.length > 0 ? (
-          <ListingTable.Container>
-            <ListingTable>
-              <ListingTable.Head>
-                <ListingTable.Row>
-                  <ListingTable.Cell>
-                    <FormattedMessage {...messages.columnName} />
-                  </ListingTable.Cell>
-                  <ListingTable.Cell>
-                    <FormattedMessage {...messages.columnKey} />
-                  </ListingTable.Cell>
-                  <ListingTable.Cell>
-                    <FormattedMessage {...messages.columnExpiresAt} />
-                  </ListingTable.Cell>
-                  <ListingTable.Cell align="right">
-                    <FormattedMessage {...messages.columnActions} />
-                  </ListingTable.Cell>
-                </ListingTable.Row>
-              </ListingTable.Head>
-              <ListingTable.Body>
-                {keys.map((key) => (
-                  <ListingTable.Row key={key.id ?? key.displayName}>
-                    <ListingTable.Cell>{key.displayName || EMPTY_VALUE}</ListingTable.Cell>
-                    <ListingTable.Cell>{key.maskedApiKey || EMPTY_VALUE}</ListingTable.Cell>
-                    <ListingTable.Cell>
-                      <Tooltip title={key.expiresAt ? new Date(key.expiresAt).toUTCString() : ''}>
-                        <span>{formatDate(key.expiresAt)}</span>
-                      </Tooltip>
-                    </ListingTable.Cell>
-                    <ListingTable.Cell align="right">
-                      <Tooltip title={intl.formatMessage(messages.revokeTooltip)}>
-                        <span>
-                          <IconButton
-                            color="error"
-                            disabled={revokeMutation.isPending || !key.id}
-                            onClick={() =>
-                              key.id &&
-                              setRevokeTarget({
-                                id: key.id,
-                                displayName: key.displayName,
-                              })
-                            }
-                            size="small"
-                          >
-                            <Trash2 size={16} />
-                          </IconButton>
-                        </span>
-                      </Tooltip>
-                    </ListingTable.Cell>
-                  </ListingTable.Row>
-                ))}
-              </ListingTable.Body>
-            </ListingTable>
-          </ListingTable.Container>
+          <Stack spacing={1}>
+            {recentKeys.map((key) => (
+              <Stack
+                alignItems="center"
+                direction="row"
+                key={key.id ?? key.displayName}
+                spacing={1}
+                sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1, p: 1.25 }}
+              >
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Typography noWrap sx={{ fontWeight: 600 }} variant="body2">
+                    {key.displayName || EMPTY_VALUE}
+                  </Typography>
+                  <Stack alignItems="center" direction="row" spacing={0.5}>
+                    <Typography color="text.secondary" noWrap variant="caption">
+                      {key.maskedApiKey || EMPTY_VALUE}
+                    </Typography>
+                    <Typography color="text.secondary" variant="caption">
+                      ·
+                    </Typography>
+                    <Tooltip title={dateTime(key.createdAt)}>
+                      <Stack alignItems="center" direction="row" spacing={0.5} sx={{ minWidth: 0 }}>
+                        <Clock color="currentColor" size={13} />
+                        <Typography color="text.secondary" noWrap variant="caption">
+                          Created
+                        </Typography>
+                        <Typography noWrap variant="caption">
+                          {relativeTime(key.createdAt)}
+                        </Typography>
+                        <Typography color="text.secondary" variant="caption">
+                          by
+                        </Typography>
+                        <Typography noWrap variant="caption">
+                          {key.createdBy || '—'}
+                        </Typography>
+                      </Stack>
+                    </Tooltip>
+                  </Stack>
+                </Box>
+                <Tooltip title={intl.formatMessage(messages.revokeTooltip)}>
+                  <span>
+                    <IconButton
+                      disabled={revokeMutation.isPending || !key.id}
+                      onClick={() =>
+                        key.id && setRevokeTarget({ id: key.id, displayName: key.displayName })
+                      }
+                      size="small"
+                    >
+                      <Trash2 size={16} />
+                    </IconButton>
+                  </span>
+                </Tooltip>
+              </Stack>
+            ))}
+            {keys.length > 5 && (
+              <Box sx={{ textAlign: 'center' }}>
+                <Button onClick={() => setDrawerOpen(true)} size="small" variant="text">
+                  See more
+                </Button>
+              </Box>
+            )}
+          </Stack>
         ) : null}
       </Stack>
+
+      <Drawer
+        anchor="right"
+        onClose={() => setDrawerOpen(false)}
+        open={drawerOpen}
+        sx={{ '& .MuiDrawer-paper': { width: { md: 560, xs: '100%' } } }}
+      >
+        <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+          <Stack
+            alignItems="center"
+            direction="row"
+            spacing={1}
+            sx={{ borderBottom: '1px solid', borderColor: 'divider', p: 2 }}
+          >
+            <IconButton
+              aria-label="Close API keys"
+              onClick={() => setDrawerOpen(false)}
+              size="small"
+            >
+              <ChevronLeft size={20} />
+            </IconButton>
+            <Typography sx={{ fontWeight: 600 }} variant="h6">
+              API keys
+            </Typography>
+          </Stack>
+          <Stack spacing={1} sx={{ flex: 1, overflowY: 'auto', p: 2 }}>
+            {keys.map((key) => (
+              <Stack
+                alignItems="center"
+                direction="row"
+                key={key.id ?? key.displayName}
+                spacing={1}
+                sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1, p: 1.25 }}
+              >
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Typography noWrap sx={{ fontWeight: 600 }} variant="body2">
+                    {key.displayName || EMPTY_VALUE}
+                  </Typography>
+                  <Stack alignItems="center" direction="row" spacing={0.5}>
+                    <Typography color="text.secondary" noWrap variant="caption">
+                      {key.maskedApiKey || EMPTY_VALUE}
+                    </Typography>
+                    <Typography color="text.secondary" variant="caption">
+                      ·
+                    </Typography>
+                    <Clock color="currentColor" size={13} />
+                    <Typography color="text.secondary" noWrap variant="caption">
+                      Created
+                    </Typography>
+                    <Typography noWrap variant="caption">
+                      {relativeTime(key.createdAt)}
+                    </Typography>
+                    <Typography color="text.secondary" variant="caption">
+                      by
+                    </Typography>
+                    <Typography noWrap variant="caption">
+                      {key.createdBy || '—'}
+                    </Typography>
+                  </Stack>
+                </Box>
+                <Tooltip title={intl.formatMessage(messages.revokeTooltip)}>
+                  <span>
+                    <IconButton
+                      disabled={revokeMutation.isPending || !key.id}
+                      onClick={() =>
+                        key.id && setRevokeTarget({ id: key.id, displayName: key.displayName })
+                      }
+                      size="small"
+                    >
+                      <Trash2 size={16} />
+                    </IconButton>
+                  </span>
+                </Tooltip>
+              </Stack>
+            ))}
+          </Stack>
+        </Box>
+      </Drawer>
 
       {/* Add key dialog */}
       <Dialog fullWidth maxWidth="sm" onClose={closeDialog} open={dialogOpen}>

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/ApiKeysPanel.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/ApiKeysPanel.tsx
@@ -102,6 +102,23 @@ const messages = defineMessages({
     defaultMessage: 'Add an API key to authenticate requests through the deployed gateways.',
     description: 'Explains what an API key is for, above the button that adds one.',
   },
+  createdMetadata: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.overview.ApiKeysPanel.createdMetadata',
+    defaultMessage: 'Created {time} by {creator}',
+    description: 'Creation time and creator shown beside an API key.',
+  },
+  closeDrawer: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.overview.ApiKeysPanel.closeDrawer',
+    defaultMessage: 'Close API keys',
+  },
+  seeMore: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.overview.ApiKeysPanel.seeMore',
+    defaultMessage: 'See more',
+  },
+  separator: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.overview.ApiKeysPanel.separator',
+    defaultMessage: '·',
+  },
   keyNameLabel: {
     id: 'apiControlPlane.pages.appShell.appShellPages.apis.overview.ApiKeysPanel.keyNameLabel',
     defaultMessage: 'Key Name',
@@ -298,22 +315,19 @@ export function ApiKeysPanel({ restApiId }: { restApiId: string }) {
                       {key.maskedApiKey || EMPTY_VALUE}
                     </Typography>
                     <Typography color="text.secondary" variant="caption">
-                      ·
+                      <FormattedMessage {...messages.separator} />
                     </Typography>
                     <Tooltip title={dateTime(key.createdAt)}>
                       <Stack alignItems="center" direction="row" spacing={0.5} sx={{ minWidth: 0 }}>
                         <Clock color="currentColor" size={13} />
                         <Typography color="text.secondary" noWrap variant="caption">
-                          Created
-                        </Typography>
-                        <Typography noWrap variant="caption">
-                          {relativeTime(key.createdAt)}
-                        </Typography>
-                        <Typography color="text.secondary" variant="caption">
-                          by
-                        </Typography>
-                        <Typography noWrap variant="caption">
-                          {key.createdBy || '—'}
+                          <FormattedMessage
+                            {...messages.createdMetadata}
+                            values={{
+                              creator: key.createdBy || '—',
+                              time: relativeTime(key.createdAt),
+                            }}
+                          />
                         </Typography>
                       </Stack>
                     </Tooltip>
@@ -337,7 +351,7 @@ export function ApiKeysPanel({ restApiId }: { restApiId: string }) {
             {keys.length > 5 && (
               <Box sx={{ textAlign: 'center' }}>
                 <Button onClick={() => setDrawerOpen(true)} size="small" variant="text">
-                  See more
+                  <FormattedMessage {...messages.seeMore} />
                 </Button>
               </Box>
             )}
@@ -359,14 +373,14 @@ export function ApiKeysPanel({ restApiId }: { restApiId: string }) {
             sx={{ borderBottom: '1px solid', borderColor: 'divider', p: 2 }}
           >
             <IconButton
-              aria-label="Close API keys"
+              aria-label={intl.formatMessage(messages.closeDrawer)}
               onClick={() => setDrawerOpen(false)}
               size="small"
             >
               <ChevronLeft size={20} />
             </IconButton>
             <Typography sx={{ fontWeight: 600 }} variant="h6">
-              API keys
+              <FormattedMessage {...messages.title} />
             </Typography>
           </Stack>
           <Stack spacing={1} sx={{ flex: 1, overflowY: 'auto', p: 2 }}>
@@ -387,20 +401,17 @@ export function ApiKeysPanel({ restApiId }: { restApiId: string }) {
                       {key.maskedApiKey || EMPTY_VALUE}
                     </Typography>
                     <Typography color="text.secondary" variant="caption">
-                      ·
+                      <FormattedMessage {...messages.separator} />
                     </Typography>
                     <Clock color="currentColor" size={13} />
                     <Typography color="text.secondary" noWrap variant="caption">
-                      Created
-                    </Typography>
-                    <Typography noWrap variant="caption">
-                      {relativeTime(key.createdAt)}
-                    </Typography>
-                    <Typography color="text.secondary" variant="caption">
-                      by
-                    </Typography>
-                    <Typography noWrap variant="caption">
-                      {key.createdBy || '—'}
+                      <FormattedMessage
+                        {...messages.createdMetadata}
+                        values={{
+                          creator: key.createdBy || '—',
+                          time: relativeTime(key.createdAt),
+                        }}
+                      />
                     </Typography>
                   </Stack>
                 </Box>

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/DeployedGatewaysPanel.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/DeployedGatewaysPanel.tsx
@@ -5,6 +5,7 @@
 
 import { Box, Button, Card, Divider, Stack, Typography } from '@wso2/oxygen-ui';
 import { Server } from '@wso2/oxygen-ui-icons-react';
+import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import { Link as RouterLink, useParams } from 'react-router-dom';
 
 import type { Gateway } from '@/api/resources/gateways';
@@ -13,11 +14,35 @@ import { routes } from '@/routes/paths';
 
 type Props = { gateways: Gateway[]; deployments: Deployment[] };
 
+const messages = defineMessages({
+  title: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.overview.DeployedGatewaysPanel.title',
+    defaultMessage: 'Deployed gateways',
+  },
+  seeMore: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.overview.DeployedGatewaysPanel.seeMore',
+    defaultMessage: 'See more',
+  },
+  status: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.overview.DeployedGatewaysPanel.status',
+    defaultMessage:
+      '{status, select, DEPLOYED {Deployed} UNDEPLOYED {Undeployed} DEPLOYING {Deploying} UNDEPLOYING {Undeploying} FAILED {Failed} ARCHIVED {Archived} other {{status}}}',
+  },
+});
+
 export function DeployedGatewaysPanel({ gateways, deployments }: Props) {
   const { orgHandle = '', projectHandler = '', apiHandler = '' } = useParams();
-  const latestDeployments = [...deployments]
+  const intl = useIntl();
+  const latestByGateway = new Map<string, Deployment>();
+  [...deployments]
     .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
-    .slice(0, 5);
+    .forEach((deployment) => {
+      if (!latestByGateway.has(deployment.gatewayId)) {
+        latestByGateway.set(deployment.gatewayId, deployment);
+      }
+    });
+  const gatewayDeployments = [...latestByGateway.values()];
+  const latestDeployments = gatewayDeployments.slice(0, 5);
   const rows =
     latestDeployments.length > 0
       ? latestDeployments.map((deployment) => ({
@@ -37,7 +62,7 @@ export function DeployedGatewaysPanel({ gateways, deployments }: Props) {
     <Card>
       <Box sx={{ px: 2, py: 1.5 }}>
         <Typography sx={{ fontWeight: 600 }} variant="h6">
-          Deployed gateways
+          <FormattedMessage {...messages.title} />
         </Typography>
       </Box>
       <Divider />
@@ -81,21 +106,21 @@ export function DeployedGatewaysPanel({ gateways, deployments }: Props) {
                   }}
                 />
                 <Typography color={successful ? 'success.main' : 'warning.main'} variant="caption">
-                  {status}
+                  {intl.formatMessage(messages.status, { status })}
                 </Typography>
               </Stack>
             </Stack>
           );
         })}
       </Stack>
-      {deployments.length > 5 && (
+      {gatewayDeployments.length > 5 && (
         <Box sx={{ borderTop: '1px solid', borderColor: 'divider', p: 1, textAlign: 'center' }}>
           <Button
             component={RouterLink}
             size="small"
             to={routes.apiDeploy(orgHandle, projectHandler, apiHandler)}
           >
-            See more
+            <FormattedMessage {...messages.seeMore} />
           </Button>
         </Box>
       )}

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/DeployedGatewaysPanel.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/DeployedGatewaysPanel.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ * Licensed under the Apache License, Version 2.0.
+ */
+
+import { Box, Button, Card, Divider, Stack, Typography } from '@wso2/oxygen-ui';
+import { Server } from '@wso2/oxygen-ui-icons-react';
+import { Link as RouterLink, useParams } from 'react-router-dom';
+
+import type { Gateway } from '@/api/resources/gateways';
+import type { Deployment } from '@/api/resources/restApis/deployments';
+import { routes } from '@/routes/paths';
+
+type Props = { gateways: Gateway[]; deployments: Deployment[] };
+
+export function DeployedGatewaysPanel({ gateways, deployments }: Props) {
+  const { orgHandle = '', projectHandler = '', apiHandler = '' } = useParams();
+  const latestDeployments = [...deployments]
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+    .slice(0, 5);
+  const rows =
+    latestDeployments.length > 0
+      ? latestDeployments.map((deployment) => ({
+          gateway: gateways.find((gateway) => gateway.id === deployment.gatewayId),
+          gatewayId: deployment.gatewayId,
+          id: deployment.deploymentId,
+          status: deployment.status,
+        }))
+      : gateways.map((gateway) => ({
+          gateway,
+          gatewayId: gateway.id ?? gateway.displayName,
+          id: gateway.id ?? gateway.displayName,
+          status: 'DEPLOYED',
+        }));
+
+  return (
+    <Card>
+      <Box sx={{ px: 2, py: 1.5 }}>
+        <Typography sx={{ fontWeight: 600 }} variant="h6">
+          Deployed gateways
+        </Typography>
+      </Box>
+      <Divider />
+      <Stack divider={<Divider />}>
+        {rows.map(({ gateway, gatewayId, id, status }) => {
+          const successful = status === 'DEPLOYED';
+          return (
+            <Stack
+              alignItems="center"
+              direction="row"
+              key={id}
+              spacing={1.25}
+              sx={{ px: 2, py: 1.5 }}
+            >
+              <Box
+                sx={{
+                  alignItems: 'center',
+                  bgcolor: 'action.hover',
+                  borderRadius: 1,
+                  color: 'primary.main',
+                  display: 'flex',
+                  height: 32,
+                  justifyContent: 'center',
+                  width: 32,
+                }}
+              >
+                <Server size={17} />
+              </Box>
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                <Typography noWrap variant="body2">
+                  {gateway?.displayName || gatewayId}
+                </Typography>
+              </Box>
+              <Stack alignItems="center" direction="row" spacing={0.5}>
+                <Box
+                  sx={{
+                    bgcolor: successful ? 'success.main' : 'warning.main',
+                    borderRadius: '50%',
+                    height: 7,
+                    width: 7,
+                  }}
+                />
+                <Typography color={successful ? 'success.main' : 'warning.main'} variant="caption">
+                  {status}
+                </Typography>
+              </Stack>
+            </Stack>
+          );
+        })}
+      </Stack>
+      {deployments.length > 5 && (
+        <Box sx={{ borderTop: '1px solid', borderColor: 'divider', p: 1, textAlign: 'center' }}>
+          <Button
+            component={RouterLink}
+            size="small"
+            to={routes.apiDeploy(orgHandle, projectHandler, apiHandler)}
+          >
+            See more
+          </Button>
+        </Box>
+      )}
+    </Card>
+  );
+}

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/DocumentsPanel.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/DocumentsPanel.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ * Licensed under the Apache License, Version 2.0.
+ */
+
+import { Box, Card, Chip, Divider, Stack, Typography } from '@wso2/oxygen-ui';
+import { FileText } from '@wso2/oxygen-ui-icons-react';
+
+import documents from './mockDocuments.json';
+
+export function DocumentsPanel() {
+  return (
+    <Card>
+      <Box sx={{ px: 2, py: 1.5 }}>
+        <Typography sx={{ fontWeight: 600 }} variant="h6">
+          Documents
+        </Typography>
+        <Typography color="text.secondary" variant="caption">
+          Guides, references, and specifications published with this API.
+        </Typography>
+      </Box>
+      <Divider />
+      <Stack divider={<Divider />}>
+        {documents.map((document) => (
+          <Stack
+            alignItems="center"
+            direction="row"
+            key={document.id}
+            spacing={1.5}
+            sx={{ px: 2, py: 1.25 }}
+          >
+            <FileText color="currentColor" size={16} />
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <Typography noWrap variant="body2">
+                {document.title}
+              </Typography>
+              <Typography color="text.secondary" noWrap variant="caption">
+                {document.description}
+              </Typography>
+            </Box>
+            <Chip label={document.type} size="small" sx={{ typography: 'caption' }} />
+            <Typography
+              color="text.secondary"
+              sx={{ display: { sm: 'block', xs: 'none' } }}
+              variant="caption"
+            >
+              2 days ago
+            </Typography>
+          </Stack>
+        ))}
+      </Stack>
+    </Card>
+  );
+}

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/DocumentsPanel.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/DocumentsPanel.tsx
@@ -5,18 +5,35 @@
 
 import { Box, Card, Chip, Divider, Stack, Typography } from '@wso2/oxygen-ui';
 import { FileText } from '@wso2/oxygen-ui-icons-react';
+import { defineMessages, FormattedMessage } from 'react-intl';
 
 import documents from './mockDocuments.json';
+
+const messages = defineMessages({
+  title: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.overview.DocumentsPanel.title',
+    defaultMessage: 'Documents',
+  },
+  description: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.overview.DocumentsPanel.description',
+    defaultMessage: 'Guides, references, and specifications published with this API.',
+  },
+  updated: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.overview.DocumentsPanel.updated',
+    defaultMessage: '2 days ago',
+    description: 'Temporary relative update time for demo document data.',
+  },
+});
 
 export function DocumentsPanel() {
   return (
     <Card>
       <Box sx={{ px: 2, py: 1.5 }}>
         <Typography sx={{ fontWeight: 600 }} variant="h6">
-          Documents
+          <FormattedMessage {...messages.title} />
         </Typography>
         <Typography color="text.secondary" variant="caption">
-          Guides, references, and specifications published with this API.
+          <FormattedMessage {...messages.description} />
         </Typography>
       </Box>
       <Divider />
@@ -44,7 +61,7 @@ export function DocumentsPanel() {
               sx={{ display: { sm: 'block', xs: 'none' } }}
               variant="caption"
             >
-              2 days ago
+              <FormattedMessage {...messages.updated} />
             </Typography>
           </Stack>
         ))}

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/InvokeUrlPanel.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/InvokeUrlPanel.tsx
@@ -36,7 +36,7 @@ import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import type { Gateway } from '@/api/resources/gateways';
 import { useNotifications } from '@/components/Notifications';
 import { gatewayEndpoint } from '../../gateways/utils/gatewayDisplay';
-import { environmentForGateway } from '../../gateways/utils/gatewayEnvironments';
+import { MOCK_ENVIRONMENTS } from '../../gateways/utils/gatewayEnvironments';
 
 const messages = defineMessages({
   copy: {
@@ -97,6 +97,15 @@ type InvokeUrlPanelProps = {
   context?: string;
 };
 
+const recordedEnvironmentName = (gateway: Gateway): string | undefined =>
+  MOCK_ENVIRONMENTS.find((environment) => environment.id === gateway.properties?.environment)?.name;
+
+const gatewayOptionLabel = (gateway: Gateway): string => {
+  const name = gateway.displayName || gateway.id || '';
+  const environment = recordedEnvironmentName(gateway);
+  return environment ? `${name} — ${environment}` : name;
+};
+
 /**
  * Invoke URL section of the Overview tab (ai-workspace): pick a deployed
  * gateway, get the gateway-specific invoke URL with a copy affordance.
@@ -137,13 +146,14 @@ export function InvokeUrlPanel({ gateways, context }: InvokeUrlPanelProps) {
           <FormControl fullWidth>
             <Select
               disabled={gateways.length === 0}
+              inputProps={{ 'aria-label': intl.formatMessage(messages.gatewaysLabel) }}
               onChange={(event) => setSelectedGatewayId(String(event.target.value))}
               size="small"
               value={selectedGateway?.id || ''}
             >
               {gateways.map((gateway) => (
                 <MenuItem key={gateway.id} value={gateway.id ?? ''}>
-                  {gateway.displayName || gateway.id} — {environmentForGateway(gateway).name}
+                  {gatewayOptionLabel(gateway)}
                 </MenuItem>
               ))}
             </Select>
@@ -155,6 +165,9 @@ export function InvokeUrlPanel({ gateways, context }: InvokeUrlPanelProps) {
               fullWidth
               size="small"
               slotProps={{
+                htmlInput: {
+                  'aria-label': intl.formatMessage(messages.urlLabel),
+                },
                 input: {
                   readOnly: true,
                   endAdornment: (

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/InvokeUrlPanel.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/InvokeUrlPanel.tsx
@@ -20,7 +20,6 @@ import { useState } from 'react';
 import {
   Box,
   FormControl,
-  FormLabel,
   Grid,
   IconButton,
   InputAdornment,
@@ -37,6 +36,7 @@ import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import type { Gateway } from '@/api/resources/gateways';
 import { useNotifications } from '@/components/Notifications';
 import { gatewayEndpoint } from '../../gateways/utils/gatewayDisplay';
+import { environmentForGateway } from '../../gateways/utils/gatewayEnvironments';
 
 const messages = defineMessages({
   copy: {
@@ -57,15 +57,14 @@ const messages = defineMessages({
   },
   description: {
     id: 'apiControlPlane.pages.appShell.appShellPages.apis.overview.InvokeUrlPanel.description',
-    defaultMessage: 'Change the gateway to generate the gateway specific invoke URL.',
+    defaultMessage: 'Pick a gateway to get its invoke URL.',
     description:
       'Explains that the URL below is per-gateway, so picking another gateway rewrites it.',
   },
   gatewaysLabel: {
     id: 'apiControlPlane.pages.appShell.appShellPages.apis.overview.InvokeUrlPanel.gatewaysLabel',
     defaultMessage: 'Gateways',
-    description:
-      'Label of the picker choosing which deployed gateway the invoke URL is built for.',
+    description: 'Label of the picker choosing which deployed gateway the invoke URL is built for.',
   },
   title: {
     id: 'apiControlPlane.pages.appShell.appShellPages.apis.overview.InvokeUrlPanel.title',
@@ -133,12 +132,9 @@ export function InvokeUrlPanel({ gateways, context }: InvokeUrlPanelProps) {
           <FormattedMessage {...messages.description} />
         </Typography>
       </Box>
-      <Grid alignItems="flex-end" container spacing={1}>
-        <Grid size={{ md: 4, xs: 12 }}>
+      <Grid container spacing={1}>
+        <Grid size={12}>
           <FormControl fullWidth>
-            <FormLabel>
-              <FormattedMessage {...messages.gatewaysLabel} />
-            </FormLabel>
             <Select
               disabled={gateways.length === 0}
               onChange={(event) => setSelectedGatewayId(String(event.target.value))}
@@ -147,17 +143,14 @@ export function InvokeUrlPanel({ gateways, context }: InvokeUrlPanelProps) {
             >
               {gateways.map((gateway) => (
                 <MenuItem key={gateway.id} value={gateway.id ?? ''}>
-                  {gateway.displayName || gateway.id}
+                  {gateway.displayName || gateway.id} — {environmentForGateway(gateway).name}
                 </MenuItem>
               ))}
             </Select>
           </FormControl>
         </Grid>
-        <Grid size={{ md: 8, xs: 12 }}>
+        <Grid size={12}>
           <FormControl fullWidth>
-            <FormLabel>
-              <FormattedMessage {...messages.urlLabel} />
-            </FormLabel>
             <TextField
               fullWidth
               size="small"

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/OverviewTab.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/OverviewTab.tsx
@@ -16,15 +16,15 @@
  * under the License.
  */
 
-import { useMemo } from 'react';
-import { Box, Divider, Stack } from '@wso2/oxygen-ui';
+import { Box, Card, Grid, Stack } from '@wso2/oxygen-ui';
 
-import { useGateways, type Gateway } from '@/api/resources/gateways';
+import type { Gateway } from '@/api/resources/gateways';
 import type { RestApi } from '@/api/resources/restApis';
-import { useDeployments } from '@/api/resources/restApis/deployments';
+import type { Deployment } from '@/api/resources/restApis/deployments';
 import { ApiKeysPanel } from './ApiKeysPanel';
+import { DeployedGatewaysPanel } from './DeployedGatewaysPanel';
+import { DocumentsPanel } from './DocumentsPanel';
 import { InvokeUrlPanel } from './InvokeUrlPanel';
-import { ProgressBanner } from './ProgressBanner';
 import { ResourcesPanel } from './ResourcesPanel';
 
 /**
@@ -32,66 +32,47 @@ import { ResourcesPanel } from './ResourcesPanel';
  * default 20-item page could hide the very gateway this API runs on. 100 is the
  * spec's ceiling on `limit`.
  */
-const GATEWAY_PAGE_LIMIT = 100;
-
 /**
  * Overview tab: resources on the left; invoke URL and
  * API keys on the right; the right column only appears once the API is
  * deployed on at least one gateway.
  */
-export function OverviewTab({ api }: { api: RestApi }) {
-  const gatewaysQuery = useGateways({ limit: GATEWAY_PAGE_LIMIT });
-  const deploymentsQuery = useDeployments(api.id);
-
-  // Gateways with an active deployment of this API, most recent first.
-  const deployedGateways = useMemo((): Gateway[] => {
-    const gateways = gatewaysQuery.data?.list ?? [];
-    const deployments = deploymentsQuery.data?.list ?? [];
-    const latestByGateway = new Map<string, number>();
-    deployments
-      .filter((deployment) => deployment.status === 'DEPLOYED')
-      .forEach((deployment) => {
-        const time = new Date(deployment.createdAt || 0).getTime();
-        const current = latestByGateway.get(deployment.gatewayId);
-        if (current === undefined || time > current) {
-          latestByGateway.set(deployment.gatewayId, time);
-        }
-      });
-    return gateways
-      .filter((gateway) => latestByGateway.has(gateway.id ?? ''))
-      .sort(
-        (a, b) => (latestByGateway.get(b.id ?? '') || 0) - (latestByGateway.get(a.id ?? '') || 0),
-      );
-  }, [gatewaysQuery.data, deploymentsQuery.data]);
+export function OverviewTab({
+  api,
+  deployedGateways,
+  deployments,
+}: {
+  api: RestApi;
+  deployedGateways: Gateway[];
+  deployments: Deployment[];
+}) {
+  const deployed = deployedGateways.length > 0;
 
   return (
-    <Stack spacing={3}>
-      <ProgressBanner api={api} deployed={deployedGateways.length > 0} />
-      <Stack direction={{ md: 'row', xs: 'column' }} spacing={2}>
-        <ResourcesPanel api={api} />
-        {deployedGateways.length > 0 && (
-          <>
-            <Divider
-              flexItem
-              orientation="vertical"
-              sx={{ display: { md: 'block', xs: 'none' } }}
-            />
-            <Box sx={{ flex: 1, minWidth: 0 }}>
+    <Grid container spacing={2}>
+      <Grid size={{ lg: deployed ? 8 : 12, xs: 12 }}>
+        <Stack spacing={2} marginTop={1}>
+          <ResourcesPanel api={api} />
+          <DocumentsPanel />
+        </Stack>
+      </Grid>
+      {deployed && (
+        <Grid size={{ lg: 4, xs: 12 }}>
+          <Stack spacing={2} marginTop={1}>
+            <Card sx={{ p: 2 }}>
               <Stack spacing={2}>
                 <InvokeUrlPanel context={api.context} gateways={deployedGateways} />
-                {/* Keys are an API-proxy affordance; `getApiCapabilities` draws
-                    the same line off `kind`. */}
                 {api.kind === 'RestApi' && (
-                  <>
-                    <Divider />
+                  <Box sx={{ borderTop: '1px solid', borderColor: 'divider', pt: 2 }}>
                     <ApiKeysPanel restApiId={api.id ?? ''} />
-                  </>
+                  </Box>
                 )}
               </Stack>
-            </Box>
-          </>
-        )}
-      </Stack>
-    </Stack>
+            </Card>
+            <DeployedGatewaysPanel deployments={deployments} gateways={deployedGateways} />
+          </Stack>
+        </Grid>
+      )}
+    </Grid>
   );
 }

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/ProgressBanner.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/ProgressBanner.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Box, ButtonBase, Card, LinearProgress, Stack, Typography } from '@wso2/oxygen-ui';
+import { Box, ButtonBase, Divider, Stack, Typography } from '@wso2/oxygen-ui';
 import {
   Check,
   FilePlus2,
@@ -36,7 +36,12 @@ const messages = defineMessages({
     id: 'apiControlPlane.pages.appShell.appShellPages.apis.overview.ProgressBanner.progress',
     defaultMessage: '{completed} of {total} completed',
     description:
-      'Counter beside the progress bar, e.g. "2 of 4 completed". Counts the steps of getting an API live, not APIs.',
+      'Counter beside the lifecycle steps, e.g. "2 of 4 completed". Counts the steps of getting an API live, not APIs.',
+  },
+  next: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.overview.ProgressBanner.next',
+    defaultMessage: 'Next: {step}',
+    description: 'The next incomplete lifecycle step shown beside the progress counter.',
   },
   stepCreate: {
     id: 'apiControlPlane.pages.appShell.appShellPages.apis.overview.ProgressBanner.step.create',
@@ -52,21 +57,15 @@ const messages = defineMessages({
   },
   stepPublish: {
     id: 'apiControlPlane.pages.appShell.appShellPages.apis.overview.ProgressBanner.step.publish',
-    defaultMessage: 'Publish to API Portal',
+    defaultMessage: 'Publish to Devportal',
     description:
-      'Fourth step of the API progress stepper — the API is listed in the developer portal, which ships under the name "API Portal".',
+      'Fourth step of the API progress stepper — the API is listed in the developer portal.',
   },
   stepTest: {
     id: 'apiControlPlane.pages.appShell.appShellPages.apis.overview.ProgressBanner.step.test',
     defaultMessage: 'Test',
     description:
       'Third step of the API progress stepper — the API has been called from the test console. A stage name, not a button command.',
-  },
-  title: {
-    id: 'apiControlPlane.pages.appShell.appShellPages.apis.overview.ProgressBanner.title',
-    defaultMessage: 'Track your progress here',
-    description:
-      'Heading of the banner that walks the user through creating, deploying, testing and publishing an API.',
   },
 });
 
@@ -138,7 +137,6 @@ export function ProgressBanner({ api, deployed }: { api: RestApi; deployed: bool
   ];
 
   const completedCount = steps.filter((step) => step.complete).length;
-  const percent = Math.round((completedCount / steps.length) * 100);
   // The first not-yet-complete step is the current, actionable one.
   const activeIndex = steps.findIndex((step) => !step.complete);
 
@@ -148,42 +146,63 @@ export function ProgressBanner({ api, deployed }: { api: RestApi; deployed: bool
   };
 
   return (
-    <Card
+    <Box
       sx={{
-        p: 2,
+        borderTop: '1px solid',
+        borderColor: 'divider',
+        px: { sm: 4, xs: 2 },
+        py: 2,
       }}
     >
-      <Stack alignItems="center" direction="row" justifyContent="space-between" sx={{ mb: 1 }}>
-        <Typography sx={{ fontWeight: 600 }} variant="h6">
-          <FormattedMessage {...messages.title} />
-        </Typography>
-        <Typography color="text.secondary" variant="caption">
-          <FormattedMessage
-            {...messages.progress}
-            values={{ completed: completedCount, total: steps.length }}
-          />
-        </Typography>
-      </Stack>
-      <LinearProgress
-        color={percent === 100 ? 'success' : 'primary'}
-        sx={{ borderRadius: 1, height: 6, mb: 2 }}
-        value={percent}
-        variant="determinate"
-      />
-      <Stack alignItems="center" direction="row" spacing={1} sx={{ flexWrap: 'wrap', rowGap: 1 }}>
-        {steps.map((step, index) => (
-          <Stack alignItems="center" direction="row" key={step.key} spacing={1}>
-            <StepPill state={stateOf(step, index)} step={step} />
-            {index < steps.length - 1 && (
-              <StepConnector
-                fromState={stateOf(step, index)}
-                toState={stateOf(steps[index + 1], index + 1)}
+      <Stack
+        alignItems="center"
+        direction={{ md: 'row', xs: 'column' }}
+        justifyContent="space-between"
+        spacing={2}
+      >
+        <Stack alignItems="center" direction="row" spacing={1} sx={{ flexWrap: 'wrap', rowGap: 1 }}>
+          {steps.map((step, index) => (
+            <Stack alignItems="center" direction="row" key={step.key} spacing={1}>
+              <StepPill state={stateOf(step, index)} step={step} />
+              {index < steps.length - 1 && (
+                <StepConnector
+                  fromState={stateOf(step, index)}
+                  toState={stateOf(steps[index + 1], index + 1)}
+                />
+              )}
+            </Stack>
+          ))}
+        </Stack>
+        <Stack
+          alignItems="center"
+          direction="row"
+          divider={<Divider flexItem orientation="vertical" />}
+          spacing={1.5}
+          sx={{ flexShrink: 0 }}
+        >
+          <Typography color="text.secondary" variant="body2">
+            <FormattedMessage
+              {...messages.progress}
+              values={{ completed: completedCount, total: steps.length }}
+            />
+          </Typography>
+          {activeIndex >= 0 && (
+            <Typography color="text.secondary" variant="body2">
+              <FormattedMessage
+                {...messages.next}
+                values={{
+                  step: (
+                    <Box component="span" sx={{ color: 'text.primary', fontWeight: 700 }}>
+                      {steps[activeIndex].label}
+                    </Box>
+                  ),
+                }}
               />
-            )}
-          </Stack>
-        ))}
+            </Typography>
+          )}
+        </Stack>
       </Stack>
-    </Card>
+    </Box>
   );
 }
 
@@ -220,13 +239,13 @@ function StepPill({ state, step }: { state: StepState; step: ProgressStep }) {
       onClick={onClick}
       sx={{
         border: '1px solid',
-        minWidth: 120,
+        minWidth: 0,
         justifyContent: 'flex-start',
         borderColor: complete ? 'success.main' : active ? 'primary.main' : 'divider',
         borderRadius: 5,
         gap: 1,
         opacity: upcoming ? 0.6 : 1,
-        px: 1,
+        px: 1.25,
         py: 0.75,
         transition: 'opacity 0.15s',
         '&:hover': onClick ? { opacity: 0.75 } : undefined,
@@ -244,12 +263,11 @@ function StepPill({ state, step }: { state: StepState; step: ProgressStep }) {
           width: 32,
         }}
       >
-        <Icon size={16} />
+        {complete ? <Check size={18} /> : <Icon size={16} />}
       </Box>
       <Typography sx={{ fontWeight: 600 }} variant="body2">
         {label}
       </Typography>
-      {complete && <Check color="var(--mui-palette-success-main)" size={16} />}
     </ButtonBase>
   );
 }

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/ResourcesPanel.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/ResourcesPanel.tsx
@@ -45,7 +45,7 @@ const messages = defineMessages({
   },
   count: {
     id: 'apiControlPlane.pages.appShell.appShellPages.apis.overview.ResourcesPanel.count',
-    defaultMessage: 'Showing {count} of {count} resources',
+    defaultMessage: 'Showing {count, plural, one {# resource} other {# resources}}',
     description: 'Number of API operations displayed in the resources panel.',
   },
 });

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/ResourcesPanel.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/ResourcesPanel.tsx
@@ -17,7 +17,7 @@
  */
 
 import { useMemo } from 'react';
-import { Box, Card, Typography } from '@wso2/oxygen-ui';
+import { Box, Card, Divider, Typography } from '@wso2/oxygen-ui';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 
 import type { RestApi } from '@/api/resources/restApis';
@@ -43,6 +43,11 @@ const messages = defineMessages({
     description:
       "Heading of the panel listing the API's operations (its OpenAPI paths). A noun, not a command.",
   },
+  count: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.overview.ResourcesPanel.count',
+    defaultMessage: 'Showing {count} of {count} resources',
+    description: 'Number of API operations displayed in the resources panel.',
+  },
 });
 
 /**
@@ -63,10 +68,7 @@ export function ResourcesPanel({ api }: { api: RestApi }) {
   const spec = useMemo(() => restApiToOpenApiSpec(api), [api]);
 
   return (
-    <Box sx={{ flex: 1, minWidth: 0 }}>
-      <Typography sx={{ fontWeight: 600, mb: 0.5 }} variant="h6">
-        <FormattedMessage {...messages.title} />
-      </Typography>
+    <Box sx={{ minWidth: 0 }}>
       {operations.length === 0 ? (
         // The placeholder brings its own bordered surface, so it stands in for
         // the scroll box rather than sitting inside it — a hairline drawn
@@ -79,33 +81,40 @@ export function ResourcesPanel({ api }: { api: RestApi }) {
       ) : (
         <Card
           sx={{
-            maxHeight: { md: 520, xs: 320 },
-            overflowY: 'auto',
-            px: 2,
-            py: 1,
             // Swagger UI ships its own canvas; keep it from fighting the
             // panel's surface.
             '& .swagger-ui': { bgcolor: 'transparent' },
           }}
         >
-          {/* Read-only, and stripped down to what a rebuilt document can
+          <Box sx={{ px: 2, py: 1.5 }}>
+            <Typography sx={{ fontWeight: 600 }} variant="h6">
+              <FormattedMessage {...messages.title} />
+            </Typography>
+            <Typography color="text.secondary" variant="caption">
+              <FormattedMessage {...messages.count} values={{ count: operations.length }} />
+            </Typography>
+          </Box>
+          <Divider />
+          <Box sx={{ maxHeight: { md: 720, xs: 420 }, overflowY: 'auto', px: 2, py: 1 }}>
+            {/* Read-only, and stripped down to what a rebuilt document can
               honestly show. The info block would repeat the page header; the
               servers/authorize strip and try-it-out belong to a console, which
               this panel is not; the responses section would be an empty table,
               because the platform kept no responses to put in it. Operations
               carry no tags either, so the lone "default" group header is
               hidden and the operations read as one flat list. */}
-          <SwaggerSpecViewer
-            disableResponseSection
-            disableTryOutBtn
-            displayRequestDuration={false}
-            enableResourceSearch
-            hideAuthorizeButton
-            hideInfoSection
-            hideServers
-            hideTagHeaders
-            spec={spec}
-          />
+            <SwaggerSpecViewer
+              disableResponseSection
+              disableTryOutBtn
+              displayRequestDuration={false}
+              enableResourceSearch
+              hideAuthorizeButton
+              hideInfoSection
+              hideServers
+              hideTagHeaders
+              spec={spec}
+            />
+          </Box>
         </Card>
       )}
     </Box>

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/mockDocuments.json
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/mockDocuments.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "getting-started",
+    "title": "Getting started",
+    "description": "Authenticate, make your first call, and read a response.",
+    "type": "How to"
+  },
+  {
+    "id": "authentication-guide",
+    "title": "Authentication guide",
+    "description": "OAuth2 scopes, API keys, and token lifetimes.",
+    "type": "How to"
+  },
+  {
+    "id": "api-reference",
+    "title": "API reference",
+    "description": "Resource paths, request formats, and response models.",
+    "type": "Reference"
+  }
+]

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/projects/components/ProjectStatistics.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/projects/components/ProjectStatistics.tsx
@@ -16,12 +16,16 @@
  * under the License.
  */
 
-import { Box, ButtonBase, Divider, Grid, Skeleton, Stack, Typography } from '@wso2/oxygen-ui';
-import { Braces, Boxes, Network, Radio } from '@wso2/oxygen-ui-icons-react';
 import type { ReactNode } from 'react';
+import { Box, ButtonBase, Divider, Grid, Skeleton, Stack, Typography } from '@wso2/oxygen-ui';
+import { Network } from '@wso2/oxygen-ui-icons-react';
 import { defineMessages, FormattedMessage, FormattedNumber, useIntl } from 'react-intl';
 
 import { useAllRestApis } from '@/api/resources/restApis';
+import grpcIcon from '@/assets/icons/gRPC.svg';
+import graphqlIcon from '@/assets/icons/graphql.svg';
+import restIcon from '@/assets/icons/rest.svg';
+import websocketIcon from '@/assets/icons/websocket.svg';
 import {
   matchesApiType,
   type ApiTypeFilter,
@@ -37,10 +41,7 @@ const messages = defineMessages({
     id: 'apiControlPlane.projects.ProjectStatistics.deployments',
     defaultMessage: 'Deployments',
   },
-  graphql: {
-    id: 'apiControlPlane.projects.ProjectStatistics.graphql',
-    defaultMessage: 'GraphQL',
-  },
+  graphql: { id: 'apiControlPlane.projects.ProjectStatistics.graphql', defaultMessage: 'GraphQL' },
   grpc: { id: 'apiControlPlane.projects.ProjectStatistics.grpc', defaultMessage: 'gRPC' },
   rest: { id: 'apiControlPlane.projects.ProjectStatistics.rest', defaultMessage: 'REST' },
   selectType: {
@@ -53,54 +54,77 @@ const messages = defineMessages({
   },
 });
 
-const ApiTypeMetric = ({
+function MetricCard({
   ariaLabel,
-  icon,
+  iconSrc,
   label,
   onClick,
-  selected,
+  selected = false,
   value,
 }: {
   ariaLabel: string;
-  icon: ReactNode;
+  iconSrc: string;
   label: ReactNode;
-  onClick: () => void;
-  selected: boolean;
+  onClick?: () => void;
+  selected?: boolean;
   value?: number;
-}) => (
-  <ButtonBase
-    aria-label={ariaLabel}
-    aria-pressed={selected}
-    onClick={onClick}
-    sx={{
-      '&:hover': { bgcolor: 'action.hover' },
-      bgcolor: selected ? 'action.selected' : 'transparent',
-      border: 1,
-      borderColor: selected ? 'primary.main' : 'transparent',
-      borderRadius: 1,
-      px: 1.5,
-      py: 1,
-      transition: 'background-color 150ms ease, border-color 150ms ease',
-      width: '100%',
-    }}
-  >
-    <Stack alignItems="center" direction="row" spacing={1.25} sx={{ width: '100%' }}>
-      <Box sx={{ color: selected ? 'primary.main' : 'text.secondary', display: 'flex' }}>
-        {icon}
-      </Box>
-      <Typography color={selected ? 'text.primary' : 'text.secondary'} variant="body1">
-        {label}
-      </Typography>
-      {value === undefined ? (
-        <Skeleton height={24} width={24} />
-      ) : (
-        <Typography sx={{ fontWeight: 700 }} variant="h6">
-          <FormattedNumber value={value} />
-        </Typography>
-      )}
-    </Stack>
-  </ButtonBase>
-);
+}) {
+  return (
+    <ButtonBase
+      aria-label={ariaLabel}
+      aria-pressed={onClick ? selected : undefined}
+      disabled={!onClick}
+      onClick={onClick}
+      sx={{
+        '&:hover': onClick ? { bgcolor: 'action.hover' } : undefined,
+        bgcolor: selected ? 'action.selected' : 'transparent',
+        border: 1,
+        borderColor: selected ? 'primary.main' : 'transparent',
+        borderRadius: 1,
+        px: 1.25,
+        py: 1,
+        transition: 'background-color 150ms ease, border-color 150ms ease',
+        width: '100%',
+      }}
+    >
+      <Stack alignItems="center" direction="row" spacing={1.25} sx={{ width: '100%' }}>
+        <Box
+          sx={{
+            alignItems: 'center',
+            border: '1px solid',
+            borderColor: 'divider',
+            borderRadius: 0.4,
+            display: 'flex',
+            flexShrink: 0,
+            height: 26,
+            justifyContent: 'center',
+            width: 26,
+          }}
+        >
+          <Box
+            alt=""
+            aria-hidden
+            component="img"
+            src={iconSrc}
+            sx={{ height: 22, objectFit: 'contain', width: 22 }}
+          />
+        </Box>
+        <Box sx={{ minWidth: 0, textAlign: 'left' }}>
+          <Typography color={selected ? 'text.primary' : 'text.secondary'} noWrap variant="body1">
+            {label}
+          </Typography>
+          {value === undefined ? (
+            <Skeleton height={30} width={30} />
+          ) : (
+            <Typography sx={{ fontWeight: 700, lineHeight: 1.15 }} variant="h6">
+              <FormattedNumber value={value} />
+            </Typography>
+          )}
+        </Box>
+      </Stack>
+    </ButtonBase>
+  );
+}
 
 type ProjectStatisticsProps = {
   onTypeFilterChange: (type: ApiTypeFilter | null) => void;
@@ -120,12 +144,17 @@ export function ProjectStatistics({ onTypeFilterChange, selectedType }: ProjectS
     onTypeFilterChange(selectedType === type ? null : type);
   const filterLabel = (label: string) => intl.formatMessage(messages.selectType, { type: label });
 
-  if (!apisQuery.isPending && total === 0) {
-    return null;
-  }
+  if (!apisQuery.isPending && total === 0) return null;
+
+  const metrics = [
+    { type: 'rest' as const, message: messages.rest, icon: restIcon },
+    { type: 'graphql' as const, message: messages.graphql, icon: graphqlIcon },
+    { type: 'async' as const, message: messages.async, icon: websocketIcon },
+    { type: 'grpc' as const, message: messages.grpc, icon: grpcIcon },
+  ];
 
   return (
-    <Grid alignItems="center" container sx={{ minHeight: 80, py: 1.5 }}>
+    <Grid alignItems="center" container sx={{ minHeight: 68, py: 1 }}>
       <Grid size={{ md: 2, xs: 12 }}>
         <Stack spacing={0.5}>
           <Typography color="text.secondary" sx={{ textTransform: 'uppercase' }} variant="caption">
@@ -157,46 +186,21 @@ export function ProjectStatistics({ onTypeFilterChange, selectedType }: ProjectS
 
       <Grid size={{ md: 7, xs: 12 }}>
         <Grid container spacing={2.5}>
-          <Grid size={{ lg: 3, sm: 6, xs: 12 }}>
-            <ApiTypeMetric
-              ariaLabel={filterLabel(intl.formatMessage(messages.rest))}
-              icon={<Boxes size={16} />}
-              label={<FormattedMessage {...messages.rest} />}
-              onClick={() => selectType('rest')}
-              selected={selectedType === 'rest'}
-              value={countType('rest')}
-            />
-          </Grid>
-          <Grid size={{ lg: 3, sm: 6, xs: 12 }}>
-            <ApiTypeMetric
-              ariaLabel={filterLabel(intl.formatMessage(messages.graphql))}
-              icon={<Braces size={16} />}
-              label={<FormattedMessage {...messages.graphql} />}
-              onClick={() => selectType('graphql')}
-              selected={selectedType === 'graphql'}
-              value={countType('graphql')}
-            />
-          </Grid>
-          <Grid size={{ lg: 3, sm: 6, xs: 12 }}>
-            <ApiTypeMetric
-              ariaLabel={filterLabel(intl.formatMessage(messages.async))}
-              icon={<Radio size={16} />}
-              label={<FormattedMessage {...messages.async} />}
-              onClick={() => selectType('async')}
-              selected={selectedType === 'async'}
-              value={countType('async')}
-            />
-          </Grid>
-          <Grid size={{ lg: 3, sm: 6, xs: 12 }}>
-            <ApiTypeMetric
-              ariaLabel={filterLabel(intl.formatMessage(messages.grpc))}
-              icon={<Network size={16} />}
-              label={<FormattedMessage {...messages.grpc} />}
-              onClick={() => selectType('grpc')}
-              selected={selectedType === 'grpc'}
-              value={countType('grpc')}
-            />
-          </Grid>
+          {metrics.map(({ type, message, icon }) => {
+            const label = intl.formatMessage(message);
+            return (
+              <Grid key={type} size={{ md: 3, sm: 6, xs: 12 }}>
+                <MetricCard
+                  ariaLabel={filterLabel(label)}
+                  iconSrc={icon}
+                  label={label}
+                  onClick={() => selectType(type)}
+                  selected={selectedType === type}
+                  value={countType(type)}
+                />
+              </Grid>
+            );
+          })}
         </Grid>
       </Grid>
 


### PR DESCRIPTION
This pull request refines the API Key management hooks and their tests, improves the API edit page UX, and updates internationalization messages for clarity and consistency. The most significant changes are grouped below.

Issue: https://github.com/wso2-enterprise/apim-saas/issues/2966


https://github.com/user-attachments/assets/948e7bb7-d4be-4687-89b3-9b3f5ef995fa


https://github.com/user-attachments/assets/9156b935-3b2b-4102-9020-d666a97256c0



### API Key Management Improvements

* The `useRevokeApiKey` hook now removes revoked REST API keys from all cached filtered lists immediately, ensuring the UI reflects revocations without waiting for a server round-trip. It also updates the cache count accordingly.
* Tests for API key hooks have been updated and expanded to verify correct cache handling and immediate removal of revoked keys.

### API Edit Page and Form Changes

* The edit form and logic have been simplified: the "Target URL" field and related upstream logic have been removed, and the form now only handles four fields (name, description, context, version). Tests for the removed fields and logic have also been deleted. [[1]](diffhunk://#diff-4648faa38803bd5194191b041ce9976092c799056189206c4e62128c94150f7cL64-R64) [[2]](diffhunk://#diff-4648faa38803bd5194191b041ce9976092c799056189206c4e62128c94150f7cL73-L94) [[3]](diffhunk://#diff-de8e5df81657762e00c7ad08aa12b4f450f7272d86985dade0a44329c4b676ddL71-L81) [[4]](diffhunk://#diff-de8e5df81657762e00c7ad08aa12b4f450f7272d86985dade0a44329c4b676ddL130-L142)
* The edit page's back button is now directly integrated into the page title for improved accessibility and layout, and the subtitle uses a caption variant.

### Internationalization and UI Text Updates

* Several i18n messages have been added, updated, or clarified, including new labels for API detail metadata, improved progress banner messages, and resource panel counts. Some unused or outdated messages were removed. [[1]](diffhunk://#diff-9da4dc257c3722931a9f13d05d7dd2c61bd9c9e0215de422e95eb12762c5052cR655-R670) [[2]](diffhunk://#diff-9da4dc257c3722931a9f13d05d7dd2c61bd9c9e0215de422e95eb12762c5052cL679-L682) [[3]](diffhunk://#diff-9da4dc257c3722931a9f13d05d7dd2c61bd9c9e0215de422e95eb12762c5052cL943-R955) [[4]](diffhunk://#diff-9da4dc257c3722931a9f13d05d7dd2c61bd9c9e0215de422e95eb12762c5052cL954-R980)

### Minor UI and Code Cleanups

* Breadcrumb spacing has been slightly adjusted for improved visual alignment.
* Imports and formatting in hooks and tests have been cleaned up for consistency. [[1]](diffhunk://#diff-195dfa2146b12e0f72800e3e65aa6ea4a1d80706efee0816627205d58120ca42L34-R34) [[2]](diffhunk://#diff-195dfa2146b12e0f72800e3e65aa6ea4a1d80706efee0816627205d58120ca42L99-R98) [[3]](diffhunk://#diff-195dfa2146b12e0f72800e3e65aa6ea4a1d80706efee0816627205d58120ca42L123-R112) [[4]](diffhunk://#diff-195dfa2146b12e0f72800e3e65aa6ea4a1d80706efee0816627205d58120ca42L132-R124) [[5]](diffhunk://#diff-195dfa2146b12e0f72800e3e65aa6ea4a1d80706efee0816627205d58120ca42L143-R135) [[6]](diffhunk://#diff-195dfa2146b12e0f72800e3e65aa6ea4a1d80706efee0816627205d58120ca42L165-R157) [[7]](diffhunk://#diff-04bdb6b0df9ffce605c507b7c57ff988b70772ec0d5e9f7be3dd2e03f15e9399L56-R57) [[8]](diffhunk://#diff-04bdb6b0df9ffce605c507b7c57ff988b70772ec0d5e9f7be3dd2e03f15e9399L95-R101) [[9]](diffhunk://#diff-04bdb6b0df9ffce605c507b7c57ff988b70772ec0d5e9f7be3dd2e03f15e9399R32)

### Test Maintenance

* Outdated tests for upstream ref handling and target URL validation in the API edit form have been removed, reflecting the simplified form logic. [[1]](diffhunk://#diff-cecc0fdbd8f5c0cd8f685b5022f154f39e13cb63cb63905b631f47c9e69482e7L124-L142) [[2]](diffhunk://#diff-de8e5df81657762e00c7ad08aa12b4f450f7272d86985dade0a44329c4b676ddL71-L81) [[3]](diffhunk://#diff-de8e5df81657762e00c7ad08aa12b4f450f7272d86985dade0a44329c4b676ddL130-L142)