### PR TITLE
Add Managed API Portals cloud plugin (api-control-plane host)

### DIFF
--- a/portals/cloud-plugins/apip-cloud-ui-managed-portals/package.json
+++ b/portals/cloud-plugins/apip-cloud-ui-managed-portals/package.json
@@ -12,11 +12,14 @@
   },
   "dependencies": {
     "@wso2/oxygen-ui": "0.5.0",
-    "@wso2/oxygen-ui-icons-react": "0.5.0",
-    "react": "19.2.3"
+    "@wso2/oxygen-ui-icons-react": "0.5.0"
+  },
+  "peerDependencies": {
+    "react": "^19.2.3"
   },
   "devDependencies": {
     "@types/react": "19.2.17",
+    "react": "19.2.3",
     "typescript": "5.9.3"
   }
 }

--- a/portals/cloud-plugins/apip-cloud-ui-managed-portals/package.json
+++ b/portals/cloud-plugins/apip-cloud-ui-managed-portals/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@wso2-enterprise/apip-cloud-ui-managed-portals",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "_phase:build": "tsc --noEmit",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@wso2/oxygen-ui": "0.5.0",
+    "@wso2/oxygen-ui-icons-react": "0.5.0",
+    "react": "19.2.3"
+  },
+  "devDependencies": {
+    "@types/react": "19.2.17",
+    "typescript": "5.9.3"
+  }
+}

--- a/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/ManagedPortalDetail.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/ManagedPortalDetail.tsx
@@ -32,19 +32,11 @@ import { useManagedPortal, useOrgEnvironments } from './hooks';
 
 export type ManagedPortalDetailProps = {
   id: string;
-  /**
-   * Called when the user is done with the detail view — either via the back
-   * button or after a successful delete. The page shell owns the list ↔ detail
-   * switch so this component does not need to know about routing.
-   */
+  /** Invoked on back button or after a successful delete; the page shell owns list/detail switching. */
   onBack: () => void;
 };
 
