### PR TITLE
fix(apikey): return 400 instead of 500 for over-length issuer/allowedTargets

### DIFF
--- a/platform-api/internal/service/apikey.go
+++ b/platform-api/internal/service/apikey.go
@@ -41,6 +41,13 @@ const (
 	apiKeyNameMaxLength     = 63
 	hashingAlgorithmSHA256  = "sha256"
 	defaultHashingAlgorithm = hashingAlgorithmSHA256
+
+	// apiKeyIssuerMaxLength / apiKeyAllowedTargetsMaxLength bound the two free-form
+	// API-key fields to the width they are persisted in (VARCHAR(255)). Both are
+	// carried verbatim — issuer is an exact-match lookup key and allowedTargets is
+	// a parsed gateway allow-list — so an over-length value is rejected, not truncated.
+	apiKeyIssuerMaxLength         = 255
+	apiKeyAllowedTargetsMaxLength = 255
 )
 
 var (
@@ -49,6 +56,21 @@ var (
 	// consecutiveHyphensRegex collapses runs of hyphens into a single hyphen
 	consecutiveHyphensRegex = regexp.MustCompile(`-+`)
 )
+
+// validateAPIKeyIssuerAndTargets enforces the storage-width limit (VARCHAR(255))
+// on the issuer and allowedTargets fields of an API-key create/update request.
+// Returns a 400 validation error when either exceeds 255 characters; the values
+// are never truncated because both are matched exactly at gateway key-resolution
+// time (issuer via `AND k.issuer = ?`, allowedTargets as a parsed gateway allow-list).
+func validateAPIKeyIssuerAndTargets(issuer *string, allowedTargets string) error {
+	if issuer != nil && len(*issuer) > apiKeyIssuerMaxLength {
+		return apperror.ValidationFailed.New("issuer must be at most 255 characters.")
+	}
+	if len(allowedTargets) > apiKeyAllowedTargetsMaxLength {
+		return apperror.ValidationFailed.New("allowedTargets must be at most 255 characters.")
+	}
+	return nil
+}
 
 // APIKeyService handles API key management operations for external API key injection
 type APIKeyService struct {
@@ -524,6 +546,10 @@ func (s *APIKeyService) CreateAPIKey(ctx context.Context, apiHandle, kind, orgId
 	}
 	allowedTargets := constants.APIKeyAllowedTargetsAll
 
+	if err := validateAPIKeyIssuerAndTargets(issuer, allowedTargets); err != nil {
+		return nil, err
+	}
+
 	displayName := strings.TrimSpace(req.DisplayName)
 	if displayName == "" {
 		displayName = keyName
@@ -650,6 +676,10 @@ func (s *APIKeyService) UpdateAPIKey(ctx context.Context, apiHandle, kind, orgId
 	if err != nil {
 		s.slogger.Error("Invalid expiration for API key update", "apiHandle", apiHandle, "keyName", keyName, "error", err)
 		return fmt.Errorf("invalid expiration: %w", err)
+	}
+
+	if err := validateAPIKeyIssuerAndTargets(req.Issuer, constants.APIKeyAllowedTargetsAll); err != nil {
+		return err
 	}
 
 	dbKey := &model.APIKey{

--- a/platform-api/internal/service/apikey_validation_test.go
+++ b/platform-api/internal/service/apikey_validation_test.go
@@ -1,0 +1,71 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package service
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/wso2/api-platform/platform-api/internal/apperror"
+)
+
+// TestValidateAPIKeyIssuerAndTargets pins the 255-character storage limit on the
+// API-key issuer and allowedTargets fields: exactly 255 is accepted, 256 is
+// rejected with a 400 validation error. Both are carried verbatim (issuer is an
+// exact-match lookup key, allowedTargets a parsed gateway allow-list) so an
+// over-length value must be rejected, never truncated.
+func TestValidateAPIKeyIssuerAndTargets(t *testing.T) {
+	issuer255 := strings.Repeat("a", 255)
+	issuer256 := strings.Repeat("a", 256)
+	targets255 := strings.Repeat("b", 255)
+	targets256 := strings.Repeat("b", 256)
+
+	tests := []struct {
+		name           string
+		issuer         *string
+		allowedTargets string
+		wantErr        bool
+	}{
+		{"nil issuer, ALL targets", nil, "ALL", false},
+		{"issuer at limit", &issuer255, "ALL", false},
+		{"issuer over limit", &issuer256, "ALL", true},
+		{"targets at limit", nil, targets255, false},
+		{"targets over limit", nil, targets256, true},
+		{"issuer checked before targets", &issuer256, targets256, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateAPIKeyIssuerAndTargets(tt.issuer, tt.allowedTargets)
+			if !tt.wantErr {
+				if err != nil {
+					t.Errorf("validateAPIKeyIssuerAndTargets() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validateAPIKeyIssuerAndTargets() = nil, want a validation error")
+			}
+			var appErr *apperror.Error
+			if !errors.As(err, &appErr) || appErr.HTTPStatus != http.StatusBadRequest {
+				t.Errorf("expected a 400 validation error, got %v", err)
+			}
+		})
+	}
+}

--- a/platform-api/internal/service/llm_apikey.go
+++ b/platform-api/internal/service/llm_apikey.go
@@ -291,6 +291,10 @@ func (s *LLMProviderAPIKeyService) CreateLLMProviderAPIKey(
 		allowedTargets = strings.TrimSpace(*req.AllowedTargets)
 	}
 
+	if err := validateAPIKeyIssuerAndTargets(issuer, allowedTargets); err != nil {
+		return nil, err
+	}
+
 	// Persist the API key to the database before broadcasting
 	dbKey := &model.APIKey{
 		UUID:           apiKeyUUID,

--- a/platform-api/internal/service/llm_proxy_apikey.go
+++ b/platform-api/internal/service/llm_proxy_apikey.go
@@ -250,6 +250,10 @@ func (s *LLMProxyAPIKeyService) CreateLLMProxyAPIKey(
 		allowedTargets = strings.TrimSpace(*req.AllowedTargets)
 	}
 
+	if err := validateAPIKeyIssuerAndTargets(issuer, allowedTargets); err != nil {
+		return nil, err
+	}
+
 	// Persist the API key to the database before broadcasting
 	dbKey := &model.APIKey{
 		UUID:           apiKeyUUID,

--- a/platform-api/resources/openapi.yaml
+++ b/platform-api/resources/openapi.yaml
@@ -6279,6 +6279,7 @@ components:
         issuer:
           type: string
           description: Identifier of the API Portal that provisioned this API key. Null if not provided.
+          maxLength: 255
           nullable: true
           example: "api-platform-devportal"
 
@@ -6348,6 +6349,7 @@ components:
         issuer:
           type: string
           description: Identifies the portal that created this key
+          maxLength: 255
           example: "api-platform-devportal"
 
     UpdateAPIKeyResponse:
@@ -8146,6 +8148,7 @@ components:
         issuer:
           type: string
           description: Identifier of the API Portal that provisioned this API key. Null if not provided.
+          maxLength: 255
           nullable: true
           example: "api-platform-devportal"
         allowedTargets:
@@ -8153,6 +8156,7 @@ components:
           description: |
             Comma-separated list of gateways this key is valid for.
             Use 'ALL' to allow all targets (default).
+          maxLength: 255
           nullable: true
           example: "dev_gateway,test_gateway"
     CreateLLMProviderAPIKeyResponse:
@@ -8205,6 +8209,7 @@ components:
         issuer:
           type: string
           description: Identifier of the API Portal that provisioned this API key. Null if not provided.
+          maxLength: 255
           nullable: true
           example: "api-platform-devportal"
         allowedTargets:
@@ -8212,6 +8217,7 @@ components:
           description: |
             Comma-separated list of gateways this key is valid for.
             Use 'ALL' to allow all targets (default).
+          maxLength: 255
           nullable: true
           example: "dev_gateway,test_gateway"
     CreateLLMProxyAPIKeyResponse:


### PR DESCRIPTION
### Description

Validates the API-key `issuer` and `allowedTargets` request fields at the REST layer, rejecting any value longer than 255 characters with HTTP 400.

Both fields are persisted in a `VARCHAR(255)` column and are **carried verbatim** — `issuer` is an exact-match lookup key at gateway key-resolution (`AND k.issuer = ?`) and `allowedTargets` is a parsed comma-separated gateway allow-list. An over-length value must therefore be **rejected, not truncated**: a silent clip would break key resolution (the stored issuer no longer equals the gateway's lookup value) or mis-scope the key (a dropped trailing gateway id). Neither field was length-validated at the REST layer before — the API relied on the bare column.

### Not a breaking change

Because the columns are already `VARCHAR(255)`, an over-length value **already fails today** — Postgres rejects the insert (`value too long for type character varying(255)`), surfacing as an unhandled **500**. This change validates one layer earlier and returns a clean **400** for the *identical* input. No request that previously succeeded now fails, so this is a **fix**, not a breaking change. (The mirror v1 PR against `platform-api/v0.10.x` *is* breaking, because there the columns are unbounded `TEXT`.)

### What changed

- `internal/service/apikey.go` — `apiKeyIssuerMaxLength` / `apiKeyAllowedTargetsMaxLength = 255` + a shared `validateAPIKeyIssuerAndTargets` helper that returns `apperror.ValidationFailed` (HTTP 400).
- Validation is applied on the generic API-key **create** and **update** paths and both the **LLM provider** and **LLM proxy** API-key create paths.
- `resources/openapi.yaml` — `maxLength: 255` on `issuer` (in `CreateAPIKeyRequest`, `UpdateAPIKeyRequest`, `CreateLLMProviderAPIKeyRequest`, `CreateLLMProxyAPIKeyRequest`) and on `allowedTargets` (in the two LLM request schemas).
- `internal/service/apikey_validation_test.go` *(new)* — boundary test (255 accepted / 256 rejected → 400).

### Type of Change
- [ ] Infrastructure or component change
- [ ] Breaking change
- [ ] change requires a documentation update

_(Non-breaking bug fix: converts an existing 500 into a 400 for over-255 input — see "Not a breaking change" above.)_

### Testing

- `go build ./internal/...` — clean.
- `go vet ./internal/service/...` — clean.
- `go test ./internal/service/` — passes (incl. the new boundary test; no regressions in the existing api-key suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
