### PR TITLE
Deploy to several gateways at once from the deploy dialog

### DIFF
--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/DeployFeature.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/DeployFeature.tsx
@@ -164,41 +164,6 @@ const DeployFeature: FC<DeployFeatureProps> = ({ port }) => {
   };
 
   /**
-   * Puts a stopped gateway back by DEPLOYING to it, not by reviving what it used
-   * to run. There is no per-gateway redeploy: restoring its old deployment would
-   * put that old build back while the rest of the environment had moved on, which
-   * is the split the one-build-per-environment rule exists to prevent.
-   *
-   * So it deploys the build the environment is currently running. With nothing
-   * else deployed there, there is no build to join and the user is sent to the
-   * dialog to choose one instead.
-   */
-  const handleRedeploy = (environment: Environment, gatewayId: string) => {
-    const gateway = environment.gateways.find((candidate) => candidate.id === gatewayId);
-    if (!client || !gateway) return;
-    const liveBuild = environment.gateways.find(
-      (candidate) => candidate.id !== gatewayId && candidate.status === 'DEPLOYED'
-    )?.buildId;
-    if (!liveBuild) {
-      notify(
-        `Nothing else is deployed in ${environment.name}, so there is no build to join. Use Deploy to choose one.`,
-        'info'
-      );
-      return;
-    }
-    void runAction(
-      () =>
-        client.deploy({
-          environment: environment.name,
-          gateways: [{ gatewayId, endpointUrl: gateway.endpointUrl }],
-          buildId: liveBuild,
-        }),
-      `Deploying ${gateway.name}.`,
-      `Unable to deploy ${gateway.name}.`
-    );
-  };
-
-  /**
    * Retrying sends the gateway the build it already has, not a new one: a failed
    * deployment is retried as it was, so a retry never quietly ships something
    * else. A later environment can only be reached by promoting into it, so the
@@ -286,7 +251,6 @@ const DeployFeature: FC<DeployFeatureProps> = ({ port }) => {
       onDeploy={handleDeploy}
       onStopGateway={handleStop}
       onRetryGateway={handleRetry}
-      onRedeployGateway={handleRedeploy}
     />
   );
 };

--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/DeployFeature.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/DeployFeature.tsx
@@ -184,8 +184,8 @@ const DeployFeature: FC<DeployFeatureProps> = ({ port }) => {
           buildId: gateway.buildId,
           fromEnvironment: index > 0 ? environments[index - 1]?.name : undefined,
         }),
-      `Redeploying ${gateway.name}.`,
-      `Unable to redeploy ${gateway.name}.`
+      `Retrying ${gateway.name}.`,
+      `Unable to retry ${gateway.name}.`
     );
   };
 

--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/DeployFeature.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/DeployFeature.tsx
@@ -153,6 +153,21 @@ const DeployFeature: FC<DeployFeatureProps> = ({ port }) => {
     );
   };
 
+  /**
+   * Deleting a build is how a slot is freed once the API is at its limit and
+   * deploying is refused for it. The platform is the authority on whether a build
+   * can go — a gateway may have claimed it since the page last loaded — so a
+   * refusal surfaces as it comes back rather than being predicted here.
+   */
+  const handleDeleteBuild = (buildId: string) => {
+    if (!client) return;
+    void runAction(
+      () => client.deleteBuild(buildId),
+      `Deleted build ${buildId}.`,
+      `Unable to delete build ${buildId}.`
+    );
+  };
+
   const handleStop = (environment: Environment, gatewayId: string) => {
     const gateway = environment.gateways.find((candidate) => candidate.id === gatewayId);
     if (!client || !gateway?.deploymentId) return;
@@ -251,6 +266,7 @@ const DeployFeature: FC<DeployFeatureProps> = ({ port }) => {
       onDeploy={handleDeploy}
       onStopGateway={handleStop}
       onRetryGateway={handleRetry}
+      onDeleteBuild={handleDeleteBuild}
     />
   );
 };

