### PR TITLE
[APICP] Deny access when a route names an org the session isn't scoped to

### DIFF
--- a/portals/api-control-plane/src/contexts/auth/AuthProvider.tsx
+++ b/portals/api-control-plane/src/contexts/auth/AuthProvider.tsx
@@ -160,11 +160,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     })();
   }, []);
 
-  // Platform API calls are always routed through the same-origin proxy,
-  // which forwards the session's bearer token itself — there is no
-  // console-side org-token exchange to perform.
-  const exchangeOrgToken = useCallback(async () => true, []);
-
   const value = useMemo<AuthState>(
     () => ({
       mode: runtimeConfig.authMode,
@@ -175,10 +170,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       user,
       login,
       loginWithCredentials,
-      exchangeOrgToken,
       logout,
     }),
-    [error, exchangeOrgToken, login, loginWithCredentials, logout, status, user]
+    [error, login, loginWithCredentials, logout, status, user]
   );
 
   return (

--- a/portals/api-control-plane/src/contexts/auth/authTypes.ts
+++ b/portals/api-control-plane/src/contexts/auth/authTypes.ts
@@ -56,6 +56,5 @@ export type AuthState = {
     password: string,
     returnTo?: string
   ) => Promise<boolean>;
-  exchangeOrgToken: (orgHandle: string) => Promise<boolean>;
   logout: () => void;
 };

--- a/portals/api-control-plane/src/i18n/messages/en.json
+++ b/portals/api-control-plane/src/i18n/messages/en.json
@@ -1714,6 +1714,17 @@
   "apiControlPlane.pages.appShell.appShellPages.system.NotFoundPage.title": {
     "defaultMessage": "Page not found"
   },
+  "apiControlPlane.pages.appShell.appShellPages.system.OrganizationAccessDeniedPage.goToMyOrganization": {
+    "defaultMessage": "Go to my organization",
+    "description": "Button returning to the signed-in user's own organization home. Verb phrase."
+  },
+  "apiControlPlane.pages.appShell.appShellPages.system.OrganizationAccessDeniedPage.subtitle": {
+    "defaultMessage": "Check the link, or go to your own organization instead."
+  },
+  "apiControlPlane.pages.appShell.appShellPages.system.OrganizationAccessDeniedPage.title": {
+    "defaultMessage": "You do not have access to this organization",
+    "description": "Shown when the URL names an organization the signed-in session is not scoped to."
+  },
   "apiControlPlane.pages.appShell.appShellPages.system.OrganizationRedirectPage.emptyDescription": {
     "defaultMessage": "Your account is authenticated, but it is not associated with an organization."
   },

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/system/SystemPages.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/system/SystemPages.tsx
@@ -77,6 +77,23 @@ const unauthorizedMessages = defineMessages({
   },
 });
 
