### PR TITLE
Revamp API Creation flow

### DIFF
--- a/portals/api-control-plane/src/i18n/messages/en.json
+++ b/portals/api-control-plane/src/i18n/messages/en.json
@@ -33,12 +33,12 @@
   "api.create.ApiCreationProgress.stage.validating": {
     "defaultMessage": "Validating configuration"
   },
-  "api.create.ApiCreationProgress.subtitle": {
-    "defaultMessage": "“{name}” will be ready in a moment.",
-    "description": "{name} is the display name the user gave the API. Never translated."
-  },
   "api.create.ApiCreationProgress.title": {
     "defaultMessage": "We are in the process of creating your API Proxy"
+  },
+  "api.create.ApiCreationProgress.titleWithName": {
+    "defaultMessage": "We are in the process of creating your {name} API Proxy",
+    "description": "{name} is the display name the user gave the API. Never translated."
   },
   "api.create.ApiCreationSteps.step.apiType": {
     "defaultMessage": "API type",
@@ -52,18 +52,24 @@
     "defaultMessage": "Source",
     "description": "Progress step where the user supplies a contract or a backend endpoint."
   },
+  "api.create.ApiCreationWizard.action.back": {
+    "defaultMessage": "Back"
+  },
+  "api.create.ApiCreationWizard.action.continue": {
+    "defaultMessage": "Continue"
+  },
   "api.create.ApiCreationWizard.apiType.generic": {
     "defaultMessage": "API",
     "description": "Stands in for the chosen API type when the wizard is opened straight at a later step."
   },
   "api.create.ApiCreationWizard.apiType.subtitle": {
-    "defaultMessage": "This decides how the gateway exposes your backend. Only REST is available today."
+    "defaultMessage": "Choose how the gateway should expose your backend."
   },
   "api.create.ApiCreationWizard.apiType.title": {
     "defaultMessage": "What kind of API are you exposing?"
   },
   "api.create.ApiCreationWizard.configure.subtitle": {
-    "defaultMessage": "Name it, set where it routes, and create it."
+    "defaultMessage": "Review the API details, configure its backend endpoint, and create it."
   },
   "api.create.ApiCreationWizard.configure.title": {
     "defaultMessage": "Configure and create"
@@ -74,6 +80,16 @@
   "api.create.ApiCreationWizard.source.title": {
     "defaultMessage": "How do you want to define your {apiType}?",
     "description": "{apiType} is the type picked in the first step, e.g. \"REST API\". Reads as one sentence."
+  },
+  "api.create.ApiCreationWizard.stepCount": {
+    "defaultMessage": "Step {current} of 3"
+  },
+  "api.create.ApiCreationWizard.title": {
+    "defaultMessage": "Create an API"
+  },
+  "api.create.ApiTypeSelector.badge.available": {
+    "defaultMessage": "Available",
+    "description": "Badge on an API type that can be selected now."
   },
   "api.create.ApiTypeSelector.badge.comingSoon": {
     "defaultMessage": "Coming soon",
@@ -88,7 +104,7 @@
     "description": "Accessible name for the group of API type cards. Noun, not a command."
   },
   "api.create.ApiTypeSelector.subtitle": {
-    "defaultMessage": "This decides how the gateway exposes your backend. Only REST is available today.",
+    "defaultMessage": "Choose how the gateway should expose your backend.",
     "description": "Supporting line under the API type selector heading."
   },
   "api.create.ApiTypeSelector.title": {
@@ -165,6 +181,10 @@
   },
   "api.create.defineApi.scratch.title": {
     "defaultMessage": "Design from scratch"
+  },
+  "api.create.fromContract.action.clearUrl": {
+    "defaultMessage": "Clear URL",
+    "description": "Clears the API contract URL field and its loaded preview."
   },
   "api.create.fromContract.action.sampleUrl": {
     "defaultMessage": "Try with Sample URL",
@@ -309,25 +329,25 @@
     "description": "Neutral helper line under the drop zone. {maxSize} is a formatted size such as \"10 MB\"."
   },
   "api.create.fromContract.upload.action": {
-    "defaultMessage": "Select file"
+    "defaultMessage": "Upload"
   },
   "api.create.fromContract.upload.hint": {
-    "defaultMessage": "One file · {extensions}",
+    "defaultMessage": "Drag & drop your file or click to select · Accepted file types: {extensions}",
     "description": "Sits under the drop-zone heading; {extensions} is a list such as \".json, .yaml\"."
   },
   "api.create.fromContract.upload.remove": {
     "defaultMessage": "Remove {fileName}",
     "description": "Accessible name for the button that discards the chosen file."
   },
-  "api.create.fromContract.upload.replace": {
-    "defaultMessage": "Replace file",
-    "description": "Reopens the file picker so the chosen contract can be swapped for another."
-  },
   "api.create.fromContract.upload.required": {
     "defaultMessage": "Select an API contract file to continue"
   },
   "api.create.fromContract.upload.title": {
-    "defaultMessage": "Drag and drop your contract here"
+    "defaultMessage": "Upload API Contract"
+  },
+  "api.create.fromContract.upload.uploadedFile": {
+    "defaultMessage": "Uploaded file",
+    "description": "Heading above the selected API contract file."
   },
   "api.create.fromContract.upload.unsupported": {
     "defaultMessage": "That file type is not supported. Accepted types: {extensions}"
@@ -409,9 +429,6 @@
   "api.create.generalForm.section.basicInformation": {
     "defaultMessage": "Basic information"
   },
-  "api.create.generalForm.subtitle": {
-    "defaultMessage": "Provide the details to configure and expose your API proxy."
-  },
   "api.create.generalForm.targetUrl.error.invalid": {
     "defaultMessage": "Enter a full URL, for example https://api.example.com."
   },
@@ -423,9 +440,6 @@
   },
   "api.create.generalForm.targetUrl.label": {
     "defaultMessage": "Target URL"
-  },
-  "api.create.generalForm.title": {
-    "defaultMessage": "Create an API Proxy"
   },
   "api.create.generalForm.version.error.pattern": {
     "defaultMessage": "Use letters, numbers, dots, hyphens and underscores — no spaces or slashes."
@@ -700,13 +714,10 @@
     "description": "Button opening the API Designer VS Code extension listing in a new tab. \"API Designer\" is a product name — leave it untranslated."
   },
   "apiControlPlane.pages.appShell.appShellPages.apis.create.components.DesignWithAiPanel.body": {
-    "defaultMessage": "Draw operations on a canvas, check them against governance rules, and design with AI in VS Code."
+    "defaultMessage": "Design, edit, and validate OpenAPI 3.x APIs directly in VS Code. Includes Spectral governance checks and AI-readiness assessment."
   },
   "apiControlPlane.pages.appShell.appShellPages.apis.create.components.DesignWithAiPanel.docs": {
     "defaultMessage": "How to get started"
-  },
-  "apiControlPlane.pages.appShell.appShellPages.apis.create.components.DesignWithAiPanel.skeletonHint": {
-    "defaultMessage": "Or carry on here - the skeleton on the right is a starting point you can edit by hand."
   },
   "apiControlPlane.pages.appShell.appShellPages.apis.create.components.DesignWithAiPanel.title": {
     "defaultMessage": "Design with AI"
@@ -942,6 +953,12 @@
   },
   "apiControlPlane.pages.appShell.appShellPages.apis.overview.DeployedGatewaysPanel.title": {
     "defaultMessage": "Deployed gateways"
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.overview.EndpointsPanel.notConfigured": {
+    "defaultMessage": "No endpoint configured"
+  },
+  "apiControlPlane.pages.appShell.appShellPages.apis.overview.EndpointsPanel.title": {
+    "defaultMessage": "Endpoints"
   },
   "apiControlPlane.pages.appShell.appShellPages.apis.overview.DocumentsPanel.description": {
     "defaultMessage": "Guides, references, and specifications published with this API."

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/components/ResourcePreviewPlaceholder.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/components/ResourcePreviewPlaceholder.tsx
@@ -20,7 +20,7 @@ import { alpha, Box, Chip, Stack, Typography, type Theme } from '@wso2/oxygen-ui
 import { ChevronDown } from '@wso2/oxygen-ui-icons-react';
 import { defineMessages, useIntl } from 'react-intl';
 
-import { ambientGlowSx, hairline } from '@/theme/receipes';
+import { hairline } from '@/theme/receipes';
 import { methodColor, type ChipColor } from '../utils/developEdit';
 
 const messages = defineMessages({
@@ -78,7 +78,7 @@ const BAR_LONG_WIDTH = '56%';
  * piece of content.
  */
 const barSx = (width: string) => (theme: Theme) => ({
-  bgcolor: alpha(theme.palette.background.paper, 0.85),
+  bgcolor: alpha(theme.palette.text.primary, 0.18),
   borderRadius: 999,
   flexShrink: 0,
   height: 6,
@@ -116,18 +116,11 @@ export const ResourcePreviewPlaceholder = ({
       data-testid={testId}
       sx={(theme) => ({
         alignItems: 'center',
-        // A faint wash of the same families the method chips use, so the
-        // surface belongs to the listing sitting on it. The two paper stops
-        // hold the middle flat, so the tints read as a hint at the edges rather
-        // than a visible top-to-bottom ramp. Every stop derives from a palette
-        // token, so it re-tints itself in dark mode instead of staying a pale
-        // smudge.
-        backgroundImage: `linear-gradient(180deg, ${alpha(
-          theme.palette.success.light,
-          0.05,
-        )} 0%, ${theme.palette.background.paper} 38%, ${
-          theme.palette.background.paper
-        } 66%, ${alpha(theme.palette.info.light, 0.06)} 100%)`,
+        bgcolor: alpha(theme.palette.text.primary, 0.025),
+        backgroundImage: `radial-gradient(circle at 50% 15%, ${alpha(
+          theme.palette.primary.main,
+          0.06,
+        )}, transparent 42%)`,
         border: hairline(theme),
         borderColor: 'divider',
         borderRadius: 2,
@@ -136,48 +129,11 @@ export const ResourcePreviewPlaceholder = ({
         // `minHeight` rather than `height`: it fills a short pane, but a tall
         // enough one lets the content set the height instead of clipping it.
         minHeight: '100%',
-        // The glows are positioned against this box and bleed past its edges.
         overflow: 'hidden',
         p: { sm: 3, xs: 2.25 },
         position: 'relative',
       })}
     >
-      <Box
-        aria-hidden
-        sx={(theme) => ({
-          ...ambientGlowSx,
-          bgcolor: alpha(theme.palette.success.light, 0.34),
-          height: 150,
-          left: '50%',
-          top: theme.spacing(-5),
-          transform: 'translateX(-50%)',
-          width: 300,
-        })}
-      />
-      <Box
-        aria-hidden
-        sx={(theme) => ({
-          ...ambientGlowSx,
-          bgcolor: alpha(theme.palette.warning.light, 0.24),
-          height: 130,
-          left: '50%',
-          top: '42%',
-          transform: 'translate(-50%, -50%)',
-          width: 220,
-        })}
-      />
-      <Box
-        aria-hidden
-        sx={(theme) => ({
-          ...ambientGlowSx,
-          bgcolor: alpha(theme.palette.info.light, 0.36),
-          bottom: theme.spacing(-6),
-          height: 180,
-          right: theme.spacing(-5),
-          width: 220,
-        })}
-      />
-
       <Stack
         sx={{
           alignItems: 'center',
@@ -188,7 +144,7 @@ export const ResourcePreviewPlaceholder = ({
           zIndex: 1,
         }}
       >
-        <Stack aria-hidden spacing={1.2} sx={{ mb: { sm: 5.5, xs: 4.5 }, width: '100%' }}>
+        <Stack aria-hidden spacing={1} sx={{ mb: { sm: 4, xs: 3 }, width: '100%' }}>
           {PLACEHOLDER_ROWS.map((row) => (
             <Stack
               direction="row"
@@ -203,7 +159,7 @@ export const ResourcePreviewPlaceholder = ({
                   border: hairline(theme),
                   borderColor: alpha(tone, 0.22),
                   borderRadius: 1.25,
-                  boxShadow: row.ghost ? 'none' : theme.shadows[1],
+                  boxShadow: 'none',
                   minHeight: { sm: 40, xs: 38 },
                   px: 1.35,
                   py: 0.9,

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/ApiCreationWizard.test.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/ApiCreationWizard.test.tsx
@@ -17,6 +17,7 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useEffect } from 'react';
 
 import { resetHttpClient } from '@/api/core/http';
 import { accepts, collection, failure, recorder } from '@/test/msw';
@@ -51,14 +52,18 @@ vi.mock('./components/ApiTypeSelector', () => ({
 }));
 
 vi.mock('./components/DefineApiPanel', () => ({
-  DefineApiPanel: ({ onDraftChange }: { onDraftChange: (draft: unknown) => void }) => (
-    <button
-      onClick={() => onDraftChange({ displayName: 'Orders API', version: '1.0' })}
-      type="button"
-    >
-      Use this contract
-    </button>
-  ),
+  DefineApiPanel: ({ onDraftChange }: { onDraftChange: (draft: unknown) => void }) => {
+    useEffect(() => () => onDraftChange(null), [onDraftChange]);
+
+    return (
+      <button
+        onClick={() => onDraftChange({ displayName: 'Orders API', version: '1.0' })}
+        type="button"
+      >
+        Use this contract
+      </button>
+    );
+  },
 }));
 
 const scope = makeConsoleScope();
@@ -85,6 +90,18 @@ const submitCreate = async () => {
 };
 
 describe('ApiCreationWizard — explicit creation boundary', () => {
+  it('preserves the selected source when returning from configuration', async () => {
+    const { user } = renderWithProviders(<ApiCreationWizard />, { route, scope });
+
+    await user.click(screen.getByRole('button', { name: 'Choose REST' }));
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
+    await user.click(screen.getByRole('button', { name: 'Use this contract' }));
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
+    await user.click(screen.getByRole('button', { name: 'Back' }));
+
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeEnabled();
+  });
+
   it('shows Step 3 without posting when Continue is clicked, then posts on Create', async () => {
     const createRequests = recorder();
     server.use(accepts('post', '/rest-apis', { id: 'orders-api' }, { record: createRequests }));

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/ApiCreationWizard.test.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/ApiCreationWizard.test.tsx
@@ -19,7 +19,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { resetHttpClient } from '@/api/core/http';
-import { collection, failure } from '@/test/msw';
+import { accepts, collection, failure, recorder } from '@/test/msw';
 import { makeConsoleScope } from '@/test/mockScope';
 import { server } from '@/test/server';
 import { renderWithProviders, screen } from '@/test/utils';
@@ -51,9 +51,9 @@ vi.mock('./components/ApiTypeSelector', () => ({
 }));
 
 vi.mock('./components/DefineApiPanel', () => ({
-  DefineApiPanel: ({ onDataFetched }: { onDataFetched: (draft: unknown) => void }) => (
+  DefineApiPanel: ({ onDraftChange }: { onDraftChange: (draft: unknown) => void }) => (
     <button
-      onClick={() => onDataFetched({ displayName: 'Orders API', version: '1.0' })}
+      onClick={() => onDraftChange({ displayName: 'Orders API', version: '1.0' })}
       type="button"
     >
       Use this contract
@@ -75,12 +75,36 @@ const submitCreate = async () => {
   const { user } = rendered;
 
   await user.click(screen.getByRole('button', { name: 'Choose REST' }));
+  await user.click(screen.getByRole('button', { name: 'Continue' }));
   await user.click(screen.getByRole('button', { name: 'Use this contract' }));
+  await user.click(screen.getByRole('button', { name: 'Continue' }));
   await user.type(screen.getByLabelText(/Target URL/), 'https://orders.example.com');
   await user.click(screen.getByRole('button', { name: 'Create' }));
 
   return rendered;
 };
+
+describe('ApiCreationWizard — explicit creation boundary', () => {
+  it('shows Step 3 without posting when Continue is clicked, then posts on Create', async () => {
+    const createRequests = recorder();
+    server.use(accepts('post', '/rest-apis', { id: 'orders-api' }, { record: createRequests }));
+    const { user } = renderWithProviders(<ApiCreationWizard />, { route, scope });
+
+    await user.click(screen.getByRole('button', { name: 'Choose REST' }));
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
+    await user.click(screen.getByRole('button', { name: 'Use this contract' }));
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
+
+    expect(screen.getByText('Step 3 of 3')).toBeInTheDocument();
+    expect(screen.getByLabelText(/Target URL/)).toBeInTheDocument();
+    expect(createRequests.count()).toBe(0);
+
+    await user.type(screen.getByLabelText(/Target URL/), 'https://orders.example.com');
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+
+    expect(createRequests.count()).toBe(1);
+  });
+});
 
 describe('ApiCreationWizard — a rejected create', () => {
   it('returns to the form with the reason on the field, when the user can fix it', async () => {

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/ApiCreationWizard.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/ApiCreationWizard.tsx
@@ -16,7 +16,8 @@
  * under the License.
  */
 
-import { Box, Stack, Typography } from '@wso2/oxygen-ui';
+import { Box, Button, Divider, Stack, Typography } from '@wso2/oxygen-ui';
+import { ArrowRight } from '@wso2/oxygen-ui-icons-react';
 import { useCallback, useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { useNavigate } from 'react-router-dom';
@@ -34,12 +35,26 @@ import {
   ApiCreationProgress,
   type ApiCreationProgressStatus,
 } from './components/ApiCreationProgress';
+import { API_TYPES } from './uiConfig';
+
+const CONFIGURE_FORM_ID = 'api-creation-configure-form';
 
 const messages = defineMessages({
+  back: {
+    id: 'api.create.ApiCreationWizard.action.back',
+    defaultMessage: 'Back',
+  },
+  continue: {
+    id: 'api.create.ApiCreationWizard.action.continue',
+    defaultMessage: 'Continue',
+  },
+  createAnApi: {
+    id: 'api.create.ApiCreationWizard.title',
+    defaultMessage: 'Create an API',
+  },
   apiTypeSubtitle: {
     id: 'api.create.ApiCreationWizard.apiType.subtitle',
-    defaultMessage:
-      'This decides how the gateway exposes your backend. Only REST is available today.',
+    defaultMessage: 'Choose how the gateway should expose your backend.',
   },
   apiTypeTitle: {
     id: 'api.create.ApiCreationWizard.apiType.title',
@@ -47,7 +62,7 @@ const messages = defineMessages({
   },
   configureSubtitle: {
     id: 'api.create.ApiCreationWizard.configure.subtitle',
-    defaultMessage: 'Name it, set where it routes, and create it.',
+    defaultMessage: 'Review the API details, configure its backend endpoint, and create it.',
   },
   configureTitle: {
     id: 'api.create.ApiCreationWizard.configure.title',
@@ -70,12 +85,19 @@ const messages = defineMessages({
     description:
       '{apiType} is the type picked in the first step, e.g. "REST API". Reads as one sentence.',
   },
+  stepCount: {
+    id: 'api.create.ApiCreationWizard.stepCount',
+    defaultMessage: 'Step {current} of 3',
+  },
 });
 
 export const ApiCreationWizard = () => {
   const intl = useIntl();
   const [step, setStep] = useState<ApiCreationStepKey>('apiType');
-  const [apiType, setApiType] = useState<ApiType | null>(null);
+  const [apiType, setApiType] = useState<ApiType | null>(
+    () => API_TYPES.find((candidate) => candidate.enabled) ?? null,
+  );
+  const [sourceDraft, setSourceDraft] = useState<ApiCreationWizardDraftState | null>(null);
 
   const [prefilledData, setPrefilledData] = useState<Partial<GeneralApiCreationFormState>>({});
 
@@ -122,10 +144,10 @@ export const ApiCreationWizard = () => {
    * A fresh import also supersedes any earlier submission, so the form starts
    * from the new document rather than restoring values typed against the old.
    */
-  const handleDataExtracted = (data: ApiCreationWizardDraftState) => {
-    setPrefilledData(data);
+  const continueFromSource = () => {
+    if (sourceDraft === null) return;
+    setPrefilledData(sourceDraft);
     setSubmittedValues(null);
-
     setStep('configure');
   };
 
@@ -230,57 +252,132 @@ export const ApiCreationWizard = () => {
     );
   }
 
+  const stepNumber = step === 'apiType' ? 1 : step === 'source' ? 2 : 3;
+
   return (
-    <Box sx={{ width: '100%' }}>
-      <Stack direction="column" spacing={2} sx={{ alignItems: 'center' }}>
-        <ApiCreationSteps activeStep={step} onStepClick={(step) => setStep(step)} />
+    <Box
+      sx={{
+        border: 1,
+        borderColor: 'divider',
+        borderRadius: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        minHeight: 620,
+        overflow: 'hidden',
+        width: '100%',
+      }}
+    >
+      <Stack
+        direction="row"
+        spacing={2}
+        sx={{ alignItems: 'center', borderBottom: 1, borderColor: 'divider', minHeight: 48, px: 3 }}
+      >
+        <Typography sx={{ fontWeight: 700, whiteSpace: 'nowrap' }} variant="body2">
+          {intl.formatMessage(messages.createAnApi)}
+        </Typography>
+        <Divider flexItem orientation="vertical" sx={{ my: 1.5 }} />
+        <ApiCreationSteps activeStep={step} onStepClick={(nextStep) => setStep(nextStep)} />
+      </Stack>
 
-        <Box sx={{ alignSelf: 'flex-start' }}>
-          <Typography variant="h1" sx={{ textAlign: 'left', mb: 1, fontWeight: 700 }}>
-            {getTitleForStep(step)}
-          </Typography>
-          <Typography variant="body1" sx={{ textAlign: 'left' }}>
-            {getSubtitleForStep(step)}
-          </Typography>
-        </Box>
+      <Box sx={{ flex: 1, p: { md: 3.5, xs: 2 } }}>
+        <Stack
+          direction="column"
+          spacing={step === 'configure' ? 2 : 3}
+          sx={{ alignItems: 'flex-start' }}
+        >
+          <Box>
+            <Typography variant="h1" sx={{ textAlign: 'left', mb: 1, fontWeight: 700 }}>
+              {getTitleForStep(step)}
+            </Typography>
+            <Typography variant="body1" sx={{ textAlign: 'left' }}>
+              {getSubtitleForStep(step)}
+            </Typography>
+          </Box>
 
-        <Box sx={{ alignSelf: 'flex-start', width: '100%' }}>
-          {step === 'apiType' && (
-            <ApiTypeSelector
-              onChange={(apiType) => {
-                setApiType(apiType);
-                setStep('source');
-              }}
-            />
-          )}
-
-          {step === 'source' && (
-            // `onAuthorizeGitHub` and `onRefreshSwaggerHubOrganizations` are
-            // deliberately not passed: neither flow is wired yet, and the
-            // panel hides the control belonging to a handler it wasn't given
-            // rather than rendering a button that does nothing.
-            <DefineApiPanel
-              initialApiTypeKey={apiType?.key}
-              onDataFetched={handleDataExtracted}
-              onBack={() => setStep('apiType')}
-            />
-          )}
-
-          {step === 'configure' && (
-            <Box sx={{ maxWidth: '80%', mt: 1 }}>
-              <GeneralCreateApiForm
-                // What the user actually submitted, when there is such an
-                // attempt to come back from: the form remounts after the
-                // progress screen, so anything hand-typed would otherwise
-                // revert to the spec-derived draft.
-                initialValues={submittedValues ?? prefilledData}
-                onSubmit={onGeneralFormSumit}
-                onBack={() => setStep('source')}
-                serverErrors={formErrors ?? undefined}
+          <Box sx={{ width: '100%' }}>
+            {step === 'apiType' && (
+              <ApiTypeSelector
+                onChange={(apiType) => {
+                  setApiType(apiType);
+                }}
+                value={apiType?.key}
               />
-            </Box>
+            )}
+
+            {step === 'source' && (
+              // `onAuthorizeGitHub` and `onRefreshSwaggerHubOrganizations` are
+              // deliberately not passed: neither flow is wired yet, and the
+              // panel hides the control belonging to a handler it wasn't given
+              // rather than rendering a button that does nothing.
+              <DefineApiPanel initialApiTypeKey={apiType?.key} onDraftChange={setSourceDraft} />
+            )}
+
+            {step === 'configure' && (
+              <Box sx={{ maxWidth: '80%' }}>
+                <GeneralCreateApiForm
+                  formId={CONFIGURE_FORM_ID}
+                  hideActions
+                  // What the user actually submitted, when there is such an
+                  // attempt to come back from: the form remounts after the
+                  // progress screen, so anything hand-typed would otherwise
+                  // revert to the spec-derived draft.
+                  initialValues={submittedValues ?? prefilledData}
+                  onSubmit={onGeneralFormSumit}
+                  onBack={() => setStep('source')}
+                  serverErrors={formErrors ?? undefined}
+                />
+              </Box>
+            )}
+          </Box>
+        </Stack>
+      </Box>
+
+      <Stack
+        direction="row"
+        sx={{
+          alignItems: 'center',
+          borderTop: 1,
+          borderColor: 'divider',
+          justifyContent: 'space-between',
+          minHeight: 56,
+          px: 3,
+        }}
+      >
+        <Typography color="text.secondary" sx={{ fontWeight: 600 }} variant="caption">
+          {intl.formatMessage(messages.stepCount, { current: stepNumber })}
+        </Typography>
+        <Stack direction="row" spacing={1}>
+          <Button
+            disabled={step === 'apiType'}
+            onClick={() => setStep(step === 'configure' ? 'source' : 'apiType')}
+            type="button"
+            variant="text"
+          >
+            {intl.formatMessage(messages.back)}
+          </Button>
+          {step === 'configure' ? (
+            <Button form={CONFIGURE_FORM_ID} key="create-api" type="submit" variant="contained">
+              {intl.formatMessage({
+                id: 'api.create.generalForm.action.create',
+                defaultMessage: 'Create',
+              })}
+            </Button>
+          ) : (
+            <Button
+              disabled={step === 'apiType' ? !apiType : sourceDraft === null}
+              endIcon={<ArrowRight size={16} />}
+              key="continue-wizard"
+              onClick={() => {
+                if (step === 'apiType') setStep('source');
+                else continueFromSource();
+              }}
+              type="button"
+              variant="contained"
+            >
+              {intl.formatMessage(messages.continue)}
+            </Button>
           )}
-        </Box>
+        </Stack>
       </Stack>
     </Box>
   );

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/ApiCreationWizard.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/ApiCreationWizard.tsx
@@ -304,12 +304,11 @@ export const ApiCreationWizard = () => {
               />
             )}
 
-            {step === 'source' && (
-              // `onAuthorizeGitHub` and `onRefreshSwaggerHubOrganizations` are
-              // deliberately not passed: neither flow is wired yet, and the
-              // panel hides the control belonging to a handler it wasn't given
-              // rather than rendering a button that does nothing.
-              <DefineApiPanel initialApiTypeKey={apiType?.key} onDraftChange={setSourceDraft} />
+            {step !== 'apiType' && (
+              <Box sx={{ display: step === 'source' ? 'block' : 'none' }}>
+                {/* Kept mounted during configuration so Back preserves the selected source and edits. */}
+                <DefineApiPanel initialApiTypeKey={apiType?.key} onDraftChange={setSourceDraft} />
+              </Box>
             )}
 
             {step === 'configure' && (

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/ApiCreationProgress.test.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/ApiCreationProgress.test.tsx
@@ -44,7 +44,14 @@ describe('ApiCreationProgress', () => {
       />,
     );
 
-    expect(screen.getByText('Orders API', { exact: false })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', {
+        name: 'We are in the process of creating your Orders API API Proxy',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('will be ready in a moment.', { exact: false }),
+    ).not.toBeInTheDocument();
 
     // Far longer than the flow could plausibly take: the bar must still be
     // short of 100, because only the server's answer may claim completion.

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/ApiCreationProgress.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/ApiCreationProgress.tsx
@@ -67,14 +67,14 @@ const messages = defineMessages({
     id: 'api.create.ApiCreationProgress.stage.validating',
     defaultMessage: 'Validating configuration',
   },
-  subtitle: {
-    id: 'api.create.ApiCreationProgress.subtitle',
-    defaultMessage: '“{name}” will be ready in a moment.',
-    description: '{name} is the display name the user gave the API. Never translated.',
-  },
   title: {
     id: 'api.create.ApiCreationProgress.title',
     defaultMessage: 'We are in the process of creating your API Proxy',
+  },
+  titleWithName: {
+    id: 'api.create.ApiCreationProgress.titleWithName',
+    defaultMessage: 'We are in the process of creating your {name} API Proxy',
+    description: '{name} is the display name the user gave the API. Never translated.',
   },
 });
 
@@ -122,7 +122,7 @@ const stageFor = (percent: number) =>
   (STAGES.find((stage) => percent < stage.until) ?? STAGES[STAGES.length - 1]).label;
 
 /** Diameter of the progress ring, in px. Shared by the ring and its track. */
-const RING_SIZE = 56;
+const RING_SIZE = 48;
 const RING_THICKNESS = 3;
 
 /** Geometry of the illustration, in its own viewBox units. */
@@ -136,7 +136,7 @@ const ART = {
  * Rendered width of the illustration, in px. The drawing scales to it from the
  * viewBox, so this is the only knob for how large it appears on screen.
  */
-const ART_DISPLAY_WIDTH = 720;
+const ART_DISPLAY_WIDTH = 560;
 
 /**
  * Tooth counts of the two gears, which double as their turn durations in
@@ -357,16 +357,14 @@ export const ApiCreationProgress = ({
   const rounded = Math.round(percent);
 
   return (
-    <Stack spacing={4} sx={{ alignItems: 'center', py: 8, textAlign: 'center', width: '100%' }}>
-      <Stack spacing={1} sx={{ alignItems: 'center', maxWidth: 'sm' }}>
-        <Typography sx={{ fontWeight: 700 }} variant="h1">
-          <FormattedMessage {...messages.title} />
+    <Stack spacing={3} sx={{ alignItems: 'center', py: 6, textAlign: 'center', width: '100%' }}>
+      <Stack sx={{ alignItems: 'center', maxWidth: 'md' }}>
+        <Typography sx={{ fontWeight: 700 }} variant="h2">
+          <FormattedMessage
+            {...(displayName ? messages.titleWithName : messages.title)}
+            values={displayName ? { name: displayName } : undefined}
+          />
         </Typography>
-        {displayName && (
-          <Typography color="text.secondary" variant="body1">
-            <FormattedMessage {...messages.subtitle} values={{ name: displayName }} />
-          </Typography>
-        )}
       </Stack>
 
       <ApiProxyAssemblyArt />

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/ApiCreationSteps.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/ApiCreationSteps.tsx
@@ -76,14 +76,15 @@ export type ApiCreationStepsProps = {
 };
 
 /** Step circle diameter; connector offset is derived from this. */
-const STEP_ICON_SIZE = 32;
+const STEP_ICON_SIZE = 22;
 
 /**
  * Connector line between steps. Tints completed lines with primary color.
  */
 const ProgressConnector = styled(StepConnector)(({ theme }) => ({
   [`& .${stepConnectorClasses.line}`]: {
-    borderColor: theme.palette.divider,
+    borderColor: alpha(theme.palette.text.primary, 0.3),
+    borderTopWidth: 1,
   },
   [`&.${stepConnectorClasses.active} .${stepConnectorClasses.line}, &.${stepConnectorClasses.completed} .${stepConnectorClasses.line}`]:
     {
@@ -114,13 +115,12 @@ export const ApiCreationSteps = ({ activeStep, onStepClick }: ApiCreationStepsPr
           borderRadius: '50%',
           boxShadow: `0 0 0 ${theme.spacing(0.5)} ${alpha(theme.palette.primary.main, 0.16)}`,
         },
-        [`& .${stepLabelClasses.label}`]: { typography: 'body1' },
+        [`& .${stepLabelClasses.label}`]: { typography: 'body2' },
         [`& .${stepLabelClasses.label}.${stepLabelClasses.active}`]: {
           color: 'text.primary',
           fontWeight: theme.typography.fontWeightBold,
         },
-        maxWidth: theme.breakpoints.values.sm,
-        mx: 'auto',
+        maxWidth: 360,
         width: '100%',
       })}
     >

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/ApiResourcesPreview.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/ApiResourcesPreview.tsx
@@ -105,39 +105,39 @@ export const ApiResourcesPreview = ({ onSpecChange, spec, warnings }: ApiResourc
         overflow: 'hidden',
       }}
     >
-      <Stack
-        direction="row"
-        spacing={2}
-        sx={{
-          alignItems: 'center',
-          flexShrink: 0,
-          justifyContent: 'space-between',
-        }}
-      >
-        <Typography sx={{ fontWeight: 700 }} variant="subtitle1">
-          <FormattedMessage {...messages.title} />
-        </Typography>
-        <FormControlLabel
-          control={
-            <Switch
-              checked={showSource}
-              onChange={(event) => setShowSource(event.target.checked)}
-              size="small"
-              // MUI v9 routes input attributes through slotProps; the older
-              // `inputProps` never reaches the element, leaving the control
-              // without an accessible name.
-              slotProps={{
-                input: { 'aria-label': intl.formatMessage(messages.source) },
-              }}
-            />
-          }
-          // Nothing to read until something has been fetched.
-          disabled={!hasContract}
-          label={<FormattedMessage {...messages.source} />}
-          labelPlacement="start"
-          sx={{ m: 0 }}
-        />
-      </Stack>
+      {hasContract ? (
+        <Stack
+          direction="row"
+          spacing={2}
+          sx={{
+            alignItems: 'center',
+            flexShrink: 0,
+            justifyContent: 'space-between',
+          }}
+        >
+          <Typography sx={{ fontWeight: 700 }} variant="subtitle1">
+            <FormattedMessage {...messages.title} />
+          </Typography>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={showSource}
+                onChange={(event) => setShowSource(event.target.checked)}
+                size="small"
+                // MUI v9 routes input attributes through slotProps; the older
+                // `inputProps` never reaches the element, leaving the control
+                // without an accessible name.
+                slotProps={{
+                  input: { 'aria-label': intl.formatMessage(messages.source) },
+                }}
+              />
+            }
+            label={<FormattedMessage {...messages.source} />}
+            labelPlacement="start"
+            sx={{ m: 0 }}
+          />
+        </Stack>
+      ) : null}
 
       {/* The edited definition's own verdict, above both views because it
           describes the document rather than either way of looking at it. */}
@@ -151,7 +151,7 @@ export const ApiResourcesPreview = ({ onSpecChange, spec, warnings }: ApiResourc
         sx={{
           flex: 1,
           minHeight: 0,
-          mt: 1,
+          mt: hasContract ? 1 : 0,
           // The editor manages its own scrolling so its toolbar stays put; the
           // read-only views are blocks this box has to scroll for.
           overflow: editable && showSource ? 'hidden' : 'auto',

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/ApiTypeSelector.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/ApiTypeSelector.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Box, Chip, Form, Stack, Tooltip } from '@wso2/oxygen-ui';
+import { alpha, Box, Chip, Form, Stack, Tooltip, Typography } from '@wso2/oxygen-ui';
 import { CircleCheck } from '@wso2/oxygen-ui-icons-react';
 import { useState } from 'react';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
@@ -25,7 +25,7 @@ import { selectableCardSx } from '@/theme/receipes';
 import type { ApiType } from '../types';
 import { API_TYPES } from '../uiConfig';
 
-const CARD_WIDTH = 260;
+const CARD_WIDTH = 264;
 
 const messages = defineMessages({
   comingSoon: {
@@ -37,6 +37,11 @@ const messages = defineMessages({
     id: 'api.create.ApiTypeSelector.tooltip.comingSoon',
     defaultMessage: 'Not available yet.',
     description: 'Tooltip explaining why an unreleased API type card cannot be clicked.',
+  },
+  available: {
+    id: 'api.create.ApiTypeSelector.badge.available',
+    defaultMessage: 'Available',
+    description: 'Badge on an API type that can be selected now.',
   },
   groupLabel: {
     id: 'api.create.ApiTypeSelector.groupLabel',
@@ -50,8 +55,7 @@ const messages = defineMessages({
   },
   subtitle: {
     id: 'api.create.ApiTypeSelector.subtitle',
-    defaultMessage:
-      'This decides how the gateway exposes your backend. Only REST is available today.',
+    defaultMessage: 'Choose how the gateway should expose your backend.',
     description: 'Supporting line under the API type selector heading.',
   },
   title: {
@@ -98,20 +102,18 @@ export const ApiTypeSelector = ({ onChange, value }: ApiTypeSelectorProps) => {
   };
 
   return (
-    // Centered, max-width layout; the cards keep a fixed width and wrap.
+    // The compact, left-aligned grid is deliberately bounded to three columns.
     <Stack
       spacing={3}
       sx={{
-        maxWidth: (theme) => theme.breakpoints.values.md,
-        mx: 'auto',
-        px: { md: 4, xs: 2 },
+        maxWidth: CARD_WIDTH * 3 + 32,
         width: '100%',
       }}
     >
       <Box
         aria-label={intl.formatMessage(messages.groupLabel)}
         role="group"
-        sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, justifyContent: 'center' }}
+        sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, justifyContent: 'flex-start' }}
       >
         {API_TYPES.map((apiType) => {
           const disabled = !apiType.enabled;
@@ -126,63 +128,65 @@ export const ApiTypeSelector = ({ onChange, value }: ApiTypeSelectorProps) => {
                   tooltip needs a plain element of its own to hang off. */}
               <Box sx={{ display: 'flex' }}>
                 <Form.CardButton
-                  alignItems="center"
+                  alignItems="flex-start"
                   aria-disabled={disabled || undefined}
                   disabled={disabled}
                   onClick={disabled ? undefined : () => handleSelect(apiType)}
                   selected={selected}
                   sx={(theme) => ({
                     ...selectableCardSx(theme, { disabled, selected }),
-                    height: '100%',
-                    justifyContent: 'flex-start',
+                    height: 142,
+                    justifyContent: 'space-between',
+                    p: 2,
                     width: CARD_WIDTH,
-                    ...(disabled && { cursor: 'default', pointerEvents: 'none' }),
+                    '& > *': { width: '100%' },
+                    ...(selected && {
+                      backgroundColor: alpha(theme.palette.primary.main, 0.1),
+                    }),
+                    ...(disabled && {
+                      borderColor: alpha(theme.palette.text.primary, 0.55),
+                      cursor: 'default',
+                      pointerEvents: 'none',
+                    }),
                   })}
                   tabIndex={disabled ? -1 : undefined}
                   variant="outlined"
                 >
-                  <Form.CardHeader
-                    subheader={<FormattedMessage {...apiType.description} />}
-                    subheaderTypographyProps={{ variant: 'caption' }}
-                    // CardButton left-aligns its content; the header is the one
-                    // part that reads better centred under the mark. `caption`
-                    // maps to a `span`, so it has to become a block before
-                    // `textAlign` has anything to centre.
-                    sx={{
-                      '& .MuiCardHeader-subheader': {
-                        display: 'block',
-                        textAlign: 'center',
-                      },
-                    }}
-                    title={
-                      <Form.Stack
-                        direction="column"
-                        spacing={1}
-                        sx={{ alignItems: 'center', justifyContent: 'center' }}
-                      >
-                        {apiType.icon}
-                        <Form.Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
-                          <Form.Body sx={{ fontWeight: 600 }}>
-                            <FormattedMessage {...apiType.title} />
-                          </Form.Body>
-                          {selected ? (
-                            <Box
-                              aria-label={intl.formatMessage(messages.selected)}
-                              role="img"
-                              sx={{ color: 'primary.main', display: 'flex' }}
-                            >
-                              <CircleCheck size={16} />
-                            </Box>
-                          ) : null}
-                        </Form.Stack>
-                      </Form.Stack>
-                    }
-                  />
-                  {disabled ? (
-                    <Form.CardContent sx={{ pt: 0 }}>
-                      <Chip label={<FormattedMessage {...messages.comingSoon} />} size="small" />
-                    </Form.CardContent>
-                  ) : null}
+                  <Stack
+                    direction="row"
+                    sx={{ alignItems: 'flex-start', justifyContent: 'space-between' }}
+                  >
+                    {apiType.icon}
+                    <Chip
+                      color={disabled ? 'default' : 'primary'}
+                      label={
+                        <FormattedMessage
+                          {...(disabled ? messages.comingSoon : messages.available)}
+                        />
+                      }
+                      size="small"
+                      variant="outlined"
+                    />
+                  </Stack>
+                  <Stack spacing={0.25} sx={{ textAlign: 'left' }}>
+                    <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
+                      <Form.Body sx={{ fontWeight: 700 }}>
+                        <FormattedMessage {...apiType.title} />
+                      </Form.Body>
+                      {selected ? (
+                        <Box
+                          aria-label={intl.formatMessage(messages.selected)}
+                          role="img"
+                          sx={{ color: 'primary.main', display: 'flex' }}
+                        >
+                          <CircleCheck size={16} />
+                        </Box>
+                      ) : null}
+                    </Stack>
+                    <Typography color="text.secondary" variant="caption">
+                      <FormattedMessage {...apiType.description} />
+                    </Typography>
+                  </Stack>
                 </Form.CardButton>
               </Box>
             </Tooltip>

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/ContractSourceForm.test.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/ContractSourceForm.test.tsx
@@ -143,8 +143,8 @@ describe('ContractSourceForm — automatic fetch', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it('clears the URL and loaded contract from the field action', async () => {
-    stubSpecHost();
+  it('clears fetched state and re-fetches when the same URL is entered again', async () => {
+    const fetchMock = stubSpecHost();
     const onContractChange = vi.fn();
     const { user } = renderWithProviders(
       <ContractSourceForm onContractChange={onContractChange} />,
@@ -162,6 +162,16 @@ describe('ContractSourceForm — automatic fetch', () => {
 
     expect(field).toHaveValue('');
     await waitFor(() => expect(onContractChange).toHaveBeenLastCalledWith(null));
+
+    await user.type(field, 'https://example.com/openapi.yaml');
+    await user.tab();
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    await waitFor(() =>
+      expect(onContractChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({ dialect: 'openapi-3.0' }),
+      ),
+    );
   });
 
   it('does not read it again when the field is left untouched', async () => {

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/ContractSourceForm.test.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/ContractSourceForm.test.tsx
@@ -93,8 +93,8 @@ describe('ContractSourceForm — file upload', () => {
     await user.click(screen.getByRole('button', { name: /Remove openapi\.yaml/ }));
 
     await waitFor(() => expect(screen.queryByText('openapi.yaml')).not.toBeInTheDocument());
-    // Removing is not an error, so the neutral line comes back.
-    expect(screen.getByText(/Accepted: /)).toBeInTheDocument();
+    // Removing is not an error, so the neutral guidance in the card comes back.
+    expect(screen.getByText(/Accepted file types:/)).toBeInTheDocument();
     expect(screen.queryByText(/is not supported/)).not.toBeInTheDocument();
   });
 });
@@ -141,6 +141,27 @@ describe('ContractSourceForm — automatic fetch', () => {
       ),
     );
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the URL and loaded contract from the field action', async () => {
+    stubSpecHost();
+    const onContractChange = vi.fn();
+    const { user } = renderWithProviders(
+      <ContractSourceForm onContractChange={onContractChange} />,
+    );
+    const field = screen.getByLabelText(/URL for API Contract/);
+
+    await user.type(field, 'https://example.com/openapi.yaml');
+    await user.tab();
+    await waitFor(() =>
+      expect(onContractChange).toHaveBeenCalledWith(
+        expect.objectContaining({ dialect: 'openapi-3.0' }),
+      ),
+    );
+    await user.click(screen.getByRole('button', { name: 'Clear URL' }));
+
+    expect(field).toHaveValue('');
+    await waitFor(() => expect(onContractChange).toHaveBeenLastCalledWith(null));
   });
 
   it('does not read it again when the field is left untouched', async () => {

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/ContractSourceForm.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/ContractSourceForm.tsx
@@ -1600,7 +1600,13 @@ export const ContractSourceForm = ({
                     <Tooltip title={intl.formatMessage(messages.clearUrl)}>
                       <IconButton
                         aria-label={intl.formatMessage(messages.clearUrl)}
-                        onClick={() => contractUrl.setValue('')}
+                        onClick={() => {
+                          contractUrl.setValue('');
+                          setFetched(null);
+                          setRequest(null);
+                          setFetching(false);
+                          setFetchError(null);
+                        }}
                         onMouseDown={(event) => event.preventDefault()}
                         size="small"
                         type="button"

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/ContractSourceForm.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/ContractSourceForm.tsx
@@ -27,6 +27,7 @@ import {
   Form,
   FormControl,
   FormHelperText,
+  FormLabel,
   Grid,
   IconButton,
   InputAdornment,
@@ -42,7 +43,16 @@ import {
   alpha,
   type Theme,
 } from '@wso2/oxygen-ui';
-import { FileText, GitHub, Pencil, RefreshCw, Upload, X } from '@wso2/oxygen-ui-icons-react';
+import {
+  Eraser as Broom,
+  FileText,
+  GitHub,
+  Pencil,
+  RefreshCw,
+  Trash2,
+  Upload,
+  Zap,
+} from '@wso2/oxygen-ui-icons-react';
 import yaml from 'js-yaml';
 import {
   useEffect,
@@ -182,6 +192,11 @@ const SAMPLE_CONTRACT_URLS: Record<string, string> = {
 const SAMPLE_REPOSITORY_URL = 'https://github.com/wso2/bijira-samples';
 
 const messages = defineMessages({
+  clearUrl: {
+    id: 'api.create.fromContract.action.clearUrl',
+    defaultMessage: 'Clear URL',
+    description: 'Clears the API contract URL field and its loaded preview.',
+  },
   fetching: {
     id: 'api.create.fromContract.status.fetching',
     defaultMessage: 'Reading the contract…',
@@ -374,11 +389,12 @@ const messages = defineMessages({
   },
   uploadAction: {
     id: 'api.create.fromContract.upload.action',
-    defaultMessage: 'Select file',
+    defaultMessage: 'Upload',
   },
   uploadHint: {
     id: 'api.create.fromContract.upload.hint',
-    defaultMessage: 'One file \u00b7 {extensions}',
+    defaultMessage:
+      'Drag & drop your file or click to select \u00b7 Accepted file types: {extensions}',
     description: 'Sits under the drop-zone heading; {extensions} is a list such as ".json, .yaml".',
   },
   uploadRemove: {
@@ -386,10 +402,10 @@ const messages = defineMessages({
     defaultMessage: 'Remove {fileName}',
     description: 'Accessible name for the button that discards the chosen file.',
   },
-  uploadReplace: {
-    id: 'api.create.fromContract.upload.replace',
-    defaultMessage: 'Replace file',
-    description: 'Reopens the file picker so the chosen contract can be swapped for another.',
+  uploadedFile: {
+    id: 'api.create.fromContract.upload.uploadedFile',
+    defaultMessage: 'Uploaded file',
+    description: 'Heading above the selected API contract file.',
   },
   uploadRequired: {
     id: 'api.create.fromContract.upload.required',
@@ -397,7 +413,7 @@ const messages = defineMessages({
   },
   uploadTitle: {
     id: 'api.create.fromContract.upload.title',
-    defaultMessage: 'Drag and drop your contract here',
+    defaultMessage: 'Upload API Contract',
   },
   uploadUnsupported: {
     id: 'api.create.fromContract.upload.unsupported',
@@ -558,6 +574,7 @@ const SampleLink = ({ onClick }: { onClick: () => void }) => (
   <Button
     onClick={onClick}
     size="small"
+    startIcon={<Zap size={16} />}
     sx={{ alignSelf: 'flex-start', px: 0, textTransform: 'none' }}
     type="button"
     variant="text"
@@ -679,15 +696,7 @@ const ContractFileControl = ({
         <FormattedMessage {...messages.uploadUnsupported} values={{ extensions: extensionList }} />
       );
     }
-    return (
-      <FormattedMessage
-        {...messages.uploadAccepted}
-        values={{
-          extensions: extensionList,
-          maxSize: formatFileSize(intl, MAX_CONTRACT_BYTES),
-        }}
-      />
-    );
+    return undefined;
   })();
 
   return (
@@ -707,91 +716,93 @@ const ContractFileControl = ({
         type="file"
       />
 
-      <Box
+      <Card
         onClick={file === null ? openPicker : undefined}
         onDragLeave={() => setDraggedOver(false)}
         onDragOver={handleDragOver}
         onDrop={handleDrop}
         sx={(theme) => ({
-          alignItems: 'center',
           bgcolor: draggedOver ? 'action.hover' : 'background.default',
           border: hairline(theme),
           borderColor: draggedOver ? 'primary.main' : 'divider',
           borderRadius: 2,
           borderStyle: 'dashed',
           cursor: file === null ? 'pointer' : 'default',
-          display: 'flex',
-          justifyContent: 'center',
-          px: 3,
-          py: file === null ? 5 : 3,
+          minHeight: 300,
         })}
+        variant="outlined"
       >
-        {file === null ? (
-          <Stack spacing={1} sx={{ alignItems: 'center', textAlign: 'center' }}>
-            <Box sx={iconTileSx(7)}>
-              <Upload size={24} />
-            </Box>
-            <Typography sx={{ fontWeight: 700, pt: 1 }} variant="h6">
-              <FormattedMessage {...messages.uploadTitle} />
-            </Typography>
-            <Typography color="text.secondary" variant="body2">
-              <FormattedMessage {...messages.uploadHint} values={{ extensions: extensionList }} />
-            </Typography>
-            <Button onClick={openPicker} sx={{ mt: 2 }} variant="contained">
-              <FormattedMessage {...messages.uploadAction} />
-            </Button>
-          </Stack>
-        ) : (
-          <Stack spacing={1} sx={{ alignItems: 'center', width: '100%' }}>
-            <Stack
-              direction="row"
-              spacing={2}
-              sx={(theme) => ({
-                alignItems: 'center',
-                bgcolor: 'background.paper',
-                border: hairline(theme),
-                borderColor: 'divider',
-                borderRadius: 2,
-                maxWidth: theme.spacing(60),
-                px: 2,
-                py: 1.5,
-                width: '100%',
-              })}
-            >
-              <Box sx={iconTileSx(5)}>
-                <FileText size={20} />
+        <CardContent
+          sx={{
+            alignItems: 'center',
+            display: 'flex',
+            justifyContent: 'center',
+            minHeight: 300,
+            p: 3,
+            '&:last-child': { pb: 3 },
+          }}
+        >
+          {file === null ? (
+            <Stack spacing={1} sx={{ alignItems: 'center', textAlign: 'center' }}>
+              <Box sx={iconTileSx(7)}>
+                <Upload size={24} />
               </Box>
-              <Box sx={{ flexGrow: 1, minWidth: 0 }}>
-                <Stack direction="row" spacing={1} sx={{ alignItems: 'center', minWidth: 0 }}>
-                  <Typography noWrap sx={{ fontWeight: 600 }} variant="body1">
-                    {file.name}
-                  </Typography>
-                  {fileExtensionLabel(file.name) === '' ? null : (
-                    <Chip label={fileExtensionLabel(file.name)} size="small" />
-                  )}
-                </Stack>
-                <Typography color="text.secondary" variant="caption">
-                  {formatFileSize(intl, file.size)}
-                </Typography>
-              </Box>
-              <IconButton
-                aria-label={intl.formatMessage(messages.uploadRemove, {
-                  fileName: file.name,
-                })}
-                onClick={() => onReject('removed')}
-                size="small"
-              >
-                <X size={16} />
-              </IconButton>
+              <Typography sx={{ fontWeight: 700, pt: 1 }} variant="h6">
+                <FormattedMessage {...messages.uploadTitle} />
+              </Typography>
+              <Typography color="text.secondary" variant="body2">
+                <FormattedMessage {...messages.uploadHint} values={{ extensions: extensionList }} />
+              </Typography>
+              <Button onClick={openPicker} sx={{ mt: 2 }} type="button" variant="contained">
+                <FormattedMessage {...messages.uploadAction} />
+              </Button>
             </Stack>
-            <Button onClick={openPicker} sx={{ mt: 1 }} variant="text">
-              <FormattedMessage {...messages.uploadReplace} />
-            </Button>
-          </Stack>
-        )}
-      </Box>
+          ) : (
+            <Stack spacing={2} sx={{ alignItems: 'center', width: '100%' }}>
+              <Typography sx={{ fontWeight: 700 }} variant="h6">
+                <FormattedMessage {...messages.uploadedFile} />
+              </Typography>
+              <Card sx={{ maxWidth: 480, width: '100%' }}>
+                <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
+                  <Stack direction="row" spacing={2} sx={{ alignItems: 'center' }}>
+                    <Box sx={iconTileSx(5)}>
+                      <FileText size={20} />
+                    </Box>
+                    <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+                      <Stack direction="row" spacing={1} sx={{ alignItems: 'center', minWidth: 0 }}>
+                        <Typography noWrap sx={{ fontWeight: 600 }} variant="body1">
+                          {file.name}
+                        </Typography>
+                        {fileExtensionLabel(file.name) === '' ? null : (
+                          <Chip label={fileExtensionLabel(file.name)} size="small" />
+                        )}
+                      </Stack>
+                      <Typography color="text.secondary" variant="caption">
+                        {formatFileSize(intl, file.size)}
+                      </Typography>
+                    </Box>
+                    <IconButton
+                      aria-label={intl.formatMessage(messages.uploadRemove, {
+                        fileName: file.name,
+                      })}
+                      color="error"
+                      onClick={() => onReject('removed')}
+                      size="small"
+                      type="button"
+                    >
+                      <Trash2 size={16} />
+                    </IconButton>
+                  </Stack>
+                </CardContent>
+              </Card>
+            </Stack>
+          )}
+        </CardContent>
+      </Card>
 
-      <FormHelperText id={helperId}>{helperText}</FormHelperText>
+      {helperText === undefined ? null : (
+        <FormHelperText id={helperId}>{helperText}</FormHelperText>
+      )}
     </FormControl>
   );
 };
@@ -1570,7 +1581,7 @@ export const ContractSourceForm = ({
           value={sourceKey}
         >
           {availableSources.map((candidate) => (
-            <ToggleButton key={candidate} value={candidate}>
+            <ToggleButton key={candidate} type="button" value={candidate}>
               {intl.formatMessage(SOURCE_LABELS[candidate])}
             </ToggleButton>
           ))}
@@ -1579,17 +1590,55 @@ export const ContractSourceForm = ({
 
       {sourceKey === 'url' ? (
         <Form.Stack spacing={1}>
-          <ContractTextControl
-            field={contractUrl}
-            id="contractUrl"
-            invalidMessage={messages.urlInvalid}
-            label={intl.formatMessage(messages.urlLabel)}
-            // Leaving a valid URL is the whole gesture: the contract is read
-            // then, rather than on a button afterwards.
-            onCommitted={(url) => requestFetch({ apiTypeKey, sourceKey: 'url', url })}
-            placeholder={intl.formatMessage(messages.urlPlaceholder)}
-            requiredMessage={messages.urlRequired}
-          />
+          <FormControl error={contractUrl.error !== null} fullWidth required>
+            <FormLabel htmlFor="contractUrl">{intl.formatMessage(messages.urlLabel)}</FormLabel>
+            <OutlinedInput
+              aria-describedby="contractUrl-helper"
+              endAdornment={
+                contractUrl.value === '' ? undefined : (
+                  <InputAdornment position="end">
+                    <Tooltip title={intl.formatMessage(messages.clearUrl)}>
+                      <IconButton
+                        aria-label={intl.formatMessage(messages.clearUrl)}
+                        onClick={() => contractUrl.setValue('')}
+                        onMouseDown={(event) => event.preventDefault()}
+                        size="small"
+                        type="button"
+                      >
+                        <Broom size={18} />
+                      </IconButton>
+                    </Tooltip>
+                  </InputAdornment>
+                )
+              }
+              id="contractUrl"
+              name="contractUrl"
+              onBlur={() => {
+                // Leaving a valid URL is the whole gesture: the contract is
+                // read then, rather than on a button afterwards.
+                if (contractUrl.commit()) {
+                  requestFetch({
+                    apiTypeKey,
+                    sourceKey: 'url',
+                    url: contractUrl.value.trim(),
+                  });
+                }
+              }}
+              onChange={(event) => contractUrl.handleChange(event.target.value)}
+              placeholder={intl.formatMessage(messages.urlPlaceholder)}
+              sx={{ mt: 0.75 }}
+              value={contractUrl.value}
+            />
+            {contractUrl.error === null ? null : (
+              <FormHelperText id="contractUrl-helper">
+                <FormattedMessage
+                  {...(contractUrl.error === 'required'
+                    ? messages.urlRequired
+                    : messages.urlInvalid)}
+                />
+              </FormHelperText>
+            )}
+          </FormControl>
           <SampleLink onClick={fillWithSampleUrl} />
         </Form.Stack>
       ) : null}
@@ -1677,6 +1726,7 @@ export const ContractSourceForm = ({
                                 edge="end"
                                 onClick={() => setDirectoryDialogOpen(true)}
                                 size="small"
+                                type="button"
                               >
                                 <Pencil size={16} />
                               </IconButton>
@@ -1781,10 +1831,15 @@ export const ContractSourceForm = ({
             sx={{ alignSelf: 'flex-start' }}
             value="public"
           >
-            <ToggleButton sx={{ px: 3, textTransform: 'none' }} value="public">
+            <ToggleButton sx={{ px: 3, textTransform: 'none' }} type="button" value="public">
               <FormattedMessage {...messages.swaggerHubPublic} />
             </ToggleButton>
-            <ToggleButton disabled sx={{ px: 3, textTransform: 'none' }} value="authorized">
+            <ToggleButton
+              disabled
+              sx={{ px: 3, textTransform: 'none' }}
+              type="button"
+              value="authorized"
+            >
               <Tooltip title={intl.formatMessage(messages.swaggerHubAuthorizedHint)}>
                 <Box component="span">
                   <FormattedMessage {...messages.swaggerHubAuthorized} />
@@ -1837,6 +1892,7 @@ export const ContractSourceForm = ({
                   aria-label={intl.formatMessage(messages.swaggerHubRefresh)}
                   onClick={onRefreshSwaggerHubOrganizations}
                   size="small"
+                  type="button"
                 >
                   <RefreshCw size={18} />
                 </IconButton>

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/DefineApiPanel.test.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/DefineApiPanel.test.tsx
@@ -55,12 +55,12 @@ vi.mock('./SpecCodeEditor', () => ({
  * has a definition on screen without a fetch standing between the test and the
  * editor, and the edit path under test is the same one a fetched contract takes.
  */
-const openScratchSource = async (onDataFetched = vi.fn()) => {
-  const { user } = renderWithProviders(<DefineApiPanel onDataFetched={onDataFetched} />);
+const openScratchSource = async (onDraftChange = vi.fn()) => {
+  const { user } = renderWithProviders(<DefineApiPanel onDraftChange={onDraftChange} />);
 
   await user.click(screen.getByRole('button', { name: /Design from scratch/ }));
   await user.click(screen.getByRole('checkbox', { name: 'Source' }));
-  return { onDataFetched, user };
+  return { onDraftChange, user };
 };
 
 /** The editor arrives in its own chunk, so the first look at it is awaited. */
@@ -71,7 +71,7 @@ const editor = async (): Promise<HTMLTextAreaElement> =>
 
 describe('DefineApiPanel — editing the definition', () => {
   it('carries the edited definition forward instead of the one it started from', async () => {
-    const { onDataFetched, user } = await openScratchSource();
+    const { onDraftChange, user } = await openScratchSource();
 
     await user.click(screen.getByRole('button', { name: 'Edit' }));
     fireEvent.change(await editor(), {
@@ -85,14 +85,14 @@ describe('DefineApiPanel — editing the definition', () => {
       },
     });
     await user.click(screen.getByRole('button', { name: 'Save' }));
-    await user.click(screen.getByRole('button', { name: 'Continue' }));
 
-    expect(onDataFetched).toHaveBeenCalledTimes(1);
-    expect(onDataFetched.mock.calls[0][0]).toMatchObject({
-      displayName: 'Edited by hand',
-      upstream: { main: { url: 'https://orders.example.com' } },
-      version: '3.2.1',
-    });
+    expect(onDraftChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        displayName: 'Edited by hand',
+        upstream: { main: { url: 'https://orders.example.com' } },
+        version: '3.2.1',
+      }),
+    );
   });
 
   it('reports what the edited definition is missing, once it is the one on screen', async () => {

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/DefineApiPanel.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/DefineApiPanel.tsx
@@ -17,8 +17,8 @@
  */
 
 import {
+  alpha,
   Box,
-  Button,
   Card,
   Divider,
   Stack,
@@ -26,11 +26,10 @@ import {
   ToggleButtonGroup,
   Typography,
 } from '@wso2/oxygen-ui';
-import { Download, Sparkles } from '@wso2/oxygen-ui-icons-react';
-import { useCallback, useState, type ReactNode } from 'react';
+import { FileCode2, Pencil } from '@wso2/oxygen-ui-icons-react';
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
 import { defineMessages, FormattedMessage, useIntl, type MessageDescriptor } from 'react-intl';
 
-import { hairline } from '@/theme/receipes';
 import { DEFAULT_API_SKELETON } from '../utils/apiSkeleton';
 import type { ApiCreationWizardDraftState, ApiType } from '../types';
 import { ApiResourcesPreview } from './ApiResourcesPreview';
@@ -61,11 +60,6 @@ const messages = defineMessages({
     defaultMessage: 'How do you want to define this API?',
     description: 'Accessible name for the pair of approach tabs at the top of the step.',
   },
-  back: {
-    id: 'api.create.defineApi.action.back',
-    defaultMessage: 'Back',
-    description: 'Returns to the previous step of the API creation wizard.',
-  },
   contractDescription: {
     id: 'api.create.defineApi.contract.description',
     defaultMessage: 'Import from a URL or a file.',
@@ -73,11 +67,6 @@ const messages = defineMessages({
   contractTitle: {
     id: 'api.create.defineApi.contract.title',
     defaultMessage: 'Start with a contract',
-  },
-  next: {
-    id: 'api.create.defineApi.action.next',
-    defaultMessage: 'Continue',
-    description: 'Carries the definition in the preview pane on to the next step.',
   },
   scratchDescription: {
     id: 'api.create.defineApi.scratch.description',
@@ -99,13 +88,13 @@ type Approach = {
 const APPROACHES: Approach[] = [
   {
     description: messages.contractDescription,
-    icon: <Download size={18} />,
+    icon: <FileCode2 size={18} />,
     key: 'contract',
     title: messages.contractTitle,
   },
   {
     description: messages.scratchDescription,
-    icon: <Sparkles size={18} />,
+    icon: <Pencil size={18} />,
     key: 'scratch',
     title: messages.scratchTitle,
   },
@@ -118,10 +107,8 @@ export type DefineApiPanelProps = {
   initialApiTypeKey?: string;
   /** Starts the GitHub OAuth flow. The button renders either way, inert until wired. */
   onAuthorizeGitHub?: () => void;
-  /** Called by Back. */
-  onBack?: () => void;
-  /** Called by Next, with the draft the wizard collects. */
-  onDataFetched: (data: ApiCreationWizardDraftState) => void;
+  /** Keeps the wizard footer supplied with the definition currently on screen. */
+  onDraftChange: (data: ApiCreationWizardDraftState | null) => void;
   /** Re-fetches the SwaggerHub organizations. Inert until the import is wired. */
   onRefreshSwaggerHubOrganizations?: () => void;
 };
@@ -138,8 +125,7 @@ export const DefineApiPanel = ({
   apiTypes,
   initialApiTypeKey,
   onAuthorizeGitHub,
-  onBack,
-  onDataFetched,
+  onDraftChange,
   onRefreshSwaggerHubOrganizations,
 }: DefineApiPanelProps) => {
   const intl = useIntl();
@@ -178,24 +164,19 @@ export const DefineApiPanel = ({
   const edit = approach === 'scratch' ? scratchEdit : contractEdit;
   const spec = edit?.spec ?? (approach === 'scratch' ? DEFAULT_API_SKELETON : contract?.spec);
 
-  const handleProceed = () => {
-    // The draft the wizard collects — display name, version, context — is read
-    // off the definition, which is the next piece of work; advancing with an
-    // empty draft keeps this step's contract with the wizard until then.
-    // get the basic informarion from the spec and pass it to the onDataFetched callback
-    let draft: ApiCreationWizardDraftState = {};
-    if (spec) {
-      draft = extractApiDetails(spec);
-    }
-    onDataFetched(draft);
-  };
+  const draft = useMemo(() => (spec === undefined ? null : extractApiDetails(spec)), [spec]);
+
+  useEffect(() => {
+    onDraftChange(draft);
+    return () => onDraftChange(null);
+  }, [draft, onDraftChange]);
 
   return (
     <Stack spacing={3}>
       {/* One surface for the whole step: the two approaches sit flush on top of
           the panels they open, like tabs on their own body, rather than
           floating above as separate cards. */}
-      <Card variant="outlined">
+      <Card sx={{ border: 0, overflow: 'visible' }} variant="outlined">
         <ToggleButtonGroup
           aria-label={intl.formatMessage(messages.approachLabel)}
           exclusive
@@ -208,22 +189,25 @@ export const DefineApiPanel = ({
             }
           }}
           sx={(theme) => ({
-            // The buttons are the card's own header row, so they give up the
-            // borders and radii a standalone group would draw.
+            p: 0,
             '& .MuiToggleButtonGroup-grouped': {
-              border: 0,
-              borderRadius: 0,
+              border: `1px solid ${alpha(theme.palette.text.primary, 0.32)}`,
+              borderBottom: 0,
+              borderRadius: `${theme.shape.borderRadius}px ${theme.shape.borderRadius}px 0 0`,
+              flex: 1,
               justifyContent: 'flex-start',
               p: 2,
               textTransform: 'none',
               '&:not(:first-of-type)': {
-                border: hairline(theme),
-                borderBottom: 0,
-                borderColor: 'divider',
-                borderRight: 0,
-                borderTop: 0,
+                borderLeft: `1px solid ${alpha(theme.palette.text.primary, 0.32)}`,
+                marginLeft: 0,
               },
-              '&.Mui-selected': { bgcolor: 'action.selected' },
+              '&.Mui-selected, &.Mui-selected:hover': {
+                bgcolor: 'action.selected',
+                border: `1px solid ${theme.palette.primary.main}`,
+                borderBottom: 0,
+                borderRadius: `${theme.shape.borderRadius}px ${theme.shape.borderRadius}px 0 0`,
+              },
             },
           })}
           value={approach}
@@ -263,8 +247,6 @@ export const DefineApiPanel = ({
           })}
         </ToggleButtonGroup>
 
-        <Divider />
-
         <Stack
           direction={{ lg: 'row', xs: 'column' }}
           divider={
@@ -280,6 +262,22 @@ export const DefineApiPanel = ({
               }}
             />
           }
+          sx={(theme) => ({
+            border: 1,
+            borderColor: 'primary.main',
+            borderRadius: `0 0 ${theme.shape.borderRadius}px ${theme.shape.borderRadius}px`,
+            borderTop: 0,
+            position: 'relative',
+            '&::before': {
+              bgcolor: 'primary.main',
+              content: '""',
+              height: '1px',
+              left: approach === 'contract' ? '50%' : 0,
+              position: 'absolute',
+              top: 0,
+              width: '50%',
+            },
+          })}
         >
           <Box sx={{ flex: 1, minWidth: 0, p: 3 }}>
             {approach === 'contract' ? (
@@ -307,23 +305,6 @@ export const DefineApiPanel = ({
           </Box>
         </Stack>
       </Card>
-
-      {/* Both buttons on the trailing edge, Back beside the action it steps
-          away from rather than at the opposite corner of the step. */}
-      <Stack direction="row" spacing={2} sx={{ alignItems: 'center', justifyContent: 'flex-end' }}>
-        <Button onClick={onBack} type="button" variant="text">
-          <FormattedMessage {...messages.back} />
-        </Button>
-        <Button
-          // Nothing to carry forward until the pane has a definition in it.
-          disabled={spec === undefined}
-          onClick={handleProceed}
-          type="button"
-          variant="contained"
-        >
-          {intl.formatMessage(messages.next)}
-        </Button>
-      </Stack>
     </Stack>
   );
 };

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/DesignWithAiPanel.test.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/DesignWithAiPanel.test.tsx
@@ -41,10 +41,4 @@ describe('DesignWithAiPanel', () => {
       runtimeConfig.apiDesignerDocsUrl,
     );
   });
-
-  it('keeps the editable skeleton as an alternative to leaving the wizard', () => {
-    renderWithProviders(<DesignWithAiPanel />);
-
-    expect(screen.getByText(/skeleton on the right/)).toBeInTheDocument();
-  });
 });

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/DesignWithAiPanel.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/DesignWithAiPanel.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Box, Button, Link, Stack, Typography } from '@wso2/oxygen-ui';
+import { Box, Button, Stack, Typography } from '@wso2/oxygen-ui';
 import { ExternalLink } from '@wso2/oxygen-ui-icons-react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
@@ -33,16 +33,11 @@ const messages = defineMessages({
   body: {
     id: 'apiControlPlane.pages.appShell.appShellPages.apis.create.components.DesignWithAiPanel.body',
     defaultMessage:
-      'Draw operations on a canvas, check them against governance rules, and design with AI in VS Code.',
+      'Design, edit, and validate OpenAPI 3.x APIs directly in VS Code. Includes Spectral governance checks and AI-readiness assessment.',
   },
   docs: {
     id: 'apiControlPlane.pages.appShell.appShellPages.apis.create.components.DesignWithAiPanel.docs',
     defaultMessage: 'How to get started',
-  },
-  skeletonHint: {
-    id: 'apiControlPlane.pages.appShell.appShellPages.apis.create.components.DesignWithAiPanel.skeletonHint',
-    defaultMessage:
-      'Or carry on here - the skeleton on the right is a starting point you can edit by hand.',
   },
   title: {
     id: 'apiControlPlane.pages.appShell.appShellPages.apis.create.components.DesignWithAiPanel.title',
@@ -100,18 +95,17 @@ export const DesignWithAiPanel = () => (
         <FormattedMessage {...messages.body} />
       </Typography>
 
-      <Link
+      <Button
+        component="a"
+        endIcon={<ExternalLink size={16} />}
         href={runtimeConfig.apiDesignerDocsUrl}
         rel="noopener noreferrer"
+        size="small"
         target="_blank"
-        variant="body2"
+        variant="text"
       >
         <FormattedMessage {...messages.docs} />
-      </Link>
-
-      <Typography color="text.secondary" sx={{ pt: 1 }} variant="body2">
-        <FormattedMessage {...messages.skeletonHint} />
-      </Typography>
+      </Button>
     </Stack>
   </Box>
 );

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/GeneralCreateApiForm.test.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/GeneralCreateApiForm.test.tsx
@@ -62,6 +62,25 @@ beforeEach(() => {
 });
 
 describe('GeneralCreateApiForm — initial values', () => {
+  it('explains that the scratch backend is a placeholder until it is replaced', async () => {
+    const { user } = renderForm({
+      displayName: 'Untitled API',
+      upstream: { main: { url: 'https://example.com' } },
+    });
+
+    expect(
+      screen.getByText(/using https:\/\/example\.com as a placeholder backend/i),
+    ).toBeInTheDocument();
+
+    const targetUrl = screen.getByLabelText(/Target URL/);
+    await user.clear(targetUrl);
+    await user.type(targetUrl, 'https://api.example.org');
+
+    expect(
+      screen.queryByText(/using https:\/\/example\.com as a placeholder backend/i),
+    ).not.toBeInTheDocument();
+  });
+
   it('derives the base path from project, identifier and version when the draft names none', () => {
     renderForm({ displayName: 'Orders API', version: '2.1' });
 

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/GeneralCreateApiForm.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/components/GeneralCreateApiForm.tsx
@@ -25,7 +25,7 @@ import {
   FormControl,
   FormHelperText,
   Grid,
-  InputLabel,
+  FormLabel,
   OutlinedInput,
   Paper,
   Stack,
@@ -47,6 +47,8 @@ import type { CreateApiFormErrors, CreateApiFormField } from '../utils/serverFie
 import { ApiCreationWizardDraftState, GeneralApiCreationFormState } from '../types';
 
 export type GeneralCreateApiFormProps = {
+  formId?: string;
+  hideActions?: boolean;
   initialValues?: ApiCreationWizardDraftState;
   onSubmit: (values: GeneralApiCreationFormState) => void;
   onBack: () => void;
@@ -110,6 +112,11 @@ const messages = defineMessages({
     id: 'api.create.generalForm.section.backendEndpoint',
     defaultMessage: 'Backend endpoint',
   },
+  placeholderBackendNotice: {
+    id: 'api.create.generalForm.targetUrl.placeholder.notice',
+    defaultMessage:
+      'This API is using https://example.com as a placeholder backend. Replace it with your actual backend URL now, or update it before deploying.',
+  },
   identifierErrorPattern: {
     id: 'api.create.generalForm.identifier.error.pattern',
     defaultMessage: 'Use lowercase letters and numbers, separated by single hyphens.',
@@ -147,10 +154,6 @@ const messages = defineMessages({
     id: 'api.create.generalForm.identifier.status.checking',
     defaultMessage: 'Checking whether this identifier is free…',
   },
-  subtitle: {
-    id: 'api.create.generalForm.subtitle',
-    defaultMessage: 'Provide the details to configure and expose your API proxy.',
-  },
   targetUrlErrorInvalid: {
     id: 'api.create.generalForm.targetUrl.error.invalid',
     defaultMessage: 'Enter a full URL, for example https://api.example.com.',
@@ -166,10 +169,6 @@ const messages = defineMessages({
   targetUrlLabel: {
     id: 'api.create.generalForm.targetUrl.label',
     defaultMessage: 'Target URL',
-  },
-  title: {
-    id: 'api.create.generalForm.title',
-    defaultMessage: 'Create an API Proxy',
   },
   versionErrorPattern: {
     id: 'api.create.generalForm.version.error.pattern',
@@ -188,16 +187,6 @@ const messages = defineMessages({
     defaultMessage: 'Version',
   },
 });
-
-/**
- * Small uppercase rule above a group of fields. `Form.Header` is fixed at `h4`,
- * so the size comes from the theme's `overline` typography rather than a
- * font-size literal.
- */
-const SECTION_LABEL_SX = {
-  color: 'text.secondary',
-  typography: 'overline',
-} as const;
 
 export const DEFAULT_FORM_STATE: GeneralApiCreationFormState = {
   id: '',
@@ -529,16 +518,7 @@ export const GeneralCreateApiForm = (props: GeneralCreateApiFormProps) => {
   const targetUrlLabel = intl.formatMessage(messages.targetUrlLabel);
 
   return (
-    <Stack component="form" noValidate spacing={3} onSubmit={onFormSubmit}>
-      <Box>
-        <Typography sx={{ fontWeight: 700 }} variant="h5">
-          <FormattedMessage {...messages.title} />
-        </Typography>
-        <Typography color="text.secondary" sx={{ mt: 0.5 }} variant="body2">
-          <FormattedMessage {...messages.subtitle} />
-        </Typography>
-      </Box>
-
+    <Stack component="form" id={props.formId} noValidate spacing={3} onSubmit={onFormSubmit}>
       {/* `Alert` carries `role="alert"`, so this is announced when it appears
         ,the inputs themselves say which values to change. */}
       {showRejection && (
@@ -562,20 +542,20 @@ export const GeneralCreateApiForm = (props: GeneralCreateApiFormProps) => {
       )}
 
       <Paper component="section" sx={{ p: 3 }}>
-        <Form.Header sx={SECTION_LABEL_SX}>
+        <Typography sx={{ fontWeight: 600 }} variant="body2">
           <FormattedMessage {...messages.basicInformation} />
-        </Form.Header>
+        </Typography>
 
         <Form.Stack spacing={2} sx={{ mt: 1.5 }}>
           <Grid container spacing={2}>
             <Grid size={{ xs: 12, md: 4 }}>
               <FormControl error={Boolean(fieldErrors.displayName)} fullWidth required>
-                <InputLabel htmlFor="displayName">{nameLabel}</InputLabel>
+                <FormLabel htmlFor="displayName">{nameLabel}</FormLabel>
                 <OutlinedInput
                   aria-describedby="displayName-error"
                   id="displayName"
-                  label={nameLabel}
                   name="displayName"
+                  sx={{ mt: 0.75 }}
                   onBlur={() => markTouched('displayName')}
                   onChange={(event) => handleDisplayNameChange(event.target.value)}
                   value={formState.displayName}
@@ -586,12 +566,12 @@ export const GeneralCreateApiForm = (props: GeneralCreateApiFormProps) => {
 
             <Grid size={{ xs: 12, md: 4 }}>
               <FormControl error={Boolean(fieldErrors.id)} fullWidth required>
-                <InputLabel htmlFor="identifier">{identifierLabel}</InputLabel>
+                <FormLabel htmlFor="identifier">{identifierLabel}</FormLabel>
                 <OutlinedInput
                   aria-describedby="identifier-error"
                   id="identifier"
-                  label={identifierLabel}
                   name="identifier"
+                  sx={{ mt: 0.75 }}
                   onBlur={() => markTouched('id')}
                   onChange={(event) => handleIdentifierChange(event.target.value)}
                   value={formState.id}
@@ -604,12 +584,12 @@ export const GeneralCreateApiForm = (props: GeneralCreateApiFormProps) => {
 
             <Grid size={{ xs: 12, md: 4 }}>
               <FormControl error={Boolean(fieldErrors.version)} fullWidth required>
-                <InputLabel htmlFor="version">{versionLabel}</InputLabel>
+                <FormLabel htmlFor="version">{versionLabel}</FormLabel>
                 <OutlinedInput
                   aria-describedby="version-error"
                   id="version"
-                  label={versionLabel}
                   name="version"
+                  sx={{ mt: 0.75 }}
                   onBlur={() => markTouched('version')}
                   onChange={(event) => handleVersionChange(event.target.value)}
                   value={formState.version}
@@ -620,12 +600,12 @@ export const GeneralCreateApiForm = (props: GeneralCreateApiFormProps) => {
           </Grid>
 
           <FormControl error={Boolean(fieldErrors.context)} fullWidth required>
-            <InputLabel htmlFor="context">{contextLabel}</InputLabel>
+            <FormLabel htmlFor="context">{contextLabel}</FormLabel>
             <OutlinedInput
               aria-describedby="context-error"
               id="context"
-              label={contextLabel}
               name="context"
+              sx={{ mt: 0.75 }}
               onBlur={() => markTouched('context')}
               onChange={(event) => handleBasePathChange(event.target.value)}
               value={formState.context}
@@ -634,14 +614,14 @@ export const GeneralCreateApiForm = (props: GeneralCreateApiFormProps) => {
           </FormControl>
 
           <FormControl fullWidth>
-            <InputLabel htmlFor="description">{descriptionLabel}</InputLabel>
+            <FormLabel htmlFor="description">{descriptionLabel}</FormLabel>
             <OutlinedInput
               id="description"
-              label={descriptionLabel}
               multiline
               name="description"
               onChange={(event) => setField('description', event.target.value)}
               rows={3}
+              sx={{ mt: 0.75 }}
               value={formState.description ?? ''}
             />
           </FormControl>
@@ -649,18 +629,24 @@ export const GeneralCreateApiForm = (props: GeneralCreateApiFormProps) => {
       </Paper>
 
       <Paper component="section" sx={{ p: 3, mt: 1 }}>
-        <Form.Header sx={SECTION_LABEL_SX}>
+        <Typography sx={{ fontWeight: 600 }} variant="body2">
           <FormattedMessage {...messages.endpointSection} />
-        </Form.Header>
+        </Typography>
 
         <Form.Stack spacing={2} sx={{ mt: 1.5 }}>
+          {formState.upstream.main.url.trim() === 'https://example.com' ? (
+            <Alert severity="info">
+              <FormattedMessage {...messages.placeholderBackendNotice} />
+            </Alert>
+          ) : null}
+
           <FormControl error={Boolean(fieldErrors.targetUrl)} fullWidth required>
-            <InputLabel htmlFor="targetUrl">{targetUrlLabel}</InputLabel>
+            <FormLabel htmlFor="targetUrl">{targetUrlLabel}</FormLabel>
             <OutlinedInput
               aria-describedby="targetUrl-error"
               id="targetUrl"
-              label={targetUrlLabel}
               name="targetUrl"
+              sx={{ mt: 0.75 }}
               onBlur={() => markTouched('targetUrl')}
               onChange={(event) => setMainUpstreamUrl(event.target.value)}
               value={formState.upstream.main.url}
@@ -670,18 +656,24 @@ export const GeneralCreateApiForm = (props: GeneralCreateApiFormProps) => {
         </Form.Stack>
       </Paper>
 
-      <Divider />
+      {!props.hideActions && <Divider />}
 
       {/* Both buttons on the trailing edge, the same pairing as the step
           before this one. */}
-      <Stack direction="row" spacing={2} sx={{ alignItems: 'center', justifyContent: 'flex-end' }}>
-        <Button variant="text" onClick={props.onBack}>
-          <FormattedMessage {...messages.back} />
-        </Button>
-        <Button type="submit" variant="contained">
-          <FormattedMessage {...messages.create} />
-        </Button>
-      </Stack>
+      {!props.hideActions && (
+        <Stack
+          direction="row"
+          spacing={2}
+          sx={{ alignItems: 'center', justifyContent: 'flex-end' }}
+        >
+          <Button onClick={props.onBack} type="button" variant="text">
+            <FormattedMessage {...messages.back} />
+          </Button>
+          <Button type="submit" variant="contained">
+            <FormattedMessage {...messages.create} />
+          </Button>
+        </Stack>
+      )}
     </Stack>
   );
 };

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/utils/apiSkeleton.ts
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/utils/apiSkeleton.ts
@@ -30,6 +30,7 @@ export const DEFAULT_API_SKELETON: Record<string, unknown> = {
     version: '1.0.0',
     description: 'A starting point. Edit the operations, or ask AI to refine them.',
   },
+  servers: [{ url: 'https://example.com' }],
   paths: {
     '/resources': {
       get: {

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/EndpointsPanel.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/EndpointsPanel.tsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ * Licensed under the Apache License, Version 2.0.
+ */
+
+import { Box, Card, Divider, Link, Stack, Typography } from '@wso2/oxygen-ui';
+import { Globe } from '@wso2/oxygen-ui-icons-react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+const messages = defineMessages({
+  notConfigured: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.overview.EndpointsPanel.notConfigured',
+    defaultMessage: 'No endpoint configured',
+  },
+  title: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.apis.overview.EndpointsPanel.title',
+    defaultMessage: 'Endpoints',
+  },
+});
+
+type Props = {
+  url?: string;
+};
+
+export function EndpointsPanel({ url }: Props) {
+  return (
+    <Card>
+      <Box sx={{ px: 2, py: 1.5 }}>
+        <Typography sx={{ fontWeight: 600 }} variant="h6">
+          <FormattedMessage {...messages.title} />
+        </Typography>
+      </Box>
+      <Divider />
+      <Stack alignItems="center" direction="row" spacing={1.25} sx={{ px: 2, py: 1.5 }}>
+        <Box
+          sx={{
+            alignItems: 'center',
+            bgcolor: 'action.hover',
+            borderRadius: 1,
+            color: 'primary.main',
+            display: 'flex',
+            flexShrink: 0,
+            height: 32,
+            justifyContent: 'center',
+            width: 32,
+          }}
+        >
+          <Globe size={17} />
+        </Box>
+        {url ? (
+          <Link
+            // href={url}
+            rel="noopener noreferrer"
+            sx={{
+              '&:hover': { textDecoration: 'none' },
+              minWidth: 0,
+              overflow: 'hidden',
+              textDecoration: 'none',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+            target="_blank"
+            variant="body2"
+          >
+            {url}
+          </Link>
+        ) : (
+          <Typography color="text.secondary" variant="body2">
+            <FormattedMessage {...messages.notConfigured} />
+          </Typography>
+        )}
+      </Stack>
+    </Card>
+  );
+}

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/OverviewTab.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/overview/OverviewTab.tsx
@@ -23,7 +23,8 @@ import type { RestApi } from '@/api/resources/restApis';
 import type { Deployment } from '@/api/resources/restApis/deployments';
 import { ApiKeysPanel } from './ApiKeysPanel';
 import { DeployedGatewaysPanel } from './DeployedGatewaysPanel';
-import { DocumentsPanel } from './DocumentsPanel';
+import { EndpointsPanel } from './EndpointsPanel';
+// import { DocumentsPanel } from './DocumentsPanel';
 import { InvokeUrlPanel } from './InvokeUrlPanel';
 import { ResourcesPanel } from './ResourcesPanel';
 
@@ -33,9 +34,7 @@ import { ResourcesPanel } from './ResourcesPanel';
  * spec's ceiling on `limit`.
  */
 /**
- * Overview tab: resources on the left; invoke URL and
- * API keys on the right; the right column only appears once the API is
- * deployed on at least one gateway.
+ * Overview tab: resources on the left and API connectivity details on the right.
  */
 export function OverviewTab({
   api,
@@ -50,29 +49,33 @@ export function OverviewTab({
 
   return (
     <Grid container spacing={2}>
-      <Grid size={{ lg: deployed ? 8 : 12, xs: 12 }}>
+      <Grid size={{ lg: 8, xs: 12 }}>
         <Stack spacing={2} marginTop={1}>
           <ResourcesPanel api={api} />
-          <DocumentsPanel />
+          {/* Uncomment DocumentsPanel when documents should be shown on the overview. */}
+          {/* <DocumentsPanel /> */}
         </Stack>
       </Grid>
-      {deployed && (
-        <Grid size={{ lg: 4, xs: 12 }}>
-          <Stack spacing={2} marginTop={1}>
-            <Card sx={{ p: 2 }}>
-              <Stack spacing={2}>
-                <InvokeUrlPanel context={api.context} gateways={deployedGateways} />
-                {api.kind === 'RestApi' && (
-                  <Box sx={{ borderTop: '1px solid', borderColor: 'divider', pt: 2 }}>
-                    <ApiKeysPanel restApiId={api.id ?? ''} />
-                  </Box>
-                )}
-              </Stack>
-            </Card>
-            <DeployedGatewaysPanel deployments={deployments} gateways={deployedGateways} />
-          </Stack>
-        </Grid>
-      )}
+      <Grid size={{ lg: 4, xs: 12 }}>
+        <Stack spacing={2} marginTop={1}>
+          {deployed && (
+            <>
+              <Card sx={{ p: 2 }}>
+                <Stack spacing={2}>
+                  <InvokeUrlPanel context={api.context} gateways={deployedGateways} />
+                  {api.kind === 'RestApi' && (
+                    <Box sx={{ borderTop: '1px solid', borderColor: 'divider', pt: 2 }}>
+                      <ApiKeysPanel restApiId={api.id ?? ''} />
+                    </Box>
+                  )}
+                </Stack>
+              </Card>
+              <DeployedGatewaysPanel deployments={deployments} gateways={deployedGateways} />
+            </>
+          )}
+          <EndpointsPanel url={api.upstream?.main?.url} />
+        </Stack>
+      </Grid>
     </Grid>
   );
 }


### PR DESCRIPTION
This pull request primarily updates the API creation wizard's user interface and internationalization (i18n) messages to improve clarity, usability, and accessibility. It introduces new step navigation, clearer button labels, and more descriptive instructions throughout the API creation flow. Additionally, it refines the visual appearance of resource preview placeholders and enhances test coverage for the new step-by-step flow.

Issue: https://github.com/wso2-enterprise/apim-saas/issues/2974

https://github.com/user-attachments/assets/43a27c3e-86c8-403b-b7e2-edbc1ee5662f



**API Creation Wizard UX and i18n Improvements:**

- Introduced new i18n messages for clearer button labels like "Back" and "Continue", a wizard title, step count indicator, and improved subtitles for each step to guide users through the API creation process. [[1]](diffhunk://#diff-9da4dc257c3722931a9f13d05d7dd2c61bd9c9e0215de422e95eb12762c5052cR55-R72) [[2]](diffhunk://#diff-9da4dc257c3722931a9f13d05d7dd2c61bd9c9e0215de422e95eb12762c5052cR84-R93) [[3]](diffhunk://#diff-9da4dc257c3722931a9f13d05d7dd2c61bd9c9e0215de422e95eb12762c5052cL36-R42) [[4]](diffhunk://#diff-9da4dc257c3722931a9f13d05d7dd2c61bd9c9e0215de422e95eb12762c5052cL91-R107)
- Updated instructions and hints for file uploads and contract selection to be more descriptive and user-friendly, including changes to button text, helper text, and removal of redundant messages. [[1]](diffhunk://#diff-9da4dc257c3722931a9f13d05d7dd2c61bd9c9e0215de422e95eb12762c5052cL312-R350) [[2]](diffhunk://#diff-9da4dc257c3722931a9f13d05d7dd2c61bd9c9e0215de422e95eb12762c5052cR185-R188)
- Added new panel titles and empty state messages for the API overview page, improving clarity for users when viewing endpoints and deployed gateways.

**API Creation Wizard Functionality and Testing:**

- Refactored the wizard to use explicit step navigation with "Continue" and "Back" actions, ensuring that API creation only occurs after the final confirmation step. Added a visible step count for user orientation. [[1]](diffhunk://#diff-d3f2061e2363298981e84b14b32de0735353dd16e3e2789d2a7a47e44eb63998L19-R20) [[2]](diffhunk://#diff-d3f2061e2363298981e84b14b32de0735353dd16e3e2789d2a7a47e44eb63998R38-R65) [[3]](diffhunk://#diff-d3f2061e2363298981e84b14b32de0735353dd16e3e2789d2a7a47e44eb63998R88-R100)
- Enhanced test coverage for the wizard, including a new test that verifies no API is created until the final "Create" action is taken, ensuring the new navigation logic works as intended. [[1]](diffhunk://#diff-c47ec1a23ce11a951aaa2df2580f5bd817bd5b3ffd824b23f568a8ba0dbb9fc4L22-R22) [[2]](diffhunk://#diff-c47ec1a23ce11a951aaa2df2580f5bd817bd5b3ffd824b23f568a8ba0dbb9fc4L54-R56) [[3]](diffhunk://#diff-c47ec1a23ce11a951aaa2df2580f5bd817bd5b3ffd824b23f568a8ba0dbb9fc4R78-R108)

**Visual and Theming Updates:**

- Simplified and unified the visual style of the `ResourcePreviewPlaceholder` component by removing ambient glow effects, adjusting background colors, and refining spacing for a cleaner and more consistent appearance. [[1]](diffhunk://#diff-08fb53c0211171beae3ca4c26ea35f139787b2aeadd5fa7a96ff6179590c7136L23-R23) [[2]](diffhunk://#diff-08fb53c0211171beae3ca4c26ea35f139787b2aeadd5fa7a96ff6179590c7136L81-R81) [[3]](diffhunk://#diff-08fb53c0211171beae3ca4c26ea35f139787b2aeadd5fa7a96ff6179590c7136L119-R123) [[4]](diffhunk://#diff-08fb53c0211171beae3ca4c26ea35f139787b2aeadd5fa7a96ff6179590c7136L139-L180) [[5]](diffhunk://#diff-08fb53c0211171beae3ca4c26ea35f139787b2aeadd5fa7a96ff6179590c7136L191-R147) [[6]](diffhunk://#diff-08fb53c0211171beae3ca4c26ea35f139787b2aeadd5fa7a96ff6179590c7136L206-R162)

**Documentation and Descriptions:**

- Improved descriptions and default messages for design-related panels and helper texts, making the purpose and features of each section clearer to users.

Overall, these changes significantly enhance the clarity, usability, and accessibility of the API creation experience in the control plane.