### PR TITLE
fix(handle)!: tighten handle max length 63 → 40 for v2 parity

### DIFF
--- a/platform-api/src/internal/constants/error.go
+++ b/platform-api/src/internal/constants/error.go
@@ -24,7 +24,7 @@ var (
 	ErrHandleDoesNotExist     = errors.New("handle does not exist")
 	ErrHandleEmpty            = errors.New("handle cannot be empty")
 	ErrHandleTooShort         = errors.New("handle must be at least 3 characters")
-	ErrHandleTooLong          = errors.New("handle must be at most 63 characters")
+	ErrHandleTooLong          = errors.New("handle must be at most 40 characters")
 	ErrInvalidHandle          = errors.New("handle must be lowercase alphanumeric with hyphens only (no consecutive hyphens, cannot start or end with hyphen)")
 	ErrHandleGenerationFailed = errors.New("failed to generate unique handle after maximum retries")
 	ErrHandleSourceEmpty      = errors.New("source string cannot be empty for handle generation")

--- a/platform-api/src/internal/utils/handle.go
+++ b/platform-api/src/internal/utils/handle.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	handleMinLength = 3
-	handleMaxLength = 63
+	handleMaxLength = 40
 	maxRetries      = 5
 	suffixLength    = 4
 )
@@ -49,7 +49,7 @@ var (
 // - No special characters
 // - No consecutive hyphens
 // - Cannot start or end with hyphen
-// - Length between 3 and 63 characters
+// - Length between 3 and 40 characters
 func ValidateHandle(handle string) error {
 	if handle == "" {
 		return constants.ErrHandleEmpty

--- a/platform-api/src/internal/utils/handle_test.go
+++ b/platform-api/src/internal/utils/handle_test.go
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package utils
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"platform-api/src/internal/constants"
+)
+
+// TestValidateHandle_LengthBoundary pins the handle length ceiling at 40:
+// a 40-char handle is accepted, a 41-char handle is rejected with
+// constants.ErrHandleTooLong. This matches Platform API v2's VARCHAR(40) limit.
+func TestValidateHandle_LengthBoundary(t *testing.T) {
+	tests := []struct {
+		name    string
+		handle  string
+		wantErr error
+	}{
+		{"40 chars accepted", strings.Repeat("a", 40), nil},
+		{"41 chars rejected", strings.Repeat("a", 41), constants.ErrHandleTooLong},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := len(tt.handle); (tt.wantErr == nil) != (got <= 40) {
+				t.Fatalf("test setup wrong: handle len %d vs wantErr %v", got, tt.wantErr)
+			}
+			err := ValidateHandle(tt.handle)
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("ValidateHandle(%d chars) = %v, want %v", len(tt.handle), err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestValidateHandle_ChoreoUUID confirms the Choreo APIM case — a 36-char
+// lowercase UUID sent as the resource handle — still validates unchanged.
+func TestValidateHandle_ChoreoUUID(t *testing.T) {
+	uuid := "e331974d-368b-411b-b038-c6598d85731c" // 36 chars, canonical randomUUID shape
+	if len(uuid) != 36 {
+		t.Fatalf("test setup wrong: uuid len = %d, want 36", len(uuid))
+	}
+	if err := ValidateHandle(uuid); err != nil {
+		t.Errorf("ValidateHandle(36-char UUID) = %v, want nil", err)
+	}
+}
+
+// TestSanitizeToHandle_TruncatesTo40 verifies sanitizeToHandle never emits a
+// handle longer than 40 chars and never leaves a trailing hyphen when the
+// truncation boundary lands on one.
+func TestSanitizeToHandle_TruncatesTo40(t *testing.T) {
+	// 60 chars, all valid alphanumeric -> truncated straight to 40.
+	if got := sanitizeToHandle(strings.Repeat("a", 60)); len(got) != 40 {
+		t.Errorf("sanitizeToHandle(60 x 'a') len = %d, want 40", len(got))
+	}
+
+	// Boundary lands on a hyphen: "aaa…(39)a bbb…" -> the space becomes a
+	// hyphen at position 40, which must be trimmed off after truncation.
+	in := strings.Repeat("a", 39) + " " + strings.Repeat("b", 20)
+	got := sanitizeToHandle(in)
+	if len(got) > 40 {
+		t.Errorf("sanitizeToHandle length = %d, want <= 40", len(got))
+	}
+	if strings.HasSuffix(got, "-") {
+		t.Errorf("sanitizeToHandle = %q, must not end with '-'", got)
+	}
+}


### PR DESCRIPTION
### Description

Aligns Platform API **v1** handle validation with **v2**'s `VARCHAR(40)` limit, so a handle that cannot be migrated verbatim can no longer be created.

v1 accepts 3–63-char handles (`handleMaxLength = 63`) in a `VARCHAR(255)` column; v2 caps handles at `VARCHAR(40)` and `ValidateHandle` rejects anything over 40. A v1 handle of 41–63 chars therefore cannot be carried into v2 verbatim — and a handle is an external id that **cannot be re-slugged** after the fact (Choreo APIM addresses resources by it). Tightening v1 to 40 closes the door on any *future* over-40 handle. Choreo APIM only ever sends 36-char `UUID.randomUUID()` values, so this is safe for it.

### What changed

- `src/internal/utils/handle.go` — `handleMaxLength` **63 → 40** (the single constant drives `ValidateHandle`, the `sanitizeToHandle` truncation, and the suffix-fit math — none hardcoded) + doc comment.
- `src/internal/constants/error.go` — `ErrHandleTooLong` message `at most 63` → `at most 40`.
- `src/internal/utils/handle_test.go` *(new)* — pins the boundary: 40 accepted / 41 rejected with `ErrHandleTooLong`, the 36-char Choreo APIM UUID still passes, and `sanitizeToHandle` truncates to ≤40 with no trailing hyphen.

### ⚠ Data precondition (before merge/rollout)

This change only rejects **new/updated** handles > 40; it does not touch existing rows. Confirm the Prod DB has **no existing handle > 40** first — a read-only length scan across the four tables that carry a handle (`organizations`, `applications`, `artifacts`, `llm_provider_templates`).

### Type of Change
- [ ] Infrastructure or component change
- [x] Breaking change — handles of 41–63 characters are now rejected by `ValidateHandle`; they were accepted before.
- [ ] change requires a documentation update

### Testing

- `go build ./src/...` — clean.
- `go test ./src/internal/utils/... ./src/internal/constants/...` — passes, including the 3 new boundary tests (40 accepted / 41 rejected / 36-char UUID passes / truncate-to-40).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

