### PR TITLE
feat(apikey)!: cap issuer and allowedTargets at 255 characters

### DIFF
--- a/platform-api/src/internal/constants/error.go
+++ b/platform-api/src/internal/constants/error.go
@@ -32,6 +32,8 @@ var (
 	ErrOrganizationNotFound   = errors.New("organization not found")
 	ErrMultipleOrganizations  = errors.New("multiple organizations found")
 	ErrInvalidInput           = errors.New("invalid input parameters")
+	ErrIssuerTooLong          = errors.New("issuer must be at most 255 characters")
+	ErrAllowedTargetsTooLong  = errors.New("allowedTargets must be at most 255 characters")
 )
 
 var (

--- a/platform-api/src/internal/handler/llm_apikey.go
+++ b/platform-api/src/internal/handler/llm_apikey.go
@@ -178,6 +178,10 @@ func (h *LLMProviderAPIKeyHandler) CreateAPIKey(c *gin.Context) {
 				"No gateway connections available"))
 			return
 		}
+		if errors.Is(err, constants.ErrIssuerTooLong) || errors.Is(err, constants.ErrAllowedTargetsTooLong) {
+			c.JSON(http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", err.Error()))
+			return
+		}
 
 		h.slogger.Error("Failed to create LLM provider API key", "providerId", providerID, "organizationId", orgID, "error", err)
 		c.JSON(http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error",

--- a/platform-api/src/internal/handler/llm_proxy_apikey.go
+++ b/platform-api/src/internal/handler/llm_proxy_apikey.go
@@ -178,6 +178,10 @@ func (h *LLMProxyAPIKeyHandler) CreateAPIKey(c *gin.Context) {
 				"No gateway connections available"))
 			return
 		}