-/**
- * Small labelled read-only field used by the detail summary — kept inline
- * rather than pulled into its own file since the layout is trivial and this
- * component is the only caller today.
- */
+/** Labelled read-only field for the detail summary. */
 function Field({ label, value }: { label: string; value: string }) {
   return (
     <Stack spacing={0.5}>
@@ -60,10 +52,7 @@ function Field({ label, value }: { label: string; value: string }) {
 
 export default function ManagedPortalDetail({ id, onBack }: ManagedPortalDetailProps) {
   const { portal, isLoading, error, update, remove } = useManagedPortal(id);
-  // Populate the login-environment picker from the org's real env list.
-  // Fetched on mount; the dropdown renders empty options + a helper text if
-  // the fetch fails so the operator sees something actionable rather than a
-  // silently blank dropdown.
+  // Populates the login-environment picker with the org's real envs so the operator can't type an env that fails at provision-time.
   const { environments, isLoading: envsLoading, error: envsError } = useOrgEnvironments();
 
   const [editOpen, setEditOpen] = useState(false);
@@ -73,9 +62,7 @@ export default function ManagedPortalDetail({ id, onBack }: ManagedPortalDetailP
   const [submitting, setSubmitting] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
 
-  // Seed the edit form from the loaded portal whenever the dialog opens, so a
-  // Cancel-then-reopen picks up the latest server-side values (matters after
-  // a successful save; keeps the form idempotent otherwise).
+  // Reseed on each open so Cancel-then-reopen reflects the latest server-side values.
   useEffect(() => {
     if (editOpen && portal) {
       setName(portal.name);
@@ -88,9 +75,7 @@ export default function ManagedPortalDetail({ id, onBack }: ManagedPortalDetailP
     if (!portal) return;
     setSubmitting(true);
     try {
-      // Send only the fields the user actually changed. This keeps updates
-      // idempotent (a no-op save does not stamp identical values) and avoids
-      // an accidental clear of a field the user did not touch.
+      // Send only changed fields so a no-op save doesn't restamp values and untouched fields aren't cleared.
       const patch = {
         ...(name.trim() !== portal.name ? { name: name.trim() } : {}),
         ...(description !== (portal.description ?? '') ? { description: description.trim() } : {}),
@@ -105,8 +90,7 @@ export default function ManagedPortalDetail({ id, onBack }: ManagedPortalDetailP
       await update(patch);
       setEditOpen(false);
     } catch {
-      // Notification handled by the hook; keep the dialog open with the
-      // user's typed values so they can adjust and retry.
+      // Hook already notified; leave the dialog open with user input for retry.
     } finally {
       setSubmitting(false);
     }
@@ -160,8 +144,7 @@ export default function ManagedPortalDetail({ id, onBack }: ManagedPortalDetailP
                   <Button
                     variant="contained"
                     startIcon={<ArrowUpRight size={18} />}
-                    // noreferrer for external navigation; opens in a new tab so
-                    // the operator's console session isn't left behind.
+                    // New tab preserves the console session; noreferrer for external navigation.
                     href={portal.url}
                     target="_blank"
                     rel="noopener noreferrer"
@@ -237,16 +220,7 @@ export default function ManagedPortalDetail({ id, onBack }: ManagedPortalDetailP
             </FormControl>
             <FormControl fullWidth>
               <FormLabel>Login environment</FormLabel>
-              {/*
-               * Sourced from the org's real env list (useOrgEnvironments) so
-               * the operator can only pick a name that actually exists on
-               * the DP — a free-text TextField would let them save a value
-               * that fails at portal-provision time. If the portal's current
-               * env is somehow absent from the fetched list (e.g. deleted
-               * out-of-band), it's still included as a synthetic option so
-               * the user sees the mismatch rather than a silent selection
-               * swap.
-               */}
+              {/* Current env is added as a synthetic option if missing from the list, so an out-of-band deletion shows as a mismatch rather than a silent swap. */}
               <Select
                 fullWidth
                 value={loginEnvironment}

--- a/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/ManagedPortalDetail.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/ManagedPortalDetail.tsx
@@ -1,0 +1,319 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+import { useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  FormControl,
+  FormLabel,
+  IconButton,
+  MenuItem,
+  PageContent,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from '@wso2/oxygen-ui';
+import { ArrowLeft, ArrowUpRight, Pencil, Trash2 } from '@wso2/oxygen-ui-icons-react';
+
+import { useManagedPortal, useOrgEnvironments } from './hooks';
+
+export type ManagedPortalDetailProps = {
+  id: string;
+  /**
+   * Called when the user is done with the detail view — either via the back
+   * button or after a successful delete. The page shell owns the list ↔ detail
+   * switch so this component does not need to know about routing.
+   */
+  onBack: () => void;
+};
+
+/**
+ * Small labelled read-only field used by the detail summary — kept inline
+ * rather than pulled into its own file since the layout is trivial and this
+ * component is the only caller today.
+ */
+function Field({ label, value }: { label: string; value: string }) {
+  return (
+    <Stack spacing={0.5}>
+      <Typography variant="caption" color="text.secondary" sx={{ textTransform: 'uppercase', letterSpacing: 0.6 }}>
+        {label}
+      </Typography>
+      <Typography variant="body2" sx={{ fontFamily: value.startsWith('http') || /^[a-z0-9-]+$/.test(value) ? 'monospace' : undefined }}>
+        {value || '—'}
+      </Typography>
+    </Stack>
+  );
+}
+
+export default function ManagedPortalDetail({ id, onBack }: ManagedPortalDetailProps) {
+  const { portal, isLoading, error, update, remove } = useManagedPortal(id);
+  // Populate the login-environment picker from the org's real env list.
+  // Fetched on mount; the dropdown renders empty options + a helper text if
+  // the fetch fails so the operator sees something actionable rather than a
+  // silently blank dropdown.
+  const { environments, isLoading: envsLoading, error: envsError } = useOrgEnvironments();
+
+  const [editOpen, setEditOpen] = useState(false);
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [loginEnvironment, setLoginEnvironment] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  // Seed the edit form from the loaded portal whenever the dialog opens, so a
+  // Cancel-then-reopen picks up the latest server-side values (matters after
+  // a successful save; keeps the form idempotent otherwise).
+  useEffect(() => {
+    if (editOpen && portal) {
+      setName(portal.name);
+      setDescription(portal.description ?? '');
+      setLoginEnvironment(portal.loginEnvironment ?? '');
+    }
+  }, [editOpen, portal]);
+
+  const handleSave = async () => {
+    if (!portal) return;
+    setSubmitting(true);
+    try {
+      // Send only the fields the user actually changed. This keeps updates
+      // idempotent (a no-op save does not stamp identical values) and avoids
+      // an accidental clear of a field the user did not touch.
+      const patch = {
+        ...(name.trim() !== portal.name ? { name: name.trim() } : {}),
+        ...(description !== (portal.description ?? '') ? { description: description.trim() } : {}),
+        ...(loginEnvironment !== (portal.loginEnvironment ?? '')
+          ? { loginEnvironment: loginEnvironment.trim() }
+          : {}),
+      };
+      if (Object.keys(patch).length === 0) {
+        setEditOpen(false);
+        return;
+      }
+      await update(patch);
+      setEditOpen(false);
+    } catch {
+      // Notification handled by the hook; keep the dialog open with the
+      // user's typed values so they can adjust and retry.
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleDeleteConfirm = async () => {
+    try {
+      await remove();
+      setDeleteOpen(false);
+      onBack();
+    } catch {
+      setDeleteOpen(false);
+    }
+  };
+
+  return (
+    <PageContent fullWidth>
+      <Stack spacing={3}>
+        <Stack direction="row" alignItems="center" spacing={1}>
+          <IconButton onClick={onBack} aria-label="Back to portals list" size="small">
+            <ArrowLeft size={20} />
+          </IconButton>
+          <Typography variant="body2" color="text.secondary">
+            Managed API Portals
+          </Typography>
+        </Stack>
+
+        {isLoading ? (
+          <Typography variant="body2" color="text.secondary">
+            Loading portal…
+          </Typography>
+        ) : error ? (
+          <Typography variant="body2" color="error">
+            {error.message}
+          </Typography>
+        ) : !portal ? (
+          <Typography variant="body2" color="text.secondary">
+            Portal not found.
+          </Typography>
+        ) : (
+          <>
+            <Box sx={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 2 }}>
+              <Stack spacing={0.5} sx={{ minWidth: 0, flex: 1 }}>
+                <Typography variant="h5">{portal.name}</Typography>
+                <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
+                  {portal.handle}
+                </Typography>
+              </Stack>
+              <Stack direction="row" spacing={1} sx={{ flexShrink: 0 }}>
+                {portal.url && (
+                  <Button
+                    variant="contained"
+                    startIcon={<ArrowUpRight size={18} />}
+                    // noreferrer for external navigation; opens in a new tab so
+                    // the operator's console session isn't left behind.
+                    href={portal.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Visit Portal
+                  </Button>
+                )}
+                <Button
+                  variant="outlined"
+                  startIcon={<Pencil size={18} />}
+                  onClick={() => setEditOpen(true)}
+                >
+                  Edit
+                </Button>
+                <Button
+                  variant="outlined"
+                  color="error"
+                  startIcon={<Trash2 size={18} />}
+                  onClick={() => setDeleteOpen(true)}
+                >
+                  Delete
+                </Button>
+              </Stack>
+            </Box>
+
+            <Divider />
+
+            <Stack spacing={2.5} sx={{ maxWidth: 640 }}>
+              <Field label="Handle" value={portal.handle} />
+              <Field label="Description" value={portal.description ?? ''} />
+              <Field label="URL" value={portal.url ?? ''} />
+              <Field label="Login environment" value={portal.loginEnvironment ?? ''} />
+              {portal.updatedAt && <Field label="Last updated" value={portal.updatedAt} />}
+            </Stack>
+          </>
+        )}
+      </Stack>
+
+      {/* Edit portal */}
+      <Dialog
+        open={editOpen}
+        onClose={() => (submitting ? undefined : setEditOpen(false))}
+        fullWidth
+        maxWidth="sm"
+      >
+        <DialogTitle>Edit Portal</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ mt: 1 }}>
+            <FormControl fullWidth>
+              <FormLabel>Handle</FormLabel>
+              <TextField fullWidth value={portal?.handle ?? ''} disabled />
+            </FormControl>
+            <FormControl fullWidth>
+              <FormLabel>Name</FormLabel>
+              <TextField
+                fullWidth
+                autoFocus
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                disabled={submitting}
+              />
+            </FormControl>
+            <FormControl fullWidth>
+              <FormLabel>Description</FormLabel>
+              <TextField
+                fullWidth
+                multiline
+                minRows={2}
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+                disabled={submitting}
+              />
+            </FormControl>
+            <FormControl fullWidth>
+              <FormLabel>Login environment</FormLabel>
+              {/*
+               * Sourced from the org's real env list (useOrgEnvironments) so
+               * the operator can only pick a name that actually exists on
+               * the DP — a free-text TextField would let them save a value
+               * that fails at portal-provision time. If the portal's current
+               * env is somehow absent from the fetched list (e.g. deleted
+               * out-of-band), it's still included as a synthetic option so
+               * the user sees the mismatch rather than a silent selection
+               * swap.
+               */}
+              <Select
+                fullWidth
+                value={loginEnvironment}
+                onChange={(event) => setLoginEnvironment(String(event.target.value))}
+                disabled={submitting || envsLoading}
+                displayEmpty
+              >
+                {loginEnvironment && !environments.some((e) => e.name === loginEnvironment) && (
+                  <MenuItem value={loginEnvironment}>
+                    {loginEnvironment} (not in current environment list)
+                  </MenuItem>
+                )}
+                {environments.map((env) => (
+                  <MenuItem key={env.name} value={env.name}>
+                    {env.displayName ? `${env.displayName} (${env.name})` : env.name}
+                  </MenuItem>
+                ))}
+                {environments.length === 0 && !envsLoading && (
+                  <MenuItem value="" disabled>
+                    No environments — provision one first
+                  </MenuItem>
+                )}
+              </Select>
+              {envsError && (
+                <Typography variant="caption" color="error" sx={{ mt: 0.5 }}>
+                  Failed to load environments: {envsError.message}
+                </Typography>
+              )}
+            </FormControl>
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            variant="outlined"
+            color="secondary"
+            onClick={() => setEditOpen(false)}
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            disabled={submitting || !name.trim()}
+            onClick={handleSave}
+          >
+            Save
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Delete portal */}
+      <Dialog open={deleteOpen} onClose={() => setDeleteOpen(false)}>
+        <DialogTitle>Delete Portal</DialogTitle>
+        <DialogContent>
+          <Typography>
+            Are you sure you want to delete <strong>{portal?.name}</strong>? This action cannot be undone.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button variant="outlined" color="secondary" onClick={() => setDeleteOpen(false)}>
+            Cancel
+          </Button>
+          <Button color="error" onClick={handleDeleteConfirm}>
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </PageContent>
+  );
+}

--- a/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/ManagedPortalsList.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/ManagedPortalsList.tsx
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+import { useState } from 'react';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  FormControl,
+  FormLabel,
+  IconButton,
+  PageContent,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from '@wso2/oxygen-ui';
+import { Plus, Trash2 } from '@wso2/oxygen-ui-icons-react';
+
+import { useManagedPortalList } from './hooks';
+import type { ManagedPortal } from './types';
+
+export type ManagedPortalsListProps = {
+  /**
+   * Called when a row's non-action area is clicked, so the page shell can
+   * open the detail view. The delete icon stops event propagation so it does
+   * not double-fire into onSelect.
+   */
+  onSelect: (id: string) => void;
+};
+
+export default function ManagedPortalsList({ onSelect }: ManagedPortalsListProps) {
+  const { portals, isLoading, error, create, remove } = useManagedPortalList();
+
+  // Create dialog state.
+  //
+  // No loginEnvironment field in the Create form: the backend picks the org's
+  // preferred login env from environments.Service.List (see the plugin's
+  // Service.Create). Rationale — the "which env authenticates consumers" pick
+  // is server authority (matches the operator's org bootstrap), not the
+  // portal creator's choice on first-create. Editing switches later via the
+  // Edit form's env dropdown.
+  const [createOpen, setCreateOpen] = useState(false);
+  const [handle, setHandle] = useState('');
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  // Delete confirmation state.
+  const [deleteTarget, setDeleteTarget] = useState<ManagedPortal | null>(null);
+
+  const resetCreateForm = () => {
+    setHandle('');
+    setName('');
+    setDescription('');
+  };
+
+  const handleCreate = async () => {
+    setSubmitting(true);
+    try {
+      await create({
+        handle: handle.trim(),
+        name: name.trim(),
+        description: description.trim() || undefined,
+        // loginEnvironment omitted — backend picks from environments.Service.List
+      });
+      resetCreateForm();
+      setCreateOpen(false);
+    } catch {
+      // Notification already handled inside the hook; keep dialog open so the
+      // caller can fix and retry without losing typed values.
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!deleteTarget) return;
+    try {
+      await remove(deleteTarget.id);
+    } catch {
+      // notified by hook
+    } finally {
+      setDeleteTarget(null);
+    }
+  };
+
+  return (
+    <PageContent fullWidth>
+      <Stack spacing={3}>
+        <Box sx={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 2 }}>
+          <Stack spacing={0.5} sx={{ minWidth: 0, flex: 1 }}>
+            <Typography variant="h5">Managed API Portals</Typography>
+            <Typography color="text.secondary">
+              WSO2-managed developer portals for your organization.
+            </Typography>
+          </Stack>
+          <Button
+            variant="contained"
+            startIcon={<Plus size={20} />}
+            onClick={() => setCreateOpen(true)}
+            sx={{ flexShrink: 0 }}
+          >
+            Create Portal
+          </Button>
+        </Box>
+
+        <Divider />
+
+        {isLoading ? (
+          <Typography variant="body2" color="text.secondary">
+            Loading portals…
+          </Typography>
+        ) : error ? (
+          <Typography variant="body2" color="error">
+            {error.message}
+          </Typography>
+        ) : portals.length === 0 ? (
+          <Typography variant="body2" color="text.secondary">
+            No managed portals yet.
+          </Typography>
+        ) : (
+          <TableContainer>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Portal</TableCell>
+                  <TableCell>URL</TableCell>
+                  <TableCell>Login environment</TableCell>
+                  <TableCell align="right">Actions</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {portals.map((portal) => (
+                  <TableRow
+                    key={portal.id}
+                    hover
+                    onClick={() => onSelect(portal.id)}
+                    sx={{ cursor: 'pointer' }}
+                  >
+                    <TableCell sx={{ minWidth: 240 }}>
+                      <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+                        {portal.name}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
+                        {portal.handle}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
+                        {portal.url ?? '—'}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2" color="text.secondary">
+                        {portal.loginEnvironment ?? '—'}
+                      </Typography>
+                    </TableCell>
+                    <TableCell align="right">
+                      <IconButton
+                        size="small"
+                        color="error"
+                        aria-label={`Delete ${portal.name}`}
+                        onClick={(event) => {
+                          // Prevent the row click from also firing onSelect —
+                          // deleting is an explicit action, not a navigation.
+                          event.stopPropagation();
+                          setDeleteTarget(portal);
+                        }}
+                      >
+                        <Trash2 size={16} />
+                      </IconButton>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+      </Stack>
+
+      {/* Create portal */}
+      <Dialog
+        open={createOpen}
+        onClose={() => (submitting ? undefined : setCreateOpen(false))}
+        fullWidth
+        maxWidth="sm"
+      >
+        <DialogTitle>Create Portal</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ mt: 1 }}>
+            <FormControl fullWidth>
+              <FormLabel>Handle</FormLabel>
+              <TextField
+                fullWidth
+                autoFocus
+                placeholder="e.g. acme-portal"
+                value={handle}
+                onChange={(event) => setHandle(event.target.value)}
+                disabled={submitting}
+              />
+            </FormControl>
+            <FormControl fullWidth>
+              <FormLabel>Name</FormLabel>
+              <TextField
+                fullWidth
+                placeholder="e.g. Acme Developer Portal"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                disabled={submitting}
+              />
+            </FormControl>
+            <FormControl fullWidth>
+              <FormLabel>Description</FormLabel>
+              <TextField
+                fullWidth
+                multiline
+                minRows={2}
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+                disabled={submitting}
+              />
+            </FormControl>
+            {/*
+             * No Login-environment field on Create. The backend picks the
+             * org's preferred login env from the environments list (see the
+             * plugin's Service.Create). The Edit form (ManagedPortalDetail)
+             * exposes the picker for switching later.
+             */}
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            variant="outlined"
+            color="secondary"
+            onClick={() => setCreateOpen(false)}
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            disabled={submitting || !handle.trim() || !name.trim()}
+            onClick={handleCreate}
+          >
+            Create
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Delete portal */}
+      <Dialog open={Boolean(deleteTarget)} onClose={() => setDeleteTarget(null)}>
+        <DialogTitle>Delete Portal</DialogTitle>
+        <DialogContent>
+          <Typography>
+            Are you sure you want to delete <strong>{deleteTarget?.name}</strong>? This action cannot be undone.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button variant="outlined" color="secondary" onClick={() => setDeleteTarget(null)}>
+            Cancel
+          </Button>
+          <Button color="error" onClick={handleDeleteConfirm}>
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </PageContent>
+  );
+}

--- a/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/ManagedPortalsList.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/ManagedPortalsList.tsx
@@ -36,32 +36,20 @@ import { useManagedPortalList } from './hooks';
 import type { ManagedPortal } from './types';
 
 export type ManagedPortalsListProps = {
-  /**
-   * Called when a row's non-action area is clicked, so the page shell can
-   * open the detail view. The delete icon stops event propagation so it does
-   * not double-fire into onSelect.
-   */
+  /** Invoked when a row's non-action area is clicked; the delete icon stops propagation to avoid double-firing. */
   onSelect: (id: string) => void;
 };
 
 export default function ManagedPortalsList({ onSelect }: ManagedPortalsListProps) {
   const { portals, isLoading, error, create, remove } = useManagedPortalList();
 
-  // Create dialog state.
-  //
-  // No loginEnvironment field in the Create form: the backend picks the org's
-  // preferred login env from environments.Service.List (see the plugin's
-  // Service.Create). Rationale — the "which env authenticates consumers" pick
-  // is server authority (matches the operator's org bootstrap), not the
-  // portal creator's choice on first-create. Editing switches later via the
-  // Edit form's env dropdown.
+  // No loginEnvironment on create: server is authoritative on org bootstrap; Edit exposes the switch later.
   const [createOpen, setCreateOpen] = useState(false);
   const [handle, setHandle] = useState('');
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [submitting, setSubmitting] = useState(false);
 
-  // Delete confirmation state.
   const [deleteTarget, setDeleteTarget] = useState<ManagedPortal | null>(null);
 
   const resetCreateForm = () => {
@@ -77,13 +65,12 @@ export default function ManagedPortalsList({ onSelect }: ManagedPortalsListProps
         handle: handle.trim(),
         name: name.trim(),
         description: description.trim() || undefined,
-        // loginEnvironment omitted — backend picks from environments.Service.List
+        // loginEnvironment omitted; server picks the org's preferred env.
       });
       resetCreateForm();
       setCreateOpen(false);
     } catch {
-      // Notification already handled inside the hook; keep dialog open so the
-      // caller can fix and retry without losing typed values.
+      // Hook already notified; leave the dialog open with user input for retry.
     } finally {
       setSubmitting(false);
     }
@@ -94,7 +81,7 @@ export default function ManagedPortalsList({ onSelect }: ManagedPortalsListProps
     try {
       await remove(deleteTarget.id);
     } catch {
-      // notified by hook
+      // Hook already notified.
     } finally {
       setDeleteTarget(null);
     }
@@ -177,8 +164,7 @@ export default function ManagedPortalsList({ onSelect }: ManagedPortalsListProps
                         color="error"
                         aria-label={`Delete ${portal.name}`}
                         onClick={(event) => {
-                          // Prevent the row click from also firing onSelect —
-                          // deleting is an explicit action, not a navigation.
+                          // Stop the row's onSelect from firing on delete.
                           event.stopPropagation();
                           setDeleteTarget(portal);
                         }}
@@ -236,12 +222,7 @@ export default function ManagedPortalsList({ onSelect }: ManagedPortalsListProps
                 disabled={submitting}
               />
             </FormControl>
-            {/*
-             * No Login-environment field on Create. The backend picks the
-             * org's preferred login env from the environments list (see the
-             * plugin's Service.Create). The Edit form (ManagedPortalDetail)
-             * exposes the picker for switching later.
-             */}
+            {/* No Login-environment field on Create; the server picks the org's preferred env, and Edit exposes the picker later. */}
           </Stack>
         </DialogContent>
         <DialogActions>

--- a/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/ManagedPortalsList.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/ManagedPortalsList.tsx
@@ -137,7 +137,16 @@ export default function ManagedPortalsList({ onSelect }: ManagedPortalsListProps
                   <TableRow
                     key={portal.id}
                     hover
+                    tabIndex={0}
+                    role="button"
+                    aria-label={`Open ${portal.name}`}
                     onClick={() => onSelect(portal.id)}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        onSelect(portal.id);
+                      }
+                    }}
                     sx={{ cursor: 'pointer' }}
                   >
                     <TableCell sx={{ minWidth: 240 }}>
@@ -183,7 +192,11 @@ export default function ManagedPortalsList({ onSelect }: ManagedPortalsListProps
       {/* Create portal */}
       <Dialog
         open={createOpen}
-        onClose={() => (submitting ? undefined : setCreateOpen(false))}
+        onClose={() => {
+          if (submitting) return;
+          resetCreateForm();
+          setCreateOpen(false);
+        }}
         fullWidth
         maxWidth="sm"
       >
@@ -229,7 +242,10 @@ export default function ManagedPortalsList({ onSelect }: ManagedPortalsListProps
           <Button
             variant="outlined"
             color="secondary"
-            onClick={() => setCreateOpen(false)}
+            onClick={() => {
+              resetCreateForm();
+              setCreateOpen(false);
+            }}
             disabled={submitting}
           >
             Cancel

--- a/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/ManagedPortalsPage.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/ManagedPortalsPage.tsx
@@ -8,11 +8,11 @@
  */
 
 import { useMemo, useState } from 'react';
+import { PageContent, Typography } from '@wso2/oxygen-ui';
 
 import type { CloudHostPort } from './hostPort';
 import ManagedPortalDetail from './ManagedPortalDetail';
 import ManagedPortalsList from './ManagedPortalsList';
-import { createMockPortalPort } from './mockPort';
 import { PortalFeatureProvider } from './portContext';
 import { createRealPortalPort, resolveApiBase } from './realPort';
 
@@ -22,14 +22,27 @@ export type ManagedPortalsPageProps = {
 };
 
 export function ManagedPortalsPage({ port }: ManagedPortalsPageProps) {
-  // Real port when a platform-api base is configured, otherwise an in-memory mock (tests / storybook).
+  // Fail closed when the platform-api base is missing; tests / storybook build the mock port directly.
   const portalPort = useMemo(() => {
     const base = resolveApiBase();
-    return base ? createRealPortalPort(base, port.orgHandle) : createMockPortalPort();
+    return base ? createRealPortalPort(base, port.orgHandle) : null;
   }, [port.orgHandle]);
 
   // Local state (no URL param) keeps react-router out of this feature package; refresh loses the selection.
   const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  if (!portalPort) {
+    return (
+      <PageContent fullWidth>
+        <Typography variant="h5">Managed API Portals</Typography>
+        <Typography color="error" sx={{ mt: 2 }}>
+          Managed API Portals is not available: platform-api base URL is not
+          configured. Set window.__RUNTIME_CONFIG__.platformApiBaseUrl (or
+          window.config.platformApiBaseUrl) on the host to enable this feature.
+        </Typography>
+      </PageContent>
+    );
+  }
 
   return (
     <PortalFeatureProvider value={{ port: portalPort, host: port }}>

--- a/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/ManagedPortalsPage.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/ManagedPortalsPage.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+import { useMemo, useState } from 'react';
+
+import type { CloudHostPort } from './hostPort';
+import ManagedPortalDetail from './ManagedPortalDetail';
+import ManagedPortalsList from './ManagedPortalsList';
+import { createMockPortalPort } from './mockPort';
+import { PortalFeatureProvider } from './portContext';
+import { createRealPortalPort, resolveApiBase } from './realPort';
+
+export type ManagedPortalsPageProps = {
+  /**
+   * Host capabilities, supplied by whichever console mounts this feature —
+   * never imported directly. This is what makes the component reusable across
+   * more than one host app.
+   */
+  port: CloudHostPort;
+};
+
+export function ManagedPortalsPage({ port }: ManagedPortalsPageProps) {
+  // Construct the port once per mount: the real, BFF-backed port when the
+  // console exposes a platform-api base, otherwise an in-memory mock (tests /
+  // storybook). ManagedPortalsList/useManagedPortalList only ever see PortalPort.
+  const portalPort = useMemo(() => {
+    const base = resolveApiBase();
+    return base ? createRealPortalPort(base, port.orgHandle) : createMockPortalPort();
+  }, [port.orgHandle]);
+
+  // Which portal, if any, is being viewed in detail. Kept as local state (not
+  // a URL param) to avoid dragging react-router into the feature package —
+  // the same choice apip-cloud-ui-gateways makes. A refresh loses the current
+  // selection, which is acceptable for a first cut; revisit if the console
+  // grows deep-link requirements.
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  return (
+    <PortalFeatureProvider value={{ port: portalPort, host: port }}>
+      {selectedId ? (
+        <ManagedPortalDetail id={selectedId} onBack={() => setSelectedId(null)} />
+      ) : (
+        <ManagedPortalsList onSelect={setSelectedId} />
+      )}
+    </PortalFeatureProvider>
+  );
+}

--- a/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/ManagedPortalsPage.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/ManagedPortalsPage.tsx
@@ -17,28 +17,18 @@ import { PortalFeatureProvider } from './portContext';
 import { createRealPortalPort, resolveApiBase } from './realPort';
 
 export type ManagedPortalsPageProps = {
-  /**
-   * Host capabilities, supplied by whichever console mounts this feature —
-   * never imported directly. This is what makes the component reusable across
-   * more than one host app.
-   */
+  /** Host capabilities supplied by the mounting console; kept as a prop so the feature stays host-agnostic. */
   port: CloudHostPort;
 };
 
 export function ManagedPortalsPage({ port }: ManagedPortalsPageProps) {
-  // Construct the port once per mount: the real, BFF-backed port when the
-  // console exposes a platform-api base, otherwise an in-memory mock (tests /
-  // storybook). ManagedPortalsList/useManagedPortalList only ever see PortalPort.
+  // Real port when a platform-api base is configured, otherwise an in-memory mock (tests / storybook).
   const portalPort = useMemo(() => {
     const base = resolveApiBase();
     return base ? createRealPortalPort(base, port.orgHandle) : createMockPortalPort();
   }, [port.orgHandle]);
 
-  // Which portal, if any, is being viewed in detail. Kept as local state (not
-  // a URL param) to avoid dragging react-router into the feature package —
-  // the same choice apip-cloud-ui-gateways makes. A refresh loses the current
-  // selection, which is acceptable for a first cut; revisit if the console
-  // grows deep-link requirements.
+  // Local state (no URL param) keeps react-router out of this feature package; refresh loses the selection.
   const [selectedId, setSelectedId] = useState<string | null>(null);
 
   return (

--- a/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/hooks.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/hooks.ts
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { usePortalFeature } from './portContext';
+import type {
+  CreateManagedPortalInput,
+  ManagedPortal,
+  OrgEnvironment,
+  UpdateManagedPortalInput,
+} from './types';
+
+function errorMessage(err: unknown, fallback: string): string {
+  return err instanceof Error && err.message ? err.message : fallback;
+}
+
+/**
+ * Loads a single managed portal by id and exposes update + delete against it.
+ * A separate hook (rather than reusing useManagedPortalList) so the detail
+ * page can render without waiting on the whole list to load — the id-scoped
+ * fetch also returns metadata fields (loginEnvironment) the list projection
+ * strips, so a fresh get is the right shape for the detail view.
+ */
+export function useManagedPortal(id: string) {
+  const { port, host } = usePortalFeature();
+
+  const [portal, setPortal] = useState<ManagedPortal | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const refetch = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      setPortal(await port.get(id));
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error('Failed to load portal'));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [port, id]);
+
+  useEffect(() => {
+    void refetch();
+  }, [refetch]);
+
+  const update = useCallback(
+    async (input: UpdateManagedPortalInput) => {
+      try {
+        const updated = await port.update(id, input);
+        host.notify(`Portal "${updated.name}" updated`, 'success');
+        setPortal(updated);
+        return updated;
+      } catch (err) {
+        host.notify(errorMessage(err, 'Failed to update portal'), 'error');
+        throw err;
+      }
+    },
+    [port, id, host]
+  );
+
+  const remove = useCallback(async () => {
+    try {
+      await port.remove(id);
+      host.notify('Portal deleted', 'success');
+    } catch (err) {
+      host.notify(errorMessage(err, 'Failed to delete portal'), 'error');
+      throw err;
+    }
+  }, [port, id, host]);
+
+  return { portal, isLoading, error, refetch, update, remove };
+}
+
+/** List + create + update + delete managed portals via the feature's PortalPort. */
+export function useManagedPortalList() {
+  const { port, host } = usePortalFeature();
+
+  const [portals, setPortals] = useState<ManagedPortal[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const refetch = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      setPortals(await port.list());
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error('Failed to load portals'));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [port]);
+
+  useEffect(() => {
+    void refetch();
+  }, [refetch]);
+
+  const create = useCallback(
+    async (input: CreateManagedPortalInput) => {
+      try {
+        const portal = await port.create(input);
+        host.notify(`Portal "${portal.name}" created`, 'success');
+        await refetch();
+        return portal;
+      } catch (err) {
+        host.notify(errorMessage(err, 'Failed to create portal'), 'error');
+        throw err;
+      }
+    },
+    [port, refetch, host]
+  );
+
+  const update = useCallback(
+    async (id: string, input: UpdateManagedPortalInput) => {
+      try {
+        const portal = await port.update(id, input);
+        host.notify(`Portal "${portal.name}" updated`, 'success');
+        await refetch();
+        return portal;
+      } catch (err) {
+        host.notify(errorMessage(err, 'Failed to update portal'), 'error');
+        throw err;
+      }
+    },
+    [port, refetch, host]
+  );
+
+  const remove = useCallback(
+    async (id: string) => {
+      try {
+        await port.remove(id);
+        host.notify('Portal deleted', 'success');
+        await refetch();
+      } catch (err) {
+        host.notify(errorMessage(err, 'Failed to delete portal'), 'error');
+        throw err;
+      }
+    },
+    [port, refetch, host]
+  );
+
+  return { portals, isLoading, error, refetch, create, update, remove };
+}
+
+/**
+ * Loads the caller-org's data-plane environments once (on mount) and exposes
+ * a stable list + loading/error signals. Used by:
+ *   - the Create form, to pick a default env silently rather than asking the
+ *     operator to type one,
+ *   - the Edit form, to render a Select of the real available envs (rather
+ *     than a free-text TextField that lets operators name envs that don't
+ *     exist and trigger a runtime provisioning error).
+ *
+ * Kept as its own hook (not folded into useManagedPortalList) so:
+ *   - a page that only edits a single portal doesn't pay for the list call, and
+ *   - callers can render the env selector while the portal list is still loading.
+ */
+export function useOrgEnvironments() {
+  const { port } = usePortalFeature();
+
+  const [environments, setEnvironments] = useState<OrgEnvironment[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setIsLoading(true);
+    setError(null);
+    port
+      .listEnvironments()
+      .then((envs) => {
+        if (!cancelled) setEnvironments(envs);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err : new Error('Failed to load environments'));
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [port]);
+
+  return { environments, isLoading, error };
+}

--- a/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/hooks.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/hooks.ts
@@ -21,13 +21,7 @@ function errorMessage(err: unknown, fallback: string): string {
   return err instanceof Error && err.message ? err.message : fallback;
 }
 
-/**
- * Loads a single managed portal by id and exposes update + delete against it.
- * A separate hook (rather than reusing useManagedPortalList) so the detail
- * page can render without waiting on the whole list to load — the id-scoped
- * fetch also returns metadata fields (loginEnvironment) the list projection
- * strips, so a fresh get is the right shape for the detail view.
- */
+/** Loads one portal by id (GET returns metadata the list projection strips) and exposes update/delete. */
 export function useManagedPortal(id: string) {
   const { port, host } = usePortalFeature();
 
@@ -150,19 +144,7 @@ export function useManagedPortalList() {
   return { portals, isLoading, error, refetch, create, update, remove };
 }
 
-/**
- * Loads the caller-org's data-plane environments once (on mount) and exposes
- * a stable list + loading/error signals. Used by:
- *   - the Create form, to pick a default env silently rather than asking the
- *     operator to type one,
- *   - the Edit form, to render a Select of the real available envs (rather
- *     than a free-text TextField that lets operators name envs that don't
- *     exist and trigger a runtime provisioning error).
- *
- * Kept as its own hook (not folded into useManagedPortalList) so:
- *   - a page that only edits a single portal doesn't pay for the list call, and
- *   - callers can render the env selector while the portal list is still loading.
- */
+/** Loads the org's data-plane environments once on mount; used to populate env selectors. */
 export function useOrgEnvironments() {
   const { port } = usePortalFeature();
 

--- a/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/hostPort.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/hostPort.ts
@@ -5,15 +5,9 @@
  * Dissemination of any information or reproduction of any material contained
  * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
  * You may not alter or remove any copyright or other notice from copies of this content.
- *
- * Mirrors `CloudHostPort` from api-platform's `portals/api-control-plane/src/hostPort.tsx`.
- * Duplicated, not imported — api-platform and apim-saas are separate git
- * repos. Kept deliberately small and stable; keep this in sync by hand if
- * the upstream shape changes. This feature package only ever receives a
- * value of this shape as a plain prop (`render(port)` / `<ManagedPortalsPage
- * port={port} />`) — never a shared context object, so there's no
- * cross-repo context-identity problem to worry about.
  */
+
+// Duplicated (not imported) from api-platform's api-control-plane/hostPort so the two repos stay decoupled; keep in sync by hand.
 
 export type NotifySeverity = 'success' | 'info' | 'warning' | 'error';
 

--- a/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/hostPort.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/hostPort.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ *
+ * Mirrors `CloudHostPort` from api-platform's `portals/api-control-plane/src/hostPort.tsx`.
+ * Duplicated, not imported — api-platform and apim-saas are separate git
+ * repos. Kept deliberately small and stable; keep this in sync by hand if
+ * the upstream shape changes. This feature package only ever receives a
+ * value of this shape as a plain prop (`render(port)` / `<ManagedPortalsPage
+ * port={port} />`) — never a shared context object, so there's no
+ * cross-repo context-identity problem to worry about.
+ */
+
+export type NotifySeverity = 'success' | 'info' | 'warning' | 'error';
+
+export type CloudHostPort = {
+  orgHandle: string;
+  projectHandle?: string;
+  navigate: (path: string) => void;
+  notify: (message: string, severity?: NotifySeverity) => void;
+};

--- a/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/index.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/index.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+export { ManagedPortalsPage, type ManagedPortalsPageProps } from './ManagedPortalsPage';
+export type { CloudHostPort, NotifySeverity } from './hostPort';
+export { createMockPortalPort } from './mockPort';
+export { createRealPortalPort, resolveApiBase } from './realPort';
+export { useManagedPortalList } from './hooks';
+export type {
+  CreateManagedPortalInput,
+  ManagedPortal,
+  PortalPort,
+  UpdateManagedPortalInput,
+} from './types';

--- a/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/mockPort.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/mockPort.ts
@@ -22,6 +22,10 @@ const delay = <T>(value: T, ms = 300): Promise<T> =>
 
 const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value));
 
+// Real port relies on the server to reject bad handles; the mock has to check
+// itself so a value like "team/portal" doesn't produce an invalid hostname.
+const HANDLE_PATTERN = /^[a-z0-9-]+$/;
+
 /** Builds an in-memory PortalPort, optionally seeded. Seed is copied so callers can reuse it across instances. */
 export function createMockPortalPort(seed?: ManagedPortal[]): PortalPort {
   const portals: ManagedPortal[] = seed ? clone(seed) : [];
@@ -39,6 +43,9 @@ export function createMockPortalPort(seed?: ManagedPortal[]): PortalPort {
       const handle = input.handle.trim();
       const name = input.name.trim();
       if (!handle) throw new Error('A portal handle is required');
+      if (!HANDLE_PATTERN.test(handle)) {
+        throw new Error('Portal handle must contain only lowercase letters, digits, and hyphens');
+      }
       if (!name) throw new Error('A portal name is required');
       if (portals.some((p) => p.handle === handle)) {
         throw new Error(`A portal "${handle}" already exists`);

--- a/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/mockPort.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/mockPort.ts
@@ -7,11 +7,7 @@
  * You may not alter or remove any copyright or other notice from copies of this content.
  */
 
-// An in-memory PortalPort — used only as a fallback when no platform-api base
-// is configured (tests / storybook). The console always constructs the real,
-// BFF-backed port in a normal deployment. Both satisfy the same PortalPort
-// interface, so ManagedPortalsList/useManagedPortalList never know which is
-// in play.
+// In-memory PortalPort fallback for tests / storybook when no platform-api base is configured.
 
 import type {
   CreateManagedPortalInput,
@@ -26,7 +22,7 @@ const delay = <T>(value: T, ms = 300): Promise<T> =>
 
 const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value));
 
-/** Builds a fresh in-memory port, optionally seeded with portals. */
+/** Builds an in-memory PortalPort, optionally seeded. */
 export function createMockPortalPort(seed?: ManagedPortal[]): PortalPort {
   const portals: ManagedPortal[] = seed ?? [];
 
@@ -85,9 +81,7 @@ export function createMockPortalPort(seed?: ManagedPortal[]): PortalPort {
       await delay(undefined);
     },
     async listEnvironments(): Promise<OrgEnvironment[]> {
-      // Small fixed list for storybook / tests. Real org data comes from the
-      // BFF-backed port. Kept intentionally short and non-empty so form
-      // interactions render sensibly during offline development.
+      // Fixed non-empty list so form interactions render sensibly offline.
       return delay([
         { name: 'development', displayName: 'Development' },
         { name: 'staging', displayName: 'Staging' },

--- a/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/mockPort.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/mockPort.ts
@@ -22,9 +22,9 @@ const delay = <T>(value: T, ms = 300): Promise<T> =>
 
 const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value));
 
-/** Builds an in-memory PortalPort, optionally seeded. */
+/** Builds an in-memory PortalPort, optionally seeded. Seed is copied so callers can reuse it across instances. */
 export function createMockPortalPort(seed?: ManagedPortal[]): PortalPort {
-  const portals: ManagedPortal[] = seed ?? [];
+  const portals: ManagedPortal[] = seed ? clone(seed) : [];
 
   return {
     async list() {
@@ -48,7 +48,7 @@ export function createMockPortalPort(seed?: ManagedPortal[]): PortalPort {
         handle,
         name,
         description: input.description?.trim() || undefined,
-        loginEnvironment: input.loginEnvironment?.trim() || 'prod',
+        loginEnvironment: input.loginEnvironment?.trim() || 'production',
         url: `https://pending-${handle}.portals.invalid`,
         updatedAt: new Date().toISOString(),
       };

--- a/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/mockPort.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/mockPort.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+// An in-memory PortalPort — used only as a fallback when no platform-api base
+// is configured (tests / storybook). The console always constructs the real,
+// BFF-backed port in a normal deployment. Both satisfy the same PortalPort
+// interface, so ManagedPortalsList/useManagedPortalList never know which is
+// in play.
+
+import type {
+  CreateManagedPortalInput,
+  ManagedPortal,
+  OrgEnvironment,
+  PortalPort,
+  UpdateManagedPortalInput,
+} from './types';
+
+const delay = <T>(value: T, ms = 300): Promise<T> =>
+  new Promise((resolve) => setTimeout(() => resolve(value), ms));
+
+const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value));
+
+/** Builds a fresh in-memory port, optionally seeded with portals. */
+export function createMockPortalPort(seed?: ManagedPortal[]): PortalPort {
+  const portals: ManagedPortal[] = seed ?? [];
+
+  return {
+    async list() {
+      return delay(clone(portals));
+    },
+    async get(id: string) {
+      const found = portals.find((p) => p.id === id);
+      if (!found) throw new Error('Portal not found');
+      return delay(clone(found));
+    },
+    async create(input: CreateManagedPortalInput) {
+      const handle = input.handle.trim();
+      const name = input.name.trim();
+      if (!handle) throw new Error('A portal handle is required');
+      if (!name) throw new Error('A portal name is required');
+      if (portals.some((p) => p.handle === handle)) {
+        throw new Error(`A portal "${handle}" already exists`);
+      }
+      const portal: ManagedPortal = {
+        id: handle,
+        handle,
+        name,
+        description: input.description?.trim() || undefined,
+        loginEnvironment: input.loginEnvironment?.trim() || 'prod',
+        url: `https://pending-${handle}.portals.invalid`,
+        updatedAt: new Date().toISOString(),
+      };
+      portals.push(portal);
+      return delay(clone(portal));
+    },
+    async update(id: string, input: UpdateManagedPortalInput) {
+      const portal = portals.find((p) => p.id === id);
+      if (!portal) throw new Error('Portal not found');
+      if (input.name !== undefined) {
+        const trimmed = input.name.trim();
+        if (!trimmed) throw new Error('Name cannot be empty');
+        portal.name = trimmed;
+      }
+      if (input.description !== undefined) {
+        portal.description = input.description.trim() || undefined;
+      }
+      if (input.loginEnvironment !== undefined) {
+        const trimmed = input.loginEnvironment.trim();
+        if (!trimmed) throw new Error('loginEnvironment cannot be empty');
+        portal.loginEnvironment = trimmed;
+      }
+      portal.updatedAt = new Date().toISOString();
+      return delay(clone(portal));
+    },
+    async remove(id: string) {
+      const idx = portals.findIndex((p) => p.id === id);
+      if (idx === -1) throw new Error('Portal not found');
+      portals.splice(idx, 1);
+      await delay(undefined);
+    },
+    async listEnvironments(): Promise<OrgEnvironment[]> {
+      // Small fixed list for storybook / tests. Real org data comes from the
+      // BFF-backed port. Kept intentionally short and non-empty so form
+      // interactions render sensibly during offline development.
+      return delay([
+        { name: 'development', displayName: 'Development' },
+        { name: 'staging', displayName: 'Staging' },
+        { name: 'production', displayName: 'Production' },
+      ]);
+    },
+  };
+}

--- a/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/portContext.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/portContext.tsx
@@ -5,13 +5,9 @@
  * Dissemination of any information or reproduction of any material contained
  * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
  * You may not alter or remove any copyright or other notice from copies of this content.
- *
- * This feature's own data-injection seam — local to this package only, never
- * crossing the api-platform/apim-saas boundary (the boundary-crossing shape
- * is `CloudHostPort`, received as a plain prop by `ManagedPortalsPage`).
- * Kept as a context purely so `useManagedPortalList` doesn't need
- * `PortalPort`/`notify` prop-drilled through every list/dialog component.
  */
+
+// Package-local context so hooks aren't forced to prop-drill port/notify through every dialog.
 import { createContext, useContext, type ReactNode } from 'react';
 
 import type { CloudHostPort } from './hostPort';

--- a/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/portContext.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/portContext.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ *
+ * This feature's own data-injection seam — local to this package only, never
+ * crossing the api-platform/apim-saas boundary (the boundary-crossing shape
+ * is `CloudHostPort`, received as a plain prop by `ManagedPortalsPage`).
+ * Kept as a context purely so `useManagedPortalList` doesn't need
+ * `PortalPort`/`notify` prop-drilled through every list/dialog component.
+ */
+import { createContext, useContext, type ReactNode } from 'react';
+
+import type { CloudHostPort } from './hostPort';
+import type { PortalPort } from './types';
+
+type PortalFeatureContextValue = {
+  port: PortalPort;
+  host: CloudHostPort;
+};
+
+const PortalFeatureContext = createContext<PortalFeatureContextValue | null>(null);
+
+export function PortalFeatureProvider({
+  value,
+  children,
+}: {
+  value: PortalFeatureContextValue;
+  children: ReactNode;
+}) {
+  return (
+    <PortalFeatureContext.Provider value={value}>{children}</PortalFeatureContext.Provider>
+  );
+}
+
+export function usePortalFeature(): PortalFeatureContextValue {
+  const ctx = useContext(PortalFeatureContext);
+  if (!ctx) {
+    throw new Error(
+      'usePortalFeature must be used within a PortalFeatureProvider (rendered by ManagedPortalsPage)'
+    );
+  }
+  return ctx;
+}

--- a/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/realPort.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/realPort.ts
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ *
+ * The real PortalPort — talks to apip-platform-api through the console BFF's
+ * same-origin proxy. Mirrors how ManagedGatewaysPage's realPort reaches
+ * apip-platform-api's `/managed-gateways` resource; here we hit the sibling
+ * `/managed-api-portals` resource added by the same plugin.
+ *
+ * LIST projects the cloud OAS ManagedApiPortalList; the core row's list
+ * projection strips metadata by design, so `loginEnvironment` is empty on list
+ * results and populated only by GET (matching the plugin service's own
+ * projection). CREATE, PUT and DELETE go to the same resource.
+ */
+
+import type {
+  CreateManagedPortalInput,
+  ManagedPortal,
+  OrgEnvironment,
+  PortalPort,
+  UpdateManagedPortalInput,
+} from './types';
+
+const CSRF_HEADER = 'X-Requested-By';
+const CSRF_HEADER_VALUE = 'api-control-plane';
+const ORG_HEADER = 'X-Org-Id';
+
+type WindowRuntimeConfig = Partial<{
+  platformApiBaseUrl: string;
+  PLATFORM_API_BASE_URL: string;
+  platformApiVersion: string;
+  PLATFORM_API_VERSION: string;
+}>;
+
+function windowConfig(): WindowRuntimeConfig {
+  if (typeof window === 'undefined') return {};
+  const w = window as unknown as {
+    __RUNTIME_CONFIG__?: WindowRuntimeConfig;
+    config?: WindowRuntimeConfig;
+  };
+  return { ...(w.__RUNTIME_CONFIG__ ?? {}), ...(w.config ?? {}) };
+}
+
+/**
+ * The same-origin request base for platform-api calls
+ * (`${platformApiBaseUrl}/api/${version}`, e.g. `/proxy/api/v0.9`), or `null`
+ * when the console has no platform-api base configured (tests → mock port).
+ */
+export function resolveApiBase(): string | null {
+  const cfg = windowConfig();
+  const base = cfg.platformApiBaseUrl || cfg.PLATFORM_API_BASE_URL || '';
+  if (!base) return null;
+  const version = cfg.platformApiVersion || cfg.PLATFORM_API_VERSION || 'v0.9';
+  return `${base}/api/${version}`;
+}
+
+async function request<T>(
+  base: string,
+  orgRef: string,
+  method: string,
+  path: string,
+  body?: unknown
+): Promise<T> {
+  const mutating = method !== 'GET';
+  const response = await fetch(`${base}${path}`, {
+    method,
+    credentials: 'same-origin',
+    headers: {
+      Accept: 'application/json',
+      [ORG_HEADER]: orgRef,
+      ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+      ...(mutating ? { [CSRF_HEADER]: CSRF_HEADER_VALUE } : {}),
+    },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+
+  if (!response.ok) {
+    let message = `Request failed (${response.status})`;
+    try {
+      const errBody = (await response.json()) as {
+        message?: string;
+        description?: string;
+        error?: string;
+      };
+      message = errBody.description || errBody.message || errBody.error || message;
+    } catch {
+      // non-JSON error body — keep the status-based message
+    }
+    throw new Error(message);
+  }
+
+  if (response.status === 204) return undefined as T;
+  return (await response.json()) as T;
+}
+
+// Wire shapes from the plugin's OAS (services/apip-platform-api/resources/openapi.yaml).
+type WirePortal = {
+  id?: string;
+  handle?: string;
+  name: string;
+  description?: string | null;
+  url?: string;
+  loginEnvironment?: string;
+  updatedAt?: string;
+};
+type WirePortalList = { count?: number; list?: WirePortal[] };
+
+// EnvironmentList shape from the plugin's OAS. `name` is what the plugin's
+// loginEnvironment field expects; the response carries more fields we ignore.
+type WireEnvironment = { name?: string; displayName?: string };
+type WireEnvironmentList = { count?: number; list?: WireEnvironment[] };
+
+function fromWire(w: WirePortal): ManagedPortal {
+  return {
+    id: w.id ?? w.handle ?? '',
+    handle: w.handle ?? w.id ?? '',
+    name: w.name,
+    description: w.description ?? undefined,
+    url: w.url,
+    loginEnvironment: w.loginEnvironment,
+    updatedAt: w.updatedAt,
+  };
+}
+
+/**
+ * A PortalPort backed by the console BFF proxy at `base`
+ * (e.g. `/proxy/api/v0.9`), scoped to `orgHandle` (sent as X-Org-Id).
+ */
+export function createRealPortalPort(base: string, orgHandle: string): PortalPort {
+  const url = (id: string) => `/managed-api-portals/${encodeURIComponent(id)}`;
+  return {
+    async list() {
+      const body = await request<WirePortalList>(base, orgHandle, 'GET', '/managed-api-portals');
+      return (body.list ?? []).map(fromWire);
+    },
+    async get(id: string) {
+      const body = await request<WirePortal>(base, orgHandle, 'GET', url(id));
+      return fromWire(body);
+    },
+    async create(input: CreateManagedPortalInput) {
+      const body = await request<WirePortal>(base, orgHandle, 'POST', '/managed-api-portals', {
+        handle: input.handle,
+        name: input.name,
+        description: input.description,
+        loginEnvironment: input.loginEnvironment,
+      });
+      return fromWire(body);
+    },
+    async update(id: string, input: UpdateManagedPortalInput) {
+      const body = await request<WirePortal>(base, orgHandle, 'PUT', url(id), {
+        name: input.name,
+        description: input.description,
+        loginEnvironment: input.loginEnvironment,
+      });
+      return fromWire(body);
+    },
+    async remove(id: string) {
+      await request<void>(base, orgHandle, 'DELETE', url(id));
+    },
+    async listEnvironments(): Promise<OrgEnvironment[]> {
+      // Sibling endpoint served by the same cloud plugin
+      // (services/apip-platform-api/internal/environments/handler.go);
+      // reached via the same BFF proxy + org-id header as the portal calls.
+      const body = await request<WireEnvironmentList>(base, orgHandle, 'GET', '/environments');
+      return (body.list ?? [])
+        .filter((e): e is WireEnvironment & { name: string } => typeof e.name === 'string' && e.name.length > 0)
+        .map((e) => ({ name: e.name, displayName: e.displayName }));
+    },
+  };
+}

--- a/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/realPort.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/realPort.ts
@@ -22,6 +22,9 @@ const CSRF_HEADER = 'X-Requested-By';
 const CSRF_HEADER_VALUE = 'api-control-plane';
 const ORG_HEADER = 'X-Org-Id';
 
+// Bounded so a stalled BFF request can't leave UI mutations pending indefinitely.
+const REQUEST_TIMEOUT_MS = 30_000;
+
 type WindowRuntimeConfig = Partial<{
   platformApiBaseUrl: string;
   PLATFORM_API_BASE_URL: string;
@@ -55,17 +58,30 @@ async function request<T>(
   body?: unknown
 ): Promise<T> {
   const mutating = method !== 'GET';
-  const response = await fetch(`${base}${path}`, {
-    method,
-    credentials: 'same-origin',
-    headers: {
-      Accept: 'application/json',
-      [ORG_HEADER]: orgRef,
-      ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
-      ...(mutating ? { [CSRF_HEADER]: CSRF_HEADER_VALUE } : {}),
-    },
-    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
-  });
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  let response: Response;
+  try {
+    response = await fetch(`${base}${path}`, {
+      method,
+      credentials: 'same-origin',
+      signal: controller.signal,
+      headers: {
+        Accept: 'application/json',
+        [ORG_HEADER]: orgRef,
+        ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+        ...(mutating ? { [CSRF_HEADER]: CSRF_HEADER_VALUE } : {}),
+      },
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    });
+  } catch (err) {
+    if ((err as { name?: string }).name === 'AbortError') {
+      throw new Error(`Request timed out after ${REQUEST_TIMEOUT_MS / 1000}s`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeout);
+  }
 
   if (!response.ok) {
     let message = `Request failed (${response.status})`;
@@ -103,9 +119,13 @@ type WireEnvironment = { name?: string; displayName?: string };
 type WireEnvironmentList = { count?: number; list?: WireEnvironment[] };
 
 function fromWire(w: WirePortal): ManagedPortal {
+  const identifier = w.id ?? w.handle;
+  if (!identifier) {
+    throw new Error('Portal response is missing both id and handle');
+  }
   return {
-    id: w.id ?? w.handle ?? '',
-    handle: w.handle ?? w.id ?? '',
+    id: identifier,
+    handle: w.handle ?? identifier,
     name: w.name,
     description: w.description ?? undefined,
     url: w.url,

--- a/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/realPort.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/realPort.ts
@@ -5,17 +5,10 @@
  * Dissemination of any information or reproduction of any material contained
  * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
  * You may not alter or remove any copyright or other notice from copies of this content.
- *
- * The real PortalPort — talks to apip-platform-api through the console BFF's
- * same-origin proxy. Mirrors how ManagedGatewaysPage's realPort reaches
- * apip-platform-api's `/managed-gateways` resource; here we hit the sibling
- * `/managed-api-portals` resource added by the same plugin.
- *
- * LIST projects the cloud OAS ManagedApiPortalList; the core row's list
- * projection strips metadata by design, so `loginEnvironment` is empty on list
- * results and populated only by GET (matching the plugin service's own
- * projection). CREATE, PUT and DELETE go to the same resource.
  */
+
+// PortalPort backed by apip-platform-api via the console BFF's same-origin proxy.
+// LIST strips metadata by design so loginEnvironment is empty on list rows and only populated by GET.
 
 import type {
   CreateManagedPortalInput,
@@ -45,11 +38,7 @@ function windowConfig(): WindowRuntimeConfig {
   return { ...(w.__RUNTIME_CONFIG__ ?? {}), ...(w.config ?? {}) };
 }
 
-/**
- * The same-origin request base for platform-api calls
- * (`${platformApiBaseUrl}/api/${version}`, e.g. `/proxy/api/v0.9`), or `null`
- * when the console has no platform-api base configured (tests → mock port).
- */
+/** Same-origin request base for platform-api calls, or null when unconfigured (tests fall back to mock). */
 export function resolveApiBase(): string | null {
   const cfg = windowConfig();
   const base = cfg.platformApiBaseUrl || cfg.PLATFORM_API_BASE_URL || '';
@@ -88,7 +77,7 @@ async function request<T>(
       };
       message = errBody.description || errBody.message || errBody.error || message;
     } catch {
-      // non-JSON error body — keep the status-based message
+      // Non-JSON body; keep the status-based message.
     }
     throw new Error(message);
   }
@@ -97,7 +86,7 @@ async function request<T>(
   return (await response.json()) as T;
 }
 
-// Wire shapes from the plugin's OAS (services/apip-platform-api/resources/openapi.yaml).
+// Wire shapes match the plugin's OAS.
 type WirePortal = {
   id?: string;
   handle?: string;
@@ -109,8 +98,7 @@ type WirePortal = {
 };
 type WirePortalList = { count?: number; list?: WirePortal[] };
 
-// EnvironmentList shape from the plugin's OAS. `name` is what the plugin's
-// loginEnvironment field expects; the response carries more fields we ignore.
+// `name` is the value loginEnvironment expects; other response fields are ignored.
 type WireEnvironment = { name?: string; displayName?: string };
 type WireEnvironmentList = { count?: number; list?: WireEnvironment[] };
 
@@ -126,10 +114,7 @@ function fromWire(w: WirePortal): ManagedPortal {
   };
 }
 
-/**
- * A PortalPort backed by the console BFF proxy at `base`
- * (e.g. `/proxy/api/v0.9`), scoped to `orgHandle` (sent as X-Org-Id).
- */
+/** PortalPort backed by the BFF proxy at `base`, scoped to `orgHandle` via the X-Org-Id header. */
 export function createRealPortalPort(base: string, orgHandle: string): PortalPort {
   const url = (id: string) => `/managed-api-portals/${encodeURIComponent(id)}`;
   return {
@@ -162,9 +147,7 @@ export function createRealPortalPort(base: string, orgHandle: string): PortalPor
       await request<void>(base, orgHandle, 'DELETE', url(id));
     },
     async listEnvironments(): Promise<OrgEnvironment[]> {
-      // Sibling endpoint served by the same cloud plugin
-      // (services/apip-platform-api/internal/environments/handler.go);
-      // reached via the same BFF proxy + org-id header as the portal calls.
+      // Sibling endpoint reached via the same BFF proxy and org-id header as the portal calls.
       const body = await request<WireEnvironmentList>(base, orgHandle, 'GET', '/environments');
       return (body.list ?? [])
         .filter((e): e is WireEnvironment & { name: string } => typeof e.name === 'string' && e.name.length > 0)

--- a/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/types.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/types.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+// Domain types owned by this feature. Self-contained: it defines its own model
+// and reaches data only through PortalPort, never a specific host's API client.
+
+export interface ManagedPortal {
+  /** Portal id — same as handle in the current backend. */
+  id: string;
+  /** URL-friendly slug the caller supplied on create; immutable. */
+  handle: string;
+  /** Display name. */
+  name: string;
+  /** Optional caller-supplied description. */
+  description?: string;
+  /**
+   * Public URL of the portal, allocated by the cloud plugin. Undefined until
+   * the runtime is provisioned (Phase 5 placeholder impl fills it with a
+   * per-portal pending URL).
+   */
+  url?: string;
+  /**
+   * Data-plane environment whose Thunder STS backs portal-user login (portal
+   * consumers subscribing to APIs). Empty on list responses (the core row's
+   * list projection strips metadata by design) and populated on GET.
+   * Renamed from `stsEnvironment` to name it by role (what it's for) rather
+   * than by mechanism (which auth server type backs it).
+   */
+  loginEnvironment?: string;
+  /** ISO timestamp of the last row change. */
+  updatedAt?: string;
+}
+
+export interface CreateManagedPortalInput {
+  handle: string;
+  name: string;
+  description?: string;
+  /**
+   * Optional. When omitted (the new Create-form default), the plugin
+   * dynamically picks the org's preferred login env from
+   * environments.Service.List — see the backend's Service.Create for the
+   * pick order. Callers only pass this to override the server-side pick.
+   */
+  loginEnvironment?: string;
+}
+
+export interface UpdateManagedPortalInput {
+  name?: string;
+  description?: string;
+  loginEnvironment?: string;
+}
+
+/**
+ * A single row from the cloud plugin's GET /environments — one entry per
+ * data-plane environment the org has. Used by the Create / Edit forms to
+ * populate the Login environment selector so the operator picks a real value
+ * rather than typing a free-form string that may not exist.
+ *
+ * Only the minimum shape the UI needs is modelled here; the wire payload
+ * carries more fields (dnsPrefix, id, description, ...) that we ignore.
+ */
+export interface OrgEnvironment {
+  /** Canonical env name — what the plugin's loginEnvironment field expects. */
+  name: string;
+  /** Human-readable name for the dropdown. Falls back to `name` when empty. */
+  displayName?: string;
+}
+
+/**
+ * The data contract this feature is built against. `ManagedPortalsPage`
+ * constructs a real, BFF-backed port when the console's platform-api base
+ * is present, falling back to an in-memory mock otherwise (tests). Neither
+ * `ManagedPortalsList` nor `useManagedPortalList` ever sees anything but
+ * this interface.
+ */
+export interface PortalPort {
+  list(): Promise<ManagedPortal[]>;
+  get(id: string): Promise<ManagedPortal>;
+  create(input: CreateManagedPortalInput): Promise<ManagedPortal>;
+  update(id: string, input: UpdateManagedPortalInput): Promise<ManagedPortal>;
+  remove(id: string): Promise<void>;
+  /**
+   * Lists the caller-org's data-plane environments. Used by Create/Edit to
+   * populate the Login environment selector. Empty list = zero environments
+   * provisioned yet (org just signed up) — caller should treat that as an
+   * error and show a "no environments yet" message rather than falling back
+   * to a hardcoded default.
+   */
+  listEnvironments(): Promise<OrgEnvironment[]>;
+}

--- a/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/types.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-managed-portals/src/types.ts
@@ -7,31 +7,20 @@
  * You may not alter or remove any copyright or other notice from copies of this content.
  */
 
-// Domain types owned by this feature. Self-contained: it defines its own model
-// and reaches data only through PortalPort, never a specific host's API client.
+// Feature-owned domain types; data reaches this feature only through PortalPort.
 
 export interface ManagedPortal {
-  /** Portal id — same as handle in the current backend. */
+  /** Portal id; equal to `handle` in the current backend. */
   id: string;
-  /** URL-friendly slug the caller supplied on create; immutable. */
+  /** Immutable URL-friendly slug supplied on create. */
   handle: string;
   /** Display name. */
   name: string;
   /** Optional caller-supplied description. */
   description?: string;
-  /**
-   * Public URL of the portal, allocated by the cloud plugin. Undefined until
-   * the runtime is provisioned (Phase 5 placeholder impl fills it with a
-   * per-portal pending URL).
-   */
+  /** Public portal URL allocated by the cloud plugin; undefined until the runtime is provisioned. */
   url?: string;
-  /**
-   * Data-plane environment whose Thunder STS backs portal-user login (portal
-   * consumers subscribing to APIs). Empty on list responses (the core row's
-   * list projection strips metadata by design) and populated on GET.
-   * Renamed from `stsEnvironment` to name it by role (what it's for) rather
-   * than by mechanism (which auth server type backs it).
-   */
+  /** Data-plane env whose auth server backs portal-user login. Empty on list responses; populated by GET. */
   loginEnvironment?: string;
   /** ISO timestamp of the last row change. */
   updatedAt?: string;
@@ -41,12 +30,7 @@ export interface CreateManagedPortalInput {
   handle: string;
   name: string;
   description?: string;
-  /**
-   * Optional. When omitted (the new Create-form default), the plugin
-   * dynamically picks the org's preferred login env from
-   * environments.Service.List — see the backend's Service.Create for the
-   * pick order. Callers only pass this to override the server-side pick.
-   */
+  /** When omitted, the server picks the org's preferred env; pass only to override that choice. */
   loginEnvironment?: string;
 }
 
@@ -56,41 +40,21 @@ export interface UpdateManagedPortalInput {
   loginEnvironment?: string;
 }
 
-/**
- * A single row from the cloud plugin's GET /environments — one entry per
- * data-plane environment the org has. Used by the Create / Edit forms to
- * populate the Login environment selector so the operator picks a real value
- * rather than typing a free-form string that may not exist.
- *
- * Only the minimum shape the UI needs is modelled here; the wire payload
- * carries more fields (dnsPrefix, id, description, ...) that we ignore.
- */
+/** One data-plane environment; only the fields the UI's env selector needs. */
 export interface OrgEnvironment {
-  /** Canonical env name — what the plugin's loginEnvironment field expects. */
+  /** Canonical env name; what the loginEnvironment field expects. */
   name: string;
-  /** Human-readable name for the dropdown. Falls back to `name` when empty. */
+  /** Optional label; the UI falls back to `name` when empty. */
   displayName?: string;
 }
 
-/**
- * The data contract this feature is built against. `ManagedPortalsPage`
- * constructs a real, BFF-backed port when the console's platform-api base
- * is present, falling back to an in-memory mock otherwise (tests). Neither
- * `ManagedPortalsList` nor `useManagedPortalList` ever sees anything but
- * this interface.
- */
+/** Data seam this feature depends on; satisfied by real (BFF) or mock (tests) implementations. */
 export interface PortalPort {
   list(): Promise<ManagedPortal[]>;
   get(id: string): Promise<ManagedPortal>;
   create(input: CreateManagedPortalInput): Promise<ManagedPortal>;
   update(id: string, input: UpdateManagedPortalInput): Promise<ManagedPortal>;
   remove(id: string): Promise<void>;
-  /**
-   * Lists the caller-org's data-plane environments. Used by Create/Edit to
-   * populate the Login environment selector. Empty list = zero environments
-   * provisioned yet (org just signed up) — caller should treat that as an
-   * error and show a "no environments yet" message rather than falling back
-   * to a hardcoded default.
-   */
+  /** Empty list means the org has no environments yet; callers should surface that rather than defaulting. */
   listEnvironments(): Promise<OrgEnvironment[]>;
 }

--- a/portals/cloud-plugins/apip-cloud-ui-managed-portals/tsconfig.json
+++ b/portals/cloud-plugins/apip-cloud-ui-managed-portals/tsconfig.json
@@ -5,10 +5,10 @@
     "moduleResolution": "Bundler",
     "baseUrl": ".",
     "paths": {
-      "@wso2/oxygen-ui": ["../../api-control-plane/node_modules/@wso2/oxygen-ui"],
-      "@wso2/oxygen-ui-icons-react": ["../../api-control-plane/node_modules/@wso2/oxygen-ui-icons-react"],
-      "react": ["../../api-control-plane/node_modules/@types/react/index.d.ts"],
-      "react/jsx-runtime": ["../../api-control-plane/node_modules/@types/react/jsx-runtime.d.ts"]
+      "@wso2/oxygen-ui": ["../../ai-workspace/node_modules/@wso2/oxygen-ui"],
+      "@wso2/oxygen-ui-icons-react": ["../../ai-workspace/node_modules/@wso2/oxygen-ui-icons-react"],
+      "react": ["../../ai-workspace/node_modules/@types/react/index.d.ts"],
+      "react/jsx-runtime": ["../../ai-workspace/node_modules/@types/react/jsx-runtime.d.ts"]
     },
     "jsx": "react-jsx",
     "strict": true,

--- a/portals/cloud-plugins/apip-cloud-ui-managed-portals/tsconfig.json
+++ b/portals/cloud-plugins/apip-cloud-ui-managed-portals/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "baseUrl": ".",
+    "paths": {
+      "@wso2/oxygen-ui": ["../../api-control-plane/node_modules/@wso2/oxygen-ui"],
+      "@wso2/oxygen-ui-icons-react": ["../../api-control-plane/node_modules/@wso2/oxygen-ui-icons-react"],
+      "react": ["../../api-control-plane/node_modules/@types/react/index.d.ts"],
+      "react/jsx-runtime": ["../../api-control-plane/node_modules/@types/react/jsx-runtime.d.ts"]
+    },
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"]
+}

--- a/portals/cloud-plugins/apip-cloud-ui/package.json
+++ b/portals/cloud-plugins/apip-cloud-ui/package.json
@@ -14,6 +14,7 @@
     "@wso2-enterprise/apip-cloud-ui-deploy": "file:../apip-cloud-ui-deploy",
     "@wso2-enterprise/apip-cloud-ui-environments-new": "file:../apip-cloud-ui-environments-new",
     "@wso2-enterprise/apip-cloud-ui-gateways": "file:../apip-cloud-ui-gateways",
+    "@wso2-enterprise/apip-cloud-ui-managed-portals": "file:../apip-cloud-ui-managed-portals",
     "@wso2-enterprise/apip-cloud-ui-pipelines": "file:../apip-cloud-ui-pipelines",
     "@wso2/oxygen-ui": "0.5.0",
     "@wso2/oxygen-ui-icons-react": "0.5.0",

--- a/portals/cloud-plugins/apip-cloud-ui/src/hosts/api-control-plane.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui/src/hosts/api-control-plane.tsx
@@ -65,11 +65,8 @@ import { defineCloudPlugin, getCloudExtensions, type CloudPluginFeature } from '
  *
  * `managed-api-portals` is an organization-level sidebar item, one WSO2-managed
  * developer portal per entry in the org. Talks to apip-platform-api's cloud-only
- * `/managed-api-portals` resource (apim-saas PR #2957) via the host port. The
- * open-source console has no counterpart; this is a SaaS-only surface. Distinct
- * from the OSS `/api-portals` REST added by api-platform PR #3219, per product
- * decision, managed portals and OSS api-portals stay two systems forever
- * (SaaS lifecycle vs plain registry).
+ * `/managed-api-portals` resource via the host port; SaaS-only, distinct from
+ * the OSS `/api-portals` registry (SaaS lifecycle vs plain registry).
  */
 export const cloudPluginFeatures: CloudPluginFeature<ApiControlPlaneExtension>[] = [
   defineCloudPlugin({
@@ -180,7 +177,7 @@ export const cloudPluginFeatures: CloudPluginFeature<ApiControlPlaneExtension>[]
       {
         id: 'managed-api-portals',
         slot: 'sidebar.organization',
-        // After Pipelines (50); no built-in item competes for this position.
+        // Placed after Pipelines (50); no built-in item competes for 60.
         order: 60,
         routePath: 'managed-api-portals',
         render: (port) => <ManagedPortalsPage port={port} />,

--- a/portals/cloud-plugins/apip-cloud-ui/src/hosts/api-control-plane.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui/src/hosts/api-control-plane.tsx
@@ -7,11 +7,12 @@
  * You may not alter or remove any copyright or other notice from copies of this content.
  */
 
-import { Layers, Workflow } from '@wso2/oxygen-ui-icons-react';
+import { Globe, Layers, Workflow } from '@wso2/oxygen-ui-icons-react';
 
 import { DeployFeature } from '@wso2-enterprise/apip-cloud-ui-deploy';
 import { EnvironmentsFeature } from '@wso2-enterprise/apip-cloud-ui-environments-new';
 import { GatewaysFeature } from '@wso2-enterprise/apip-cloud-ui-gateways';
+import { ManagedPortalsPage } from '@wso2-enterprise/apip-cloud-ui-managed-portals';
 import {
   PipelinesFeature,
   ProjectPipelinesFeature,
@@ -57,10 +58,18 @@ import { defineCloudPlugin, getCloudExtensions, type CloudPluginFeature } from '
  * what renders there changes. It is the one API-scoped feature here, so it needs
  * the API in scope, which the Port carries as `apiHandle`. Because the override
  * replaces the whole page, it also replaces the `ScopeGate` the built-in page
- * wraps itself in — so it is re-applied here. Without it, reaching Deploy from an
+ * wraps itself in - so it is re-applied here. Without it, reaching Deploy from an
  * organization- or project-level page (which the sidebar allows, and is a normal
  * thing to do) left a dead end instead of the project/API picker that navigates
  * to the scoped URL.
+ *
+ * `managed-api-portals` is an organization-level sidebar item, one WSO2-managed
+ * developer portal per entry in the org. Talks to apip-platform-api's cloud-only
+ * `/managed-api-portals` resource (apim-saas PR #2957) via the host port. The
+ * open-source console has no counterpart; this is a SaaS-only surface. Distinct
+ * from the OSS `/api-portals` REST added by api-platform PR #3219, per product
+ * decision, managed portals and OSS api-portals stay two systems forever
+ * (SaaS lifecycle vs plain registry).
  */
 export const cloudPluginFeatures: CloudPluginFeature<ApiControlPlaneExtension>[] = [
   defineCloudPlugin({
@@ -161,6 +170,23 @@ export const cloudPluginFeatures: CloudPluginFeature<ApiControlPlaneExtension>[]
         icon: <Workflow size={20} />,
         level: 'project',
         isVisible: (scope) => scope.isProjectScope,
+      },
+    ],
+  }),
+  defineCloudPlugin({
+    id: 'managed-api-portals',
+    version: '0.1.0',
+    extensions: [
+      {
+        id: 'managed-api-portals',
+        slot: 'sidebar.organization',
+        // After Pipelines (50); no built-in item competes for this position.
+        order: 60,
+        routePath: 'managed-api-portals',
+        render: (port) => <ManagedPortalsPage port={port} />,
+        label: 'Managed API Portals',
+        icon: <Globe size={20} />,
+        level: 'organization',
       },
     ],
   }),

--- a/portals/cloud-plugins/apip-cloud-ui/tsconfig.json
+++ b/portals/cloud-plugins/apip-cloud-ui/tsconfig.json
@@ -7,6 +7,7 @@
       "@wso2-enterprise/apip-cloud-ui-deploy": ["../apip-cloud-ui-deploy/src/index.ts"],
       "@wso2-enterprise/apip-cloud-ui-environments-new": ["../apip-cloud-ui-environments-new/src/index.ts"],
       "@wso2-enterprise/apip-cloud-ui-gateways": ["../apip-cloud-ui-gateways/src/index.ts"],
+      "@wso2-enterprise/apip-cloud-ui-managed-portals": ["../apip-cloud-ui-managed-portals/src/index.ts"],
       "@wso2-enterprise/apip-cloud-ui-pipelines": ["../apip-cloud-ui-pipelines/src/index.ts"],
       "@wso2/oxygen-ui": ["../../ai-workspace/node_modules/@wso2/oxygen-ui"],
       "@wso2/oxygen-ui-icons-react": ["../../ai-workspace/node_modules/@wso2/oxygen-ui-icons-react"],


### PR DESCRIPTION
## Summary

Adds the **Managed API Portals** cloud plugin at `portals/cloud-plugins/apip-cloud-ui-managed-portals/` and wires it into the api-control-plane host as a new organization-level sidebar item (order 60, after Pipelines).

The plugin ships a self-contained `PortalPort` abstraction (BFF-backed real port + in-memory mock), a hand-mirrored `CloudHostPort` type so it stays host-agnostic, and a list/create/detail flow with local view state (no react-router coupling from this package).

## Depends on

The cloud backend that exposes `/managed-api-portals` (apip-platform-api plugin). This plugin's fetches only return real data once the backend lands and the api-control-plane image is rebuilt with the cloud-plugins bundle.

## Invariant

Managed API Portals and OSS `/api-portals` are two separate systems by product decision and stay independent forever. Cloud handles full lifecycle (DCR, secret rotation, provisioning); OSS is a plain registry for self-hosted operators.

## Tested

- `npm run typecheck` in `apip-cloud-ui-managed-portals` and `apip-cloud-ui`
- Managed API Portals appears below Pipelines in the org sidebar
- Create / view / edit / delete flow against the mock port renders correctly
- Fails closed with a config-error message when `platformApiBaseUrl` is missing
