### PR TITLE
Validate cloud resource names and show progress in the cloud extension forms

### DIFF
--- a/portals/cloud-plugins/apip-cloud-ui-environments-new/src/EnvironmentForm.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-environments-new/src/EnvironmentForm.tsx
@@ -20,6 +20,7 @@ import { useState, type FC } from "react";
 import {
   Box,
   Button,
+  CircularProgress,
   FormControl,
   FormControlLabel,
   FormLabel,
@@ -124,7 +125,12 @@ const EnvironmentForm: FC<EnvironmentFormProps> = ({ port, onBack, notify }) => 
         </Box>
 
         <Stack direction="row" spacing={1.5}>
-          <Button variant="outlined" color="secondary" onClick={onBack}>
+          <Button
+            variant="outlined"
+            color="secondary"
+            disabled={saving}
+            onClick={onBack}
+          >
             Cancel
           </Button>
           <Tooltip
@@ -139,6 +145,11 @@ const EnvironmentForm: FC<EnvironmentFormProps> = ({ port, onBack, notify }) => 
                 variant="contained"
                 disabled={!canSubmit}
                 onClick={handleSubmit}
+                startIcon={
+                  saving ? (
+                    <CircularProgress size={16} color="inherit" />
+                  ) : undefined
+                }
               >
                 {saving ? "Creating…" : "Create"}
               </Button>

--- a/portals/cloud-plugins/apip-cloud-ui-environments-new/src/EnvironmentForm.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-environments-new/src/EnvironmentForm.tsx
@@ -34,6 +34,7 @@ import {
 import { ChevronLeft } from "@wso2/oxygen-ui-icons-react";
 import type { NotifySeverity } from "./hostPort";
 import type { EnvironmentPort } from "./types";
+import { validateEnvironmentName } from "./utils/name";
 
 export type EnvironmentFormProps = {
   port: EnvironmentPort;
@@ -41,15 +42,38 @@ export type EnvironmentFormProps = {
   notify?: (message: string, severity?: NotifySeverity) => void;
 };
 
+/** Shown until the name breaks a rule, so the constraint is known up front. */
+const NAME_HELPER_TEXT =
+  "Lowercase letters, numbers and hyphens only. The name cannot be changed later.";
+
 const EnvironmentForm: FC<EnvironmentFormProps> = ({ port, onBack, notify }) => {
   const [name, setName] = useState("");
   const [critical, setCritical] = useState(false);
-  const canSubmit = name.trim().length > 0;
+  const [saving, setSaving] = useState(false);
+  const nameError = validateEnvironmentName(name);
+  const canSubmit = name.trim().length > 0 && !nameError && !saving;
 
   const handleSubmit = async () => {
-    const created = await port.create({ name: name.trim(), critical });
-    notify?.(`Environment "${created.name}" created.`, "success");
-    onBack();
+    // Guard against a second click issuing a duplicate create while the first is
+    // still in flight.
+    if (saving) return;
+    setSaving(true);
+    try {
+      const created = await port.create({ name: name.trim(), critical });
+      notify?.(`Environment "${created.name}" created.`, "success");
+      onBack();
+    } catch (error) {
+      // Without this the rejection is unhandled: the form sits there having said
+      // nothing, and the user has no way to tell the create failed.
+      notify?.(
+        error instanceof Error
+          ? error.message
+          : "Unable to create the environment.",
+        "error",
+      );
+    } finally {
+      setSaving(false);
+    }
   };
 
   return (
@@ -78,6 +102,8 @@ const EnvironmentForm: FC<EnvironmentFormProps> = ({ port, onBack, notify }) => 
             placeholder="Enter environment name"
             value={name}
             onChange={(event) => setName(event.target.value)}
+            error={Boolean(nameError)}
+            helperText={nameError ?? NAME_HELPER_TEXT}
           />
         </FormControl>
 
@@ -102,7 +128,11 @@ const EnvironmentForm: FC<EnvironmentFormProps> = ({ port, onBack, notify }) => 
             Cancel
           </Button>
           <Tooltip
-            title={canSubmit ? "" : "Enter an environment name to continue."}
+            title={
+              canSubmit || saving
+                ? ""
+                : nameError ?? "Enter an environment name to continue."
+            }
           >
             <span>
               <Button
@@ -110,7 +140,7 @@ const EnvironmentForm: FC<EnvironmentFormProps> = ({ port, onBack, notify }) => 
                 disabled={!canSubmit}
                 onClick={handleSubmit}
               >
-                Create
+                {saving ? "Creating…" : "Create"}
               </Button>
             </span>
           </Tooltip>

--- a/portals/cloud-plugins/apip-cloud-ui-environments-new/src/EnvironmentsList.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-environments-new/src/EnvironmentsList.tsx
@@ -23,6 +23,7 @@ import {
   Box,
   Button,
   Card,
+  CircularProgress,
   Dialog,
   DialogActions,
   DialogContent,
@@ -73,6 +74,7 @@ const EnvironmentsList: FC<EnvironmentsListProps> = ({ port, readOnly, onCreateC
   const [environments, setEnvironments] = useState<Environment[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
   const [deleteTarget, setDeleteTarget] = useState<Environment | null>(null);
+  const [deleting, setDeleting] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
   // Bumped on every refetch so a slower, superseded request's completion
   // (e.g. the initial load racing a Retry click) can recognize it's stale
@@ -109,15 +111,20 @@ const EnvironmentsList: FC<EnvironmentsListProps> = ({ port, readOnly, onCreateC
   }, [environments, searchQuery]);
 
   const handleDelete = async () => {
-    if (!deleteTarget) return;
+    // The dialog stays open, with its button busy, until the delete settles. An
+    // environment delete waits on OpenChoreo confirming the removal, so closing
+    // first left the row on screen with nothing to say a delete was running.
+    if (!deleteTarget || deleting) return;
+    setDeleting(true);
     try {
       await port.remove(deleteTarget.id);
       refetch();
       notify?.(`Environment "${deleteTarget.name}" deleted.`, 'success');
+      setDeleteTarget(null);
     } catch (err) {
       notify?.(errorMessage(err, `Failed to delete environment "${deleteTarget.name}".`), 'error');
     } finally {
-      setDeleteTarget(null);
+      setDeleting(false);
     }
   };
 
@@ -202,12 +209,19 @@ const EnvironmentsList: FC<EnvironmentsListProps> = ({ port, readOnly, onCreateC
         </TableContainer>
       </Card>
 
-      <Dialog open={Boolean(deleteTarget)} onClose={() => setDeleteTarget(null)}>
+      <Dialog open={Boolean(deleteTarget)} onClose={deleting ? undefined : () => setDeleteTarget(null)}>
         <DialogTitle>Delete Environment</DialogTitle>
         <DialogContent><DialogContentText>Are you sure you want to delete {deleteTarget?.name}?</DialogContentText></DialogContent>
         <DialogActions>
-          <Button variant="outlined" color="secondary" onClick={() => setDeleteTarget(null)}>Cancel</Button>
-          <Button color="error" onClick={handleDelete}>Delete</Button>
+          <Button variant="outlined" color="secondary" disabled={deleting} onClick={() => setDeleteTarget(null)}>Cancel</Button>
+          <Button
+            color="error"
+            onClick={handleDelete}
+            disabled={deleting}
+            startIcon={deleting ? <CircularProgress size={16} color="inherit" /> : undefined}
+          >
+            {deleting ? 'Deleting…' : 'Delete'}
+          </Button>
         </DialogActions>
       </Dialog>
     </PageContent>

--- a/portals/cloud-plugins/apip-cloud-ui-environments-new/src/utils/name.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-environments-new/src/utils/name.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * An environment's name becomes its OpenChoreo resource name, so it has to be a
+ * DNS-1123 label: the backend rejects anything else. Checking it here means the
+ * rule is visible while the name is being typed rather than after submitting.
+ */
+
+/** The longest name Kubernetes accepts for a single object. */
+const MAX_ENVIRONMENT_NAME_LENGTH = 63;
+
+const DNS1123_LABEL = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
+
+/**
+ * Returns the message to show for `name`, or `undefined` when it is usable. An
+ * empty name is left to the submit button's own disabled state rather than
+ * reported as an error the moment the field is focused.
+ */
+export function validateEnvironmentName(name: string): string | undefined {
+  const trimmed = name.trim();
+  if (!trimmed) return undefined;
+
+  if (trimmed.length > MAX_ENVIRONMENT_NAME_LENGTH) {
+    return `Use at most ${MAX_ENVIRONMENT_NAME_LENGTH} characters.`;
+  }
+  if (!DNS1123_LABEL.test(trimmed)) {
+    return 'Use only lowercase letters, numbers and hyphens, starting and ending with a letter or number.';
+  }
+  return undefined;
+}

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/GatewayForm.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/GatewayForm.tsx
@@ -20,6 +20,7 @@ import { useState, type FC } from 'react';
 import {
   Box,
   Button,
+  CircularProgress,
   FormControl,
   FormLabel,
   Grid,
@@ -44,7 +45,8 @@ export type GatewayFormProps = {
   types: GatewayType[];
   environments: Environment[];
   onBack: () => void;
-  onSubmit: (input: GatewayInput) => void;
+  /** Returning a promise lets the form keep its submit button busy until the save settles. */
+  onSubmit: (input: GatewayInput) => void | Promise<void>;
 };
 
 /** Shown before a name is typed, so the naming rule is known up front. */
@@ -82,16 +84,26 @@ const GatewayForm: FC<GatewayFormProps> = ({
     nameError ??
     (derivedHandle ? `Handle: ${derivedHandle}` : isEdit ? undefined : NAME_HELPER_TEXT);
 
-  const missingRequired = name.trim().length === 0 || environmentId.length === 0;
-  const canSubmit = !missingRequired && !nameError;
+  const [submitting, setSubmitting] = useState(false);
 
-  const handleSubmit = () => {
-    onSubmit({
-      name: name.trim(),
-      description: description.trim() || undefined,
-      type,
-      environmentId,
-    });
+  const missingRequired = name.trim().length === 0 || environmentId.length === 0;
+  const canSubmit = !missingRequired && !nameError && !submitting;
+
+  const handleSubmit = async () => {
+    // Provisioning a gateway takes seconds, so the button has to show the work is
+    // under way — and a second click must not issue a second create.
+    if (submitting) return;
+    setSubmitting(true);
+    try {
+      await onSubmit({
+        name: name.trim(),
+        description: description.trim() || undefined,
+        type,
+        environmentId,
+      });
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   return (
@@ -162,15 +174,20 @@ const GatewayForm: FC<GatewayFormProps> = ({
         </Grid>
 
         <Box sx={{ mt: 3, display: 'flex', gap: 1 }}>
-          <Button variant="outlined" color="secondary" onClick={onBack}>
+          <Button variant="outlined" color="secondary" disabled={submitting} onClick={onBack}>
             Cancel
           </Button>
           {/* An invalid name explains itself in the field's helper text, so the
               tooltip only covers the still-empty case. */}
           <Tooltip title={missingRequired ? 'Fill in the required fields to continue.' : ''}>
             <span>
-              <Button variant="contained" disabled={!canSubmit} onClick={handleSubmit}>
-                {isEdit ? 'Save Changes' : 'Add Gateway'}
+              <Button
+                variant="contained"
+                disabled={!canSubmit}
+                onClick={handleSubmit}
+                startIcon={submitting ? <CircularProgress size={16} color="inherit" /> : undefined}
+              >
+                {submitting ? (isEdit ? 'Saving…' : 'Adding…') : isEdit ? 'Save Changes' : 'Add Gateway'}
               </Button>
             </span>
           </Tooltip>

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/GatewayForm.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/GatewayForm.tsx
@@ -32,7 +32,7 @@ import {
 import { ChevronLeft } from '@wso2/oxygen-ui-icons-react';
 import EnvironmentSelect from './components/EnvironmentSelect';
 import GatewayTypeSelector from './components/GatewayTypeSelector';
-import { validateGatewayName } from './utils/name';
+import { gatewayHandleFromName, validateGatewayName } from './utils/name';
 import type { Environment, Gateway, GatewayInput, GatewayType } from './types';
 
 export type GatewayFormProps = {
@@ -46,6 +46,9 @@ export type GatewayFormProps = {
   onBack: () => void;
   onSubmit: (input: GatewayInput) => void;
 };
+
+/** Shown before a name is typed, so the naming rule is known up front. */
+const NAME_HELPER_TEXT = 'The gateway handle is derived from this name and cannot be changed later.';
 
 const GatewayForm: FC<GatewayFormProps> = ({
   mode = 'create',
@@ -71,6 +74,13 @@ const GatewayForm: FC<GatewayFormProps> = ({
   // handle is immutable — so an edit must not be blocked by rules that no longer
   // apply to what it changes.
   const nameError = isEdit ? undefined : validateGatewayName(name, environmentId);
+
+  // The handle is what the gateway is addressed by and cannot be changed later,
+  // so show what the name will become instead of leaving the user to guess.
+  const derivedHandle = isEdit ? '' : gatewayHandleFromName(name);
+  const nameHelperText =
+    nameError ??
+    (derivedHandle ? `Handle: ${derivedHandle}` : isEdit ? undefined : NAME_HELPER_TEXT);
 
   const missingRequired = name.trim().length === 0 || environmentId.length === 0;
   const canSubmit = !missingRequired && !nameError;
@@ -117,7 +127,7 @@ const GatewayForm: FC<GatewayFormProps> = ({
                 value={name}
                 onChange={(event) => setName(event.target.value)}
                 error={Boolean(nameError)}
-                helperText={nameError}
+                helperText={nameHelperText}
                 autoFocus
               />
             </FormControl>

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/GatewaysList.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/GatewaysList.tsx
@@ -23,6 +23,7 @@ import {
   Button,
   Card,
   Chip,
+  CircularProgress,
   Dialog,
   DialogActions,
   DialogContent,
@@ -54,7 +55,8 @@ export type GatewaysListProps = {
   environments: Environment[];
   onAddClick: () => void;
   onEditClick: (gatewayId: string) => void;
-  onDelete: (gatewayId: string, name: string) => void;
+  /** Returning a promise lets the confirm dialog stay open, and busy, until the delete settles. */
+  onDelete: (gatewayId: string, name: string) => void | Promise<void>;
 };
 
 function truncateText(text: string, maxLength: number): string {
@@ -71,6 +73,7 @@ const GatewaysList: FC<GatewaysListProps> = ({
 }) => {
   const [searchQuery, setSearchQuery] = useState('');
   const [deleteTarget, setDeleteTarget] = useState<{ id: string; name: string } | null>(null);
+  const [deleting, setDeleting] = useState(false);
   const [settingsGateway, setSettingsGateway] = useState<Gateway | null>(null);
 
   // Environments are keyed by name, so a gateway that points at an environment
@@ -89,10 +92,18 @@ const GatewaysList: FC<GatewaysListProps> = ({
     );
   }, [gateways, searchQuery]);
 
-  const handleDeleteConfirm = () => {
-    if (!deleteTarget) return;
-    onDelete(deleteTarget.id, deleteTarget.name);
-    setDeleteTarget(null);
+  const handleDeleteConfirm = async () => {
+    // The dialog stays open, with its button busy, until the delete settles:
+    // closing first left the row on screen with nothing to say a delete was even
+    // running, and let a second gateway be deleted while the first was in flight.
+    if (!deleteTarget || deleting) return;
+    setDeleting(true);
+    try {
+      await onDelete(deleteTarget.id, deleteTarget.name);
+      setDeleteTarget(null);
+    } finally {
+      setDeleting(false);
+    }
   };
 
   return (
@@ -255,17 +266,22 @@ const GatewaysList: FC<GatewaysListProps> = ({
         )}
       </Grid>
 
-      <Dialog open={Boolean(deleteTarget)} onClose={() => setDeleteTarget(null)}>
+      <Dialog open={Boolean(deleteTarget)} onClose={deleting ? undefined : () => setDeleteTarget(null)}>
         <DialogTitle>Delete Gateway</DialogTitle>
         <DialogContent>
           <DialogContentText>Are you sure you want to delete {deleteTarget?.name}?</DialogContentText>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setDeleteTarget(null)} variant="outlined" color="secondary">
+          <Button onClick={() => setDeleteTarget(null)} variant="outlined" color="secondary" disabled={deleting}>
             Cancel
           </Button>
-          <Button color="error" onClick={handleDeleteConfirm}>
-            Delete
+          <Button
+            color="error"
+            onClick={handleDeleteConfirm}
+            disabled={deleting}
+            startIcon={deleting ? <CircularProgress size={16} color="inherit" /> : undefined}
+          >
+            {deleting ? 'Deleting…' : 'Delete'}
           </Button>
         </DialogActions>
       </Dialog>

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/utils/name.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/utils/name.ts
@@ -29,9 +29,7 @@ const MAX_GATEWAY_NAME_LENGTH = MAX_GATEWAY_HANDLE_LENGTH - 2;
 /** Reserved for the gateway provisioned automatically with the environment. */
 const RESERVED_GATEWAY_NAME = 'default';
 
-const DNS1123_NAME = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
-
-/** How many characters a gateway name may use in the given environment. */
+/** How many characters a gateway handle may use in the given environment. */
 export function gatewayNameBudget(environment: string): number {
   return environment
     ? MAX_GATEWAY_HANDLE_LENGTH - environment.length - 1
@@ -39,31 +37,50 @@ export function gatewayNameBudget(environment: string): number {
 }
 
 /**
- * Validates a new gateway's name against the same rules the backend applies to
- * it, returning the message to show or `undefined` when the name is fine.
+ * Derives the handle a gateway will be addressed by from its display name, the
+ * same conversion the backend applies (and the same one behind a project's or an
+ * API's id): lowercased, with spaces and underscores folded to hyphens and
+ * anything else dropped.
  *
- * On create the name is what the gateway's handle is derived from, so it has to
- * be a DNS-1123 name that fits the handle column alongside the environment —
- * otherwise the create call fails after the form has already been submitted.
- * Case is not part of it: the backend lowercases before validating, so `Prod-1`
- * is accepted and becomes `prod-1`. An empty name is left to the field's own
- * `required` handling rather than reported here.
+ * Returns `''` when nothing usable survives, which the caller reports rather
+ * than substituting a name of its own.
+ */
+export function gatewayHandleFromName(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[\s_]+/g, '-')
+    .replace(/[^a-z0-9-]/g, '')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/**
+ * Validates a new gateway's name against the same rules the backend applies,
+ * returning the message to show or `undefined` when the name is fine.
+ *
+ * The name is a display name: it may be written however the user likes, and the
+ * handle is derived from it, so casing and spaces are not errors. What it cannot
+ * be is a name no handle can be built from, the reserved bootstrap name, or one
+ * whose handle does not fit the handle column alongside the environment. An
+ * empty name is left to the field's own `required` handling rather than reported
+ * here.
  */
 export function validateGatewayName(name: string, environment: string): string | undefined {
-  const handle = name.trim().toLowerCase();
-  if (!handle) return undefined;
+  if (!name.trim()) return undefined;
 
+  const handle = gatewayHandleFromName(name);
+  if (!handle) {
+    return 'Include at least one letter or number.';
+  }
   if (handle === RESERVED_GATEWAY_NAME) {
     return `"${RESERVED_GATEWAY_NAME}" is reserved for the gateway created with the environment.`;
-  }
-  if (!DNS1123_NAME.test(handle)) {
-    return 'Use only letters, digits and hyphens, starting and ending with a letter or digit.';
   }
 
   const budget = gatewayNameBudget(environment);
   if (handle.length > budget) {
     return environment
-      ? `Too long for the "${environment}" environment: use at most ${budget} characters (the handle "${environment}-<name>" must fit ${MAX_GATEWAY_HANDLE_LENGTH} characters).`
+      ? `Too long for the "${environment}" environment: the handle "${handle}" must be at most ${budget} characters (the full handle "${environment}-<handle>" has to fit ${MAX_GATEWAY_HANDLE_LENGTH}).`
       : `Use at most ${budget} characters.`;
   }
   return undefined;

--- a/portals/cloud-plugins/apip-cloud-ui-pipelines/src/PipelineCreatePage.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-pipelines/src/PipelineCreatePage.tsx
@@ -11,6 +11,7 @@ import { useRef, useState, type FC } from 'react';
 import {
   Box,
   Button,
+  CircularProgress,
   IconButton,
   PageContent,
   PageTitle,
@@ -251,7 +252,7 @@ const PipelineCreatePage: FC<PipelineCreatePageProps> = ({
         </Box>
 
         <Box sx={{ mt: 3, display: 'flex', gap: 1 }}>
-          <Button variant="outlined" color="secondary" onClick={onBack}>
+          <Button variant="outlined" color="secondary" disabled={saving} onClick={onBack}>
             Cancel
           </Button>
           <Tooltip
@@ -262,8 +263,13 @@ const PipelineCreatePage: FC<PipelineCreatePageProps> = ({
               : ''}
           >
             <span>
-              <Button variant="contained" disabled={!canSubmit || saving} onClick={handleSubmit}>
-                {isEdit ? 'Save Changes' : 'Create'}
+              <Button
+                variant="contained"
+                disabled={!canSubmit || saving}
+                onClick={handleSubmit}
+                startIcon={saving ? <CircularProgress size={16} color="inherit" /> : undefined}
+              >
+                {saving ? (isEdit ? 'Saving…' : 'Creating…') : isEdit ? 'Save Changes' : 'Create'}
               </Button>
             </span>
           </Tooltip>

--- a/portals/cloud-plugins/apip-cloud-ui-pipelines/src/PipelineCreatePage.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-pipelines/src/PipelineCreatePage.tsx
@@ -24,6 +24,7 @@ import EnvironmentGatewayPicker from './components/EnvironmentGatewayPicker';
 import PipelineStageCard from './components/PipelineStageCard';
 import type { CreatePipelineInput, Environment, Pipeline } from './types';
 import { orderEnvironments } from './utils';
+import { validatePipelineName } from './utils/name';
 
 export type PipelineCreatePageProps = {
   environments: Environment[];
@@ -46,6 +47,10 @@ type ChainEntry = {
   environment: string;
   defaultGatewayId: string;
 };
+
+/** Shown until the name breaks a rule, so the constraint is known up front. */
+const NAME_HELPER_TEXT =
+  'Lowercase letters, numbers and hyphens only. The name cannot be changed later.';
 
 const findEnvironment = (environments: Environment[], name: string) =>
   environments.find((environment) => environment.name === name);
@@ -103,9 +108,14 @@ const PipelineCreatePage: FC<PipelineCreatePageProps> = ({
     setChain((prev) => prev.filter((entry) => entry.environment !== environment));
   };
 
+  // Only a new pipeline is named here; an existing one cannot be renamed, so its
+  // stored name is never re-validated (and an older name that predates the rule
+  // must not be reported as an error on a page that cannot fix it).
+  const nameError = isEdit ? undefined : validatePipelineName(name);
+
   // A pipeline needs at least two environments to form a promotion path
   // (source -> target), which is what the platform-api requires.
-  const canSubmit = name.trim().length > 0 && chain.length >= 2;
+  const canSubmit = name.trim().length > 0 && !nameError && chain.length >= 2;
 
   const handleSubmit = async () => {
     // Guard against a second click issuing a duplicate create/update while the
@@ -155,7 +165,10 @@ const PipelineCreatePage: FC<PipelineCreatePageProps> = ({
             value={name}
             onChange={(event) => setName(event.target.value)}
             disabled={isEdit}
-            helperText={isEdit ? 'A pipeline cannot be renamed after it is created.' : undefined}
+            error={Boolean(nameError)}
+            helperText={
+              isEdit ? 'A pipeline cannot be renamed after it is created.' : nameError ?? NAME_HELPER_TEXT
+            }
             autoFocus={!isEdit}
           />
         </Box>

--- a/portals/cloud-plugins/apip-cloud-ui-pipelines/src/PipelinesListPage.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-pipelines/src/PipelinesListPage.tsx
@@ -11,6 +11,7 @@ import { useState, type FC } from 'react';
 import {
   Box,
   Button,
+  CircularProgress,
   Collapse,
   Dialog,
   DialogActions,
@@ -41,7 +42,8 @@ export type PipelinesListPageProps = {
   environments: Environment[];
   onCreateClick: () => void;
   onEditClick: (id: string) => void;
-  onDelete: (id: string) => void;
+  /** Returning a promise lets the confirm dialog stay open, and busy, until the delete settles. */
+  onDelete: (id: string) => void | Promise<void>;
 };
 
 const findEnvironment = (environments: Environment[], name: string) =>
@@ -56,6 +58,7 @@ const PipelinesListPage: FC<PipelinesListPageProps> = ({
 }) => {
   const [expandedIds, setExpandedIds] = useState<string[]>(() => pipelines.map((p) => p.id));
   const [pendingDelete, setPendingDelete] = useState<Pipeline | null>(null);
+  const [deleting, setDeleting] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
 
   const toggleExpanded = (id: string) => {
@@ -64,10 +67,18 @@ const PipelinesListPage: FC<PipelinesListPageProps> = ({
     );
   };
 
-  const handleConfirmDelete = () => {
-    if (!pendingDelete || pendingDelete.isDefault) return;
-    onDelete(pendingDelete.id);
-    setPendingDelete(null);
+  const handleConfirmDelete = async () => {
+    // The dialog stays open, with its button busy, until the delete settles:
+    // closing first left the pipeline on screen with nothing to say a delete was
+    // running, and a second click could issue a second delete.
+    if (!pendingDelete || pendingDelete.isDefault || deleting) return;
+    setDeleting(true);
+    try {
+      await onDelete(pendingDelete.id);
+      setPendingDelete(null);
+    } finally {
+      setDeleting(false);
+    }
   };
 
   const normalizedQuery = searchQuery.trim().toLowerCase();
@@ -224,7 +235,7 @@ const PipelinesListPage: FC<PipelinesListPageProps> = ({
         </Stack>
       )}
 
-      <Dialog open={!!pendingDelete} onClose={() => setPendingDelete(null)}>
+      <Dialog open={!!pendingDelete} onClose={deleting ? undefined : () => setPendingDelete(null)}>
         <DialogTitle>Delete pipeline?</DialogTitle>
         <DialogContent>
           <Typography variant="body2">
@@ -233,9 +244,17 @@ const PipelinesListPage: FC<PipelinesListPageProps> = ({
           </Typography>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setPendingDelete(null)}>Cancel</Button>
-          <Button color="error" variant="contained" onClick={handleConfirmDelete}>
-            Delete
+          <Button onClick={() => setPendingDelete(null)} disabled={deleting}>
+            Cancel
+          </Button>
+          <Button
+            color="error"
+            variant="contained"
+            onClick={handleConfirmDelete}
+            disabled={deleting}
+            startIcon={deleting ? <CircularProgress size={16} color="inherit" /> : undefined}
+          >
+            {deleting ? 'Deleting…' : 'Delete'}
           </Button>
         </DialogActions>
       </Dialog>

--- a/portals/cloud-plugins/apip-cloud-ui-pipelines/src/utils/name.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-pipelines/src/utils/name.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+/**
+ * A pipeline's name becomes its OpenChoreo resource name, so it has to be a
+ * DNS-1123 label: the backend rejects anything else. Checking it here means the
+ * rule is visible while the name is being typed, instead of the create failing
+ * after the whole pipeline has been built.
+ */
+
+/** The longest name Kubernetes accepts for a single object. */
+const MAX_PIPELINE_NAME_LENGTH = 63;
+
+const DNS1123_LABEL = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
+
+/**
+ * Returns the message to show for `name`, or `undefined` when it is usable. An
+ * empty name is left to the submit button's own disabled state rather than
+ * reported as an error the moment the field is focused.
+ */
+export function validatePipelineName(name: string): string | undefined {
+  const trimmed = name.trim();
+  if (!trimmed) return undefined;
+
+  if (trimmed.length > MAX_PIPELINE_NAME_LENGTH) {
+    return `Use at most ${MAX_PIPELINE_NAME_LENGTH} characters.`;
+  }
+  if (!DNS1123_LABEL.test(trimmed)) {
+    return 'Use only lowercase letters, numbers and hyphens, starting and ending with a letter or number.';
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Purpose
Environment and pipeline names have to be lowercase DNS-1123 names, but neither form said so — an invalid name was only rejected once the request came back, after a whole pipeline had been built. Separately, none of the create/update/delete buttons in these features showed that a request was in flight; the three confirm dialogs closed the instant Delete was clicked, so a delete ran with nothing on screen to say so.

## Goals
Validate names while they are typed, and show progress on every mutating action.

## Approach
- Environment and pipeline name fields validate as you type and state the rule in their helper text.
- The gateway name is a display name the handle is derived from, so it now previews the resulting handle instead of rejecting spaces and capitals.
- Every create/update/delete button gets a spinner and a present-tense label while its request is in flight, and each confirm dialog stays open until the delete settles. This follows the pattern the project-pipeline binding already used.
- The environment create had no error handling at all: a failure left the rejection unhandled and the form silent. It now reports it.

## User stories
N/A

## Documentation
N/A — no product doc covers these forms.

## Automation tests
 - Unit tests
   > N/A — these packages are gated by `tsc --noEmit`, which passes for all three.
 - Integration tests
   > N/A

## Samples
N/A

## Security checks
 - Followed secure coding standards? **yes**
 - Ran FindSecurityBugs plugin and verified report? **N/A** (TypeScript only)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Related PRs
Backend counterpart applies the same rules server-side.

## Test environment
Chrome 152, macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