+		if errors.Is(err, constants.ErrIssuerTooLong) || errors.Is(err, constants.ErrAllowedTargetsTooLong) {
+			c.JSON(http.StatusBadRequest, utils.NewErrorResponse(400, "Bad Request", err.Error()))
+			return
+		}
 
 		h.slogger.Error("Failed to create LLM proxy API key", "proxyId", proxyID, "organizationId", orgID, "error", err)
 		c.JSON(http.StatusInternalServerError, utils.NewErrorResponse(500, "Internal Server Error",

--- a/platform-api/src/internal/service/apikey.go
+++ b/platform-api/src/internal/service/apikey.go
@@ -40,6 +40,13 @@ const (
 	apiKeyNameMaxLength     = 63
 	hashingAlgorithmSHA256  = "sha256"
 	defaultHashingAlgorithm = hashingAlgorithmSHA256
+
+	// apiKeyIssuerMaxLength / apiKeyAllowedTargetsMaxLength bound the two free-form
+	// API-key fields to the width v2 persists them in (VARCHAR(255)). Both are
+	// carried verbatim — issuer is an exact-match lookup key and allowedTargets is
+	// a parsed gateway allow-list — so an over-length value is rejected, not truncated.
+	apiKeyIssuerMaxLength         = 255
+	apiKeyAllowedTargetsMaxLength = 255
 )
 
 var (
@@ -48,6 +55,22 @@ var (
 	// consecutiveHyphensRegex collapses runs of hyphens into a single hyphen
 	consecutiveHyphensRegex = regexp.MustCompile(`-+`)
 )
+
+// validateAPIKeyIssuerAndTargets enforces the storage-width limit on the issuer
+// and allowedTargets fields of an API-key create request. Returns a validation
+// error (mapped to HTTP 400 by the handlers) when either exceeds 255 characters;
+// the values are never truncated because both are matched exactly at gateway
+// key-resolution time (issuer via `AND k.issuer = ?`, allowedTargets as a parsed
+// gateway allow-list).
+func validateAPIKeyIssuerAndTargets(issuer *string, allowedTargets string) error {
+	if issuer != nil && len(*issuer) > apiKeyIssuerMaxLength {
+		return constants.ErrIssuerTooLong
+	}
+	if len(allowedTargets) > apiKeyAllowedTargetsMaxLength {
+		return constants.ErrAllowedTargetsTooLong
+	}
+	return nil
+}
 
 // APIKeyService handles API key management operations for external API key injection
 type APIKeyService struct {

--- a/platform-api/src/internal/service/apikey_validation_test.go
+++ b/platform-api/src/internal/service/apikey_validation_test.go
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package service
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"platform-api/src/internal/constants"
+)
+
+// TestValidateAPIKeyIssuerAndTargets pins the 255-character storage limit on the
+// API-key issuer and allowedTargets fields: exactly 255 is accepted, 256 is
+// rejected. Both are carried verbatim (issuer is an exact-match lookup key,
+// allowedTargets a parsed gateway allow-list) so an over-length value must be
+// rejected, never truncated.
+func TestValidateAPIKeyIssuerAndTargets(t *testing.T) {
+	issuer255 := strings.Repeat("a", 255)
+	issuer256 := strings.Repeat("a", 256)
+	targets255 := strings.Repeat("b", 255)
+	targets256 := strings.Repeat("b", 256)
+
+	tests := []struct {
+		name           string
+		issuer         *string
+		allowedTargets string
+		wantErr        error
+	}{
+		{"nil issuer, ALL targets", nil, "ALL", nil},
+		{"issuer at limit", &issuer255, "ALL", nil},
+		{"issuer over limit", &issuer256, "ALL", constants.ErrIssuerTooLong},
+		{"targets at limit", nil, targets255, nil},
+		{"targets over limit", nil, targets256, constants.ErrAllowedTargetsTooLong},
+		{"issuer checked before targets", &issuer256, targets256, constants.ErrIssuerTooLong},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateAPIKeyIssuerAndTargets(tt.issuer, tt.allowedTargets)
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("validateAPIKeyIssuerAndTargets() = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/platform-api/src/internal/service/llm_apikey.go
+++ b/platform-api/src/internal/service/llm_apikey.go
@@ -259,6 +259,10 @@ func (s *LLMProviderAPIKeyService) CreateLLMProviderAPIKey(
 		allowedTargets = strings.TrimSpace(*req.AllowedTargets)
 	}
 
+	if err := validateAPIKeyIssuerAndTargets(issuer, allowedTargets); err != nil {
+		return nil, err
+	}
+
 	// Persist the API key to the database before broadcasting
 	dbKey := &model.APIKey{
 		UUID:           apiKeyUUID,

--- a/platform-api/src/internal/service/llm_proxy_apikey.go
+++ b/platform-api/src/internal/service/llm_proxy_apikey.go
@@ -240,6 +240,10 @@ func (s *LLMProxyAPIKeyService) CreateLLMProxyAPIKey(
 		allowedTargets = strings.TrimSpace(*req.AllowedTargets)
 	}
 
+	if err := validateAPIKeyIssuerAndTargets(issuer, allowedTargets); err != nil {
+		return nil, err
+	}
+
 	// Persist the API key to the database before broadcasting
 	dbKey := &model.APIKey{
 		UUID:           apiKeyUUID,

--- a/platform-api/src/resources/openapi.yaml
+++ b/platform-api/src/resources/openapi.yaml
@@ -11052,6 +11052,7 @@ components:
         issuer:
           type: string
           description: Identifier of the developer portal that provisioned this API key. Null if not provided.
+          maxLength: 255
           nullable: true
           example: "api-platform-devportal"
         allowedTargets:
@@ -11059,6 +11060,7 @@ components:
           description: |
             Comma-separated list of gateways this key is valid for.
             Use 'ALL' to allow all targets (default).
+          maxLength: 255
           nullable: true
           example: "dev_gateway,test_gateway"
     CreateLLMProviderAPIKeyResponse:
@@ -11107,6 +11109,7 @@ components:
         issuer:
           type: string
           description: Identifier of the developer portal that provisioned this API key. Null if not provided.
+          maxLength: 255
           nullable: true
           example: "api-platform-devportal"
         allowedTargets:
@@ -11114,6 +11117,7 @@ components:
           description: |
             Comma-separated list of gateways this key is valid for.
             Use 'ALL' to allow all targets (default).
+          maxLength: 255
           nullable: true
           example: "dev_gateway,test_gateway"
     CreateLLMProxyAPIKeyResponse:


### PR DESCRIPTION
### Description

Validates the API-key `issuer` and `allowedTargets` request fields at the REST layer, rejecting any value longer than 255 characters with HTTP 400.

Both fields are persisted in a `VARCHAR(255)` column and are **carried verbatim** — `issuer` is an exact-match lookup key at gateway key-resolution (`AND k.issuer = ?`) and `allowedTargets` is a parsed comma-separated gateway allow-list. An over-length value must therefore be **rejected, not truncated**: a silent clip would break key resolution (the stored issuer no longer equals the gateway's lookup value) or mis-scope the key (a dropped trailing gateway id). Neither field was length-validated before — the API relied on the bare column.

### What changed

- `service/apikey.go` — `apiKeyIssuerMaxLength` / `apiKeyAllowedTargetsMaxLength = 255` + a shared `validateAPIKeyIssuerAndTargets` helper.
- `service/llm_apikey.go` + `service/llm_proxy_apikey.go` — validate on both create paths (reject over-length).
- `constants/error.go` — `ErrIssuerTooLong`, `ErrAllowedTargetsTooLong`.
- `handler/llm_apikey.go` + `handler/llm_proxy_apikey.go` — map the new errors to HTTP 400.
- `resources/openapi.yaml` — `maxLength: 255` on `issuer` / `allowedTargets` in `CreateLLMProviderAPIKeyRequest` and `CreateLLMProxyAPIKeyRequest`.
- `service/apikey_validation_test.go` *(new)* — boundary test (255 accepted / 256 rejected).

### Type of Change
- [ ] Infrastructure or component change
- [x] Breaking change — `issuer` / `allowedTargets` values longer than 255 characters are now rejected; they were accepted before.
- [ ] change requires a documentation update

### Testing

- `go build ./src/...` — clean.
- `go vet` on the edited packages — clean.
- `go test ./src/internal/service/... ./src/internal/constants/...` — passes, including the new boundary test (255 accepted / 256 rejected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
