### PR TITLE
Add new Resource page UI

### DIFF
--- a/portals/api-control-plane/src/components/SwaggerOperationsView/SwaggerOperationsView.test.tsx
+++ b/portals/api-control-plane/src/components/SwaggerOperationsView/SwaggerOperationsView.test.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { renderWithProviders, screen } from '@/test/utils';
+import { SwaggerOperationsView } from './SwaggerOperationsView';
+
+describe('SwaggerOperationsView', () => {
+  it('renders method, path, and available descriptions from API operations', () => {
+    renderWithProviders(
+      <SwaggerOperationsView
+        operations={[
+          {
+            name: 'listBooks',
+            description: 'List all the reading list books',
+            request: { method: 'GET', path: '/books' },
+          },
+          { name: 'addBook', request: { method: 'POST', path: '/books' } },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('GET')).toBeInTheDocument();
+    expect(screen.getByText('POST')).toBeInTheDocument();
+    expect(screen.getAllByText('/books')).toHaveLength(2);
+    expect(screen.getByText('List all the reading list books')).toBeInTheDocument();
+  });
+
+  it('renders an empty state when the API has no operations', () => {
+    renderWithProviders(<SwaggerOperationsView operations={[]} />);
+    expect(screen.getByText('No operations available.')).toBeInTheDocument();
+  });
+
+  it('allows an editable view to delete an operation', async () => {
+    const onDelete = vi.fn();
+    const { user } = renderWithProviders(
+      <SwaggerOperationsView
+        onDelete={onDelete}
+        operations={[{ name: 'getBook', request: { method: 'GET', path: '/books/{id}' } }]}
+        showDelete
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Delete GET /books/{id}' }));
+    expect(onDelete).toHaveBeenCalledWith(0);
+  });
+
+  it('only shows delete controls when requested and disables staged deletions', () => {
+    const operation = { name: 'getBook', request: { method: 'GET' as const, path: '/books' } };
+    const { rerender } = renderWithProviders(<SwaggerOperationsView operations={[operation]} />);
+
+    expect(screen.queryByRole('button', { name: 'Delete GET /books' })).not.toBeInTheDocument();
+
+    rerender(
+      <SwaggerOperationsView
+        isOperationDisabled={() => true}
+        onDelete={vi.fn()}
+        operations={[operation]}
+        showDelete
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Delete GET /books' })).toBeDisabled();
+  });
+});

--- a/portals/api-control-plane/src/components/SwaggerOperationsView/SwaggerOperationsView.tsx
+++ b/portals/api-control-plane/src/components/SwaggerOperationsView/SwaggerOperationsView.tsx
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  alpha,
+  Box,
+  Chip,
+  IconButton,
+  Stack,
+  Tooltip,
+  Typography,
+  type Theme,
+} from '@wso2/oxygen-ui';
+import { Trash2 } from '@wso2/oxygen-ui-icons-react';
+import { FormattedMessage } from 'react-intl';
+
+import type { Operation } from '@/api/resources/restApis';
+
+type ChipColor = 'default' | 'error' | 'info' | 'primary' | 'secondary' | 'success' | 'warning';
+
+const methodColor = (method: string): ChipColor => {
+  switch (method.toUpperCase()) {
+    case 'GET':
+      return 'info';
+    case 'POST':
+      return 'success';
+    case 'PUT':
+      return 'warning';
+    case 'DELETE':
+      return 'error';
+    case 'PATCH':
+      return 'secondary';
+    default:
+      return 'default';
+  }
+};
+
+const methodTone = (theme: Theme, method: string) => {
+  const color = methodColor(method);
+  return color === 'default' ? theme.palette.text.primary : theme.palette[color].main;
+};
+
+export type SwaggerOperationsViewProps = {
+  operations: Operation[];
+  isOperationDisabled?: (operation: Operation, index: number) => boolean;
+  onDelete?: (index: number) => void;
+  showDelete?: boolean;
+};
+
+/** Compact Swagger-style operation summary shared by pages that do not need Swagger's detail UI. */
+export function SwaggerOperationsView({
+  operations,
+  isOperationDisabled,
+  onDelete,
+  showDelete = false,
+}: SwaggerOperationsViewProps) {
+  if (operations.length === 0) {
+    return (
+      <Typography color="text.secondary" variant="body2">
+        <FormattedMessage
+          id="apiControlPlane.components.SwaggerOperationsView.empty"
+          defaultMessage="No operations available."
+        />
+      </Typography>
+    );
+  }
+
+  return (
+    <Stack spacing={1.5}>
+      {operations.map((operation, index) => {
+        const { method, path } = operation.request;
+        const disabled = isOperationDisabled?.(operation, index) ?? false;
+        return (
+          <Box
+            key={`${method}-${path}-${index}`}
+            sx={(theme) => {
+              const tone = methodTone(theme, method);
+              return {
+                alignItems: 'center',
+                bgcolor: alpha(tone, 0.08),
+                border: '1px solid',
+                borderColor: alpha(tone, 0.3),
+                borderRadius: 0.5,
+                display: 'flex',
+                gap: 1.5,
+                minHeight: 48,
+                opacity: disabled ? 0.45 : 1,
+                px: 1,
+                py: 0.75,
+              };
+            }}
+          >
+            <Chip
+              color={methodColor(method)}
+              label={method}
+              size="small"
+              sx={{ borderRadius: 0.4, flexShrink: 0, fontWeight: 700, minWidth: 80 }}
+            />
+            <Typography sx={{ flexShrink: 0, fontSize: '0.95rem', fontWeight: 700 }}>
+              {path}
+            </Typography>
+            {operation.description && (
+              <Typography
+                color="text.secondary"
+                noWrap
+                sx={{ flex: 1, minWidth: 0, opacity: 0.7 }}
+                variant="body2"
+              >
+                {operation.description}
+              </Typography>
+            )}
+            {showDelete && onDelete && (
+              <Tooltip title="Delete resource">
+                <Box component="span" sx={{ display: 'inline-flex', flexShrink: 0 }}>
+                  <IconButton
+                    aria-label={`Delete ${method} ${path}`}
+                    color="error"
+                    disabled={disabled}
+                    onClick={() => onDelete(index)}
+                    size="small"
+                  >
+                    <Trash2 size={17} />
+                  </IconButton>
+                </Box>
+              </Tooltip>
+            )}
+          </Box>
+        );
+      })}
+    </Stack>
+  );
+}

--- a/portals/api-control-plane/src/components/SwaggerOperationsView/index.ts
+++ b/portals/api-control-plane/src/components/SwaggerOperationsView/index.ts
@@ -1,0 +1,1 @@
+export { SwaggerOperationsView, type SwaggerOperationsViewProps } from './SwaggerOperationsView';

--- a/portals/api-control-plane/src/navigation/navigationRegistry.tsx
+++ b/portals/api-control-plane/src/navigation/navigationRegistry.tsx
@@ -27,10 +27,11 @@ import {
   Gauge,
   Home,
   Layers,
+  List,
   MessagesSquare,
   Network,
+  PanelTop,
   Rocket,
-  Route,
   ScrollText,
   Settings,
   ShieldCheck,
@@ -292,9 +293,9 @@ export const navigationRegistry: NavigationDefinition[] = [
         to: routes.apiDevelopPolicies,
       },
       {
-        icon: <Route />,
+        icon: <List />,
         id: 'develop-routing',
-        label: 'Routing',
+        label: 'Resources',
         to: routes.apiDevelopRouting,
       },
       {
@@ -393,7 +394,7 @@ export const navigationRegistry: NavigationDefinition[] = [
     label: 'Portals',
     group: CLUSTER.api,
     order: 80,
-    icon: <FileText />,
+    icon: <PanelTop />,
     ...adaptive([
       { level: 'api', to: routes.apiPortals },
       { level: 'project', to: routes.projectPortals },

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/utils/apiSkeleton.ts
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/apis/create/utils/apiSkeleton.ts
@@ -17,8 +17,8 @@
  */
 
 /**
- * The definition "design from scratch" starts from: one collection and one
- * item, with the four operations most APIs begin with. It is a document the
+ * The definition "design from scratch" starts with a wildcard resource and
+ * the four operations most APIs begin with. It is a document the
  * user goes on to edit (by hand, or by asking the AI to refine it), so its
  * text is content rather than UI copy and deliberately does not go through
  * `react-intl` — the same way a code sample or a backend payload doesn't.
@@ -32,35 +32,25 @@ export const DEFAULT_API_SKELETON: Record<string, unknown> = {
   },
   servers: [{ url: 'https://example.com' }],
   paths: {
-    '/resources': {
+    '/*': {
       get: {
-        operationId: 'listResources',
-        summary: 'List or retrieve resources',
+        summary: 'Get Resource',
+        description: 'Retrieve all resources',
         responses: { '200': { description: 'A page of resources.' } },
       },
       post: {
-        operationId: 'createResource',
-        summary: 'Create a resource',
+        summary: 'POST Resource',
+        description: 'Create a new resource',
         responses: { '201': { description: 'The resource that was created.' } },
       },
-    },
-    '/resources/{resourceId}': {
-      parameters: [
-        {
-          in: 'path',
-          name: 'resourceId',
-          required: true,
-          schema: { type: 'string' },
-        },
-      ],
-      put: {
-        operationId: 'updateResource',
-        summary: 'Update a resource',
+      patch: {
+        summary: 'Update Resource',
+        description: 'Update an existing resource',
         responses: { '200': { description: 'The resource after the update.' } },
       },
       delete: {
-        operationId: 'deleteResource',
-        summary: 'Delete a resource',
+        summary: 'Delete Resource',
+        description: 'Delete an existing resource',
         responses: { '204': { description: 'The resource was deleted.' } },
       },
     },

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/develop/routings/ResourcesPanel.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/develop/routings/ResourcesPanel.tsx
@@ -158,7 +158,7 @@ export function ResourcesPanel({ api }: { api: RestApi }) {
   };
 
   const addResource = () => {
-    if (!pathValid) return;
+    if (update.isPending || !pathValid) return;
     setOperations((current) => [
       {
         name: operationName(method, trimmedPath),
@@ -171,7 +171,7 @@ export function ResourcesPanel({ api }: { api: RestApi }) {
   };
 
   const save = () => {
-    if (!api.id) return;
+    if (!api.id || update.isPending) return;
     const savedOperations = operations.filter(
       (operation) => !deletedOperations.has(operationKey(operation)),
     );
@@ -200,6 +200,7 @@ export function ResourcesPanel({ api }: { api: RestApi }) {
           </PageTitle.SubHeader>
         </PageTitle>
         <Button
+          disabled={update.isPending}
           onClick={() => setDialogOpen(true)}
           startIcon={<Plus size={18} />}
           sx={{ flexShrink: 0, whiteSpace: 'nowrap' }}
@@ -253,8 +254,11 @@ export function ResourcesPanel({ api }: { api: RestApi }) {
         }}
       >
         <SwaggerOperationsView
-          isOperationDisabled={(operation) => deletedOperations.has(operationKey(operation))}
+          isOperationDisabled={(operation) =>
+            update.isPending || deletedOperations.has(operationKey(operation))
+          }
           onDelete={(index) =>
+            !update.isPending &&
             setDeletedOperations((current) =>
               new Set(current).add(operationKey(visibleOperations[index])),
             )
@@ -286,6 +290,7 @@ export function ResourcesPanel({ api }: { api: RestApi }) {
                 <FormattedMessage {...messages.method} />
               </FormLabel>
               <Select
+                disabled={update.isPending}
                 labelId="resource-method-label"
                 onChange={(event) =>
                   setMethod(event.target.value as Operation['request']['method'])
@@ -305,6 +310,7 @@ export function ResourcesPanel({ api }: { api: RestApi }) {
                 <FormattedMessage {...messages.path} />
               </FormLabel>
               <TextField
+                disabled={update.isPending}
                 error={!pathValid}
                 fullWidth
                 helperText={!pathValid ? intl.formatMessage(messages.pathHelp) : undefined}
@@ -319,6 +325,7 @@ export function ResourcesPanel({ api }: { api: RestApi }) {
                 <FormattedMessage {...messages.descriptionLabel} />
               </FormLabel>
               <TextField
+                disabled={update.isPending}
                 fullWidth
                 id="resource-description"
                 multiline
@@ -334,7 +341,11 @@ export function ResourcesPanel({ api }: { api: RestApi }) {
           <Button color="secondary" onClick={closeDialog} variant="outlined">
             <FormattedMessage {...messages.cancel} />
           </Button>
-          <Button disabled={!pathValid} onClick={addResource} variant="contained">
+          <Button
+            disabled={update.isPending || !pathValid}
+            onClick={addResource}
+            variant="contained"
+          >
             <FormattedMessage {...messages.add} />
           </Button>
         </DialogActions>

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/develop/routings/ResourcesPanel.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/develop/routings/ResourcesPanel.tsx
@@ -1,0 +1,344 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  FormLabel,
+  InputAdornment,
+  MenuItem,
+  PageTitle,
+  Select,
+  Stack,
+  TextField,
+} from '@wso2/oxygen-ui';
+import { Plus, Search } from '@wso2/oxygen-ui-icons-react';
+import { useState } from 'react';
+import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
+
+import { useUpdateRestApi, type Operation, type RestApi } from '@/api/resources/restApis';
+import { useNotifications } from '@/components/Notifications';
+import { SwaggerOperationsView } from '@/components/SwaggerOperationsView';
+import { SaveBar } from '../SaveBar';
+import { useDirtyTracking } from '../useDirtyTracking';
+
+const METHODS: Operation['request']['method'][] = [
+  'GET',
+  'POST',
+  'PUT',
+  'DELETE',
+  'PATCH',
+  'HEAD',
+  'OPTIONS',
+];
+
+const messages = defineMessages({
+  title: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.develop.routings.ResourcesPanel.title',
+    defaultMessage: 'Resources',
+  },
+  description: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.develop.routings.ResourcesPanel.description',
+    defaultMessage: 'View and manage the methods, paths, and descriptions available in {apiName}.',
+  },
+  addResource: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.develop.routings.ResourcesPanel.addResource',
+    defaultMessage: 'Add resource',
+  },
+  dialogTitle: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.develop.routings.ResourcesPanel.dialogTitle',
+    defaultMessage: 'Add new resource',
+  },
+  method: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.develop.routings.ResourcesPanel.method',
+    defaultMessage: 'Method',
+  },
+  path: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.develop.routings.ResourcesPanel.path',
+    defaultMessage: 'Resource path',
+  },
+  pathHelp: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.develop.routings.ResourcesPanel.pathHelp',
+    defaultMessage: 'The path must start with / and must be unique for the selected method.',
+  },
+  descriptionLabel: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.develop.routings.ResourcesPanel.descriptionLabel',
+    defaultMessage: 'Description',
+  },
+  cancel: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.develop.routings.ResourcesPanel.cancel',
+    defaultMessage: 'Cancel',
+  },
+  add: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.develop.routings.ResourcesPanel.add',
+    defaultMessage: 'Add',
+  },
+  saved: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.develop.routings.ResourcesPanel.saved',
+    defaultMessage: 'Resources saved.',
+  },
+  searchResources: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.develop.routings.ResourcesPanel.searchResources',
+    defaultMessage: 'Search resources',
+  },
+  allMethods: {
+    id: 'apiControlPlane.pages.appShell.appShellPages.develop.routings.ResourcesPanel.allMethods',
+    defaultMessage: 'All methods',
+  },
+});
+
+const operationName = (method: string, path: string) => {
+  const suffix = path
+    .split(/[^A-Za-z0-9]+/)
+    .filter(Boolean)
+    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+    .join('');
+  return `${method.toLowerCase()}${suffix || 'Root'}`;
+};
+
+export function ResourcesPanel({ api }: { api: RestApi }) {
+  const intl = useIntl();
+  const { notify } = useNotifications();
+  const update = useUpdateRestApi();
+  const [operations, setOperations] = useState<Operation[]>(api.operations ?? []);
+  const [deletedOperations, setDeletedOperations] = useState<Set<string>>(new Set());
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [method, setMethod] = useState<Operation['request']['method']>('GET');
+  const [path, setPath] = useState('/');
+  const [description, setDescription] = useState('');
+  const [search, setSearch] = useState('');
+  const [methodFilter, setMethodFilter] = useState('all');
+  const deletedOperationKeys = [...deletedOperations].sort();
+  const { dirty, markSaved } = useDirtyTracking({ deletedOperationKeys, operations });
+
+  const operationKey = (operation: Operation) =>
+    `${operation.request.method}:${operation.request.path}`;
+
+  const trimmedPath = path.trim();
+  const duplicate = operations.some(
+    (operation) => operation.request.method === method && operation.request.path === trimmedPath,
+  );
+  const pathValid = trimmedPath.startsWith('/') && !duplicate;
+  const searchTerm = search.trim().toLowerCase();
+  const visibleOperations = operations.filter((operation) => {
+    const matchesMethod = methodFilter === 'all' || operation.request.method === methodFilter;
+    const matchesSearch =
+      searchTerm === '' ||
+      operation.request.path.toLowerCase().includes(searchTerm) ||
+      operation.name?.toLowerCase().includes(searchTerm) ||
+      operation.description?.toLowerCase().includes(searchTerm);
+    return matchesMethod && matchesSearch;
+  });
+
+  const closeDialog = () => {
+    setDialogOpen(false);
+    setMethod('GET');
+    setPath('/');
+    setDescription('');
+  };
+
+  const addResource = () => {
+    if (!pathValid) return;
+    setOperations((current) => [
+      {
+        name: operationName(method, trimmedPath),
+        ...(description.trim() && { description: description.trim() }),
+        request: { method, path: trimmedPath },
+      },
+      ...current,
+    ]);
+    closeDialog();
+  };
+
+  const save = () => {
+    if (!api.id) return;
+    const savedOperations = operations.filter(
+      (operation) => !deletedOperations.has(operationKey(operation)),
+    );
+    update.mutate(
+      { restApiId: api.id, body: { ...api, operations: savedOperations } },
+      {
+        onSuccess: () => {
+          setOperations(savedOperations);
+          setDeletedOperations(new Set());
+          markSaved({ deletedOperationKeys: [], operations: savedOperations });
+          notify(intl.formatMessage(messages.saved), 'success');
+        },
+      },
+    );
+  };
+
+  return (
+    <>
+      <Stack alignItems="flex-start" direction="row" justifyContent="space-between" spacing={2}>
+        <PageTitle>
+          <PageTitle.Header>
+            <FormattedMessage {...messages.title} />
+          </PageTitle.Header>
+          <PageTitle.SubHeader>
+            <FormattedMessage {...messages.description} values={{ apiName: api.displayName }} />
+          </PageTitle.SubHeader>
+        </PageTitle>
+        <Button
+          onClick={() => setDialogOpen(true)}
+          startIcon={<Plus size={18} />}
+          sx={{ flexShrink: 0, whiteSpace: 'nowrap' }}
+          variant="outlined"
+        >
+          <FormattedMessage {...messages.addResource} />
+        </Button>
+      </Stack>
+
+      <Stack alignItems="center" direction="row" spacing={1.5} sx={{ mt: 2 }}>
+        <TextField
+          fullWidth
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder={intl.formatMessage(messages.searchResources)}
+          size="small"
+          slotProps={{
+            input: {
+              startAdornment: (
+                <InputAdornment position="start">
+                  <Search size={18} />
+                </InputAdornment>
+              ),
+            },
+          }}
+          value={search}
+        />
+        <TextField
+          onChange={(event) => setMethodFilter(event.target.value)}
+          select
+          size="small"
+          sx={{ flexShrink: 0, minWidth: 180 }}
+          value={methodFilter}
+        >
+          <MenuItem value="all">
+            <FormattedMessage {...messages.allMethods} />
+          </MenuItem>
+          {METHODS.map((value) => (
+            <MenuItem key={value} value={value}>
+              {value}
+            </MenuItem>
+          ))}
+        </TextField>
+      </Stack>
+
+      <Box
+        sx={{
+          maxHeight: { md: 'calc(100vh - 360px)', xs: '55vh' },
+          mt: 1.5,
+          overflowY: 'auto',
+          pr: 0.5,
+        }}
+      >
+        <SwaggerOperationsView
+          isOperationDisabled={(operation) => deletedOperations.has(operationKey(operation))}
+          onDelete={(index) =>
+            setDeletedOperations((current) =>
+              new Set(current).add(operationKey(visibleOperations[index])),
+            )
+          }
+          operations={visibleOperations}
+          showDelete
+        />
+      </Box>
+
+      <SaveBar
+        dirty={dirty}
+        disabled={!api.id}
+        onCancel={() => {
+          setOperations(api.operations ?? []);
+          setDeletedOperations(new Set());
+        }}
+        onSave={save}
+        saving={update.isPending}
+      />
+
+      <Dialog fullWidth maxWidth="xs" onClose={closeDialog} open={dialogOpen}>
+        <DialogTitle>
+          <FormattedMessage {...messages.dialogTitle} />
+        </DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ pt: 0.5 }}>
+            <FormControl fullWidth>
+              <FormLabel id="resource-method-label">
+                <FormattedMessage {...messages.method} />
+              </FormLabel>
+              <Select
+                labelId="resource-method-label"
+                onChange={(event) =>
+                  setMethod(event.target.value as Operation['request']['method'])
+                }
+                size="small"
+                value={method}
+              >
+                {METHODS.map((value) => (
+                  <MenuItem key={value} value={value}>
+                    {value}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <FormControl fullWidth>
+              <FormLabel htmlFor="resource-path">
+                <FormattedMessage {...messages.path} />
+              </FormLabel>
+              <TextField
+                error={!pathValid}
+                fullWidth
+                helperText={!pathValid ? intl.formatMessage(messages.pathHelp) : undefined}
+                id="resource-path"
+                onChange={(event) => setPath(event.target.value)}
+                size="small"
+                value={path}
+              />
+            </FormControl>
+            <FormControl fullWidth>
+              <FormLabel htmlFor="resource-description">
+                <FormattedMessage {...messages.descriptionLabel} />
+              </FormLabel>
+              <TextField
+                fullWidth
+                id="resource-description"
+                multiline
+                onChange={(event) => setDescription(event.target.value)}
+                rows={3}
+                size="small"
+                value={description}
+              />
+            </FormControl>
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button color="secondary" onClick={closeDialog} variant="outlined">
+            <FormattedMessage {...messages.cancel} />
+          </Button>
+          <Button disabled={!pathValid} onClick={addResource} variant="contained">
+            <FormattedMessage {...messages.add} />
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/develop/routings/RoutingPage.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/develop/routings/RoutingPage.tsx
@@ -57,7 +57,7 @@ export function RoutingPage() {
   ) : !apiQuery.data ? (
     <ErrorState title={intl.formatMessage(messages.notFound)} />
   ) : (
-    <ResourcesPanel api={apiQuery.data} />
+    <ResourcesPanel key={apiQuery.data.id ?? params.apiHandler} api={apiQuery.data} />
   );
 
   return (

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/develop/routings/RoutingPage.tsx
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/develop/routings/RoutingPage.tsx
@@ -23,7 +23,7 @@ import { ErrorState, LoadingState } from '@/components/StateViews';
 import { routes } from '@/routes/paths';
 import { useConsoleScope } from '@/scope/ConsoleScopeProvider';
 import { ScopeGate } from '@/scope/ScopeGate';
-import { RoutingPanel } from './RoutingPanel';
+import { ResourcesPanel } from './ResourcesPanel';
 
 const messages = defineMessages({
   loading: {
@@ -57,7 +57,7 @@ export function RoutingPage() {
   ) : !apiQuery.data ? (
     <ErrorState title={intl.formatMessage(messages.notFound)} />
   ) : (
-    <RoutingPanel api={apiQuery.data} />
+    <ResourcesPanel api={apiQuery.data} />
   );
 
   return (

--- a/portals/api-control-plane/src/pages/appShell/appShellPages/develop/useDirtyTracking.ts
+++ b/portals/api-control-plane/src/pages/appShell/appShellPages/develop/useDirtyTracking.ts
@@ -32,8 +32,8 @@ import { useRef } from 'react';
 export function useDirtyTracking<T>(snapshot: T) {
   const baseline = useRef(JSON.stringify(snapshot));
   const dirty = JSON.stringify(snapshot) !== baseline.current;
-  const markSaved = () => {
-    baseline.current = JSON.stringify(snapshot);
+  const markSaved = (savedSnapshot: T = snapshot) => {
+    baseline.current = JSON.stringify(savedSnapshot);
   };
   return { dirty, markSaved };
 }


### PR DESCRIPTION
This pull request introduces a new `ResourcesPanel` page for managing API resources, improves the UI for viewing and editing API operations, and updates navigation labels and icons for clarity. The changes include a new, reusable `SwaggerOperationsView` component with full test coverage, a refactor of the routing feature to use the new resources panel, and several navigation improvements.

Issue: https://github.com/wso2-enterprise/apim-saas/issues/2981


https://github.com/user-attachments/assets/b963fd01-c0b7-4b3d-9e28-48a67ccbfcd5



**New Resources management UI:**

* Added `ResourcesPanel` (`ResourcesPanel.tsx`) for viewing, searching, adding, and deleting API resources (methods/paths/descriptions), including dialog forms, search/filter, and integration with the API update flow.
* Replaced the old `RoutingPanel` with the new `ResourcesPanel` in the routing page, updating imports and usage accordingly. [[1]](diffhunk://#diff-3c1375750660cf1afcba10ed5094752d06c393f30fb4122455a00a007e0a9dd8L26-R26) [[2]](diffhunk://#diff-3c1375750660cf1afcba10ed5094752d06c393f30fb4122455a00a007e0a9dd8L60-R60)

**Reusable operations view component:**

* Added `SwaggerOperationsView` component and its props/types for compact, editable, and filterable display of API operations, with support for deletion and disabled states.
* Added comprehensive tests for `SwaggerOperationsView` covering rendering, empty state, deletion, and disabled controls.
* Exported `SwaggerOperationsView` and its types from the index for use in other modules.

**Navigation and UI improvements:**

* Updated navigation to rename "Routing" to "Resources" and switched the icon from `Route` to `List`.
* Changed the "Portals" navigation icon from `FileText` to `PanelTop` for better visual representation.
* Added missing imports for new icons in the navigation registry.

**Utilities:**

* Improved the `useDirtyTracking` hook to allow marking a custom snapshot as saved, supporting more accurate dirty state tracking after saving.