### PR TITLE
Prefill the deploy endpoint, redeploy suspended deployments, and scope-gate the deploy page

### DIFF
--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/DeployFeature.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/DeployFeature.tsx
@@ -49,6 +49,7 @@ const DeployFeature: FC<DeployFeatureProps> = ({ port }) => {
 
   const [environments, setEnvironments] = useState<Environment[]>([]);
   const [builds, setBuilds] = useState<Build[]>([]);
+  const [apiEndpointUrl, setApiEndpointUrl] = useState<string | undefined>(undefined);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
@@ -90,6 +91,14 @@ const DeployFeature: FC<DeployFeatureProps> = ({ port }) => {
   useEffect(() => {
     void load();
   }, [load]);
+
+  // Read once per API rather than on every settling poll: the API's own backend
+  // URL is not pipeline state, and it is only the deploy form's starting value,
+  // so failing to read it must leave the rest of the page working.
+  useEffect(() => {
+    if (!client) return;
+    void client.readApiEndpointUrl().then(setApiEndpointUrl, () => setApiEndpointUrl(undefined));
+  }, [client]);
 
   // A deployment settles asynchronously once its gateway acknowledges, so poll
   // while anything is in flight and stop as soon as everything has settled.
@@ -237,6 +246,7 @@ const DeployFeature: FC<DeployFeatureProps> = ({ port }) => {
     <DeployPage
       environments={environments}
       builds={builds}
+      apiEndpointUrl={apiEndpointUrl}
       busy={busy}
       onDeploy={handleDeploy}
       onStopGateway={handleStop}

--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/DeployFeature.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/DeployFeature.tsx
@@ -166,6 +166,21 @@ const DeployFeature: FC<DeployFeatureProps> = ({ port }) => {
   };
 
   /**
+   * Puts a suspended deployment back on its gateway. The deployment is immutable,
+   * so this restores exactly what was running — same build, same endpoint — and
+   * builds nothing, which is what separates it from a retry.
+   */
+  const handleRedeploy = (environment: Environment, gatewayId: string) => {
+    const gateway = environment.gateways.find((candidate) => candidate.id === gatewayId);
+    if (!client || !gateway?.deploymentId) return;
+    void runAction(
+      () => client.redeploy(environment.name, gatewayId, gateway.deploymentId!),
+      `Redeploying ${gateway.name}.`,
+      `Unable to redeploy ${gateway.name}.`
+    );
+  };
+
+  /**
    * Retrying sends the gateway the build it already has, not a new one: a failed
    * deployment is retried as it was, so a retry never quietly ships something
    * else. A later environment can only be reached by promoting into it, so the
@@ -251,6 +266,7 @@ const DeployFeature: FC<DeployFeatureProps> = ({ port }) => {
       onDeploy={handleDeploy}
       onStopGateway={handleStop}
       onRetryGateway={handleRetry}
+      onRedeployGateway={handleRedeploy}
     />
   );
 };

--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/DeployPage.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/DeployPage.tsx
@@ -29,6 +29,8 @@ export type DeployPageProps = {
   environments: Environment[];
   /** The API's builds, newest first. */
   builds: Build[];
+  /** The backend URL the API is defined against; the deploy form starts from it. */
+  apiEndpointUrl?: string;
   busy: boolean;
   /** Deploys to `target`; `from` is set when this is a promotion. */
   onDeploy: (
@@ -58,6 +60,7 @@ type DialogState = {
 const DeployPage: FC<DeployPageProps> = ({
   environments,
   builds,
+  apiEndpointUrl,
   busy,
   onDeploy,
   onStopGateway,
@@ -178,6 +181,7 @@ const DeployPage: FC<DeployPageProps> = ({
         environment={target}
         sourceEnvironment={source}
         builds={builds}
+        apiEndpointUrl={apiEndpointUrl}
         initialBuildId={dialog?.buildId}
         createBuild={dialog?.createBuild ?? false}
         submitting={busy}

--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/DeployPage.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/DeployPage.tsx
@@ -42,6 +42,7 @@ export type DeployPageProps = {
   ) => void;
   onStopGateway: (environment: Environment, gatewayId: string) => void;
   onRetryGateway: (environment: Environment, gatewayId: string) => void;
+  onRedeployGateway: (environment: Environment, gatewayId: string) => void;
 };
 
 /**
@@ -65,6 +66,7 @@ const DeployPage: FC<DeployPageProps> = ({
   onDeploy,
   onStopGateway,
   onRetryGateway,
+  onRedeployGateway,
 }) => {
   const [dialog, setDialog] = useState<DialogState>(null);
 
@@ -168,6 +170,7 @@ const DeployPage: FC<DeployPageProps> = ({
                   }
                   onStopGateway={(gatewayId) => onStopGateway(environment, gatewayId)}
                   onRetryGateway={(gatewayId) => onRetryGateway(environment, gatewayId)}
+                  onRedeployGateway={(gatewayId) => onRedeployGateway(environment, gatewayId)}
                 />
               </Fragment>
             ))}

--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/components/DeployDialog.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/components/DeployDialog.tsx
@@ -44,6 +44,8 @@ export type DeployDialogProps = {
   /** The environment a promotion carries the build out of. */
   sourceEnvironment?: Environment;
   builds: Build[];
+  /** The backend URL the API is defined against; the endpoint field starts from it. */
+  apiEndpointUrl?: string;
   initialBuildId?: string;
   /** A new build will be created on confirmation; the latest build is informational. */
   createBuild: boolean;
@@ -72,6 +74,7 @@ const DeployDialog: FC<DeployDialogProps> = ({
   environment,
   sourceEnvironment,
   builds,
+  apiEndpointUrl,
   initialBuildId,
   createBuild,
   submitting,
@@ -105,13 +108,14 @@ const DeployDialog: FC<DeployDialogProps> = ({
           sourceEnvironment?.gateways.some((gateway) => gateway.buildId === build.buildId)
         )
       : builds;
-  const selectedBuildId = createBuild
-    ? (builds[0]?.buildId ?? '')
-    : (buildId || initialBuildId || availableBuilds[0]?.buildId || '');
+  const selectedBuildId = buildId || initialBuildId || availableBuilds[0]?.buildId || '';
   const selectedGateway =
     environment.gateways.find((gateway) => gateway.id === gatewayId) ??
     pickDefaultGateway(environment.gateways);
-  const endpointUrl = endpointDraft ?? selectedGateway?.endpointUrl ?? '';
+  // What this gateway already serves comes first, so re-deploying to it keeps the
+  // endpoint it is running; a gateway with nothing on it starts from the API's own
+  // backend URL rather than an empty field.
+  const endpointUrl = endpointDraft ?? selectedGateway?.endpointUrl ?? apiEndpointUrl ?? '';
   const isSingleGateway = environment.gateways.length === 1;
   // Whether the gateway can receive a deployment is its own health, not the state
   // of what is deployed on it: a healthy gateway with nothing deployed is exactly
@@ -211,17 +215,9 @@ const DeployDialog: FC<DeployDialogProps> = ({
           </Box>
         )}
 
-        <Box sx={{ mb: 2.5 }}>
-          <FormLabel sx={{ ...sectionLabelSx, display: 'block', mb: 1 }}>Build</FormLabel>
-          {createBuild ? (
-            <TextField
-              fullWidth
-              size="small"
-              value={selectedBuildId || 'New build'}
-              slotProps={{ input: { readOnly: true } }}
-              // helperText="A new build will be created when you deploy."
-            />
-          ) : (
+        {createBuild ? null : (
+          <Box sx={{ mb: 2.5 }}>
+            <FormLabel sx={{ ...sectionLabelSx, display: 'block', mb: 1 }}>Build</FormLabel>
             <FormControl fullWidth size="small">
               <Select
                 value={selectedBuildId}
@@ -242,8 +238,8 @@ const DeployDialog: FC<DeployDialogProps> = ({
                 )}
               </Select>
             </FormControl>
-          )}
-        </Box>
+          </Box>
+        )}
 
         <Box>
           <FormLabel sx={{ ...sectionLabelSx, display: 'block', mb: 1 }}>Endpoint URL</FormLabel>

--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/components/EnvironmentCard.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/components/EnvironmentCard.tsx
@@ -30,6 +30,7 @@ export type EnvironmentCardProps = {
   onPromoteClick: () => void;
   onStopGateway: (gatewayId: string) => void;
   onRetryGateway: (gatewayId: string) => void;
+  onRedeployGateway: (gatewayId: string) => void;
 };
 
 const sectionLabelSx = {
@@ -47,6 +48,7 @@ const EnvironmentCard: FC<EnvironmentCardProps> = ({
   onPromoteClick,
   onStopGateway,
   onRetryGateway,
+  onRedeployGateway,
 }) => {
   const { gateways } = environment;
   const activeCount = activeGatewayCount(gateways);
@@ -95,6 +97,7 @@ const EnvironmentCard: FC<EnvironmentCardProps> = ({
                 environmentName={environment.name}
                 busy={busy}
                 onRetry={() => onRetryGateway(gateway.id)}
+                onRedeploy={() => onRedeployGateway(gateway.id)}
                 onStop={() => onStopGateway(gateway.id)}
               />
             ))}

--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/components/GatewayRow.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/components/GatewayRow.tsx
@@ -33,6 +33,8 @@ export type GatewayRowProps = {
   environmentName: string;
   busy: boolean;
   onRetry: () => void;
+  /** Puts a suspended deployment back on the gateway, unchanged. */
+  onRedeploy: () => void;
   onStop: () => void;
 };
 
@@ -41,6 +43,7 @@ const GatewayRow: FC<GatewayRowProps> = ({
   environmentName,
   busy,
   onRetry,
+  onRedeploy,
   onStop,
 }) => {
   const [expanded, setExpanded] = useState(false);
@@ -48,17 +51,26 @@ const GatewayRow: FC<GatewayRowProps> = ({
   const tone = gatewayStatusTone(gateway.status);
   const scopeLabel = `${environmentName} · ${gateway.name}`;
 
-  // A failed deployment is retried; a live one is stopped. Nothing to do while a
-  // deployment is still settling, or where there is none at all.
-  const failed = gateway.status === 'FAILED';
-  const actionLabel = failed ? 'Re deploy' : 'Stop deployment';
+  // What the one action button does depends on what the gateway is doing:
+  //
+  //  - suspended (UNDEPLOYED) — put the SAME deployment back, artifact and all;
+  //  - failed — deploy its build again, which makes a new deployment;
+  //  - serving — stop it.
+  //
+  // Nothing to do while a deployment is still settling, or where there is none.
+  const action: 'redeploy' | 'retry' | 'stop' =
+    gateway.status === 'UNDEPLOYED' ? 'redeploy' : gateway.status === 'FAILED' ? 'retry' : 'stop';
+  const actionLabel = action === 'stop' ? 'Stop deployment' : 'Redeploy';
   const actionDisabled =
     busy ||
     gateway.status === 'NOT_DEPLOYED' ||
     gateway.status === 'DEPLOYING' ||
     gateway.status === 'UNDEPLOYING' ||
-    (!failed && !gateway.deploymentId);
-  const handleActionClick = failed ? onRetry : onStop;
+    // Retrying re-deploys the build, so it needs no deployment; the other two act
+    // on the deployment itself.
+    (action !== 'retry' && !gateway.deploymentId);
+  const handleActionClick =
+    action === 'redeploy' ? onRedeploy : action === 'retry' ? onRetry : onStop;
 
   return (
     <Card>
@@ -134,7 +146,13 @@ const GatewayRow: FC<GatewayRowProps> = ({
               </>
             ) : null}
 
-            <Button fullWidth variant="outlined" color="error" disabled={actionDisabled} onClick={handleActionClick}>
+            <Button
+              fullWidth
+              variant="outlined"
+              color={action === 'stop' ? 'error' : 'primary'}
+              disabled={actionDisabled}
+              onClick={handleActionClick}
+            >
               {actionLabel}
             </Button>
           </Box>

--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/components/GatewayRow.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/components/GatewayRow.tsx
@@ -104,33 +104,35 @@ const GatewayRow: FC<GatewayRowProps> = ({
             ) : null}
 
             {gateway.status !== 'NOT_DEPLOYED' ? (
-              <Card>
-                <CardContent
-                  sx={{
-                    p: 1.25,
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'space-between',
-                    '&:last-child': { pb: 1.25 },
-                  }}
-                >
-                  <Box>
-                    <Typography variant="body2" sx={{ fontWeight: 500 }}>
-                      ID {gateway.buildId}
-                    </Typography>
-                    <Typography variant="caption" color="text.secondary">
-                      Deployed {gateway.deployedAt ? relativeTime(gateway.deployedAt) : '—'}
-                    </Typography>
-                  </Box>
-                </CardContent>
-              </Card>
-            ) : null}
+              <>
+                <Card>
+                  <CardContent
+                    sx={{
+                      p: 1.25,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      '&:last-child': { pb: 1.25 },
+                    }}
+                  >
+                    <Box>
+                      <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                        ID {gateway.buildId}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        Deployed {gateway.deployedAt ? relativeTime(gateway.deployedAt) : '—'}
+                      </Typography>
+                    </Box>
+                  </CardContent>
+                </Card>
 
-            <ActionRow
-              label="Endpoint URL"
-              icon={<Eye size={14} />}
-              onClick={() => setEndpointUrlOpen(true)}
-            />
+                <ActionRow
+                  label="Endpoint URL"
+                  icon={<Eye size={14} />}
+                  onClick={() => setEndpointUrlOpen(true)}
+                />
+              </>
+            ) : null}
 
             <Button fullWidth variant="outlined" color="error" disabled={actionDisabled} onClick={handleActionClick}>
               {actionLabel}

--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/deployApi.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/deployApi.ts
@@ -51,6 +51,15 @@ type ManagedGatewayDTO = {
 };
 
 /**
+ * The API's own record. Only its upstream is read: `main.url` is the backend the
+ * API is defined against, which is what a deployment serves unless it is given
+ * an endpoint of its own.
+ */
+type RestApiDTO = {
+  upstream?: { main?: { url?: string } };
+};
+
+/**
  * The deployment data client, built from the host-injected `apiFetch`.
  *
  * Everything is addressed by project and API handle, and the server resolves the
@@ -106,6 +115,16 @@ export function createDeployClient(apiFetch: ApiFetch, projectHandle: string, ap
         createdBy: dto.createdBy,
         createdAt: dto.createdAt,
       }));
+    },
+
+    /**
+     * The backend URL the API is defined against, which the deploy and promote
+     * forms start from so a first deployment does not have to be typed out.
+     * Absent when the API declares its upstream by reference rather than by URL.
+     */
+    async readApiEndpointUrl(): Promise<string | undefined> {
+      const api = await apiFetch<RestApiDTO>('GET', `/rest-apis/${encodeURIComponent(apiHandle)}`);
+      return api?.upstream?.main?.url;
     },
 
     /**

--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/deployApi.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/deployApi.ts
@@ -150,6 +150,19 @@ export function createDeployClient(apiFetch: ApiFetch, projectHandle: string, ap
       });
     },
 
+    /**
+     * Serves a suspended deployment again on the same gateway. The deployment is
+     * immutable, so it comes back exactly as it was — same build, same endpoint —
+     * and nothing is rendered or built.
+     */
+    async redeploy(environment: string, gatewayId: string, deploymentId: string): Promise<void> {
+      const query = `?environment=${encodeURIComponent(environment)}&gatewayId=${encodeURIComponent(gatewayId)}`;
+      await apiFetch(
+        'POST',
+        `${base}/deployments/${encodeURIComponent(deploymentId)}/redeploy${query}`
+      );
+    },
+
     /** Stops serving one deployment on one gateway; the rest are untouched. */
     async undeploy(environment: string, gatewayId: string, deploymentId: string): Promise<void> {
       const query = `?environment=${encodeURIComponent(environment)}&gatewayId=${encodeURIComponent(gatewayId)}`;

--- a/portals/cloud-plugins/apip-cloud-ui/src/hosts/api-control-plane.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui/src/hosts/api-control-plane.tsx
@@ -21,6 +21,8 @@ import {
   PAGE_GATEWAYS_SLOT,
   type ApiControlPlaneExtension,
 } from '../../../../api-control-plane/src/extensions';
+import { routes } from '../../../../api-control-plane/src/routes/paths';
+import { ScopeGate } from '../../../../api-control-plane/src/scope/ScopeGate';
 import { defineCloudPlugin, getCloudExtensions, type CloudPluginFeature } from '../plugin';
 
 /**
@@ -53,7 +55,12 @@ import { defineCloudPlugin, getCloudExtensions, type CloudPluginFeature } from '
  * `deploy` overrides the built-in API Deploy page via the `page.apiDeploy` slot,
  * the same way `gateways` does: the nav entry and route stay native, and only
  * what renders there changes. It is the one API-scoped feature here, so it needs
- * the API in scope, which the Port carries as `apiHandle`.
+ * the API in scope, which the Port carries as `apiHandle`. Because the override
+ * replaces the whole page, it also replaces the `ScopeGate` the built-in page
+ * wraps itself in — so it is re-applied here. Without it, reaching Deploy from an
+ * organization- or project-level page (which the sidebar allows, and is a normal
+ * thing to do) left a dead end instead of the project/API picker that navigates
+ * to the scoped URL.
  */
 export const cloudPluginFeatures: CloudPluginFeature<ApiControlPlaneExtension>[] = [
   defineCloudPlugin({
@@ -113,7 +120,15 @@ export const cloudPluginFeatures: CloudPluginFeature<ApiControlPlaneExtension>[]
         // Settings-tab pipeline, which only match `sidebar.*` / `settings.*.tabs`.
         order: 0,
         routePath: 'deploy',
-        render: (port) => <DeployFeature port={port} />,
+        render: (port) => (
+          <ScopeGate
+            prompt="Deployments are made for a single API."
+            requires="api"
+            to={routes.apiDeploy}
+          >
+            <DeployFeature port={port} />
+          </ScopeGate>
+        ),
         label: 'Deploy',
         level: 'api',
       },


### PR DESCRIPTION
## Purpose

Three problems on the deploy plugin's page:

1. **The endpoint field started empty.** Every deploy and promote made the user retype the backend URL, even though the API already declares one.
2. **A suspended deployment offered "Stop deployment".** The button was enabled and could only fail — there was nothing left to stop.
3. **Reaching Deploy without an API in scope was a dead end.** The sidebar shows the item at every scope, so clicking it from an organization- or project-level page is normal, but the page override replaced the built-in one along with the `ScopeGate` it wraps itself in.

Plus two bits of detail shown where they mean nothing: a build id in the "Build and Deploy" dialog (the id of the *previous* build, while that dialog creates a new one), and an Endpoint URL viewer on gateways with nothing deployed.

## Goals

- Prefill the endpoint from the API's own `upstream.main.url`, so a first deploy needs no typing.
- Offer **Redeploy** on a suspended deployment, restoring that same deployment rather than building anything.
- Give the overridden Deploy route the same project/API picker every other API-scoped page has.
- Drop the misleading build id and the endpoint viewer where there is no deployment.

## Approach

**Endpoint default.** `deployApi` gains `readApiEndpointUrl()` (`GET /rest-apis/{handle}` → `upstream.main.url`). `DeployFeature` reads it once per API — deliberately not inside `load()`, so it is not re-fetched by the 4-second settling poll — and a failure leaves the rest of the page working. Precedence in the dialog: what the user typed → what this gateway already serves → the API's endpoint → empty. A gateway already running something keeps its own endpoint, so a re-deploy never silently changes it.

**Redeploy.** The row's single action is now derived from the gateway's state instead of one boolean: suspended restores the deployment (`POST .../deployments/{deploymentId}/redeploy`), failed re-deploys its build as a new deployment, serving stops. Only stopping is styled destructive. Restoring relies on the deployment being immutable, so the gateway gets back exactly what it was serving — same build, same endpoint, nothing rendered.

**Scope gate.** The `page.apiDeploy` override is wrapped in `ScopeGate requires="api" to={routes.apiDeploy}` at the registration seam, matching the built-in page. Done there rather than in `AppRoutes` so the open-source route is untouched and `ScopeGate`'s dependencies stay out of the initial bundle, which that file explicitly guards.

`UNDEPLOYED` already mapped to "Suspended" in the status vocabulary, so no change was needed there.

## Documentation

N/A — no new user-facing concepts; the deploy page's existing controls behave correctly rather than differently.

## Automation tests

- Unit tests
  > None: these packages carry no test setup (their `build` script is `tsc --noEmit`), and this change adds no runtime module worth standing one up for. Verified by typecheck — `tsc --noEmit` clean on `apip-cloud-ui-deploy`, and the host package reports the same 27 pre-existing `import.meta.env` errors before and after, so the wider import graph adds none.
- Integration tests
  > Exercised by hand against a running console: first deploy prefilled from the API's upstream, a suspended gateway offering Redeploy and coming back on the same build, and the Deploy item from an organization-level page showing the project/API picker.

## Security checks

- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin and verified report: N/A — TypeScript only
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets: yes

## Samples

Deploy page states: a gateway with nothing deployed shows no build id and no endpoint viewer; a suspended one shows **Suspended** with **Redeploy**; a serving one shows **Active** with **Stop deployment**.

## Related PRs

Redeploy calls a `redeploy` route on the deployment API the plugin talks to, which is added alongside this change; the rest is self-contained.

## Test environment

Node 24, Chrome, macOS (arm64).
