### PR TITLE
Poll gateway status while a gateway is still coming up

### DIFF
--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/GatewaysFeature.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/GatewaysFeature.tsx
@@ -43,6 +43,14 @@ export type GatewaysFeatureProps = {
  * feature). It owns the data: it loads `/managed-gateways` and `/environments`
  * through the host-injected `apiFetch` and feeds the presentational list/form.
  */
+/**
+ * How often the list re-reads gateway status while a gateway is still coming up.
+ * A newly created gateway is inactive until its data-plane gateway finishes
+ * provisioning and its controller dials in, which takes tens of seconds — long
+ * enough that without this the user has to reload the page to see it go active.
+ */
+const STATUS_POLL_INTERVAL_MS = 5000;
+
 const GatewaysFeature: FC<GatewaysFeatureProps> = ({ port, gatewayTypes }) => {
   const { apiFetch, notify } = port;
   const client = useMemo(() => createGatewaysClient(apiFetch), [apiFetch]);
@@ -62,29 +70,60 @@ const GatewaysFeature: FC<GatewaysFeatureProps> = ({ port, gatewayTypes }) => {
   // since.
   const loadSeqRef = useRef(0);
 
-  const load = useCallback(async () => {
-    const seq = ++loadSeqRef.current;
-    setLoading(true);
-    setError(null);
-    try {
-      const [gatewayList, environmentList] = await Promise.all([
-        client.listGateways(),
-        client.listEnvironments(),
-      ]);
-      if (seq !== loadSeqRef.current) return;
-      setGateways(gatewayList);
-      setEnvironments(environmentList);
-    } catch (loadError) {
-      if (seq !== loadSeqRef.current) return;
-      setError(loadError instanceof Error ? loadError.message : 'Unable to load gateways.');
-    } finally {
-      if (seq === loadSeqRef.current) setLoading(false);
-    }
-  }, [client]);
+  // `silent` is for the status poll below: it must not show the spinner or
+  // replace the list with an error page, so it only ever writes fresh data.
+  const load = useCallback(
+    async ({ silent = false }: { silent?: boolean } = {}) => {
+      const seq = ++loadSeqRef.current;
+      if (!silent) {
+        setLoading(true);
+        setError(null);
+      }
+      try {
+        const [gatewayList, environmentList] = await Promise.all([
+          client.listGateways(),
+          client.listEnvironments(),
+        ]);
+        if (seq !== loadSeqRef.current) return;
+        setGateways(gatewayList);
+        setEnvironments(environmentList);
+        // Any load that reaches fresh data clears a previous failure.
+        setError(null);
+      } catch (loadError) {
+        if (seq !== loadSeqRef.current) return;
+        // A failed poll is left silent: the list already on screen stays, and
+        // the next tick may well succeed. Only a foreground load reports.
+        if (!silent) {
+          setError(loadError instanceof Error ? loadError.message : 'Unable to load gateways.');
+        }
+      } finally {
+        if (!silent && seq === loadSeqRef.current) setLoading(false);
+      }
+    },
+    [client]
+  );
 
   useEffect(() => {
     void load();
   }, [load]);
+
+  // Poll only while there is something to wait for: a gateway that is not yet
+  // active. Once they are all active the interval is torn down, so a settled
+  // list costs nothing. Creating another gateway makes this true again and the
+  // poll restarts. Deliberately keyed on the boolean, not on `gateways`, so a
+  // poll's own result does not reset the interval.
+  const awaitingStatus = gateways.some((gateway) => gateway.status !== 'active');
+
+  useEffect(() => {
+    if (view !== 'list' || !awaitingStatus) return undefined;
+    const timer = window.setInterval(() => {
+      // Skip a tick mid-write: the create/delete paths refresh on their own, and
+      // the in-flight request would race this one for the newest sequence.
+      if (submittingRef.current || deletingRef.current) return;
+      void load({ silent: true });
+    }, STATUS_POLL_INTERVAL_MS);
+    return () => window.clearInterval(timer);
+  }, [view, awaitingStatus, load]);
 
   const submitGateway = useCallback(
     async (input: GatewayInput, gatewayId?: string): Promise<boolean> => {


### PR DESCRIPTION
## Purpose

A newly created gateway is inactive until its data-plane gateway finishes provisioning and its controller dials in, which takes tens of seconds. The list read status once on mount, so the only way to see a gateway go active was to reload the page.

## Goals

The gateways list reflects status on its own while a gateway is coming up, and costs nothing once everything is active.

## Approach

`load` gained a `silent` mode and the list polls with it every 5s.

Silent means the poll only ever writes fresh data: it does not raise the spinner (which would blank the list every tick) and does not surface its own failure (the list already on screen stays, and the next tick may succeed). A foreground load — mount, Retry, or the refresh after a create/delete — behaves exactly as before.

The interval only exists while there is something to wait for:

- **only on the list view** — not while the create/edit form is open
- **only while a gateway is not active**, so a settled list polls not at all; creating another gateway makes that true again and the poll restarts
- keyed on that **boolean**, not on `gateways`, so a poll's own result does not tear down and rebuild its own interval
- a tick is **skipped while a create or delete is in flight**, since those refresh on their own and would otherwise race the poll for the newest load sequence

The existing `loadSeqRef` guard already ensures only the newest response may write state, so an overlapping poll can never restore a gateway that was deleted meanwhile.

Not added: a stop-after-N-minutes cap for a gateway that never comes up. Polling ends as soon as the user leaves the page, which bounds it in practice, and a permanently-inactive gateway is a real condition worth continuing to watch. Worth revisiting if it shows up as noise.

## User stories

- As a cloud user I see a gateway I just created become active without reloading the page.

## Documentation

N/A — no API or config change.

## Automation tests

- Unit tests
  > No new tests: the plugin packages have no test setup, so there is nowhere to add a timer test without introducing one. The logic is confined to one component's effect.
- Integration tests
  > Typechecked the plugin package clean. Behaviour to verify on a cloud build: create a gateway, stay on the list, and it flips Inactive → Active on its own within ~5s of the controller connecting; with all gateways active, no further `/managed-gateways` requests are issued.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? no — TypeScript UI change
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

- #3362 — wired this list to platform-api.
- #3378 — added the Status and Environment columns this keeps current.

## Test environment

macOS (arm64), Node 24, Chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