--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/DeployFeature.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/DeployFeature.tsx
@@ -135,18 +135,16 @@ const DeployFeature: FC<DeployFeatureProps> = ({ port }) => {
    */
   const handleDeploy = (
     target: Environment,
-    gatewayId: string,
-    endpointUrl: string,
+    gateways: { gatewayId: string; endpointUrl?: string }[],
     from?: Environment,
     buildId?: string
   ) => {
-    if (!client) return;
+    if (!client || gateways.length === 0) return;
     void runAction(
       () =>
         client.deploy({
           environment: target.name,
-          gatewayId,
-          endpointUrl,
+          gateways,
           fromEnvironment: from?.name,
           buildId,
         }),
@@ -192,10 +190,12 @@ const DeployFeature: FC<DeployFeatureProps> = ({ port }) => {
     const index = environments.findIndex((candidate) => candidate.name === environment.name);
     void runAction(
       () =>
+        // Only this gateway: the retry ships the build its peers are already
+        // running, so the environment stays on one build and the backend does not
+        // require them to be redeployed alongside it.
         client.deploy({
           environment: environment.name,
-          gatewayId,
-          endpointUrl: gateway.endpointUrl,
+          gateways: [{ gatewayId, endpointUrl: gateway.endpointUrl }],
           buildId: gateway.buildId,
           fromEnvironment: index > 0 ? environments[index - 1]?.name : undefined,
         }),

--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/DeployFeature.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/DeployFeature.tsx
@@ -164,17 +164,37 @@ const DeployFeature: FC<DeployFeatureProps> = ({ port }) => {
   };
 
   /**
-   * Puts a suspended deployment back on its gateway. The deployment is immutable,
-   * so this restores exactly what was running — same build, same endpoint — and
-   * builds nothing, which is what separates it from a retry.
+   * Puts a stopped gateway back by DEPLOYING to it, not by reviving what it used
+   * to run. There is no per-gateway redeploy: restoring its old deployment would
+   * put that old build back while the rest of the environment had moved on, which
+   * is the split the one-build-per-environment rule exists to prevent.
+   *
+   * So it deploys the build the environment is currently running. With nothing
+   * else deployed there, there is no build to join and the user is sent to the
+   * dialog to choose one instead.
    */
   const handleRedeploy = (environment: Environment, gatewayId: string) => {
     const gateway = environment.gateways.find((candidate) => candidate.id === gatewayId);
-    if (!client || !gateway?.deploymentId) return;
+    if (!client || !gateway) return;
+    const liveBuild = environment.gateways.find(
+      (candidate) => candidate.id !== gatewayId && candidate.status === 'DEPLOYED'
+    )?.buildId;
+    if (!liveBuild) {
+      notify(
+        `Nothing else is deployed in ${environment.name}, so there is no build to join. Use Deploy to choose one.`,
+        'info'
+      );
+      return;
+    }
     void runAction(
-      () => client.redeploy(environment.name, gatewayId, gateway.deploymentId!),
-      `Redeploying ${gateway.name}.`,
-      `Unable to redeploy ${gateway.name}.`
+      () =>
+        client.deploy({
+          environment: environment.name,
+          gateways: [{ gatewayId, endpointUrl: gateway.endpointUrl }],
+          buildId: liveBuild,
+        }),
+      `Deploying ${gateway.name}.`,
+      `Unable to deploy ${gateway.name}.`
     );
   };
 

--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/DeployPage.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/DeployPage.tsx
@@ -45,6 +45,34 @@ export type DeployPageProps = {
   ) => void;
   onStopGateway: (environment: Environment, gatewayId: string) => void;
   onRetryGateway: (environment: Environment, gatewayId: string) => void;
+  /** Deletes a build, freeing a slot when the API is at its build limit. */
+  onDeleteBuild: (buildId: string) => void;
+};
+
+/**
+ * The statuses that mean a gateway is holding a build — on it, going on, or coming
+ * off. The platform refuses to delete a build in any of them, so the page says so
+ * up front instead of offering the action and having it rejected. Suspended and
+ * failed deployments are deliberately absent: their builds ARE deletable, and they
+ * are the ones automatic cleanup will not reclaim.
+ */
+const GATEWAY_HELD_STATUSES = ['DEPLOYED', 'DEPLOYING', 'UNDEPLOYING'];
+
+/**
+ * Why each build cannot be deleted, by build id, naming the environment that is
+ * holding it so the reason is actionable rather than just a refusal.
+ */
+const undeletableBuildReasons = (environments: Environment[]): Record<string, string> => {
+  const reasons: Record<string, string> = {};
+  environments.forEach((environment) => {
+    environment.gateways.forEach((gateway) => {
+      if (!gateway.buildId || !gateway.status) return;
+      if (!GATEWAY_HELD_STATUSES.includes(gateway.status)) return;
+      reasons[gateway.buildId] =
+        `This build is on a gateway in ${environment.name}. Undeploy it before deleting the build.`;
+    });
+  });
+  return reasons;
 };
 
 /**
@@ -68,6 +96,7 @@ const DeployPage: FC<DeployPageProps> = ({
   onDeploy,
   onStopGateway,
   onRetryGateway,
+  onDeleteBuild,
 }) => {
   const [dialog, setDialog] = useState<DialogState>(null);
 
@@ -156,10 +185,12 @@ const DeployPage: FC<DeployPageProps> = ({
             <BuildAreaCard
               builds={builds}
               targetEnvironment={environments[0]}
+              undeletableBuilds={undeletableBuildReasons(environments)}
               busy={busy}
               onDeployClick={(buildId, createBuild) =>
                 setDialog({ targetIndex: 0, buildId, createBuild })
               }
+              onDeleteBuild={onDeleteBuild}
             />
 
             {environments.map((environment, index) => (

--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/DeployPage.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/DeployPage.tsx
@@ -32,11 +32,14 @@ export type DeployPageProps = {
   /** The backend URL the API is defined against; the deploy form starts from it. */
   apiEndpointUrl?: string;
   busy: boolean;
-  /** Deploys to `target`; `from` is set when this is a promotion. */
+  /**
+   * Deploys to `target`; `from` is set when this is a promotion. Every gateway
+   * goes in one call with its own endpoint, because an environment runs a single
+   * build of an API at a time.
+   */
   onDeploy: (
     target: Environment,
-    gatewayId: string,
-    endpointUrl: string,
+    gateways: { gatewayId: string; endpointUrl?: string }[],
     from?: Environment,
     buildId?: string
   ) => void;
@@ -74,8 +77,11 @@ const DeployPage: FC<DeployPageProps> = ({
   const source =
     dialog?.sourceIndex !== undefined ? environments[dialog.sourceIndex] : undefined;
 
-  const handleConfirm = (gatewayId: string, endpointUrl: string, buildId?: string) => {
-    if (target) onDeploy(target, gatewayId, endpointUrl, source, buildId);
+  const handleConfirm = (
+    gateways: { gatewayId: string; endpointUrl?: string }[],
+    buildId?: string
+  ) => {
+    if (target) onDeploy(target, gateways, source, buildId);
     setDialog(null);
   };
 

--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/DeployPage.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/DeployPage.tsx
@@ -45,7 +45,6 @@ export type DeployPageProps = {
   ) => void;
   onStopGateway: (environment: Environment, gatewayId: string) => void;
   onRetryGateway: (environment: Environment, gatewayId: string) => void;
-  onRedeployGateway: (environment: Environment, gatewayId: string) => void;
 };
 
 /**
@@ -69,7 +68,6 @@ const DeployPage: FC<DeployPageProps> = ({
   onDeploy,
   onStopGateway,
   onRetryGateway,
-  onRedeployGateway,
 }) => {
   const [dialog, setDialog] = useState<DialogState>(null);
 
@@ -176,7 +174,6 @@ const DeployPage: FC<DeployPageProps> = ({
                   }
                   onStopGateway={(gatewayId) => onStopGateway(environment, gatewayId)}
                   onRetryGateway={(gatewayId) => onRetryGateway(environment, gatewayId)}
-                  onRedeployGateway={(gatewayId) => onRedeployGateway(environment, gatewayId)}
                 />
               </Fragment>
             ))}

--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/components/BuildAreaCard.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/components/BuildAreaCard.tsx
@@ -31,7 +31,7 @@ import {
   Tooltip,
   Typography,
 } from '@wso2/oxygen-ui';
-import { ChevronDown, Clock, X } from '@wso2/oxygen-ui-icons-react';
+import { ChevronDown, Clock, Trash2, X } from '@wso2/oxygen-ui-icons-react';
 import { relativeTime } from '../utils/time';
 import { activeGatewayCount } from '../utils/status';
 import type { Build, Environment } from '../types';
@@ -40,9 +40,20 @@ export type BuildAreaCardProps = {
   /** The API's builds, newest first. */
   builds: Build[];
   targetEnvironment: Environment;
+  /**
+   * Why each build cannot be deleted, by build id. A build a gateway is serving is
+   * refused by the platform, so it is shown disabled with the reason rather than
+   * offered and then rejected. Builds absent from this map are deletable.
+   */
+  undeletableBuilds: Record<string, string>;
   busy: boolean;
   /** Opens deployment using an existing build, or creates a build when omitted. */
   onDeployClick: (buildId?: string, createBuild?: boolean) => void;
+  /**
+   * Deletes a build. An API keeps a limited number, so this is how room is made
+   * once deploying is refused for having no free slot.
+   */
+  onDeleteBuild: (buildId: string) => void;
 };
 
 const VISIBLE_BUILD_COUNT = 5;
@@ -55,12 +66,18 @@ type DeployAction = 'deploy' | 'build-and-deploy';
 const BuildAreaCard: FC<BuildAreaCardProps> = ({
   builds,
   targetEnvironment,
+  undeletableBuilds,
   busy,
   onDeployClick,
+  onDeleteBuild,
 }) => {
   const [deployMenuAnchor, setDeployMenuAnchor] = useState<HTMLElement | null>(null);
   const [buildsDrawerOpen, setBuildsDrawerOpen] = useState(false);
   const [selectedDeployAction, setSelectedDeployAction] = useState<DeployAction>('deploy');
+  // Deleting a build cannot be undone, so the trash icon asks first rather than
+  // acting. Confirming inline keeps it out of a modal, which the All Builds drawer
+  // would otherwise have to stack one inside.
+  const [pendingDelete, setPendingDelete] = useState<string | null>(null);
   const latestBuild = builds[0] ?? null;
   const visibleBuilds = builds.slice(0, VISIBLE_BUILD_COUNT);
   const canDeploy = activeGatewayCount(targetEnvironment.gateways) > 0;
@@ -86,30 +103,86 @@ const BuildAreaCard: FC<BuildAreaCardProps> = ({
 
   const renderBuilds = (items: Build[]) => (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-      {items.map((build) => (
-        <Card key={build.buildId} variant="outlined">
-          <CardContent sx={{ p: 1.25, '&:last-child': { pb: 1.25 } }}>
-            <Typography
-              variant="body2"
-              sx={{
-                color: 'text.primary',
-                fontWeight: 700,
-                fontSize: 14,
-              }}
-            >
-              {build.buildId}
-            </Typography>
-            {build.createdAt ? (
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.5 }}>
-                <Clock size={13} />
-                <Typography variant="caption" color="text.secondary" sx={{ fontSize: 12 }}>
-                  {relativeTime(build.createdAt)}
-                </Typography>
+      {items.map((build) => {
+        const blockedReason = undeletableBuilds[build.buildId];
+        const confirming = pendingDelete === build.buildId;
+        return (
+          <Card key={build.buildId} variant="outlined">
+            <CardContent sx={{ p: 1.25, '&:last-child': { pb: 1.25 } }}>
+              <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
+                <Box sx={{ minWidth: 0, flex: 1 }}>
+                  <Typography
+                    variant="body2"
+                    sx={{
+                      color: 'text.primary',
+                      fontWeight: 700,
+                      fontSize: 14,
+                    }}
+                  >
+                    {build.buildId}
+                  </Typography>
+                  {build.description ? (
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{ display: 'block', mt: 0.25, fontSize: 12 }}
+                    >
+                      {build.description}
+                    </Typography>
+                  ) : null}
+                  {build.createdAt ? (
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.5 }}>
+                      <Clock size={13} />
+                      <Typography variant="caption" color="text.secondary" sx={{ fontSize: 12 }}>
+                        {relativeTime(build.createdAt)}
+                      </Typography>
+                    </Box>
+                  ) : null}
+                </Box>
+                {confirming ? null : (
+                  <Tooltip title={blockedReason || 'Delete this build'}>
+                    <span>
+                      <IconButton
+                        size="small"
+                        aria-label={`Delete build ${build.buildId}`}
+                        disabled={busy || Boolean(blockedReason)}
+                        onClick={() => setPendingDelete(build.buildId)}
+                      >
+                        <Trash2 size={15} />
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                )}
               </Box>
-            ) : null}
-          </CardContent>
-        </Card>
-      ))}
+              {confirming ? (
+                <Box sx={{ mt: 1 }}>
+                  <Typography variant="caption" color="text.secondary" sx={{ fontSize: 12 }}>
+                    Delete this build? Deployments that ran it stay on their gateways but can no
+                    longer be promoted onward.
+                  </Typography>
+                  <Box sx={{ display: 'flex', gap: 1, mt: 1 }}>
+                    <Button
+                      size="small"
+                      color="error"
+                      variant="contained"
+                      disabled={busy}
+                      onClick={() => {
+                        setPendingDelete(null);
+                        onDeleteBuild(build.buildId);
+                      }}
+                    >
+                      Delete
+                    </Button>
+                    <Button size="small" disabled={busy} onClick={() => setPendingDelete(null)}>
+                      Cancel
+                    </Button>
+                  </Box>
+                </Box>
+              ) : null}
+            </CardContent>
+          </Card>
+        );
+      })}
     </Box>
   );
 

--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/components/BuildAreaCard.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/components/BuildAreaCard.tsx
@@ -157,8 +157,7 @@ const BuildAreaCard: FC<BuildAreaCardProps> = ({
               {confirming ? (
                 <Box sx={{ mt: 1 }}>
                   <Typography variant="caption" color="text.secondary" sx={{ fontSize: 12 }}>
-                    Delete this build? Deployments that ran it stay on their gateways but can no
-                    longer be promoted onward.
+                    Delete this build?
                   </Typography>
                   <Box sx={{ display: 'flex', gap: 1, mt: 1 }}>
                     <Button

--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/components/DeployDialog.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/components/DeployDialog.tsx
@@ -154,6 +154,15 @@ const DeployDialog: FC<DeployDialogProps> = ({
   // what is on it: a healthy gateway with nothing deployed is exactly what a first
   // deployment targets.
   const inactiveSelected = selected.filter((gateway) => gateway.health !== 'active');
+  // A locked gateway cannot be unticked, so telling its owner to unselect it would
+  // be an instruction they cannot follow. Both still block — deploying an
+  // environment is one call that rolls every gateway back if any fails, so letting
+  // it through would only trade a dead end for a failed deploy — but the way out
+  // differs, so the two are said separately.
+  const inactiveLocked = inactiveSelected.filter((gateway) => lockedIds.includes(gateway.id));
+  const inactiveSelectable = inactiveSelected.filter(
+    (gateway) => !lockedIds.includes(gateway.id)
+  );
   const missingUrls = selected.filter((gateway) => endpointFor(gateway).trim().length === 0);
   const canConfirm =
     selected.length > 0 &&
@@ -182,12 +191,22 @@ const DeployDialog: FC<DeployDialogProps> = ({
             : `Carries a build running in ${sourceEnvironment?.name ?? 'the previous environment'} forward to ${environment.name}, with the endpoint you give here.`}
         </Typography>
 
-        {inactiveSelected.length > 0 ? (
+        {inactiveSelectable.length > 0 ? (
           <Alert severity="warning" sx={{ mb: 2 }}>
-            {inactiveSelected.map((gateway) => gateway.name).join(', ')}
-            {inactiveSelected.length === 1 ? ' is inactive and ' : ' are inactive and '}
-            can't receive a deployment. Unselect{inactiveSelected.length === 1 ? ' it' : ' them'} to
-            continue.
+            {inactiveSelectable.map((gateway) => gateway.name).join(', ')}
+            {inactiveSelectable.length === 1 ? ' is inactive and ' : ' are inactive and '}
+            can't receive a deployment. Unselect
+            {inactiveSelectable.length === 1 ? ' it' : ' them'} to continue.
+          </Alert>
+        ) : null}
+
+        {inactiveLocked.length > 0 ? (
+          <Alert severity="warning" sx={{ mb: 2 }}>
+            {inactiveLocked.map((gateway) => gateway.name).join(', ')}
+            {inactiveLocked.length === 1
+              ? ' is inactive and already has this API deployed on it, so it cannot be left out of this deployment. Activate it, or stop its deployment in '
+              : ' are inactive and already have this API deployed on them, so they cannot be left out of this deployment. Activate them, or stop their deployments in '}
+            {environment.name}, to continue.
           </Alert>
         ) : null}
 

--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/components/DeployDialog.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/components/DeployDialog.tsx
@@ -21,15 +21,18 @@ import {
   Alert,
   Box,
   Button,
+  Checkbox,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
   FormControl,
+  FormControlLabel,
   FormLabel,
   MenuItem,
   Select,
   TextField,
+  Tooltip,
   Typography,
 } from '@wso2/oxygen-ui';
 import StatusDot from './StatusDot';
@@ -51,7 +54,15 @@ export type DeployDialogProps = {
   createBuild: boolean;
   submitting: boolean;
   onClose: () => void;
-  onConfirm: (gatewayId: string, endpointUrl: string, buildId?: string) => void;
+  /**
+   * Confirms the deploy with every selected gateway and its endpoint. Plural
+   * because an environment runs a single build of an API at a time, so the
+   * gateways go in one call.
+   */
+  onConfirm: (
+    gateways: { gatewayId: string; endpointUrl?: string }[],
+    buildId?: string
+  ) => void;
 };
 
 const sectionLabelSx = {
@@ -86,16 +97,16 @@ const DeployDialog: FC<DeployDialogProps> = ({
   // Holding the resolved values instead would leave the first render of a freshly
   // opened dialog with nothing selected, since the effect that filled them ran
   // after it, and would let a background refresh overwrite a half-typed URL.
-  const [gatewayId, setGatewayId] = useState('');
+  const [selectedIds, setSelectedIds] = useState<string[] | null>(null);
   const [buildId, setBuildId] = useState('');
-  const [endpointDraft, setEndpointDraft] = useState<string | null>(null);
+  const [endpointDrafts, setEndpointDrafts] = useState<Record<string, string>>({});
   const [urlTouched, setUrlTouched] = useState(false);
 
   useEffect(() => {
     if (!open) return;
-    setGatewayId('');
+    setSelectedIds(null);
     setBuildId('');
-    setEndpointDraft(null);
+    setEndpointDrafts({});
     setUrlTouched(false);
   }, [open]);
 
@@ -109,29 +120,45 @@ const DeployDialog: FC<DeployDialogProps> = ({
         )
       : builds;
   const selectedBuildId = buildId || initialBuildId || availableBuilds[0]?.buildId || '';
-  const selectedGateway =
-    environment.gateways.find((gateway) => gateway.id === gatewayId) ??
-    pickDefaultGateway(environment.gateways);
-  // What this gateway already serves comes first, so re-deploying to it keeps the
-  // endpoint it is running; a gateway with nothing on it starts from the API's own
-  // backend URL rather than an empty field.
-  const endpointUrl = endpointDraft ?? selectedGateway?.endpointUrl ?? apiEndpointUrl ?? '';
+  // A gateway the API is already deployed on must stay in the set: the
+  // environment runs one build, so this deploy has to reach it too. They are
+  // shown ticked and locked, and undeploying is the way to drop one.
+  const alreadyDeployed = environment.gateways.filter((gateway) => !!gateway.deploymentId);
+  const lockedIds = alreadyDeployed.map((gateway) => gateway.id);
+
+  // Until the user touches the list, the selection is the already-deployed
+  // gateways, or the environment's default for a first deploy.
+  const defaultSelection =
+    lockedIds.length > 0
+      ? lockedIds
+      : [pickDefaultGateway(environment.gateways)?.id].filter((id): id is string => !!id);
+  const selection = selectedIds ?? defaultSelection;
+  const selected = environment.gateways.filter((gateway) => selection.includes(gateway.id));
+
+  // What a gateway already serves comes first, so redeploying keeps the endpoint
+  // it is running; one with nothing on it starts from the API's own backend URL.
+  const endpointFor = (gateway: Gateway) =>
+    endpointDrafts[gateway.id] ?? gateway.endpointUrl ?? apiEndpointUrl ?? '';
+
   const isSingleGateway = environment.gateways.length === 1;
-  // Whether the gateway can receive a deployment is its own health, not the state
-  // of what is deployed on it: a healthy gateway with nothing deployed is exactly
-  // what a first deployment targets.
-  const isSelectedInactive = selectedGateway ? selectedGateway.health !== 'active' : false;
-  const urlMissing = endpointUrl.trim().length === 0;
+  // Whether a gateway can receive a deployment is its own health, not the state of
+  // what is on it: a healthy gateway with nothing deployed is exactly what a first
+  // deployment targets.
+  const inactiveSelected = selected.filter((gateway) => gateway.health !== 'active');
+  const missingUrls = selected.filter((gateway) => endpointFor(gateway).trim().length === 0);
   const canConfirm =
-    !!selectedGateway &&
-    !isSelectedInactive &&
-    !urlMissing &&
+    selected.length > 0 &&
+    inactiveSelected.length === 0 &&
+    missingUrls.length === 0 &&
     (createBuild || selectedBuildId.length > 0);
 
-  const handleSelectGateway = (id: string) => {
-    setGatewayId(id);
-    setEndpointDraft(null);
-    setUrlTouched(false);
+  const toggleGateway = (id: string) => {
+    // Locked gateways cannot be unticked — the backend refuses a deploy that drops
+    // them, so offering it here would only produce an error.
+    if (lockedIds.includes(id)) return;
+    setSelectedIds(
+      selection.includes(id) ? selection.filter((each) => each !== id) : [...selection, id]
+    );
   };
 
   return (
@@ -146,72 +173,147 @@ const DeployDialog: FC<DeployDialogProps> = ({
             : `Carries a build running in ${sourceEnvironment?.name ?? 'the previous environment'} forward to ${environment.name}, with the endpoint you give here.`}
         </Typography>
 
-        {isSelectedInactive ? (
+        {inactiveSelected.length > 0 ? (
           <Alert severity="warning" sx={{ mb: 2 }}>
-            {selectedGateway?.name} is inactive and can't receive a deployment. Choose an active gateway to continue.
+            {inactiveSelected.map((gateway) => gateway.name).join(', ')}
+            {inactiveSelected.length === 1 ? ' is inactive and ' : ' are inactive and '}
+            can't receive a deployment. Unselect{inactiveSelected.length === 1 ? ' it' : ' them'} to
+            continue.
           </Alert>
         ) : null}
 
-        {isSingleGateway && selectedGateway ? (
+        {isSingleGateway && selected.length === 1 ? (
           <Box sx={{ mb: 2.5 }}>
             <FormLabel sx={{ ...sectionLabelSx, display: 'block', mb: 1 }}>Gateway</FormLabel>
             <Box
               sx={{
                 display: 'flex',
                 alignItems: 'center',
+                justifyContent: 'space-between',
                 gap: 1,
-                px: 1.5,
-                py: 1,
                 border: '1px solid',
                 borderColor: 'divider',
-                borderRadius: 1.5,
+                borderRadius: 1,
+                px: 1.5,
+                py: 1,
               }}
             >
-              <StatusDot tone={selectedGateway.health === 'active' ? 'success' : 'default'} />
-              <Box sx={{ flexGrow: 1, minWidth: 0 }}>
-                <Typography variant="body2" sx={{ fontWeight: 500 }} noWrap>
-                  {selectedGateway.name}
-                </Typography>
-                {selectedGateway.host ? (
-                  <Typography variant="caption" color="text.secondary" noWrap display="block">
-                    {selectedGateway.host}
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <StatusDot tone={selected[0].health === 'active' ? 'success' : 'default'} />
+                <Box>
+                  <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                    {selected[0].name}
                   </Typography>
-                ) : null}
+                  {selected[0].host ? (
+                    <Typography variant="caption" color="text.secondary">
+                      {selected[0].host}
+                    </Typography>
+                  ) : null}
+                </Box>
               </Box>
-              <StatusPill tone={gatewayStatusTone(selectedGateway.status)} />
+              <StatusPill tone={gatewayStatusTone(selected[0].status)} />
             </Box>
+            <TextField
+              fullWidth
+              size="small"
+              required
+              sx={{ mt: 1 }}
+              label="Endpoint URL"
+              placeholder="https://api.example.com"
+              value={endpointFor(selected[0])}
+              onChange={(event) =>
+                setEndpointDrafts({ ...endpointDrafts, [selected[0].id]: event.target.value })
+              }
+              onBlur={() => setUrlTouched(true)}
+              error={urlTouched && endpointFor(selected[0]).trim().length === 0}
+              helperText={
+                urlTouched && endpointFor(selected[0]).trim().length === 0
+                  ? 'Endpoint URL is required.'
+                  : ' '
+              }
+            />
           </Box>
         ) : (
           <Box sx={{ mb: 2.5 }}>
-            <FormLabel sx={{ ...sectionLabelSx, display: 'block', mb: 1 }}>Gateway</FormLabel>
-            <FormControl fullWidth size="small">
-              <Select
-                value={selectedGateway?.id ?? ''}
-                onChange={(event) => handleSelectGateway(event.target.value as string)}
-                renderValue={(value) => {
-                  const gateway = environment.gateways.find((candidate) => candidate.id === value);
-                  if (!gateway) return null;
-                  return (
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                      <StatusDot tone={gateway.health === 'active' ? 'success' : 'default'} />
-                      <Typography variant="body2">{gateway.name}</Typography>
+            <FormLabel sx={{ ...sectionLabelSx, display: 'block', mb: 1 }}>Gateways</FormLabel>
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+              {lockedIds.length > 0
+                ? 'Every gateway this API is already deployed on stays selected — an environment runs one build at a time. Undeploy a gateway to stop deploying to it.'
+                : 'Select the gateways to deploy to. They all receive the same build.'}
+            </Typography>
+            <Box sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1 }}>
+              {environment.gateways.map((gateway, index) => {
+                const isSelected = selection.includes(gateway.id);
+                const isLocked = lockedIds.includes(gateway.id);
+                return (
+                  <Box
+                    key={gateway.id}
+                    sx={{
+                      px: 1.5,
+                      py: 1,
+                      borderTop: index === 0 ? 'none' : '1px solid',
+                      borderColor: 'divider',
+                    }}
+                  >
+                    <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 1 }}>
+                      <Tooltip
+                        title={
+                          isLocked
+                            ? 'Already deployed here. Undeploy it first to stop deploying to it.'
+                            : ''
+                        }
+                      >
+                        <FormControlLabel
+                          sx={{ mr: 0 }}
+                          control={
+                            <Checkbox
+                              size="small"
+                              checked={isSelected}
+                              disabled={isLocked}
+                              onChange={() => toggleGateway(gateway.id)}
+                            />
+                          }
+                          label={
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                              <StatusDot tone={gateway.health === 'active' ? 'success' : 'default'} />
+                              <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                                {gateway.name}
+                                {gateway.isDefault ? ' · Default' : ''}
+                              </Typography>
+                            </Box>
+                          }
+                        />
+                      </Tooltip>
+                      <StatusPill tone={gatewayStatusTone(gateway.status)} />
                     </Box>
-                  );
-                }}
-              >
-                {environment.gateways.map((gateway) => (
-                  <MenuItem key={gateway.id} value={gateway.id}>
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                      <StatusDot tone={gateway.health === 'active' ? 'success' : 'default'} />
-                      <Typography variant="body2" sx={{ fontWeight: 500 }}>
-                        {gateway.name}
-                        {gateway.isDefault ? ' · Default' : ''}
-                      </Typography>
-                    </Box>
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
+                    {/* The endpoint is per gateway: two gateways of one environment
+                        can serve different backends, so each selected one gets its
+                        own field rather than sharing a single value. */}
+                    {isSelected ? (
+                      <TextField
+                        fullWidth
+                        size="small"
+                        required
+                        sx={{ mt: 1 }}
+                        label="Endpoint URL"
+                        placeholder="https://api.example.com"
+                        value={endpointFor(gateway)}
+                        onChange={(event) =>
+                          setEndpointDrafts({ ...endpointDrafts, [gateway.id]: event.target.value })
+                        }
+                        onBlur={() => setUrlTouched(true)}
+                        error={urlTouched && endpointFor(gateway).trim().length === 0}
+                        helperText={
+                          urlTouched && endpointFor(gateway).trim().length === 0
+                            ? 'Endpoint URL is required.'
+                            : ' '
+                        }
+                      />
+                    ) : null}
+                  </Box>
+                );
+              })}
+            </Box>
           </Box>
         )}
 
@@ -241,20 +343,6 @@ const DeployDialog: FC<DeployDialogProps> = ({
           </Box>
         )}
 
-        <Box>
-          <FormLabel sx={{ ...sectionLabelSx, display: 'block', mb: 1 }}>Endpoint URL</FormLabel>
-          <TextField
-            fullWidth
-            size="small"
-            required
-            placeholder="https://api.example.com"
-            value={endpointUrl}
-            onChange={(event) => setEndpointDraft(event.target.value)}
-            onBlur={() => setUrlTouched(true)}
-            error={urlTouched && urlMissing}
-            helperText={urlTouched && urlMissing ? 'Endpoint URL is required.' : ' '}
-          />
-        </Box>
       </DialogContent>
       <DialogActions sx={{ px: 3, pb: 2 }}>
         <Button onClick={onClose} disabled={submitting}>
@@ -263,15 +351,15 @@ const DeployDialog: FC<DeployDialogProps> = ({
         <Button
           variant="contained"
           disabled={!canConfirm || submitting}
-          onClick={() => {
-            if (selectedGateway) {
-              onConfirm(
-                selectedGateway.id,
-                endpointUrl.trim(),
-                createBuild ? undefined : selectedBuildId
-              );
-            }
-          }}
+          onClick={() =>
+            onConfirm(
+              selected.map((gateway) => ({
+                gatewayId: gateway.id,
+                endpointUrl: endpointFor(gateway).trim(),
+              })),
+              createBuild ? undefined : selectedBuildId
+            )
+          }
         >
           {submitting ? `${actionLabel}ing...` : actionLabel}
         </Button>

--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/components/DeployDialog.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/components/DeployDialog.tsx
@@ -22,6 +22,7 @@ import {
   Box,
   Button,
   Checkbox,
+  Chip,
   Dialog,
   DialogActions,
   DialogContent,
@@ -328,26 +329,50 @@ const DeployDialog: FC<DeployDialogProps> = ({
         {createBuild ? null : (
           <Box sx={{ mb: 2.5 }}>
             <FormLabel sx={{ ...sectionLabelSx, display: 'block', mb: 1 }}>Build</FormLabel>
-            <FormControl fullWidth size="small">
-              <Select
-                value={selectedBuildId}
-                onChange={(event) => setBuildId(event.target.value as string)}
-                displayEmpty
-                disabled={availableBuilds.length === 0}
-              >
-                {availableBuilds.length === 0 ? (
-                  <MenuItem value="" disabled>
-                    No deployed builds available
-                  </MenuItem>
-                ) : (
-                  availableBuilds.map((build) => (
-                    <MenuItem key={build.buildId} value={build.buildId}>
-                      {build.buildId}
+            {/* Promoting has nothing to choose: the source environment runs one
+                build, and promoting carries that one forward. Showing a dropdown
+                implied a decision the pipeline does not offer. */}
+            {mode === 'promote' ? (
+              selectedBuildId ? (
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <Chip
+                    label={selectedBuildId}
+                    size="small"
+                    variant="outlined"
+                    sx={{ height: 20, fontSize: '0.7rem' }}
+                  />
+                  <Typography variant="caption" color="text.secondary">
+                    from {sourceEnvironment?.name}
+                  </Typography>
+                </Box>
+              ) : (
+                <Typography variant="body2" color="text.secondary">
+                  Nothing is deployed in {sourceEnvironment?.name ?? 'the source environment'} to
+                  promote.
+                </Typography>
+              )
+            ) : (
+              <FormControl fullWidth size="small">
+                <Select
+                  value={selectedBuildId}
+                  onChange={(event) => setBuildId(event.target.value as string)}
+                  displayEmpty
+                  disabled={availableBuilds.length === 0}
+                >
+                  {availableBuilds.length === 0 ? (
+                    <MenuItem value="" disabled>
+                      No builds available
                     </MenuItem>
-                  ))
-                )}
-              </Select>
-            </FormControl>
+                  ) : (
+                    availableBuilds.map((build) => (
+                      <MenuItem key={build.buildId} value={build.buildId}>
+                        {build.buildId}
+                      </MenuItem>
+                    ))
+                  )}
+                </Select>
+              </FormControl>
+            )}
           </Box>
         )}
 

--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/components/DeployDialog.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/components/DeployDialog.tsx
@@ -120,10 +120,18 @@ const DeployDialog: FC<DeployDialogProps> = ({
         )
       : builds;
   const selectedBuildId = buildId || initialBuildId || availableBuilds[0]?.buildId || '';
-  // A gateway the API is already deployed on must stay in the set: the
-  // environment runs one build, so this deploy has to reach it too. They are
-  // shown ticked and locked, and undeploying is the way to drop one.
-  const alreadyDeployed = environment.gateways.filter((gateway) => !!gateway.deploymentId);
+  // A gateway the API is LIVE on must stay in the set: the environment runs one
+  // build, so this deploy has to reach it too. They are shown ticked and locked,
+  // and undeploying is the way to drop one.
+  //
+  // Keyed on the status, not on deploymentId: a stopped gateway keeps its
+  // deployment id — that is how it is identified — so testing for the id locked
+  // gateways that were undeployed, leaving no way to deploy or promote without
+  // them. The whole point of stopping one is to drop it from the set.
+  const liveStatuses = ['DEPLOYED', 'DEPLOYING', 'FAILED'];
+  const alreadyDeployed = environment.gateways.filter((gateway) =>
+    liveStatuses.includes(gateway.status)
+  );
   const lockedIds = alreadyDeployed.map((gateway) => gateway.id);
 
   // Until the user touches the list, the selection is the already-deployed

--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/components/EnvironmentCard.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/components/EnvironmentCard.tsx
@@ -51,7 +51,6 @@ const EnvironmentCard: FC<EnvironmentCardProps> = ({
   const { gateways } = environment;
   const activeCount = activeGatewayCount(gateways);
   const deployed = hasAnyDeployment(gateways);
-  const canPromote = !!nextEnvironment && activeGatewayCount(nextEnvironment.gateways) > 0;
   // What the environment is running: the distinct builds across the gateways that
   // are actually serving. A settling or stopped gateway is not part of what the
   // environment serves, so it does not contribute a build here.
@@ -63,10 +62,21 @@ const EnvironmentCard: FC<EnvironmentCardProps> = ({
     )
   ).sort();
 
-  const promoteDisabledReason =
-    nextEnvironment && !canPromote
-      ? `All gateways in ${nextEnvironment.name} are inactive. Activate a gateway before promoting.`
-      : '';
+  // A promotion carries THIS environment's build forward, so there has to be one:
+  // once every gateway here is stopped the environment is running nothing and the
+  // backend refuses the promotion. Gating it here means the button does not offer
+  // an action that can only fail.
+  const hasBuildToPromote = runningBuilds.length > 0;
+  const canPromote =
+    !!nextEnvironment && activeGatewayCount(nextEnvironment.gateways) > 0 && hasBuildToPromote;
+
+  const promoteDisabledReason = !nextEnvironment
+    ? ''
+    : !hasBuildToPromote
+      ? `Nothing is deployed in ${environment.name} to promote. Deploy here first.`
+      : activeGatewayCount(nextEnvironment.gateways) === 0
+        ? `All gateways in ${nextEnvironment.name} are inactive. Activate a gateway before promoting.`
+        : '';
 
   return (
     <Card
@@ -79,50 +89,54 @@ const EnvironmentCard: FC<EnvironmentCardProps> = ({
       <CardContent
         sx={{ p: 2.5, display: 'flex', flexDirection: 'column', gap: 1.5, '&:last-child': { pb: 2.5 } }}
       >
-        <Box>
-          <Typography sx={{ fontSize: 16, fontWeight: 600 }}>{environment.name}</Typography>
-          <Typography variant="body2" color="text.secondary">
-            {activeCount} of {gateways.length} gateway{gateways.length === 1 ? '' : 's'} active
-          </Typography>
-        </Box>
+        {/* Name on the left, the environment's build on the right: the build is a
+            property of the ENVIRONMENT now — every gateway in it runs the same one
+            — so it sits beside the name rather than being read off the rows and
+            compared, and it uses the space the header was leaving empty.
 
-        {/* The build belongs to the ENVIRONMENT now, not to each gateway: they all
-            run the same one. So it is stated once, here, rather than being left to
-            be read off the rows and compared.
-
-            More than one build showing means the environment is split — which the
-            deploy rules are meant to prevent — so it is called out rather than
+            More than one build showing means the environment is split, which the
+            deploy rules are meant to prevent, so it is called out rather than
             quietly listing both. */}
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, flexWrap: 'wrap' }}>
-          <Typography sx={sectionLabelSx}>Build</Typography>
-          {runningBuilds.length === 0 ? (
-            <Typography variant="caption" color="text.disabled">
-              Nothing deployed
+        <Box sx={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 1 }}>
+          <Box sx={{ minWidth: 0 }}>
+            <Typography sx={{ fontSize: 16, fontWeight: 600 }}>{environment.name}</Typography>
+            <Typography variant="body2" color="text.secondary">
+              {activeCount} of {gateways.length} gateway{gateways.length === 1 ? '' : 's'} active
             </Typography>
-          ) : runningBuilds.length === 1 ? (
-            <Chip
-              label={runningBuilds[0]}
-              size="small"
-              variant="outlined"
-              sx={{ height: 20, fontSize: '0.7rem' }}
-            />
-          ) : (
-            <>
-              {runningBuilds.map((buildId) => (
-                <Chip
-                  key={buildId}
-                  label={buildId}
-                  size="small"
-                  color="warning"
-                  variant="outlined"
-                  sx={{ height: 20, fontSize: '0.7rem' }}
-                />
-              ))}
-              <Typography variant="caption" color="warning.main">
-                Split across builds
+          </Box>
+          <Box sx={{ textAlign: 'right', flexShrink: 0 }}>
+            <Typography sx={{ ...sectionLabelSx, display: 'block' }}>Build</Typography>
+            {runningBuilds.length === 0 ? (
+              <Typography variant="caption" color="text.disabled">
+                Nothing deployed
               </Typography>
-            </>
-          )}
+            ) : runningBuilds.length === 1 ? (
+              <Chip
+                label={runningBuilds[0]}
+                size="small"
+                variant="outlined"
+                sx={{ height: 20, fontSize: '0.7rem', mt: 0.25 }}
+              />
+            ) : (
+              <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 0.25 }}>
+                <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', justifyContent: 'flex-end' }}>
+                  {runningBuilds.map((buildId) => (
+                    <Chip
+                      key={buildId}
+                      label={buildId}
+                      size="small"
+                      color="warning"
+                      variant="outlined"
+                      sx={{ height: 20, fontSize: '0.7rem' }}
+                    />
+                  ))}
+                </Box>
+                <Typography variant="caption" color="warning.main">
+                  Split across builds
+                </Typography>
+              </Box>
+            )}
+          </Box>
         </Box>
 
         <Divider />

--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/components/EnvironmentCard.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/components/EnvironmentCard.tsx
@@ -30,7 +30,6 @@ export type EnvironmentCardProps = {
   onPromoteClick: () => void;
   onStopGateway: (gatewayId: string) => void;
   onRetryGateway: (gatewayId: string) => void;
-  onRedeployGateway: (gatewayId: string) => void;
 };
 
 const sectionLabelSx = {
@@ -48,12 +47,22 @@ const EnvironmentCard: FC<EnvironmentCardProps> = ({
   onPromoteClick,
   onStopGateway,
   onRetryGateway,
-  onRedeployGateway,
 }) => {
   const { gateways } = environment;
   const activeCount = activeGatewayCount(gateways);
   const deployed = hasAnyDeployment(gateways);
   const canPromote = !!nextEnvironment && activeGatewayCount(nextEnvironment.gateways) > 0;
+  // What the environment is running: the distinct builds across the gateways that
+  // are actually serving. A settling or stopped gateway is not part of what the
+  // environment serves, so it does not contribute a build here.
+  const runningBuilds = Array.from(
+    new Set(
+      gateways
+        .filter((gateway) => gateway.status === 'DEPLOYED' && !!gateway.buildId)
+        .map((gateway) => gateway.buildId as string)
+    )
+  ).sort();
+
   const promoteDisabledReason =
     nextEnvironment && !canPromote
       ? `All gateways in ${nextEnvironment.name} are inactive. Activate a gateway before promoting.`
@@ -77,6 +86,45 @@ const EnvironmentCard: FC<EnvironmentCardProps> = ({
           </Typography>
         </Box>
 
+        {/* The build belongs to the ENVIRONMENT now, not to each gateway: they all
+            run the same one. So it is stated once, here, rather than being left to
+            be read off the rows and compared.
+
+            More than one build showing means the environment is split — which the
+            deploy rules are meant to prevent — so it is called out rather than
+            quietly listing both. */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, flexWrap: 'wrap' }}>
+          <Typography sx={sectionLabelSx}>Build</Typography>
+          {runningBuilds.length === 0 ? (
+            <Typography variant="caption" color="text.disabled">
+              Nothing deployed
+            </Typography>
+          ) : runningBuilds.length === 1 ? (
+            <Chip
+              label={runningBuilds[0]}
+              size="small"
+              variant="outlined"
+              sx={{ height: 20, fontSize: '0.7rem' }}
+            />
+          ) : (
+            <>
+              {runningBuilds.map((buildId) => (
+                <Chip
+                  key={buildId}
+                  label={buildId}
+                  size="small"
+                  color="warning"
+                  variant="outlined"
+                  sx={{ height: 20, fontSize: '0.7rem' }}
+                />
+              ))}
+              <Typography variant="caption" color="warning.main">
+                Split across builds
+              </Typography>
+            </>
+          )}
+        </Box>
+
         <Divider />
 
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
@@ -97,7 +145,6 @@ const EnvironmentCard: FC<EnvironmentCardProps> = ({
                 environmentName={environment.name}
                 busy={busy}
                 onRetry={() => onRetryGateway(gateway.id)}
-                onRedeploy={() => onRedeployGateway(gateway.id)}
                 onStop={() => onStopGateway(gateway.id)}
               />
             ))}

--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/components/GatewayRow.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/components/GatewayRow.tsx
@@ -18,7 +18,7 @@
 
 import { useState, type FC } from 'react';
 import { Box, Button, Card, CardContent, Collapse, Typography } from '@wso2/oxygen-ui';
-import { ChevronDown, ChevronUp, Eye } from '@wso2/oxygen-ui-icons-react';
+import { ChevronDown, ChevronUp, Clock, Eye } from '@wso2/oxygen-ui-icons-react';
 import ActionRow from './ActionRow';
 import EndpointUrlDrawer from './EndpointUrlDrawer';
 import StatusDot from './StatusDot';
@@ -118,26 +118,20 @@ const GatewayRow: FC<GatewayRowProps> = ({
 
             {gateway.status !== 'NOT_DEPLOYED' ? (
               <>
-                <Card>
-                  <CardContent
-                    sx={{
-                      p: 1.25,
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'space-between',
-                      '&:last-child': { pb: 1.25 },
-                    }}
-                  >
-                    <Box>
-                      <Typography variant="body2" sx={{ fontWeight: 500 }}>
-                        ID {gateway.buildId}
-                      </Typography>
-                      <Typography variant="caption" color="text.secondary">
-                        Deployed {gateway.deployedAt ? relativeTime(gateway.deployedAt) : '—'}
-                      </Typography>
-                    </Box>
-                  </CardContent>
-                </Card>
+                {/*
+                  When the deployment landed, as a plain line rather than a card: the
+                  build it runs is shown once on the environment, so repeating it per
+                  gateway only added a label with nothing beside it whenever the build
+                  had since been reclaimed.
+                */}
+                {gateway.deployedAt ? (
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                    <Clock size={13} />
+                    <Typography variant="caption" color="text.secondary">
+                      Deployed {relativeTime(gateway.deployedAt)}
+                    </Typography>
+                  </Box>
+                ) : null}
 
                 <ActionRow
                   label="Endpoint URL"

--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/components/GatewayRow.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/components/GatewayRow.tsx
@@ -34,7 +34,6 @@ export type GatewayRowProps = {
   busy: boolean;
   onRetry: () => void;
   /** Puts a suspended deployment back on the gateway, unchanged. */
-  onRedeploy: () => void;
   onStop: () => void;
 };
 
@@ -43,7 +42,6 @@ const GatewayRow: FC<GatewayRowProps> = ({
   environmentName,
   busy,
   onRetry,
-  onRedeploy,
   onStop,
 }) => {
   const [expanded, setExpanded] = useState(false);
@@ -53,24 +51,27 @@ const GatewayRow: FC<GatewayRowProps> = ({
 
   // What the one action button does depends on what the gateway is doing:
   //
-  //  - suspended (UNDEPLOYED) — put the SAME deployment back, artifact and all;
   //  - failed — deploy its build again, which makes a new deployment;
   //  - serving — stop it.
   //
+  // A stopped gateway offers nothing here. Putting one back is a deploy, which
+  // goes through the deploy dialog so it joins the build the environment is on —
+  // reviving its old deployment from this row would put that old build back
+  // while the rest of the environment had moved on.
+  //
   // Nothing to do while a deployment is still settling, or where there is none.
-  const action: 'redeploy' | 'retry' | 'stop' =
-    gateway.status === 'UNDEPLOYED' ? 'redeploy' : gateway.status === 'FAILED' ? 'retry' : 'stop';
-  const actionLabel = action === 'stop' ? 'Stop deployment' : 'Redeploy';
+  const action: 'retry' | 'stop' = gateway.status === 'FAILED' ? 'retry' : 'stop';
+  const actionLabel = action === 'stop' ? 'Stop deployment' : 'Retry';
   const actionDisabled =
     busy ||
     gateway.status === 'NOT_DEPLOYED' ||
+    gateway.status === 'UNDEPLOYED' ||
     gateway.status === 'DEPLOYING' ||
     gateway.status === 'UNDEPLOYING' ||
-    // Retrying re-deploys the build, so it needs no deployment; the other two act
-    // on the deployment itself.
+    // Retrying re-deploys the build, so it needs no deployment; stopping acts on
+    // the deployment itself.
     (action !== 'retry' && !gateway.deploymentId);
-  const handleActionClick =
-    action === 'redeploy' ? onRedeploy : action === 'retry' ? onRetry : onStop;
+  const handleActionClick = action === 'retry' ? onRetry : onStop;
 
   return (
     <Card>

--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/deployApi.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/deployApi.ts
@@ -165,13 +165,6 @@ export function createDeployClient(apiFetch: ApiFetch, projectHandle: string, ap
      * immutable, so it comes back exactly as it was — same build, same endpoint —
      * and nothing is rendered or built.
      */
-    async redeploy(environment: string, gatewayId: string, deploymentId: string): Promise<void> {
-      const query = `?environment=${encodeURIComponent(environment)}&gatewayId=${encodeURIComponent(gatewayId)}`;
-      await apiFetch(
-        'POST',
-        `${base}/deployments/${encodeURIComponent(deploymentId)}/redeploy${query}`
-      );
-    },
 
     /** Stops serving one deployment on one gateway; the rest are untouched. */
     async undeploy(environment: string, gatewayId: string, deploymentId: string): Promise<void> {

--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/deployApi.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/deployApi.ts
@@ -134,19 +134,29 @@ export function createDeployClient(apiFetch: ApiFetch, projectHandle: string, ap
      * Supplying `buildId` deploys that existing build. `fromEnvironment` promotes
      * instead, carrying that environment's build forward untouched.
      */
+    /**
+     * Deploys (or promotes) one build onto every gateway named, each with its own
+     * endpoint. An environment runs a single build of an API at a time, so this is
+     * one call rather than one per gateway: the backend puts the same build on all
+     * of them and rolls every gateway back if any one fails.
+     *
+     * The gateways must include every gateway the API is already deployed on in
+     * that environment; leaving one out is refused with 409.
+     */
     async deploy(input: {
       environment: string;
-      gatewayId: string;
-      endpointUrl?: string;
+      gateways: { gatewayId: string; endpointUrl?: string }[];
       fromEnvironment?: string;
       buildId?: string;
     }): Promise<void> {
       await apiFetch('POST', `${base}/deployments`, {
         environment: input.environment,
-        gatewayId: input.gatewayId,
+        gateways: input.gateways.map((gateway) => ({
+          gatewayId: gateway.gatewayId,
+          ...(gateway.endpointUrl ? { parameters: { productionEndpoint: gateway.endpointUrl } } : {}),
+        })),
         ...(input.fromEnvironment ? { fromEnvironment: input.fromEnvironment } : {}),
         ...(input.buildId ? { buildId: input.buildId } : {}),
-        ...(input.endpointUrl ? { parameters: { productionEndpoint: input.endpointUrl } } : {}),
       });
     },
 

--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/deployApi.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/deployApi.ts
@@ -36,7 +36,12 @@ type StageDTO = {
   gateways?: GatewayDeploymentDTO[];
 };
 
-type BuildDTO = { buildId: string; createdBy?: string; createdAt?: string };
+type BuildDTO = {
+  buildId: string;
+  description?: string;
+  createdBy?: string;
+  createdAt?: string;
+};
 
 /**
  * The gateways resource, which owns a gateway's identity and health. The
@@ -112,9 +117,28 @@ export function createDeployClient(apiFetch: ApiFetch, projectHandle: string, ap
       const response = await apiFetch<{ list?: BuildDTO[] }>('GET', `${base}/builds`);
       return (response?.list ?? []).map((dto) => ({
         buildId: dto.buildId,
+        description: dto.description,
         createdBy: dto.createdBy,
         createdAt: dto.createdAt,
       }));
+    },
+
+    /**
+     * Deletes one of the API's builds, which is how room is made once an API is at
+     * its build limit and deploying is refused.
+     *
+     * This goes straight to the API's own resource rather than through the project
+     * path: a build belongs to the API, not to a pipeline, and the platform already
+     * scopes the call to the caller's organization. Refused with 409 while a gateway
+     * is serving the build; undeploying releases it. Deployments that ran the build
+     * survive and stay redeployable from their own artifact, but stop reporting it,
+     * so they can no longer be promoted onward.
+     */
+    async deleteBuild(buildId: string): Promise<void> {
+      await apiFetch(
+        'DELETE',
+        `/rest-apis/${encodeURIComponent(apiHandle)}/builds/${encodeURIComponent(buildId)}`
+      );
     },
 
     /**
@@ -127,13 +151,6 @@ export function createDeployClient(apiFetch: ApiFetch, projectHandle: string, ap
       return api?.upstream?.main?.url;
     },
 
-    /**
-     * Deploys to one gateway of an environment with the endpoint it should serve.
-     *
-     * Deploying without a `buildId` snapshots the API and deploys the new build.
-     * Supplying `buildId` deploys that existing build. `fromEnvironment` promotes
-     * instead, carrying that environment's build forward untouched.
-     */
     /**
      * Deploys (or promotes) one build onto every gateway named, each with its own
      * endpoint. An environment runs a single build of an API at a time, so this is
@@ -159,12 +176,6 @@ export function createDeployClient(apiFetch: ApiFetch, projectHandle: string, ap
         ...(input.buildId ? { buildId: input.buildId } : {}),
       });
     },
-
-    /**
-     * Serves a suspended deployment again on the same gateway. The deployment is
-     * immutable, so it comes back exactly as it was — same build, same endpoint —
-     * and nothing is rendered or built.
-     */
 
     /** Stops serving one deployment on one gateway; the rest are untouched. */
     async undeploy(environment: string, gatewayId: string, deploymentId: string): Promise<void> {

--- a/portals/cloud-plugins/apip-cloud-ui-deploy/src/types.ts
+++ b/portals/cloud-plugins/apip-cloud-ui-deploy/src/types.ts
@@ -80,6 +80,8 @@ export type Environment = {
  */
 export type Build = {
   buildId: string;
+  /** The note recorded when the build was prepared, if any. */
+  description?: string;
   createdAt?: string;
   createdBy?: string;
 };

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/GatewayForm.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/GatewayForm.tsx
@@ -211,10 +211,14 @@ const GatewayForm: FC<GatewayFormProps> = ({
               control={
                 <Switch
                   checked={isDefault}
-                  // Nothing to be the default of until an environment is chosen,
-                  // and an existing default cannot be unset here — it is handed
-                  // over by marking another gateway.
-                  disabled={(gateway?.isDefault ?? false) || environmentId.length === 0}
+                  // Locked in three cases: nothing to be the default of until an
+                  // environment is chosen; an existing default cannot be unset
+                  // here (it is handed over by marking another gateway); and the
+                  // first gateway of its type BECOMES the default whatever this
+                  // says, so offering to untick it would be a lie.
+                  disabled={
+                    (gateway?.isDefault ?? false) || environmentId.length === 0 || isFirstOfType
+                  }
                   onChange={(event) => setIsDefault(event.target.checked)}
                 />
               }

--- a/portals/cloud-plugins/apip-cloud-ui-gateways/src/GatewaysList.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-gateways/src/GatewaysList.tsx
@@ -210,7 +210,13 @@ const GatewaysList: FC<GatewaysListProps> = ({
                                     gateways in one environment can each be
                                     marked — one per type. */}
                                 {gateway.isDefault ? (
-                                  <Chip label="Default" size="small" color="primary" />
+                                  <Chip
+                                    label="Default"
+                                    size="small"
+                                    color="primary"
+                                    variant="outlined"
+                                    sx={{ height: 20, fontSize: '0.7rem' }}
+                                  />
                                 ) : null}
                               </Box>
                             </TableCell>

--- a/portals/cloud-plugins/apip-cloud-ui-pipelines/src/PipelinesFeature.tsx
+++ b/portals/cloud-plugins/apip-cloud-ui-pipelines/src/PipelinesFeature.tsx
@@ -54,8 +54,12 @@ const PipelinesFeature: FC<PipelinesFeatureProps> = ({ port }) => {
     setLoading(true);
     setError(null);
     try {
-      const environmentList = await apiFetch<EnvironmentListDTO>('GET', '/environments');
-      const pipelineList = await apiFetch<PipelineListDTO>('GET', '/pipelines');
+      // Independent of each other, so they go together rather than one after the
+      // other: the page waits for the slower of the two instead of their sum.
+      const [environmentList, pipelineList] = await Promise.all([
+        apiFetch<EnvironmentListDTO>('GET', '/environments'),
+        apiFetch<PipelineListDTO>('GET', '/pipelines'),
+      ]);
       const assembledEnvironments = assembleEnvironments(environmentList?.list ?? []);
       setEnvironments(assembledEnvironments);
       setPipelines(


### PR DESCRIPTION
## Purpose
An environment runs a single build of an API at a time, so deploying is a set operation: one build onto several gateways. The deploy dialog offered one gateway and one endpoint, which cannot express that.

## Goals
Select gateways rather than a gateway, give each its own endpoint, and make the already-deployed ones impossible to drop by accident.

## Approach
- The dialog's gateway `Select` becomes a checkbox list. Every selected gateway gets **its own Endpoint URL field**, because two gateways of one environment can serve different backends and a deployment owns its parameters.
- Gateways the API is already deployed on are **ticked and locked**, with the reason in a tooltip: the backend refuses a deploy that drops one (409), so offering to untick it would only produce an error. Undeploying is how you stop deploying to a gateway.
- Default selection is the already-deployed set, or the environment's default gateway for a first deploy.
- The client sends one `POST …/deployments` with `gateways: [{gatewayId, parameters}]`.
- Retrying a single failed gateway still sends only that gateway — it ships the build its peers already run, so the environment stays on one build and the backend's check exempts it.
- An inactive selected gateway is named in the warning rather than blocking silently.

Four further changes came out of testing the above, all of them about an
environment running one build:

- **The environment's build is shown on its card**, beside the name, because that is
  the property of the environment rather than of each gateway. More than one build
  listed means the environment is split, which is worth seeing.
- **Promotion is gated on there being a build to carry.** A promotion carries this
  environment's build forward, so the button is disabled with a reason when nothing
  is deployed here, instead of offering a promotion the backend then refuses.
- **The per-gateway redeploy is gone.** It served a deployment's stored artifact
  again, which could revive a build older than the one the environment now runs —
  the opposite of the single-build rule. A suspended gateway is deployed to afresh.
  The retry toast says "Retrying" rather than "Redeploying" to match.
- **A stopped gateway is no longer locked into the set.** The locked set is keyed on
  status (`DEPLOYED`, `DEPLOYING`, `FAILED`), not on `deploymentId`: a stopped
  gateway keeps its deployment id, so testing the id locked gateways that had been
  undeployed and left no way to deploy or promote without them — which is the whole
  point of stopping one.

### Deleting a build

An API keeps a limited number of builds. When automatic cleanup cannot reclaim one —
every stored build is held by a deployment somewhere — deploying is refused, and the
page had no way out of it.

- Delete lives in the **Build Area**, whose `renderBuilds` is shared by the inline
  list and the All Builds drawer, so both get it from one change. It asks before
  acting, inline rather than in a modal (the drawer would otherwise stack one
  inside).
- It is disabled, naming the environment, while a gateway is holding the build —
  `DEPLOYED`, `DEPLOYING` or `UNDEPLOYING`. Suspended and failed deployments are
  deliberately not in that set: their builds are exactly the ones automatic cleanup
  will not reclaim, so they are what this is for. The disable is a courtesy, not the
  gate — a gateway may have claimed a build since the page loaded, so the platform's
  refusal decides, surfacing through the existing action toast.
- A build's `description` now shows under its id, which is what makes a list of
  builds something you can choose from.
- `deleteBuild` calls `DELETE /rest-apis/{apiId}/builds/{buildId}` on the API's own
  resource rather than through the project path — a build belongs to the API, not to
  a pipeline — following the `GET /rest-apis/{apiId}` call already in this client.
- The gateway card's build-id card gives way to a plain "Deployed <when>" line. The
  build a gateway runs is already shown once on the environment, so repeating it per
  gateway only contributed an `ID` label with nothing beside it once the build had
  been reclaimed.

Two comments left behind when the per-gateway redeploy was dropped are removed as
well: an orphaned block documenting the removed `redeploy` method, and a "Deploys to
one gateway" block sitting above the bulk-deploy function.

## User stories
N/A

## Documentation
N/A — no product doc covers this screen.

## Automation tests
 - Unit tests
   > N/A — this package is gated by `tsc --noEmit`, which passes (as do the other three cloud plugins).
 - Integration tests
   > N/A

## Samples
N/A

## Security checks
 - Followed secure coding standards? **yes**
 - Ran FindSecurityBugs plugin and verified report? **N/A** (TypeScript only)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Related PRs
Needs the matching backend change in apim-saas#2989, and the build delete endpoint
plus the build `description` from #3364. Stacked on #3415, so it also carries those
commits until that one merges.

## Test environment
Chrome 152, macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