+const organizationAccessDeniedMessages = defineMessages({
+  title: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.system.OrganizationAccessDeniedPage.title',
+    defaultMessage: 'You do not have access to this organization',
+    description: 'Shown when the URL names an organization the signed-in session is not scoped to.',
+  },
+  subtitle: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.system.OrganizationAccessDeniedPage.subtitle',
+    defaultMessage: 'Check the link, or go to your own organization instead.',
+  },
+  goToMyOrganization: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.system.OrganizationAccessDeniedPage.goToMyOrganization',
+    defaultMessage: 'Go to my organization',
+    description: 'Button returning to the signed-in user\'s own organization home. Verb phrase.',
+  },
+});
+
 const sessionExpiredMessages = defineMessages({
   title: {
     id: 'apiControlPlane.pages.appShell.appShellPages.system.SessionExpiredPage.title',
@@ -178,6 +195,41 @@ export function UnauthorizedPage() {
           <FormattedMessage {...unauthorizedMessages.clearSession} />
         </Button>
       </Stack>
+    </PageContent>
+  );
+}
+
+/**
+ * Rendered by `ConsoleScopeProvider` in place of the app shell when the URL's
+ * `:orgHandle` doesn't match the signed-in session's own organization —
+ * e.g. a link to someone else's org, still carrying your own session. There
+ * is no per-org token exchange in this console (the BFF forwards one bearer
+ * token per session, see `AuthProvider`), so a mismatch here can never be
+ * resolved client-side; the only way in is signing in to that organization.
+ */
+export function OrganizationAccessDeniedPage() {
+  const navigate = useNavigate();
+  const auth = useAuth();
+  const myOrgHandle = auth.user?.org?.handle;
+
+  return (
+    <PageContent>
+      <PageTitle>
+        <PageTitle.Header>
+          <FormattedMessage {...organizationAccessDeniedMessages.title} />
+        </PageTitle.Header>
+        <PageTitle.SubHeader>
+          <FormattedMessage {...organizationAccessDeniedMessages.subtitle} />
+        </PageTitle.SubHeader>
+      </PageTitle>
+      {myOrgHandle && (
+        <Button
+          variant="contained"
+          onClick={() => navigate(routes.organizationHome(myOrgHandle))}
+        >
+          <FormattedMessage {...organizationAccessDeniedMessages.goToMyOrganization} />
+        </Button>
+      )}
     </PageContent>
   );
 }

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/system/SystemPages.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/system/SystemPages.tsx
@@ -206,11 +206,20 @@ export function UnauthorizedPage() {
  * is no per-org token exchange in this console (the BFF forwards one bearer
  * token per session, see `AuthProvider`), so a mismatch here can never be
  * resolved client-side; the only way in is signing in to that organization.
+ *
+ * `myOrgHandle` is passed in rather than independently read from `useAuth()`
+ * here: `ConsoleScopeProvider` already read `user.org.handle` once to decide
+ * `orgAccessDenied` in the first place, and the recovery link must point at
+ * that exact same value — a second, independent read of "the session's own
+ * org handle" is only guaranteed to agree with the first by convention, not
+ * by anything the type system enforces.
  */
-export function OrganizationAccessDeniedPage() {
+export function OrganizationAccessDeniedPage({
+  myOrgHandle,
+}: {
+  myOrgHandle?: string;
+}) {
   const navigate = useNavigate();
-  const auth = useAuth();
-  const myOrgHandle = auth.user?.org?.handle;
 
   return (
     <PageContent>

--- a/portals/api-control-plane/src/scope/ConsoleScopeContext.ts
+++ b/portals/api-control-plane/src/scope/ConsoleScopeContext.ts
@@ -32,10 +32,11 @@ export type ConsoleRouteParams = {
 };
 
 /**
- * Token-ready scope identifiers the data hooks default to when called with no
- * args. `orgHandle` is only populated once the org-token exchange for the
- * active org has completed (it mirrors the provider's `queryOrgHandle`), so
- * context-aware queries never fire before their bearer token is ready.
+ * Scope identifiers the data hooks default to when called with no args.
+ * `orgHandle` is only populated once the route's `:orgHandle` has been
+ * confirmed to match the signed-in session's own organization (see
+ * `orgAccessDenied` below), so context-aware queries never fire against an
+ * organization the session isn't actually scoped to.
  */
 export type ActiveScope = {
   orgHandle?: string;
@@ -51,6 +52,14 @@ export type ConsoleScope = {
   isLoading: boolean;
   isOrganizationScope: boolean;
   isProjectScope: boolean;
+  /**
+   * True when the route names an organization (`params.orgHandle`) other
+   * than the one the signed-in session's bearer token is actually scoped to.
+   * `ConsoleScopeProvider` renders an access-denied page instead of the app
+   * shell whenever this is true — see its module comment for why the check
+   * lives there rather than in a per-page gate.
+   */
+  orgAccessDenied: boolean;
   organization?: Organization;
   organizations: Organization[];
   params: ConsoleRouteParams;

--- a/portals/api-control-plane/src/scope/ConsoleScopeContext.ts
+++ b/portals/api-control-plane/src/scope/ConsoleScopeContext.ts
@@ -33,10 +33,15 @@ export type ConsoleRouteParams = {
 
 /**
  * Scope identifiers the data hooks default to when called with no args.
- * `orgHandle` is only populated once the route's `:orgHandle` has been
- * confirmed to match the signed-in session's own organization (see
+ *
+ * For a session with a known organization claim, `orgHandle` is only
+ * populated once the route's `:orgHandle` has been confirmed to match it (see
  * `orgAccessDenied` below), so context-aware queries never fire against an
- * organization the session isn't actually scoped to.
+ * organization the session isn't actually scoped to. The one exception: a
+ * session with *no* organization claim at all (basic/file-based auth, which
+ * has no notion of multiple organizations) has nothing to confirm against, so
+ * `orgHandle` here is the route param passed through unconfirmed — treat it
+ * as session-scoped only when a session organization is actually known.
  */
 export type ActiveScope = {
   orgHandle?: string;

--- a/portals/api-control-plane/src/scope/ConsoleScopeProvider.test.tsx
+++ b/portals/api-control-plane/src/scope/ConsoleScopeProvider.test.tsx
@@ -96,14 +96,56 @@ describe('ConsoleScopeProvider — organization access boundary', () => {
     expect(projectRequests.count()).toBe(0);
   });
 
-  it('offers a way back to the signed-in user\'s own organization', async () => {
-    renderWithProviders(<AppRoutes />, {
+  it('navigates back to the signed-in user\'s own organization, not just anywhere', async () => {
+    const { user } = renderWithProviders(<AppRoutes />, {
       route: '/organizations/apip-anusha/home',
       authState: authStateForOwnOrg(),
     });
 
-    const link = await screen.findByRole('button', { name: /go to my organization/i });
-    expect(link).toBeInTheDocument();
+    await user.click(
+      await screen.findByRole('button', { name: /go to my organization/i })
+    );
+
+    // A wrong destination would land back on the access-denied page (it
+    // gates every organization route, including a bad recovery target) —
+    // so finding the app shell here proves the button's target was correct,
+    // not merely present.
+    expect(await screen.findByText(/WSO2 LLC/)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/You do not have access to this organization/)
+    ).not.toBeInTheDocument();
+  });
+
+  it('keys the access decision and recovery target on the session claim alone, independent of the organizations API list', async () => {
+    // The organizations list (platform-api's own canonical `Organization.id`
+    // records) doesn't even contain the session's own org here — simulating
+    // it disagreeing with, or simply not yet corroborating, the session claim.
+    // The access check must still follow the session claim by itself, not
+    // silently depend on the list agreeing with it.
+    server.use(
+      collection('/organizations', [
+        anOrganization({ id: 'someone-elses-org', displayName: 'Someone Else' }),
+      ])
+    );
+
+    const { user } = renderWithProviders(<AppRoutes />, {
+      route: '/organizations/apip-anusha/home',
+      authState: authStateForOwnOrg(),
+    });
+
+    expect(
+      await screen.findByText(/You do not have access to this organization/)
+    ).toBeInTheDocument();
+
+    await user.click(
+      await screen.findByRole('button', { name: /go to my organization/i })
+    );
+
+    // Recovers to the session's own org handle ("lasanthas"), not anything
+    // sourced from the (non-corroborating) organizations list.
+    expect(
+      screen.queryByText(/You do not have access to this organization/)
+    ).not.toBeInTheDocument();
   });
 
   it('does not gate a session with no organization claim (basic/file-based auth)', async () => {

--- a/portals/api-control-plane/src/scope/ConsoleScopeProvider.test.tsx
+++ b/portals/api-control-plane/src/scope/ConsoleScopeProvider.test.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AppRoutes } from '../routes/AppRoutes';
+import {
+  anOrganization,
+  aProject,
+  collection,
+  recorder,
+  resource,
+  type Recorder,
+} from '../test/msw';
+import { makeAuthState } from '../test/mockAuthState';
+import { server } from '../test/server';
+import { renderWithProviders, screen } from '../test/utils';
+
+// This console's session is scoped to exactly one organization for its whole
+// lifetime (the BFF forwards one bearer token per session — see
+// `ConsoleScopeProvider`'s module comment). These tests guard the boundary
+// that keeps a route naming a *different* organization from ever reaching the
+// app shell or platform-api with that org's handle.
+describe('ConsoleScopeProvider — organization access boundary', () => {
+  const org = anOrganization({ id: 'lasanthas', displayName: 'lasanthas' });
+  let projectRequests: Recorder;
+
+  beforeEach(() => {
+    vi.stubEnv('VITE_USE_MOCK_API', 'true');
+    projectRequests = recorder();
+    server.use(
+      // Organizations are never scope-gated (see `useOrganizations`), so this
+      // request is expected to fire regardless of the org-access outcome —
+      // only `projectRequests` below is the one that must stay silent.
+      collection('/organizations', [org]),
+      resource('/organizations/:organizationId', org),
+      collection('/projects', [aProject({ id: 'default' })], {
+        record: projectRequests,
+      }),
+      // Org-home also renders gateway count and per-project API counts.
+      collection('/gateways', []),
+      collection('/rest-apis', [])
+    );
+  });
+  afterEach(() => vi.unstubAllEnvs());
+
+  const authStateForOwnOrg = () =>
+    makeAuthState({
+      user: {
+        name: 'Test User',
+        email: 'test.user@example.com',
+        org: { id: 'lasanthas', name: 'lasanthas', handle: 'lasanthas' },
+      },
+    });
+
+  it('renders the app shell when the route names the session\'s own organization', async () => {
+    renderWithProviders(<AppRoutes />, {
+      route: '/organizations/lasanthas/home',
+      authState: authStateForOwnOrg(),
+    });
+
+    expect(await screen.findByText(/WSO2 LLC/)).toBeInTheDocument();
+  });
+
+  it('denies access instead of showing the shell when the route names a different organization', async () => {
+    renderWithProviders(<AppRoutes />, {
+      route: '/organizations/apip-anusha/home',
+      authState: authStateForOwnOrg(),
+    });
+
+    expect(
+      await screen.findByText(/You do not have access to this organization/)
+    ).toBeInTheDocument();
+
+    // The app shell (sidebar/header) must not have mounted at all — not even
+    // to render "apip-anusha" as a label.
+    expect(screen.queryByText('apip-anusha')).not.toBeInTheDocument();
+
+    // No project request may have gone out labelled for the mismatched org.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(projectRequests.count()).toBe(0);
+  });
+
+  it('offers a way back to the signed-in user\'s own organization', async () => {
+    renderWithProviders(<AppRoutes />, {
+      route: '/organizations/apip-anusha/home',
+      authState: authStateForOwnOrg(),
+    });
+
+    const link = await screen.findByRole('button', { name: /go to my organization/i });
+    expect(link).toBeInTheDocument();
+  });
+
+  it('does not gate a session with no organization claim (basic/file-based auth)', async () => {
+    renderWithProviders(<AppRoutes />, {
+      route: '/organizations/lasanthas/home',
+      authState: makeAuthState(),
+    });
+
+    expect(await screen.findByText(/WSO2 LLC/)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/You do not have access to this organization/)
+    ).not.toBeInTheDocument();
+  });
+});

--- a/portals/api-control-plane/src/scope/ConsoleScopeProvider.tsx
+++ b/portals/api-control-plane/src/scope/ConsoleScopeProvider.tsx
@@ -16,11 +16,12 @@
  * under the License.
  */
 
-import { ReactNode, useEffect, useMemo, useRef, useState } from 'react';
+import { ReactNode, useMemo } from 'react';
 import { useLocation, useParams } from 'react-router-dom';
 
 import { ApiScopeProvider } from '../api/core/ApiScopeProvider';
 import { useAuth } from '../contexts/auth/AuthProvider';
+import { OrganizationAccessDeniedPage } from '../pages/appShell/appShellPages/system/SystemPages';
 import { getApiCapabilities } from '../pages/appShell/appShellPages/apis/utils/apiCapabilities';
 import {
   ConsoleScopeContext,
@@ -40,12 +41,29 @@ export {
   type ConsoleScope,
 } from './ConsoleScopeContext';
 
+/**
+ * This console's BFF forwards one bearer token per session (see
+ * `AuthProvider`) — there is no per-org token exchange, so a session is
+ * scoped to exactly one organization for its whole lifetime. That organization
+ * is resolved server-side from the token's own claims and exposed as
+ * `user.org` on `/api/session` (see `bff/internal/session/claims.go`).
+ *
+ * The route, however, carries its own `:orgHandle` segment — and nothing
+ * stops a link from naming a *different* organization than the session's own.
+ * Because `organizations`/`projects`/`environments` on platform-api don't
+ * accept an explicit org id (they implicitly answer "for whichever org this
+ * bearer token belongs to"), blindly trusting `params.orgHandle` to label
+ * whatever those calls return is what let the console show your own org's
+ * data under someone else's org handle. So this provider checks the route's
+ * org handle against `user.org.handle` *before* anything else, and renders an
+ * access-denied page in place of the whole app shell on a mismatch — never a
+ * per-page gate, since every org-scoped page's data ultimately traces back to
+ * this same session-bound org.
+ */
 export function ConsoleScopeProvider({ children }: { children: ReactNode }) {
   const routeParams = useParams<ConsoleRouteParams>();
   const location = useLocation();
-  const { exchangeOrgToken, isAuthenticated } = useAuth();
-  const [tokenReadyOrgHandle, setTokenReadyOrgHandle] = useState<string>();
-  const [orgTokenError, setOrgTokenError] = useState<Error>();
+  const { user } = useAuth();
   const pathnameParams = useMemo(
     () => getRouteParamsFromPathname(location.pathname),
     [location.pathname]
@@ -73,47 +91,20 @@ export function ConsoleScopeProvider({ children }: { children: ReactNode }) {
       routeParams.projectHandler,
     ]
   );
-  // `exchangeOrgToken` may not be referentially stable (it closes over Asgardeo
-  // SDK functions). Read it through a ref and key the effect on stable
-  // primitives only, so the exchange fires exactly once per org — never on
-  // every render, which would recurse into repeated token-exchange calls.
-  const exchangeOrgTokenRef = useRef(exchangeOrgToken);
-  exchangeOrgTokenRef.current = exchangeOrgToken;
 
-  useEffect(() => {
-    let isMounted = true;
+  // A session with no `org` claim at all (basic/file-based auth, which has no
+  // notion of multiple organizations — see `AuthProvider`) has nothing to
+  // mismatch against, so it isn't gated here. Only a *known* session org that
+  // disagrees with the route is treated as denied.
+  const sessionOrgHandle = user?.org?.handle;
+  const orgAccessDenied = Boolean(
+    params.orgHandle && sessionOrgHandle && params.orgHandle !== sessionOrgHandle
+  );
 
-    if (!params.orgHandle || !isAuthenticated) {
-      setTokenReadyOrgHandle(undefined);
-      setOrgTokenError(undefined);
-      return () => {
-        isMounted = false;
-      };
-    }
-
-    setTokenReadyOrgHandle(undefined);
-    setOrgTokenError(undefined);
-    exchangeOrgTokenRef
-      .current(params.orgHandle)
-      .then(() => {
-        if (isMounted) setTokenReadyOrgHandle(params.orgHandle);
-      })
-      .catch((error) => {
-        if (!isMounted) return;
-        setOrgTokenError(
-          error instanceof Error
-            ? error
-            : new Error('Unable to exchange organization token')
-        );
-      });
-
-    return () => {
-      isMounted = false;
-    };
-  }, [isAuthenticated, params.orgHandle]);
-
-  const queryOrgHandle =
-    tokenReadyOrgHandle === params.orgHandle ? params.orgHandle : undefined;
+  // Only ever query with an org handle the session actually owns — never the
+  // raw route param — so a mismatched route can't leak a real request out
+  // under the wrong label.
+  const queryOrgHandle = orgAccessDenied ? undefined : params.orgHandle;
 
   const apiQuery = useRestApi(params.apiHandler, {orgId: queryOrgHandle });
   const organizationsQuery = useOrganizations();
@@ -138,9 +129,6 @@ export function ConsoleScopeProvider({ children }: { children: ReactNode }) {
 
   const value = useMemo<ConsoleScope>(
     () => ({
-      // Token-ready identifiers the data hooks default to (orgHandle only set
-      // post token-exchange via queryOrgHandle), so context-aware queries never
-      // fire before their bearer token is ready.
       activeScope: {
         orgHandle: queryOrgHandle,
         projectHandler: params.projectHandler,
@@ -151,27 +139,27 @@ export function ConsoleScopeProvider({ children }: { children: ReactNode }) {
       isApiScope: Boolean(params.apiHandler),
       isLoading:
         organizationsQuery.isLoading ||
-        Boolean(params.orgHandle && !tokenReadyOrgHandle && !orgTokenError) ||
         projectsQuery.isLoading ||
         projectQuery.isLoading ||
         apiQuery.isLoading,
       isOrganizationScope: Boolean(params.orgHandle),
       isProjectScope: Boolean(params.projectHandler),
+      orgAccessDenied,
       organization,
       organizations: organizationsQuery.data?.list || [],
       params,
       project,
       projects: projectsQuery.data?.list || [],
-      projectsError: orgTokenError || projectsQuery.error || undefined,
+      projectsError: projectsQuery.error || undefined,
     }),
     [
       capabilities,
       component,
       apiQuery.isLoading,
+      orgAccessDenied,
       organization,
       organizationsQuery.data,
       organizationsQuery.isLoading,
-      orgTokenError,
       params,
       project,
       projectQuery.isLoading,
@@ -179,9 +167,12 @@ export function ConsoleScopeProvider({ children }: { children: ReactNode }) {
       projectsQuery.error,
       projectsQuery.isLoading,
       queryOrgHandle,
-      tokenReadyOrgHandle,
     ]
   );
+
+  if (orgAccessDenied) {
+    return <OrganizationAccessDeniedPage />;
+  }
 
   return (
     <ConsoleScopeContext.Provider value={value}>
@@ -194,10 +185,6 @@ export function ConsoleScopeProvider({ children }: { children: ReactNode }) {
         once the contexts are split properly, `ApiScopeProvider` moves above
         this one and takes its ids straight from the router, and this nesting
         goes away.
-
-        Note the ids differ from the ones above deliberately — the API layer
-        wants the raw route params, not the token-gated `queryOrgHandle` the old
-        hooks need, because it has no token exchange to wait on.
       */}
       <ApiScopeProvider
         orgId={params.orgHandle}

--- a/portals/api-control-plane/src/scope/ConsoleScopeProvider.tsx
+++ b/portals/api-control-plane/src/scope/ConsoleScopeProvider.tsx
@@ -92,11 +92,22 @@ export function ConsoleScopeProvider({ children }: { children: ReactNode }) {
     ]
   );
 
+  const organizationsQuery = useOrganizations();
+
+  // `user.org.handle` (a JWT claim resolved server-side, see
+  // `bff/internal/session/claims.go`) is read exactly once, here, and used
+  // for both the access check below and the recovery destination passed to
+  // `OrganizationAccessDeniedPage` — never re-derived independently in a
+  // second place. Two independent reads of "the session's own org handle"
+  // are only guaranteed to agree by convention, not by anything the type
+  // system enforces; a page that read it separately could silently drift
+  // from what this check actually verified.
+  const sessionOrgHandle = user?.org?.handle;
+
   // A session with no `org` claim at all (basic/file-based auth, which has no
   // notion of multiple organizations — see `AuthProvider`) has nothing to
   // mismatch against, so it isn't gated here. Only a *known* session org that
   // disagrees with the route is treated as denied.
-  const sessionOrgHandle = user?.org?.handle;
   const orgAccessDenied = Boolean(
     params.orgHandle && sessionOrgHandle && params.orgHandle !== sessionOrgHandle
   );
@@ -107,7 +118,6 @@ export function ConsoleScopeProvider({ children }: { children: ReactNode }) {
   const queryOrgHandle = orgAccessDenied ? undefined : params.orgHandle;
 
   const apiQuery = useRestApi(params.apiHandler, {orgId: queryOrgHandle });
-  const organizationsQuery = useOrganizations();
   const projectsQuery = useProjects({}, {orgId: queryOrgHandle });
   const projectQuery = useProject(params.projectHandler, {orgId: queryOrgHandle });
 
@@ -171,7 +181,7 @@ export function ConsoleScopeProvider({ children }: { children: ReactNode }) {
   );
 
   if (orgAccessDenied) {
-    return <OrganizationAccessDeniedPage />;
+    return <OrganizationAccessDeniedPage myOrgHandle={sessionOrgHandle} />;
   }
 
   return (

--- a/portals/api-control-plane/src/test/mockAuthState.ts
+++ b/portals/api-control-plane/src/test/mockAuthState.ts
@@ -38,7 +38,6 @@ export function makeAuthState(overrides: Partial<AuthState> = {}): AuthState {
       : undefined,
     login: vi.fn(),
     loginWithCredentials: vi.fn().mockResolvedValue(true),
-    exchangeOrgToken: vi.fn().mockResolvedValue(true),
     logout: vi.fn(),
     ...overrides,
   };

--- a/portals/api-control-plane/src/test/mockScope.ts
+++ b/portals/api-control-plane/src/test/mockScope.ts
@@ -48,6 +48,7 @@ export function makeConsoleScope(overrides: Partial<ConsoleScope> = {}): Console
     isLoading: false,
     isOrganizationScope: Boolean(organization),
     isProjectScope: Boolean(project),
+    orgAccessDenied: false,
     organization,
     organizations: overrides.organizations ?? [anOrganization()],
     params,


### PR DESCRIPTION
## Purpose
This PR blocks accessing an org via route names while the session isn't scoped to that org.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
