### PR TITLE
[APIP] Fix startup xDS snapshot using legacy cluster names after controller restart

### DIFF
--- a/event-gateway/gateway-controller/cmd/controller/main.go
+++ b/event-gateway/gateway-controller/cmd/controller/main.go
@@ -393,13 +393,10 @@ func main() {
 		}
 	}
 
-	// Build the transformer registry and wire it into the Envoy translator BEFORE
+	// Build the transformer registry and wire it into the Envoy translator before
 	// the initial xDS snapshot below, so the first snapshot already uses the
 	// transformer-path cluster/route names ("upstream_<name>_<host>_<port>") that the
-	// policy engine's resources reference. Wiring it later would leave the startup
-	// snapshot on the legacy naming path ("cluster_<scheme>_<host>"), breaking every
-	// previously deployed non-WebSub API with 503 cluster_not_found after a controller
-	// restart (issue #3197). WebSubApi is intentionally excluded so it keeps using the
+	// policy engine's resources reference. WebSubApi is intentionally excluded so it keeps using the
 	// async-specific legacy translation path.
 	restTransformer := transform.NewRestAPITransformer(&cfg.Router, cfg, policyDefinitions)
 	llmTransformer := transform.NewLLMTransformer(configStore, db, &cfg.Router, cfg, policyDefinitions, policyVersionResolver)

--- a/event-gateway/gateway-controller/cmd/controller/main.go
+++ b/event-gateway/gateway-controller/cmd/controller/main.go
@@ -393,6 +393,25 @@ func main() {
 		}
 	}
 
