### PR TITLE
Change Deploy page UI

### DIFF
--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/DeployFeature.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/DeployFeature.tsx
@@ -120,14 +120,16 @@ const DeployFeature: FC<DeployFeatureProps> = ({ port }) => {
 
   /**
    * Deploy and promote are the same call: what separates them is whether a source
-   * environment is named. Deploying to the first environment ships the API as it
-   * stands; promoting carries the source's build forward.
+   * environment is named. Deploying to the first environment either ships a
+   * selected build or creates a new one; promoting carries the source's build
+   * forward.
    */
   const handleDeploy = (
     target: Environment,
     gatewayId: string,
     endpointUrl: string,
-    from?: Environment
+    from?: Environment,
+    buildId?: string
   ) => {
     if (!client) return;
     void runAction(
@@ -137,6 +139,7 @@ const DeployFeature: FC<DeployFeatureProps> = ({ port }) => {
           gatewayId,
           endpointUrl,
           fromEnvironment: from?.name,
+          buildId,
         }),
       `${from ? 'Promoting to' : 'Deploying to'} ${target.name}.`,
       `Unable to ${from ? 'promote to' : 'deploy to'} ${target.name}.`

--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/DeployPage.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/DeployPage.tsx
@@ -35,7 +35,8 @@ export type DeployPageProps = {
     target: Environment,
     gatewayId: string,
     endpointUrl: string,
-    from?: Environment
+    from?: Environment,
+    buildId?: string
   ) => void;
   onStopGateway: (environment: Environment, gatewayId: string) => void;
   onRetryGateway: (environment: Environment, gatewayId: string) => void;
@@ -47,7 +48,12 @@ export type DeployPageProps = {
  * being arranged here, so the view cannot imply a promotion the pipeline does
  * not allow.
  */
-type DialogState = { targetIndex: number; sourceIndex?: number } | null;
+type DialogState = {
+  targetIndex: number;
+  sourceIndex?: number;
+  buildId?: string;
+  createBuild?: boolean;
+} | null;
 
 const DeployPage: FC<DeployPageProps> = ({
   environments,
@@ -63,8 +69,8 @@ const DeployPage: FC<DeployPageProps> = ({
   const source =
     dialog?.sourceIndex !== undefined ? environments[dialog.sourceIndex] : undefined;
 
-  const handleConfirm = (gatewayId: string, endpointUrl: string) => {
-    if (target) onDeploy(target, gatewayId, endpointUrl, source);
+  const handleConfirm = (gatewayId: string, endpointUrl: string, buildId?: string) => {
+    if (target) onDeploy(target, gatewayId, endpointUrl, source, buildId);
     setDialog(null);
   };
 
@@ -142,7 +148,9 @@ const DeployPage: FC<DeployPageProps> = ({
               builds={builds}
               targetEnvironment={environments[0]}
               busy={busy}
-              onDeployClick={() => setDialog({ targetIndex: 0 })}
+              onDeployClick={(buildId, createBuild) =>
+                setDialog({ targetIndex: 0, buildId, createBuild })
+              }
             />
 
             {environments.map((environment, index) => (
@@ -168,7 +176,10 @@ const DeployPage: FC<DeployPageProps> = ({
         open={dialog !== null}
         mode={source ? 'promote' : 'deploy'}
         environment={target}
-        sourceEnvironmentName={source?.name}
+        sourceEnvironment={source}
+        builds={builds}
+        initialBuildId={dialog?.buildId}
+        createBuild={dialog?.createBuild ?? false}
         submitting={busy}
         onClose={() => setDialog(null)}
         onConfirm={handleConfirm}

--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/components/BuildAreaCard.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/components/BuildAreaCard.tsx
@@ -16,9 +16,22 @@
  * under the License.
  */
 
-import type { FC } from 'react';
-import { Box, Button, Card, CardContent, Divider, Tooltip, Typography } from '@wso2/oxygen-ui';
-import StatusDot from './StatusDot';
+import { useState, type FC, type MouseEvent } from 'react';
+import {
+  Box,
+  Button,
+  ButtonGroup,
+  Card,
+  CardContent,
+  Divider,
+  Drawer,
+  IconButton,
+  Menu,
+  MenuItem,
+  Tooltip,
+  Typography,
+} from '@wso2/oxygen-ui';
+import { ChevronDown, Clock, X } from '@wso2/oxygen-ui-icons-react';
 import { relativeTime } from '../utils/time';
 import { activeGatewayCount } from '../utils/status';
 import type { Build, Environment } from '../types';
@@ -28,14 +41,16 @@ export type BuildAreaCardProps = {
   builds: Build[];
   targetEnvironment: Environment;
   busy: boolean;
-  onDeployClick: () => void;
+  /** Opens deployment using an existing build, or creates a build when omitted. */
+  onDeployClick: (buildId?: string, createBuild?: boolean) => void;
 };
 
+const VISIBLE_BUILD_COUNT = 5;
+type DeployAction = 'deploy' | 'build-and-deploy';
+
 /**
- * The head of the pipeline. Deploying from here ships the API as it stands: the
- * server snapshots it and deploys that snapshot, so there is no build step to
- * perform first and the card reports what was last built rather than asking for
- * one.
+ * The head of the pipeline. An existing build can be deployed as-is, or the API
+ * can be rebuilt before it is deployed to the first environment.
  */
 const BuildAreaCard: FC<BuildAreaCardProps> = ({
   builds,
@@ -43,11 +58,60 @@ const BuildAreaCard: FC<BuildAreaCardProps> = ({
   busy,
   onDeployClick,
 }) => {
+  const [deployMenuAnchor, setDeployMenuAnchor] = useState<HTMLElement | null>(null);
+  const [buildsDrawerOpen, setBuildsDrawerOpen] = useState(false);
+  const [selectedDeployAction, setSelectedDeployAction] = useState<DeployAction>('deploy');
   const latestBuild = builds[0] ?? null;
+  const visibleBuilds = builds.slice(0, VISIBLE_BUILD_COUNT);
   const canDeploy = activeGatewayCount(targetEnvironment.gateways) > 0;
   const deployDisabledReason = canDeploy
     ? ''
     : `All gateways in ${targetEnvironment.name} are inactive. Activate a gateway before deploying.`;
+
+  const openDeployMenu = (event: MouseEvent<HTMLButtonElement>) => {
+    setDeployMenuAnchor(event.currentTarget);
+  };
+
+  const chooseDeployAction = (action: DeployAction) => {
+    setSelectedDeployAction(action);
+    setDeployMenuAnchor(null);
+  };
+
+  const runSelectedDeployAction = () => {
+    onDeployClick(
+      selectedDeployAction === 'deploy' ? latestBuild?.buildId : undefined,
+      selectedDeployAction === 'build-and-deploy'
+    );
+  };
+
+  const renderBuilds = (items: Build[]) => (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+      {items.map((build) => (
+        <Card key={build.buildId} variant="outlined">
+          <CardContent sx={{ p: 1.25, '&:last-child': { pb: 1.25 } }}>
+            <Typography
+              variant="body2"
+              sx={{
+                color: 'text.primary',
+                fontWeight: 700,
+                fontSize: 14,
+              }}
+            >
+              {build.buildId}
+            </Typography>
+            {build.createdAt ? (
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.5 }}>
+                <Clock size={13} />
+                <Typography variant="caption" color="text.secondary" sx={{ fontSize: 12 }}>
+                  {relativeTime(build.createdAt)}
+                </Typography>
+              </Box>
+            ) : null}
+          </CardContent>
+        </Card>
+      ))}
+    </Box>
+  );
 
   return (
     <Card
@@ -63,48 +127,107 @@ const BuildAreaCard: FC<BuildAreaCardProps> = ({
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, mt: 1.5 }}>
           <Divider />
 
-          <Tooltip title={deployDisabledReason}>
-            <span style={{ display: 'block' }}>
-              <Button
-                fullWidth
-                variant="contained"
-                disabled={!canDeploy || busy}
-                onClick={onDeployClick}
-                sx={{ fontWeight: 600 }}
-              >
-                Deploy
-              </Button>
-            </span>
-          </Tooltip>
+          {latestBuild ? (
+            <Tooltip title={deployDisabledReason}>
+              <span style={{ display: 'block' }}>
+                <ButtonGroup
+                  variant="contained"
+                  disabled={!canDeploy || busy}
+                  sx={{ display: 'flex', width: '100%' }}
+                >
+                  <Button
+                    onClick={runSelectedDeployAction}
+                    sx={{ flex: '1 1 auto', width: 'auto', minWidth: 0, fontWeight: 600 }}
+                  >
+                    {selectedDeployAction === 'deploy' ? 'Deploy' : 'Build and Deploy'}
+                  </Button>
+                  <Button
+                    aria-label="Choose deploy action"
+                    aria-haspopup="menu"
+                    aria-expanded={Boolean(deployMenuAnchor)}
+                    onClick={openDeployMenu}
+                    sx={{ flex: '0 0 44px', width: 44, minWidth: 44, maxWidth: 44, px: 0 }}
+                  >
+                    <ChevronDown size={18} />
+                  </Button>
+                </ButtonGroup>
+              </span>
+            </Tooltip>
+          ) : (
+            <Tooltip title={deployDisabledReason}>
+              <span style={{ display: 'block' }}>
+                <Button
+                  fullWidth
+                  variant="contained"
+                  disabled={!canDeploy || busy}
+                  onClick={() => onDeployClick(undefined, true)}
+                  sx={{ fontWeight: 600 }}
+                >
+                  Build and deploy
+                </Button>
+              </span>
+            </Tooltip>
+          )}
 
-          <Card>
-            <CardContent sx={{ p: 1.5, '&:last-child': { pb: 1.5 } }}>
-              {latestBuild ? (
-                <>
-                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
-                    <StatusDot tone="success" />
-                    <Typography variant="body2" sx={{ fontWeight: 500 }}>
-                      Latest build
-                    </Typography>
-                    {latestBuild.createdAt ? (
-                      <Typography variant="caption" color="text.disabled">
-                        · {relativeTime(latestBuild.createdAt)}
-                      </Typography>
-                    ) : null}
-                  </Box>
-                  <Typography variant="caption" color="text.secondary" display="block" sx={{ pl: 2.25, mt: 0.5 }}>
-                    ID {latestBuild.buildId}
-                  </Typography>
-                </>
-              ) : (
+          <Menu
+            anchorEl={deployMenuAnchor}
+            open={Boolean(deployMenuAnchor)}
+            onClose={() => setDeployMenuAnchor(null)}
+          >
+            <MenuItem onClick={() => chooseDeployAction('deploy')}>Deploy</MenuItem>
+            <MenuItem onClick={() => chooseDeployAction('build-and-deploy')}>
+              Build and Deploy
+            </MenuItem>
+          </Menu>
+
+          {visibleBuilds.length > 0 ? (
+            <Box>
+              {renderBuilds(visibleBuilds)}
+
+              {builds.length > VISIBLE_BUILD_COUNT ? (
+                <Button
+                  size="small"
+                  onClick={() => setBuildsDrawerOpen(true)}
+                  sx={{ mt: 1, px: 0 }}
+                >
+                  See more
+                </Button>
+              ) : null}
+            </Box>
+          ) : (
+            <Card variant="outlined">
+              <CardContent sx={{ p: 1.5, '&:last-child': { pb: 1.5 } }}>
                 <Typography variant="body2" color="text.disabled">
                   No builds yet. Deploying prepares one.
                 </Typography>
-              )}
-            </CardContent>
-          </Card>
+              </CardContent>
+            </Card>
+          )}
         </Box>
       </CardContent>
+
+      <Drawer anchor="right" open={buildsDrawerOpen} onClose={() => setBuildsDrawerOpen(false)}>
+        <Box sx={{ width: 360, p: 3 }}>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              mb: 2,
+            }}
+          >
+            <Typography sx={{ fontSize: 16, fontWeight: 600 }}>All Builds</Typography>
+            <IconButton
+              size="small"
+              onClick={() => setBuildsDrawerOpen(false)}
+              aria-label="Close builds"
+            >
+              <X size={18} />
+            </IconButton>
+          </Box>
+          {renderBuilds(builds)}
+        </Box>
+      </Drawer>
     </Card>
   );
 };

--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/components/DeployDialog.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/components/DeployDialog.tsx
@@ -35,17 +35,21 @@ import {
 import StatusDot from './StatusDot';
 import StatusPill from './StatusPill';
 import { gatewayStatusTone } from '../utils/status';
-import type { Environment, Gateway } from '../types';
+import type { Build, Environment, Gateway } from '../types';
 
 export type DeployDialogProps = {
   open: boolean;
   mode: 'deploy' | 'promote';
   environment: Environment | null;
   /** The environment a promotion carries the build out of. */
-  sourceEnvironmentName?: string;
+  sourceEnvironment?: Environment;
+  builds: Build[];
+  initialBuildId?: string;
+  /** A new build will be created on confirmation; the latest build is informational. */
+  createBuild: boolean;
   submitting: boolean;
   onClose: () => void;
-  onConfirm: (gatewayId: string, endpointUrl: string) => void;
+  onConfirm: (gatewayId: string, endpointUrl: string, buildId?: string) => void;
 };
 
 const sectionLabelSx = {
@@ -66,7 +70,10 @@ const DeployDialog: FC<DeployDialogProps> = ({
   open,
   mode,
   environment,
-  sourceEnvironmentName,
+  sourceEnvironment,
+  builds,
+  initialBuildId,
+  createBuild,
   submitting,
   onClose,
   onConfirm,
@@ -77,12 +84,14 @@ const DeployDialog: FC<DeployDialogProps> = ({
   // opened dialog with nothing selected, since the effect that filled them ran
   // after it, and would let a background refresh overwrite a half-typed URL.
   const [gatewayId, setGatewayId] = useState('');
+  const [buildId, setBuildId] = useState('');
   const [endpointDraft, setEndpointDraft] = useState<string | null>(null);
   const [urlTouched, setUrlTouched] = useState(false);
 
   useEffect(() => {
     if (!open) return;
     setGatewayId('');
+    setBuildId('');
     setEndpointDraft(null);
     setUrlTouched(false);
   }, [open]);
@@ -90,6 +99,15 @@ const DeployDialog: FC<DeployDialogProps> = ({
   if (!environment) return null;
 
   const actionLabel = mode === 'deploy' ? 'Deploy' : 'Promote';
+  const availableBuilds =
+    mode === 'promote'
+      ? builds.filter((build) =>
+          sourceEnvironment?.gateways.some((gateway) => gateway.buildId === build.buildId)
+        )
+      : builds;
+  const selectedBuildId = createBuild
+    ? (builds[0]?.buildId ?? '')
+    : (buildId || initialBuildId || availableBuilds[0]?.buildId || '');
   const selectedGateway =
     environment.gateways.find((gateway) => gateway.id === gatewayId) ??
     pickDefaultGateway(environment.gateways);
@@ -100,7 +118,11 @@ const DeployDialog: FC<DeployDialogProps> = ({
   // what a first deployment targets.
   const isSelectedInactive = selectedGateway ? selectedGateway.health !== 'active' : false;
   const urlMissing = endpointUrl.trim().length === 0;
-  const canConfirm = !!selectedGateway && !isSelectedInactive && !urlMissing;
+  const canConfirm =
+    !!selectedGateway &&
+    !isSelectedInactive &&
+    !urlMissing &&
+    (createBuild || selectedBuildId.length > 0);
 
   const handleSelectGateway = (id: string) => {
     setGatewayId(id);
@@ -117,7 +139,7 @@ const DeployDialog: FC<DeployDialogProps> = ({
         <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
           {mode === 'deploy'
             ? `Deploys this API as it stands now to ${environment.name}. Select the gateway to deploy to.`
-            : `Carries the build running in ${sourceEnvironmentName ?? 'the previous environment'} forward to ${environment.name}, with the endpoint you give here.`}
+            : `Carries a build running in ${sourceEnvironment?.name ?? 'the previous environment'} forward to ${environment.name}, with the endpoint you give here.`}
         </Typography>
 
         {isSelectedInactive ? (
@@ -189,6 +211,40 @@ const DeployDialog: FC<DeployDialogProps> = ({
           </Box>
         )}
 
+        <Box sx={{ mb: 2.5 }}>
+          <FormLabel sx={{ ...sectionLabelSx, display: 'block', mb: 1 }}>Build</FormLabel>
+          {createBuild ? (
+            <TextField
+              fullWidth
+              size="small"
+              value={selectedBuildId || 'New build'}
+              slotProps={{ input: { readOnly: true } }}
+              // helperText="A new build will be created when you deploy."
+            />
+          ) : (
+            <FormControl fullWidth size="small">
+              <Select
+                value={selectedBuildId}
+                onChange={(event) => setBuildId(event.target.value as string)}
+                displayEmpty
+                disabled={availableBuilds.length === 0}
+              >
+                {availableBuilds.length === 0 ? (
+                  <MenuItem value="" disabled>
+                    No deployed builds available
+                  </MenuItem>
+                ) : (
+                  availableBuilds.map((build) => (
+                    <MenuItem key={build.buildId} value={build.buildId}>
+                      {build.buildId}
+                    </MenuItem>
+                  ))
+                )}
+              </Select>
+            </FormControl>
+          )}
+        </Box>
+
         <Box>
           <FormLabel sx={{ ...sectionLabelSx, display: 'block', mb: 1 }}>Endpoint URL</FormLabel>
           <TextField
@@ -212,7 +268,13 @@ const DeployDialog: FC<DeployDialogProps> = ({
           variant="contained"
           disabled={!canConfirm || submitting}
           onClick={() => {
-            if (selectedGateway) onConfirm(selectedGateway.id, endpointUrl.trim());
+            if (selectedGateway) {
+              onConfirm(
+                selectedGateway.id,
+                endpointUrl.trim(),
+                createBuild ? undefined : selectedBuildId
+              );
+            }
           }}
         >
           {submitting ? `${actionLabel}ing...` : actionLabel}

--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/deployApi.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/deployApi.ts
@@ -111,11 +111,9 @@ export function createDeployClient(apiFetch: ApiFetch, projectHandle: string, ap
     /**
      * Deploys to one gateway of an environment with the endpoint it should serve.
      *
-     * Deploying to the pipeline's first environment ships the API as it stands:
-     * the server snapshots it and deploys that snapshot, so there is no separate
-     * build step to perform first. `fromEnvironment` promotes instead, carrying
-     * that environment's build forward untouched. `buildId` redeploys a gateway
-     * onto the exact build it is already running.
+     * Deploying without a `buildId` snapshots the API and deploys the new build.
+     * Supplying `buildId` deploys that existing build. `fromEnvironment` promotes
+     * instead, carrying that environment's build forward untouched.
      */
     async deploy(input: {
       environment: string;


### PR DESCRIPTION
This pull request enhances the deployment workflow in the API deployment UI, allowing users to choose between deploying an existing build or creating a new build when deploying to the first environment. The changes improve flexibility and user experience by introducing build selection, updating dialog flows, and improving the build list UI.

**Deployment workflow enhancements:**

* Added support for deploying either an existing build or creating a new build when deploying to the first environment, by introducing `buildId` and `createBuild` options throughout the deployment flow (`DeployFeature.tsx`, `DeployPage.tsx`, `deployApi.ts`). [[1]](diffhunk://#diff-79ca8cf63b5556ea9b91f80740db6c45fec0a6b15f990b52e8b3d39a15d609e1L123-R132) [[2]](diffhunk://#diff-b42ce78b67f5da894ad0306fecd705a882dbdf3140402efaf1ffdcfbb1d17cdeL38-R39) [[3]](diffhunk://#diff-a69dc33429ee0d68c041d41b5b0a911c5529cd10fadf18a8b21e769de2b617c7L114-R116)
* Updated the deployment dialog to allow users to select from available builds or indicate that a new build should be created, including UI for build selection and display (`DeployDialog.tsx`). [[1]](diffhunk://#diff-6edce785cfe3b9d2ab4cd2833c685bf77602961652aa6660329239e8ba1ba072L38-R52) [[2]](diffhunk://#diff-6edce785cfe3b9d2ab4cd2833c685bf77602961652aa6660329239e8ba1ba072L69-R76) [[3]](diffhunk://#diff-6edce785cfe3b9d2ab4cd2833c685bf77602961652aa6660329239e8ba1ba072R87-R110) [[4]](diffhunk://#diff-6edce785cfe3b9d2ab4cd2833c685bf77602961652aa6660329239e8ba1ba072L103-R125) [[5]](diffhunk://#diff-6edce785cfe3b9d2ab4cd2833c685bf77602961652aa6660329239e8ba1ba072L120-R142) [[6]](diffhunk://#diff-6edce785cfe3b9d2ab4cd2833c685bf77602961652aa6660329239e8ba1ba072R214-R247) [[7]](diffhunk://#diff-6edce785cfe3b9d2ab4cd2833c685bf77602961652aa6660329239e8ba1ba072L215-R277)

**UI improvements for build management:**

* Enhanced the build area card to display a list of recent builds, allow users to select a build for deployment, and provide a drawer for viewing all builds (`BuildAreaCard.tsx`). [[1]](diffhunk://#diff-caada400c8739715c8f3fa8b7ffac3ac5ba43a7ce1add26576a6f050007b3e90L19-R34) [[2]](diffhunk://#diff-caada400c8739715c8f3fa8b7ffac3ac5ba43a7ce1add26576a6f050007b3e90L31-R115) [[3]](diffhunk://#diff-caada400c8739715c8f3fa8b7ffac3ac5ba43a7ce1add26576a6f050007b3e90R130-R230)

**Prop and state management updates:**

* Extended component props and state to support the new deployment options, including passing `buildId`, `createBuild`, and lists of builds to relevant components (`DeployPage.tsx`, `BuildAreaCard.tsx`, `DeployDialog.tsx`). [[1]](diffhunk://#diff-b42ce78b67f5da894ad0306fecd705a882dbdf3140402efaf1ffdcfbb1d17cdeL50-R56) [[2]](diffhunk://#diff-b42ce78b67f5da894ad0306fecd705a882dbdf3140402efaf1ffdcfbb1d17cdeL66-R73) [[3]](diffhunk://#diff-b42ce78b67f5da894ad0306fecd705a882dbdf3140402efaf1ffdcfbb1d17cdeL145-R153) [[4]](diffhunk://#diff-b42ce78b67f5da894ad0306fecd705a882dbdf3140402efaf1ffdcfbb1d17cdeL171-R182) [[5]](diffhunk://#diff-caada400c8739715c8f3fa8b7ffac3ac5ba43a7ce1add26576a6f050007b3e90L31-R115) [[6]](diffhunk://#diff-6edce785cfe3b9d2ab4cd2833c685bf77602961652aa6660329239e8ba1ba072L38-R52) [[7]](diffhunk://#diff-6edce785cfe3b9d2ab4cd2833c685bf77602961652aa6660329239e8ba1ba072L69-R76)

These changes provide a more flexible and user-friendly deployment process, especially for teams that need to control exactly which build is deployed to production or want to trigger new builds as part of deployment.