+	// Build the transformer registry and wire it into the Envoy translator BEFORE
+	// the initial xDS snapshot below, so the first snapshot already uses the
+	// transformer-path cluster/route names ("upstream_<name>_<host>_<port>") that the
+	// policy engine's resources reference. Wiring it later would leave the startup
+	// snapshot on the legacy naming path ("cluster_<scheme>_<host>"), breaking every
+	// previously deployed non-WebSub API with 503 cluster_not_found after a controller
+	// restart (issue #3197). WebSubApi is intentionally excluded so it keeps using the
+	// async-specific legacy translation path.
+	restTransformer := transform.NewRestAPITransformer(&cfg.Router, cfg, policyDefinitions)
+	llmTransformer := transform.NewLLMTransformer(configStore, db, &cfg.Router, cfg, policyDefinitions, policyVersionResolver)
+	transformerRegistry := transform.NewRegistry(restTransformer, llmTransformer)
+
+	xdsTranslator.SetTransformers(map[string]models.ConfigTransformer{
+		"RestApi":     transformerRegistry,
+		"Mcp":         transformerRegistry,
+		"LlmProvider": transformerRegistry,
+		"LlmProxy":    transformerRegistry,
+	})
+
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	if err := snapshotManager.UpdateSnapshot(ctx, ""); err != nil {
 		log.Warn("Failed to generate initial xDS snapshot", slog.Any("error", err))
@@ -431,17 +450,9 @@ func main() {
 	policyManager := policyxds.NewPolicyManager(policySnapshotManager, log)
 	policyManager.SetRuntimeStore(runtimeStore)
 
-	restTransformer := transform.NewRestAPITransformer(&cfg.Router, cfg, policyDefinitions)
-	llmTransformer := transform.NewLLMTransformer(configStore, db, &cfg.Router, cfg, policyDefinitions, policyVersionResolver)
-	transformerRegistry := transform.NewRegistry(restTransformer, llmTransformer)
+	// Share the transformer registry (built before the initial xDS snapshot above)
+	// with the policy manager so both snapshot paths key resources identically.
 	policyManager.SetTransformers(transformerRegistry)
-
-	xdsTranslator.SetTransformers(map[string]models.ConfigTransformer{
-		"RestApi":     transformerRegistry,
-		"Mcp":         transformerRegistry,
-		"LlmProvider": transformerRegistry,
-		"LlmProxy":    transformerRegistry,
-	})
 
 	loadedAPIs := configStore.GetAll()
 	if _, err := loadRuntimeConfigsFromExistingAPIConfigurations(loadedAPIs, runtimeStore, secretsService, transformerRegistry, log, cfg.Controller.Server.SkipInvalidDeploymentsOnStartup); err != nil {

--- a/gateway/gateway-controller/cmd/controller/main.go
+++ b/gateway/gateway-controller/cmd/controller/main.go
@@ -387,7 +387,7 @@ func main() {
 	// from the transformer path). With no transformers wired the translator silently
 	// falls back to the legacy path, which names clusters "cluster_<scheme>_<host>" —
 	// the policy engine then routes to upstream_* clusters that don't exist in Envoy,
-	// and every API returns 503 cluster_not_found until it is redeployed (issue #3197).
+	// and every API returns 503 cluster_not_found until it is redeployed
 	restTransformer := transform.NewRestAPITransformer(&cfg.Router, cfg, policyDefinitions)
 	llmTransformer := transform.NewLLMTransformer(configStore, db, &cfg.Router, cfg, policyDefinitions, policyVersionResolver)
 	transformerRegistry := transform.NewRegistry(restTransformer, llmTransformer)

--- a/gateway/gateway-controller/cmd/controller/main.go
+++ b/gateway/gateway-controller/cmd/controller/main.go
@@ -381,6 +381,32 @@ func main() {
 		}
 	}
 
+	// Build transformer registry for StoredConfig → RuntimeDeployConfig conversion.
+	// This MUST happen before the initial xDS snapshot below: the Envoy translator
+	// and the policy engine must agree on cluster names ("upstream_<name>_<host>_<port>"
+	// from the transformer path). With no transformers wired the translator silently
+	// falls back to the legacy path, which names clusters "cluster_<scheme>_<host>" —
+	// the policy engine then routes to upstream_* clusters that don't exist in Envoy,
+	// and every API returns 503 cluster_not_found until it is redeployed (issue #3197).
+	restTransformer := transform.NewRestAPITransformer(&cfg.Router, cfg, policyDefinitions)
+	llmTransformer := transform.NewLLMTransformer(configStore, db, &cfg.Router, cfg, policyDefinitions, policyVersionResolver)
+	transformerRegistry := transform.NewRegistry(restTransformer, llmTransformer)
+
+	// Wire the transformer into the Envoy xDS translator so Envoy routes are built from the
+	// RuntimeDeployConfig (RDC) path — identical to how the policy engine's RouteConfig/PolicyChain
+	// resources are keyed. Without this the Envoy translator falls back to the legacy per-operation
+	// path, which (a) does not render header matchers and (b) names routes "method|path|vhost"
+	// (3 segments), while the policy resources are keyed "method|path|vhost|<header-hash>". The
+	// policy engine resolves the chain by the Envoy route name, so the mismatch makes every
+	// header-matched route fail with 500 ("policy chain not found"). WebSubApi is intentionally
+	// excluded so it keeps using the async-specific legacy translation path.
+	translator.SetTransformers(map[string]models.ConfigTransformer{
+		"RestApi":     transformerRegistry,
+		"Mcp":         transformerRegistry,
+		"LlmProvider": transformerRegistry,
+		"LlmProxy":    transformerRegistry,
+	})
+
 	// Generate initial xDS snapshot
 	log.Info("Generating initial xDS snapshot")
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -440,26 +466,9 @@ func main() {
 	policyManager := policyxds.NewPolicyManager(policySnapshotManager, log)
 	policyManager.SetRuntimeStore(runtimeStore)
 
-	// Build transformer registry for StoredConfig → RuntimeDeployConfig conversion
-	restTransformer := transform.NewRestAPITransformer(&cfg.Router, cfg, policyDefinitions)
-	llmTransformer := transform.NewLLMTransformer(configStore, db, &cfg.Router, cfg, policyDefinitions, policyVersionResolver)
-	transformerRegistry := transform.NewRegistry(restTransformer, llmTransformer)
+	// Share the transformer registry (built before the initial xDS snapshot above)
+	// with the policy manager so both snapshot paths key resources identically.
 	policyManager.SetTransformers(transformerRegistry)
-
-	// Wire the same transformer into the Envoy xDS translator so Envoy routes are built from the
-	// RuntimeDeployConfig (RDC) path — identical to how the policy engine's RouteConfig/PolicyChain
-	// resources are keyed. Without this the Envoy translator falls back to the legacy per-operation
-	// path, which (a) does not render header matchers and (b) names routes "method|path|vhost"
-	// (3 segments), while the policy resources are keyed "method|path|vhost|<header-hash>". The
-	// policy engine resolves the chain by the Envoy route name, so the mismatch makes every
-	// header-matched route fail with 500 ("policy chain not found"). WebSubApi is intentionally
-	// excluded so it keeps using the async-specific legacy translation path.
-	translator.SetTransformers(map[string]models.ConfigTransformer{
-		"RestApi":     transformerRegistry,
-		"Mcp":         transformerRegistry,
-		"LlmProvider": transformerRegistry,
-		"LlmProxy":    transformerRegistry,
-	})
 
 	// Load runtime configs from existing API configurations on startup.
 	// We write directly to runtimeStore to avoid triggering N separate snapshot updates;

--- a/gateway/gateway-controller/pkg/xds/translator.go
+++ b/gateway/gateway-controller/pkg/xds/translator.go
@@ -719,7 +719,17 @@ func (t *Translator) TranslateConfigs(
 		var err error
 
 		// Try RuntimeDeployConfig transformer path first (produces minimal metadata routes)
-		if transformer, ok := t.transformers[cfg.Kind]; ok {
+		transformer, ok := t.transformers[cfg.Kind]
+		if !ok && cfg.Kind != "WebSubApi" {
+			// Transformers should be registered for every non-WebSub kind before the
+			// first snapshot is generated. Falling back here means Envoy cluster/route
+			// names will not match the policy engine's resources (503 cluster_not_found /
+			// 500 policy chain not found) — see issue #3197.
+			log.Warn("No transformer registered for config kind, using legacy translation path",
+				slog.String("id", cfg.UUID),
+				slog.String("kind", cfg.Kind))
+		}
+		if ok {
 			rdc, transformErr := transformer.Transform(cfg)
 			if transformErr != nil {
 				log.Error("Failed to transform config via RuntimeDeployConfig, falling back to legacy path",

--- a/gateway/gateway-controller/pkg/xds/translator.go
+++ b/gateway/gateway-controller/pkg/xds/translator.go
@@ -724,7 +724,7 @@ func (t *Translator) TranslateConfigs(
 			// Transformers should be registered for every non-WebSub kind before the
 			// first snapshot is generated. Falling back here means Envoy cluster/route
 			// names will not match the policy engine's resources (503 cluster_not_found /
-			// 500 policy chain not found) — see issue #3197.
+			// 500 policy chain not found)
 			log.Warn("No transformer registered for config kind, using legacy translation path",
 				slog.String("id", cfg.UUID),
 				slog.String("kind", cfg.Kind))


### PR DESCRIPTION
Fixes https://github.com/wso2/api-platform/issues/3197
This pull request ensures that the Envoy xDS translator and the policy engine both use the same transformer registry before generating the initial xDS snapshot. This alignment guarantees that cluster and route names are consistent across both systems, preventing routing and policy lookup errors. The changes also add improved logging for missing transformers and clarify the transformer wiring process.

Key improvements:

**Transformer Registry Initialization and Wiring:**
* The transformer registry is now constructed before the initial xDS snapshot and injected into both the Envoy xDS translator and the policy manager. This ensures that both systems key resources identically and prevents mismatches that could result in 503 or 500 errors. WebSubApi is intentionally excluded to preserve its legacy translation path. [[1]](diffhunk://#diff-19dc17be1cbfe1d2bf10917895b40be689bc3ac7e61deb6f3745b29f1aac1b90R396-R411) [[2]](diffhunk://#diff-8a2e610ad42a25eef18e3b7000b3c9fc4d59aaba36d2db2ff77a2d0a787361ebR384-R409)

* The policy manager now shares the same transformer registry as the xDS translator, ensuring both snapshot paths use identical resource keys. Redundant registry creation and wiring code has been removed for clarity and correctness. [[1]](diffhunk://#diff-19dc17be1cbfe1d2bf10917895b40be689bc3ac7e61deb6f3745b29f1aac1b90L434-L445) [[2]](diffhunk://#diff-8a2e610ad42a25eef18e3b7000b3c9fc4d59aaba36d2db2ff77a2d0a787361ebL443-L463)

**Error Handling and Logging:**
* Added a warning log if a transformer is missing for a config kind (except WebSubApi), highlighting potential misconfigurations that would cause resource name mismatches and related errors.